### PR TITLE
Update minimal specviz notebook for more complete workflow

### DIFF
--- a/notebooks/Minimal Specviz.ipynb
+++ b/notebooks/Minimal Specviz.ipynb
@@ -1,6 +1,22 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# A Minimal Specviz+notebook Workflow\n",
+    "\n",
+    "This notebook provides a short example of combining the Specviz interactive visualization tool of the `jdaviz` package with a more traditional non-interactive Python workflow.  The science case is loading a single 1D-spectrum (from the [Sloan Digital Sky Survey](https://www.sdss.org/)) and measuring the flux in a single spectral line (${\\rm H}\\alpha$)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We begin by creating an instance of the `Specviz` helper class, which provides a range of conveniences for the discerning astronomy to easily work with the visualization tool.  Ending the cell with the `.app` attribute of that instance will show the viz tool."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -16,7 +32,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Make two selections in a continuum area."
+    "The above is currently empty. While one could use the \"import\" option to find a local file on disk, a notebook workflow is more amenable to downloading and loading a spectrum directly in Python code.  To do this, we load our spectrum using the `specutils` package. This provides maximum flexibility because `Spectrum1D` objects can either be created from local data files, URLs (as shown below), or manually from user-provided arrays.\n",
+    "\n",
+    "We then use the `Specviz.load_data` method to load the data into the array - this should then immediately show the spectrum in the cell above. "
    ]
   },
   {
@@ -34,22 +52,56 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That spectrum looks great! But the line we are looking for is pretty narrow.  We could use the UI to zoom, which can be done using the pan/zoom tool, but you can also execute the cell below to zoom the view in on the region around ${\\rm H}\\alpha$:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# THIS SHOULD BE UPDATED WHEN 159/161 are in!\n",
-    "# ss_groups = specviz.app.data_collection.subset_groups\n",
-    "# subregs = []\n",
-    "# for grp in ss_groups:\n",
-    "#     ss = grp.subsets[0].subset_state\n",
-    "#     subregs.append((ss.lo, ss.hi)*spec.spectral_axis.unit)\n",
-    "# sr = specutils.SpectralRegion(subregs)\n",
-    "# sr\n",
-    "\n",
-    "sr = specviz.get_regions().get('Subset 1')\n",
-    "sr"
+    "# zoom in on Halpha region\n",
+    "v = specviz.app.get_viewer('spectrum-viewer')\n",
+    "v.state.x_min = 6500\n",
+    "v.state.x_max = 6750"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now use the Glupyter range selection tool (expand the menu and choose the second tool), and select the area around the ${\\rm H}\\alpha$ line.  Then you can execute the cell below to get that selection into a format `specutils` understands:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "line_region = specviz.get_spectral_regions()['Subset 1']\n",
+    "line_region"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# To reproduce the exact values this notebook was written assuming, uncomment the below\n",
+    "# line_region = specutils.SpectralRegion(6557.48830955*u.angstrom, 6584.69919391*u.angstrom)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now with that region selected, we can build a Gaussian + Constant continuum model to fit the selected line, and then fit it to just the data in the selected region:"
    ]
   },
   {
@@ -59,28 +111,58 @@
    "outputs": [],
    "source": [
     "from astropy.modeling import models\n",
-    "from specutils import fitting\n",
+    "from specutils.fitting import fit_lines\n",
+    "from  specutils import manipulation\n",
     "\n",
-    "cmod = fitting.fit_lines(spec, models.Chebyshev1D(20), window=sr)\n",
+    "line_model_guess = models.Gaussian1D(mean=(line_region.lower + line_region.upper)/2, \n",
+    "                                     stddev=3, \n",
+    "                                     amplitude=1000) + models.Const1D(200)\n",
     "\n",
+    "#fit that model to the selected region\n",
+    "\n",
+    "# after a bug fix, the below should just be a single line:\n",
+    "# fit_lines(spec, line_model_guess, window=line_region)\n",
+    "\n",
+    "extracted = manipulation.extract_region(spec, line_region)\n",
+    "extracted.mask[:] = False\n",
+    "fitted_line = fit_lines(extracted, line_model_guess)\n",
+    "\n",
+    "fitted_line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we plot that model with the spectrum to examine the fit:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
     "from matplotlib import pyplot as plt\n",
-    "plt.plot(spec.spectral_axis, spec.flux)\n",
-    "plt.plot(spec.spectral_axis, cmod(spec.spectral_axis))\n",
-    "plt.ylim(0, 1000)"
+    "from astropy import units as u\n",
+    "\n",
+    "plt.plot(spec.spectral_axis, spec.flux, lw=3)\n",
+    "\n",
+    "model_lamb = np.linspace(v.state.x_min, v.state.x_max, 1000)*u.angstrom\n",
+    "plt.plot(model_lamb, fitted_line(model_lamb), '-', lw=2)\n",
+    "\n",
+    "plt.xlim(v.state.x_min, v.state.x_max)\n",
+    "plt.ylim(v.state.y_min, v.state.y_max);"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Need to show above in specviz..."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "That is *wrong*.  But assume it's right:"
+    "Looks good! \n",
+    "\n",
+    "Now to achieve the final goal of a line flux measurement, we can integrate over the line: "
    ]
   },
   {
@@ -89,36 +171,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "contsub = spec - cmod(spec.spectral_axis)\n",
-    "specviz.load_data(contsub)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Make an additional line selection"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# THIS SHOULD BE UPDATED WHEN 159/161 are in!\n",
-    "ss = specviz.app.data_collection.subset_groups[-1].subsets[0].subset_state\n",
-    "newsr = specutils.SpectralRegion(ss.lo*spec.spectral_axis.unit, ss.hi*spec.spectral_axis.unit)\n",
-    "newsr"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "specutils.analysis.line_flux(contsub, newsr)"
+    "from scipy.integrate import quad\n",
+    "\n",
+    "quad(fitted_line.unitless_model.left, 6500, 6700)[0] * fitted_line.return_units*spec.spectral_axis.unit"
    ]
   }
  ],


### PR DESCRIPTION
The version of the minimal specviz notebook from #179 was somewhat incomplete as a science workflow.  This PR updates it to be a complete (if short) scientific "story". 

There's still one cell that has a "needs to be fixed" element (related to issues with the window machinery in `specutils.analysis.fit_lines`), but that will  require a specutils update so I think we can do one more follow-on when that's in specutils.