### PR TITLE
Add snackbar warning if data not retrieved

### DIFF
--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -97,7 +97,7 @@ class LineListTool(TemplateMixin):
 
         try:
             viewer_data = self.app.get_viewer('spectrum-viewer').data()
-        except:
+        except TypeError:
             warn_message = SnackbarMessage("Line list plugin could not retrieve data from viewer",
                                             sender=self, color="error")
             self.hub.broadcast(warn_message)

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -95,7 +95,13 @@ class LineListTool(TemplateMixin):
         if msg is not None and msg.viewer_id != self._viewer_id:
             return
 
-        viewer_data = self.app.get_viewer('spectrum-viewer').data()
+        try:
+            viewer_data = self.app.get_viewer('spectrum-viewer').data()
+        except:
+            warn_message = SnackbarMessage("Line list plugin could not retrieve data from viewer",
+                                            sender=self, color="error")
+            self.hub.broadcast(warn_message)
+            return
 
         # If no data is currently plotted, don't attempt to update
         if len(viewer_data) == 0:


### PR DESCRIPTION
What it says on the tin - fixes a failing test, although I think the root issue is that the data being added in the test isn't compatible with the data translators on the backend and thus cause `get_data_from_viewer("spectrum-viewer")` to fail. So this should be considered a stopgap that gets the tests to pass (since the line list plugin method no longer fails) but doesn't address the underlying issue that the tests might need to be updated to pass better constructed data.