### PR TITLE
Model Fitting UI Plugin

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -641,7 +641,6 @@ class Application(TemplateMixin):
                 viewer.remove_data(data)
 
     def _on_data_added(self, msg):
-<<<<<<< HEAD
         """
         Callback for when data is added to the internal ``DataCollection``.
         Adds a new data item dictionary to the ``data_items`` state list.
@@ -687,31 +686,6 @@ class Application(TemplateMixin):
         """
         children = [] if children is None else children
         viewers = [] if viewers is None else viewers
-=======
-        self.state.data_items.append(
-            {
-                'id': str(uuid.uuid4()),
-                'name': msg.data.label,
-                'locked': False,  # not bool(self.selected_viewer_item),
-                'children': [
-                    # {'id': 2, 'name': 'Calendar : app'},
-                    # {'id': 3, 'name': 'Chrome : app'},
-                    # {'id': 4, 'name': 'Webstorm : app'},
-                ],
-            })
-
-    def _create_stack_item(self, container='gl-stack', children=None,
-                           viewers=None):
-        if children is not None:# and not isinstance(children, ListCallbackProperty):
-            children = children #ListCallbackProperty(children)
-        else:
-            children = [] #ListCallbackProperty([])
-
-        if viewers is not None:# and not isinstance(viewers, ListCallbackProperty):
-            viewers = viewers #ListCallbackProperty(viewers)
-        else:
-            viewers = [] #ListCallbackProperty([])
->>>>>>> Remove default property values
 
         return {
             'id': str(uuid.uuid4()),
@@ -719,7 +693,6 @@ class Application(TemplateMixin):
             'children': children,
             'viewers': viewers}
 
-<<<<<<< HEAD
     @staticmethod
     def _create_viewer_item(viewer, name=None, reference=None):
         """
@@ -741,16 +714,11 @@ class Application(TemplateMixin):
             Dictionary containing information for this viewer item.
         """
         tools = viewer.toolbar_selection_tools
-=======
-    def _create_viewer_item(self, name, widget, tools, layer_options,
-                            viewer_options):
->>>>>>> Remove default property values
         tools.borderless = True
         tools.tile = True
 
         return {
             'id': str(uuid.uuid4()),
-<<<<<<< HEAD
             'name': name or "Unnamed Viewer",
             'widget': "IPY_MODEL_" + viewer.figure_widget.model_id,
             'tools': "IPY_MODEL_" + viewer.toolbar_selection_tools.model_id,
@@ -759,15 +727,6 @@ class Application(TemplateMixin):
             'selected_data_items': [],
             'collapse': True,
             'reference': reference}
-=======
-            'widget': widget,
-            'name': "Slider Test",
-            'tools': tools,
-            'layer_options': layer_options,
-            'viewer_options': viewer_options,
-            'selected_data_items': ListCallbackProperty([]),
-            'collapse': True}
->>>>>>> Remove default property values
 
     def _on_new_viewer(self, msg):
         """
@@ -874,13 +833,8 @@ class Application(TemplateMixin):
 
         if config.get('viewer_area') is not None:
             stack_items = compose_viewer_area(config.get('viewer_area'))
-<<<<<<< HEAD
             self.state.stack_items.extend(stack_items)
             # self.vue_relayout()
-=======
-            # print(stack_items)
-            self.state.stack_items.extend(['test'])
->>>>>>> Remove default property values
 
         # Add the toolbar item filter to the toolbar component
         for name in config.get('toolbar', []):

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -20,7 +20,8 @@ from ipygoldenlayout import GoldenLayout
 from ipysplitpanes import SplitPanes
 from traitlets import Dict
 
-from .core.events import LoadDataMessage, NewViewerMessage, AddDataMessage, SnackbarMessage
+from .core.events import (LoadDataMessage, NewViewerMessage, AddDataMessage,
+                          SnackbarMessage, RemoveDataMessage)
 from .core.registries import tool_registry, tray_registry, viewer_registry
 from .core.template_mixin import TemplateMixin
 from .utils import load_template
@@ -627,7 +628,9 @@ class Application(TemplateMixin):
 
             viewer.add_data(data)
 
-            add_data_message = AddDataMessage(data, viewer, sender=self)
+            add_data_message = AddDataMessage(data, viewer,
+                                              viewer_id=viewer_id,
+                                              sender=self)
             self.hub.broadcast(add_data_message)
 
         # Remove any deselected data objects from viewer
@@ -639,6 +642,11 @@ class Application(TemplateMixin):
         for data in viewer_data:
             if data.label not in active_data_labels:
                 viewer.remove_data(data)
+
+                remove_data_message = RemoveDataMessage(data, viewer,
+                                                        viewer_id=viewer_id,
+                                                        sender=self)
+                self.hub.broadcast(remove_data_message)
 
     def _on_data_added(self, msg):
         """

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -641,6 +641,7 @@ class Application(TemplateMixin):
                 viewer.remove_data(data)
 
     def _on_data_added(self, msg):
+<<<<<<< HEAD
         """
         Callback for when data is added to the internal ``DataCollection``.
         Adds a new data item dictionary to the ``data_items`` state list.
@@ -686,6 +687,31 @@ class Application(TemplateMixin):
         """
         children = [] if children is None else children
         viewers = [] if viewers is None else viewers
+=======
+        self.state.data_items.append(
+            {
+                'id': str(uuid.uuid4()),
+                'name': msg.data.label,
+                'locked': False,  # not bool(self.selected_viewer_item),
+                'children': [
+                    # {'id': 2, 'name': 'Calendar : app'},
+                    # {'id': 3, 'name': 'Chrome : app'},
+                    # {'id': 4, 'name': 'Webstorm : app'},
+                ],
+            })
+
+    def _create_stack_item(self, container='gl-stack', children=None,
+                           viewers=None):
+        if children is not None:# and not isinstance(children, ListCallbackProperty):
+            children = children #ListCallbackProperty(children)
+        else:
+            children = [] #ListCallbackProperty([])
+
+        if viewers is not None:# and not isinstance(viewers, ListCallbackProperty):
+            viewers = viewers #ListCallbackProperty(viewers)
+        else:
+            viewers = [] #ListCallbackProperty([])
+>>>>>>> Remove default property values
 
         return {
             'id': str(uuid.uuid4()),
@@ -693,6 +719,7 @@ class Application(TemplateMixin):
             'children': children,
             'viewers': viewers}
 
+<<<<<<< HEAD
     @staticmethod
     def _create_viewer_item(viewer, name=None, reference=None):
         """
@@ -714,11 +741,16 @@ class Application(TemplateMixin):
             Dictionary containing information for this viewer item.
         """
         tools = viewer.toolbar_selection_tools
+=======
+    def _create_viewer_item(self, name, widget, tools, layer_options,
+                            viewer_options):
+>>>>>>> Remove default property values
         tools.borderless = True
         tools.tile = True
 
         return {
             'id': str(uuid.uuid4()),
+<<<<<<< HEAD
             'name': name or "Unnamed Viewer",
             'widget': "IPY_MODEL_" + viewer.figure_widget.model_id,
             'tools': "IPY_MODEL_" + viewer.toolbar_selection_tools.model_id,
@@ -727,6 +759,15 @@ class Application(TemplateMixin):
             'selected_data_items': [],
             'collapse': True,
             'reference': reference}
+=======
+            'widget': widget,
+            'name': "Slider Test",
+            'tools': tools,
+            'layer_options': layer_options,
+            'viewer_options': viewer_options,
+            'selected_data_items': ListCallbackProperty([]),
+            'collapse': True}
+>>>>>>> Remove default property values
 
     def _on_new_viewer(self, msg):
         """
@@ -833,8 +874,13 @@ class Application(TemplateMixin):
 
         if config.get('viewer_area') is not None:
             stack_items = compose_viewer_area(config.get('viewer_area'))
+<<<<<<< HEAD
             self.state.stack_items.extend(stack_items)
             # self.vue_relayout()
+=======
+            # print(stack_items)
+            self.state.stack_items.extend(['test'])
+>>>>>>> Remove default property values
 
         # Add the toolbar item filter to the toolbar component
         for name in config.get('toolbar', []):

--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -15,6 +15,7 @@ toolbar:
 tray:
   - g-gaussian-smooth
   - g-collapse
+  - g-model-fitting
 viewer_area:
   - container: col
     children:

--- a/jdaviz/configs/default/plugins/model_fitting/initializers.py
+++ b/jdaviz/configs/default/plugins/model_fitting/initializers.py
@@ -44,7 +44,7 @@ def initialize_voigt1d(params, fixed, name):
                           amplitude_L=params["amplitude_L"],
                           fwhm_L=params["fwhm_L"],
                           fwhm_G=params["fwhm_G"],
-                          name=name
+                          name=name,
                           fixed=fixed)
 
 model_initializers = {"Gaussian1D": initialize_gaussian1d,

--- a/jdaviz/configs/default/plugins/model_fitting/initializers.py
+++ b/jdaviz/configs/default/plugins/model_fitting/initializers.py
@@ -1,4 +1,5 @@
 from astropy.modeling import models, powerlaws
+import astropy.units as u
 
 def get_params(model_dict):
     return {x["name"]: u.Quantity(x["value"], x["unit"]) for x in model_dict["parameters"]}

--- a/jdaviz/configs/default/plugins/model_fitting/initializers.py
+++ b/jdaviz/configs/default/plugins/model_fitting/initializers.py
@@ -7,40 +7,44 @@ def get_params(model_dict):
 def get_fixed(model_dict):
     return {x["name"]: x["fixed"] for x in model_dict["parameters"]}
 
-def initialize_gaussian1d(params, fixed):
+def initialize_gaussian1d(params, fixed, name):
     return models.Gaussian1D(amplitude=params["amplitude"],
                              mean=params["mean"],
                              stddev=params["stddev"],
-                             name=model_dict["id"],
+                             name=name,
                              fixed = fixed)
 
-def initialize_const1d(params, fixed):
+def initialize_const1d(params, fixed, name):
     return models.Const1D(amplitude=params["amplitude"],
-                          name=model_dict["id"],
+                          name=name,
                           fixed = fixed)
 
-def initialize_linear1d(params, fixed):
+def initialize_linear1d(params, fixed, name):
     return models.Linear1D(slope=params["slope"],
                            intercept=params["intercept"],
+                           name=name,
                            fixed=fixed)
 
-def initialize_powerlaw1d(params, fixed):
+def initialize_powerlaw1d(params, fixed, name):
     return powerlaws.PowerLaw1D(amplitude=params["amplitude"],
                                 x_0=params["x_0"],
                                 alpha=params["alpha"],
+                                name=name,
                                 fixed=fixed)
 
-def initialize_lorentz1d(params, fixed):
+def initialize_lorentz1d(params, fixed, name):
     return models.Lorentz1D(amplitude=params["amplitude"],
                             x_0=params["x_0"],
                             fwhm=params["fwhm"],
+                            name=name,
                             fixed=fixed)
 
-def initialize_voigt1d(params, fixed):
+def initialize_voigt1d(params, fixed, name):
     return models.Voigt1D(x_0=params["x_0"],
                           amplitude_L=params["amplitude_L"],
                           fwhm_L=params["fwhm_L"],
                           fwhm_G=params["fwhm_G"],
+                          name=name
                           fixed=fixed)
 
 model_initializers = {"Gaussian1D": initialize_gaussian1d,
@@ -62,4 +66,4 @@ model_parameters = {"Gaussian1D": ["amplitude", "stddev", "mean"],
 def initialize_model(model_dict):
     params = get_params(model_dict)
     fixed = get_fixed(model_dict)
-    return model_initializers[model_dict["model_type"]](params, fixed)
+    return model_initializers[model_dict["model_type"]](params, fixed, model_dict["id"])

--- a/jdaviz/configs/default/plugins/model_fitting/initializers.py
+++ b/jdaviz/configs/default/plugins/model_fitting/initializers.py
@@ -1,0 +1,64 @@
+from astropy.modeling import models, powerlaws
+
+def get_params(model_dict):
+    return {x["name"]: u.Quantity(x["value"], x["unit"]) for x in model_dict["parameters"]}
+
+def get_fixed(model_dict):
+    return {x["name"]: x["fixed"] for x in model_dict["parameters"]}
+
+def initialize_gaussian1d(params, fixed):
+    return models.Gaussian1D(amplitude=params["amplitude"],
+                             mean=params["mean"],
+                             stddev=params["stddev"],
+                             name=model_dict["id"],
+                             fixed = fixed)
+
+def initialize_const1d(params, fixed):
+    return models.Const1D(amplitude=params["amplitude"],
+                          name=model_dict["id"],
+                          fixed = fixed)
+
+def initialize_linear1d(params, fixed):
+    return models.Linear1D(slope=params["slope"],
+                           intercept=params["intercept"],
+                           fixed=fixed)
+
+def initialize_powerlaw1d(params, fixed):
+    return powerlaws.PowerLaw1D(amplitude=params["amplitude"],
+                                x_0=params["x_0"],
+                                alpha=params["alpha"],
+                                fixed=fixed)
+
+def initialize_lorentz1d(params, fixed):
+    return models.Lorentz1D(amplitude=params["amplitude"],
+                            x_0=params["x_0"],
+                            fwhm=params["fwhm"],
+                            fixed=fixed)
+
+def initialize_voigt1d(params, fixed):
+    return models.Voigt1D(x_0=params["x_0"],
+                          amplitude_L=params["amplitude_L"],
+                          fwhm_L=params["fwhm_L"],
+                          fwhm_G=params["fwhm_G"],
+                          fixed=fixed)
+
+model_initializers = {"Gaussian1D": initialize_gaussian1d,
+                      "Const1D": initialize_const1d,
+                      "Linear1D": initialize_linear1d,
+                      "PowerLaw1D": initialize_powerlaw1d,
+                      "Lorentz1D": initialize_lorentz1d,
+                      "Voigt1D": initialize_voigt1d,
+                      }
+
+model_parameters = {"Gaussian1D": ["amplitude", "stddev", "mean"],
+                    "Const1D": ["amplitude"],
+                    "Linear1D": ["slope", "intercept"],
+                    "PowerLaw1D": ["amplitude", "x_0", "alpha"],
+                    "Lorentz1D": ["amplitude", "x_0", "fwhm"],
+                    "Voigt1D": ["x_0", "amplitude_L", "fwhm_L", "fwhm_G"],
+                    }
+
+def initialize_model(model_dict):
+    params = get_params(model_dict)
+    fixed = get_fixed(model_dict)
+    return model_initializers[model_dict["model_type"]](params, fixed)

--- a/jdaviz/configs/default/plugins/model_fitting/initializers.py
+++ b/jdaviz/configs/default/plugins/model_fitting/initializers.py
@@ -1,69 +1,309 @@
-from astropy.modeling import models, powerlaws
-import astropy.units as u
+"""
+This module is used to initialize spectral models to the data at hand.
 
