### PR TITLE
Implement basic UI for file loading

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -12,7 +12,7 @@ from traitlets import Unicode, Bool, Dict
 from .components.viewer_area import ViewerArea
 from .components.toolbar import DefaultToolbar
 from .components.tray_area import TrayArea
-from .core.events import AddViewerMessage, NewViewerMessage
+from .core.events import AddViewerMessage, NewViewerMessage, LoadDataMessage
 from .core.registries import tools
 from .utils import load_template
 
@@ -80,6 +80,10 @@ class Application(v.VuetifyTemplate, HubListener):
         # Subscribe to viewer messages
         self.hub.subscribe(self, NewViewerMessage,
                            handler=self._on_new_viewer)
+
+        # Subscribe to load data messages
+        self.hub.subscribe(self, LoadDataMessage,
+                           handler=lambda msg: self.load_data(msg.path))
 
     @property
     def hub(self):

--- a/jdaviz/components/file_loader/__init__.py
+++ b/jdaviz/components/file_loader/__init__.py
@@ -1,0 +1,1 @@
+from .file_loader import FileLoader

--- a/jdaviz/components/file_loader/file_loader.py
+++ b/jdaviz/components/file_loader/file_loader.py
@@ -1,0 +1,30 @@
+from ...core.template_mixin import TemplateMixin
+from ...utils import load_template
+from traitlets import Unicode, Bool, observe
+import os
+from ...core.events import LoadDataMessage
+
+__all__ = ['FileLoader']
+
+
+class FileLoader(TemplateMixin):
+    template = load_template("file_loader.vue", __file__).tag(sync=True)
+    file_path = Unicode("").tag(sync=True)
+    dialog = Bool(False).tag(sync=True)
+    valid_path = Bool(True).tag(sync=True)
+    error_message = Unicode().tag(sync=True)
+
+    @observe("file_path")
+    def _on_file_path_changed(self, event):
+        if not os.path.exists(event['new']) or not os.path.isfile(event['new']):
+            self.error_message = "No file exists at given path"
+            self.valid_path = False
+        else:
+            self.error_message = ""
+            self.valid_path = True
+
+    def vue_load_data(self, *args, **kwargs):
+        if os.path.exists(self.file_path):
+            load_data_message = LoadDataMessage(self.file_path, sender=self)
+            self.hub.broadcast(load_data_message)
+            self.dialog = False

--- a/jdaviz/components/file_loader/file_loader.vue
+++ b/jdaviz/components/file_loader/file_loader.vue
@@ -1,0 +1,37 @@
+<template>
+  <v-dialog v-model="dialog" width="500" persistent>
+    <template v-slot:activator="{ on }">
+      <v-btn tile depressed v-on="on" color="primary">
+        Import
+        <v-icon right>mdi-plus</v-icon>
+      </v-btn>
+    </template>
+
+    <v-card>
+      <v-card-title class="headline blue lighten-4" primary-title>Import Data</v-card-title>
+
+      <v-card-text>
+        <v-container>
+          <v-row>
+            <v-col>
+              <!-- <v-file-input v-model="files" label="File input"></v-file-input> -->
+              <v-text-field
+                label="File Path"
+                placeholder="/path/to/data/file"
+                v-model="file_path"
+                :error-messages="error_message"
+              ></v-text-field>
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-card-text>
+      <v-divider></v-divider>
+
+      <v-card-actions>
+        <div class="flex-grow-1"></div>
+        <v-btn color="primary" text @click="dialog = false">Cancel</v-btn>
+        <v-btn color="primary" text @click="load_data" :disabled="!valid_path">Import</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>

