### PR TITLE
Link Mosviz spectrum viewer x axes

### DIFF
--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -34,7 +34,6 @@ class MosViz(ConfigHelper):
             idx = float((np.abs(world - new_val)).argmin())
             scales = self.app.get_viewer('spectrum-2d-viewer').scales
             old_idx = getattr(scales['x'], name)
-            print(idx, old_idx)
             if idx != old_idx:
                 setattr(scales['x'], name, idx)
 
@@ -53,7 +52,6 @@ class MosViz(ConfigHelper):
             val = world[new_idx]
             scales = self.app.get_viewer('spectrum-viewer').scales
             old_val = getattr(scales['x'], name)
-            print(val, old_val)
             if val != old_val:
                 setattr(scales['x'], name, val)
 

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -80,7 +80,7 @@ class MosViz(ConfigHelper):
             # that the viewers will desync
             try:
                 val = world[new_idx+extend_by]
-            except:
+            except IndexError:
                 val=old_val
                 msg = "Warning: panning too far away from the data may desync \
                        the 1D and 2D spectrum viewers"

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -41,7 +41,7 @@ class MosViz(ConfigHelper):
                 return
             new_val = change['new']
             spec1d = self.app.get_viewer('table-viewer')._selected_data["spectrum-viewer"]
-            extend_by = int(self.app.data_collection[spec1d]["World 0"].shape[0] / 2)
+            extend_by = int(self.app.data_collection[spec1d]["World 0"].shape[0])
             world = self._extend_world(spec1d, extend_by)
 
             idx = float((np.abs(world - new_val)).argmin()) - extend_by
@@ -61,7 +61,7 @@ class MosViz(ConfigHelper):
                 return
             new_idx = int(np.around(change['new']))
             spec1d = self.app.get_viewer('table-viewer')._selected_data["spectrum-viewer"]
-            extend_by = int(self.app.data_collection[spec1d]["World 0"].shape[0] / 2)
+            extend_by = int(self.app.data_collection[spec1d]["World 0"].shape[0])
             world = self._extend_world(spec1d, extend_by)
 
             val = world[new_idx+extend_by]

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -16,6 +16,9 @@ class MosViz(ConfigHelper):
         spec1d = self.app.get_viewer("spectrum-viewer")
         spec1d.scales['x'].observe(self._update_spec2d_x_axis)
 
+        spec2d = self.app.get_viewer("spectrum-2d-viewer")
+        spec2d.scales['x'].observe(self._update_spec1d_x_axis)
+
     def _update_spec2d_x_axis(self, change):
         # This assumes the two spectrum viewers have the same x-axis shape and
         # wavelength solution, which should always hold
@@ -34,6 +37,25 @@ class MosViz(ConfigHelper):
             print(idx, old_idx)
             if idx != old_idx:
                 setattr(scales['x'], name, idx)
+
+    def _update_spec1d_x_axis(self, change):
+        # This assumes the two spectrum viewers have the same x-axis shape and
+        # wavelength solution, which should always hold
+        if change['old'] is None:
+            pass
+        else:
+            name = change['name']
+            if name not in ['min', 'max']:
+                return
+            new_idx = int(np.around(change['new']))
+            spec1d = self.app.get_viewer('table-viewer')._selected_data["spectrum-viewer"]
+            world = self.app.data_collection[spec1d]["World 0"]
+            val = world[new_idx]
+            scales = self.app.get_viewer('spectrum-viewer').scales
+            old_val = getattr(scales['x'], name)
+            print(val, old_val)
+            if val != old_val:
+                setattr(scales['x'], name, val)
 
     def load_data(self, spectra_1d, spectra_2d, images, spectra_1d_label=None,
                   spectra_2d_label=None, images_label=None):

--- a/jdaviz/configs/mosviz/plugins/viewers.py
+++ b/jdaviz/configs/mosviz/plugins/viewers.py
@@ -40,6 +40,8 @@ class MOSVizProfile2DView(BqplotImageView):
     #  axes, the default conversion class must handle cubes
     default_class = SpectralCube
 
+    tools = ['bqplot:panzoom_x']
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Setup viewer option defaults

--- a/jdaviz/configs/mosviz/plugins/viewers.py
+++ b/jdaviz/configs/mosviz/plugins/viewers.py
@@ -70,12 +70,6 @@ class MOSVizTableViewer(TableViewer):
         self._selected_data = {}
 
     def _on_row_selected(self, event):
-        # If no data is selected, ensure that all selected data is removed
-        if len(self._selected_data.keys()) > 0:
-            for viewer_reference, data_label in self._selected_data.items():
-                remove_data_from_viewer_message = RemoveDataFromViewerMessage(
-                    viewer_reference, data_label, sender=self)
-                self.session.hub.broadcast(remove_data_from_viewer_message)
 
         # Grab the index of the latest selected row
         selected_index = event['new']
@@ -86,37 +80,40 @@ class MOSVizTableViewer(TableViewer):
             selected_data = comp_data[selected_index]
 
             if component.label == '1D Spectra':
