### PR TITLE
Parallel cube fitting

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -21,7 +21,7 @@ from glue.core import BaseData, HubListener, Data, DataCollection
 from glue.core.autolinking import find_possible_links
 from glue.core.link_helpers import LinkSame
 from glue.core.message import (DataCollectionAddMessage,
-                               DataCollectionDeleteMessage)
+                               DataCollectionDeleteMessage, SubsetCreateMessage)
 from glue.core.state_objects import State
 from glue.core.subset import Subset
 from glue_jupyter.app import JupyterApplication
@@ -62,7 +62,8 @@ class ApplicationState(State):
         'show': False,
         'test': "",
         'color': None,
-        'timeout': 3000
+        'timeout': 3000,
+        'loading': False
     }, docstring="State of the quick toast messages.")
 
     settings = DictCallbackProperty({
@@ -168,6 +169,8 @@ class Application(VuetifyTemplate, HubListener):
         self.hub.subscribe(self, SnackbarMessage,
                            handler=self._on_snackbar_message)
 
+        self.hub.subscribe(self, SubsetCreateMessage, handler=lambda x: print("HERE"))
+
         # Add callback that updates the layout when the data item array changes
         self.state.add_callback('stack_items', self.vue_relayout)
 
@@ -223,6 +226,7 @@ class Application(VuetifyTemplate, HubListener):
         self.state.snackbar['text'] = msg.text
         self.state.snackbar['color'] = msg.color
         self.state.snackbar['timeout'] = msg.timeout
+        self.state.snackbar['loading'] = msg.loading
         self.state.snackbar['show'] = True
 
     def _link_new_data(self):

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -387,10 +387,7 @@ class Application(VuetifyTemplate, HubListener):
 
         # If a data label was provided, return only the data requested
         if data_label is not None:
-            if data_label in data:
-                data = {data_label: data.get(data_label)}
-            else:
-                data = {}
+            return data.get(data_label)
 
         return data
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -21,7 +21,7 @@ from glue.core import BaseData, HubListener, Data, DataCollection
 from glue.core.autolinking import find_possible_links
 from glue.core.link_helpers import LinkSame
 from glue.core.message import (DataCollectionAddMessage,
-                               DataCollectionDeleteMessage, SubsetCreateMessage)
+                               DataCollectionDeleteMessage)
 from glue.core.state_objects import State
 from glue.core.subset import Subset
 from glue_jupyter.app import JupyterApplication
@@ -168,8 +168,6 @@ class Application(VuetifyTemplate, HubListener):
         #  message box
         self.hub.subscribe(self, SnackbarMessage,
                            handler=self._on_snackbar_message)
-
-        self.hub.subscribe(self, SubsetCreateMessage, handler=lambda x: print("HERE"))
 
         # Add callback that updates the layout when the data item array changes
         self.state.add_callback('stack_items', self.vue_relayout)

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -57,7 +57,20 @@
       absolute
     >
       {{ state.snackbar.text }}
-      <v-btn text @click="state.snackbar.show = false">Close</v-btn>
+
+      <v-progress-circular
+              v-if="state.snackbar.loading"
+              indeterminate
+      ></v-progress-circular>
+
+      <v-btn
+              v-if="!state.snackbar.loading"
+              text
+              @click="state.snackbar.show = false"
+      >
+        Close
+      </v-btn>
+
     </v-snackbar>
   </v-app>
 </template>
@@ -71,8 +84,6 @@ export default {
     }
   },
   created() {
-    console.log("Created");
-    console.log(this.$vuetify.theme);
     this.$vuetify.theme.themes.light = {
       primary: "#00617E",
       secondary: "#007DA4",

--- a/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
+++ b/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
@@ -9,7 +9,6 @@ import astropy.units as u
 
 from specutils.spectra import Spectrum1D
 from specutils.fitting import fit_lines
-from spectral_cube import SpectralCube
 
 __all__ = ['fit_model_to_spectrum']
 

--- a/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
+++ b/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
@@ -159,7 +159,7 @@ def _fit_3D(initial_model, spectrum):
     # sequentially). Instead, chunk the spaxel list based on the number of
     # available processors, and have each processor do the model fitting
     # on the entire subset of spaxel tuples, then return the set of results.
-    for spx in np.array_split(spaxels, 8):
+    for spx in np.array_split(spaxels, mp.cpu_count() - 1):
         # Worker for the multiprocess pool.
         worker = SpaxelWorker(spectrum.flux,
                               spectrum.spectral_axis,

--- a/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
+++ b/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
@@ -186,7 +186,7 @@ def _fit_3D(initial_model, spectrum):
 
 
 class SpaxelWorker:
-    '''
+    """
     A class with callable instances that perform fitting over a
     spaxel. It provides the callable for the `Pool.apply_async`
     function, and also holds everything necessary to perform the
@@ -198,7 +198,7 @@ class SpaxelWorker:
     modify parameter values in an already built CompoundModel
     instance. We need to use the current model instance while
     it still exists.
-    '''
+    """
     def __init__(self, flux_cube, wave_array, initial_model):
         self.cube = flux_cube
         self.wave = wave_array
@@ -223,7 +223,7 @@ class SpaxelWorker:
 
         fitted_values = fitted_model(self.wave)
 
-        return (x, y, fitted_model, fitted_values)
+        return x, y, fitted_model, fitted_values
 
 
 def _build_model(component_list, expression):
@@ -300,7 +300,7 @@ def _handle_parameter_units(model, fitted_parameters_cube, param_units):
 
 def _generate_spaxel_list(spectrum):
     """
-    Generates a list wuth tuples, each one addressing the (x,y)
+    Generates a list with tuples, each one addressing the (x,y)
     coordinates of a spaxel in a 3-D spectrum cube.
 
     Parameters

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -130,7 +130,7 @@ class ModelFitting(TemplateMixin):
         for m in self.component_models:
             name = m["id"]
             if len(self.component_models) > 1:
-                m_fit = self._fitted_model.unitless_model[name]
+                m_fit = self._fitted_model[name]
             else:
                 m_fit = self._fitted_model
             temp_params = []

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -285,7 +285,8 @@ class ModelFitting(TemplateMixin):
         # that the user has selected a pre-existing 1d data object.
         if data.ndim != 3:
             snackbar_message = SnackbarMessage(
-                f"Selected data {self._selected_data_label} is not cube-like.",
+                f"Selected data {self._selected_data_label} is not cube-like",
+                color='error',
                 sender=self)
             self.hub.broadcast(snackbar_message)
             return
@@ -302,6 +303,13 @@ class ModelFitting(TemplateMixin):
         #  in the cube we select
         wcs = data.coords.sub([WCSSUB_SPECTRAL])
         spec = Spectrum1D(flux=values, wcs=wcs)
+
+        # TODO: in vuetify >2.3, timeout should be set to -1 to keep open
+        #  indefinitely
+        snackbar_message = SnackbarMessage(
+            "Fitting model to cube...",
+            loading=True, timeout=0, sender=self)
+        self.hub.broadcast(snackbar_message)
 
         fitted_model, fitted_spectrum = fit_model_to_spectrum(
             spec,

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -3,12 +3,15 @@ import pickle
 
 import astropy.modeling.models as models
 import astropy.units as u
+import numpy as np
+from astropy.wcs import WCSSUB_SPECTRAL
 from glue.core.message import (SubsetCreateMessage,
                                SubsetDeleteMessage,
                                SubsetUpdateMessage)
+from specutils import Spectrum1D
 from traitlets import Bool, Int, List, Unicode
 
-from jdaviz.core.events import AddDataMessage, RemoveDataMessage
+from jdaviz.core.events import AddDataMessage, RemoveDataMessage, SnackbarMessage
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import TemplateMixin
 from jdaviz.utils import load_template
@@ -60,6 +63,7 @@ class ModelFitting(TemplateMixin):
         self._display_order = False
         self.model_save_path = os.getcwd()
         self.model_label = "Model"
+        self._selected_data_label = None
 
         self.hub.subscribe(self, AddDataMessage,
                            handler=self._on_viewer_data_changed)
@@ -79,7 +83,7 @@ class ModelFitting(TemplateMixin):
     def _on_viewer_data_changed(self, msg=None):
         """
         Callback method for when data is added or removed from a viewer, or
-        when a subset is created, deleted, or updated. This method receieves
+        when a subset is created, deleted, or updated. This method receives
         a glue message containing viewer information in the case of the former
         set of events, and updates the available data list displayed to the
         user.
@@ -165,7 +169,8 @@ class ModelFitting(TemplateMixin):
             label of the data collection object selected by the user.
         """
         selected_spec = self.app.get_data_from_viewer("spectrum-viewer",
-                                                      data_label=event)[event]
+                                                      data_label=event)
+        self._selected_data_label = event
 
         if self._units == {}:
             self._units["x"] = str(
@@ -250,7 +255,7 @@ class ModelFitting(TemplateMixin):
     def vue_model_fitting(self, *args, **kwargs):
         """
         Run fitting on the initialized models, fixing any parameters marked
-        as such by the user, then update the displauyed parameters with fit
+        as such by the user, then update the displayed parameters with fit
         values
         """
         fitted_model, fitted_spectrum = fit_model_to_spectrum(
@@ -265,6 +270,39 @@ class ModelFitting(TemplateMixin):
         self._update_parameters_from_fit()
 
         self.save_enabled = True
+
+    def vue_fit_model_to_cube(self, *args, **kwargs):
+        data = self.app.data_collection[self._selected_data_label]
+
+        # First, ensure that the selected data is cube-like. It is possible
+        # that the user has selected a pre-existing 1d data object.
+        if data.ndim != 3:
+            snackbar_message = SnackbarMessage(
+                f"Selected data {self._selected_data_label} is not cube-like.",
+                sender=self)
+            self.hub.broadcast(snackbar_message)
+            return
+
+        # Get the primary data component
+        attribute = data.main_components[0]
+        component = data.get_component(attribute)
+        temp_values = data.get_data(attribute)
+
+        # Transpose the axis order
+        values = np.moveaxis(temp_values, 0, -1) * u.Unit(component.units)
+
+        # We manually create a Spectrum1D object from the flux information
+        #  in the cube we select
+        wcs = data.coords.sub([WCSSUB_SPECTRAL])
+        spec = Spectrum1D(flux=values, wcs=wcs)
+
+        fitted_model, fitted_spectrum = fit_model_to_spectrum(
+            spec,
+            self._initialized_models.values(),
+            self.model_equation,
+            run_fitter=True)
+
+        self.app.data_collection["Fitted Model Cube"] = fitted_model
 
     def vue_register_spectrum(self, event):
         """

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -1,5 +1,6 @@
 import os
 import pickle
+import re
 
 import astropy.modeling.models as models
 import astropy.units as u
@@ -320,8 +321,13 @@ class ModelFitting(TemplateMixin):
         # Transpose the axis order back
         values = np.moveaxis(fitted_spectrum.flux.value, -1, 0)
 
+        count = max(map(lambda s: int(next(iter(re.findall("\d$", s)), 0)),
+                        self.data_collection.labels)) + 1
+
+        label = f"{self.model_label} [Cube] {count}"
+
         # Create new glue data object
-        output_cube = Data(label="Fitted Model Cube",
+        output_cube = Data(label=label,
                            coords=data.coords)
         output_cube['flux'] = values
         output_cube.get_component('flux').units = \

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -1,199 +1,199 @@
 <template>
   <v-card flat tile>
-    <v-container>
-      <v-row>
-        <v-col class="py-0">
-          <v-select
-              :items="dc_items"
-              @change="data_selected"
-              label="Data"
-              hint="Select the data set to be fitted."
-              persistent-hint
-          ></v-select>
-        </v-col>
-      </v-row>
-    </v-container>
+    <v-card>
+      <v-card-text>
+        <v-container>
+          <v-row>
+            <v-col>
+              <v-select
+                :items="dc_items"
+                @change="data_selected"
+                label="Data"
+                hint="Select the data set to be fitted."
+                persistent-hint
+              ></v-select>
+            </v-col>
+        </v-container>
+      </v-card-text>
+      <v-divider></v-divider>
 
-    <v-divider></v-divider>
-
-    <v-container>
-      <v-row
+      <v-card-text>
+        <v-container>
+          <v-row
           align="start"
-      >
-        <v-col>
-          <v-select
-              :items="available_models"
-              @change="model_selected"
-              label="Model"
-              hint="Select a model to fit"
-              persistent-hint
-          ></v-select>
-        </v-col>
-        <v-col>
-          <v-text-field
-              label="Model ID"
-              v-model="temp_name"
-              hint="A unique string label for this component model"
-              persistent-hint
-              :rules="[() => !!temp_name || 'This field is required']"
           >
-          </v-text-field>
-        </v-col>
-        <v-col v-if="display_order">
-          <v-text-field
-              label="Order"
-              type="number"
-              v-model.number="poly_order"
-              hint="Order of polynomial to fit"
-              persistent-hint
-          >
-          </v-text-field>
-        </v-col>
-      </v-row>
-      <v-row justify="end">
-        <v-col>
-          <v-btn color="primary" text @click="add_model">Add Model</v-btn>
-        </v-col>
-      </v-row>
-    </v-container>
-    <v-divider></v-divider>
+            <v-col>
+              <v-select
+                :items="available_models"
+                @change="model_selected"
+                label="Model"
+                hint="Select a model to fit"
+                persistent-hint
+              ></v-select>
+            </v-col>
+            <v-col>
+              <v-text-field
+                label="Model ID"
+                v-model="temp_name"
+                hint="A unique string label for this component model"
+                persistent-hint
+                :rules="[() => !!temp_name || 'This field is required']"
+              >
+              </v-text-field>
+            </v-col>
+            <v-col v-if="display_order">
+              <v-text-field
+                label="Order"
+                type="number"
+                v-model.number="poly_order"
+                hint="Order of polynomial to fit"
+                persistent-hint
+              >
+              </v-text-field>
+            </v-col>
+          </v-row>
+          <v-row
+          justify="end">
+            <v-btn color="primary" text @click="add_model">Add Model</v-btn>
+          </v-row>
+        </v-container>
+      </v-card-text>
+      <v-divider></v-divider>
 
-    <v-card-subtitle>Model Parameters</v-card-subtitle>
-    <v-container>
-      <v-expansion-panels>
-        <v-expansion-panel
+      <v-card-subtitle>Model Parameters</v-card-subtitle>
+      <v-card-text>
+        <v-container>
+        <v-expansion-panels>
+          <v-expansion-panel
             v-for="item in component_models" :key="item.id"
-        >
-          <v-expansion-panel-header v-slot="{ open }">
-            <v-row no-gutters>
-              <v-col cols=1>
-                <v-btn @click.native.stop="remove_model(item.id)" icon>
-                  <v-icon>mdi-close-circle</v-icon>
-                </v-btn>
-              </v-col>
-              <v-col cols="3">{{ item.id }} ({{ item.model_type }})</v-col>
-              <v-col cols="8" class="text--secondary">
-                <v-fade-transition leave-absolute>
-                  <span v-if="open">Enter parameters for model initialization</span>
-                  <v-row
+          >
+            <v-expansion-panel-header v-slot="{ open }">
+              <v-row no-gutters>
+                <v-col cols=1>
+                  <v-btn @click.native.stop="remove_model(item.id)" icon>
+                    <v-icon>mdi-close-circle</v-icon>
+                  </v-btn>
+                </v-col>
+                <v-col cols="3">{{ item.id }} ({{ item.model_type }})</v-col>
+                <v-col cols="8" class="text--secondary">
+                  <v-fade-transition leave-absolute>
+                    <span v-if="open">Enter parameters for model initialization</span>
+                    <v-row
                       v-else
                       no-gutters
                       style="width: 100%"
-                  >
-                    <v-col cols="4" v-for="param in item.parameters">
+                    >
+                      <v-col cols="4" v-for="param in item.parameters">
                       {{ param.name }} : {{ param.value }}
-                    </v-col>
-                  </v-row>
-                </v-fade-transition>
-              </v-col>
-            </v-row>
-          </v-expansion-panel-header>
-          <v-expansion-panel-content>
-            <v-row
+                      </v-col>
+                    </v-row>
+                  </v-fade-transition>
+                </v-col>
+              </v-row>
+            </v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <v-row
                 justify="left"
                 align="center"
                 no-gutters
-            >
-              <v-col cols=2>
-                <p class="font-weight-bold">Parameter</p>
-              </v-col>
-              <v-col cols=3>
-                <p class="font-weight-bold">Value</p>
-              </v-col>
-              <v-col cols=4>
-                <p class="font-weight-bold">Unit</p>
-              </v-col>
-              <v-col cols=2>
-                <p class="font-weight-bold">Fixed?</p>
-              </v-col>
-            </v-row>
-            <v-row
+              >
+                <v-col cols=2>
+                  <p class="font-weight-bold">Parameter</p>
+                </v-col>
+                <v-col cols=3>
+                  <p class="font-weight-bold">Value</p>
+                </v-col>
+                <v-col cols=4>
+                  <p class="font-weight-bold">Unit</p>
+                </v-col>
+                <v-col cols=2>
+                  <p class="font-weight-bold">Fixed?</p>
+                </v-col>
+              </v-row>
+              <v-row
                 justify="left"
                 align="center"
                 no-gutters
                 v-for="param in item.parameters"
-            >
-              <v-col cols=2>
-                {{ param.name }}
-              </v-col>
-              <v-col cols=2>
-                <v-text-field
+              >
+                <v-col cols = 2>
+                  {{ param.name }}
+                </v-col>
+                <v-col cols = 2>
+                  <v-text-field
                     v-model="param.value"
-                >
-                </v-text-field>
-              </v-col>
-              <v-col cols=1></v-col>
-              <v-col cols=3>
-                {{ param.unit }}
-              </v-col>
-              <v-col cols=1></v-col>
-              <v-col cols=2>
-                <v-checkbox v-model="param.fixed">
-                </v-checkbox>
-              </v-col>
-            </v-row>
-          </v-expansion-panel-content>
-        </v-expansion-panel>
-      </v-expansion-panels>
-    </v-container>
-    <v-divider></v-divider>
+                  >
+                  </v-text-field>
+                </v-col>
+                <v-col cols=1></v-col>
+                <v-col cols=3>
+                  {{ param.unit }}
+                </v-col>
+                <v-col cols=1></v-col>
+                <v-col cols=2>
+                  <v-checkbox v-model="param.fixed">
+                  </v-checkbox>
+                </v-col>
+              </v-row>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
+        </v-container>
+      </v-card-text>
+      <v-divider></v-divider>
 
-    <v-card-subtitle>Model Equation Editor</v-card-subtitle>
+      <v-card-subtitle>Model Equation Editor</v-card-subtitle>
+      <v-card-text>
+        <v-container>
+          <v-text-field
+            v-model="model_equation"
+            hint="Equation specifying how to combine the component models, using their model IDs and basic arithmetic operators"
+            persistent-hint
+            :rules="[() => !!model_equation || 'This field is required']"
+            @change="equation_changed"
+            :error="eq_error"
+          >
+          </v-text-field>
+        </v-container>
+      </v-card-text>
+      <v-divider></v-divider>
 
-    <v-container>
-      <v-text-field
-          v-model="model_equation"
-          hint="Equation specifying how to combine the component models, using their model IDs and basic arithmetic operators"
+      <v-card-actions>
+        <div class="flex-grow-1"></div>
+        <v-text-field
+          v-model="model_label"
+          label="Model Label"
+          hint="Label for the modeled spectrum in the data dropdown menus"
           persistent-hint
-          :rules="[() => !!model_equation || 'This field is required']"
-          @change="equation_changed"
-          :error="eq_error"
-      >
-      </v-text-field>
-    </v-container>
-
-    <v-divider></v-divider>
-
-    <v-container>
-      <v-row>
-        <v-col>
-          <v-text-field
-              v-model="model_label"
-              label="Model Label"
-              hint="Label for the modeled spectrum in the data dropdown menus"
-              persistent-hint
-          >
-          </v-text-field>
-        </v-col>
-        <v-col>
-          <v-text-field
-              v-model="model_save_path"
-              label="Filepath"
-              hint="Path to save output file [Model Label].pkl"
-              persistent-hint
-          >
-          </v-text-field>
-        </v-col>
-      </v-row>
-    </v-container>
-
-    <v-card-actions>
-      <div class="flex-grow-1"></div>
-      <v-row
+        >
+        </v-text-field>
+        <c-col cols=1><v-col>
+        <v-text-field
+          v-model="model_save_path"
+          label="Filepath"
+          hint="Path to save output file [Model Label].pkl"
+          persistent-hint
+        >
+        </v-text-field>
+      </v-card-actions>
+      <v-card-actions>
+        <div class="flex-grow-1"></div>
+        <v-row
           justify="left"
           align="center"
           no-gutters
-      >
+        >
         <v-btn color="primary" text @click="model_fitting">Fit</v-btn>
         <v-btn color="primary" text @click="fit_model_to_cube">Apply to Cube</v-btn>
         <v-btn color="primary" text @click="register_spectrum">Add to Viewer</v-btn>
         <v-btn
-            color="primary"
-            text
-            @click="save_model">
-          Save to File
-        </v-btn>
-      </v-row>
-    </v-card-actions>
+           color="primary"
+           text
+           @click="save_model">
+           Save to File
+         </v-btn>
+        </v-row>
+      </v-card-actions>
+    </v-card>
   </v-card>
 </template>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -1,198 +1,199 @@
 <template>
   <v-card flat tile>
-    <v-card>
-      <v-card-text>
-        <v-container>
-          <v-row>
-            <v-col>
-              <v-select
-                :items="dc_items"
-                @change="data_selected"
-                label="Data"
-                hint="Select the data set to be fitted."
-                persistent-hint
-              ></v-select>
-            </v-col>
-        </v-container>
-      </v-card-text>
-      <v-divider></v-divider>
+    <v-container>
+      <v-row>
+        <v-col class="py-0">
+          <v-select
+              :items="dc_items"
+              @change="data_selected"
+              label="Data"
+              hint="Select the data set to be fitted."
+              persistent-hint
+          ></v-select>
+        </v-col>
+      </v-row>
+    </v-container>
 
-      <v-card-text>
-        <v-container>
-          <v-row
+    <v-divider></v-divider>
+
+    <v-container>
+      <v-row
           align="start"
+      >
+        <v-col>
+          <v-select
+              :items="available_models"
+              @change="model_selected"
+              label="Model"
+              hint="Select a model to fit"
+              persistent-hint
+          ></v-select>
+        </v-col>
+        <v-col>
+          <v-text-field
+              label="Model ID"
+              v-model="temp_name"
+              hint="A unique string label for this component model"
+              persistent-hint
+              :rules="[() => !!temp_name || 'This field is required']"
           >
-            <v-col>
-              <v-select
-                :items="available_models"
-                @change="model_selected"
-                label="Model"
-                hint="Select a model to fit"
-                persistent-hint
-              ></v-select>
-            </v-col>
-            <v-col>
-              <v-text-field
-                label="Model ID"
-                v-model="temp_name"
-                hint="A unique string label for this component model"
-                persistent-hint
-                :rules="[() => !!temp_name || 'This field is required']"
-              >
-              </v-text-field>
-            </v-col>
-            <v-col v-if="display_order">
-              <v-text-field
-                label="Order"
-                type="number"
-                v-model.number="poly_order"
-                hint="Order of polynomial to fit"
-                persistent-hint
-              >
-              </v-text-field>
-            </v-col>
-          </v-row>
-          <v-row
-          justify="end">
-            <v-btn color="primary" text @click="add_model">Add Model</v-btn>
-          </v-row>
-        </v-container>
-      </v-card-text>
-      <v-divider></v-divider>
+          </v-text-field>
+        </v-col>
+        <v-col v-if="display_order">
+          <v-text-field
+              label="Order"
+              type="number"
+              v-model.number="poly_order"
+              hint="Order of polynomial to fit"
+              persistent-hint
+          >
+          </v-text-field>
+        </v-col>
+      </v-row>
+      <v-row justify="end">
+        <v-col>
+          <v-btn color="primary" text @click="add_model">Add Model</v-btn>
+        </v-col>
+      </v-row>
+    </v-container>
+    <v-divider></v-divider>
 
-      <v-card-subtitle>Model Parameters</v-card-subtitle>
-      <v-card-text>
-        <v-container>
-        <v-expansion-panels>
-          <v-expansion-panel
+    <v-card-subtitle>Model Parameters</v-card-subtitle>
+    <v-container>
+      <v-expansion-panels>
+        <v-expansion-panel
             v-for="item in component_models" :key="item.id"
-          >
-            <v-expansion-panel-header v-slot="{ open }">
-              <v-row no-gutters>
-                <v-col cols=1>
-                  <v-btn @click.native.stop="remove_model(item.id)" icon>
-                    <v-icon>mdi-close-circle</v-icon>
-                  </v-btn>
-                </v-col>
-                <v-col cols="3">{{ item.id }} ({{ item.model_type }})</v-col>
-                <v-col cols="8" class="text--secondary">
-                  <v-fade-transition leave-absolute>
-                    <span v-if="open">Enter parameters for model initialization</span>
-                    <v-row
+        >
+          <v-expansion-panel-header v-slot="{ open }">
+            <v-row no-gutters>
+              <v-col cols=1>
+                <v-btn @click.native.stop="remove_model(item.id)" icon>
+                  <v-icon>mdi-close-circle</v-icon>
+                </v-btn>
+              </v-col>
+              <v-col cols="3">{{ item.id }} ({{ item.model_type }})</v-col>
+              <v-col cols="8" class="text--secondary">
+                <v-fade-transition leave-absolute>
+                  <span v-if="open">Enter parameters for model initialization</span>
+                  <v-row
                       v-else
                       no-gutters
                       style="width: 100%"
-                    >
-                      <v-col cols="4" v-for="param in item.parameters">
+                  >
+                    <v-col cols="4" v-for="param in item.parameters">
                       {{ param.name }} : {{ param.value }}
-                      </v-col>
-                    </v-row>
-                  </v-fade-transition>
-                </v-col>
-              </v-row>
-            </v-expansion-panel-header>
-            <v-expansion-panel-content>
-              <v-row
+                    </v-col>
+                  </v-row>
+                </v-fade-transition>
+              </v-col>
+            </v-row>
+          </v-expansion-panel-header>
+          <v-expansion-panel-content>
+            <v-row
                 justify="left"
                 align="center"
                 no-gutters
-              >
-                <v-col cols=2>
-                  <p class="font-weight-bold">Parameter</p>
-                </v-col>
-                <v-col cols=3>
-                  <p class="font-weight-bold">Value</p>
-                </v-col>
-                <v-col cols=4>
-                  <p class="font-weight-bold">Unit</p>
-                </v-col>
-                <v-col cols=2>
-                  <p class="font-weight-bold">Fixed?</p>
-                </v-col>
-              </v-row>
-              <v-row
+            >
+              <v-col cols=2>
+                <p class="font-weight-bold">Parameter</p>
+              </v-col>
+              <v-col cols=3>
+                <p class="font-weight-bold">Value</p>
+              </v-col>
+              <v-col cols=4>
+                <p class="font-weight-bold">Unit</p>
+              </v-col>
+              <v-col cols=2>
+                <p class="font-weight-bold">Fixed?</p>
+              </v-col>
+            </v-row>
+            <v-row
                 justify="left"
                 align="center"
                 no-gutters
                 v-for="param in item.parameters"
-              >
-                <v-col cols = 2>
-                  {{ param.name }}
-                </v-col>
-                <v-col cols = 2>
-                  <v-text-field
+            >
+              <v-col cols=2>
+                {{ param.name }}
+              </v-col>
+              <v-col cols=2>
+                <v-text-field
                     v-model="param.value"
-                  >
-                  </v-text-field>
-                </v-col>
-                <v-col cols=1></v-col>
-                <v-col cols=3>
-                  {{ param.unit }}
-                </v-col>
-                <v-col cols=1></v-col>
-                <v-col cols=2>
-                  <v-checkbox v-model="param.fixed">
-                  </v-checkbox>
-                </v-col>
-              </v-row>
-            </v-expansion-panel-content>
-          </v-expansion-panel>
-        </v-expansion-panels>
-        </v-container>
-      </v-card-text>
-      <v-divider></v-divider>
+                >
+                </v-text-field>
+              </v-col>
+              <v-col cols=1></v-col>
+              <v-col cols=3>
+                {{ param.unit }}
+              </v-col>
+              <v-col cols=1></v-col>
+              <v-col cols=2>
+                <v-checkbox v-model="param.fixed">
+                </v-checkbox>
+              </v-col>
+            </v-row>
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </v-container>
+    <v-divider></v-divider>
 
-      <v-card-subtitle>Model Equation Editor</v-card-subtitle>
-      <v-card-text>
-        <v-container>
+    <v-card-subtitle>Model Equation Editor</v-card-subtitle>
+
+    <v-container>
+      <v-text-field
+          v-model="model_equation"
+          hint="Equation specifying how to combine the component models, using their model IDs and basic arithmetic operators"
+          persistent-hint
+          :rules="[() => !!model_equation || 'This field is required']"
+          @change="equation_changed"
+          :error="eq_error"
+      >
+      </v-text-field>
+    </v-container>
+
+    <v-divider></v-divider>
+
+    <v-container>
+      <v-row>
+        <v-col>
           <v-text-field
-            v-model="model_equation"
-            hint="Equation specifying how to combine the component models, using their model IDs and basic arithmetic operators"
-            persistent-hint
-            :rules="[() => !!model_equation || 'This field is required']"
-            @change="equation_changed"
-            :error="eq_error"
+              v-model="model_label"
+              label="Model Label"
+              hint="Label for the modeled spectrum in the data dropdown menus"
+              persistent-hint
           >
           </v-text-field>
-        </v-container>
-      </v-card-text>
-      <v-divider></v-divider>
+        </v-col>
+        <v-col>
+          <v-text-field
+              v-model="model_save_path"
+              label="Filepath"
+              hint="Path to save output file [Model Label].pkl"
+              persistent-hint
+          >
+          </v-text-field>
+        </v-col>
+      </v-row>
+    </v-container>
 
-      <v-card-actions>
-        <div class="flex-grow-1"></div>
-        <v-text-field
-          v-model="model_label"
-          label="Model Label"
-          hint="Label for the modeled spectrum in the data dropdown menus"
-          persistent-hint
-        >
-        </v-text-field>
-        <c-col cols=1><v-col>
-        <v-text-field
-          v-model="model_save_path"
-          label="Filepath"
-          hint="Path to save output file [Model Label].pkl"
-          persistent-hint
-        >
-        </v-text-field>
-      </v-card-actions>
-      <v-card-actions>
-        <div class="flex-grow-1"></div>
-        <v-row
+    <v-card-actions>
+      <div class="flex-grow-1"></div>
+      <v-row
           justify="left"
           align="center"
           no-gutters
-        >
+      >
         <v-btn color="primary" text @click="model_fitting">Fit</v-btn>
-        <v-btn color="primary" text @click="register_spectrum"">Add to Viewer</v-btn>
+        <v-btn color="primary" text @click="fit_model_to_cube">Apply to Cube</v-btn>
+        <v-btn color="primary" text @click="register_spectrum">Add to Viewer</v-btn>
         <v-btn
-           color="primary"
-           text
-           @click="save_model">
-           Save to File
-         </v-btn>
-        </v-row>
-      </v-card-actions>
-    </v-card>
+            color="primary"
+            text
+            @click="save_model">
+          Save to File
+        </v-btn>
+      </v-row>
+    </v-card-actions>
   </v-card>
 </template>

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -87,7 +87,6 @@ module.exports = {
   name: "g-viewer-tab",
   props: ["stack", "dataItems"],
   created() {
-      console.log("HERE" + this.$parent.computeChildrenPath);
     this.$parent.childMe = () => {
       return this.$children[0];
     };

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -152,12 +152,14 @@ class RemoveDataMessage(Message):
 
 
 class SnackbarMessage(Message):
-    def __init__(self, text, color=None, timeout=5000, *args, **kwargs):
+    def __init__(self, text, color=None, timeout=5000, loading=False,
+                 *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self._text = text
         self._color = color
         self._timeout = timeout
+        self._loading = loading
 
     @property
     def text(self):
@@ -170,6 +172,11 @@ class SnackbarMessage(Message):
     @property
     def timeout(self):
         return self._timeout
+
+    @property
+    def loading(self):
+        return self._loading
+
 
 class AddLineListMessage(Message):
     def __init__(self, table, *args, **kwargs):


### PR DESCRIPTION
Implements a new option in the model fitting plugin to apply a fit to the entire cube.

Outstanding issues:

- [x] Inconsistent unit errors when using compound models
- [x] Inordinate amount of time required for cube fitting

The first implementation of the parallelized code was extremely slow because the limiting factor was the communication overhead from the processors. _Every_ spaxel was queued to run on a separate processor (or the next available), so the couple million cross-processor shuttling of serialized data added up. Instead, we now parse the spaxel array into as many chunks as there are processors and let all spaxel subsets run on their respective processor, and only return after _all_ fitting for the subset has occurred. This provides the expected speed.

Likewise, I've also extended the snackbar to support a loading state so that there is feedback to the user while fitting is occuring.