### PR TITLE
Add line analysis plugin

### DIFF
--- a/jdaviz/configs/specviz/plugins/__init__.py
+++ b/jdaviz/configs/specviz/plugins/__init__.py
@@ -1,3 +1,4 @@
 from .viewers import *
 from .parsers import *
 from .unit_conversion.unit_conversion import *
+from line_analysis.line_analysis import *

--- a/jdaviz/configs/specviz/plugins/__init__.py
+++ b/jdaviz/configs/specviz/plugins/__init__.py
@@ -1,4 +1,4 @@
 from .viewers import *
 from .parsers import *
 from .unit_conversion.unit_conversion import *
-from line_analysis.line_analysis import *
+from .line_analysis.line_analysis import *

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -132,8 +132,12 @@ class LineAnalysis(TemplateMixin):
         for function in FUNCTIONS:
             # Centroid function requires a region argument, create one to pass
             if function == "Centroid":
-                spec_region = self._spectrum1d.spectral_axis[np.where(self._spectrum1d.mask == False)]
-                spec_region = SpectralRegion(spec_region[0], spec_region[-1])
+                spectral_axis = self._spectrum1d.spectral_axis
+                if self._spectrum1d.mask is None:
+                    spec_region = SpectralRegion(spectral_axis[0], spectral_axis[-1])
+                else:
+                    spec_region = self._spectrum1d.spectral_axis[np.where(self._spectrum1d.mask == False)]
+                    spec_region = SpectralRegion(spec_region[0], spec_region[-1])
                 temp_result = FUNCTIONS[function](self._spectrum1d, spec_region)
             else:
                 temp_result = FUNCTIONS[function](self._spectrum1d)

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -19,7 +19,7 @@ __all__ = ['LineAnalysis']
 
 FUNCTIONS = {"Line Flux": analysis.line_flux,
         "Equivalent Width": analysis.equivalent_width,
-        "Gaussian Signma Width": analysis.gaussian_sigma_width,
+        "Gaussian Sigma Width": analysis.gaussian_sigma_width,
         "Gaussian FWHM": analysis.gaussian_fwhm,
         "Centroid": analysis.centroid}
 
@@ -138,4 +138,3 @@ class LineAnalysis(TemplateMixin):
             temp_result = FUNCTIONS[self.temp_function](self._spectrum1d)
         self.result = str(temp_result)
         self.result_available = True
