### PR TITLE
Remove collapse plugin from SpecViz

### DIFF
--- a/jdaviz/configs/specviz/specviz.yaml
+++ b/jdaviz/configs/specviz/specviz.yaml
@@ -13,7 +13,6 @@ toolbar:
   - g-subset-tools
 tray:
   - g-gaussian-smooth
-  - g-collapse
   - g-model-fitting
   - g-unit-conversion
   - g-line-list


### PR DESCRIPTION
That's it. Just that. It kind of pained me to go through the whole process for just a single line change... but I have to be a "good developer" or something :P

For actual detail, the collapse plugin only makes sense in a cube scenario (collapsing the multiple dimensions of a cube down into a 2D product). Thus, it should only be included in cubeviz, and not in specviz