-def get_params(model_dict):
-    return {x["name"]: u.Quantity(x["value"], x["unit"]) for x in model_dict["parameters"]}
+This is used by model-fitting code that has to create spectral model
+instances with sensible parameter values such that they can be used as
+first guesses by the fitting algorithms.
+"""
+import numpy as np
 
-def get_fixed(model_dict):
-    return {x["name"]: x["fixed"] for x in model_dict["parameters"]}
+__all__ = [
+    'initialize'
+]
 
-def initialize_gaussian1d(params, fixed, name):
-    return models.Gaussian1D(amplitude=params["amplitude"],
-                             mean=params["mean"],
-                             stddev=params["stddev"],
-                             name=name,
-                             fixed = fixed)
-
-def initialize_const1d(params, fixed, name):
-    return models.Const1D(amplitude=params["amplitude"],
-                          name=name,
-                          fixed = fixed)
-
-def initialize_linear1d(params, fixed, name):
-    return models.Linear1D(slope=params["slope"],
-                           intercept=params["intercept"],
-                           name=name,
-                           fixed=fixed)
-
-def initialize_powerlaw1d(params, fixed, name):
-    return powerlaws.PowerLaw1D(amplitude=params["amplitude"],
-                                x_0=params["x_0"],
-                                alpha=params["alpha"],
-                                name=name,
-                                fixed=fixed)
-
-def initialize_lorentz1d(params, fixed, name):
-    return models.Lorentz1D(amplitude=params["amplitude"],
-                            x_0=params["x_0"],
-                            fwhm=params["fwhm"],
-                            name=name,
-                            fixed=fixed)
-
-def initialize_voigt1d(params, fixed, name):
-    return models.Voigt1D(x_0=params["x_0"],
-                          amplitude_L=params["amplitude_L"],
-                          fwhm_L=params["fwhm_L"],
-                          fwhm_G=params["fwhm_G"],
-                          name=name,
-                          fixed=fixed)
-
-model_initializers = {"Gaussian1D": initialize_gaussian1d,
-                      "Const1D": initialize_const1d,
-                      "Linear1D": initialize_linear1d,
-                      "PowerLaw1D": initialize_powerlaw1d,
-                      "Lorentz1D": initialize_lorentz1d,
-                      "Voigt1D": initialize_voigt1d,
-                      }
+AMPLITUDE = 'amplitude'
+POSITION  = 'position'
+WIDTH     = 'width'
 
 model_parameters = {"Gaussian1D": ["amplitude", "stddev", "mean"],
-                    "Const1D": ["amplitude"],
-                    "Linear1D": ["slope", "intercept"],
-                    "PowerLaw1D": ["amplitude", "x_0", "alpha"],
-                    "Lorentz1D": ["amplitude", "x_0", "fwhm"],
-                    "Voigt1D": ["x_0", "amplitude_L", "fwhm_L", "fwhm_G"],
-                    }
+                     "Const1D": ["amplitude"],
+                     "Linear1D": ["slope", "intercept"],
+                     "PowerLaw1D": ["amplitude", "x_0", "alpha"],
+                     "Lorentz1D": ["amplitude", "x_0", "fwhm"],
+                     "Voigt1D": ["x_0", "amplitude_L", "fwhm_L", "fwhm_G"],
+                     }
 
-def initialize_model(model_dict):
-    params = get_params(model_dict)
-    fixed = get_fixed(model_dict)
-    return model_initializers[model_dict["model_type"]](params, fixed, model_dict["id"])
+def _get_model_name(model):
+    class_string = str(model.__class__)
+    return class_string.split('\'>')[0].split(".")[-1]
+
+
+class _Linear1DInitializer(object):
+    """
+    Initialization that is specific to the Linear1D model.
+
+    Notes
+    -----
+    In a way, we need this specialized initializer because
+    the linear 1D model is more like a kind of polynomial.
+    It doesn't mesh well with other non-linear models.
+    """
+    def initialize(self, instance, x, y):
+        """
+        Initialize the model
+
+        Parameters
+        ----------
+        instance: `~astropy.modeling.models`
+            The model to initialize.
+
+        x, y: numpy.ndarray
+            The data to use to initialize from.
+
+        Returns
+        -------
+        instance: `~astropy.modeling.models`
+            The initialized model.
+        """
+
+        # y_range = np.max(y) - np.min(y)
+        # x_range = x[-1] - x[0]
+        # slope = y_range / x_range
+        # y0 = y[0]
+
+        y_mean = np.mean(y)
+
+        instance.slope.value = 0.0
+        instance.intercept.value = y_mean.value
+
+        return instance
+
+
+class _WideBand1DInitializer(object):
+    """
+    Initialization that is applicable to all "wide band"
+    models
+
+    A "wide band" model is one that has an amplitude and
+    a position in wavelength space where this amplitude
+    is defined.
+
+    Parameters
+    ----------
+    factor: float
+        The scale factor to apply to the amplitutde
+    """
+    def __init__(self, factor=1.0):
+        self._factor = factor
+
+    def initialize(self, instance, x, y):
+        """
+        Initialize the model
+
+        Parameters
+        ----------
+        instance: `~astropy.modeling.models`
+            The model to initialize.
+
+        x, y: numpy.ndarray
+            The data to use to initialize from.
+
+        Returns
+        -------
+        instance: `~astropy.modeling.models`
+            The initialized model.
+        """
+        y_mean = np.mean(y)
+        x_range = x[-1] - x[0]
+        position = x_range / 2.0 + x[0]
+
+        name = _get_model_name(instance)
+
+        _setattr(instance, name, AMPLITUDE, y_mean * self._factor)
+        _setattr(instance, name, POSITION, position)
+
+        return instance
+
+
+class _LineProfile1DInitializer(object):
+    """
+    Initialization that is applicable to all "line profile"
+    models.
+
+    A "line profile" model is one that has an amplitude, a width,
+    and a defined position in wavelength space.
+
+    Parameters
+    ----------
+    factor: float
+        The scale factor to apply to the amplitutde
+    """
+    def __init__(self, factor=1.0):
+        self._factor = factor
+
+    def _set_width_attribute(self, instance, name, fwhm):
+        """
+        Each line profile class has its own way of naming
+        and defining the width parameter. Subclasses should
+        override this method to conform to the specific
+        definitions.
+
+        Parameters
+        ----------
+        name : str
+            The attribute name
+
+        instance: `~astropy.modeling.models`
+            The model to initialize.
+
+        fwhm : float
+            FWHM
+        """
+        raise NotImplementedError
+
+    def initialize(self, instance, x, y):
+        """
+        Initialize the model
+
+        Parameters
+        ----------
+        instance: `~astropy.modeling.models`
+            The model to initialize.
+
+        x, y: numpy.ndarray
+            The data to use to initialize from.
+
+        Returns
+        -------
+        instance: `~astropy.modeling.models`
+            The initialized model.
+        """
+
+        # X centroid estimates the position
+        centroid = np.sum(x * y) / np.sum(y)
+
+        # width can be estimated by the weighted
+        # 2nd moment of the X coordinate.
+        dx = x - np.mean(x)
+        fwhm = 2 * np.sqrt(np.sum((dx * dx) * y) / np.sum(y))
+
+        # amplitude is derived from area.
+        delta_x = x[1:] - x[:-1]
+        sum_y = np.sum((y[1:] - np.min(y[1:])) * delta_x)
+        height = sum_y / (fwhm / 2.355 * np.sqrt( 2 * np.pi))
+
+        name = _get_model_name(instance)
+
+        _setattr(instance, name, AMPLITUDE, height * self._factor)
+        _setattr(instance, name, POSITION, centroid)
+
+        self._set_width_attribute(instance, name, fwhm)
+
+        return instance
+
+
+class _Width_LineProfile1DInitializer(_LineProfile1DInitializer):
+    def _set_width_attribute(self, instance, name, fwhm):
+        _setattr(instance, name, WIDTH, fwhm)
+
+
+class _Sigma_LineProfile1DInitializer(_LineProfile1DInitializer):
+    def _set_width_attribute(self, instance, name, fwhm):
+        _setattr(instance, name, WIDTH, fwhm / 2.355)
+
+
+def _setattr(instance, mname, pname, value):
+    """
+    Sets parameter value by mapping parameter name to model type.
+
+    Prevents the parameter value setting to be stopped on its tracks
+    by non-existent model names or parameter names.
+
+    Parameters
+    ----------
+    instance: `~astropy.modeling.models`
+        The model to initialize.
+
+    mname: str
+        Model name.
+
+    pname: str
+        Parameter name.
+
+    value: any
+        The value to assign.
+    """
+    # this has to handle both Quantities and plain floats
+    try:
+        setattr(instance, _p_names[mname][pname], value.value)
+    except AttributeError:
+        setattr(instance, _p_names[mname][pname], value)
+    except KeyError:
+        pass
+
+
+# This associates each initializer to its corresponding spectral model.
+# Some models are not really line profiles, but their parameter names
+# and roles are the same as in a typical line profile, so they can be
+# initialized in the same way.
+_initializers = {
+    'Beta1D':                     _WideBand1DInitializer,
+    'Const1D':                    _WideBand1DInitializer,
+    'PowerLaw1D':                 _WideBand1DInitializer,
+    'BrokenPowerLaw1D':           _WideBand1DInitializer,
+    'ExponentialCutoffPowerLaw1D':_WideBand1DInitializer,
+    'LogParabola1D':              _WideBand1DInitializer,
+    'Box1D':                      _Width_LineProfile1DInitializer,
+    'Gaussian1D':                 _Sigma_LineProfile1DInitializer,
+    'Lorentz1D':                  _Width_LineProfile1DInitializer,
+    'Voigt1D':                    _Width_LineProfile1DInitializer,
+    'MexicanHat1D':               _Sigma_LineProfile1DInitializer,
+    'Trapezoid1D':                _Width_LineProfile1DInitializer,
+    'Linear1D':                   _Linear1DInitializer,
+    # 'Spline1D':                   spline.Spline1DInitializer
+}
+
+# Models can have parameter names that are similar amongst them, but not quite the same.
+# This maps the standard names used in the code to the actual names used by astropy.
+_p_names = {
+    'Gaussian1D':                 {AMPLITUDE:'amplitude',  POSITION:'mean', WIDTH:'stddev'},
+    'GaussianAbsorption':         {AMPLITUDE:'amplitude',  POSITION:'mean', WIDTH:'stddev'},
+    'Lorentz1D':                  {AMPLITUDE:'amplitude',  POSITION:'x_0',  WIDTH:'fwhm'},
+    'Voigt1D':                    {AMPLITUDE:'amplitude_L',POSITION:'x_0',  WIDTH:'fwhm_G'},
+    'Box1D':                      {AMPLITUDE:'amplitude',  POSITION:'x_0',  WIDTH:'width'},
+    'MexicanHat1D':               {AMPLITUDE:'amplitude',  POSITION:'x_0',  WIDTH:'sigma'},
+    'Trapezoid1D':                {AMPLITUDE:'amplitude',  POSITION:'x_0',  WIDTH:'width'},
+    'Beta1D':                     {AMPLITUDE:'amplitude',  POSITION:'x_0'},
+    'PowerLaw1D':                 {AMPLITUDE:'amplitude',  POSITION:'x_0'},
+    'ExponentialCutoffPowerLaw1D':{AMPLITUDE:'amplitude',  POSITION:'x_0'},
+    'LogParabola1D':              {AMPLITUDE:'amplitude',  POSITION:'x_0'},
+    'BrokenPowerLaw1D':           {AMPLITUDE:'amplitude',  POSITION:'x_break'},
+    'Const1D':                    {AMPLITUDE:'amplitude'},
+    }
+
+
+def initialize(instance, x, y):
+    """
+    Initialize given model.
+
+    X and Y are for now Quantity arrays with the
+    independent and dependent variables. It's assumed X values
+    are stored in increasing order in the array.
+
+    Parameters
+    ----------
+    instance: `~astropy.modeling.models`
+        The model to initialize.
+
+    x, y: numpy.ndarray
+        The data to use to initialize from.
+
+    Returns
+    -------
+    instance: `~astropy.modeling.models`
+        The initialized model.
+        If there are any errors, the instance is returned
+        uninitialized.
+    """
+    if x is None or y is None:
+        return instance
+
+    name = _get_model_name(instance)
+
+    try:
+        initializer = _initializers[name]()
+
+        return initializer.initialize(instance, x, y)
+
+    except KeyError:
+        return instance

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -57,7 +57,10 @@ class ModelFitting(TemplateMixin):
     def _update_parameters_from_fit(self):
         for m in self.component_models:
             name = m["id"]
-            m_fit = self._fitted_model[name]
+            if len(self.component_models) > 1:
+                m_fit = self._fitted_model[name]
+            else:
+                m_fit = self._fitted_model
             temp_params = []
             for i in range(0, len(m_fit.parameters)):
                 temp_param = [x for x in m["parameters"] if x["name"] ==

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -1,22 +1,20 @@
-import pickle
 import os
-from time import sleep
+import pickle
 
-from glue.core.link_helpers import LinkSame
-from glue.core.message import (DataCollectionAddMessage,
-                               DataCollectionDeleteMessage)
-from traitlets import Bool, Int, List, Dict, Unicode
-import astropy.units as u
 import astropy.modeling.models as models
-from specutils.spectra import Spectrum1D
+import astropy.units as u
+from glue.core.link_helpers import LinkSame
+from glue.core.message import (SubsetCreateMessage,
+                               SubsetDeleteMessage,
+                               SubsetUpdateMessage)
+from traitlets import Bool, Int, List, Unicode
 
-
+from jdaviz.core.events import AddDataMessage, RemoveDataMessage
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import TemplateMixin
 from jdaviz.utils import load_template
-
-from .initializers import initialize, model_parameters
 from .fitting_backend import fit_model_to_spectrum
+from .initializers import initialize, model_parameters
 
 __all__ = ['ModelFitting']
 
@@ -28,6 +26,7 @@ MODELS = {
      'Voigt1D': models.Voigt1D,
      'Lorentz1D': models.Lorentz1D
      }
+
 
 @tray_registry('g-model-fitting', label="Model Fitting")
 class ModelFitting(TemplateMixin):
@@ -64,11 +63,56 @@ class ModelFitting(TemplateMixin):
         self.model_save_path = os.getcwd()
         self.model_label = "Model"
 
-    def _on_data_updated(self, msg):
-        self.dc_items
+        self.hub.subscribe(self, AddDataMessage,
+                           handler=self._on_viewer_data_changed)
+
+        self.hub.subscribe(self, RemoveDataMessage,
+                           handler=self._on_viewer_data_changed)
+
+        self.hub.subscribe(self, SubsetCreateMessage,
+                           handler=lambda x: self._on_viewer_data_changed())
+
+        self.hub.subscribe(self, SubsetDeleteMessage,
+                           handler=lambda x: self._on_viewer_data_changed())
+
+        self.hub.subscribe(self, SubsetUpdateMessage,
+                           handler=lambda x: self._on_viewer_data_changed())
+
+    def _on_viewer_data_changed(self, msg=None):
+        """
+        Callback method for when data is added or removed from a viewer, or
+        when a subset is created, deleted, or updated. This method receieves
+        a glue message containing viewer information in the case of the former
+        set of events, and updates the available data list displayed to the
+        user.
+
+        Notes
+        -----
+        We do not attempt to parse any data at this point, at it can cause
+        visible lag in the application.
+
+        Parameters
+        ----------
+        msg : `glue.core.Message`
+            The glue message passed to this callback method.
+        """
+        self._viewer_id = self.app._viewer_item_by_reference(
+            'spectrum-viewer').get('id')
+
+        # Subsets are global and are not linked to specific viewer instances,
+        # so it's not required that we match any specific ids for that case.
+        # However, if the msg is not none, check to make sure that it's the
+        # viewer we care about.
+        if msg is not None and msg.viewer_id != self._viewer_id:
+            return
+
+        viewer = self.app.get_viewer('spectrum-viewer')
+
+        self.dc_items = [layer_state.layer.label
+                         for layer_state in viewer.state.layers]
 
     def _param_units(self, param, order = 0):
-        '''Helper function to handle units that depend on x and y'''
+        """Helper function to handle units that depend on x and y"""
         y_params = ["amplitude", "amplitude_L", "intercept"]
 
         if param == "slope":
@@ -99,8 +143,8 @@ class ModelFitting(TemplateMixin):
         self.component_models = component_models
 
     def _update_initialized_parameters(self):
-        """If the user changes a parameter value, we need to change it in the
-        initialized model."""
+        # If the user changes a parameter value, we need to change it in the
+        # initialized model
         for m in self.component_models:
             name = m["id"]
             for param in m["parameters"]:
@@ -108,20 +152,35 @@ class ModelFitting(TemplateMixin):
                 setattr(self._initialized_models[name], param["name"],
                         quant_param)
 
-    def vue_populate_data(self, event):
-        """Populated the data list when the model fitting data dropdown is clicked"""
-        self._viewer_spectra = self.app.get_data_from_viewer("spectrum-viewer")
-        self.dc_items = list(self._viewer_spectra.keys())
+    def vue_data_selected(self, event):
+        """
+        Callback method for when the user has selected data from the drop down
+        in the front-end. It is here that we actually parse and create a new
+        data object from the selected data. From this data object, unit
+        information is scraped, and the selected spectrum is stored for later
+        use in fitting.
+
+        Parameters
+        ----------
+        event : str
+            IPyWidget callback event object. In this case, represents the data
+            label of the data collection object selected by the user.
+        """
+        selected_spec = self.app.get_data_from_viewer("spectrum-viewer",
+                                                      data_label=event)
+
         if self._units == {}:
-            self._units["x"] = str(self._viewer_spectra[self.dc_items[0]].spectral_axis.unit)
-            self._units["y"] = str(self._viewer_spectra[self.dc_items[0]].flux.unit)
+            self._units["x"] = str(
+                selected_spec.spectral_axis.unit)
+            self._units["y"] = str(
+                selected_spec.flux.unit)
+
         for label in self.dc_items:
             if label in self.data_collection:
                 self._label_to_link = label
                 break
 
-    def vue_data_selected(self, event):
-        self._spectrum1d = self._viewer_spectra[event]
+        self._spectrum1d = selected_spec
 
     def vue_model_selected(self, event):
         # Add the model selected to the list of models
@@ -132,11 +191,13 @@ class ModelFitting(TemplateMixin):
             self.display_order = False
 
     def _initialize_polynomial(self, new_model):
-        initialized_model = initialize(MODELS[self.temp_model](name=self.temp_name,
-                                                               degree = self.poly_order),
-                                       self._spectrum1d.spectral_axis,
-                                       self._spectrum1d.flux)
+        initialized_model = initialize(
+            MODELS[self.temp_model](name=self.temp_name, degree=self.poly_order),
+            self._spectrum1d.spectral_axis,
+            self._spectrum1d.flux)
+
         self._initialized_models[self.temp_name] = initialized_model
+
         for i in range(self.poly_order + 1):
             param = "c{}".format(i)
             initial_val = getattr(initialized_model, param).value
@@ -155,11 +216,12 @@ class ModelFitting(TemplateMixin):
         if self.temp_model == "Polynomial1D":
             new_model = self._initialize_polynomial(new_model)
         else:
-            # Have a separate private dict with the initialized models, since they
-            # don't play well with JSON for widget interaction
-            initialized_model = initialize(MODELS[self.temp_model](name=self.temp_name),
-                                           self._spectrum1d.spectral_axis,
-                                           self._spectrum1d.flux)
+            # Have a separate private dict with the initialized models, since
+            # they don't play well with JSON for widget interaction
+            initialized_model = initialize(
+                MODELS[self.temp_model](name=self.temp_name),
+                self._spectrum1d.spectral_axis,
+                self._spectrum1d.flux)
 
             self._initialized_models[self.temp_name] = initialized_model
 
@@ -174,7 +236,8 @@ class ModelFitting(TemplateMixin):
         self.component_models = self.component_models + [new_model]
 
     def vue_remove_model(self, event):
-        self.component_models = [x for x in self.component_models if x["id"] != event]
+        self.component_models = [x for x in self.component_models
+                                 if x["id"] != event]
         del(self._initialized_models[event])
 
     def vue_save_model(self, event):
@@ -197,10 +260,11 @@ class ModelFitting(TemplateMixin):
         as such by the user, then update the displauyed parameters with fit
         values
         """
