### PR TITLE
Data translation tests

### DIFF
--- a/jdaviz/tests/test_data_translation.py
+++ b/jdaviz/tests/test_data_translation.py
@@ -1,0 +1,56 @@
+import pytest
+
+import numpy as np
+
+from astropy import units as u
+from astropy.units import Quantity
+from astropy.units.quantity import allclose
+
+from glue.config import data_translator
+from glue.core import Data, DataCollection
+
+from specutils import Spectrum1D
+
+
+@data_translator(Spectrum1D)
+class Spectrum1DHandler:
+    def to_data(self, obj):
+        data = Data()
+        data['spectral_axis'] = obj.spectral_axis
+        data['flux'] = obj.data
+        data.get_component('flux').units = str(obj.flux.unit)
+        data.meta['s1d'] = obj
+        return data
+
+    def to_object(self, data):
+        return data.meta['s1d']
+
+
+def test_translation():
+    input_flux   = Quantity(np.array([0.2, 0.3, 2.2, 0.3]), u.Jy)
+    input_spaxis = Quantity(np.array([1, 2, 3, 4]), u.micron)
+    spec = Spectrum1D(input_flux, spectral_axis=input_spaxis)
+
+    dc = DataCollection()
+
+    # Translate Spectrum1D -> Data
+    dc['spec'] = spec
+
+    assert len(dc) == 1
+
+    assert(isinstance(dc.data[0], Data))
+    spectrum = dc.data[0].meta['s1d']
+    assert(isinstance(spectrum, Spectrum1D))
+
+    # we could check more of the internals.
+    allclose(spectrum.flux, input_flux, atol=1e-5*u.Jy)
+    allclose(spectrum.spectral_axis, input_spaxis, atol=1e-5*u.micron)
+
+    # Translate back Data -> Spectrum1D
+    spectrum = dc['spec'].get_object()
+
+    assert(isinstance(spectrum, Spectrum1D))
+
+    # we could check more of the internals.
+    allclose(spectrum.flux, input_flux, atol=1e-5*u.Jy)
+    allclose(spectrum.spectral_axis, input_spaxis, atol=1e-5*u.micron)

--- a/jdaviz/tests/test_data_translation.py
+++ b/jdaviz/tests/test_data_translation.py
@@ -30,7 +30,7 @@ class Spectrum1DHandler:
 
 
 def test_translation():
-    input_flux   = Quantity(np.array([0.2, 0.3, 2.2, 0.3]), u.Jy)
+    input_flux = Quantity(np.array([0.2, 0.3, 2.2, 0.3]), u.Jy)
     input_spaxis = Quantity(np.array([1, 2, 3, 4]), u.micron)
     spec = Spectrum1D(input_flux, spectral_axis=input_spaxis)
 

--- a/jdaviz/tests/test_data_translation.py
+++ b/jdaviz/tests/test_data_translation.py
@@ -1,5 +1,3 @@
-import pytest
-
 import numpy as np
 
 from astropy import units as u

--- a/notebooks/test_data_translation.ipynb
+++ b/notebooks/test_data_translation.ipynb
@@ -1,0 +1,130 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from specutils import Spectrum1D\n",
+    "from astropy import units as u\n",
+    "from glue.config import data_translator\n",
+    "from glue.core import Data, DataCollection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@data_translator(Spectrum1D)\n",
+    "class Spectrum1DHandler:\n",
+    "    def to_data(self, obj):\n",
+    "        data = Data()\n",
+    "        data['spectral_axis'] = obj.spectral_axis\n",
+    "        data['flux'] = obj.data\n",
+    "        data.get_component('flux').units = str(spec.flux.unit)\n",
+    "        data.meta['s1d'] = obj\n",
+    "        return data\n",
+    "\n",
+    "    def to_object(self, data):\n",
+    "        return data.meta['s1d']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spec = Spectrum1D([0.2, 0.3, 2.2, 0.3] * u.Jy, spectral_axis=[1, 2, 3, 4] * u.micron)\n",
+    "dc = DataCollection()\n",
+    "dc['spec'] = spec "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataCollection (1 data set)\n",
+      "\t  0: spec\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(dc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data Set: spec\n",
+      "Number of dimensions: 1\n",
+      "Shape: 4\n",
+      "Main components:\n",
+      " - spectral_axis\n",
+      " - flux [Jy]\n",
+      "Coordinate components:\n",
+      " - Pixel Axis 0 [x]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(dc['spec'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Spectrum1D(flux=<Quantity [0.2, 0.3, 2.2, 0.3] Jy>, spectral_axis=<Quantity [1., 2., 3., 4.] micron>)>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dc['spec'].get_object()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR contains code that tests the translation between glue Data objects and Spectrum1D objects. 

This is in response to JDAT-135 and JDAT-136.

Note that this requires glue-core 0.16. This causes some tests to fail when code is pushed into the ibusko/jdaviz/dev branch.