### PR TITLE
fix up getSpectrum1D

### DIFF
--- a/jdaviz/vizcomponents/viewer/viewer1d.py
+++ b/jdaviz/vizcomponents/viewer/viewer1d.py
@@ -1,5 +1,6 @@
 import logging
 
+import numpy as np
 from ipywidgets import Box
 from astropy import units as u
 from glue.core.subset import RangeSubsetState
@@ -38,11 +39,10 @@ class Viewer1D(Viewer):
                     hasattr(l.layer, 'subset_state') and isinstance(l.layer.subset_state, RangeSubsetState)]
 
     def getSpectrum1D(self, index=0):
-        wave = self._v1d.state.layers[0].layer.get_component('Wave')
-        wavelengths = wave.data[0]
-        if index is not None:
-            return Spectrum1D(flux=self._v1d.state.layers[0].layer.subsets[index]['FLUX'] * u.Jy,
-                              wavelength=wavelengths * u.AA)
-        else:
-            return [Spectrum1D(flux=layer.layer.subsets[index]['FLUX'] * u.Jy,
-                               wavelength=wavelengths * u.AA) for layer in self._v1d.state.layers]
+        # this should be replaced by something glue-native... it really only works for the specific cubes in testing
+        dc = self._vizapp.glue_app.data_collection
+        flux_unit = u.Unit(dc[0].meta['BUNIT'].replace('/spaxel', '').replace('Ang', 'angstrom'))
+        wave_unit = u.Unit(dc[0].meta['CUNIT3'])
+
+        x, y = self._v1d.state.layers[0].profile
+        return Spectrum1D(spectral_axis=x*wave_unit, flux=y*flux_unit)

--- a/jdaviz/vizcomponents/viewer/viewer1d.py
+++ b/jdaviz/vizcomponents/viewer/viewer1d.py
@@ -38,7 +38,7 @@ class Viewer1D(Viewer):
                     self._v1d.state.layers if
                     hasattr(l.layer, 'subset_state') and isinstance(l.layer.subset_state, RangeSubsetState)]
 
-    def getSpectrum1D(self, index=0):
+    def get_spectrum1D(self, index=0):
         # this should be replaced by something glue-native... it really only works for the specific cubes in testing
         dc = self._vizapp.glue_app.data_collection
         flux_unit = u.Unit(dc[0].meta['BUNIT'].replace('/spaxel', '').replace('Ang', 'angstrom'))

--- a/jdaviz/vizcomponents/viewer/viewernd.py
+++ b/jdaviz/vizcomponents/viewer/viewernd.py
@@ -24,7 +24,7 @@ class ViewerND(Viewer):
     def show(self):
         return Box([self._v3d.layout])
 
-    def getSpectrum1D(self, index=-1):
+    def get_spectrum1D(self, index=-1):
         # this should be replaced by something glue-native... it really only works for the specific cubes in testing
         dc = self._vizapp.glue_app.data_collection
         flux_unit = u.Unit(dc[0].meta['BUNIT'].replace('/spaxel', '').replace('Ang', 'angstrom'))

--- a/jdaviz/vizcomponents/viewer/viewernd.py
+++ b/jdaviz/vizcomponents/viewer/viewernd.py
@@ -1,5 +1,9 @@
 import logging
 
+import numpy as np
+from astropy import units as u
+from specutils import Spectrum1D
+
 from ipywidgets import Box
 from .viewer import Viewer
 
@@ -19,3 +23,27 @@ class ViewerND(Viewer):
 
     def show(self):
         return Box([self._v3d.layout])
+
+    def getSpectrum1D(self, index=-1):
+        # this should be replaced by something glue-native... it really only works for the specific cubes in testing
+        dc = self._vizapp.glue_app.data_collection
+        flux_unit = u.Unit(dc[0].meta['BUNIT'].replace('/spaxel', '').replace('Ang', 'angstrom'))
+        wave_unit = dc[0].meta['CUNIT3']
+
+        wave = self._v3d.state.layers[0].layer.get_component('Wave')
+        wavelengths = wave.data[:, 0, 0]
+
+        flux = self._v3d.state.layers[index].layer['FLUX']
+        if len(flux.shape) == 3:
+            # spectrum1D should be [M1,M2,...], N where N is the wavelength axis, but the cube is (N, M1, M2)
+            reflux = np.moveaxis(flux, 0, -1)
+        elif len(flux.shape) == 1:
+            # subsets are flattened.  We assume the leading axis is the wavelength axis for consistency with above
+            reflux = flux.reshape(wavelengths.shape[0], flux.shape[0]//wavelengths.shape[0])
+            # but now transpose to get [M, N]
+            reflux = reflux.T
+        else:
+            raise ValueError('unexpected shape of data cube')
+
+        return Spectrum1D(flux=reflux * flux_unit,
+                          spectral_axis=wavelengths * wave_unit)


### PR DESCRIPTION
This PR fixes some oddities I noticed about getSpectrum1D. More specifically it does the following:

1. Fixes the `Spectrum1D` invocation to properly give the spectral axis (see astropy/specutils#466
2. changes the profile viewer `getSpectrum1D` to yield the spectrum as shown in the profile viewer
3. adds a `getSpectrum1D` to the `ViewerND` which gets the subsets *without* the "profile" collapsing.  That is, it gets the true data cube.  (This is probably wrong for some datasets where the wavelength array is not the same at every spaxel, but that's a problem for another day)
4. changes both to `get_spectrum1D`

There's a bit of data-specific hackery I did with the unit parsing... @astrofrog might advise if there's an easy way to get out the "wave" and "flux" units more cleanly.  But if not I think this is good enough for current needs.