### PR TITLE
Add line list plugin to cubeviz and do associated debugging

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -234,8 +234,13 @@ class Application(VuetifyTemplate, HubListener):
         them so that they can be displayed on the same profile1D plot.
         """
         new_len = len(self.data_collection)
+        # Can't link if there's no world_component_ids
+        if self.data_collection[new_len-1].world_component_ids == []:
+            return
         for i in range(0, new_len-1):
-                self.data_collection.add_link(LinkSame(self.data_collection[i].world_component_ids[0],
+            if self.data_collection[i].world_component_ids == []:
+                continue
+            self.data_collection.add_link(LinkSame(self.data_collection[i].world_component_ids[0],
                     self.data_collection[new_len-1].world_component_ids[0]))
 
     def load_data(self, file_obj, **kwargs):

--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -19,6 +19,7 @@ tray:
   - g-gaussian-smooth
   - g-collapse
   - g-model-fitting
+  - g-line-list
 viewer_area:
   - container: col
     children:

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -1,6 +1,41 @@
 from jdaviz.core.helpers import ConfigHelper
+from jdaviz.core.events import AddLineListMessage
 
 class CubeViz(ConfigHelper):
     """CubeViz Helper class"""
 
     _default_configuration = 'cubeviz'
+
+    ## Helper functions and properties related to line lists
+    def load_line_list(self, line_table, replace=False):
+        """
+        Convenience function to get to the viewer function. Also
+        broadcasts a message so the line list plugin UI can display lines
+        loaded via the notebook.
+        """
+        lt = self.app.get_viewer('spectrum-viewer').load_line_list(line_table,
+                                                                   replace=replace,
+                                                                   return_table=True)
+        add_line_list_message = AddLineListMessage(table=lt, sender=self)
+        self.app.hub.broadcast(add_line_list_message)
+
+
+    def erase_spectral_lines(self, name=None):
+        """Convenience function to get to the viewer function"""
+        self.app.get_viewer('spectrum-viewer').erase_spectral_lines(name=name)
+
+    def plot_spectral_line(self, line):
+        """Convenience function to get to the viewer function"""
+        self.app.get_viewer('spectrum-viewer').plot_spectral_line(line)
+
+    def plot_spectral_lines(self):
+        """Convenience function to get to the viewer function"""
+        self.app.get_viewer('spectrum-viewer').plot_spectral_lines()
+
+    @property
+    def spectral_lines(self):
+        return self.app.get_viewer('spectrum-viewer').spectral_lines
+
+    @property
+    def available_linelists(self):
+        return self.app.get_viewer('spectrum-viewer').available_linelists()

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -1,41 +1,7 @@
 from jdaviz.core.helpers import ConfigHelper
-from jdaviz.core.events import AddLineListMessage
+from ..default.plugins.line_lists.line_list_mixin import LineListMixin
 
-class CubeViz(ConfigHelper):
+class CubeViz(ConfigHelper, LineListMixin):
     """CubeViz Helper class"""
 
     _default_configuration = 'cubeviz'
-
-    ## Helper functions and properties related to line lists
-    def load_line_list(self, line_table, replace=False):
-        """
-        Convenience function to get to the viewer function. Also
-        broadcasts a message so the line list plugin UI can display lines
-        loaded via the notebook.
-        """
-        lt = self.app.get_viewer('spectrum-viewer').load_line_list(line_table,
-                                                                   replace=replace,
-                                                                   return_table=True)
-        add_line_list_message = AddLineListMessage(table=lt, sender=self)
-        self.app.hub.broadcast(add_line_list_message)
-
-
-    def erase_spectral_lines(self, name=None):
-        """Convenience function to get to the viewer function"""
-        self.app.get_viewer('spectrum-viewer').erase_spectral_lines(name=name)
-
-    def plot_spectral_line(self, line):
-        """Convenience function to get to the viewer function"""
-        self.app.get_viewer('spectrum-viewer').plot_spectral_line(line)
-
-    def plot_spectral_lines(self):
-        """Convenience function to get to the viewer function"""
-        self.app.get_viewer('spectrum-viewer').plot_spectral_lines()
-
-    @property
-    def spectral_lines(self):
-        return self.app.get_viewer('spectrum-viewer').spectral_lines
-
-    @property
-    def available_linelists(self):
-        return self.app.get_viewer('spectrum-viewer').available_linelists()

--- a/jdaviz/configs/default/plugins/line_lists/line_list_mixin.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_list_mixin.py
@@ -1,0 +1,40 @@
+from jdaviz.core.events import AddLineListMessage
+
+__all__ = ['LineListMixin']
+
+class LineListMixin:
+    """
+    Line list-related methods and properties for use in the configuration
+    helper classes.
+    """
+    def load_line_list(self, line_table, replace=False):
+        """
+        Convenience function to get to the viewer function. Also
+        broadcasts a message so the line list plugin UI can display lines
+        loaded via the notebook.
+        """
+        lt = self.app.get_viewer('spectrum-viewer').load_line_list(line_table,
+                                                                   replace=replace,
+                                                                   return_table=True)
+        add_line_list_message = AddLineListMessage(table=lt, sender=self)
+        self.app.hub.broadcast(add_line_list_message)
+
+    def erase_spectral_lines(self, name=None):
+        """Convenience function to get to the viewer function"""
+        self.app.get_viewer('spectrum-viewer').erase_spectral_lines(name=name)
+
+    def plot_spectral_line(self, line):
+        """Convenience function to get to the viewer function"""
+        self.app.get_viewer('spectrum-viewer').plot_spectral_line(line)
+
+    def plot_spectral_lines(self):
+        """Convenience function to get to the viewer function"""
+        self.app.get_viewer('spectrum-viewer').plot_spectral_lines()
+
+    @property
+    def spectral_lines(self):
+        return self.app.get_viewer('spectrum-viewer').spectral_lines
+
+    @property
+    def available_linelists(self):
+        return self.app.get_viewer('spectrum-viewer').available_linelists()

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -8,9 +8,9 @@ import astropy.units as u
 from specutils import Spectrum1D, SpectrumCollection, SpectralRegion
 
 from jdaviz.core.helpers import ConfigHelper
-from jdaviz.core.events import AddLineListMessage
+from ..default.plugins.line_lists.line_list_mixin import LineListMixin
 
-class SpecViz(ConfigHelper):
+class SpecViz(ConfigHelper, LineListMixin):
     """
     SpecViz Helper class
 