-        raise ValueError("{} {}".format(self.result_available, self.result))

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -1,0 +1,164 @@
+import os
+import pickle
+
+import astropy.modeling.models as models
+import astropy.units as u
+from glue.core.link_helpers import LinkSame
+from glue.core.message import (SubsetCreateMessage,
+                               SubsetDeleteMessage,
+                               SubsetUpdateMessage)
+from traitlets import Bool, Int, List, Unicode
+
+from jdaviz.core.events import AddDataMessage, RemoveDataMessage
+from jdaviz.core.registries import tray_registry
+from jdaviz.core.template_mixin import TemplateMixin
+from jdaviz.utils import load_template
+from .fitting_backend import fit_model_to_spectrum
+from .initializers import initialize, model_parameters
+
+__all__ = ['ModelFitting']
+
+FUNCTIONS = {}
+
+MODELS = {
+     'Const1D': models.Const1D,
+     'Linear1D': models.Linear1D,
+     'Polynomial1D': models.Polynomial1D,
+     'Gaussian1D': models.Gaussian1D,
+     'Voigt1D': models.Voigt1D,
+     'Lorentz1D': models.Lorentz1D
+     }
+
+
+@tray_registry('specviz-line-analysis', label="Line Analysis")
+class ModelFitting(TemplateMixin):
+    dialog = Bool(False).tag(sync=True)
+    template = load_template("line_analysis.vue", __file__).tag(sync=True)
+    dc_items = List([]).tag(sync=True)
+    temp_function = Unicode().tag(sync=True)
+    available_functions = List(list(FUNCTIONS.keys())).tag(sync=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._viewer_spectra = None
+        self._spectrum1d = None
+        self._units = {}
+
+        self.hub.subscribe(self, AddDataMessage,
+                           handler=self._on_viewer_data_changed)
+
+        self.hub.subscribe(self, RemoveDataMessage,
+                           handler=self._on_viewer_data_changed)
+
+        self.hub.subscribe(self, SubsetCreateMessage,
+                           handler=lambda x: self._on_viewer_data_changed())
+
+        self.hub.subscribe(self, SubsetDeleteMessage,
+                           handler=lambda x: self._on_viewer_data_changed())
+
+        self.hub.subscribe(self, SubsetUpdateMessage,
+                           handler=lambda x: self._on_viewer_data_changed())
+
+    def _on_viewer_data_changed(self, msg=None):
+        """
+        Callback method for when data is added or removed from a viewer, or
+        when a subset is created, deleted, or updated. This method receieves
+        a glue message containing viewer information in the case of the former
+        set of events, and updates the available data list displayed to the
+        user.
+
+        Notes
+        -----
+        We do not attempt to parse any data at this point, at it can cause
+        visible lag in the application.
+
+        Parameters
+        ----------
+        msg : `glue.core.Message`
+            The glue message passed to this callback method.
+        """
+        self._viewer_id = self.app._viewer_item_by_reference(
+            'spectrum-viewer').get('id')
+
+        # Subsets are global and are not linked to specific viewer instances,
+        # so it's not required that we match any specific ids for that case.
+        # However, if the msg is not none, check to make sure that it's the
+        # viewer we care about.
+        if msg is not None and msg.viewer_id != self._viewer_id:
+            return
+
+        viewer = self.app.get_viewer('spectrum-viewer')
+
+        self.dc_items = [layer_state.layer.label
+                         for layer_state in viewer.state.layers]
+
+    def vue_data_selected(self, event):
+        """
+        Callback method for when the user has selected data from the drop down
+        in the front-end. It is here that we actually parse and create a new
+        data object from the selected data. From this data object, unit
+        information is scraped, and the selected spectrum is stored for later
+        use in fitting.
+
+        Parameters
+        ----------
+        event : str
+            IPyWidget callback event object. In this case, represents the data
+            label of the data collection object selected by the user.
+        """
+        selected_spec = self.app.get_data_from_viewer("spectrum-viewer",
+                                                      data_label=event)
+
+        if self._units == {}:
+            self._units["x"] = str(
+                selected_spec.spectral_axis.unit)
+            self._units["y"] = str(
+                selected_spec.flux.unit)
+
+        for label in self.dc_items:
+            if label in self.data_collection:
+                self._label_to_link = label
+                break
+
+        self._spectrum1d = selected_spec
+
+    def vue_function_selected(self, event):
+        # Add the model selected to the list of models
+        self.temp_function = event
+
+    def vue_add_model(self, event):
+        """Add the selected model and input string ID to the list of models"""
+        new_model = {"id": self.temp_name, "model_type": self.temp_model,
+                     "parameters": []}
+
+        # Need to do things differently for polynomials, since the order varies
+        if self.temp_model == "Polynomial1D":
+            new_model = self._initialize_polynomial(new_model)
+        else:
+            # Have a separate private dict with the initialized models, since
+            # they don't play well with JSON for widget interaction
+            initialized_model = initialize(
+                MODELS[self.temp_model](name=self.temp_name),
+                self._spectrum1d.spectral_axis,
+                self._spectrum1d.flux)
+
+            self._initialized_models[self.temp_name] = initialized_model
+
+            for param in model_parameters[new_model["model_type"]]:
+                initial_val = getattr(initialized_model, param).value
+                new_model["parameters"].append({"name": param,
+                                                "value": initial_val,
+                                                "unit": self._param_units(param),
+                                                "fixed": False})
+
+        new_model["Initialized"] = True
+        self.component_models = self.component_models + [new_model]
+
+    def vue_run_function(self, *args, **kwargs):
+        """
+        Run fitting on the initialized models, fixing any parameters marked
+        as such by the user, then update the displauyed parameters with fit
+        values
+        """
+        pass

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -105,7 +105,7 @@ class LineAnalysis(TemplateMixin):
             label of the data collection object selected by the user.
         """
         selected_spec = self.app.get_data_from_viewer("spectrum-viewer",
-                                                      data_label=event)[event]
+                                                      data_label=event)
 
         if self._units == {}:
             self._units["x"] = str(

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -1,13 +1,14 @@
 import os
 import pickle
 
+import numpy as np
 import astropy.units as u
 from glue.core.link_helpers import LinkSame
 from glue.core.message import (SubsetCreateMessage,
                                SubsetDeleteMessage,
                                SubsetUpdateMessage)
 from traitlets import Bool, Int, List, Unicode
-from specutils import analysis
+from specutils import analysis, SpectralRegion
 
 from jdaviz.core.events import AddDataMessage, RemoveDataMessage
 from jdaviz.core.registries import tray_registry
@@ -129,7 +130,12 @@ class LineAnalysis(TemplateMixin):
         as such by the user, then update the displauyed parameters with fit
         values
         """
-        temp_result = FUNCTIONS[self.temp_function](self._spectrum1d)
+        if self.temp_function == "Centroid":
+            spec_region = self._spectrum1d.spectral_axis[np.where(self._spectrum1d.mask == False)]
+            spec_region = SpectralRegion(spec_region[0], spec_region[-1])
+            temp_result = FUNCTIONS[self.temp_function](self._spectrum1d, spec_region)
+        else:
+            temp_result = FUNCTIONS[self.temp_function](self._spectrum1d)
         self.result = str(temp_result)
         self.result_available = True
         raise ValueError("{} {}".format(self.result_available, self.result))

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -13,6 +13,7 @@
                 persistent-hint
               ></v-select>
             </v-col>
+          </v-row>
         </v-container>
       </v-card-text>
       <v-divider></v-divider>

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -21,15 +21,15 @@
       <v-card-text>
         <v-container>
           <v-row>
-            <v-col cols=4>Function</v-col>
-            <v-col cols=8>Result</v-col>
+            <v-col cols=6><U>Function</U></v-col>
+            <v-col cols=6><U>Result</U></v-col>
           </v-row>
           <v-row 
             v-if="result_available"
             v-for="item in results"
             :key="item.function">
-            <v-col cols=4>{{  item.function  }} </v-col>
-            <v-col cols=8>{{ item.result }}</v-col>
+            <v-col cols=6>{{  item.function  }} </v-col>
+            <v-col cols=6>{{ item.result }}</v-col>
           </v-row>
         </v-container>
       </v-card-text>

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -1,0 +1,43 @@
+<template>
+  <v-card flat tile>
+    <v-card>
+      <v-card-text>
+        <v-container>
+          <v-row>
+            <v-col>
+              <v-select
+                :items="dc_items"
+                @change="data_selected"
+                label="Data"
+                hint="Select the data set to be fitted."
+                persistent-hint
+              ></v-select>
+            </v-col>
+        </v-container>
+      </v-card-text>
+      <v-divider></v-divider>
+
+      <v-card-text>
+        <v-container>
+          <v-row
+          align="start"
+          >
+            <v-col>
+              <v-select
+                :items="available_functions"
+                @change="function_selected"
+                label="Model"
+                hint="Select a function to apply"
+                persistent-hint
+              ></v-select>
+            </v-col>
+            <v-col>
+              <v-btn color="primary" text @click="run_function">Run</v-btn>
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-card-text>
+      <v-divider></v-divider>
+    </v-card>
+  </v-card>
+</template>

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -21,19 +21,24 @@
         <v-container>
           <v-row
           align="start"
+          justify="center"
           >
-            <v-col>
+            <v-col cols=8>
               <v-select
                 :items="available_functions"
                 @change="function_selected"
-                label="Model"
+                label="Function"
                 hint="Select a function to apply"
                 persistent-hint
               ></v-select>
             </v-col>
-            <v-col>
+            <v-col cols = 2>
               <v-btn color="primary" text @click="run_function">Run</v-btn>
             </v-col>
+          </v-row>
+          <v-row v-if="result_available">
+            <v-col cols=4>Result: </v-col>
+            <v-col cols=8>{{ result }}</v-col>
           </v-row>
         </v-container>
       </v-card-text>

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -20,26 +20,16 @@
 
       <v-card-text>
         <v-container>
-          <v-row
-          align="start"
-          justify="center"
-          >
-            <v-col cols=8>
-              <v-select
-                :items="available_functions"
-                @change="function_selected"
-                label="Function"
-                hint="Select a function to apply"
-                persistent-hint
-              ></v-select>
-            </v-col>
-            <v-col cols = 2>
-              <v-btn color="primary" text @click="run_function">Run</v-btn>
-            </v-col>
+          <v-row>
+            <v-col cols=4>Function</v-col>
+            <v-col cols=8>Result</v-col>
           </v-row>
-          <v-row v-if="result_available">
-            <v-col cols=4>Result: </v-col>
-            <v-col cols=8>{{ result }}</v-col>
+          <v-row 
+            v-if="result_available"
+            v-for="item in results"
+            :key="item.function">
+            <v-col cols=4>{{  item.function  }} </v-col>
+            <v-col cols=8>{{ item.result }}</v-col>
           </v-row>
         </v-container>
       </v-card-text>

--- a/jdaviz/configs/specviz/specviz.yaml
+++ b/jdaviz/configs/specviz/specviz.yaml
@@ -14,14 +14,12 @@ toolbar:
   - g-data-tools
   - g-subset-tools
 tray:
-<<<<<<< HEAD
   - g-gaussian-smooth
   - g-model-fitting
   - specviz-line-analysis
   - g-unit-conversion
   - g-line-list
   - specviz-line-analysis
->>>>>>> Add line analysis plugin to specviz config
 viewer_area:
   - container: col
     children:

--- a/jdaviz/configs/specviz/specviz.yaml
+++ b/jdaviz/configs/specviz/specviz.yaml
@@ -16,7 +16,6 @@ toolbar:
 tray:
   - g-gaussian-smooth
   - g-model-fitting
-  - specviz-line-analysis
   - g-unit-conversion
   - g-line-list
   - specviz-line-analysis

--- a/jdaviz/configs/specviz/specviz.yaml
+++ b/jdaviz/configs/specviz/specviz.yaml
@@ -14,10 +14,13 @@ toolbar:
   - g-data-tools
   - g-subset-tools
 tray:
+<<<<<<< HEAD
   - g-gaussian-smooth
   - g-model-fitting
   - g-unit-conversion
   - g-line-list
+  - specviz-line-analysis
+>>>>>>> Add line analysis plugin to specviz config
 viewer_area:
   - container: col
     children:

--- a/jdaviz/configs/specviz/specviz.yaml
+++ b/jdaviz/configs/specviz/specviz.yaml
@@ -17,6 +17,7 @@ tray:
 <<<<<<< HEAD
   - g-gaussian-smooth
   - g-model-fitting
+  - specviz-line-analysis
   - g-unit-conversion
   - g-line-list
   - specviz-line-analysis

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ install_requires =
     click
     spectral-cube
     asteval
-    astroquery
 
 [options.extras_require]
 test =

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     click
     spectral-cube
     asteval
+    astroquery
 
 [options.extras_require]
 test =


### PR DESCRIPTION
Adds basic line analysis functionality.

Note that this depends on [glue-astronomy PR 17](https://github.com/glue-viz/glue-astronomy/pull/17)

Also note that it seems that the `specutils.analysis.line_flux` function is broken for masked Spectrum1Ds (this was supposed to be included in [PR 670](https://github.com/astropy/specutils/pull/670) but maybe a bug slipped through?) - do we want to remove that from the analysis options until there's a fix, or should I try to figure out what's wrong in this PR? Currently that function always returns a NaN result for a masked input.