--- a/jdaviz/components/tray_area/tray_area.py
+++ b/jdaviz/components/tray_area/tray_area.py
@@ -10,6 +10,7 @@ from ...core.events import (LoadDataMessage, DataSelectedMessage,
 from ...core.registries import trays, viewers
 from ...core.template_mixin import TemplateMixin
 from ...components.data_tree import DataTree
+from ..file_loader import FileLoader
 
 __all__ = ['TrayArea']
 
@@ -20,8 +21,6 @@ with open(os.path.join(os.path.dirname(__file__), "tray_area.vue")) as f:
 class TrayArea(TemplateMixin):
     template = Unicode(TEMPLATE).tag(sync=True)
     drawer = Bool(True).tag(sync=True)
-    valid = Bool(True).tag(sync=True)
-    dialog = Bool(False).tag(sync=True)
     data = Unicode("""
     {
         files: undefined
@@ -53,7 +52,8 @@ class TrayArea(TemplateMixin):
         super().__init__(*args, **kwargs)
 
         # Attach tray plugins from the registries
-        components = {'g-data-tree': DataTree(session=self.session)}
+        components = {'g-data-tree': DataTree(session=self.session),
+                      'g-file-loader': FileLoader(session=self.session)}
         components.update({k: v.get('cls')(session=self.session)
                            for k, v in trays.members.items()})
 
@@ -64,20 +64,6 @@ class TrayArea(TemplateMixin):
         #  dicts containing just the viewer name and label.
         self.viewers = [{'name': k, 'label': v['label']}
                         for k, v in viewers.members.items()]
-
-    def vue_load_data(self, *args, **kwargs):
-        self.dialog = False
-        return
-        # TODO: hack because of current incompatibility with ipywidget types
-        #  and vuetify templates.
-        for path in ["/Users/nearl/data/single_g235h-f170lp_x1d.fits"]:
-            load_data_message = LoadDataMessage(path, sender=self)
-            self.hub.broadcast(load_data_message)
-
-        self.dialog = False
-
-    def vue_file_inputted(self, *args, **kwargs):
-        print(args, kwargs)
 
     def vue_create_viewer(self, name):
         viewer_cls = viewers.members[name]['cls']

--- a/jdaviz/components/tray_area/tray_area.vue
+++ b/jdaviz/components/tray_area/tray_area.vue
@@ -2,31 +2,7 @@
   <v-navigation-drawer v-model="drawer" app width="350px" absolute>
     <v-toolbar tile dense flat color="blue lighten-4">
       <v-toolbar-items>
-        <v-dialog v-model="dialog" width="500" persistent>
-          <template v-slot:activator="{ on }">
-            <v-btn tile depressed v-on="on" color="primary">
-              Import
-              <v-icon right>mdi-plus</v-icon>
-            </v-btn>
-          </template>
-
-          <v-form v-model="valid">
-            <v-card>
-              <v-card-title class="headline grey lighten-2" primary-title>Import Data</v-card-title>
-
-              <v-card-text>
-                <v-file-input v-model="files" label="File input"></v-file-input>
-              </v-card-text>
-              <v-divider></v-divider>
-
-              <v-card-actions>
-                <div class="flex-grow-1"></div>
-                <v-btn color="primary" text @click="dialog = false">Cancel</v-btn>
-                <v-btn color="primary" text @click="load_data(convertFile())">Import</v-btn>
-              </v-card-actions>
-            </v-card>
-          </v-form>
-        </v-dialog>
+        <g-file-loader></g-file-loader>
 
         <v-menu offset-y>
           <template v-slot:activator="{ on: menu }">

--- a/jdaviz/components/viewer_area/stack.vue
+++ b/jdaviz/components/viewer_area/stack.vue
@@ -45,6 +45,7 @@
           <v-navigation-drawer
             v-model="drawer"
             absolute
+            disable-resize-watcher
             temporary
             right
             overlay-opacity="0"

--- a/jdaviz/configs/default/plugins/gaussian_smoothing/gaussian_smoothing.vue
+++ b/jdaviz/configs/default/plugins/gaussian_smoothing/gaussian_smoothing.vue
@@ -11,44 +11,42 @@
       </v-tooltip>
     </template>
 
-    <v-form>
-      <v-card>
-        <v-card-title class="headline blue lighten-4" primary-title>Gaussian Smoothing</v-card-title>
+    <v-card>
+      <v-card-title class="headline blue lighten-4" primary-title>Gaussian Smoothing</v-card-title>
 
-        <v-card-text>
-          <v-container>
-            <v-row>
-              <v-col>
-                <v-select
-                  :items="dc_items"
-                  @change="data_selected"
-                  label="Data"
-                  hint="Select the data set to be smoothed."
-                ></v-select>
-              </v-col>
-            </v-row>
-            <v-row>
-              <v-col>
-                <v-text-field
-                  ref="stddev"
-                  label="Standard deviation"
-                  v-model="stddev"
-                  hint="The stddev of the kernel, in pixels."
-                  persistent-hint
-                  :rules="[() => !!stddev || 'This field is required']"
-                ></v-text-field>
-              </v-col>
-            </v-row>
-          </v-container>
-        </v-card-text>
-        <v-divider></v-divider>
+      <v-card-text>
+        <v-container>
+          <v-row>
+            <v-col>
+              <v-select
+                :items="dc_items"
+                @change="data_selected"
+                label="Data"
+                hint="Select the data set to be smoothed."
+              ></v-select>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-text-field
+                ref="stddev"
+                label="Standard deviation"
+                v-model="stddev"
+                hint="The stddev of the kernel, in pixels."
+                persistent-hint
+                :rules="[() => !!stddev || 'This field is required']"
+              ></v-text-field>
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-card-text>
+      <v-divider></v-divider>
 
-        <v-card-actions>
-          <div class="flex-grow-1"></div>
-          <v-btn color="primary" text @click="dialog = false">Cancel</v-btn>
-          <v-btn color="primary" text @click="gaussian_smooth">Apply</v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-form>
+      <v-card-actions>
+        <div class="flex-grow-1"></div>
+        <v-btn color="primary" text @click="dialog = false">Cancel</v-btn>
+        <v-btn color="primary" text @click="gaussian_smooth">Apply</v-btn>
+      </v-card-actions>
+    </v-card>
   </v-dialog>
 </template>


### PR DESCRIPTION
This PR introduces a basic file loading dialog that asks the user to input an absolute file path. It checks whether the file exists and disallows loading attempts if it does not.

Note that this does not currently use the specutils loading machinery, but instead directly utilizes glue. This is an on-going conversation about how best to handle this in the UI.