### PR TITLE
Extract SpectralRegions from specviz app

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -21,10 +21,7 @@ from glue.core.state_objects import State
 from glue.core.subset import Subset
 from glue_jupyter.app import JupyterApplication
 from glue_jupyter.state_traitlets_helpers import GlueState
-from ipygoldenlayout import GoldenLayout
 from ipyvuetify import VuetifyTemplate
-from ipysplitpanes import SplitPanes
-from traitlets import Dict
 
 from .core.events import (LoadDataMessage, NewViewerMessage, AddDataMessage,
                           SnackbarMessage, RemoveDataMessage)

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -53,6 +53,16 @@ class SpecViz(ConfigHelper):
         return self.app.get_data_from_viewer('spectrum-viewer')
 
     def get_spectral_regions(self):
+        """
+        Retrieves glue subset objects from the spectrum viewer and converts
+        them to `~specutils.SpectralRegion` objects.
+
+        Returns
+        -------
+        spec_regs : dict
+            Mapping from the names of the subsets to the subsets expressed
+            as `specutils.SpectralRegion` objects.
+        """
         regions = self.app.get_subsets_from_viewer('spectrum-viewer')
 
         spec_regs = {}

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -52,14 +52,13 @@ class SpecViz(ConfigHelper):
         """Returns the current data loaded into the main viewer"""
         return self.app.get_data_from_viewer('spectrum-viewer')
 
-    def get_regions(self):
+    def get_spectral_regions(self):
         regions = self.app.get_subsets_from_viewer('spectrum-viewer')
 
         spec_regs = {}
 
         for name, reg in regions.items():
-            spec_reg = SpectralRegion((reg.center.x - reg.width * 0.5,
-                                       reg.center.x + reg.width * 0.5))
+            spec_reg = SpectralRegion.from_center(reg.center.x, reg.width)
 
             spec_regs[name] = spec_reg
 

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -1,7 +1,7 @@
 import pathlib
 import uuid
 
-from specutils import Spectrum1D, SpectrumCollection
+from specutils import Spectrum1D, SpectrumCollection, SpectralRegion
 
 from jdaviz.core.helpers import ConfigHelper
 
@@ -11,19 +11,28 @@ class SpecViz(ConfigHelper):
 
     _default_configuration = 'specviz'
 
-    def load_data(self, data, data_label='', format=None):
-        """Loads a data file or Spectrum1D object into SpecViz
+    def load_data(self, data, data_label=None, format=None):
+        """
+        Loads a data file or `~specutils.Spectrum1D` object into SpecViz.
 
-        :param data: Spectrum1D spectra, or path to compatible data file
-        :param data_label: Name/identifier of data
-        :param format: Spectrum1D data format to load
+        Parameters
+        ----------
+        data : str or `~specutils.Spectrum1D`
+            Spectrum1D spectra, or path to compatible data file.
+        data_label : str
+            The Glue data label found in the ``DataCollection``.
+        format : str
+            Loader format specification used to indicate data format in
+            `~specutils.Spectrum1D.read` io method.
         """
         # If no data label is assigned, give it a unique identifier
-        if not data_label:
+        if data_label is None:
             data_label = "specviz_data|" + uuid.uuid4().hex
+
         # If data provided is a path, try opening into a Spectrum1D object
         try:
             path = pathlib.Path(data)
+
             if path.is_file():
                 data = Spectrum1D.read(path, format=format)
             else:
@@ -31,12 +40,27 @@ class SpecViz(ConfigHelper):
         # If not, it must be a Spectrum1D object. Otherwise, it's unsupported
         except TypeError:
             if type(data) is SpectrumCollection:
-                raise TypeError("SpectrumCollection detected. Please provide a Spectrum1D")
+                raise TypeError("`SpectrumCollection` detected. Please "
+                                "provide a `Spectrum1D`.")
             elif type(data) is not Spectrum1D:
                 raise TypeError("Data is not a Spectrum1D object or compatible file")
+
         self.app.add_data(data, data_label)
         self.app.add_data_to_viewer('spectrum-viewer', data_label)
 
     def get_spectra(self):
         """Returns the current data loaded into the main viewer"""
         return self.app.get_data_from_viewer('spectrum-viewer')
+
+    def get_regions(self):
+        regions = self.app.get_subsets_from_viewer('spectrum-viewer')
+
+        spec_regs = {}
+
+        for name, reg in regions.items():
+            spec_reg = SpectralRegion((reg.center.x - reg.width * 0.5,
+                                       reg.center.x + reg.width * 0.5))
+
+            spec_regs[name] = spec_reg
+
+        return spec_regs


### PR DESCRIPTION
This PR allows for extracting subsets as `SpectralRegion` objects from the specviz app. Requires #159.