-        fitted_model, fitted_spectrum = fit_model_to_spectrum(self._spectrum1d,
-                                                              self._initialized_models.values(),
-                                                              self.model_equation,
-                                                              run_fitter=True)
+        fitted_model, fitted_spectrum = fit_model_to_spectrum(
+            self._spectrum1d,
+            self._initialized_models.values(),
+            self.model_equation,
+            run_fitter=True)
         self._fitted_model = fitted_model
         self._fitted_spectrum = fitted_spectrum
 
@@ -214,7 +278,8 @@ class ModelFitting(TemplateMixin):
         Add a spectrum to the data collection based on the currently displayed
         parameters (these could be user input or fit values).
         """
-        # Make sure the initialized models are updated with any user-specified parameters
+        # Make sure the initialized models are updated with any user-specified
+        # parameters
         self._update_initialized_parameters()
 
         # Need to run the model fitter with run_fitter=False to get spectrum
@@ -236,8 +301,9 @@ class ModelFitting(TemplateMixin):
             self.data_collection.remove(self.data_collection[label])
         self.data_collection[label] = spectrum
         self.save_enabled = True
-        self.data_collection.add_link(LinkSame(self.data_collection[self._label_to_link].pixel_component_ids[0],
-                                               self.data_collection[label].pixel_component_ids[0]))
+        self.data_collection.add_link(
+            LinkSame(self.data_collection[self._label_to_link].pixel_component_ids[0],
+                     self.data_collection[label].pixel_component_ids[0]))
 
         #sleep(1)
         #self.app.add_data_to_viewer('spectrum-viewer', label)

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -73,8 +73,9 @@ class ModelFitting(TemplateMixin):
         """Populated the data list when the model fitting plugin is opened"""
         self._viewer_spectra = self.app.get_data_from_viewer("spectrum-viewer")
         self.dc_items = list(self._viewer_spectra.keys())
-        self._units["x"] =str(self._viewer_spectra[self.dc_items[0]].spectral_axis.unit)
-        self._units["y"] = str(self._viewer_spectra[self.dc_items[0]].flux.unit)
+        if self._units == {}:
+            self._units["x"] =str(self._viewer_spectra[self.dc_items[0]].spectral_axis.unit)
+            self._units["y"] = str(self._viewer_spectra[self.dc_items[0]].flux.unit)
 
     def vue_data_selected(self, event):
         self._spectrum1d = self._viewer_spectra[event]

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -3,7 +3,7 @@ import pickle
 from glue.core.link_helpers import LinkSame
 from glue.core.message import (DataCollectionAddMessage,
                                DataCollectionDeleteMessage)
-from traitlets import Bool, List, Dict, Unicode
+from traitlets import Bool, Int, List, Dict, Unicode
 import astropy.units as u
 import astropy.modeling.models as models
 from specutils.spectra import Spectrum1D
@@ -40,6 +40,8 @@ class ModelFitting(TemplateMixin):
     model_equation = Unicode().tag(sync=True)
     eq_error = Bool(False).tag(sync=True)
     component_models = List([]).tag(sync=True)
+    display_order = Bool(False).tag(sync=True)
+    poly_order = Int(0).tag(sync=True)
 
     available_models = List(list(MODELS.keys())).tag(sync=True)
 
@@ -53,16 +55,21 @@ class ModelFitting(TemplateMixin):
         self._fitted_spectrum = None
         self.component_models = []
         self._initialized_models = {}
-
-    def _param_units(self, param):
-        '''Helper function to handle units that depend on x and y'''
-        y_params = ["amplitude", "amplitude_L", "intercept"]
-        if param == "slope":
-            return "{}/{}".format(self._units["y"], self._units["x"])
-        return self._units["y"] if param in y_params else self._units["x"]
+        self._display_order = False
 
     def _on_data_updated(self, msg):
-       self.dc_items = [x.label for x in self.data_collection]
+        self.dc_items
+
+    def _param_units(self, param, order = 0):
+        '''Helper function to handle units that depend on x and y'''
+        y_params = ["amplitude", "amplitude_L", "intercept"]
+
+        if param == "slope":
+            return str(u.Unit(self._units["y"]) / u.Unit(self._units["x"]))
+        elif param == "poly":
+            return str(u.Unit(self._units["y"]) / u.Unit(self._units["x"])**order)
+
+        return self._units["y"] if param in y_params else self._units["x"]
 
     def _update_parameters_from_fit(self):
         """Insert the results of the model fit into the component_models"""
@@ -89,7 +96,7 @@ class ModelFitting(TemplateMixin):
         self._viewer_spectra = self.app.get_data_from_viewer("spectrum-viewer")
         self.dc_items = list(self._viewer_spectra.keys())
         if self._units == {}:
-            self._units["x"] =str(self._viewer_spectra[self.dc_items[0]].spectral_axis.unit)
+            self._units["x"] = str(self._viewer_spectra[self.dc_items[0]].spectral_axis.unit)
             self._units["y"] = str(self._viewer_spectra[self.dc_items[0]].flux.unit)
 
     def vue_data_selected(self, event):
@@ -98,25 +105,50 @@ class ModelFitting(TemplateMixin):
     def vue_model_selected(self, event):
         # Add the model selected to the list of models
         self.temp_model = event
+        if event == "Polynomial1D":
+            self.display_order = True
+        else:
+            self.display_order = False
+
+    def _initialize_polynomial(self, new_model):
+        initialized_model = initialize(MODELS[self.temp_model](name=self.temp_name,
+                                                               degree = self.poly_order),
+                                       self._spectrum1d.spectral_axis,
+                                       self._spectrum1d.flux)
+        self._initialized_models[self.temp_name] = initialized_model
+        for i in range(self.poly_order + 1):
+            param = "c{}".format(i)
+            initial_val = getattr(initialized_model, param).value
+            new_model["parameters"].append({"name": param,
+                                            "value": initial_val,
+                                            "unit": self._param_units("poly", i),
+                                            "fixed": False})
+        return new_model
 
     def vue_add_model(self, event):
         """Add the selected model and input string ID to the list of models"""
         new_model = {"id": self.temp_name, "model_type": self.temp_model,
                      "parameters": []}
-        # Have a separate private dict with the initialized models, since they
-        # don't play well with JSON for widget interaction
-        initialized_model = initialize(MODELS[self.temp_model](name=self.temp_name),
-                                        self._spectrum1d.spectral_axis,
-                                        self._spectrum1d.flux)
 
-        self._initialized_models[self.temp_name] = initialized_model
+        # Need to do things differently for polynomials, since the order varies
+        if self.temp_model == "Polynomial1D":
+            new_model = self._initialize_polynomial(new_model)
+        else:
+            # Have a separate private dict with the initialized models, since they
+            # don't play well with JSON for widget interaction
+            initialized_model = initialize(MODELS[self.temp_model](name=self.temp_name),
+                                           self._spectrum1d.spectral_axis,
+                                           self._spectrum1d.flux)
 
-        for param in model_parameters[new_model["model_type"]]:
-            initial_val = getattr(initialized_model, param).value
-            new_model["parameters"].append({"name": param,
-                                            "value": initial_val,
-                                            "unit": self._param_units(param),
-                                            "fixed": False})
+            self._initialized_models[self.temp_name] = initialized_model
+
+            for param in model_parameters[new_model["model_type"]]:
+                initial_val = getattr(initialized_model, param).value
+                new_model["parameters"].append({"name": param,
+                                                "value": initial_val,
+                                                "unit": self._param_units(param),
+                                                "fixed": False})
+
         self.component_models = self.component_models + [new_model]
 
     def vue_remove_model(self, event):

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -14,19 +14,19 @@ from .fitting_backend import fit_model_to_spectrum
 __all__ = ['ModelFitting']
 
 def get_params(model_dict):
-    return {x.name: u.Quantity(x.value, x.unit) for x in model_dict.parameters}
+    return {x["name"]: u.Quantity(x["value"], x["unit"]) for x in model_dict["parameters"]}
 
 def initialize_gaussian1d(model_dict):
     params = get_params(model_dict)
     return models.Gaussian1D(amplitude=params["amplitude"],
                              mean=params["mean"],
                              stddev=params["stddev"],
-                             name=model_dict["name"])
+                             name=model_dict["id"])
 
 def initialize_const1d(model_dict):
     params = get_params(model_dict)
     return models.Const1D(amplitude=params["amplitude"],
-                          name=model_dict["name"])
+                          name=model_dict["id"])
 
 model_initializers = {"Gaussian1D": initialize_gaussian1d,
                       "Const1D": initialize_const1d}
@@ -101,6 +101,6 @@ class ModelFitting(TemplateMixin):
 
     def vue_model_fitting(self, *args, **kwargs):
         # This will be where the model fitting code is run
-        self.component_models = [model_initializers[x.model_type](x) for x in self.compenent_models]
-        fit_model_to_spectrum(self._selected_data, self.component_models, self.model_equation
+        self.component_models = [model_initializers[x["model_type"]](x) for x in self.component_models]
+        fit_model_to_spectrum(self._selected_data, self.component_models, self.model_equation)
         self.dialog = False

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -50,6 +50,8 @@ class ModelFitting(TemplateMixin):
     template = load_template("model_fitting.vue", __file__).tag(sync=True)
     dc_items = List([]).tag(sync=True)
 
+    save_enabled = Bool(False).tag(sync=True)
+    model_savename = Unicode("fitted_model.pkl").tag(sync=True)
     temp_name = Unicode().tag(sync=True)
     temp_model = Unicode().tag(sync=True)
     model_equation = Unicode().tag(sync=True)
@@ -105,7 +107,7 @@ class ModelFitting(TemplateMixin):
         self.component_models = [x for x in self.component_models if x["id"] != event]
 
     def vue_save_model(self, event):
-        with open('fitted_model.pkl', 'wb') as f:
+        with open(self.model_savename, 'wb') as f:
             pickle.dump(self._fitted_model, f)
 
     def vue_equation_changed(self, event):
@@ -122,4 +124,4 @@ class ModelFitting(TemplateMixin):
         self._fitted_model = fitted_model
         self._fitted_spectrum = fitted_spectrum
         self.data_collection["Model fit"] = self._fitted_spectrum
-        self.dialog = False
+        self.save_enabled = True

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -61,6 +61,8 @@ class ModelFitting(TemplateMixin):
         self._initialized_models = {}
         self._display_order = False
         self._label_to_link = ""
+        self.model_save_path = os.getcwd()
+        self.model_label = "Model"
 
     def _on_data_updated(self, msg):
         self.dc_items

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -16,17 +16,24 @@ __all__ = ['ModelFitting']
 def get_params(model_dict):
     return {x["name"]: u.Quantity(x["value"], x["unit"]) for x in model_dict["parameters"]}
 
+def get_fixed(model_dict):
+    return {x["name"]: x["fixed"] for x in model_dict["parameters"]}
+
 def initialize_gaussian1d(model_dict):
     params = get_params(model_dict)
+    fixed = get_fixed(model_dict)
     return models.Gaussian1D(amplitude=params["amplitude"],
                              mean=params["mean"],
                              stddev=params["stddev"],
-                             name=model_dict["id"])
+                             name=model_dict["id"],
+                             fixed = fixed)
 
 def initialize_const1d(model_dict):
     params = get_params(model_dict)
+    fixed = get_fixed(model_dict)
     return models.Const1D(amplitude=params["amplitude"],
-                          name=model_dict["id"])
+                          name=model_dict["id"],
+                          fixed = fixed)
 
 model_initializers = {"Gaussian1D": initialize_gaussian1d,
                       "Const1D": initialize_const1d}
@@ -68,17 +75,7 @@ class ModelFitting(TemplateMixin):
         self._param_units = {"amplitude": "1E-17 erg/s/cm^2/Angstrom/spaxel",
                              "stddev": "m",
                              "mean": "m"}
-        self.component_models = [{"id": "Ex1",
-                                  "model_type": "Gaussian1D",
-                                  "parameters": [
-                                        {"name": "stddev", "value": 1,
-                                         "unit": "Angstrom", "fixed": False},
-                                        {"name": "mean", "value": 5,
-                                         "unit": "Angstrom", "fixed": False},
-                                        {"name": "amp", "value": 10,
-                                         "unit": "Jy", "fixed": False}
-                                        ]
-                                  }]
+        self.component_models = []
 
     def _on_data_updated(self, msg):
        self.dc_items = [x.label for x in self.data_collection]

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -95,10 +95,14 @@ class ModelFitting(TemplateMixin):
         self.component_models = []
         self.component_models = component_models
 
-    def vue_parameter_updated(self, event):
+    def _update_initialized_parameters(self):
         """If the user changes a parameter value, we need to change it in the
         initialized model."""
-        pass
+        for m in self.component_models:
+            name = m["id"]
+            for param in m["parameters"]:
+                setattr(self._initialized_models[name], param["name"],
+                        param["value"])
 
     def vue_populate_data(self, event):
         """Populated the data list when the model fitting data dropdown is clicked"""
@@ -162,6 +166,7 @@ class ModelFitting(TemplateMixin):
                                                 "unit": self._param_units(param),
                                                 "fixed": False})
 
+        new_model["Initialized"] = True
         self.component_models = self.component_models + [new_model]
 
     def vue_remove_model(self, event):
@@ -205,6 +210,9 @@ class ModelFitting(TemplateMixin):
         Add a spectrum to the data collection based on the currently displayed
         parameters (these could be user input or fit values).
         """