-                if self._selected_data.get('spectrum-viewer') != selected_data:
+                prev_data = self._selected_data.get('spectrum-viewer')
+                if prev_data != selected_data:
                     remove_data_from_viewer_message = RemoveDataFromViewerMessage(
-                        'spectrum-viewer', selected_data, sender=self)
+                        'spectrum-viewer', prev_data, sender=self)
                     self.session.hub.broadcast(remove_data_from_viewer_message)
 
-                add_data_to_viewer_message = AddDataToViewerMessage(
-                    'spectrum-viewer', selected_data, sender=self)
-                self.session.hub.broadcast(add_data_to_viewer_message)
+                    add_data_to_viewer_message = AddDataToViewerMessage(
+                        'spectrum-viewer', selected_data, sender=self)
+                    self.session.hub.broadcast(add_data_to_viewer_message)
 
-                self._selected_data['spectrum-viewer'] = selected_data
+                    self._selected_data['spectrum-viewer'] = selected_data
 
             if component.label == '2D Spectra':
-                if self._selected_data.get('spectrum-2d-viewer') != selected_data:
+                prev_data = self._selected_data.get('spectrum-2d-viewer')
+                if prev_data != selected_data:
                     remove_data_from_viewer_message = RemoveDataFromViewerMessage(
-                        'spectrum-2d-viewer', selected_data, sender=self)
+                        'spectrum-2d-viewer', prev_data, sender=self)
                     self.session.hub.broadcast(remove_data_from_viewer_message)
 
-                add_data_to_viewer_message = AddDataToViewerMessage(
-                    'spectrum-2d-viewer', selected_data, sender=self)
-                self.session.hub.broadcast(add_data_to_viewer_message)
+                    add_data_to_viewer_message = AddDataToViewerMessage(
+                        'spectrum-2d-viewer', selected_data, sender=self)
+                    self.session.hub.broadcast(add_data_to_viewer_message)
 
-                self._selected_data['spectrum-2d-viewer'] = selected_data
+                    self._selected_data['spectrum-2d-viewer'] = selected_data
 
             if component.label == 'Images':
-                if self._selected_data.get('image-viewer') != selected_data:
+                prev_data = self._selected_data.get('image-viewer')
+                if prev_data != selected_data:
                     remove_data_from_viewer_message = RemoveDataFromViewerMessage(
-                        'image-viewer', selected_data, sender=self)
+                        'image-viewer', prev_data, sender=self)
                     self.session.hub.broadcast(remove_data_from_viewer_message)
 
-                add_data_to_viewer_message = AddDataToViewerMessage(
-                    'image-viewer', selected_data, sender=self)
-                self.session.hub.broadcast(add_data_to_viewer_message)
+                    add_data_to_viewer_message = AddDataToViewerMessage(
+                        'image-viewer', selected_data, sender=self)
+                    self.session.hub.broadcast(add_data_to_viewer_message)
 
-                self._selected_data['image-viewer'] = selected_data
+                    self._selected_data['image-viewer'] = selected_data

--- a/jdaviz/configs/mosviz/tests/test_helper.py
+++ b/jdaviz/configs/mosviz/tests/test_helper.py
@@ -66,7 +66,7 @@ SPECSYS = 'BARYCENT'           / Reference frame of spectral coordinates
         new_hdr[key] = value
 
     wcs = WCS(new_hdr)
-    data = np.random.sample((15, 1, 1174))
+    data = np.random.sample((15, 1, 1024))
     spectral_cube = SpectralCube(data, wcs=wcs)
 
     return spectral_cube
@@ -186,7 +186,7 @@ def test_load_spectrum2d(mosviz_app, spectrum2d):
 
     data = mosviz_app.app.get_data_from_viewer('spectrum-2d-viewer')
 
-    assert list(data.values())[0].shape == (15, 1, 1174)
+    assert list(data.values())[0].shape == (15, 1, 1024)
     assert list(data.keys())[0] == label
 
 
@@ -205,3 +205,22 @@ def test_load_image(mosviz_app, image):
     # assert isinstance(list(data.values())[0], CCDData)
     assert list(data.values())[0].shape == (55, 55)
     assert list(data.keys())[0] == f"{label} 0"
+
+def test_viewer_axis_link(mosviz_app, spectrum1d, spectrum2d):
+    label1d = "Test 1D Spectrum"
+    mosviz_app.load_1d_spectra(spectrum1d, data_labels=label1d)
+
+    label2d = "Test 2D Spectrum"
+    mosviz_app.load_2d_spectra(spectrum2d, data_labels=label2d)
+
+    table = mosviz_app.app.get_viewer('table-viewer')
+    table.widget_table.vue_on_row_clicked(0)
+
+    scale_2d = mosviz_app.app.get_viewer('spectrum-2d-viewer').scales['x']
+    scale_1d = mosviz_app.app.get_viewer('spectrum-viewer').scales['x']
+
+    scale_2d.min = 200.0
+    assert scale_1d.min == spectrum1d.spectral_axis.value[200]
+
+    scale_1d.max = 7564
+    assert scale_2d.max == 800.0


### PR DESCRIPTION
Adds `observe` methods on the x-axes of the Mosviz spectrum viewers to update the other spectrum viewer's x scale when one is changed.

Edit: I should also mention that I streamlined the table viewer to send less messages when a row is selected, and not update e.g. the image viewer if the new and old rows share the same image.