### PR TITLE
Fix command line parsing

### DIFF
--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -12,10 +12,25 @@ CONFIGS_DIR = os.path.join(os.path.dirname(__file__), 'configs')
 
 
 @click.command()
-@click.argument('filename')
-@click.option('--layout', default='default')
-def main(filename, layout):
+@click.argument('filename', nargs=1, type=click.Path(exists=True))
+@click.option('--layout',
+              default='default',
+              nargs=1,
+              show_default=True,
+              type=click.Choice(['default', 'cubeviz', 'specviz', 'mosviz'],
+                                case_sensitive=False),
+              help="Configuration to use on application startup")
+def main(filename, layout='default'):
+    """
+    Start a JDAViz application instance with data loaded from FILENAME.\f
 
+    Parameters
+    ----------
+    filename : str
+        The path to the file to be loaded into the JDAViz application.
+    layout : str, optional
+        Optional specification for which configuration to use on startup.
+    """
     filename = os.path.abspath(filename)
 
     with open(os.path.join(CONFIGS_DIR, layout, layout + '.ipynb')) as f:
@@ -24,14 +39,17 @@ def main(filename, layout):
     start_dir = os.path.abspath('.')
 
     nbdir = tempfile.mkdtemp()
+
     with open(os.path.join(nbdir, 'notebook.ipynb'), 'w') as nbf:
-        nbf.write(notebook_template.replace('CONFIG_NAME', layout).replace('DATA_FILENAME', filename).strip())
+        nbf.write(notebook_template.replace('CONFIG_NAME', layout).replace(
+            'DATA_FILENAME', filename).strip())
 
     os.chdir(nbdir)
+
     try:
         Voila.notebook_path = 'notebook.ipynb'
         VoilaConfiguration.template = 'jdaviz-default'
         VoilaConfiguration.enable_nbextensions = True
-        sys.exit(Voila().launch_instance())
+        sys.exit(Voila().launch_instance(argv=[]))
     finally:
         os.chdir(start_dir)


### PR DESCRIPTION
Resolves #224. The problem was that, by default, Voila will attempt to read command line arguments, which includes the arguments that are provided to Click. The issue described in #224 is not actually a Click problem, it was the result of `argparse` being used in the traitlet's `Application` class. This PR ensures that argument handling is only done in Click. It also improves the cli help and adds some built-in Click argument value checkers.