### PR TITLE
fix: padding of goldenlayout tabs is different in notebook context

### DIFF
--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -122,4 +122,8 @@ export default {
   padding-top: 0px;
   margin-top: 0px;
 }
+
+.vuetify-styles .lm_header ul {
+  padding-left: 0;
+}
 </style>


### PR DESCRIPTION
In the notebook context the Vuetify styles for the ul tag win from
the goldenlayout styles because of the extra .vuetify-styles
prefix used.