### PR TITLE
Add notebook interactions to spec1d cubeviz example

### DIFF
--- a/examples/cubeviz-example.ipynb
+++ b/examples/cubeviz-example.ipynb
@@ -2,11 +2,24 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>.container { width:100% !important; }</style>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from IPython.core.display import display, HTML\n",
     "display(HTML(\"<style>.container { width:100% !important; }</style>\"))\n",
@@ -23,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,9 +48,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ungzipped version of file manga-7495-12704-LOGCUBE.fits.gz present, using that\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "from urllib.request import urlretrieve\n",
@@ -72,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,22 +111,65 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "scrolled": false
    },
    "outputs": [],
    "source": [
-    "c = cubeviz.CubeViz(filename, vizapp)"
+    "# it turns out this file has incorrect units in its wcs.  So we fix up the WCS manually... which we can do in the notebook for this particular dataset!\n",
+    "def process_data(cv):\n",
+    "    w = cv._vizapp._glue_app.data_collection[0].coords.wcs\n",
+    "    w.wcs.crval[-1]*=1e10\n",
+    "    w.wcs.cd[2, 2]*=1e10\n",
+    "    repr(w.wcs)\n",
+    "    w.world_axis_units[-1] = 'angstrom'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: FITSFixedWarning: PLATEID = 7495 / Current plate \n",
+      "a string value was expected. [astropy.wcs.wcs]\n",
+      "WARNING:astropy:FITSFixedWarning: PLATEID = 7495 / Current plate \n",
+      "a string value was expected.\n",
+      "/Users/erik/miniconda3/envs/jdaviz-dev/lib/python3.7/site-packages/glue/viewers/common/viewer.py:179: UserWarning: Add large data set?\n",
+      "  warnings.warn(message)\n"
+     ]
+    }
+   ],
+   "source": [
+    "c = cubeviz.CubeViz(filename, vizapp, process_data=process_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5b7040a4432e49b6981318a99991da1b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Layout(children=[Flex(children=[Layout(children=[Flex(children=[Layout(children=[Menu(children=[Btn(children=[…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "c.show()"
    ]
@@ -119,13 +183,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
     "s = c.pviewer._v1d.state\n",
-    "s.y_min, s.y_max  = 0, 3\n",
-    "s.x_min, s.x_max = 4000/1e10, 9200/1e10"
+    "s.y_min, s.y_max  = 0, .3\n",
+    "s.x_min, s.x_max = 6000, 7500"
    ]
   },
   {
@@ -137,18 +201,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$6774.9998 \\; \\mathrm{\\mathring{A}}$"
+      ],
+      "text/plain": [
+       "<Quantity 6774.99984277 Angstrom>"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from astropy import units as u\n",
     "from specutils import analysis, SpectralRegion, Spectrum1D\n",
     "\n",
     "# get the selection\n",
     "spec = c.pviewer.get_spectrum1D(-1)\n",
-    "\n",
-    "# the input dataset had incorrect units.  But we can fix it here because we are in a notebook!\n",
-    "spec = Spectrum1D(spectral_axis=spec.spectral_axis*1e10, flux=spec.flux)\n",
     "\n",
     "analysis.centroid(spec, SpectralRegion(6760*u.angstrom, 6790*u.angstrom))"
    ]

--- a/examples/cubeviz-example.ipynb
+++ b/examples/cubeviz-example.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "from IPython.core.display import display, HTML\n",
@@ -106,6 +108,49 @@
    "outputs": [],
    "source": [
     "c.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can manually set the viewer bounds programatically if desired:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s = c.pviewer._v1d.state\n",
+    "s.y_min, s.y_max  = 0, 3\n",
+    "s.x_min, s.x_max = 4000/1e10, 9200/1e10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or we can even do scientific analysis tasks on the selected spectrum (note this will either use the total spectrum or the selection from the cube viewer to work):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy import units as u\n",
+    "from specutils import analysis, SpectralRegion, Spectrum1D\n",
+    "\n",
+    "# get the selection\n",
+    "spec = c.pviewer.get_spectrum1D(-1)\n",
+    "\n",
+    "# the input dataset had incorrect units.  But we can fix it here because we are in a notebook!\n",
+    "spec = Spectrum1D(spectral_axis=spec.spectral_axis*1e10, flux=spec.flux)\n",
+    "\n",
+    "analysis.centroid(spec, SpectralRegion(6760*u.angstrom, 6790*u.angstrom))"
    ]
   }
  ],

--- a/examples/cubeviz-example.ipynb
+++ b/examples/cubeviz-example.ipynb
@@ -2,24 +2,11 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<style>.container { width:100% !important; }</style>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from IPython.core.display import display, HTML\n",
     "display(HTML(\"<style>.container { width:100% !important; }</style>\"))\n",
