### PR TITLE
Add spatial smoothing option for Gaussian Smooth in Cubeviz

### DIFF
--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -92,7 +92,7 @@ class GaussianSmooth(TemplateMixin):
         """
 
         size = float(self.stddev)
-        cube = self._selected_data.get_object()
+        cube = self._selected_data.get_object(cls=SpectralCube)
         # Extend the 2D kernel to have a length 1 spectral dimension, so that
         # we can do "3d" convolution to the whole cube
         kernel = np.expand_dims(Gaussian2DKernel(size), 0)

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.vue
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.vue
@@ -12,6 +12,17 @@
           ></v-select>
         </v-col>
       </v-row>
+      <v-row v-if="show_modes">
+        <v-col>
+          <v-select
+            :items="smooth_modes"
+            v-model="selected_mode"
+            label="Smoothing Type"
+            hint="Smooth data spectrally or spatially"
+            persistent-hint
+          ></v-select>
+        </v-col>
+      </v-row>
       <v-row>
         <v-col>
           <v-text-field
@@ -30,8 +41,16 @@
 
     <v-card-actions>
       <div class="flex-grow-1"></div>
-      <v-btn :disabled="stddev <= 0 || selected_data == ''"
-      color="accent" text @click="gaussian_smooth">Apply</v-btn>
+      <v-btn v-if="selected_mode=='Spectral'"
+        :disabled="stddev <= 0 || selected_data == ''"
+        color="accent" text 
+        @click="spectral_smooth"
+      >Apply</v-btn>
+      <v-btn v-else
+        :disabled="stddev <= 0 || selected_data == ''"
+        color="accent" text
+        @click="spatial_convolution"
+      >Apply</v-btn>
     </v-card-actions>
   </v-card>
 </template>

--- a/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
@@ -2,13 +2,14 @@ import numpy as np
 
 from glue.core import Data
 from jdaviz import Application
+from spectral_cube import SpectralCube
 
 from ..gaussian_smooth import GaussianSmooth
 
 
 def test_linking_after_spectral_smooth(spectral_cube_wcs):
 
-    app = Application()
+    app = Application(configuration="cubeviz")
     dc = app.data_collection
     dc.append(Data(x=np.ones((3, 4, 5)), label='test', coords=spectral_cube_wcs))
 
@@ -24,3 +25,18 @@ def test_linking_after_spectral_smooth(spectral_cube_wcs):
 
     assert dc.external_links[0].cids1[0] is dc[0].world_component_ids[0]
     assert dc.external_links[0].cids2[0] is dc[1].world_component_ids[0]
+
+def test_spatial_convolution(spectral_cube_wcs):
+
+    app = Application()
+    dc = app.data_collection
+    dc.append(Data(x=np.ones((3, 4, 5)), label='test', coords=spectral_cube_wcs))
+
+    gs = GaussianSmooth(app=app)
+    gs._on_data_selected({'new': 'test'})
+    gs.stddev = '3'
+    gs.vue_spatial_convolution()
+
+    assert len(dc) == 2
+    assert dc[1].label == "Smoothed test"
+    assert dc["Smoothed test"].get_object(cls=SpectralCube).shape == (3,4,5)

--- a/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
@@ -6,7 +6,7 @@ from jdaviz import Application
 from ..gaussian_smooth import GaussianSmooth
 
 
-def test_linking_after_gaussian_smooth(spectral_cube_wcs):
+def test_linking_after_spectral_smooth(spectral_cube_wcs):
 
     app = Application()
     dc = app.data_collection
@@ -16,7 +16,7 @@ def test_linking_after_gaussian_smooth(spectral_cube_wcs):
 
     gs._on_data_selected({'new': 'test'})
     gs.stddev = '3.2'
-    gs.vue_gaussian_smooth()
+    gs.vue_spectral_smooth()
 
     assert len(dc) == 2
     assert dc[1].label == 'Smoothed test'


### PR DESCRIPTION
What it says in the title. The only hitch I'm seeing is that adding the smoothed data cube to the data collection seems to hit an amount of data that's a bit hard for the app to handle - I'm occasionally getting some `IOPub` message rate limitation errors after adding the smoothed data.

I'll also note that I was never able to get `SpectralCube.spatial_smooth` (which uses parallelization) to work, so this is using the `astropy.convolution.convolve` funtion directly.