### PR TITLE
Enable collapsing over a spectral region

### DIFF
--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -4,7 +4,9 @@ from glue.core.message import (DataCollectionAddMessage,
 from glue.core import Data
 from glue.core.link_helpers import LinkSame
 from spectral_cube import SpectralCube
-from traitlets import List, Unicode, Int, observe
+from specutils import SpectralRegion
+from traitlets import List, Unicode, Int, Any, observe
+from regions import RectanglePixelRegion
 
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import tray_registry
@@ -32,6 +34,12 @@ class Collapse(TemplateMixin):
     funcs = List(['Mean', 'Median', 'Min', 'Max']).tag(sync=True)
     selected_func = Unicode('Mean').tag(sync=True)
 
+    spectral_min = Any().tag(sync=True)
+    spectral_max = Any().tag(sync=True)
+    spectral_unit = Unicode().tag(sync=True)
+    spectral_subset_items = List(["None"]).tag(sync=True)
+    selected_subset = Unicode().tag(sync=True)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -44,6 +52,14 @@ class Collapse(TemplateMixin):
 
     def _on_data_updated(self, msg):
         self.data_items = [x.label for x in self.data_collection]
+        # Default to selecting the first loaded data
+        if self._selected_data is None:
+            self.selected_data_item = self.data_items[0]
+            # Also set the spectral min and max to default to the full range
+            cube = self._selected_data.get_object(cls=SpectralCube)
+            self.spectral_min = cube.spectral_axis[0].value
+            self.spectral_max = cube.spectral_axis[-1].value
+            self.spectral_unit = str(cube.spectral_axis.unit)
 
     @observe('selected_data_item')
     def _on_data_item_selected(self, event):
@@ -51,6 +67,35 @@ class Collapse(TemplateMixin):
                                     if x.label == event['new']))
 
         self.axes = list(range(len(self._selected_data.shape)))
+
+    @observe("selected_subset")
+    def _on_subset_selected(self, event):
+        # If "None" selected, reset based on bounds of selected data
+        self._selected_subset = self.selected_subset
+        if self._selected_subset == "None":
+            cube = self._selected_data.get_object(cls=SpectralCube)
+            self.spectral_min = cube.spectral_axis[0].value
+            self.spectral_max = cube.spectral_axis[-1].value
+        else:
+            spec_sub = self._spectral_subsets[self._selected_subset]
+            unit = u.Unit(self.spectral_unit)
+            spec_reg = SpectralRegion.from_center(spec_sub.center.x * unit,
+                                                  spec_sub.width * unit)
+            self.spectral_min = spec_reg.lower.value
+            self.spectral_max = spec_reg.upper.value
+
+    def vue_list_subsets(self, event):
+         """Populate the spectral subset selection dropdown"""
+         temp_subsets = self.app.get_subsets_from_viewer("spectrum-viewer")
+         temp_list = ["None"]
+         temp_dict = {}
+         # Attempt to filter out spatial subsets
+         for key, region in temp_subsets.items():
+             if type(region) == RectanglePixelRegion:
+                 temp_dict[key] = region
+                 temp_list.append(key)
+         self._spectral_subsets = temp_dict
+         self.spectral_subset_items = temp_list
 
     def vue_collapse(self, *args, **kwargs):
         try:
@@ -63,6 +108,13 @@ class Collapse(TemplateMixin):
             self.hub.broadcast(snackbar_message)
 
             return
+
+        # If collapsing over the spectral axis, cut out the desired spectral
+        # region. Defaults to the entire spectrum.
+        if self.selected_axis == 0:
+            spec_min = float(self.spectral_min) * u.Unit(self.spectral_unit)
+            spec_max = float(self.spectral_max) * u.Unit(self.spectral_unit)
+            spec = spec.spectral_slab(spec_min, spec_max)
 
         collapsed_spec = getattr(spec, self.selected_func.lower())(
             axis=self.selected_axis)

--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -54,9 +54,9 @@ class Collapse(TemplateMixin):
         self.data_items = [x.label for x in self.data_collection]
         # Default to selecting the first loaded cube
         if self._selected_data is None:
-            for i in range(len(self.dc_items)):
+            for i in range(len(self.data_items)):
                 try:
-                    self.selected_data_item = self.data_items[0]
+                    self.selected_data_item = self.data_items[i]
                     # Also set the spectral min and max to default to the
                     # full range
                     cube = self._selected_data.get_object(cls=SpectralCube)

--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -52,14 +52,19 @@ class Collapse(TemplateMixin):
 
     def _on_data_updated(self, msg):
         self.data_items = [x.label for x in self.data_collection]
-        # Default to selecting the first loaded data
+        # Default to selecting the first loaded cube
         if self._selected_data is None:
