### PR TITLE
Implement registries for plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ distribute-*.tar.gz
 .project
 .pydevproject
 .settings
+.idea
 
 # Mac OSX
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ distribute-*.tar.gz
 .pydevproject
 .settings
 .idea
+.vscode
+.pytest_cache
 
 # Mac OSX
 .DS_Store

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -10,5 +10,5 @@ dependencies:
     - matplotlib
     - numpy
     - sphinx-astropy
-#   - pip:
-#       - dependency_from_pip
+    - pip:
+        - sphinx-rtd-theme

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,8 +100,6 @@ matrix:
         - os: linux
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
-        - os: linux
-          env: PYTHON_VERSION=3.7 ASTROPY_VERSION=lts NUMPY_VERSION=1.13
 
         # Add a job that runs from cron only and tests against astropy dev and
         # numpy dev to give a change for early discovery of issues and feedback

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,12 +43,12 @@ env:
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'
 
-        
+
         # List runtime dependencies for the package that are available as conda
         # packages here.
         - CONDA_DEPENDENCIES=''
         - CONDA_DEPENDENCIES_DOC='sphinx-astropy'
-        
+
         # List other runtime dependencies for the package that are available as
         # pip packages here.
         - PIP_DEPENDENCIES='sphinx-rtd-theme'
@@ -101,7 +101,7 @@ matrix:
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
         - os: linux
-          env: PYTHON_VERSION=3.6 ASTROPY_VERSION=lts NUMPY_VERSION=1.13
+          env: PYTHON_VERSION=3.7 ASTROPY_VERSION=lts NUMPY_VERSION=1.13
 
         # Add a job that runs from cron only and tests against astropy dev and
         # numpy dev to give a change for early discovery of issues and feedback
@@ -122,7 +122,7 @@ matrix:
         # time.
 
         - os: linux
-          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.14
+          env: PYTHON_VERSION=3.7 NUMPY_VERSION=1.14
         - os: linux
           env: NUMPY_VERSION=1.15
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ env:
 
         # List other runtime dependencies for the package that are available as
         # pip packages here.
-        - PIP_DEPENDENCIES='sphinx-rtd-theme'
+        - PIP_DEPENDENCIES='sphinx-rtd-theme ipyvuetify glue-core'
 
         # Conda packages for affiliated packages are hosted in channel
         # "astropy" while builds for astropy LTS with recent numpy versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,12 +43,12 @@ env:
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'
 
-
+        
         # List runtime dependencies for the package that are available as conda
         # packages here.
         - CONDA_DEPENDENCIES=''
         - CONDA_DEPENDENCIES_DOC='sphinx-astropy'
-
+        
         # List other runtime dependencies for the package that are available as
         # pip packages here.
         - PIP_DEPENDENCIES='sphinx-rtd-theme'
@@ -100,8 +100,8 @@ matrix:
         - os: linux
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
-        # - os: linux
-        #   env: PYTHON_VERSION=3.7 ASTROPY_VERSION=lts NUMPY_VERSION=1.13
+        - os: linux
+          env: PYTHON_VERSION=3.6 ASTROPY_VERSION=lts NUMPY_VERSION=1.13
 
         # Add a job that runs from cron only and tests against astropy dev and
         # numpy dev to give a change for early discovery of issues and feedback
@@ -122,7 +122,7 @@ matrix:
         # time.
 
         - os: linux
-          env: PYTHON_VERSION=3.7 NUMPY_VERSION=1.14
+          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.14
         - os: linux
           env: NUMPY_VERSION=1.15
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,7 +105,7 @@ release = package.__version__
 #html_theme = None
 
 
-html_theme = "sphinx-rtd-theme"
+html_theme = "sphinx_rtd_theme"
 
 
 # Custom sidebar templates, maps document names to template names.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,10 +104,8 @@ release = package.__version__
 # name of a builtin theme or the name of a custom theme in html_theme_path.
 #html_theme = None
 
-html_static_path = ['_static']
-html_style = 'jdaviz.css'
 
-html_theme = "sphinx_rtd_theme"
+html_theme = "sphinx-rtd-theme"
 
 
 # Custom sidebar templates, maps document names to template names.

