### PR TITLE
fix: toolbar padding is different in the notebook context

### DIFF
--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -88,7 +88,8 @@ export default {
 </script>
 
 <style id="web-app">
-.v-toolbar__content {
+.v-toolbar__content,
+.vuetify-styles .v-toolbar__content {
   padding-left: 0px;
   padding-right: 0px;
 }


### PR DESCRIPTION
Use two selectors, one for Voila and one for the notebook context.
Vuetify styles in the notebook are prefixed with .vuetify-styles
and if that's not repeated here, this selector looses on
specificity.