-            self.selected_data_item = self.data_items[0]
-            # Also set the spectral min and max to default to the full range
-            cube = self._selected_data.get_object(cls=SpectralCube)
-            self.spectral_min = cube.spectral_axis[0].value
-            self.spectral_max = cube.spectral_axis[-1].value
-            self.spectral_unit = str(cube.spectral_axis.unit)
+            for i in range(len(self.dc_items)):
+                try:
+                    self.selected_data_item = self.data_items[0]
+                    # Also set the spectral min and max to default to the
+                    # full range
+                    cube = self._selected_data.get_object(cls=SpectralCube)
+                    self.spectral_min = cube.spectral_axis[0].value
+                    self.spectral_max = cube.spectral_axis[-1].value
+                    self.spectral_unit = str(cube.spectral_axis.unit)
+                except (ValueError, TypeError):
+                    continue
 
     @observe('selected_data_item')
     def _on_data_item_selected(self, event):
@@ -85,17 +90,17 @@ class Collapse(TemplateMixin):
             self.spectral_max = spec_reg.upper.value
 
     def vue_list_subsets(self, event):
-         """Populate the spectral subset selection dropdown"""
-         temp_subsets = self.app.get_subsets_from_viewer("spectrum-viewer")
-         temp_list = ["None"]
-         temp_dict = {}
-         # Attempt to filter out spatial subsets
-         for key, region in temp_subsets.items():
-             if type(region) == RectanglePixelRegion:
-                 temp_dict[key] = region
-                 temp_list.append(key)
-         self._spectral_subsets = temp_dict
-         self.spectral_subset_items = temp_list
+        """Populate the spectral subset selection dropdown"""
+        temp_subsets = self.app.get_subsets_from_viewer("spectrum-viewer")
+        temp_list = ["None"]
+        temp_dict = {}
+        # Attempt to filter out spatial subsets
+        for key, region in temp_subsets.items():
+            if type(region) == RectanglePixelRegion:
+                temp_dict[key] = region
+                temp_list.append(key)
+        self._spectral_subsets = temp_dict
+        self.spectral_subset_items = temp_list
 
     def vue_collapse(self, *args, **kwargs):
         try:

--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -57,12 +57,6 @@ class Collapse(TemplateMixin):
             for i in range(len(self.data_items)):
                 try:
                     self.selected_data_item = self.data_items[i]
-                    # Also set the spectral min and max to default to the
-                    # full range
-                    cube = self._selected_data.get_object(cls=SpectralCube)
-                    self.spectral_min = cube.spectral_axis[0].value
-                    self.spectral_max = cube.spectral_axis[-1].value
-                    self.spectral_unit = str(cube.spectral_axis.unit)
                 except (ValueError, TypeError):
                     continue
 
@@ -70,6 +64,12 @@ class Collapse(TemplateMixin):
     def _on_data_item_selected(self, event):
         self._selected_data = next((x for x in self.data_collection
                                     if x.label == event['new']))
+
+        # Also set the spectral min and max to default to the full range
+        cube = self._selected_data.get_object(cls=SpectralCube)
+        self.spectral_min = cube.spectral_axis[0].value
+        self.spectral_max = cube.spectral_axis[-1].value
+        self.spectral_unit = str(cube.spectral_axis.unit)
 
         self.axes = list(range(len(self._selected_data.shape)))
 

--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -38,7 +38,7 @@ class Collapse(TemplateMixin):
     spectral_max = Any().tag(sync=True)
     spectral_unit = Unicode().tag(sync=True)
     spectral_subset_items = List(["None"]).tag(sync=True)
-    selected_subset = Unicode().tag(sync=True)
+    selected_subset = Unicode("None").tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/jdaviz/configs/default/plugins/collapse/collapse.vue
+++ b/jdaviz/configs/default/plugins/collapse/collapse.vue
@@ -33,6 +33,48 @@
         </v-col>
       </v-row>
     </v-container>
+    <v-container v-if="selected_axis == 0">
+      <v-row>
+        <v-col>
+          <v-select
+            :items="spectral_subset_items"
+            v-model="selected_subset"
+            label="Spectral Region"
+            hint="Optional: limit to a spectral region defined in the spectrum viewer."
+            persistent-hint
+            @click="list_subsets"
+          ></v-select>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col>
+          <v-text-field
+            label="Lower spectral bound"
+            v-model="spectral_min"
+            hint="Lower bound of spectral region"
+            persistent-hint
+          >
+          </v-text-field>
+        </v-col>
+        <v-col cols = 2>
+          <span>{{ spectral_unit }}</span>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col>
+          <v-text-field
+            label="Upper spectral bound"
+            v-model="spectral_max"
+            hint="Lower bound of spectral region"
+            persistent-hint
+          >
+          </v-text-field>
+        </v-col>
+        <v-col cols = 2>
+          <span>{{ spectral_unit }}</span>
+        </v-col>
+      </v-row>
+    </v-container>
     <!-- <v-divider></v-divider> -->
 
     <v-card-actions>


### PR DESCRIPTION
Add Subset selection or manual bound entry to the `Collapse` plugin, which are only visible when the spectral axis is selected. This largely duplicates some relevant code from the `Moment Maps` plugin, but I didn't immediately see an elegant way to pull the shared code out to something both could import from. It's not that much code, so a little duplication is probably alright.