@@ -202,38 +202,6 @@ class SpecViz(ConfigHelper):
 
     def show(self):
         self.app
-
-    def load_line_list(self, line_table, replace=False):
-        """
-        Convenience function to get to the viewer function. Also
-        broadcasts a message so the line list plugin UI can display lines
-        loaded via the notebook.
-        """
-        lt = self.app.get_viewer('spectrum-viewer').load_line_list(line_table,
-                                                                   replace=replace,
-                                                                   return_table=True)
-        add_line_list_message = AddLineListMessage(table=lt, sender=self)
-        self.app.hub.broadcast(add_line_list_message)
-
-    def erase_spectral_lines(self, name=None):
-        """Convenience function to get to the viewer function"""
-        self.app.get_viewer('spectrum-viewer').erase_spectral_lines(name=name)
-
-    def plot_spectral_line(self, line):
-        """Convenience function to get to the viewer function"""
-        self.app.get_viewer('spectrum-viewer').plot_spectral_line(line)
-
-    def plot_spectral_lines(self):
-        """Convenience function to get to the viewer function"""
-        self.app.get_viewer('spectrum-viewer').plot_spectral_lines()
-
-    @property
-    def spectral_lines(self):
-        return self.app.get_viewer('spectrum-viewer').spectral_lines
-
-    @property
-    def available_linelists(self):
-        return self.app.get_viewer('spectrum-viewer').available_linelists()
 
     def x_limits(self, x_min=None, x_max=None):
         """Sets the limits of the x-axis

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -11,7 +11,8 @@ from jdaviz.core.helpers import ConfigHelper
 from jdaviz.core.events import AddLineListMessage
 
 class SpecViz(ConfigHelper):
-    """SpecViz Helper class
+    """
+    SpecViz Helper class
 
     """
 
@@ -204,9 +205,9 @@ class SpecViz(ConfigHelper):
 
     def load_line_list(self, line_table, replace=False):
         """
-        Convenience function to get to the viewer function. Also broadcasts
-        a message so the line list plugin UI can display lines laoded via the
-        notebook.
+        Convenience function to get to the viewer function. Also
+        broadcasts a message so the line list plugin UI can display lines
+        loaded via the notebook.
         """
         lt = self.app.get_viewer('spectrum-viewer').load_line_list(line_table,
                                                                    replace=replace,

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -44,6 +44,8 @@ class SpecvizProfileView(BqplotProfileView):
 
         # If there is already a loaded table, convert units to match. This
         # attempts to do some sane rounding after the unit conversion.
+        # TODO: Fix this so that things don't get rounded to 0 in some cases
+        """
         if self.spectral_lines is not None:
             sig_figs = []
             for row in line_table:
@@ -54,6 +56,7 @@ class SpecvizProfileView(BqplotProfileView):
             for row in line_table:
                 row["rest"] = row["rest"].round(row["sig_figs"])
             del line_table["sig_figs"]
+        """
 
         # Combine name and rest value for indexing
         if "name_rest" not in line_table.colnames:


### PR DESCRIPTION
This PR adds line list plugin to the `cubeviz` configuration, and adds helper functions to the `cubeviz` helper to enable the associated command line functionality. From testing, all the UI plugin functionality seems to work as expected in `cubeviz`. I also fixed a bug where the line list plugin would error if all data was unchecked from the spectrum viewer.

This also fixes a bug in the data linking, so that it doesn't attempt to link world coordinates for data that has none. 