--- a/jdaviz/core/registries.py
+++ b/jdaviz/core/registries.py
@@ -69,7 +69,7 @@ class TrayRegistry(UniqueDictRegistry):
         def decorator(cls):
             # The class must inherit from `VuetifyTemplate` in order to be
             # ingestible by the component initialization.
-            if not issubclass(cls, VuetifyTemplate):
+            if not issubclass(cls, (Widget, VuetifyTemplate)):
                 raise ValueError(
                     f"Unrecognized superclass for {cls.__name__}. All "
                     f"registered components must inherit from "
@@ -109,8 +109,8 @@ class ToolRegistry(UniqueDictRegistry):
     """
     def __call__(self, name=None):
         def decorator(cls):
-            # The class must inherit from `Widget` in order to be
-            # ingestible by the component initialization.
+            # The class must inherit from `VuetifyTemplate` or `Widget` in
+            # order to be ingestible by the component initialization.
             if not issubclass(cls, Widget):
                 raise ValueError(
                     f"Unrecognized superclass for `{cls.__name__}`. All "
@@ -128,9 +128,9 @@ class MenuRegistry(UniqueDictRegistry):
     """
     def __call__(self, name=None):
         def decorator(cls):
-            # The class must inherit from `VuetifyTemplate` in order to be
-            # ingestible by the component initialization.
-            if not issubclass(cls, Widget):
+            # The class must inherit from `VuetifyTemplate` or `Widget` in
+            # order to be ingestible by the component initialization.
+            if not issubclass(cls, (VuetifyTemplate, Widget)):
                 raise ValueError(
                     f"Unrecognized superclass for {cls.__name__}. All "
                     f"registered tools must inherit from "

--- a/jdaviz/core/registries.py
+++ b/jdaviz/core/registries.py
@@ -65,7 +65,7 @@ class TrayRegistry(UniqueDictRegistry):
     Registry containing references to plugins that will be added to the sidebar
     tray tabs.
     """
-    def __call__(self, name=None):
+    def __call__(self, name=None, label=None, icon=None):
         def decorator(cls):
             # The class must inherit from `VuetifyTemplate` in order to be
             # ingestible by the component initialization.
@@ -75,8 +75,31 @@ class TrayRegistry(UniqueDictRegistry):
                     f"registered components must inherit from "
                     f"`ipyvuetify.VuetifyTemplate`.")
 
-            self.add(name, cls)
+            self.add(name, cls, label, icon)
         return decorator
+
+    def add(self, name, cls, label=None, icon=None):
+        """
+        Add an item to the registry.
+
+        Parameters
+        ----------
+        name : str
+            The key referencing the associated class in the registry
+            dictionary.
+        cls : type
+            The class definition (not instance) associated with the name given
+            in the first parameter.
+        label : str, optional
+            The label displayed in the tooltip when hovering over the tray tab.
+        icon : str, optional
+            The name of the icon to render in the tray tab.
+        """
+        if name in self.members:
+            raise ValueError(f"Viewer with the name {name} already exists, "
+                             f"please choose a different name.")
+        else:
+            self.members[name] = {'label': label, 'icon': icon, 'cls': cls}
 
 
 class ToolRegistry(UniqueDictRegistry):

--- a/jdaviz/core/registries.py
+++ b/jdaviz/core/registries.py
@@ -1,9 +1,8 @@
-from glue.config import DictRegistry
 import re
-from functools import wraps
+
+from glue.config import DictRegistry
 from ipyvuetify import VuetifyTemplate
 from ipywidgets import Widget
-
 
 __all__ = ['viewers', 'trays', 'tools']
 
@@ -144,4 +143,3 @@ viewers = ViewerRegistry()
 trays = TrayRegistry()
 tools = ToolRegistry()
 menus = MenuRegistry()
-

--- a/jdaviz/core/registries.py
+++ b/jdaviz/core/registries.py
@@ -1,0 +1,124 @@
+from glue.config import DictRegistry
+import re
+from functools import wraps
+from ipyvuetify import VuetifyTemplate
+from ipywidgets import Widget
+
+
+__all__ = ['viewers', 'trays', 'tools']
+
+
+def convert(name):
+    """
+    Converts camel case strings to snake case. Used when a user does not define
+    a specific name for a registry item.
+
+    Returns
+    -------
+    str
+        Name converted to snake case.
+    """
+    s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
+
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+
+class UniqueDictRegistry(DictRegistry):
+    """
+    Base registry class that handles hashmap-like associations between a string
+    representation of a plugin and the class to be instantiated.
+    """
+    def add(self, name, cls):
+        """
+        Add an item to the registry.
+
+        Parameters
+        ----------
+        name : str
+            The name referencing the associated class in the registry.
+        cls : type
+            The class definition (not instance) associated with the name given
+            in the first parameter.
+        """
+        if name in self.members:
+            raise ValueError(f"Viewer with the name {name} already exists, "
+                             f"please choose a different name.")
+        else:
+            self.members[name] = cls
+
+
+class ViewerRegistry(UniqueDictRegistry):
+    """
+    Registry containing references to custom viewers.
+    """
+    def __call__(self, name=None):
+        def decorator(cls, key):
+            if key is None:
+                key = convert(cls.__name__)
+
+            self.add(key, cls)
+        return decorator
+
+
+class TrayRegistry(UniqueDictRegistry):
+    """
+    Registry containing references to plugins that will be added to the sidebar
+    tray tabs.
+    """
+    def __call__(self, name=None):
+        def decorator(cls):
+            # The class must inherit from `VuetifyTemplate` in order to be
+            # ingestible by the component initialization.
+            if not issubclass(cls, VuetifyTemplate):
+                raise ValueError(
+                    f"Unrecognized superclass for {cls.__name__}. All "
+                    f"registered components must inherit from "
+                    f"`ipyvuetify.VuetifyTemplate`.")
+
+            self.add(name, cls)
+        return decorator
+
+
+class ToolRegistry(UniqueDictRegistry):
+    """
+    Registry containing references to plugins which will populate the
+    application-level toolbar.
+    """
+    def __call__(self, name=None):
+        def decorator(cls):
+            # The class must inherit from `Widget` in order to be
+            # ingestible by the component initialization.
+            if not issubclass(cls, Widget):
+                raise ValueError(
+                    f"Unrecognized superclass for `{cls.__name__}`. All "
+                    f"registered tools must inherit from "
+                    f"`ipywidgets.Widget`.")
+
+            self.add(name, cls)
+        return decorator
+
+
+class MenuRegistry(UniqueDictRegistry):
+    """
+    Registry containg referenecs to plugins that will populate the application-
+    level menu bar.
+    """
+    def __call__(self, name=None):
+        def decorator(cls):
+            # The class must inherit from `VuetifyTemplate` in order to be
+            # ingestible by the component initialization.
+            if not issubclass(cls, Widget):
+                raise ValueError(
+                    f"Unrecognized superclass for {cls.__name__}. All "
+                    f"registered tools must inherit from "
+                    f"`ipywidgets.Widget`.")
+
+            self.add(name, cls)
+        return decorator
+
+
+viewers = ViewerRegistry()
+trays = TrayRegistry()
+tools = ToolRegistry()
+menus = MenuRegistry()
+

--- a/jdaviz/data/README.rst
+++ b/jdaviz/data/README.rst
@@ -1,7 +1,0 @@
-Data directory
-==============
-
-This directory contains data files included with the package source
-code distribution. Note that this is intended only for relatively small files
-- large files should be externally hosted and downloaded as needed.
-

--- a/jdaviz/data/README.rst
+++ b/jdaviz/data/README.rst
@@ -1,0 +1,7 @@
+Data directory
+==============
+
+This directory contains data files included with the package source
+code distribution. Note that this is intended only for relatively small files
+- large files should be externally hosted and downloaded as needed.
+

--- a/jdaviz/tests/test_registries.py
+++ b/jdaviz/tests/test_registries.py
@@ -1,0 +1,86 @@
+from jdaviz.core.registries import tools, trays, viewers
+import ipyvuetify as v
+from traitlets import Unicode
+from ipywidgets import Widget
+from glue_jupyter.bqplot.profile import BqplotProfileView
+from glue_jupyter.utils import validate_data_argument
+from glue_jupyter.matplotlib.profile import ProfileJupyterViewer
+
+
+def test_toolbar_registry_template():
+    # Define a new registry class object
+    @tools('j-test-tool-template')
+    class TestTool(v.VuetifyTemplate):
+        template = Unicode("""
+        <v-btn>
+            Press Me
+        <v-btn>
+        """).tag(sync=True)
+
+    test_tool = tools.members.get('j-test-tool-template')()
+
+    assert isinstance(test_tool, Widget)
+    assert 'j-test-tool-template' in tools.members
+
+
+def test_toolbar_registry_widget():
+    @tools('j-test-tool-widget')
+    class TestTool(v.Btn):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+            self.children = ["Press Me"]
+
+    test_tool = tools.members.get('j-test-tool-widget')()
+
+    assert isinstance(test_tool, Widget)
+    assert 'j-test-tool-widget' in tools.members
+    assert test_tool.children[0] == 'Press Me'
+
+
+def test_tray_registry_template():
+    @trays('j-test-tray-template', label="Tray Template", icon='save')
+    class TestTray(v.VuetifyTemplate):
+        template = Unicode("""
+          <v-card
+            max-width="344"
+            class="mx-auto"
+          >
+            <v-card-title>I'm a title</v-card-title>
+            <v-card-text>I'm card text</v-card-text>
+            <v-card-actions>
+              <v-btn text>Click</v-btn>
+            </v-card-actions>
+          </v-card>
+        """).tag(sync=True)
+
+    test_tray = trays.members.get('j-test-tray-template').get('cls')()
+
+    assert isinstance(test_tray, Widget)
+    assert 'j-test-tray-template' in trays.members
+
+
+def test_tray_registry_widget():
+    @trays('j-test-tray-widget', label="Tray Template", icon='save')
+    class TestTray(v.Card):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+            self.max_width = 344
+
+            self.children = [
+                v.CardTitle(children=["I'm a title"]),
+                v.CardText(children=["I'm card text."]),
+                v.CardActions(children=[
+                    v.Btn(text=True,
+                          children=[
+                              "Click"
+                          ])
+                ])
+            ]
+
+    test_tray = trays.members.get('j-test-tray-widget').get('cls')()
+
+    assert isinstance(test_tray, Widget)
+    assert 'j-test-tray-widget' in trays.members
+    assert test_tray.max_width == 344

--- a/jdaviz/tests/test_registries.py
+++ b/jdaviz/tests/test_registries.py
@@ -1,10 +1,8 @@
-from jdaviz.core.registries import tools, trays, viewers
 import ipyvuetify as v
-from traitlets import Unicode
 from ipywidgets import Widget
-from glue_jupyter.bqplot.profile import BqplotProfileView
-from glue_jupyter.utils import validate_data_argument
-from glue_jupyter.matplotlib.profile import ProfileJupyterViewer
+from traitlets import Unicode
+
+from ..core.registries import tools, trays
 
 
 def test_toolbar_registry_template():

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ python_requires = ">=3.7"
 [options]
 # install_requires should be formatted as a semicolon-separated list, e.g.:
 # install_requires = astropy; scipy; matplotlib
-install_requires = astropy
+install_requires = astropy; sphinx-rtd-theme
 zip_safe = False
 use_2to3 = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ version = 0.1.dev
 author = JDADF Developers
 author_email = nearl@stsci.edu
 description = Astronomical data analysis development leveraging Jupyter platform
-long_description = 
+long_description =
 license = BSD 3-Clause
 url = https://github.com/spacetelescope/jdaviz
 edit_on_github = True
@@ -15,15 +15,15 @@ python_requires = ">=3.7"
 [options]
 # install_requires should be formatted as a semicolon-separated list, e.g.:
 # install_requires = astropy; scipy; matplotlib
-install_requires = astropy; sphinx-rtd-theme
+install_requires = astropy; sphinx-rtd-theme; ipyvuetify; glue-core
 zip_safe = False
 use_2to3 = False
 
 [options.entry_points]
 console_scripts =
-    
+
     # astropy-package-template-example = packagename.example_mod:main
-    
+
 
 [options.package_data]
 * = *.c


### PR DESCRIPTION
This supports the effort of designing the default glue-jupyter application infrastructure in which layouts are composed of reference plugin objects living in registries. This PR defines the registries and their interactions.