### PR TITLE
fix: make glue option tabs look good

### DIFF
--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -63,11 +63,15 @@
                 </v-tab-item>
 
                 <v-tab-item key="1" eager class="overflow-y-auto" style="height: 100%">
-                  <jupyter-widget :widget="viewer.layer_options" />
+                  <v-sheet class="px-4">
+                    <jupyter-widget :widget="viewer.layer_options" />
+                  </v-sheet>
                 </v-tab-item>
 
                 <v-tab-item key="2" eager class="overflow-y-auto" style="height: 100%">
-                  <jupyter-widget :widget="viewer.viewer_options" />
+                  <v-sheet class="px-4">
+                    <jupyter-widget :widget="viewer.viewer_options" />
+                  </v-sheet>
                 </v-tab-item>
               </v-tabs-items>
             </v-menu>


### PR DESCRIPTION
The v-sheet is added to give the options panel a background-color,
which is otherwise transparent for the part initially outside the
viewport.

Needs https://github.com/glue-viz/glue-jupyter/pull/172 and https://github.com/glue-viz/glue-jupyter/pull/173 to be complete.