### PR TITLE
fix: prevent notebook from capturing key events from overlay content

### DIFF
--- a/jdaviz/configs/default/plugins/data_tools/data_tools.vue
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.vue
@@ -1,6 +1,6 @@
 <template>
   <v-toolbar-items>
-    <v-dialog v-model="dialog" width="500" persistent @keydown.stop>
+    <v-dialog v-model="dialog" width="500" persistent>
       <template v-slot:activator="{ on }">
         <v-btn tile depressed v-on="on" color="accent">
           Import

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     glue-jupyter @ git+https://github.com/glue-viz/glue-jupyter.git
     echo @ git+https://github.com/glue-viz/echo.git
     ipyvue==1.3.4
-    ipyvuetify==1.4.0
+    ipyvuetify==1.4.1
     ipysplitpanes
     ipygoldenlayout==0.3.0
     voila


### PR DESCRIPTION
This is now fixed in ipyvuetify 1.4.1

See: #123 