@@ -36,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,17 +35,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Ungzipped version of file manga-7495-12704-LOGCUBE.fits.gz present, using that\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "from urllib.request import urlretrieve\n",
@@ -93,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
@@ -128,48 +107,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: FITSFixedWarning: PLATEID = 7495 / Current plate \n",
-      "a string value was expected. [astropy.wcs.wcs]\n",
-      "WARNING:astropy:FITSFixedWarning: PLATEID = 7495 / Current plate \n",
-      "a string value was expected.\n",
-      "/Users/erik/miniconda3/envs/jdaviz-dev/lib/python3.7/site-packages/glue/viewers/common/viewer.py:179: UserWarning: Add large data set?\n",
-      "  warnings.warn(message)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "c = cubeviz.CubeViz(filename, vizapp, process_data=process_data)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5b7040a4432e49b6981318a99991da1b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Layout(children=[Flex(children=[Layout(children=[Flex(children=[Layout(children=[Menu(children=[Btn(children=[…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "c.show()"
    ]
@@ -183,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,36 +147,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Or we can even do scientific analysis tasks on the selected spectrum (note this will either use the total spectrum or the selection from the cube viewer to work):"
+    "Or we can even do scientific analysis tasks on the selected spectrum:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$6774.9998 \\; \\mathrm{\\mathring{A}}$"
-      ],
-      "text/plain": [
-       "<Quantity 6774.99984277 Angstrom>"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from astropy import units as u\n",
     "from specutils import analysis, SpectralRegion, Spectrum1D\n",
     "\n",
     "# get the selection\n",
-    "spec = c.pviewer.get_spectrum1D(-1)\n",
+    "spec = c.pviewer.get_spectrum1D()\n",
     "\n",
     "analysis.centroid(spec, SpectralRegion(6760*u.angstrom, 6790*u.angstrom))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This can even be interactive - e.g., this will compute the centroid of the line selected in the profile viewer (although it will be empty if there is no selection):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pv = c.pviewer\n",
+    "analysis.centroid(pv.get_spectrum1D(), pv.getRegion())"
    ]
   }
  ],

--- a/examples/cubeviz-example.ipynb
+++ b/examples/cubeviz-example.ipynb
@@ -179,7 +179,7 @@
    "outputs": [],
    "source": [
     "pv = c.pviewer\n",
-    "analysis.centroid(pv.get_spectrum1D(), pv.getRegion())"
+    "analysis.centroid(pv.get_spectrum1D(), pv.get_region())"
    ]
   }
  ],

--- a/jdaviz/vizcomponents/applications/cubeviz.py
+++ b/jdaviz/vizcomponents/applications/cubeviz.py
@@ -7,11 +7,13 @@ from ..viewer.viewer1d import Viewer1D
 
 class CubeViz:
 
-    def __init__(self, filename, vizapp):
+    def __init__(self, filename, vizapp, process_data=None):
 
         self._vizapp = vizapp
 
         self._vizapp.glue_app.load_data(filename)
+        if process_data is not None:
+            process_data(self)
 
         #
         #  Create File Menu

--- a/jdaviz/vizcomponents/viewer/viewer1d.py
+++ b/jdaviz/vizcomponents/viewer/viewer1d.py
@@ -26,7 +26,7 @@ class Viewer1D(Viewer):
     def show(self):
         return Box([self._v1d.layout])
 
-    def getRegion(self, index=None):
+    def get_region(self, index=None):
 
         if index is not None:
             subset = self._v1d.state.layers[index].layer

--- a/jdaviz/vizcomponents/viewer/viewer1d.py
+++ b/jdaviz/vizcomponents/viewer/viewer1d.py
@@ -21,6 +21,7 @@ class Viewer1D(Viewer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._v1d = self._glue_app.profile1d(data=self._glue_app.data_collection[0], show=False)
+        self._v1d.state.function = 'mean'  #default to mean-combine
 
     def show(self):
         return Box([self._v1d.layout])


### PR DESCRIPTION
This adjusts the cubeviz notebook and some of the corresponding code to demo using the notebook idiom to combine an "interactive" and "notebook" usage.

1. It fixes up the units from the original data file to be in angstroms.  To do this I had to do a slightly hacky thing in the cubeviz initializer, but I think it's probably fine as a stand-in.  Moving forward we'll probably want to instead allow passing in data objects instead of names, but this seemed the fastest route forward.  Note @brechmos-stsci - if you want to keep using the "fixed" file, you could just delete the `process_data` part and I presume it'll be the same
2. It adds some analysis using specutils at the bottom of the notebook.
3. it renames `getRegions` to `get_regions` since that's now showcased in the notebook

The last cell is meant to be used with the interactive selection in the profile viewer.  I.e., it's just empty unless the user selects something in the profile view.