### PR TITLE
Fix failing test by return stored cls in registry

### DIFF
--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -1,5 +1,4 @@
 from astropy import units as u
-from astropy import units as u
 from glue.core.message import (DataCollectionAddMessage,
                                DataCollectionDeleteMessage)
 from glue.core import Data

--- a/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
@@ -12,11 +12,11 @@ def test_linking_after_gaussian_smooth(spectral_cube_wcs):
     dc = app.data_collection
     dc.append(Data(x=np.ones((3, 4, 5)), label='test', coords=spectral_cube_wcs))
 
-    coll = GaussianSmooth(app=app)
+    gs = GaussianSmooth(app=app)
 
-    coll.vue_data_selected('test')
-    coll.stddev = '3.2'
-    coll.vue_gaussian_smooth()
+    gs._on_data_selected({'new': 'test'})
+    gs.stddev = '3.2'
+    gs.vue_gaussian_smooth()
 
     assert len(dc) == 2
     assert dc[1].label == 'Smoothed test'

--- a/jdaviz/core/registries.py
+++ b/jdaviz/core/registries.py
@@ -55,6 +55,7 @@ class ViewerRegistry(UniqueDictRegistry):
     def __call__(self, name=None, label=None):
         def decorator(cls):
             self.add(name, cls, label)
+            return cls
         return decorator
 
     def add(self, name, cls, label=None):
@@ -95,6 +96,7 @@ class TrayRegistry(UniqueDictRegistry):
                     f"`ipyvuetify.VuetifyTemplate`.")
 
             self.add(name, cls, label, icon)
+            return cls
         return decorator
 
     def add(self, name, cls, label=None, icon=None):


### PR DESCRIPTION
This fixes the build errors seen in #127. Currently, the tray registry does not return the stored cls object on call and therefore does not get access to the plugin class proper.