### PR TITLE
MOSViz config and notebook for testing slits

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -795,6 +795,8 @@ class Application(TemplateMixin):
             path = os.path.join(default_path, "cubeviz", "cubeviz.yaml")
         elif path == 'specviz':
             path = os.path.join(default_path, "specviz", "specviz.yaml")
+        elif path == 'mosviz':
+            path = os.path.join(default_path, "mosviz", "mosviz.yaml")
         elif not os.path.isfile(path):
             raise ValueError("Configuration must be path to a .yaml file.")
 

--- a/jdaviz/configs/__init__.py
+++ b/jdaviz/configs/__init__.py
@@ -1,3 +1,4 @@
 from .cubeviz import *
 from .specviz import *
 from .default import *
+from .mosviz import *

--- a/jdaviz/configs/mosviz/__init__.py
+++ b/jdaviz/configs/mosviz/__init__.py
@@ -1,0 +1,1 @@
+from .plugins import *

--- a/jdaviz/configs/mosviz/mosviz.ipynb
+++ b/jdaviz/configs/mosviz/mosviz.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "from jdaviz.app import Application\n",
+    "from glue.core import Data\n",
+    "app = Application(configuration='mosviz')\n",
+    "data = app.load_data('DATA_FILENAME')\n",
+    "app"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/jdaviz/configs/mosviz/mosviz.yaml
+++ b/jdaviz/configs/mosviz/mosviz.yaml
@@ -1,0 +1,33 @@
+settings:
+  configuration: mosviz
+  visible:
+    menu_bar: false
+    toolbar: true
+    tray: true
+    tab_headers: false
+  context:
+    notebook:
+      max_height: 600px
+toolbar:
+  - g-data-tools
+  - g-subset-tools
+  - g-unified-slider
+tray:
+  - g-gaussian-smooth
+  - g-collapse
+viewer_area:
+  - container: col
+    children:
+      - container: row
+        viewers:
+          - name: Image viewer
+            plot: mosviz-image-viewer
+            reference: mos-image-viewer
+          - name: 2D Spectrum viewer
+            plot: mosviz-image-viewer
+            reference: mos-2d-spectrum-viewer
+      - container: row
+        viewers:
+          - name: Spectrum
+            plot: mosviz-profile-viewer
+            reference: spectrum-viewer

--- a/jdaviz/configs/mosviz/plugins/__init__.py
+++ b/jdaviz/configs/mosviz/plugins/__init__.py
@@ -1,0 +1,1 @@
+from .viewers import *

--- a/jdaviz/configs/mosviz/plugins/viewers.py
+++ b/jdaviz/configs/mosviz/plugins/viewers.py
@@ -1,0 +1,31 @@
+from glue.core import BaseData
+from glue_jupyter.bqplot.image import BqplotImageView
+from glue_jupyter.bqplot.profile import BqplotProfileView
+from specutils import Spectrum1D
+
+from jdaviz.core.registries import viewer_registry
+
+__all__ = ['MOSVizProfileView', 'MOSVizImageView']
+
+
+@viewer_registry("mosviz-profile-viewer", label="Profile 1D (MOSViz)")
+class MOSVizProfileView(BqplotProfileView):
+    default_class = Spectrum1D
+
+    def data(self, cls=None):
+        return [layer_state.layer.get_object(cls=cls or self.default_class)
+                for layer_state in self.state.layers
+                if hasattr(layer_state, 'layer') and
+                isinstance(layer_state.layer, BaseData)]
+
+
+@viewer_registry("mosviz-image-viewer", label="Image 2D (MOSViz)")
+class MOSVizImageView(BqplotImageView):
+
+    default_class = None
+
+    def data(self, cls=None):
+        return [layer_state.layer #.get_object(cls=cls or self.default_class)
+                for layer_state in self.state.layers
+                if hasattr(layer_state, 'layer') and
+                isinstance(layer_state.layer, BaseData)]

