### PR TITLE
Move plugins to tray area

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -801,10 +801,12 @@ class Application(TemplateMixin):
             })
 
         for name in config.get('tray', []):
-            tray = tray_registry.members.get(
-                name).get('cls')(app=self)
+            tray = tray_registry.members.get(name)
+            tray_item_instance = tray.get('cls')(app=self)
+            tray_item_label = tray.get('label')
 
             self.state.tray_items.append({
                 'name': name,
-                'widget': "IPY_MODEL_" + tray.model_id
+                'label': tray_item_label,
+                'widget': "IPY_MODEL_" + tray_item_instance.model_id
             })

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -46,14 +46,12 @@ class ApplicationState(State):
     drawer = CallbackProperty(
         False, docstring="State of the plugins drawer.")
 
-    snackbar = CallbackProperty(
-        False, docstring="State of the quick toast messages.")
-
-    snackbar_text = CallbackProperty(
-        "", docstring="Text to display in toast message.")
-
-    snackbar_timeout = CallbackProperty(
-        3000, docstring="Timeout for snackbar message.")
+    snackbar = DictCallbackProperty({
+        'show': False,
+        'test': "",
+        'color': None,
+        'timeout': 3000
+    }, docstring="State of the quick toast messages.")
 
     settings = DictCallbackProperty({
         'visible': {
@@ -200,10 +198,11 @@ class Application(TemplateMixin):
             The Glue snackbar message containing information about displaying
             the message box.
         """
-        self.state.snackbar = False
-        self.state.snackbar_text = msg.text
-        self.state.snackbar_timeout = msg.timeout
-        self.state.snackbar = True
+        self.state.snackbar['show'] = False
+        self.state.snackbar['text'] = msg.text
+        self.state.snackbar['color'] = msg.color
+        self.state.snackbar['timeout'] = msg.timeout
+        self.state.snackbar['show'] = True
 
     def load_data(self, path):
         """

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -95,7 +95,7 @@ export default {
 }
 
 .lm_goldenlayout {
-  background: #ffffff;
+  background: #f8f8f8;
 }
 
 .lm_content {

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -49,9 +49,13 @@
         </splitpanes>
       </v-container>
     </v-content>
-    <v-snackbar v-model="state.snackbar" :timeout="state.snackbar_timeout" absolute>
-      {{ state.snackbar_text }}
-      <v-btn color="blue" text @click="state.snackbar = false">Close</v-btn>
+    <v-snackbar
+            v-model="state.snackbar.show"
+            :timeout="state.snackbar.timeout"
+            :color="state.snackbar.color"
+            absolute>
+      {{ state.snackbar.text }}
+      <v-btn text @click="state.snackbar = false">Close</v-btn>
     </v-snackbar>
   </v-app>
 </template>

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -1,11 +1,8 @@
 <template>
   <v-app id="web-app">
-    <v-app-bar color="white" class="elevation-1" dense app absolute clipped-right>
-      <!-- <v-toolbar-items> -->
+    <v-app-bar dark dense flat app absolute clipped-right>
       <jupyter-widget :widget="item.widget" v-for="item in state.tool_items" :key="item.name"></jupyter-widget>
-      <!-- </v-toolbar-items> -->
       <v-spacer></v-spacer>
-      <!-- <v-divider vertical></v-divider> -->
       <v-toolbar-items>
         <v-btn icon @click="state.drawer = !state.drawer">
           <v-icon v-if="state.drawer">mdi-toy-brick-remove</v-icon>
@@ -18,13 +15,10 @@
       :style="checkNotebookContext() ? 'height: ' + state.settings.context.notebook.max_height : ''"
     >
       <v-container class="fill-height pa-0" fluid>
-        <!-- <v-row align="center" justify="center" class="fill-height pa-0 ma-0" style="width: 100%">
-        <v-col cols="12" class="fill-height pa-0 ma-0" style="width: 100%"> -->
-        <splitpanes class="default-theme" @resize="relayout">
+        <splitpanes @resize="relayout">
           <pane size="70">
-            <v-card tile class="ma-2" style="height: calc(100% - 16px)">
               <golden-layout
-                :style="checkNotebookContext() ? 'height: 100%;' : 'height: calc(100vh - 64px)'"
+                :style="checkNotebookContext() ? 'height: 100%;' : 'height: calc(100vh - 48px)'"
                 :has-headers="state.settings.visible.tab_headers"
               >
                 <gl-row :closable="false">
@@ -39,28 +33,24 @@
                   ></g-viewer-tab>
                 </gl-row>
               </golden-layout>
-            </v-card>
           </pane>
-          <pane size="30" v-if="state.drawer">
-            <v-card class="fill-height" style="padding: 0px; margin: 0px">
-              <v-expansion-panels accordion multiple focusable>
-                <v-expansion-panel
-                        v-for="(tray, index) in state.tray_items"
-                        :key="index"
-                >
-                  <v-expansion-panel-header>{{ tray.label }}</v-expansion-panel-header>
-                  <v-expansion-panel-content>
-                    <jupyter-widget :widget="tray.widget"></jupyter-widget>
-                  </v-expansion-panel-content>
-                </v-expansion-panel>
-              </v-expansion-panels>
-            </v-card>
+          <pane size="30" v-if="state.drawer" style="background-color: #fff;">
+            <v-expansion-panels accordion multiple focusable flat tile>
+              <v-expansion-panel v-for="(tray, index) in state.tray_items" :key="index">
+                <v-expansion-panel-header>{{ tray.label }}</v-expansion-panel-header>
+                <v-expansion-panel-content>
+                  <jupyter-widget :widget="tray.widget"></jupyter-widget>
+                </v-expansion-panel-content>
+              </v-expansion-panel>
+            </v-expansion-panels>
           </pane>
         </splitpanes>
-        <!-- </v-col>
-        </v-row> -->
       </v-container>
     </v-content>
+    <v-snackbar v-model="state.snackbar" :timeout="state.snackbar_timeout">
+      {{ state.snackbar_text }}
+      <v-btn color="blue" text @click="state.snackbar = false">Close</v-btn>
+    </v-snackbar>
   </v-app>
 </template>
 
@@ -86,8 +76,14 @@ export default {
   height: 100%;
 }
 
+.splitpanes {
+  background-color: #f8f8f8;
+}
+
 .splitpanes__splitter {
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.2), 0 2px 5px 0 rgba(0, 0, 0, 0.19);
+  background-color: #e5e5e5;
+  position: relative;
+  width: 5px;
 }
 
 .lm_goldenlayout {
@@ -97,14 +93,21 @@ export default {
 .lm_content {
   background: #ffffff;
   border: none;
-  border-top: 1px solid #cccccc;
+  /*border-top: 1px solid #cccccc;*/
 }
 
 .lm_splitter {
-  background: #999999;
-  opacity: 0.25;
+  background: #e5e5e5;
+  opacity: 1;
   z-index: 1;
-  transition: opacity 200ms ease;
+}
+
+.lm_splitter .lm_vertical {
+  width: 1px
+}
+
+.lm_splitter .lm_horizontal {
+  height: 1px
 }
 
 .lm_header .lm_tab {
@@ -123,6 +126,6 @@ export default {
 
 .v-expansion-panel__header {
   padding: 0px;
-  margin: 0px
+  margin: 0px;
 }
 </style>

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -57,7 +57,7 @@
       absolute
     >
       {{ state.snackbar.text }}
-      <v-btn text @click="state.snackbar = false">Close</v-btn>
+      <v-btn text @click="state.snackbar.show = false">Close</v-btn>
     </v-snackbar>
   </v-app>
 </template>
@@ -91,7 +91,7 @@ export default {
 .splitpanes__splitter {
   background-color: #e2e4e8;
   position: relative;
-  width: 1px;
+  width: 5px;
 }
 
 .lm_goldenlayout {
@@ -110,13 +110,13 @@ export default {
   z-index: 1;
 }
 
-.lm_splitter.lm_vertical {
+/* .lm_splitter.lm_vertical {
   height: 1px !important;
 }
 
 .lm_splitter.lm_horizontal {
   width: 1px !important;
-}
+} */
 
 .lm_header .lm_tab {
   padding-top: 0px;

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -42,7 +42,9 @@
                   <jupyter-widget :widget="tray.widget"></jupyter-widget>
                 </v-expansion-panel-content>
               </v-expansion-panel>
+
             </v-expansion-panels>
+            <v-divider></v-divider>
           </pane>
         </splitpanes>
       </v-container>
@@ -104,14 +106,10 @@ export default {
 
   .lm_splitter.lm_vertical {
     height: 1px !important;
-    margin-top: 2px;
-    margin-bottom: 2px;
   }
 
   .lm_splitter.lm_horizontal {
     width: 1px !important;
-    margin-left: 2px;
-    margin-right: 2px;
   }
 
   .lm_header .lm_tab {

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -21,7 +21,7 @@
         <!-- <v-row align="center" justify="center" class="fill-height pa-0 ma-0" style="width: 100%">
         <v-col cols="12" class="fill-height pa-0 ma-0" style="width: 100%"> -->
         <splitpanes class="default-theme" @resize="relayout">
-          <pane size="80">
+          <pane size="70">
             <v-card tile class="ma-2" style="height: calc(100% - 16px)">
               <golden-layout
                 :style="checkNotebookContext() ? 'height: 100%;' : 'height: calc(100vh - 64px)'"
@@ -41,30 +41,20 @@
               </golden-layout>
             </v-card>
           </pane>
-          <pane size="20" v-if="state.drawer">
-            <splitpanes horizontal class="elevation-2">
-              <pane>
-                <v-card tile class="ma-2" style="height: calc(100% - 16px)">
-                  <golden-layout
-                    :style="checkNotebookContext() ? 'height: 100%;' : 'height: calc(100vh - 64px)'"
-                  >
-                    <gl-stack
-                      @stateChanged="consle.log($event)"
-                      @selection-changed="consle.log($event)"
-                      :closable="false"
-                    >
-                      <gl-component
+          <pane size="30" v-if="state.drawer">
+            <v-card class="fill-height" style="padding: 0px; margin: 0px">
+              <v-expansion-panels accordion multiple focusable>
+                <v-expansion-panel
                         v-for="(tray, index) in state.tray_items"
                         :key="index"
-                        :title="tray.name"
-                      >
-                        <jupyter-widget :widget="tray.widget"></jupyter-widget>
-                      </gl-component>
-                    </gl-stack>
-                  </golden-layout>
-                </v-card>
-              </pane>
-            </splitpanes>
+                >
+                  <v-expansion-panel-header>{{ tray.label }}</v-expansion-panel-header>
+                  <v-expansion-panel-content>
+                    <jupyter-widget :widget="tray.widget"></jupyter-widget>
+                  </v-expansion-panel-content>
+                </v-expansion-panel>
+              </v-expansion-panels>
+            </v-card>
           </pane>
         </splitpanes>
         <!-- </v-col>
@@ -124,5 +114,15 @@ export default {
 
 .vuetify-styles .lm_header ul {
   padding-left: 0;
+}
+
+.v-expansion-panel-content__wrap {
+  padding: 0px;
+  margin: 0px;
+}
+
+.v-expansion-panel__header {
+  padding: 0px;
+  margin: 0px
 }
 </style>

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -12,11 +12,11 @@
     </v-app-bar>
 
     <v-content
-      :style="checkNotebookContext() ? 'height: ' + state.settings.context.notebook.max_height : ''"
+      :style="checkNotebookContext() ? 'height: ' + state.settings.context.notebook.max_height + '; border: solid 1px #e5e5e5;' : ''"
     >
       <v-container class="fill-height pa-0" fluid>
         <splitpanes @resize="relayout">
-          <pane size="70">
+          <pane size="75">
               <golden-layout
                 :style="checkNotebookContext() ? 'height: 100%;' : 'height: calc(100vh - 48px)'"
                 :has-headers="state.settings.visible.tab_headers"
@@ -34,7 +34,7 @@
                 </gl-row>
               </golden-layout>
           </pane>
-          <pane size="30" v-if="state.drawer" style="background-color: #fff;">
+          <pane size="25" v-if="state.drawer" style="background-color: #fafbfc;">
             <v-expansion-panels accordion multiple focusable flat tile>
               <v-expansion-panel v-for="(tray, index) in state.tray_items" :key="index">
                 <v-expansion-panel-header>{{ tray.label }}</v-expansion-panel-header>
@@ -47,7 +47,7 @@
         </splitpanes>
       </v-container>
     </v-content>
-    <v-snackbar v-model="state.snackbar" :timeout="state.snackbar_timeout">
+    <v-snackbar v-model="state.snackbar" :timeout="state.snackbar_timeout" absolute>
       {{ state.snackbar_text }}
       <v-btn color="blue" text @click="state.snackbar = false">Close</v-btn>
     </v-snackbar>
@@ -66,66 +66,75 @@ export default {
 </script>
 
 <style id="web-app">
-.v-toolbar__content,
-.vuetify-styles .v-toolbar__content {
-  padding-left: 0px;
-  padding-right: 0px;
-}
+  .v-toolbar__content,
+  .vuetify-styles .v-toolbar__content {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
 
-.v-tabs-items {
-  height: 100%;
-}
+  .v-tabs-items {
+    height: 100%;
+  }
 
-.splitpanes {
-  background-color: #f8f8f8;
-}
+  .splitpanes {
+    background-color: #f8f8f8;
+  }
 
-.splitpanes__splitter {
-  background-color: #e5e5e5;
-  position: relative;
-  width: 5px;
-}
+  .splitpanes__splitter {
+    background-color: #e2e4e8;
+    position: relative;
+    width: 1px;
+  }
 
-.lm_goldenlayout {
-  background: #fafafa;
-}
+  .lm_goldenlayout {
+    background: #ffffff;
+  }
 
-.lm_content {
-  background: #ffffff;
-  border: none;
-  /*border-top: 1px solid #cccccc;*/
-}
+  .lm_content {
+    background: #ffffff;
+    border: none;
+    /*border-top: 1px solid #cccccc;*/
+  }
 
-.lm_splitter {
-  background: #e5e5e5;
-  opacity: 1;
-  z-index: 1;
-}
+  .lm_splitter {
+    background: #e2e4e8;
+    opacity: 1;
+    z-index: 1;
+  }
 
-.lm_splitter .lm_vertical {
-  width: 1px
-}
+  .lm_splitter.lm_vertical {
+    height: 1px !important;
+    margin-top: 2px;
+    margin-bottom: 2px;
+  }
 
-.lm_splitter .lm_horizontal {
-  height: 1px
-}
+  .lm_splitter.lm_horizontal {
+    width: 1px !important;
+    margin-left: 2px;
+    margin-right: 2px;
+  }
 
-.lm_header .lm_tab {
-  padding-top: 0px;
-  margin-top: 0px;
-}
+  .lm_header .lm_tab {
+    padding-top: 0px;
+    margin-top: 0px;
+  }
 
-.vuetify-styles .lm_header ul {
-  padding-left: 0;
-}
+  .vuetify-styles .lm_header ul {
+    padding-left: 0;
+  }
 
-.v-expansion-panel-content__wrap {
-  padding: 0px;
-  margin: 0px;
-}
+  .v-expansion-panel-content__wrap {
+    padding: 0px;
+    margin: 0px;
+  }
 
-.v-expansion-panel__header {
-  padding: 0px;
-  margin: 0px;
-}
+  .v-expansion-panel__header {
+    padding: 0px;
+    margin: 0px;
+  }
+
+  .vuetify-styles .v-expansion-panel-content__wrap {
+    padding: 0px;
+    margin: 0px;
+  }
 </style>

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -17,43 +17,45 @@
       <v-container class="fill-height pa-0" fluid>
         <splitpanes @resize="relayout">
           <pane size="75">
-              <golden-layout
-                :style="checkNotebookContext() ? 'height: 100%;' : 'height: calc(100vh - 48px)'"
-                :has-headers="state.settings.visible.tab_headers"
-              >
-                <gl-row :closable="false">
-                  <g-viewer-tab
-                    v-for="(stack, index) in state.stack_items"
-                    :stack="stack"
-                    :key="index"
-                    :data-items="state.data_items"
-                    @resize="relayout"
-                    @destroy="destroy_viewer_item($event)"
-                    @data-item-selected="data_item_selected($event)"
-                  ></g-viewer-tab>
-                </gl-row>
-              </golden-layout>
+            <golden-layout
+              :style="checkNotebookContext() ? 'height: 100%;' : 'height: calc(100vh - 48px)'"
+              :has-headers="state.settings.visible.tab_headers"
+            >
+              <gl-row :closable="false">
+                <g-viewer-tab
+                  v-for="(stack, index) in state.stack_items"
+                  :stack="stack"
+                  :key="index"
+                  :data-items="state.data_items"
+                  @resize="relayout"
+                  @destroy="destroy_viewer_item($event)"
+                  @data-item-selected="data_item_selected($event)"
+                ></g-viewer-tab>
+              </gl-row>
+            </golden-layout>
           </pane>
           <pane size="25" v-if="state.drawer" style="background-color: #fafbfc;">
-            <v-expansion-panels accordion multiple focusable flat tile>
-              <v-expansion-panel v-for="(tray, index) in state.tray_items" :key="index">
-                <v-expansion-panel-header>{{ tray.label }}</v-expansion-panel-header>
-                <v-expansion-panel-content>
-                  <jupyter-widget :widget="tray.widget"></jupyter-widget>
-                </v-expansion-panel-content>
-              </v-expansion-panel>
-
-            </v-expansion-panels>
-            <v-divider></v-divider>
+            <v-card flat tile class="overflow-y-auto fill-height" color="#f8f8f8">
+              <v-expansion-panels accordion multiple focusable flat tile>
+                <v-expansion-panel v-for="(tray, index) in state.tray_items" :key="index">
+                  <v-expansion-panel-header>{{ tray.label }}</v-expansion-panel-header>
+                  <v-expansion-panel-content>
+                    <jupyter-widget :widget="tray.widget"></jupyter-widget>
+                  </v-expansion-panel-content>
+                </v-expansion-panel>
+              </v-expansion-panels>
+              <v-divider></v-divider>
+            </v-card>
           </pane>
         </splitpanes>
       </v-container>
     </v-content>
     <v-snackbar
-            v-model="state.snackbar.show"
-            :timeout="state.snackbar.timeout"
-            :color="state.snackbar.color"
-            absolute>
+      v-model="state.snackbar.show"
+      :timeout="state.snackbar.timeout"
+      :color="state.snackbar.color"
+      absolute
+    >
       {{ state.snackbar.text }}
       <v-btn text @click="state.snackbar = false">Close</v-btn>
     </v-snackbar>
@@ -72,71 +74,71 @@ export default {
 </script>
 
 <style id="web-app">
-  .v-toolbar__content,
-  .vuetify-styles .v-toolbar__content {
-    padding-left: 0px;
-    padding-right: 0px;
-  }
+.v-toolbar__content,
+.vuetify-styles .v-toolbar__content {
+  padding-left: 0px;
+  padding-right: 0px;
+}
 
-  .v-tabs-items {
-    height: 100%;
-  }
+.v-tabs-items {
+  height: 100%;
+}
 
-  .splitpanes {
-    background-color: #f8f8f8;
-  }
+.splitpanes {
+  background-color: #f8f8f8;
+}
 
-  .splitpanes__splitter {
-    background-color: #e2e4e8;
-    position: relative;
-    width: 1px;
-  }
+.splitpanes__splitter {
+  background-color: #e2e4e8;
+  position: relative;
+  width: 1px;
+}
 
-  .lm_goldenlayout {
-    background: #ffffff;
-  }
+.lm_goldenlayout {
+  background: #ffffff;
+}
 
-  .lm_content {
-    background: #ffffff;
-    border: none;
-    /*border-top: 1px solid #cccccc;*/
-  }
+.lm_content {
+  background: #ffffff;
+  border: none;
+  /*border-top: 1px solid #cccccc;*/
+}
 
-  .lm_splitter {
-    background: #e2e4e8;
-    opacity: 1;
-    z-index: 1;
-  }
+.lm_splitter {
+  background: #e2e4e8;
+  opacity: 1;
+  z-index: 1;
+}
 
-  .lm_splitter.lm_vertical {
-    height: 1px !important;
-  }
+.lm_splitter.lm_vertical {
+  height: 1px !important;
+}
 
-  .lm_splitter.lm_horizontal {
-    width: 1px !important;
-  }
+.lm_splitter.lm_horizontal {
+  width: 1px !important;
+}
 
-  .lm_header .lm_tab {
-    padding-top: 0px;
-    margin-top: 0px;
-  }
+.lm_header .lm_tab {
+  padding-top: 0px;
+  margin-top: 0px;
+}
 
-  .vuetify-styles .lm_header ul {
-    padding-left: 0;
-  }
+.vuetify-styles .lm_header ul {
+  padding-left: 0;
+}
 
-  .v-expansion-panel-content__wrap {
-    padding: 0px;
-    margin: 0px;
-  }
+.v-expansion-panel-content__wrap {
+  padding: 0px;
+  margin: 0px;
+}
 
-  .v-expansion-panel__header {
-    padding: 0px;
-    margin: 0px;
-  }
+.v-expansion-panel__header {
+  padding: 0px;
+  margin: 0px;
+}
 
-  .vuetify-styles .v-expansion-panel-content__wrap {
-    padding: 0px;
-    margin: 0px;
-  }
+.vuetify-styles .v-expansion-panel-content__wrap {
+  padding: 0px;
+  margin: 0px;
+}
 </style>

--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -11,9 +11,10 @@ settings:
 toolbar:
   - g-data-tools
   - g-subset-tools
+  - g-unified-slider
+tray:
   - g-gaussian-smooth
   - g-collapse
-  - g-unified-slider
 viewer_area:
   - container: col
     children:

--- a/jdaviz/configs/cubeviz/plugins/unified_slider/unified_slider.py
+++ b/jdaviz/configs/cubeviz/plugins/unified_slider/unified_slider.py
@@ -1,4 +1,4 @@
-from traitlets import Bool, Float, observe
+from traitlets import Bool, Float, observe, Any
 
 from jdaviz.core.events import AddDataMessage
 from jdaviz.core.registries import tool_registry
@@ -13,7 +13,7 @@ __all__ = ['UnifiedSlider']
 @tool_registry('g-unified-slider')
 class UnifiedSlider(TemplateMixin):
     template = load_template("unified_slider.vue", __file__).tag(sync=True)
-    slider = Float().tag(sync=True)
+    slider = Any(0).tag(sync=True)
     min_value = Float(0).tag(sync=True)
     max_value = Float(100).tag(sync=True)
     linked = Bool(True).tag(sync=True)
@@ -58,6 +58,11 @@ class UnifiedSlider(TemplateMixin):
 
     @observe('slider')
     def _on_slider_updated(self, event):
+        if not event['new']:
+            value = 0
+        else:
+            value = int(event['new'])
+
         if self.linked:
             for viewer in self._watched_viewers:
-                viewer.state.slices = (int(event['new']), 0, 0)
+                viewer.state.slices = (value, 0, 0)

--- a/jdaviz/configs/default/default.yaml
+++ b/jdaviz/configs/default/default.yaml
@@ -11,6 +11,5 @@ toolbar:
   - g-data-tools
   - g-viewer-creator
   - g-subset-tools
-  - g-gaussian-smooth
 tray:
-  - g-model-fitting
+  - g-gaussian-smooth

--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -91,5 +91,6 @@ class Collapse(TemplateMixin):
 
         snackbar_message = SnackbarMessage(
             f"Data set '{self._selected_data.label}' collapsed successfully.",
+            color="success",
             sender=self)
         self.hub.broadcast(snackbar_message)

--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -54,7 +54,16 @@ class Collapse(TemplateMixin):
         self.axes = list(range(len(self._selected_data.shape)))
 
     def vue_collapse(self, *args, **kwargs):
-        spec = self._selected_data.get_object(cls=SpectralCube)
+        try:
+            spec = self._selected_data.get_object(cls=SpectralCube)
+        except AttributeError:
+            snackbar_message = SnackbarMessage(
+                f"Unable to perform collapse over selected data.",
+                color="error",
+                sender=self)
+            self.hub.broadcast(snackbar_message)
+
+            return
 
         collapsed_spec = getattr(spec, self.selected_func.lower())(
             axis=self.selected_axis)

--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -27,7 +27,6 @@ AXES_MAPPING = [((1, 2), (0, 1)), ((0, 2), (0, 1)), ((0, 1), (0, 1))]
 @tray_registry('g-collapse', label="Collapse")
 class Collapse(TemplateMixin):
     template = load_template("collapse.vue", __file__).tag(sync=True)
-    dialog = Bool(False).tag(sync=True)
     data_items = List([]).tag(sync=True)
     selected_data_item = Unicode().tag(sync=True)
     axes = List([]).tag(sync=True)
@@ -81,5 +80,3 @@ class Collapse(TemplateMixin):
                                                self.data_collection[label].pixel_component_ids[i1c]))
         self.data_collection.add_link(LinkSame(self._selected_data.pixel_component_ids[i2],
                                                self.data_collection[label].pixel_component_ids[i2c]))
-
-        self.dialog = False

--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -9,7 +9,7 @@ from specutils import Spectrum1D
 from spectral_cube import SpectralCube
 from traitlets import Bool, List, Unicode, Int, observe
 
-from jdaviz.core.registries import tool_registry
+from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import TemplateMixin
 from jdaviz.utils import load_template
 
@@ -24,7 +24,7 @@ u.add_enabled_units([spaxel])
 AXES_MAPPING = [((1, 2), (0, 1)), ((0, 2), (0, 1)), ((0, 1), (0, 1))]
 
 
-@tool_registry('g-collapse')
+@tray_registry('g-collapse', label="Collapse")
 class Collapse(TemplateMixin):
     template = load_template("collapse.vue", __file__).tag(sync=True)
     dialog = Bool(False).tag(sync=True)

--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -2,13 +2,12 @@ from astropy import units as u
 from astropy import units as u
 from glue.core.message import (DataCollectionAddMessage,
                                DataCollectionDeleteMessage)
-from glue.core.coordinates import WCSCoordinates
-from glue.core import Data, Subset
+from glue.core import Data
 from glue.core.link_helpers import LinkSame
-from specutils import Spectrum1D
 from spectral_cube import SpectralCube
-from traitlets import Bool, List, Unicode, Int, observe
+from traitlets import List, Unicode, Int, observe
 
+from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import TemplateMixin
 from jdaviz.utils import load_template
@@ -80,3 +79,8 @@ class Collapse(TemplateMixin):
                                                self.data_collection[label].pixel_component_ids[i1c]))
         self.data_collection.add_link(LinkSame(self._selected_data.pixel_component_ids[i2],
                                                self.data_collection[label].pixel_component_ids[i2c]))
+
+        snackbar_message = SnackbarMessage(
+            f"Data set '{self._selected_data.label}' collapsed successfully.",
+            sender=self)
+        self.hub.broadcast(snackbar_message)

--- a/jdaviz/configs/default/plugins/collapse/collapse.vue
+++ b/jdaviz/configs/default/plugins/collapse/collapse.vue
@@ -1,43 +1,43 @@
 <template>
-  <v-toolbar-items>
-      <v-card flat tile>
-        <v-container style="margin: 0px; padding: 0px">
-          <v-row>
-            <v-col>
-              <v-select
-                :items="data_items"
-                v-model="selected_data_item"
-                label="Data"
-                hint="Select the data set to use in collapse."
-              ></v-select>
-            </v-col>
-          </v-row>
-          <v-row>
-            <v-col>
-              <v-select
-                :items="axes"
-                v-model="selected_axis"
-                label="Axis"
-                hint="Select the axis along with the data with be collapsed."
-              ></v-select>
-            </v-col>
-            <v-col>
-              <v-select
-                :items="funcs"
-                v-model="selected_func"
-                label="Method"
-                hint="Select the method to use in the collapse."
-              ></v-select>
-            </v-col>
-          </v-row>
-        </v-container>
-        <!-- <v-divider></v-divider> -->
+  <v-card flat tile>
+    <v-container>
+      <v-row>
+        <v-col class="py-0">
+          <v-select
+            :items="data_items"
+            v-model="selected_data_item"
+            label="Data"
+            hint="Select the data set to use in collapse."
+            persistent-hint
+          ></v-select>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col>
+          <v-select
+            :items="axes"
+            v-model="selected_axis"
+            label="Axis"
+            hint="Select the axis along with the data with be collapsed."
+            persistent-hint
+          ></v-select>
+        </v-col>
+        <v-col>
+          <v-select
+            :items="funcs"
+            v-model="selected_func"
+            label="Method"
+            hint="Select the method to use in the collapse."
+            persistent-hint
+          ></v-select>
+        </v-col>
+      </v-row>
+    </v-container>
+    <!-- <v-divider></v-divider> -->
 
-        <v-card-actions>
-          <div class="flex-grow-1"></div>
-          <v-btn color="primary" text @click="dialog = false">Cancel</v-btn>
-          <v-btn color="primary" text @click="collapse">Apply</v-btn>
-        </v-card-actions>
-      </v-card>
-  </v-toolbar-items>
+    <v-card-actions>
+      <div class="flex-grow-1"></div>
+      <v-btn color="primary" text @click="collapse">Apply</v-btn>
+    </v-card-actions>
+  </v-card>
 </template>

--- a/jdaviz/configs/default/plugins/collapse/collapse.vue
+++ b/jdaviz/configs/default/plugins/collapse/collapse.vue
@@ -1,52 +1,36 @@
 <template>
   <v-toolbar-items>
-    <v-dialog v-model="dialog" persistent max-width="450" @keydown.stop>
-      <template v-slot:activator="{ on: dialog }">
-        <v-tooltip bottom>
-          <template v-slot:activator="{ on: tooltip }">
-            <v-btn v-on="{...tooltip, ...dialog}" icon>
-              <v-icon>mdi-collapse-all</v-icon>
-            </v-btn>
-          </template>
-          <span>Collapse</span>
-        </v-tooltip>
-      </template>
-
-      <v-card>
-        <v-card-title class="headline blue lighten-4" primary-title>Cube Collapse</v-card-title>
-
-        <v-card-text>
-          <v-container>
-            <v-row>
-              <v-col>
-                <v-select
-                  :items="data_items"
-                  v-model="selected_data_item"
-                  label="Data"
-                  hint="Select the data set to use in collapse."
-                ></v-select>
-              </v-col>
-            </v-row>
-            <v-row>
-              <v-col>
-                <v-select
-                  :items="axes"
-                  v-model="selected_axis"
-                  label="Axis"
-                  hint="Select the axis along with the data with be collapsed."
-                ></v-select>
-              </v-col>
-              <v-col>
-                <v-select
-                  :items="funcs"
-                  v-model="selected_func"
-                  label="Method"
-                  hint="Select the method to use in the collapse."
-                ></v-select>
-              </v-col>
-            </v-row>
-          </v-container>
-        </v-card-text>
+      <v-card flat tile>
+        <v-container style="margin: 0px; padding: 0px">
+          <v-row>
+            <v-col>
+              <v-select
+                :items="data_items"
+                v-model="selected_data_item"
+                label="Data"
+                hint="Select the data set to use in collapse."
+              ></v-select>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-select
+                :items="axes"
+                v-model="selected_axis"
+                label="Axis"
+                hint="Select the axis along with the data with be collapsed."
+              ></v-select>
+            </v-col>
+            <v-col>
+              <v-select
+                :items="funcs"
+                v-model="selected_func"
+                label="Method"
+                hint="Select the method to use in the collapse."
+              ></v-select>
+            </v-col>
+          </v-row>
+        </v-container>
         <!-- <v-divider></v-divider> -->
 
         <v-card-actions>
@@ -55,6 +39,5 @@
           <v-btn color="primary" text @click="collapse">Apply</v-btn>
         </v-card-actions>
       </v-card>
-    </v-dialog>
   </v-toolbar-items>
 </template>

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -5,8 +5,9 @@ from glue.core.message import (DataCollectionAddMessage,
 from glue.core.link_helpers import LinkSame
 from specutils import Spectrum1D
 from specutils.manipulation import gaussian_smooth
-from traitlets import Bool, List, Unicode
+from traitlets import List, Unicode
 
+from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import TemplateMixin
 from jdaviz.utils import load_template
@@ -66,3 +67,8 @@ class GaussianSmooth(TemplateMixin):
         # (whcih could in principle be a cube or a spectrum)
         self.data_collection.add_link(LinkSame(self._selected_data.pixel_component_ids[0],
                                                self.data_collection[label].pixel_component_ids[0]))
+
+        snackbar_message = SnackbarMessage(
+            f"Data set '{self._selected_data.label}' smoothed successfully.",
+            sender=self)
+        self.hub.broadcast(snackbar_message)

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -20,7 +20,6 @@ u.add_enabled_units([spaxel])
 
 @tray_registry('g-gaussian-smooth', label="Gaussian Smooth")
 class GaussianSmooth(TemplateMixin):
-    dialog = Bool(False).tag(sync=True)
     template = load_template("gaussian_smooth.vue", __file__).tag(sync=True)
     stddev = Unicode().tag(sync=True)
     dc_items = List([]).tag(sync=True)
@@ -67,5 +66,3 @@ class GaussianSmooth(TemplateMixin):
         # (whcih could in principle be a cube or a spectrum)
         self.data_collection.add_link(LinkSame(self._selected_data.pixel_component_ids[0],
                                                self.data_collection[label].pixel_component_ids[0]))
-
-        self.dialog = False

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -4,7 +4,7 @@ from glue.core.message import (DataCollectionAddMessage,
 from glue.core.link_helpers import LinkSame
 from specutils import Spectrum1D
 from specutils.manipulation import gaussian_smooth
-from traitlets import List, Unicode, Int
+from traitlets import List, Unicode, Int, Any, observe
 
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import tray_registry
@@ -21,8 +21,9 @@ u.add_enabled_units([spaxel])
 @tray_registry('g-gaussian-smooth', label="Gaussian Smooth")
 class GaussianSmooth(TemplateMixin):
     template = load_template("gaussian_smooth.vue", __file__).tag(sync=True)
-    stddev = Unicode("0").tag(sync=True)
+    stddev = Any().tag(sync=True)
     dc_items = List([]).tag(sync=True)
+    selected_data = Unicode().tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -37,9 +38,10 @@ class GaussianSmooth(TemplateMixin):
     def _on_data_updated(self, msg):
         self.dc_items = [x.label for x in self.data_collection]
 
-    def vue_data_selected(self, event):
+    @observe("selected_data")
+    def _on_data_selected(self, event):
         self._selected_data = next((x for x in self.data_collection
-                                    if x.label == event))
+                                    if x.label == event['new']))
 
     def vue_gaussian_smooth(self, *args, **kwargs):
         # Testing inputs to make sure putting smoothed spectrum into

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -7,7 +7,7 @@ from specutils import Spectrum1D
 from specutils.manipulation import gaussian_smooth
 from traitlets import Bool, List, Unicode
 
-from jdaviz.core.registries import tool_registry
+from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import TemplateMixin
 from jdaviz.utils import load_template
 
@@ -18,7 +18,7 @@ spaxel = u.def_unit('spaxel', 1 * u.Unit(""))
 u.add_enabled_units([spaxel])
 
 
-@tool_registry('g-gaussian-smooth')
+@tray_registry('g-gaussian-smooth', label="Gaussian Smooth")
 class GaussianSmooth(TemplateMixin):
     dialog = Bool(False).tag(sync=True)
     template = load_template("gaussian_smooth.vue", __file__).tag(sync=True)

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.vue
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.vue
@@ -5,7 +5,7 @@
         <v-col class="py-0">
           <v-select
             :items="dc_items"
-            @change="data_selected"
+            v-model="selected_data"
             label="Data"
             hint="Select the data set to be smoothed."
             persistent-hint
@@ -18,10 +18,10 @@
             ref="stddev"
             label="Standard deviation"
             v-model="stddev"
+            type="number"
             hint="The stddev of the kernel, in pixels."
             persistent-hint
-            :rules="[() => !!stddev || 'This field is required']"
-            persistent-hint
+            :rules="[() => !!stddev || 'This field is required', () => stddev > 0 || 'Kernel must be greater than zero']"
           ></v-text-field>
         </v-col>
       </v-row>
@@ -30,7 +30,8 @@
 
     <v-card-actions>
       <div class="flex-grow-1"></div>
-      <v-btn color="primary" text @click="gaussian_smooth">Apply</v-btn>
+      <v-btn :disabled="stddev <= 0 || selected_data == ''"
+      color="primary" text @click="gaussian_smooth">Apply</v-btn>
     </v-card-actions>
   </v-card>
 </template>

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.vue
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.vue
@@ -1,54 +1,36 @@
 <template>
-  <v-toolbar-items>
-    <v-dialog v-model="dialog" persistent max-width="450" @keydown.stop>
-      <template v-slot:activator="{ on: dialog }">
-        <v-tooltip bottom>
-          <template v-slot:activator="{ on: tooltip }">
-            <v-btn v-on="{...tooltip, ...dialog}" icon>
-              <v-icon>mdi-chart-multiline</v-icon>
-            </v-btn>
-          </template>
-          <span>Gaussian Smooth</span>
-        </v-tooltip>
-      </template>
+  <v-card flat tile>
+    <v-container>
+      <v-row>
+        <v-col class="py-0">
+          <v-select
+            :items="dc_items"
+            @change="data_selected"
+            label="Data"
+            hint="Select the data set to be smoothed."
+            persistent-hint
+          ></v-select>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col>
+          <v-text-field
+            ref="stddev"
+            label="Standard deviation"
+            v-model="stddev"
+            hint="The stddev of the kernel, in pixels."
+            persistent-hint
+            :rules="[() => !!stddev || 'This field is required']"
+            persistent-hint
+          ></v-text-field>
+        </v-col>
+      </v-row>
+    </v-container>
+    <!-- <v-divider></v-divider> -->
 
-      <v-card>
-        <v-card-title class="headline blue lighten-4" primary-title>Gaussian Smoothing</v-card-title>
-
-        <v-card-text>
-          <v-container>
-            <v-row>
-              <v-col>
-                <v-select
-                  :items="dc_items"
-                  @change="data_selected"
-                  label="Data"
-                  hint="Select the data set to be smoothed."
-                ></v-select>
-              </v-col>
-            </v-row>
-            <v-row>
-              <v-col>
-                <v-text-field
-                  ref="stddev"
-                  label="Standard deviation"
-                  v-model="stddev"
-                  hint="The stddev of the kernel, in pixels."
-                  persistent-hint
-                  :rules="[() => !!stddev || 'This field is required']"
-                ></v-text-field>
-              </v-col>
-            </v-row>
-          </v-container>
-        </v-card-text>
-        <!-- <v-divider></v-divider> -->
-
-        <v-card-actions>
-          <div class="flex-grow-1"></div>
-          <v-btn color="primary" text @click="dialog = false">Cancel</v-btn>
-          <v-btn color="primary" text @click="gaussian_smooth">Apply</v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-  </v-toolbar-items>
+    <v-card-actions>
+      <div class="flex-grow-1"></div>
+      <v-btn color="primary" text @click="gaussian_smooth">Apply</v-btn>
+    </v-card-actions>
+  </v-card>
 </template>

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -93,7 +93,7 @@ module.exports = {
   },
   methods: {
     computeChildrenPath() {
-        return this.$parent.computeChildrenPath()
+      return this.$parent.computeChildrenPath();
     }
   },
   computed: {

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -123,3 +123,19 @@ class AddDataMessage(Message):
     @property
     def viewer(self):
         return self._viewer
+
+
+class SnackbarMessage(Message):
+    def __init__(self, text, timeout=5000, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._text = text
+        self._timeout = timeout
+
+    @property
+    def text(self):
+        return self._text
+
+    @property
+    def timeout(self):
+        return self._timeout

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -126,15 +126,20 @@ class AddDataMessage(Message):
 
 
 class SnackbarMessage(Message):
-    def __init__(self, text, timeout=5000, *args, **kwargs):
+    def __init__(self, text, color=None, timeout=5000, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self._text = text
+        self._color = color
         self._timeout = timeout
 
     @property
     def text(self):
         return self._text
+
+    @property
+    def color(self):
+        return self._color
 
     @property
     def timeout(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     glue-jupyter @ git+https://github.com/glue-viz/glue-jupyter.git
     echo @ git+https://github.com/glue-viz/echo.git
     ipyvue==1.3.2
-    ipyvuetify==1.3.0
+    ipyvuetify==1.4.0
     ipysplitpanes
     ipygoldenlayout==0.3.0
     voila


### PR DESCRIPTION
Resolves #102. This PR moves the plugins from modal popups to accordion tray items as shown below.

<img width="1353" alt="Screen Shot 2020-05-05 at 12 32 52 PM" src="https://user-images.githubusercontent.com/4141126/81091216-e5513b00-8ecc-11ea-83ba-0b56b24c8f10.png">
