### PR TITLE
Implement native file picker

### DIFF
--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -12,6 +12,7 @@ settings:
     notebook:
       max_height: 600px
 toolbar:
+  - g-file-import
   - g-data-tools
   - g-subset-tools
   - g-unified-slider

--- a/jdaviz/configs/default/default.yaml
+++ b/jdaviz/configs/default/default.yaml
@@ -8,6 +8,7 @@ settings:
     notebook:
       max_height: 600px
 toolbar:
+  - g-file-import
   - g-data-tools
   - g-viewer-creator
   - g-subset-tools

--- a/jdaviz/configs/default/plugins/__init__.py
+++ b/jdaviz/configs/default/plugins/__init__.py
@@ -5,3 +5,4 @@ from .viewer_creator import *
 from .subset_tools.subset_tools import *
 from .model_fitting.model_fitting import *
 from .collapse.collapse import *
+from .file_import import *

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.vue
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.vue
@@ -1,40 +1,5 @@
 <template>
   <v-toolbar-items>
-    <v-dialog v-model="dialog" width="500" persistent @keydown.stop>
-      <template v-slot:activator="{ on }">
-        <v-btn tile depressed v-on="on" color="accent">
-          Import
-          <v-icon right>mdi-plus</v-icon>
-        </v-btn>
-      </template>
-
-      <v-card>
-        <v-card-title class="headline" color="primary" primary-title>Import Data</v-card-title>
-
-        <v-card-text>
-          <v-container>
-            <v-row>
-              <v-col>
-                <!-- <v-file-input v-model="files" label="File input"></v-file-input> -->
-                <v-text-field
-                  label="File Path"
-                  placeholder="/path/to/data/file"
-                  v-model="file_path"
-                  :error-messages="error_message"
-                ></v-text-field>
-              </v-col>
-            </v-row>
-          </v-container>
-        </v-card-text>
-        <!-- <v-divider></v-divider> -->
-
-        <v-card-actions>
-          <div class="flex-grow-1"></div>
-          <v-btn color="primary" text @click="dialog = false">Cancel</v-btn>
-          <v-btn color="primary" text @click="load_data" :disabled="!valid_path">Import</v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
     <v-tooltip bottom>
       <template v-slot:activator="{ on }">
         <v-btn disabled v-on="on" icon tile>

--- a/jdaviz/configs/default/plugins/file_import/__init__.py
+++ b/jdaviz/configs/default/plugins/file_import/__init__.py
@@ -1,0 +1,1 @@
+from .file_import import *

--- a/jdaviz/configs/default/plugins/file_import/file_import.py
+++ b/jdaviz/configs/default/plugins/file_import/file_import.py
@@ -1,3 +1,7 @@
+import os
+import tempfile
+import uuid
+
 import ipywidgets as w
 from traitlets import Dict
 
@@ -16,26 +20,19 @@ class FileImport(TemplateMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._file_upload = w.FileUpload()
+        self._file_upload = w.FileUpload(accept='*')
         self.components = {'g-file-import': self._file_upload}
 
         self._file_upload.observe(self.on_counter_changed, names=['_counter'])
 
     def on_counter_changed(self, event):
-        print("called")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_name = str(uuid.uuid4())
+            file_path = os.path.join(tmp_dir, file_name)
 
-        for name, data in self._file_upload.value.items():
-            path = "/Users/nearl/Desktop/" + name
-            print(path)
-#             with open(path, 'w') as f:
-#                 f.write("Test")
+            with open(file_path, "wb") as tmp_file:
+                tmp_file.write(list(self._file_upload.value.values())[-1]['content'])
 
-#             img = w.Image(
-#                 value=data['content'],
-#                 format='png',
-#                 width=300,
-#                 height=400,
-#             )
-#             display(img)
+            self.app.load_data(file_path)\
 
 

--- a/jdaviz/configs/default/plugins/file_import/file_import.py
+++ b/jdaviz/configs/default/plugins/file_import/file_import.py
@@ -1,0 +1,41 @@
+import ipywidgets as w
+from traitlets import Dict
+
+from jdaviz.core.registries import tool_registry
+from jdaviz.core.template_mixin import TemplateMixin
+from jdaviz.utils import load_template
+
+__all__ = ['FileImport']
+
+
+@tool_registry('g-file-import')
+class FileImport(TemplateMixin):
+    chosen_file = Dict().tag(sync=True)
+    template = load_template("file_import.vue", __file__).tag(sync=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._file_upload = w.FileUpload()
+        self.components = {'g-file-import': self._file_upload}
+
+        self._file_upload.observe(self.on_counter_changed, names=['_counter'])
+
+    def on_counter_changed(self, event):
+        print("called")
+
+        for name, data in self._file_upload.value.items():
+            path = "/Users/nearl/Desktop/" + name
+            print(path)
+#             with open(path, 'w') as f:
+#                 f.write("Test")
+
+#             img = w.Image(
+#                 value=data['content'],
+#                 format='png',
+#                 width=300,
+#                 height=400,
+#             )
+#             display(img)
+
+

--- a/jdaviz/configs/default/plugins/file_import/file_import.vue
+++ b/jdaviz/configs/default/plugins/file_import/file_import.vue
@@ -1,25 +1,23 @@
 <template>
   <v-toolbar-items>
-    <v-btn tile depressed color="primary" @click="onClicked">
+    <v-btn tile depressed color="accent" @click="onClicked">
       Import
-      <div v-show=false id="file-uploader">
-        <g-file-import></g-file-import>
-      </div>
       <v-icon right>mdi-plus</v-icon>
     </v-btn>
+    <g-file-import v-show=false id="file-uploader"></g-file-import>
   </v-toolbar-items>
 </template>
 
 <script>
-  module.exports = {
-    name: "g-file-import",
-    props: [],
+    module.exports = {
+        name: "g-file-import",
+        props: [],
 
-    methods: {
-      onClicked(event) {
-        let uploadButton = document.getElementById("file-uploader").firstElementChild.children[0];
-        uploadButton.click();
-      },
-    },
-  };
+        methods: {
+            onClicked(event) {
+                let uploadButton = document.getElementById("file-uploader").firstElementChild;
+                uploadButton.click();
+            },
+        },
+    };
 </script>

--- a/jdaviz/configs/default/plugins/file_import/file_import.vue
+++ b/jdaviz/configs/default/plugins/file_import/file_import.vue
@@ -1,0 +1,25 @@
+<template>
+  <v-toolbar-items>
+    <v-btn tile depressed color="primary" @click="onClicked">
+      Import
+      <div v-show=false id="file-uploader">
+        <g-file-import></g-file-import>
+      </div>
+      <v-icon right>mdi-plus</v-icon>
+    </v-btn>
+  </v-toolbar-items>
+</template>
+
+<script>
+  module.exports = {
+    name: "g-file-import",
+    props: [],
+
+    methods: {
+      onClicked(event) {
+        let uploadButton = document.getElementById("file-uploader").firstElementChild.children[0];
+        uploadButton.click();
+      },
+    },
+  };
+</script>

--- a/jdaviz/configs/specviz/specviz.yaml
+++ b/jdaviz/configs/specviz/specviz.yaml
@@ -9,6 +9,7 @@ settings:
     notebook:
       max_height: 600px
 toolbar:
+  - g-file-import
   - g-data-tools
   - g-subset-tools
 tray:


### PR DESCRIPTION
Short circuits the available ipywidgets file picker to display a native file browser to importing data. Currently, this is limited to 10MB as we attempt to address the Tornado websocket upload limits.