### PR TITLE
Auto-populate cubeviz viewers

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -32,6 +32,9 @@ SplitPanes()
 GoldenLayout()
 
 CONTAINER_TYPES = dict(row='gl-row', col='gl-col', stack='gl-stack')
+EXT_TYPES = dict(flux=['flux', 'sci'],
+                 uncert=['ivar', 'err', 'var', 'uncert'],
+                 mask=['mask', 'dq'])
 
 
 class ApplicationState(State):
@@ -55,6 +58,9 @@ class ApplicationState(State):
     }, docstring="State of the quick toast messages.")
 
     settings = DictCallbackProperty({
+        'data': {
+            'auto_populate': False
+        },
         'visible': {
             'menu_bar': True,
             'toolbar': True,
@@ -217,6 +223,18 @@ class Application(TemplateMixin):
             File path for the data file to be loaded.
         """
         self._application_handler.load_data(path)
+
+        if self.state.settings['data']['auto_populate']:
+            for data in self.data_collection:
+                data_label = data.label.lower()
+
+                if any(x in data_label for x in EXT_TYPES['flux']):
+                    self.add_data_to_viewer('flux-viewer', data.label)
+                    self.add_data_to_viewer('spectrum-viewer', data.label)
+                elif any(x in data_label for x in EXT_TYPES['uncert']):
+                    self.add_data_to_viewer('uncert-viewer', data.label)
+                elif any(x in data_label for x in EXT_TYPES['mask']):
+                    self.add_data_to_viewer('mask-viewer', data.label)
 
         # Send out a toast message
         snackbar_message = SnackbarMessage("Data successfully loaded.",

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -22,7 +22,8 @@ from traitlets import Dict
 
 from .core.events import (LoadDataMessage, NewViewerMessage, AddDataMessage,
                           SnackbarMessage, RemoveDataMessage)
-from .core.registries import tool_registry, tray_registry, viewer_registry
+from .core.registries import (tool_registry, tray_registry, viewer_registry,
+                              data_parser_registry)
 from .core.template_mixin import TemplateMixin
 from .utils import load_template
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -216,7 +216,8 @@ class Application(TemplateMixin):
         """
         Provided a path to a data file, open and parse the data into the
         `~glue.core.DataCollection` for this session. This also attempts to
-        find WCS links that exist between data components.
+        find WCS links that exist between data components. Extra key word
+        arguments are passed to the parsing functions.
 
         Parameters
         ----------
@@ -227,6 +228,8 @@ class Application(TemplateMixin):
             self.state.settings['data']['parser'])
 
         if parser is not None:
+            # If the parser returns something other than known, assume it's
+            #  a message we want to make the user aware of.
             msg = parser(self, file_obj, **kwargs)
 
             if msg is not None:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -212,7 +212,7 @@ class Application(TemplateMixin):
         self.state.snackbar['timeout'] = msg.timeout
         self.state.snackbar['show'] = True
 
-    def load_data(self, file_obj, data_type=None, data_label=None):
+    def load_data(self, file_obj, **kwargs):
         """
         Provided a path to a data file, open and parse the data into the
         `~glue.core.DataCollection` for this session. This also attempts to
@@ -223,18 +223,17 @@ class Application(TemplateMixin):
         path : str
             File path for the data file to be loaded.
         """
-        if data_type is not None and data_type.lower() not in ['flux', 'mask', 'uncertainty']:
-            snackbar_message = SnackbarMessage(
-                "Data type must be one of 'flux', 'mask', or 'uncertainty'.",
-                sender=self)
-            self.hub.broadcast(snackbar_message)
-            return
-
         parser = data_parser_registry.members.get(
             self.state.settings['data']['parser'])
 
         if parser is not None:
-            parser(self, file_obj)
+            msg = parser(self, file_obj, **kwargs)
+
+            if msg is not None:
+                snackbar_message = SnackbarMessage(
+                    msg, color='error', sender=self)
+                self.hub.broadcast(snackbar_message)
+                return
         else:
             self._application_handler.load_data(file_obj)
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -24,7 +24,7 @@ from .core.events import (LoadDataMessage, NewViewerMessage, AddDataMessage,
                           SnackbarMessage, RemoveDataMessage)
 from .core.registries import tool_registry, tray_registry, viewer_registry
 from .core.template_mixin import TemplateMixin
-from .utils import load_template
+from .utils import load_template, parse_data
 
 __all__ = ['Application']
 
@@ -32,9 +32,6 @@ SplitPanes()
 GoldenLayout()
 
 CONTAINER_TYPES = dict(row='gl-row', col='gl-col', stack='gl-stack')
-EXT_TYPES = dict(flux=['flux', 'sci'],
-                 uncert=['ivar', 'err', 'var', 'uncert'],
-                 mask=['mask', 'dq'])
 
 
 class ApplicationState(State):
@@ -222,19 +219,13 @@ class Application(TemplateMixin):
         path : str
             File path for the data file to be loaded.
         """
-        self._application_handler.load_data(path)
+        ext_mapping = parse_data(path, self.data_collection)
 
         if self.state.settings['data']['auto_populate']:
-            for data in self.data_collection:
-                data_label = data.label.lower()
-
-                if any(x in data_label for x in EXT_TYPES['flux']):
-                    self.add_data_to_viewer('flux-viewer', data.label)
-                    self.add_data_to_viewer('spectrum-viewer', data.label)
-                elif any(x in data_label for x in EXT_TYPES['uncert']):
-                    self.add_data_to_viewer('uncert-viewer', data.label)
-                elif any(x in data_label for x in EXT_TYPES['mask']):
-                    self.add_data_to_viewer('mask-viewer', data.label)
+            self.add_data_to_viewer('flux-viewer', ext_mapping['flux'])
+            self.add_data_to_viewer('spectrum-viewer', ext_mapping['flux'])
+            self.add_data_to_viewer('uncert-viewer', ext_mapping['uncert'])
+            self.add_data_to_viewer('mask-viewer', ext_mapping['mask'])
 
         # Send out a toast message
         snackbar_message = SnackbarMessage("Data successfully loaded.",

--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -2,6 +2,7 @@ settings:
   configuration: cubeviz
   data:
     auto_populate: true
+    parser: cubeviz-data-parser
   visible:
     menu_bar: false
     toolbar: true

--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -1,5 +1,7 @@
 settings:
   configuration: cubeviz
+  data:
+    auto_populate: true
   visible:
     menu_bar: false
     toolbar: true

--- a/jdaviz/configs/cubeviz/plugins/__init__.py
+++ b/jdaviz/configs/cubeviz/plugins/__init__.py
@@ -1,2 +1,3 @@
 from .viewers import *
 from .unified_slider.unified_slider import *
+from .utils import *

--- a/jdaviz/configs/cubeviz/plugins/__init__.py
+++ b/jdaviz/configs/cubeviz/plugins/__init__.py
@@ -1,3 +1,3 @@
 from .viewers import *
 from .unified_slider.unified_slider import *
-from .utils import *
+from .parsers import *

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -5,6 +5,7 @@ import logging
 import numpy as np
 import os
 from jdaviz.core.registries import data_parser_registry
+from specutils import Spectrum1D
 
 EXT_TYPES = dict(flux=['flux', 'sci'],
                  uncert=['ivar', 'err', 'var', 'uncert'],
@@ -12,58 +13,104 @@ EXT_TYPES = dict(flux=['flux', 'sci'],
 
 
 @data_parser_registry("cubeviz-data-parser")
-def parse_data(file_path, app):
+def parse_data(app, file_obj, **kwargs):
     """
     Attempts to parse a data file and auto-populate available viewers in
     cubeviz.
 
     Parameters
     ----------
-    file_path : str
-        The path to a cube-like data file.
     app : `~jdaviz.app.Application`
         The application-level object used to reference the viewers.
+    file_path : str
+        The path to a cube-like data file.
     """
-    file_name = os.path.basename(file_path)
+    if isinstance(file_obj, fits.hdu.hdulist.HDUList):
+        _parse_hdu(app, file_obj)
+    elif isinstance(file_obj, str) and os.path.exists(file_obj):
+        file_name = os.path.basename(file_obj)
+        with fits.open(file_obj) as hdulist:
+            hdulist = fits.open(file_obj)
+            _parse_hdu(app, hdulist, file_name, **kwargs)
+    elif isinstance(file_obj, SpectralCube):
+        _parse_spectral_cube(app, file_obj, **kwargs)
+    elif isinstance(file_obj, Spectrum1D):
+        _parse_spectrum1d(app, file_obj, **kwargs)
 
-    with fits.open(file_path) as hdulist:
-        wcs = None
 
-        for hdu in hdulist:
-            data_label = f"{file_name}[{hdu.name}]"
+def _parse_hdu(app, hdulist, file_name=None):
+    if hasattr(hdulist, 'file_name'):
+        file_name = hdulist.file_name
 
-            if hdu.data is None:
-                continue
+    file_name = file_name or "Unknown HDU object"
 
-            # This will fail on attempting to load anything that
-            # isn't cube-shaped
+    wcs = None
+
+    for hdu in hdulist:
+        data_label = f"{file_name}[{hdu.name}]"
+
+        if hdu.data is None:
+            continue
+
+        # This will fail on attempting to load anything that
+        # isn't cube-shaped
+        try:
+            sc = SpectralCube.read(hdu)
+            wcs = sc.wcs
+        except ValueError:
+            # This will fail if the parsing of the wcs does not provide
+            # proper celestial axes
             try:
+                hdu.header.update(wcs.to_header())
                 sc = SpectralCube.read(hdu)
-                wcs = sc.wcs
-            except ValueError:
-                # This will fail if the parsing of the wcs does not provide
-                # proper celestial axes
-                try:
-                    hdu.header.update(wcs.to_header())
-                    sc = SpectralCube.read(hdu)
-                except ValueError as e:
-                    logging.error(e)
-                    continue
-            except FITSReadError as e:
+            except ValueError as e:
                 logging.error(e)
                 continue
+        except FITSReadError as e:
+            logging.error(e)
+            continue
 
-            app.data_collection[data_label] = sc
+        app.data_collection[data_label] = sc
 
-            # If the data type is some kind of integer, assume it's the mask/dq
-            if hdu.data.dtype in (np.int, np.uint, np.uint32) or \
-                    any(x in hdu.name.lower() for x in EXT_TYPES['mask']):
-                app.add_data_to_viewer('mask-viewer', data_label)
+        # If the data type is some kind of integer, assume it's the mask/dq
+        if hdu.data.dtype in (np.int, np.uint, np.uint32) or \
+                any(x in hdu.name.lower() for x in EXT_TYPES['mask']):
+            app.add_data_to_viewer('mask-viewer', data_label)
 
-            if 'errtype' in [x.lower() for x in hdu.header.keys()] or \
-                    any(x in hdu.name.lower() for x in EXT_TYPES['uncert']):
-                app.add_data_to_viewer('uncert-viewer', data_label)
+        if 'errtype' in [x.lower() for x in hdu.header.keys()] or \
+                any(x in hdu.name.lower() for x in EXT_TYPES['uncert']):
+            app.add_data_to_viewer('uncert-viewer', data_label)
 
-            if any(x in hdu.name.lower() for x in EXT_TYPES['flux']):
-                app.add_data_to_viewer('flux-viewer', data_label)
-                app.add_data_to_viewer('spectrum-viewer', data_label)
+        if any(x in hdu.name.lower() for x in EXT_TYPES['flux']):
+            app.add_data_to_viewer('flux-viewer', data_label)
+            app.add_data_to_viewer('spectrum-viewer', data_label)
+
+
+def _parse_spectral_cube(app, file_obj, data_type='flux', data_label=None):
+    data_label = data_label or f"Unknown spectral cube[{data_type.upper()}]"
+
+    app.data_collection[f"{data_label}"] = file_obj.unmasked_data[:, :, :]
+
+    if data_type == 'flux':
+        app.add_data_to_viewer('flux-viewer', f"{data_label}")
+        app.add_data_to_viewer('spectrum-viewer', f"{data_label}")
+    elif data_type == 'mask':
+        app.add_data_to_viewer('mask-viewer', f"{data_label}")
+    elif data_type == 'uncertainty':
+        app.add_data_to_viewer('uncert-viewer', f"{data_label}")
+
+    # TODO: SpectralCube does not store mask information
+    # TODO: SpectralCube does not store data quality information
+
+
+def _parse_spectrum1d(app, file_obj):
+    data_label = "Unknown spectrum object"
+
+    app.data_collection[f"{data_label}[FLUX]"] = file_obj.flux
+    app.add_data_to_viewer('flux-viewer', f"{data_label}[FLUX]")
+    app.add_data_to_viewer('spectrum-viewer', f"{data_label}[FLUX]")
+
+    app.data_collection[f"{data_label}[MASK]"] = file_obj.mask
+    app.add_data_to_viewer('mask-viewer', f"{data_label}[MASK]")
+
+    # TODO: Spectrum1D does not currently store data quality information

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -3,6 +3,7 @@ from spectral_cube import SpectralCube
 from spectral_cube.io.fits import FITSReadError
 import logging
 import numpy as np
+import os
 from jdaviz.core.registries import data_parser_registry
 
 EXT_TYPES = dict(flux=['flux', 'sci'],
@@ -20,24 +21,17 @@ def parse_data(file_path, app):
     ----------
     file_path : str
         The path to a cube-like data file.
-    data_collection : `~glue.core.DataCollection`
-        The application-level data collection into which the parsed data will
-        be placed.
-
-    Returns
-    -------
-    ext_mapping : dict
-        A mapping of the three necessary components of the cubeviz viewers to
-        the data component labels in glue.
+    app : `~jdaviz.app.Application`
+        The application-level object used to reference the viewers.
     """
-    ext_mapping = {'flux': None,
-                   'uncert': None,
-                   'mask': None}
+    file_name = os.path.basename(file_path)
 
     with fits.open(file_path) as hdulist:
         wcs = None
 
         for hdu in hdulist:
+            data_label = f"{file_name}[{hdu.name}]"
+
             if hdu.data is None:
                 continue
 
@@ -59,22 +53,17 @@ def parse_data(file_path, app):
                 logging.error(e)
                 continue
 
-            app.data_collection[hdu.name] = sc
+            app.data_collection[data_label] = sc
 
             # If the data type is some kind of integer, assume it's the mask/dq
             if hdu.data.dtype in (np.int, np.uint, np.uint32) or \
                     any(x in hdu.name.lower() for x in EXT_TYPES['mask']):
-                ext_mapping['mask'] = hdu.name
-                app.add_data_to_viewer('mask-viewer', hdu.name)
+                app.add_data_to_viewer('mask-viewer', data_label)
 
             if 'errtype' in [x.lower() for x in hdu.header.keys()] or \
                     any(x in hdu.name.lower() for x in EXT_TYPES['uncert']):
-                ext_mapping['uncert'] = hdu.name
-                app.add_data_to_viewer('uncert-viewer', hdu.name)
+                app.add_data_to_viewer('uncert-viewer', data_label)
 
             if any(x in hdu.name.lower() for x in EXT_TYPES['flux']):
-                ext_mapping['flux'] = hdu.name
-                app.add_data_to_viewer('flux-viewer', hdu.name)
-                app.add_data_to_viewer('spectrum-viewer', hdu.name)
-
-    return ext_mapping
+                app.add_data_to_viewer('flux-viewer', data_label)
+                app.add_data_to_viewer('spectrum-viewer', data_label)

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -1,11 +1,15 @@
+import logging
+import os
+
+import numpy as np
 from astropy.io import fits
 from spectral_cube import SpectralCube
 from spectral_cube.io.fits import FITSReadError
-import logging
-import numpy as np
-import os
-from jdaviz.core.registries import data_parser_registry
 from specutils import Spectrum1D
+
+from jdaviz.core.registries import data_parser_registry
+
+__all__ = ['parse_data']
 
 EXT_TYPES = dict(flux=['flux', 'sci'],
                  uncert=['ivar', 'err', 'var', 'uncert'],

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -1,14 +1,33 @@
-from astropy.wcs import WCS
-from astropy.io import fits
+import os
+
+import astropy.units as u
 import numpy as np
 import pytest
+from astropy.io import fits
+from astropy.nddata import StdDevUncertainty
+from astropy.wcs import WCS
+from spectral_cube import SpectralCube
+from specutils import Spectrum1D
+
 from jdaviz.app import Application
 
 
 @pytest.fixture
+def cubeviz_app():
+    return Application(configuration='cubeviz')
+
+
+@pytest.fixture
 def image_hdu_obj():
-    hdu = fits.ImageHDU(np.zeros((10, 10, 10)))
-    hdu.name = 'FLUX'
+    flux_hdu = fits.ImageHDU(np.random.sample((10, 10, 10)))
+    flux_hdu.name = 'FLUX'
+
+    mask_hdu = fits.ImageHDU(np.zeros((10, 10, 10)))
+    mask_hdu.name = 'MASK'
+
+    uncert_hdu = fits.ImageHDU(np.random.sample((10, 10, 10)))
+    uncert_hdu.name = 'ERR'
+
     wcs = WCS(header={
         'WCSAXES': 3, 'CRPIX1': 38.0, 'CRPIX2': 38.0, 'CRPIX3': 1.0,
         'PC1_1 ': -0.000138889, 'PC2_2 ': 0.000138889,
@@ -18,23 +37,45 @@ def image_hdu_obj():
         'CRVAL1': 205.4384, 'CRVAL2': 27.004754, 'CRVAL3': 3.62159598486E-07,
         'LONPOLE': 180.0, 'LATPOLE': 27.004754, 'MJDREFI': 0.0,
         'MJDREFF': 0.0, 'DATE-OBS': '2014-03-30', 'MJD-OBS': 56746.0,
-        'MJD-OBS': 56746.0, 'RADESYS': 'FK5', 'EQUINOX': 2000.0
+        'RADESYS': 'FK5', 'EQUINOX': 2000.0
     })
-    hdu.header.update(wcs.to_header())
 
-    return fits.HDUList([fits.PrimaryHDU(), hdu])
+    flux_hdu.header.update(wcs.to_header())
+    flux_hdu.header['BUNIT'] = '1E-17 erg/s/cm^2/Angstrom/spaxel'
 
+    mask_hdu.header.update(wcs.to_header())
+    uncert_hdu.header.update(wcs.to_header())
 
-@pytest.fixture
-def spectral_cube_obj():
-    return
-
-
-def test_fits_image_hdu_parse(image_hdu_obj):
-    app = Application(configuration='cubeviz')
-
-    app.load_data(image_hdu_obj)
+    return fits.HDUList([fits.PrimaryHDU(), flux_hdu, mask_hdu, uncert_hdu])
 
 
-def test_spectral_cube_parse(spectral_cube_obj):
+def test_fits_image_hdu_parse(image_hdu_obj, cubeviz_app):
+    cubeviz_app.load_data(image_hdu_obj)
 
+    assert len(cubeviz_app.data_collection) == 3
+    assert cubeviz_app.data_collection[0].label.endswith('[FLUX]')
+
+
+def test_spectral_cube_parse(tmpdir, image_hdu_obj, cubeviz_app):
+    f = tmpdir.join("test_fits_image.fits")
+    path = os.path.join(f.dirname, f.basename)
+    image_hdu_obj.writeto(path)
+
+    sc = SpectralCube.read(path, hdu=1)
+
+    cubeviz_app.load_data(sc)
+
+    assert len(cubeviz_app.data_collection) == 1
+    assert cubeviz_app.data_collection[0].label.endswith('[FLUX]')
+
+
+def test_spectrum1d_parse(image_hdu_obj, cubeviz_app):
+    spec = Spectrum1D(flux=np.random.sample(10) * u.Jy,
+                      spectral_axis=np.arange(10) * u.nm,
+                      uncertainty=StdDevUncertainty(
+                          np.random.sample(10) * u.Jy))
+
+    cubeviz_app.load_data(spec)
+
+    assert len(cubeviz_app.data_collection) == 1
+    assert cubeviz_app.data_collection[0].label.endswith('[FLUX]')

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -1,0 +1,40 @@
+from astropy.wcs import WCS
+from astropy.io import fits
+import numpy as np
+import pytest
+from jdaviz.app import Application
+
+
+@pytest.fixture
+def image_hdu_obj():
+    hdu = fits.ImageHDU(np.zeros((10, 10, 10)))
+    hdu.name = 'FLUX'
+    wcs = WCS(header={
+        'WCSAXES': 3, 'CRPIX1': 38.0, 'CRPIX2': 38.0, 'CRPIX3': 1.0,
+        'PC1_1 ': -0.000138889, 'PC2_2 ': 0.000138889,
+        'PC3_3 ': 8.33903304339E-11, 'CDELT1': 1.0, 'CDELT2': 1.0,
+        'CDELT3': 1.0, 'CUNIT1': 'deg', 'CUNIT2': 'deg', 'CUNIT3': 'm',
+        'CTYPE1': 'RA---TAN', 'CTYPE2': 'DEC--TAN', 'CTYPE3': 'WAVE-LOG',
+        'CRVAL1': 205.4384, 'CRVAL2': 27.004754, 'CRVAL3': 3.62159598486E-07,
+        'LONPOLE': 180.0, 'LATPOLE': 27.004754, 'MJDREFI': 0.0,
+        'MJDREFF': 0.0, 'DATE-OBS': '2014-03-30', 'MJD-OBS': 56746.0,
+        'MJD-OBS': 56746.0, 'RADESYS': 'FK5', 'EQUINOX': 2000.0
+    })
+    hdu.header.update(wcs.to_header())
+
+    return fits.HDUList([fits.PrimaryHDU(), hdu])
+
+
+@pytest.fixture
+def spectral_cube_obj():
+    return
+
+
+def test_fits_image_hdu_parse(image_hdu_obj):
+    app = Application(configuration='cubeviz')
+
+    app.load_data(image_hdu_obj)
+
+
+def test_spectral_cube_parse(spectral_cube_obj):
+

--- a/jdaviz/configs/cubeviz/plugins/utils.py
+++ b/jdaviz/configs/cubeviz/plugins/utils.py
@@ -1,0 +1,80 @@
+from astropy.io import fits
+from spectral_cube import SpectralCube
+from spectral_cube.io.fits import FITSReadError
+import logging
+import numpy as np
+from jdaviz.core.registries import data_parser_registry
+
+EXT_TYPES = dict(flux=['flux', 'sci'],
+                 uncert=['ivar', 'err', 'var', 'uncert'],
+                 mask=['mask', 'dq'])
+
+
+@data_parser_registry("cubeviz-data-parser")
+def parse_data(file_path, app):
+    """
+    Attempts to parse a data file and auto-populate available viewers in
+    cubeviz.
+
+    Parameters
+    ----------
+    file_path : str
+        The path to a cube-like data file.
+    data_collection : `~glue.core.DataCollection`
+        The application-level data collection into which the parsed data will
+        be placed.
+
+    Returns
+    -------
+    ext_mapping : dict
+        A mapping of the three necessary components of the cubeviz viewers to
+        the data component labels in glue.
+    """
+    ext_mapping = {'flux': None,
+                   'uncert': None,
+                   'mask': None}
+
+    with fits.open(file_path) as hdulist:
+        wcs = None
+
+        for hdu in hdulist:
+            if hdu.data is None:
+                continue
+
+            # This will fail on attempting to load anything that
+            # isn't cube-shaped
+            try:
+                sc = SpectralCube.read(hdu)
+                wcs = sc.wcs
+            except ValueError:
+                # This will fail if the parsing of the wcs does not provide
+                # proper celestial axes
+                try:
+                    hdu.header.update(wcs.to_header())
+                    sc = SpectralCube.read(hdu)
+                except ValueError as e:
+                    logging.error(e)
+                    continue
+            except FITSReadError as e:
+                logging.error(e)
+                continue
+
+            app.data_collection[hdu.name] = sc
+
+            # If the data type is some kind of integer, assume it's the mask/dq
+            if hdu.data.dtype in (np.int, np.uint, np.uint32) or \
+                    any(x in hdu.name.lower() for x in EXT_TYPES['mask']):
+                ext_mapping['mask'] = hdu.name
+                app.add_data_to_viewer('mask-viewer', hdu.name)
+
+            if 'errtype' in [x.lower() for x in hdu.header.keys()] or \
+                    any(x in hdu.name.lower() for x in EXT_TYPES['uncert']):
+                ext_mapping['uncert'] = hdu.name
+                app.add_data_to_viewer('uncert-viewer', hdu.name)
+
+            if any(x in hdu.name.lower() for x in EXT_TYPES['flux']):
+                ext_mapping['flux'] = hdu.name
+                app.add_data_to_viewer('flux-viewer', hdu.name)
+                app.add_data_to_viewer('spectrum-viewer', hdu.name)
+
+    return ext_mapping

--- a/jdaviz/core/registries.py
+++ b/jdaviz/core/registries.py
@@ -5,8 +5,9 @@ from ipyvuetify import VuetifyTemplate
 from ipywidgets import Widget
 
 
-__all__ = ['viewer_registry', 'tray_registry', 'tool_registry', 'ViewerRegistry', 'TrayRegistry',
-           'ToolRegistry', 'MenuRegistry']
+__all__ = ['viewer_registry', 'tray_registry', 'tool_registry',
+           'data_parser_registry', 'ViewerRegistry', 'TrayRegistry',
+           'ToolRegistry', 'MenuRegistry', 'DataParserRegistry']
 
 
 def convert(name):
@@ -163,7 +164,20 @@ class MenuRegistry(UniqueDictRegistry):
         return decorator
 
 
+class DataParserRegistry(UniqueDictRegistry):
+    """
+    Registry containing parsing functions for attempting to auto-populate the
+    application-defined initial viewers.
+    """
+    def __call__(self, name=None):
+        def decorator(func):
+            self.add(name, func)
+            return func
+        return decorator
+
+
 viewer_registry = ViewerRegistry()
 tray_registry = TrayRegistry()
 tool_registry = ToolRegistry()
 menu_registry = MenuRegistry()
+data_parser_registry = DataParserRegistry()

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -1,7 +1,16 @@
 import os
 from traitlets import Unicode
+from astropy.io import fits
+from spectral_cube import SpectralCube
+from spectral_cube.io.fits import FITSReadError
+import logging
+import numpy as  np
 
 __all__ = ['load_template']
+
+EXT_TYPES = dict(flux=['flux', 'sci'],
+                 uncert=['ivar', 'err', 'var', 'uncert'],
+                 mask=['mask', 'dq'])
 
 
 def load_template(file_name, path=None, traitlet=True):
@@ -31,3 +40,51 @@ def load_template(file_name, path=None, traitlet=True):
         return Unicode(TEMPLATE)
 
     return TEMPLATE
+
+
+def parse_data(file_path, data_collection):
+    # There may be an issue with the wcs in which it exists only on the flux
+    # data. Luckily, Glue seems to deal with this well enough. We can leverage
+    # the translation machinery by loading first as a Glue object, translate to
+    # `SpectralCube` object, and then back again.
+    ext_mapping = {'flux': None,
+                   'uncert': None,
+                   'mask': None}
+
+    with fits.open(file_path) as hdulist:
+        wcs = None
+
+        for hdu in hdulist:
+            if hdu.data is None:
+                continue
+
+            try:
+                sc = SpectralCube.read(hdu)
+                wcs = sc.wcs
+            except ValueError:
+                try:
+                    hdu.header.update(wcs.to_header())
+                    sc = SpectralCube.read(hdu)
+                except ValueError as e:
+                    logging.error(e)
+                    continue
+            except FITSReadError as e:
+                logging.error(e)
+                continue
+
+            data_collection[hdu.name] = sc
+
+            # If the data type is some kind of integer, assume it's the mask/dq
+            if hdu.data.dtype in (np.int, np.uint, np.uint32) or \
+                    any(x in hdu.name.lower() for x in EXT_TYPES['mask']):
+                ext_mapping['mask'] = hdu.name
+
+            if 'errtype' in [x.lower() for x in hdu.header.keys()] or \
+                    any(x in hdu.name.lower() for x in EXT_TYPES['uncert']):
+                ext_mapping['uncert'] = hdu.name
+
+            if 'errtype' in [x.lower() for x in hdu.header.keys()] or \
+                    any(x in hdu.name.lower() for x in EXT_TYPES['flux']):
+                ext_mapping['flux'] = hdu.name
+
+    return ext_mapping

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -1,16 +1,7 @@
 import os
 from traitlets import Unicode
-from astropy.io import fits
-from spectral_cube import SpectralCube
-from spectral_cube.io.fits import FITSReadError
-import logging
-import numpy as  np
 
 __all__ = ['load_template']
-
-EXT_TYPES = dict(flux=['flux', 'sci'],
-                 uncert=['ivar', 'err', 'var', 'uncert'],
-                 mask=['mask', 'dq'])
 
 
 def load_template(file_name, path=None, traitlet=True):
@@ -40,68 +31,3 @@ def load_template(file_name, path=None, traitlet=True):
         return Unicode(TEMPLATE)
 
     return TEMPLATE
-
-
-def parse_data(file_path, data_collection):
-    """
-    Attempts to parse a data file and auto-populate available viewers in
-    cubeviz.
-
-    Parameters
-    ----------
-    file_path : str
-        The path to a cube-like data file.
-    data_collection : `~glue.core.DataCollection`
-        The application-level data collection into which the parsed data will
-        be placed.
-
-    Returns
-    -------
-    ext_mapping : dict
-        A mapping of the three necessary components of the cubeviz viewers to
-        the data component labels in glue.
-    """
-    ext_mapping = {'flux': None,
-                   'uncert': None,
-                   'mask': None}
-
-    with fits.open(file_path) as hdulist:
-        wcs = None
-
-        for hdu in hdulist:
-            if hdu.data is None:
-                continue
-
-            # This will fail on attempting to load anything that
-            # isn't cube-shaped
-            try:
-                sc = SpectralCube.read(hdu)
-                wcs = sc.wcs
-            except ValueError:
-                # This will fail if the parsing of the wcs does not provide
-                # proper celestial axes
-                try:
-                    hdu.header.update(wcs.to_header())
-                    sc = SpectralCube.read(hdu)
-                except ValueError as e:
-                    logging.error(e)
-                    continue
-            except FITSReadError as e:
-                logging.error(e)
-                continue
-
-            data_collection[hdu.name] = sc
-
-            # If the data type is some kind of integer, assume it's the mask/dq
-            if hdu.data.dtype in (np.int, np.uint, np.uint32) or \
-                    any(x in hdu.name.lower() for x in EXT_TYPES['mask']):
-                ext_mapping['mask'] = hdu.name
-
-            if 'errtype' in [x.lower() for x in hdu.header.keys()] or \
-                    any(x in hdu.name.lower() for x in EXT_TYPES['uncert']):
-                ext_mapping['uncert'] = hdu.name
-
-            if any(x in hdu.name.lower() for x in EXT_TYPES['flux']):
-                ext_mapping['flux'] = hdu.name
-
-    return ext_mapping


### PR DESCRIPTION
This PR allows for defining a parsing function that takes in data and attempts to place it in the correct viewers. The parsing function is specific to the application instance and the reference is defined in the yaml file.

In this case, we use spectral cube to read the incoming data. There are several issues with this approach, mainly: `SpectralCube` doesn't handle uncertainties, and `SpectralCube` is only capable of parsing three dimensional data. Thus, with this approach, we do not load non-cube like data.

Alternatives include fixing specutils to properly handle and parse all aspects of cube data, but that may be for a future PR.