+        # Make sure the initialized models are updated with any user-specified parameters
+        self._update_initialized_parameters()
+
         # Need to run the model fitter with run_fitter=False to get spectrum
         model, spectrum = fit_model_to_spectrum(self._spectrum1d,
                                                 self._initialized_models.values(),

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -10,10 +10,10 @@ from .fitting_backend import fit_model_to_spectrum
 
 __all__ = ['ModelFitting']
 
-def initialize_gaussian1d():
+def initialize_gaussian1d(model_dict):
     pass
 
-def initialize_const1d():
+def initialize_const1d(model_dict):
     pass
 
 model_initializers = {"Gaussian1D": initialize_gaussian1d,
@@ -30,7 +30,10 @@ class ModelFitting(TemplateMixin):
 
     temp_name = Unicode().tag(sync=True)
     temp_model = Unicode().tag(sync=True)
+    model_equation = Unicode().tag(sync=True)
+    eq_error = Bool(False).tag(sync=True)
     component_models = List([]).tag(sync=True)
+
 
     # Hard coding this for now, but will want to pull from a config file
     available_models = List(["Gaussian1D", "Const1D"]).tag(sync=True)
@@ -79,6 +82,13 @@ class ModelFitting(TemplateMixin):
     def vue_remove_model(self, event):
         self.component_models = [x for x in self.component_models if x["id"] != event]
 
+    def vue_equation_changed(self, event):
+        # Length is a dummy check to test the infrastructure
+        if len(self.model_equation) > 6:
+            self.eq_error = True
+
     def vue_model_fitting(self, *args, **kwargs):
         # This will be where the model fitting code is run
+        self.component_models = [model_initializers[x.model_type](x) for x in self.compenent_models]
+        fit_model_to_spectrum(self._selected_data, self.component_models, self.model_equation
         self.dialog = False

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -57,6 +57,7 @@ class ModelFitting(TemplateMixin):
         self.component_models = []
         self._initialized_models = {}
         self._display_order = False
+        self._label_to_link = ""
 
     def _on_data_updated(self, msg):
         self.dc_items
@@ -99,6 +100,10 @@ class ModelFitting(TemplateMixin):
         if self._units == {}:
             self._units["x"] = str(self._viewer_spectra[self.dc_items[0]].spectral_axis.unit)
             self._units["y"] = str(self._viewer_spectra[self.dc_items[0]].flux.unit)
+        for label in self.dc_items:
+            if label in self.data_collection:
+                self._label_to_link = label
+                break
 
     def vue_data_selected(self, event):
         self._spectrum1d = self._viewer_spectra[event]
@@ -177,7 +182,12 @@ class ModelFitting(TemplateMixin):
         self._fitted_model = fitted_model
         self._fitted_spectrum = fitted_spectrum
         self.n_models += 1
-        self.data_collection["Model fit {}".format(self.n_models)] = self._fitted_spectrum
+        label = "Model fit {}".format(self.n_models)
+        self.data_collection[label] = self._fitted_spectrum
+
+        # Link data to enable overplotting
+        self.data_collection.add_link(LinkSame(self.data_collection[self._label_to_link].pixel_component_ids[0],
+                                               self.data_collection[label].pixel_component_ids[0]))
 
         # Update component model parameters with fitted values
         self._update_parameters_from_fit()

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -42,13 +42,10 @@ class ModelFitting(TemplateMixin):
         self.hub.subscribe(self, DataCollectionDeleteMessage,
                           handler=self._on_data_updated)
 
-        self._selected_data = None
+        self._viewer_spectra = None
         self._spectrum1d = None
         self._fitted_model = None
         self._fitted_spectrum = None
-        # Hard coding this for initial testing, want to populate based on
-        # selected data
-        self._units = {"x": "m", "y": "1E-17 erg/s/cm^2/Angstrom/spaxel"}
         self.component_models = []
 
     def _param_units(self, param):
@@ -73,10 +70,15 @@ class ModelFitting(TemplateMixin):
                 temp_params += temp_param
             m["parameters"] = temp_params
 
+    def vue_dialog_open(self, event):
+        """Populated the data list when the model fitting plugin is opened"""
+        self._viewer_data = self.app.get_data_from_viewer("spectrum-viewer")
+        self.dc_items = list(self._viewer_data.keys())
+        self.units["x"] =str(self.viewer_data[self.dc_items[0]].spectral_axis.unit)
+        self.units["y"] = str(self.viewer_data[self.dc_items[0]].flux.unit)
+
     def vue_data_selected(self, event):
-        self._selected_data = next((x for x in self.data_collection
-                                    if x.label == event))
-        self._spectrum1d = self._selected_data.get_object(cls=Spectrum1D)
+        self._spectrum1d = self._viewer_spectra[event]
 
     def vue_model_selected(self, event):
         # Add the model selected to the list of models

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -1,6 +1,6 @@
 from glue.core.message import (DataCollectionAddMessage,
                                DataCollectionDeleteMessage)
-from traitlets import Bool, List
+from traitlets import Bool, List, Dict, Unicode
 
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import TemplateMixin
@@ -10,15 +10,26 @@ from .fitting_backend import fit_model_to_spectrum
 
 __all__ = ['ModelFitting']
 
+def initialize_gaussian1d():
+    pass
+
+def initialize_const1d():
+    pass
+
+model_initializers = {"Gaussian1D": initialize_gaussian1d,
+                      "Const1D": initialize_const1d}
+
+model_parameters = {"Gaussian1D": [],
+                    "Const1D": []}
 
 @tray_registry('g-model-fitting')
 class ModelFitting(TemplateMixin):
     dialog = Bool(False).tag(sync=True)
     template = load_template("model_fitting.vue", __file__).tag(sync=True)
     dc_items = List([]).tag(sync=True)
+    temp_name = Unicode().tag(sync=True)
     # Hard coding this for now, but will want to pull from a config file
     available_models = List(["Gaussian1D", "Const1D"]).tag(sync=True)
-
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -26,16 +37,26 @@ class ModelFitting(TemplateMixin):
         self.hub.subscribe(self, DataCollectionAddMessage,
                            handler=self._on_data_updated)
         self.hub.subscribe(self, DataCollectionDeleteMessage,
-                           handler=self._on_data_updated)
+                          handler=self._on_data_updated)
 
         self._selected_data = None
+        self._selected_models = Dict({}).tag(sync=True)
 
     def _on_data_updated(self, msg):
-        self.dc_items = [x.label for x in self.data_collection]
+       self.dc_items = [x.label for x in self.data_collection]
 
     def vue_data_selected(self, event):
         self._selected_data = next((x for x in self.data_collection
                                     if x.label == event))
+
+    def vue_model_selected(self, event):
+        # Add the model selected to the list of models
+        #self._selected_models[event.name] = {"model_type" = event.model}
+        pass
+
+    def vue_add_model(self, event):
+        # Add the selected model and input string ID to the list of models
+        pass
 
     def vue_model_fitting(self, *args, **kwargs):
         # This will be where the model fitting code is run

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -103,7 +103,7 @@ class ModelFitting(TemplateMixin):
 
     def vue_equation_changed(self, event):
         # Length is a dummy check to test the infrastructure
-        if len(self.model_equation) > 6:
+        if len(self.model_equation) > 20:
             self.eq_error = True
 
     def vue_model_fitting(self, *args, **kwargs):
@@ -111,7 +111,8 @@ class ModelFitting(TemplateMixin):
         initialized_models = [initialize_model(x) for x in self.component_models]
         fitted_model, fitted_spectrum = fit_model_to_spectrum(self._spectrum1d,
                                                               initialized_models,
-                                                              self.model_equation)
+                                                              self.model_equation,
+                                                              run_fitter=True)
         self._fitted_model = fitted_model
         self._fitted_spectrum = fitted_spectrum
         self.data_collection["Model fit"] = self._fitted_spectrum

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -1,9 +1,12 @@
+import pickle
+
 from glue.core.message import (DataCollectionAddMessage,
                                DataCollectionDeleteMessage)
 from traitlets import Bool, List, Dict, Unicode
 import astropy.units as u
 import astropy.modeling.models as models
 from specutils.spectra import Spectrum1D
+
 
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import TemplateMixin
@@ -100,6 +103,10 @@ class ModelFitting(TemplateMixin):
 
     def vue_remove_model(self, event):
         self.component_models = [x for x in self.component_models if x["id"] != event]
+
+    def vue_save_model(self):
+        with open('fitted_model.pkl', 'w') as f:
+            pickle.dump(self._fitted_model, f)
 
     def vue_equation_changed(self, event):
         # Length is a dummy check to test the infrastructure

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -54,7 +54,6 @@ class ModelFitting(TemplateMixin):
     eq_error = Bool(False).tag(sync=True)
     component_models = List([]).tag(sync=True)
 
-
     # Hard coding this for now, but will want to pull from a config file
     available_models = List(["Gaussian1D", "Const1D"]).tag(sync=True)
 
@@ -115,4 +114,5 @@ class ModelFitting(TemplateMixin):
                                                               self.model_equation)
         self._fitted_model = fitted_model
         self._fitted_spectrum = fitted_spectrum
