### PR TITLE
Enable overplotting additional data via linking

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -219,7 +219,7 @@ class Application(VuetifyTemplate, HubListener):
         self.state.snackbar['timeout'] = msg.timeout
         self.state.snackbar['show'] = True
 
-    def link_new_data(self, old_len):
+    def _link_new_data(self, old_len):
         """
         When additional data is loaded, check to see if the spectral axis of
         any components are compatible with already loaded data. If so, link
@@ -262,7 +262,7 @@ class Application(VuetifyTemplate, HubListener):
 
         # If there is already data loaded, link it to the new data
         if old_data_len > 0:
-            self.link_new_data(old_data_len)
+            self._link_new_data(old_data_len)
 
         # Send out a toast message
         snackbar_message = SnackbarMessage("Data successfully loaded.",
@@ -530,7 +530,7 @@ class Application(VuetifyTemplate, HubListener):
 
         # If there is already data loaded, link it to the new data
         if old_data_len > 0:
-            self.link_new_data(old_data_len)
+            self._link_new_data(old_data_len)
 
         # Send out a toast message
         snackbar_message = SnackbarMessage(

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -219,17 +219,16 @@ class Application(VuetifyTemplate, HubListener):
         self.state.snackbar['timeout'] = msg.timeout
         self.state.snackbar['show'] = True
 
-    def _link_new_data(self, old_len):
+    def _link_new_data(self):
         """
         When additional data is loaded, check to see if the spectral axis of
         any components are compatible with already loaded data. If so, link
         them so that they can be displayed on the same profile1D plot.
         """
         new_len = len(self.data_collection)
-        for i in range(old_len, new_len):
-            for j in range(0, old_len):
+        for i in range(0, new_len-1):
                 self.data_collection.add_link(LinkSame(self.data_collection[i].world_component_ids[0],
-                    self.data_collection[j].world_component_ids[0]))
+                    self.data_collection[new_len-1].world_component_ids[0]))
 
     def load_data(self, file_obj, **kwargs):
         """
@@ -259,10 +258,6 @@ class Application(VuetifyTemplate, HubListener):
                 return
         else:
             self._application_handler.load_data(file_obj)