--- a/notebooks/concepts/mosviz_overplot_slit_example.ipynb
+++ b/notebooks/concepts/mosviz_overplot_slit_example.ipynb
@@ -1,0 +1,241 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load jdaviz app in mosviz configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "from jdaviz.app import Application\n",
+    "\n",
+    "app = Application(configuration='mosviz')\n",
+    "app"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.utils.data import download_file\n",
+    "\n",
+    "# This file is originally from https://data.sdss.org/sas/dr14/manga/spectro/redux/v2_1_2/7495/stack/manga-7495-12704-LOGCUBE.fits.gz\n",
+    "# but has been modified to correct some inconsistencies in the way units are parsed\n",
+    "\n",
+    "# Load cutout into the left image viewer\n",
+    "cutout_image_file = \"/Users/javerbukh/Documents/data_for_mosviz/mosviz_nirspec_data_0.3/level3/mosviz_cutouts/227.fits\"\n",
+    "app.load_data(cutout_image_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set image viewer (top left) to visualize cutout 227.fits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig_image = app.get_viewer(\"mos-image-viewer\").figure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import bqplot\n",
+    "from regions import RectanglePixelRegion, PixCoord\n",
+    "from ipywidgets import VBox\n",
+    "import numpy as np\n",
+    "from bqplot import *\n",
+    "\n",
+    "def region_to_vertices(region):\n",
+    "    p = region.to_polygon()\n",
+    "    return p.vertices.x, p.vertices.y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Extract slit data from files and visualize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load 2d spectrum data on the right image viewer\n",
+    "spectrum_2d_file = \"/Users/javerbukh/Documents/data_for_mosviz/mosviz_nirspec_data_0.3/level3/f170lp-g235m_mos_observation-6-c0e0_s00227_cal.fits\"\n",
+    "app.load_data(spectrum_2d_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set 2D Spectrum viewer (top right) to visualize f170lp-g235m_mos_observation-6-c0e0_s00227_cal.fits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig_2d = app.get_viewer(\"mos-2d-spectrum-viewer\").figure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.io import fits\n",
+    "hdu = fits.open(spectrum_2d_file)\n",
+    "header = hdu[1].header"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Code to create SkyRegions\n",
+    "\n",
+    "from regions import  RectangleSkyRegion,RectanglePixelRegion\n",
+    "from astropy.coordinates import Angle, SkyCoord\n",
+    "from astropy import units as u \n",
+    "from astropy.wcs import WCS\n",
+    "def jwst_header_to_skyregion(header):\n",
+    "    s_region = header['S_REGION']\n",
+    "    footprint = s_region.split(\"POLYGON ICRS\")[1].split()\n",
+    "    ra = np.array(footprint[::2], dtype=np.float)\n",
+    "    dec = np.array(footprint[1::2], dtype=np.float)\n",
+    "        \n",
+    "    # Find center of slit\n",
+    "    cra = (max(ra) + min(ra))/2 \n",
+    "    cdec = (max(dec) + min(dec))/2\n",
+    "    \n",
+    "    # Find center as skycoord\n",
+    "    skycoord = SkyCoord(cra, cdec,\n",
+    "                        unit=(u.Unit(u.deg),\n",
+    "                              u.Unit(u.deg)))\n",
+    "    \n",
+    "    # Puts corners of slit into skycoord object\n",
+    "    corners = SkyCoord(ra, dec, unit=\"deg\")\n",
+    "    \n",
+    "    # Compute length and width\n",
+    "    length = corners[0].separation(corners[1])\n",
+    "    width = corners[1].separation(corners[2])\n",
+    "    length = Angle(length, u.deg)\n",
+    "    width = Angle(width, u.deg)\n",
+    "    \n",
+    "    skyregion = RectangleSkyRegion(center=skycoord, width=width, height=length)\n",
+    "    return skyregion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set WCS\n",
+    "\n",
+    "sky_region = jwst_header_to_skyregion(header)\n",
+    "header_copy = header.copy()\n",
+    "header_copy['WCSAXES'] = 2\n",
+    "for key in header:\n",
+    "    if '3' in key:\n",
+    "        header_copy.remove(key)\n",
+    "wcs_2d = WCS(header_copy)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use wcs of image viewer to scale slit dimensions correctly\n",
+    "image_hdu = fits.open(cutout_image_file)\n",
+    "wcs_image = WCS(image_hdu[0].header)\n",
+    "\n",
+    "pixel_region = sky_region.to_pixel(wcs_image)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create polygon region from the pixel region and set vertices\n",
+    "pix_rec = pixel_region.to_polygon()\n",
+    "\n",
+    "x_coords = pix_rec.vertices.x\n",
+    "y_coords = pix_rec.vertices.y\n",
+    "\n",
+    "# Create LinearScale that is the same size as the image viewer\n",
+    "x_sc = LinearScale(min=fig_image.interaction.x_scale.min, max=fig_image.interaction.x_scale.max)\n",
+    "y_sc = LinearScale(min=fig_image.interaction.y_scale.min, max=fig_image.interaction.y_scale.max)\n",
+    "\n",
+    "scales={'x': x_sc, 'y':y_sc}\n",
+    "patch2 = bqplot.Lines(x=x_coords, y=y_coords, scales=scales, fill='none', colors = [\"red\"], stroke_width=2, close_path=True)\n",
+    "\n",
+    "# Visualize slit on the figure\n",
+    "fig_image.marks = fig_image.marks + [patch2]\n",
+    "fig_image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ jdaviz_plugins =
     default = jdaviz.configs.default
     cubeviz = jdaviz.configs.cubeviz
     specviz = jdaviz.configs.specviz
+    mosviz = jdaviz.configs.mosviz
 
 [tool:pytest]
 testpaths = "jdaviz" "docs"


### PR DESCRIPTION
This PR adds the mosviz config layout. The mosviz.ipynb file also contains the beginnings of the slit implementation using `bqplot.marks.Lines`. If you run the notebook, the viewer that is created in the bottom cell allows for panning of the image viewer where the red outline ("slit" in this case) follows the viewer. However, if you go back to the top (the main jdaviz app view), panning **does not** move the slit with the image viewer. I will continue to investigate this behavior but I would appreciate input from @nmearl and @mariobuikhuizen on how to proceed from here.