### PR TITLE
Fix two minor bugs in spectral subset/region retrieval

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -454,7 +454,7 @@ class Application(VuetifyTemplate, HubListener):
                     width = hi - lo
                     region = RectanglePixelRegion(
                         PixCoord(xcen, 0), width, 0,
-                        meta={'spectal_axis_unit': unit})
+                        meta={'spectral_axis_unit': unit})
                     regions[key] = region
                     continue
 

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -91,7 +91,7 @@ class SpecViz(ConfigHelper):
         for name, reg in regions.items():
             unit = reg.meta.get("spectral_axis_unit", u.Unit("Angstrom"))
             spec_reg = SpectralRegion.from_center(reg.center.x * unit,
-                                                  (reg.width / 2) * unit)
+                                                  reg.width * unit)
 
             spec_regs[name] = spec_reg
 

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -90,7 +90,8 @@ class SpecViz(ConfigHelper):
 
         for name, reg in regions.items():
             unit = reg.meta.get("spectral_axis_unit", u.Unit("Angstrom"))
-            spec_reg = SpectralRegion.from_center(reg.center.x * unit, reg.width * unit)
+            spec_reg = SpectralRegion.from_center(reg.center.x * unit,
+                                                  (reg.width / 2) * unit)
 
             spec_regs[name] = spec_reg
 


### PR DESCRIPTION
Two small fixes: a typo in the meta data label in the returned data from `app.get_subsets_from_viewer`, and a factor of two in the region edge calculations in `specviz.get_spectral_regions`.