### PR TITLE
add outline of specviz docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ produced by JWST MIRI), along with 1D spectra extracted from the cube.
 
   installation.rst
   data_prep.rst
+  specviz/index.rst
   dev/infrastructure.rst
   dev/ui_description.rst
 

--- a/docs/specviz/displaying.rst
+++ b/docs/specviz/displaying.rst
@@ -1,0 +1,27 @@
+******************
+Displaying Spectra
+******************
+
+Words go here
+
+
+
+Selecting Data Set
+==================
+
+More words...
+
+Pan/Zoom
+========
+
+More words...
+
+Defining Spectral Regions
+=========================
+
+More words...
+
+Plot Settings
+=============
+
+More words...

--- a/docs/specviz/import_data.rst
+++ b/docs/specviz/import_data.rst
@@ -1,0 +1,6 @@
+***********
+Import Data
+***********
+
+Words go here
+

--- a/docs/specviz/index.rst
+++ b/docs/specviz/index.rst
@@ -1,0 +1,14 @@
+*******
+Specviz
+*******
+
+Words go here...
+
+
+.. toctree::
+  :maxdepth: 2
+
+  import_data
+  displaying
+  plugins
+  notebook

--- a/docs/specviz/notebook.rst
+++ b/docs/specviz/notebook.rst
@@ -1,0 +1,5 @@
+***********************************
+Using SpecViz in a Jupyter Notebook 
+***********************************
+
+Words go here...

--- a/docs/specviz/plugins.rst
+++ b/docs/specviz/plugins.rst
@@ -1,0 +1,35 @@
+*********************
+Data Analysis Plugins
+*********************
+
+Overview here...
+
+Input/Output
+============
+
+More words...
+
+Gaussian Smooth
+===============
+
+More words...
+
+Model Fitting 
+=============
+
+More words...
+
+Unit Conversion
+===============
+
+More words...
+
+Line Lists
+==========
+
+More words...
+
+Line Analysis
+=============
+
+More words...


### PR DESCRIPTION
Just what it says on the tin - a currently-unpopulated outline of the docs to be followed with PRs populating the sections.