+        self.data_collection["Model fit"] = self._fitted_spectrum
         self.dialog = False

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -101,6 +101,8 @@ class ModelFitting(TemplateMixin):
 
     def vue_model_fitting(self, *args, **kwargs):
         # This will be where the model fitting code is run
-        self.component_models = [model_initializers[x["model_type"]](x) for x in self.component_models]
-        fit_model_to_spectrum(self._selected_data, self.component_models, self.model_equation)
+        initialized_models = [model_initializers[x["model_type"]](x) for x in self.component_models]
+        spec = self._selected_data.get_object(cls=Spectrum1D)
+        print(spec)
+        fit_model_to_spectrum(spec, initialized_models, self.model_equation)
         self.dialog = False

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -27,7 +27,11 @@ class ModelFitting(TemplateMixin):
     dialog = Bool(False).tag(sync=True)
     template = load_template("model_fitting.vue", __file__).tag(sync=True)
     dc_items = List([]).tag(sync=True)
+
     temp_name = Unicode().tag(sync=True)
+    temp_model = Unicode().tag(sync=True)
+    component_models = List([]).tag(sync=True)
+
     # Hard coding this for now, but will want to pull from a config file
     available_models = List(["Gaussian1D", "Const1D"]).tag(sync=True)
 
@@ -40,7 +44,7 @@ class ModelFitting(TemplateMixin):
                           handler=self._on_data_updated)
 
         self._selected_data = None
-        self._selected_models = Dict({}).tag(sync=True)
+        self.component_models = [{"id": "Example", "model_type": "Gaussian1D"}]
 
     def _on_data_updated(self, msg):
        self.dc_items = [x.label for x in self.data_collection]
@@ -51,12 +55,11 @@ class ModelFitting(TemplateMixin):
 
     def vue_model_selected(self, event):
         # Add the model selected to the list of models
-        #self._selected_models[event.name] = {"model_type" = event.model}
-        pass
+        self.temp_model = event
 
     def vue_add_model(self, event):
         # Add the selected model and input string ID to the list of models
-        pass
+        self.component_models.append({"id": self.temp_name, "model_type": self.temp_model})
 
     def vue_model_fitting(self, *args, **kwargs):
         # This will be where the model fitting code is run

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -1,5 +1,6 @@
 import pickle
 import os
+from time import sleep
 
 from glue.core.link_helpers import LinkSame
 from glue.core.message import (DataCollectionAddMessage,
@@ -221,8 +222,19 @@ class ModelFitting(TemplateMixin):
         self.n_models += 1
         label = self.model_label
         if label in self.data_collection:
-            self.data_collection.remove(label)
+            self.app.remove_data_from_viewer('spectrum-viewer', label)
+            # Some hacky code to remove the label from the data dropdown
+            temp_items = []
+            for data_item in self.app.state.data_items:
+                if data_item['name'] != label:
+                    temp_items.append(data_item)
+            self.app.state.data_items = temp_items
+            # Remove the actual Glue data object from the data_collection
+            self.data_collection.remove(self.data_collection[label])
         self.data_collection[label] = spectrum
         self.save_enabled = True
         self.data_collection.add_link(LinkSame(self.data_collection[self._label_to_link].pixel_component_ids[0],
                                                self.data_collection[label].pixel_component_ids[0]))
+
+        #sleep(1)
+        #self.app.add_data_to_viewer('spectrum-viewer', label)

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -104,8 +104,8 @@ class ModelFitting(TemplateMixin):
     def vue_remove_model(self, event):
         self.component_models = [x for x in self.component_models if x["id"] != event]
 
-    def vue_save_model(self):
-        with open('fitted_model.pkl', 'w') as f:
+    def vue_save_model(self, event):
+        with open('fitted_model.pkl', 'wb') as f:
             pickle.dump(self._fitted_model, f)
 
     def vue_equation_changed(self, event):

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -44,7 +44,13 @@ class ModelFitting(TemplateMixin):
                           handler=self._on_data_updated)
 
         self._selected_data = None
-        self.component_models = [{"id": "Example", "model_type": "Gaussian1D"}]
+        self.component_models = [{"id": "Example", "model_type": "Gaussian1D",
+                                  "parameters": [
+                                                {"name": "stddev", "value": 1},
+                                                {"name": "mean", "value": 5},
+                                                {"name": "amp", "value": 10}
+                                                ]
+                                  }]
 
     def _on_data_updated(self, msg):
        self.dc_items = [x.label for x in self.data_collection]

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -19,8 +19,8 @@ def initialize_const1d():
 model_initializers = {"Gaussian1D": initialize_gaussian1d,
                       "Const1D": initialize_const1d}
 
-model_parameters = {"Gaussian1D": [],
-                    "Const1D": []}
+model_parameters = {"Gaussian1D": ["amplitude", "stddev", "mean"],
+                    "Const1D": ["amplitude"]}
 
 @tray_registry('g-model-fitting')
 class ModelFitting(TemplateMixin):
@@ -44,7 +44,8 @@ class ModelFitting(TemplateMixin):
                           handler=self._on_data_updated)
 
         self._selected_data = None