-
-        # If there is already data loaded, link it to the new data
-        if old_data_len > 0:
-            self._link_new_data(old_data_len)
 
         # Send out a toast message
         snackbar_message = SnackbarMessage("Data successfully loaded.",
@@ -527,10 +522,6 @@ class Application(VuetifyTemplate, HubListener):
         # Include the data in the data collection
         data_label = data_label or "New Data"
         self.data_collection[data_label] = data
-
-        # If there is already data loaded, link it to the new data
-        if old_data_len > 0:
-            self._link_new_data(old_data_len)
 
         # Send out a toast message
         snackbar_message = SnackbarMessage(
@@ -860,7 +851,8 @@ class Application(VuetifyTemplate, HubListener):
     def _on_data_added(self, msg):
         """
         Callback for when data is added to the internal ``DataCollection``.
-        Adds a new data item dictionary to the ``data_items`` state list.
+        Adds a new data item dictionary to the ``data_items`` state list and
+        links the new data to previous data, if possible.
 
         Parameters
         ----------
@@ -868,6 +860,7 @@ class Application(VuetifyTemplate, HubListener):
             The Glue data collection add message containing information about
             the new data.
         """
+        self._link_new_data()
         data_item = self._create_data_item(msg.data.label)
         self.state.data_items.append(data_item)
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -852,7 +852,7 @@ class Application(VuetifyTemplate, HubListener):
         """
         Callback for when data is added to the internal ``DataCollection``.
         Adds a new data item dictionary to the ``data_items`` state list and
-        links the new data to previous data, if possible.
+        links the new data to any compatible previously loaded data.
 
         Parameters
         ----------

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -228,8 +228,8 @@ class Application(VuetifyTemplate, HubListener):
         new_len = len(self.data_collection)
         for i in range(old_len, new_len):
             for j in range(0, old_len):
-                self.data_collection.add_link(LinkSame(self.data_collection[i].pixel_component_ids[0],
-                    self.data_collection[j].pixel_component_ids[0]))
+                self.data_collection.add_link(LinkSame(self.data_collection[i].world_component_ids[0],
+                    self.data_collection[j].world_component_ids[0]))
 
     def load_data(self, file_obj, **kwargs):
         """

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -1,7 +1,6 @@
 from astropy import units as u
 from glue.core.message import (DataCollectionAddMessage,
                                DataCollectionDeleteMessage)
-from glue.core.link_helpers import LinkSame
 from specutils import Spectrum1D
 from specutils.manipulation import gaussian_smooth
 from traitlets import List, Unicode, Int, Any, observe
@@ -69,15 +68,6 @@ class GaussianSmooth(TemplateMixin):
         label = f"Smoothed {self._selected_data.label}"
 
         self.data_collection[label] = spec_smoothed
-
-        # Link the new dataset pixel-wise to the original dataset. In general
-        # direct pixel to pixel links are the most efficient and should be
-        # used in cases like this where we know there is a 1-to-1 mapping of
-        # pixel coordinates. Here the smoothing returns a 1-d spectral object
-        # which we can link to the first dimension of the original dataset
-        # (whcih could in principle be a cube or a spectrum)
-        self.data_collection.add_link(LinkSame(self._selected_data.pixel_component_ids[0],
-                                               self.data_collection[label].pixel_component_ids[0]))
 
         snackbar_message = SnackbarMessage(
             f"Data set '{self._selected_data.label}' smoothed successfully.",

--- a/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from glue.core import Data
-from glue.core.application_base import Application
+from jdaviz import Application
 
 from ..gaussian_smooth import GaussianSmooth
 
@@ -22,5 +22,5 @@ def test_linking_after_gaussian_smooth(spectral_cube_wcs):
     assert dc[1].label == 'Smoothed test'
     assert len(dc.external_links) == 1
 
-    assert dc.external_links[0].cids1[0] is dc[0].pixel_component_ids[0]
-    assert dc.external_links[0].cids2[0] is dc[1].pixel_component_ids[0]
+    assert dc.external_links[0].cids1[0] is dc[0].world_component_ids[0]
+    assert dc.external_links[0].cids2[0] is dc[1].world_component_ids[0]

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -3,7 +3,6 @@ import pickle
 
 import astropy.modeling.models as models
 import astropy.units as u
-from glue.core.link_helpers import LinkSame
 from glue.core.message import (SubsetCreateMessage,
                                SubsetDeleteMessage,
                                SubsetUpdateMessage)
@@ -59,7 +58,6 @@ class ModelFitting(TemplateMixin):
         self.component_models = []
         self._initialized_models = {}
         self._display_order = False
-        self._label_to_link = ""
         self.model_save_path = os.getcwd()
         self.model_label = "Model"
 
@@ -174,11 +172,6 @@ class ModelFitting(TemplateMixin):
                 selected_spec.spectral_axis.unit)
             self._units["y"] = str(
                 selected_spec.flux.unit)
-
-        for label in self.dc_items:
-            if label in self.data_collection:
-                self._label_to_link = label
-                break
 
         self._spectrum1d = selected_spec
 
@@ -301,9 +294,6 @@ class ModelFitting(TemplateMixin):
             self.data_collection.remove(self.data_collection[label])
         self.data_collection[label] = spectrum
         self.save_enabled = True
-        self.data_collection.add_link(
-            LinkSame(self.data_collection[self._label_to_link].pixel_component_ids[0],
-                     self.data_collection[label].pixel_component_ids[0]))
 
         #sleep(1)
         #self.app.add_data_to_viewer('spectrum-viewer', label)

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -52,6 +52,17 @@ class SpecViz(ConfigHelper):
                 )
             elif type(data) is not Spectrum1D:
                 raise TypeError("Data is not a Spectrum1D object or compatible file")
+
+        # Check to see if there's already data in the viewer and convert units
+        # if needed
+        current_spec = self.get_spectra()
+        if current_spec != {} and current_spec is not None:
+            spec_key = list(current_spec.keys())[0]
+            current_unit = current_spec[spec_key].spectral_axis.unit
+            if data.spectral_axis.unit != current_unit:
+                data = Spectrum1D(flux=data.flux,
+                                  spectral_axis=data.spectral_axis.to(current_unit))
+
         self.app.add_data(data, data_label)
         if show_in_viewer:
             self.app.add_data_to_viewer("spectrum-viewer", data_label)


### PR DESCRIPTION
Previously, datasets loaded after the first were not able to be plotted at the same time as previous datasets in the profile viewer. This fixes that by "blindly" linking subsequent datasets to ones that were loaded earlier, without any consideration of whether their units are the same and such. It sounded from discussion offline today that we intend to add intelligent unit conversion to have datasets match in a later PR.

I ended up putting this in the top level jdaviz app rather than at a lower level like the spectrum viewer, with the assumption that we're going to be standardizing around the parser model of data loading, rather than what I was seeing currently with a separate load_data function in the specviz helper. 