-        self.component_models = [{"id": "Example", "model_type": "Gaussian1D",
+        self.component_models = [{"id": "Example",
+                                  "model_type": "Gaussian1D",
                                   "parameters": [
                                                 {"name": "stddev", "value": 1},
                                                 {"name": "mean", "value": 5},
@@ -65,7 +66,12 @@ class ModelFitting(TemplateMixin):
 
     def vue_add_model(self, event):
         # Add the selected model and input string ID to the list of models
-        self.component_models.append({"id": self.temp_name, "model_type": self.temp_model})
+        new_model = {"id": self.temp_name, "model_type": self.temp_model,
+                     "parameters": []}
+        for param in model_parameters[new_model["model_type"]]:
+            new_model["parameters"][param] = None
+        self.component_models.append(new_model)
+
 
     def vue_model_fitting(self, *args, **kwargs):
         # This will be where the model fitting code is run

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -49,8 +49,14 @@ class ModelFitting(TemplateMixin):
         # Hard coding this for initial testing, want to populate based on
         # selected data
         self._units = {"x": "m", "y": "1E-17 erg/s/cm^2/Angstrom/spaxel"}
-        self._y_params = ["amplitude", "amplitude_L", "intercept"]
         self.component_models = []
+
+    def _param_units(self, param):
+        '''Helper function to handle units that depend on x and y'''
+        y_params = ["amplitude", "amplitude_L", "intercept"]
+        if param == "slope":
+            return "{}/{}".format(self._units["y"], self._units["x"])
+        return self._units["y"] if param in y_params else self._units["x"]
 
     def _on_data_updated(self, msg):
        self.dc_items = [x.label for x in self.data_collection]
@@ -82,8 +88,7 @@ class ModelFitting(TemplateMixin):
                      "parameters": []}
         for param in model_parameters[new_model["model_type"]]:
             new_model["parameters"].append({"name": param, "value": None,
-                                            "unit": self._units["y"] if param in
-                                                    self._y_params else self._units["x"],
+                                            "unit": self._param_units(param),
                                             "fixed": False})
         self.component_models = self.component_models + [new_model]
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -47,10 +47,13 @@ class ModelFitting(TemplateMixin):
         self.component_models = [{"id": "Ex1",
                                   "model_type": "Gaussian1D",
                                   "parameters": [
-                                                {"name": "stddev", "value": 1},
-                                                {"name": "mean", "value": 5},
-                                                {"name": "amp", "value": 10}
-                                                ]
+                                        {"name": "stddev", "value": 1,
+                                         "unit": "u.AA", "fixed": False},
+                                        {"name": "mean", "value": 5,
+                                         "unit": "u.AA", "fixed": False},
+                                        {"name": "amp", "value": 10,
+                                         "unit": "u.AA", "fixed": False}
+                                        ]
                                   }]
 
     def _on_data_updated(self, msg):
@@ -69,9 +72,12 @@ class ModelFitting(TemplateMixin):
         new_model = {"id": self.temp_name, "model_type": self.temp_model,
                      "parameters": []}
         for param in model_parameters[new_model["model_type"]]:
-            new_model["parameters"].append({"name": param, "value": None})
+            new_model["parameters"].append({"name": param, "value": None,
+                                            "unit": None, "fixed": False})
         self.component_models = self.component_models + [new_model]
 
+    def vue_remove_model(self, event):
+        self.component_models = [x for x in self.component_models if x["id"] != event]
 
     def vue_model_fitting(self, *args, **kwargs):
         # This will be where the model fitting code is run

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -57,7 +57,7 @@ class ModelFitting(TemplateMixin):
        self.dc_items = [x.label for x in self.data_collection]
 
     def vue_data_selected(self, event):
-        self._selected_data = next((x for x in self.data_collection
+        self._selected_data = next((x for x in self.dc_items
                                     if x.label == event))
 
     def vue_model_selected(self, event):
@@ -69,7 +69,7 @@ class ModelFitting(TemplateMixin):
         new_model = {"id": self.temp_name, "model_type": self.temp_model,
                      "parameters": []}
         for param in model_parameters[new_model["model_type"]]:
-            new_model["parameters"][param] = None
+            new_model["parameters"].append({"name": param, "value": None})
         self.component_models.append(new_model)
 
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -29,12 +29,10 @@ class ModelFitting(TemplateMixin):
     temp_name = Unicode().tag(sync=True)
     temp_model = Unicode().tag(sync=True)
     model_equation = Unicode().tag(sync=True)
-    param_units = Dict({}).tag(sync=True)
     eq_error = Bool(False).tag(sync=True)
     component_models = List([]).tag(sync=True)
 
-    # Hard coding this for now, but will want to pull from a config file
-    available_models = List(["Gaussian1D", "Const1D"]).tag(sync=True)
+    available_models = List(list(model_parameters.keys())).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -50,9 +48,8 @@ class ModelFitting(TemplateMixin):
         self._fitted_spectrum = None
         # Hard coding this for initial testing, want to populate based on
         # selected data
-        self._param_units = {"amplitude": "1E-17 erg/s/cm^2/Angstrom/spaxel",
-                             "stddev": "m",
-                             "mean": "m"}
+        self._units = {"x": "m", "y": "1E-17 erg/s/cm^2/Angstrom/spaxel"}
+        self._y_params = ["amplitude", "amplitude_L", "intercept"]
         self.component_models = []
 
     def _on_data_updated(self, msg):
@@ -85,7 +82,8 @@ class ModelFitting(TemplateMixin):
                      "parameters": []}
         for param in model_parameters[new_model["model_type"]]:
             new_model["parameters"].append({"name": param, "value": None,
-                                            "unit": self._param_units[param],
+                                            "unit": self._units["y"] if param in
+                                                    self._y_params else self._units["x"],
                                             "fixed": False})
         self.component_models = self.component_models + [new_model]
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -44,7 +44,7 @@ class ModelFitting(TemplateMixin):
                           handler=self._on_data_updated)
 
         self._selected_data = None
-        self.component_models = [{"id": "Example",
+        self.component_models = [{"id": "Ex1",
                                   "model_type": "Gaussian1D",
                                   "parameters": [
                                                 {"name": "stddev", "value": 1},
@@ -57,7 +57,7 @@ class ModelFitting(TemplateMixin):
        self.dc_items = [x.label for x in self.data_collection]
 
     def vue_data_selected(self, event):
-        self._selected_data = next((x for x in self.dc_items
+        self._selected_data = next((x for x in self.data_collection
                                     if x.label == event))
 
     def vue_model_selected(self, event):
@@ -70,7 +70,7 @@ class ModelFitting(TemplateMixin):
                      "parameters": []}
         for param in model_parameters[new_model["model_type"]]:
             new_model["parameters"].append({"name": param, "value": None})
-        self.component_models.append(new_model)
+        self.component_models = self.component_models + [new_model]
 
 
     def vue_model_fitting(self, *args, **kwargs):

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -1,13 +1,42 @@
+from glue.core.message import (DataCollectionAddMessage,
+                               DataCollectionDeleteMessage)
+from traitlets import Bool, List
+
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import TemplateMixin
 from jdaviz.utils import load_template
+
+from .fitting_backend import fit_model_to_spectrum
 
 __all__ = ['ModelFitting']
 
 
 @tray_registry('g-model-fitting')
 class ModelFitting(TemplateMixin):
+    dialog = Bool(False).tag(sync=True)
     template = load_template("model_fitting.vue", __file__).tag(sync=True)
+    dc_items = List([]).tag(sync=True)
+    # Hard coding this for now, but will want to pull from a config file
+    available_models = List(["Gaussian1D", "Const1D"]).tag(sync=True)
+
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        self.hub.subscribe(self, DataCollectionAddMessage,
+                           handler=self._on_data_updated)
+        self.hub.subscribe(self, DataCollectionDeleteMessage,
+                           handler=self._on_data_updated)
+
+        self._selected_data = None
+
+    def _on_data_updated(self, msg):
+        self.dc_items = [x.label for x in self.data_collection]
+
+    def vue_data_selected(self, event):
+        self._selected_data = next((x for x in self.data_collection
+                                    if x.label == event))
+
+    def vue_model_fitting(self, *args, **kwargs):
+        # This will be where the model fitting code is run
+        self.dialog = False

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -60,6 +60,9 @@ class ModelFitting(TemplateMixin):
                           handler=self._on_data_updated)
 
         self._selected_data = None
+        self._spectrum1d = None
+        self._fitted_model = None
+        self._fitted_spectrum = None
         # Hard coding this for initial testing, want to populate based on
         # selected data
         self._param_units = {"amplitude": "1E-17 erg/s/cm^2/Angstrom/spaxel",
@@ -83,7 +86,7 @@ class ModelFitting(TemplateMixin):
     def vue_data_selected(self, event):
         self._selected_data = next((x for x in self.data_collection
                                     if x.label == event))
-        self.spectrum1d = self._selected_data.get_object(cls=Spectrum1D)
+        self._spectrum1d = self._selected_data.get_object(cls=Spectrum1D)
 
     def vue_model_selected(self, event):
         # Add the model selected to the list of models
@@ -110,5 +113,9 @@ class ModelFitting(TemplateMixin):
     def vue_model_fitting(self, *args, **kwargs):
         # This will be where the model fitting code is run
         initialized_models = [model_initializers[x["model_type"]](x) for x in self.component_models]
-        fit_model_to_spectrum(self.spectrum1d, initialized_models, self.model_equation)
+        fitted_model, fitted_spectrum = fit_model_to_spectrum(self._spectrum1d,
+                                                              initialized_models,
+                                                              self.model_equation)
+        self._fitted_model = fitted_model
+        self._fitted_spectrum = fitted_spectrum
         self.dialog = False

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -1,5 +1,6 @@
 import pickle
 
+from glue.core.link_helpers import LinkSame
 from glue.core.message import (DataCollectionAddMessage,
                                DataCollectionDeleteMessage)
 from traitlets import Bool, List, Dict, Unicode
@@ -68,6 +69,10 @@ class ModelFitting(TemplateMixin):
                 temp_param[0]["value"] = m_fit.parameters[i]
                 temp_params += temp_param
             m["parameters"] = temp_params
+        # Trick traitlets into updating the displayed values
+        component_models = self.component_models
+        self.component_models = []
+        self.component_models = component_models
 
     def vue_dialog_open(self, event):
         """Populated the data list when the model fitting plugin is opened"""
@@ -116,6 +121,7 @@ class ModelFitting(TemplateMixin):
         self._fitted_model = fitted_model
         self._fitted_spectrum = fitted_spectrum
         self.data_collection["Model fit"] = self._fitted_spectrum
+
         # Update component model parameters with fitted values
         self._update_parameters_from_fit()
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -37,13 +37,9 @@ class ModelFitting(TemplateMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.hub.subscribe(self, DataCollectionAddMessage,
-                           handler=self._on_data_updated)
-        self.hub.subscribe(self, DataCollectionDeleteMessage,
-                          handler=self._on_data_updated)
-
         self._viewer_spectra = None
         self._spectrum1d = None
+        self._units = {}
         self._fitted_model = None
         self._fitted_spectrum = None
         self.component_models = []
@@ -72,10 +68,10 @@ class ModelFitting(TemplateMixin):
 
     def vue_dialog_open(self, event):
         """Populated the data list when the model fitting plugin is opened"""
-        self._viewer_data = self.app.get_data_from_viewer("spectrum-viewer")
-        self.dc_items = list(self._viewer_data.keys())
-        self.units["x"] =str(self.viewer_data[self.dc_items[0]].spectral_axis.unit)
-        self.units["y"] = str(self.viewer_data[self.dc_items[0]].flux.unit)
+        self._viewer_spectra = self.app.get_data_from_viewer("spectrum-viewer")
+        self.dc_items = list(self._viewer_spectra.keys())
+        self._units["x"] =str(self._viewer_spectra[self.dc_items[0]].spectral_axis.unit)
+        self._units["y"] = str(self._viewer_spectra[self.dc_items[0]].flux.unit)
 
     def vue_data_selected(self, event):
         self._spectrum1d = self._viewer_spectra[event]

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -1,6 +1,9 @@
 from glue.core.message import (DataCollectionAddMessage,
                                DataCollectionDeleteMessage)
 from traitlets import Bool, List, Dict, Unicode
+import astropy.units as u
+import astropy.modeling.models as models
+from specutils.spectra import Spectrum1D
 
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import TemplateMixin
@@ -10,11 +13,20 @@ from .fitting_backend import fit_model_to_spectrum
 
 __all__ = ['ModelFitting']
 
+def get_params(model_dict):
+    return {x.name: u.Quantity(x.value, x.unit) for x in model_dict.parameters}
+
 def initialize_gaussian1d(model_dict):
-    pass
+    params = get_params(model_dict)
+    return models.Gaussian1D(amplitude=params["amplitude"],
+                             mean=params["mean"],
+                             stddev=params["stddev"],
+                             name=model_dict["name"])
 
 def initialize_const1d(model_dict):
-    pass
+    params = get_params(model_dict)
+    return models.Const1D(amplitude=params["amplitude"],
+                          name=model_dict["name"])
 
 model_initializers = {"Gaussian1D": initialize_gaussian1d,
                       "Const1D": initialize_const1d}
@@ -51,11 +63,11 @@ class ModelFitting(TemplateMixin):
                                   "model_type": "Gaussian1D",
                                   "parameters": [
                                         {"name": "stddev", "value": 1,
-                                         "unit": "u.AA", "fixed": False},
+                                         "unit": "Angstrom", "fixed": False},
                                         {"name": "mean", "value": 5,
-                                         "unit": "u.AA", "fixed": False},
+                                         "unit": "Angstrom", "fixed": False},
                                         {"name": "amp", "value": 10,
-                                         "unit": "u.AA", "fixed": False}
+                                         "unit": "Jy", "fixed": False}
                                         ]
                                   }]
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -81,7 +81,7 @@ class ModelFitting(TemplateMixin):
         for m in self.component_models:
             name = m["id"]
             if len(self.component_models) > 1:
-                m_fit = self._fitted_model[name]
+                m_fit = self._fitted_model.unitless_model[name]
             else:
                 m_fit = self._fitted_model
             temp_params = []
@@ -102,8 +102,9 @@ class ModelFitting(TemplateMixin):
         for m in self.component_models:
             name = m["id"]
             for param in m["parameters"]:
+                quant_param = u.Quantity(param["value"], param["unit"])
                 setattr(self._initialized_models[name], param["name"],
-                        param["value"])
+                        quant_param)
 
     def vue_populate_data(self, event):
         """Populated the data list when the model fitting data dropdown is clicked"""

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -18,7 +18,7 @@ from .fitting_backend import fit_model_to_spectrum
 __all__ = ['ModelFitting']
 
 
-@tray_registry('g-model-fitting')
+@tray_registry('g-model-fitting', label="Model Fitting")
 class ModelFitting(TemplateMixin):
     dialog = Bool(False).tag(sync=True)
     template = load_template("model_fitting.vue", __file__).tag(sync=True)

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -84,6 +84,18 @@ class ModelFitting(TemplateMixin):
     def _on_data_updated(self, msg):
        self.dc_items = [x.label for x in self.data_collection]
 
+    def update_parameters_from_fit(self):
+        for m in self.component_models:
+            name = m["id"]
+            m_fit = self._fitted_model[name]
+            temp_params = []
+            for i in range(0, len(m_fit.parameters)):
+                temp_param = [x for x in m["parameters"] if x["name"] ==
+                              m_fit.param_names[i]]
+                temp_param[0]["value"] = m_fit.parameters[i]
+                temp_params += temp_param
+            m["parameters"] = temp_params
+
     def vue_data_selected(self, event):
         self._selected_data = next((x for x in self.data_collection
                                     if x.label == event))
@@ -124,4 +136,7 @@ class ModelFitting(TemplateMixin):
         self._fitted_model = fitted_model
         self._fitted_spectrum = fitted_spectrum
         self.data_collection["Model fit"] = self._fitted_spectrum
+        # Update component model parameters with fitted values
+        self.update_parameters_from_fit()
+
         self.save_enabled = True

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -51,6 +51,7 @@ class ModelFitting(TemplateMixin):
         self._viewer_spectra = None
         self._spectrum1d = None
         self._units = {}
+        self.n_models = 0
         self._fitted_model = None
         self._fitted_spectrum = None
         self.component_models = []
@@ -175,7 +176,8 @@ class ModelFitting(TemplateMixin):
                                                               run_fitter=True)
         self._fitted_model = fitted_model
         self._fitted_spectrum = fitted_spectrum
-        self.data_collection["Model fit"] = self._fitted_spectrum
+        self.n_models += 1
+        self.data_collection["Model fit {}".format(self.n_models)] = self._fitted_spectrum
 
         # Update component model parameters with fitted values
         self._update_parameters_from_fit()

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -63,63 +63,83 @@
       </v-card-text>
       <v-divider></v-divider>
 
-      <v-card-subtitle>Model Parameters<v-card-subtitle>
-      <v-expansion-panels>
-        <v-expansion-panel
-          v-for="item in component_models" :key="item.id"
-        >
-          <v-expansion-panel-header v-slot="{ open }">
-            <v-row n-gutters>
-              <v-col cols=1>
-                <v-btn @click.native.stop="remove_model" icon>
-                  <v-icon>mdi-close-circle</v-icon>
-                </v-btn>
-              </v-col>
-              <v-col cols="3">{{ item.id }} ({{ item.model_type }})</v-col>
-              <v-col cols="8" class="text--secondary">
-                <v-fade-transition leave-absolute>
-                  <span v-if="open">Enter parameters for model initialization</span>
-                  <v-row 
-                    v-else
-                    no-gutters 
-                    style="width: 100%"
+      <v-card-subtitle>Model Parameters</v-card-subtitle>
+      <v-card-text>
+        <v-container>
+        <v-expansion-panels>
+          <v-expansion-panel
+            v-for="item in component_models" :key="item.id"
+          >
+            <v-expansion-panel-header v-slot="{ open }">
+              <v-row n-gutters>
+                <v-col cols=1>
+                  <v-btn @click.native.stop="remove_model(item.id)" icon>
+                    <v-icon>mdi-close-circle</v-icon>
+                  </v-btn>
+                </v-col>
+                <v-col cols="3">{{ item.id }} ({{ item.model_type }})</v-col>
+                <v-col cols="8" class="text--secondary">
+                  <v-fade-transition leave-absolute>
+                    <span v-if="open">Enter parameters for model initialization</span>
+                    <v-row 
+                      v-else
+                      no-gutters 
+                      style="width: 100%"
+                    >
+                      <v-col cols="4" v-for="param in item.parameters">
+                      {{ param.name }} : {{ param.value }}
+                      </v-col>
+                    </v-row>
+                  </v-fade-transition>
+                </v-col>
+              </v-row>
+            </v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <v-row
+                justify="center"
+                no-gutters
+                v-for="param in item.parameters"
+              >
+                <v-col cols = 3>
+                  {{ param.name }}
+                </v-col>
+                <v-col cols = 2>
+                  <v-text-field 
+                    v-model="param.value"
                   >
-                    <v-col cols="4" v-for="param in item.parameters">
-                    {{ param.name }} : {{ param.value }}
-                    </v-col>
-                  </v-row>
-                </v-fade-transition>
-              </v-col>
-            </v-row>
-          </v-expansion-panel-header>
-          <v-expansion-panel-content>
-            <v-row
-              justify="center"
-              no-gutters
-              v-for="param in item.parameters"
-            >
-              <v-col cols = 3>
-                {{ param.name }}
-              </v-col>
-              <v-col cols = 2>
-                <v-text-field 
-                  v-model="param.value"
-                >
-                </v-text-field>
-              </v-col>
-              <v-col cols=2>
-                {{ param.unit }}
-              </v-col>
-              <v-col cols=2>
-                <v-checkbox 
-                  label="Fixed">
-                </v-checkbox>
-              </v-col>
-            </v-row>
-          </v-expansion-panel-content>
-        </v-expansion-panel>
-      </v-expansion-panels>
+                  </v-text-field>
+                </v-col>
+                <v-col cols=2>
+                  {{ param.unit }}
+                </v-col>
+                <v-col cols=2>
+                  <v-checkbox 
+                    label="Fixed">
+                  </v-checkbox>
+                </v-col>
+              </v-row>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
+        </v-container>
+      </v-card-text>
       <v-divider></v-divider>
+
+      <v-card-subtitle>Model Equation Editor</v-card-subtitle>
+      <v-card-text>
+        <v-container>
+          <v-text-field
+            v-model="model_equation"
+            hint="Equation specifying how to combine the models"
+            persistent-hint
+            :rules="[() => !!model_equation || 'This field is required']"
+            @change="equation_changed"
+            :error="eq_error"
+          >
+          </v-text-field>
+        </v-container>
+      </v-card-text>
+      <v-divider inset="false"></v-divider>
 
       <v-card-actions>
         <div class="flex-grow-1"></div>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -33,14 +33,24 @@
               ></v-select>
             </v-col>
             <v-col>
-            <v-text-field
-              label="Model ID"
-              v-model="temp_name"
-              hint="A unique ID for this component model"
-              persistent-hint
-              :rules="[() => !!temp_name || 'This field is required']"
-            >
-            </v-text-field>
+              <v-text-field
+                label="Model ID"
+                v-model="temp_name"
+                hint="A unique ID for this component model"
+                persistent-hint
+                :rules="[() => !!temp_name || 'This field is required']"
+              >
+              </v-text-field>
+            </v-col>
+            <v-col v-if="display_order">
+              <v-text-field
+                label="Order"
+                type="number"
+                v-model.number="poly_order"
+                hint="Order of polynomial to fit"
+                persistent-hint
+              >
+              </v-text-field>
             </v-col>
           </v-row>
           <v-row

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -1,18 +1,5 @@
 <template>
   <v-card flat tile>
-    <template v-slot:activator="{ on: dialog }">
-      <v-tooltip bottom>
-        <template v-slot:activator="{ on: tooltip }">
-          <v-btn
-            @click="dialog_open"
-            v-on="{...dialog}"
-          >
-            Model Fitting
-          </v-btn>
-        </template>
-      </v-tooltip>
-    </template>
-
     <v-card>
       <v-card-text>
         <v-container>
@@ -20,6 +7,7 @@
             <v-col>
               <v-select
                 :items="dc_items"
+                @click="dialog_open"
                 @change="data_selected"
                 label="Data"
                 hint="Select the data set to be fitted."

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="dialog" persistent max-width="450" @keydown.stop="">
+  <v-dialog v-model="dialog" persistent max-width="500" @keydown.stop="">
     <template v-slot:activator="{ on: dialog }">
       <v-tooltip bottom>
         <template v-slot:activator="{ on: tooltip }">
@@ -23,6 +23,7 @@
                 @change="data_selected"
                 label="Data"
                 hint="Select the data set to be fitted."
+                persistent-hint
               ></v-select>
             </v-col>
         </v-container>
@@ -31,28 +32,38 @@
 
       <v-card-text>
         <v-container>
-          <v-row>
+          <v-row
+          align="start"
+          >
             <v-col>
               <v-select
                 :items="available_models"
                 @change="model_selected"
                 label="Model"
                 hint="Select a model to fit"
+                persistent-hint
               ></v-select>
             </v-col>
             <v-col>
-              <v-text-field
-                ref="model_name"
-                label="Name for model"
-                v-model="model_name"
-                hint="A unique name for this model, to use in model equation."
-                persistent-hint
-                :rules="[() => !!model_name || 'This field is required']"
-              ></v-text-field>
+            <v-text-field
+              label="Model ID"
+              v-model="temp_name"
+              hint="A unique ID for this component model"
+              persistent-hint
+              :rules="[() => !!temp_name || 'This field is required']"
+            >
+            </v-text-field>
             </v-col>
+          </v-row>
+          <v-row
+          justify="end">
+            <v-btn color="primary" text @click="add_model">Add Model</v-btn>
           </v-row>
         </v-container>
       </v-card-text>
+      <v-divider></v-divider>
+
+      <v-card-subtitle>Model Parameters<v-card-subtitle>
       <v-divider></v-divider>
 
       <v-card-actions>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -103,7 +103,7 @@
                 <v-col cols=2>
                   <p class="font-weight-bold">Parameter</p>
                 </v-col>
-                <v-col cols=2>
+                <v-col cols=3>
                   <p class="font-weight-bold">Value</p>
                 </v-col>
                 <v-col cols=4>
@@ -122,7 +122,7 @@
                 <v-col cols = 2>
                   {{ param.name }}
                 </v-col>
-                <v-col cols = 1>
+                <v-col cols = 2>
                   <v-text-field 
                     v-model="param.value"
                   >
@@ -134,7 +134,7 @@
                 </v-col>
                 <v-col cols=1></v-col>
                 <v-col cols=2>
-                  <v-checkbox>
+                  <v-checkbox v-model="param.fixed">
                   </v-checkbox>
                 </v-col>
               </v-row>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="dialog" persistent max-width="500" @keydown.stop="">
+  <v-dialog v-model="dialog" persistent max-width="600" @keydown.stop="">
     <template v-slot:activator="{ on: dialog }">
       <v-tooltip bottom>
         <template v-slot:activator="{ on: tooltip }">
@@ -78,8 +78,9 @@
                     v-else 
                     no-gutters 
                     style="width: 100%"
+                    v-for="param in item.params"
                   >
-                    <v-col v-for="(param, i) in item.params">
+                    <v-col cols="3">
                       {{ param.name }} : {{ param.value || 'Not Set' }}
                     </v-col>
                   </v-row>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -68,9 +68,36 @@
         <v-expansion-panel
           v-for="(item, i) in component_models"
         >
-          <v-expansion-panel-header>{{ item.id }}</v-expansion-panel-header>
+          <v-expansion-panel-header>
+            <v-row n-gutters>
+              <v-col cols="4">{{ item.id }}</v-col>
+              <v-col cols="8" class="text--secondary">
+                <v-fade-transition leave-absolute>
+                  <span v-if="open">Enter values to initialize model fit</span>
+                  <v-row 
+                    v-else 
+                    no-gutters 
+                    style="width: 100%"
+                  >
+                    <v-col v-for="(param, i) in item.params">
+                      {{ param.name }} : {{ param.value || 'Not Set' }}
+                    </v-col>
+                  </v-row>
+                </v-fade-transition>
+              </v-col>
+            </v-row>
+          </v-expansion-panel-header>
           <v-expansion-panel-content>
-            TESTING
+            <v-row
+              justify="space-around"
+              no-gutters
+            >
+              <v-col
+                v-for="(param) in item.params"
+              >
+                {{ param.name }}
+              </v-col>
+            </v-row>
           </v-expansion-panel-content>
         </v-expansion-panel>
       </v-expansion-panels>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -172,7 +172,7 @@
         <v-text-field
           v-model="model_save_path"
           label="Filepath"
-          hint="Path to save output file [Model Label].pkl (defaults to notebook directory)"
+          hint="Path to save output file [Model Label].pkl"
           persistent-hint
         >
         </v-text-field>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -96,25 +96,45 @@
             </v-expansion-panel-header>
             <v-expansion-panel-content>
               <v-row
-                justify="center"
+                justify="left"
+                align="center"
+                no-gutters
+              >
+                <v-col cols=2>
+                  <p class="font-weight-bold">Parameter</p>
+                </v-col>
+                <v-col cols=2>
+                  <p class="font-weight-bold">Value</p>
+                </v-col>
+                <v-col cols=4>
+                  <p class="font-weight-bold">Unit</p>
+                </v-col>
+                <v-col cols=2>
+                  <p class="font-weight-bold">Fixed?</p>
+                </v-col>
+              </v-row>
+              <v-row
+                justify="left"
+                align="center"
                 no-gutters
                 v-for="param in item.parameters"
               >
-                <v-col cols = 3>
+                <v-col cols = 2>
                   {{ param.name }}
                 </v-col>
-                <v-col cols = 2>
+                <v-col cols = 1>
                   <v-text-field 
                     v-model="param.value"
                   >
                   </v-text-field>
                 </v-col>
-                <v-col cols=2>
+                <v-col cols=1></v-col>
+                <v-col cols=3>
                   {{ param.unit }}
                 </v-col>
+                <v-col cols=1></v-col>
                 <v-col cols=2>
-                  <v-checkbox 
-                    label="Fixed">
+                  <v-checkbox>
                   </v-checkbox>
                 </v-col>
               </v-row>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -7,7 +7,6 @@
             <v-col>
               <v-select
                 :items="dc_items"
-                @click="populate_data"
                 @change="data_selected"
                 label="Data"
                 hint="Select the data set to be fitted."
@@ -79,9 +78,9 @@
                 <v-col cols="8" class="text--secondary">
                   <v-fade-transition leave-absolute>
                     <span v-if="open">Enter parameters for model initialization</span>
-                    <v-row 
+                    <v-row
                       v-else
-                      no-gutters 
+                      no-gutters
                       style="width: 100%"
                     >
                       <v-col cols="4" v-for="param in item.parameters">
@@ -121,7 +120,7 @@
                   {{ param.name }}
                 </v-col>
                 <v-col cols = 2>
-                  <v-text-field 
+                  <v-text-field
                     v-model="param.value"
                   >
                   </v-text-field>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -66,22 +66,19 @@
       <v-card-subtitle>Model Parameters<v-card-subtitle>
       <v-expansion-panels>
         <v-expansion-panel
-          v-for="(item, i) in component_models"
+          v-for="item in component_models" :key="item.id"
         >
           <v-expansion-panel-header>
             <v-row n-gutters>
               <v-col cols="4">{{ item.id }}</v-col>
               <v-col cols="8" class="text--secondary">
                 <v-fade-transition leave-absolute>
-                  <span v-if="open">Enter values to initialize model fit</span>
                   <v-row 
-                    v-else 
                     no-gutters 
                     style="width: 100%"
-                    v-for="param in item.params"
                   >
-                    <v-col cols="3">
-                      {{ param.name }} : {{ param.value || 'Not Set' }}
+                    <v-col cols="6">
+                      This is a test!
                     </v-col>
                   </v-row>
                 </v-fade-transition>
@@ -92,10 +89,9 @@
             <v-row
               justify="space-around"
               no-gutters
+              v-for="param in item.parameters"
             >
-              <v-col
-                v-for="(param) in item.params"
-              >
+              <v-col>
                 {{ param.name }}
               </v-col>
             </v-row>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="dialog" persistent max-width="600" @keydown.stop="">
+  <v-card flat tile>
     <template v-slot:activator="{ on: dialog }">
       <v-tooltip bottom>
         <template v-slot:activator="{ on: tooltip }">
@@ -10,13 +10,10 @@
             Model Fitting
           </v-btn>
         </template>
-        <span>Model Fitting</span>
       </v-tooltip>
     </template>
 
     <v-card>
-      <v-card-title class="headline blue lighten-4" primary-title>Model Fitting</v-card-title>
-
       <v-card-text>
         <v-container>
           <v-row>
@@ -179,9 +176,8 @@
            @click="save_model">
              Save Model
           </v-btn>
-        <v-btn color="primary" text @click="dialog = false">Close</v-btn>
         <v-btn color="primary" text @click="model_fitting">Fit</v-btn>
       </v-card-actions>
     </v-card>
-  </v-dialog>
+  </v-card>
 </template>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -68,17 +68,20 @@
         <v-expansion-panel
           v-for="item in component_models" :key="item.id"
         >
-          <v-expansion-panel-header>
+          <v-expansion-panel-header v-slot="open">
             <v-row n-gutters>
               <v-col cols="4">{{ item.id }}</v-col>
               <v-col cols="8" class="text--secondary">
                 <v-fade-transition leave-absolute>
+                  <span v-if="open">Enter parameters for model initialization<span>
                   <v-row 
+                    v-else
                     no-gutters 
                     style="width: 100%"
+                    v-for="param in item.parameters"
                   >
-                    <v-col cols="6">
-                      This is a test!
+                    <v-col cols="4">
+                    {{param.name}}: {{param.value}}
                     </v-col>
                   </v-row>
                 </v-fade-transition>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -165,7 +165,7 @@
         <div class="flex-grow-1"></div>
         <v-btn color="primary" text @click="dialog = false">Cancel</v-btn>
         <v-btn color="primary" text @click="model_fitting">Fit</v-btn>
-        <v-tooltip bottom>
+        <v-tooltip top>
           <template v-slot:activator="{ on }">
             <v-btn color="primary" text @click="save_model">Save</v-btn>
           </template>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -36,7 +36,7 @@
               <v-text-field
                 label="Model ID"
                 v-model="temp_name"
-                hint="A unique ID for this component model"
+                hint="A unique string label for this component model"
                 persistent-hint
                 :rules="[() => !!temp_name || 'This field is required']"
               >
@@ -148,7 +148,7 @@
         <v-container>
           <v-text-field
             v-model="model_equation"
-            hint="Equation specifying how to combine the models"
+            hint="Equation specifying how to combine the component models, using their model IDs and basic arithmetic operators"
             persistent-hint
             :rules="[() => !!model_equation || 'This field is required']"
             @change="equation_changed"

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -122,8 +122,7 @@
                 </v-col>
                 <v-col cols = 2>
                   <v-text-field 
-                    v-model="param.value",
-                    @change="parameter_updated"
+                    v-model="param.value"
                   >
                   </v-text-field>
                 </v-col>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -7,7 +7,7 @@
             <v-col>
               <v-select
                 :items="dc_items"
-                @click="dialog_open"
+                @click="populate_data"
                 @change="data_selected"
                 label="Data"
                 hint="Select the data set to be fitted."
@@ -122,7 +122,8 @@
                 </v-col>
                 <v-col cols = 2>
                   <v-text-field 
-                    v-model="param.value"
+                    v-model="param.value",
+                    @change="parameter_updated"
                   >
                   </v-text-field>
                 </v-col>
@@ -157,24 +158,42 @@
           </v-text-field>
         </v-container>
       </v-card-text>
-      <v-divider inset="false"></v-divider>
+      <v-divider></v-divider>
 
       <v-card-actions>
         <div class="flex-grow-1"></div>
         <v-text-field
-          v-if="save_enabled"
-          v-model="model_savename"
-          hint="Specify path and filename for output pickle file"
-         >
-         </v-text-field>
-         <v-btn 
-           v-if="save_enabled" 
-           color="primary" 
-           text 
-           @click="save_model">
-             Save Model
-          </v-btn>
+          v-model="model_label"
+          label="Model Label"
+          hint="Label for the modeled spectrum in the data dropdown menus"
+          persistent-hint
+        >
+        </v-text-field>
+        <c-col cols=1><v-col>
+        <v-text-field
+          v-model="model_save_path"
+          label="Filepath"
+          hint="Path to save output file [Model Label].pkl (defaults to notebook directory)"
+          persistent-hint
+        >
+        </v-text-field>
+      </v-card-actions>
+      <v-card-actions>
+        <div class="flex-grow-1"></div>
+        <v-row
+          justify="left"
+          align="center"
+          no-gutters
+        >
         <v-btn color="primary" text @click="model_fitting">Fit</v-btn>
+        <v-btn color="primary" text @click="register_spectrum"">Add to Viewer</v-btn>
+        <v-btn
+           color="primary"
+           text
+           @click="save_model">
+           Save to File
+         </v-btn>
+        </v-row>
       </v-card-actions>
     </v-card>
   </v-card>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -3,7 +3,10 @@
     <template v-slot:activator="{ on: dialog }">
       <v-tooltip bottom>
         <template v-slot:activator="{ on: tooltip }">
-          <v-btn v-on="{...dialog}">
+          <v-btn
+            @click="dialog_open"
+            v-on="{...dialog}"
+          >
             Model Fitting
           </v-btn>
         </template>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -1,5 +1,65 @@
 <template>
-    <v-btn>
-        Model Fitting
-    </v-btn>
+  <v-dialog v-model="dialog" persistent max-width="450" @keydown.stop="">
+    <template v-slot:activator="{ on: dialog }">
+      <v-tooltip bottom>
+        <template v-slot:activator="{ on: tooltip }">
+          <v-btn v-on="{...dialog}">
+            Model Fitting
+          </v-btn>
+        </template>
+        <span>Model Fitting</span>
+      </v-tooltip>
+    </template>
+
+    <v-card>
+      <v-card-title class="headline blue lighten-4" primary-title>Model Fitting</v-card-title>
+
+      <v-card-text>
+        <v-container>
+          <v-row>
+            <v-col>
+              <v-select
+                :items="dc_items"
+                @change="data_selected"
+                label="Data"
+                hint="Select the data set to be fitted."
+              ></v-select>
+            </v-col>
+        </v-container>
+      </v-card-text>
+      <v-divider></v-divider>
+
+      <v-card-text>
+        <v-container>
+          <v-row>
+            <v-col>
+              <v-select
+                :items="available_models"
+                @change="model_selected"
+                label="Model"
+                hint="Select a model to fit"
+              ></v-select>
+            </v-col>
+            <v-col>
+              <v-text-field
+                ref="model_name"
+                label="Name for model"
+                v-model="model_name"
+                hint="A unique name for this model, to use in model equation."
+                persistent-hint
+                :rules="[() => !!model_name || 'This field is required']"
+              ></v-text-field>
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-card-text>
+      <v-divider></v-divider>
+
+      <v-card-actions>
+        <div class="flex-grow-1"></div>
+        <v-btn color="primary" text @click="dialog = false">Cancel</v-btn>
+        <v-btn color="primary" text @click="model_fitting">Fit</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
 </template>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -163,14 +163,21 @@
 
       <v-card-actions>
         <div class="flex-grow-1"></div>
-        <v-btn color="primary" text @click="dialog = false">Cancel</v-btn>
+        <v-text-field
+          v-if="save_enabled"
+          v-model="model_savename"
+          hint="Specify path and filename for output pickle file"
+         >
+         </v-text-field>
+         <v-btn 
+           v-if="save_enabled" 
+           color="primary" 
+           text 
+           @click="save_model">
+             Save Model
+          </v-btn>
+        <v-btn color="primary" text @click="dialog = false">Close</v-btn>
         <v-btn color="primary" text @click="model_fitting">Fit</v-btn>
-        <v-tooltip top>
-          <template v-slot:activator="{ on }">
-            <v-btn color="primary" text @click="save_model">Save</v-btn>
-          </template>
-          <span>Save the fitted model to fitted_model.pkl</span>
-        </v-tooltip>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -70,7 +70,12 @@
         >
           <v-expansion-panel-header v-slot="{ open }">
             <v-row n-gutters>
-              <v-col cols="4">{{ item.id }} ({{ item.model_type }})</v-col>
+              <v-col cols=1>
+                <v-btn @click.native.stop="remove_model" icon>
+                  <v-icon>mdi-close-circle</v-icon>
+                </v-btn>
+              </v-col>
+              <v-col cols="3">{{ item.id }} ({{ item.model_type }})</v-col>
               <v-col cols="8" class="text--secondary">
                 <v-fade-transition leave-absolute>
                   <span v-if="open">Enter parameters for model initialization</span>
@@ -89,18 +94,21 @@
           </v-expansion-panel-header>
           <v-expansion-panel-content>
             <v-row
-              justify="start"
+              justify="center"
               no-gutters
               v-for="param in item.parameters"
             >
-              <v-col>
+              <v-col cols = 3>
                 {{ param.name }}
               </v-col>
-              <v-col>
+              <v-col cols = 2>
                 <v-text-field 
                   v-model="param.value"
                 >
                 </v-text-field>
+              </v-col>
+              <v-col cols=2>
+                {{ param.unit }}
               </v-col>
             </v-row>
           </v-expansion-panel-content>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -68,20 +68,19 @@
         <v-expansion-panel
           v-for="item in component_models" :key="item.id"
         >
-          <v-expansion-panel-header v-slot="open">
+          <v-expansion-panel-header v-slot="{ open }">
             <v-row n-gutters>
-              <v-col cols="4">{{ item.id }}</v-col>
+              <v-col cols="4">{{ item.id }} ({{ item.model_type }})</v-col>
               <v-col cols="8" class="text--secondary">
                 <v-fade-transition leave-absolute>
-                  <span v-if="open">Enter parameters for model initialization<span>
+                  <span v-if="open">Enter parameters for model initialization</span>
                   <v-row 
                     v-else
                     no-gutters 
                     style="width: 100%"
-                    v-for="param in item.parameters"
                   >
-                    <v-col cols="4">
-                    {{param.name}}: {{param.value}}
+                    <v-col cols="4" v-for="param in item.parameters">
+                    {{ param.name }} : {{ param.value }}
                     </v-col>
                   </v-row>
                 </v-fade-transition>
@@ -90,12 +89,18 @@
           </v-expansion-panel-header>
           <v-expansion-panel-content>
             <v-row
-              justify="space-around"
+              justify="start"
               no-gutters
               v-for="param in item.parameters"
             >
               <v-col>
                 {{ param.name }}
+              </v-col>
+              <v-col>
+                <v-text-field 
+                  v-model="param.value"
+                >
+                </v-text-field>
               </v-col>
             </v-row>
           </v-expansion-panel-content>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -165,6 +165,12 @@
         <div class="flex-grow-1"></div>
         <v-btn color="primary" text @click="dialog = false">Cancel</v-btn>
         <v-btn color="primary" text @click="model_fitting">Fit</v-btn>
+        <v-tooltip bottom>
+          <template v-slot:activator="{ on }">
+            <v-btn color="primary" text @click="save_model">Save</v-btn>
+          </template>
+          <span>Save the fitted model to fitted_model.pkl</span>
+        </v-tooltip>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -64,6 +64,16 @@
       <v-divider></v-divider>
 
       <v-card-subtitle>Model Parameters<v-card-subtitle>
+      <v-expansion-panels>
+        <v-expansion-panel
+          v-for="(item, i) in component_models"
+        >
+          <v-expansion-panel-header>{{ item.id }}</v-expansion-panel-header>
+          <v-expansion-panel-content>
+            TESTING
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
       <v-divider></v-divider>
 
       <v-card-actions>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -110,6 +110,11 @@
               <v-col cols=2>
                 {{ param.unit }}
               </v-col>
+              <v-col cols=2>
+                <v-checkbox 
+                  label="Fixed">
+                </v-checkbox>
+              </v-col>
             </v-row>
           </v-expansion-panel-content>
         </v-expansion-panel>

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -87,6 +87,7 @@ module.exports = {
   name: "g-viewer-tab",
   props: ["stack", "dataItems"],
   created() {
+      console.log("HERE" + this.$parent.computeChildrenPath);
     this.$parent.childMe = () => {
       return this.$children[0];
     };

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -3,7 +3,7 @@ from glue.core.message import Message
 __all__ = ['NewViewerMessage', 'AddViewerMessage', 'LoadDataMessage',
            'DataSelectedMessage', 'ViewerSelectedMessage',
            'RemoveStackMessage', 'SplitStackMessage', 'RemoveItemMessage',
-           'AddDataMessage']
+           'AddDataMessage', 'SnackbarMessage', 'RemoveDataMessage']
 
 
 class NewViewerMessage(Message):
@@ -110,11 +110,12 @@ class RemoveItemMessage(Message):
 
 
 class AddDataMessage(Message):
-    def __init__(self, data, viewer, *args, **kwargs):
+    def __init__(self, data, viewer, viewer_id=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self._data = data
         self._viewer = viewer
+        self._viewer_id = viewer_id
 
     @property
     def data(self):
@@ -123,6 +124,31 @@ class AddDataMessage(Message):
     @property
     def viewer(self):
         return self._viewer
+
+    @property
+    def viewer_id(self):
+        return self._viewer_id
+
+
+class RemoveDataMessage(Message):
+    def __init__(self, data, viewer, viewer_id=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._data = data
+        self._viewer = viewer
+        self._viewer_id = viewer_id
+
+    @property
+    def data(self):
+        return self._data
+
+    @property
+    def viewer(self):
+        return self._viewer
+
+    @property
+    def viewer_id(self):
+        return self._viewer_id
 
 
 class SnackbarMessage(Message):


### PR DESCRIPTION
This PR adds a model fitting plugin, which pulls 1D spectra from the spectrum viewer and gives the user similar options to those in the old specutils. I still have some debugging to do, since it looks like the model parameters aren't being updated after fitting the model, but I wanted to make this available to get other eyes on it for comments/suggestions. Note that this depends on https://github.com/spacetelescope/jdaviz/pull/114. 