### PR TITLE
Set axes labels

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -906,12 +906,8 @@ class Application(VuetifyTemplate, HubListener):
             print("In set axes labels")
             active_data = self.data_collection[active_data_labels[0]]
             if hasattr(active_data, "_preferred_translation") \
-                    and active_data._preferred_translation is not None \
-                    and type(active_data.get_object()) is Spectrum1D:
+                    and active_data._preferred_translation is not None:
                 print("running set plot axes labels")
-                self._set_plot_axes_labels(active_data.get_object(), viewer_id)
-            else:
-                #print(f"{active_data}: {type(active_data)}: {active_data.get_object().spectral_axis}")
                 self._set_plot_axes_labels(active_data.get_object(), viewer_id)
 
     def _on_data_added(self, msg):

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -35,6 +35,8 @@ from .core.registries import (tool_registry, tray_registry, viewer_registry,
                               data_parser_registry)
 from .utils import load_template
 
+#from .configs.mosviz.plugins.viewers import MOSVizProfile2DView
+
 __all__ = ['Application']
 
 SplitPanes()
@@ -583,55 +585,18 @@ class Application(VuetifyTemplate, HubListener):
                 f"of:\n\t" + f"\n\t".join([
                     data_item['name'] for data_item in self.state.data_items]))
 
-    def _set_plot_axes_labels(self, data, viewer_id):
+    def _set_plot_axes_labels(self,viewer_id):
         """
         Sets the plot axes labels to be the units of the data to be loaded.
 
         Parameters
         ----------
-        data : `~Spectrum1D`
-            Data from ``DataCollection`` that will have its units as the plot
-            label axes.
         viewer_id : str
             The UUID associated with the desired viewer item.
         """
         viewer = self._viewer_by_id(viewer_id)
 
-        if type(data) is Spectrum1D:
-            # Set axes labels for the spectrum viewer
-
-            spectral_axis_unit_type = data.spectral_axis.unit.physical_type.title()
-            # flux_unit_type = data.flux.unit.physical_type.title()
-            flux_unit_type = "Flux density"
-
-            if data.spectral_axis.unit.is_equivalent(u.m):
-                spectral_axis_unit_type = "Wavelength"
-            elif data.spectral_axis.unit.is_equivalent(u.pixel):
-                spectral_axis_unit_type = "pixel"
-
-            viewer.figure.axes[0].label = f"{spectral_axis_unit_type} [{data.spectral_axis.unit.to_string()}]"
-            viewer.figure.axes[1].label = f"{flux_unit_type} [{data.flux.unit.to_string()}]"
-
-        elif type(data) is SpectralCube:
-            # Set axes labels for the spectrum 2d viewer
-
-            viewer.figure.axes[0].visible = False
-
-            viewer.figure.axes[1].label = "y: pixels"
-            viewer.figure.axes[1].tick_format = None
-            viewer.figure.axes[1].label_location = 'start'
-
-        elif type(data) is CCDData:
-            # Set axes labels for the image viewer
-
-            viewer.figure.axes[1].tick_format = None
-            viewer.figure.axes[0].tick_format = None
-
-            viewer.figure.axes[1].label = "y: pixels"
-            viewer.figure.axes[0].label = "x: pixels"
-
-        # Make it so y axis label is not covering tick numbers.
-        viewer.figure.axes[1].label_offset = "-50"
+        viewer.set_plot_axes()
 
     def remove_data_from_viewer(self, viewer_reference, data_label):
         """
@@ -906,7 +871,8 @@ class Application(VuetifyTemplate, HubListener):
             active_data = self.data_collection[active_data_labels[0]]
             if hasattr(active_data, "_preferred_translation") \
                     and active_data._preferred_translation is not None:
-                self._set_plot_axes_labels(active_data.get_object(), viewer_id)
+                pass
+                self._set_plot_axes_labels(viewer_id)
 
     def _on_data_added(self, msg):
         """

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -598,9 +598,11 @@ class Application(VuetifyTemplate, HubListener):
         viewer = self._viewer_by_id(viewer_id)
 
         if type(data) is Spectrum1D:
-            # Get the units of the data to be loaded.
+            # Set axes labels for the spectrum viewer
+
             spectral_axis_unit_type = data.spectral_axis.unit.physical_type.title()
-            flux_unit_type = data.flux.unit.physical_type.title()
+            # flux_unit_type = data.flux.unit.physical_type.title()
+            flux_unit_type = "Flux density"
 
             if data.spectral_axis.unit.is_equivalent(u.m):
                 spectral_axis_unit_type = "Wavelength"
@@ -611,24 +613,22 @@ class Application(VuetifyTemplate, HubListener):
             viewer.figure.axes[1].label = f"{flux_unit_type} [{data.flux.unit.to_string()}]"
 
         elif type(data) is SpectralCube:
-            # Get the units of the data to be loaded.
-            spectral_axis_unit_type = data.spectral_axis.unit.physical_type.title()
-            flux_unit_type = data.unit.physical_type.title()
+            # Set axes labels for the spectrum 2d viewer
 
-            if data.spectral_axis.unit.is_equivalent(u.m):
-                spectral_axis_unit_type = "Wavelength"
-            elif data.spectral_axis.unit.is_equivalent(u.pixel):
-                spectral_axis_unit_type = "pixel"
+            viewer.figure.axes[0].visible = False
 
-            viewer.figure.axes[0].label = f"{spectral_axis_unit_type} [{data.spectral_axis.unit.to_string()}]"
-            viewer.figure.axes[1].label = f"{flux_unit_type} [{data.unit.to_string()}]"
+            viewer.figure.axes[1].label = "y: pixels"
+            viewer.figure.axes[1].tick_format = None
+            viewer.figure.axes[1].label_location = 'start'
 
         elif type(data) is CCDData:
-            # Get the units of the data to be loaded.
-            flux_unit_type = data.unit.physical_type.title()
+            # Set axes labels for the image viewer
 
-            viewer.figure.axes[0].label = f""
-            viewer.figure.axes[1].label = f"{flux_unit_type} [{data.unit.to_string()}]"
+            viewer.figure.axes[1].tick_format = None
+            viewer.figure.axes[0].tick_format = None
+
+            viewer.figure.axes[1].label = "y: pixels"
+            viewer.figure.axes[0].label = "x: pixels"
 
         # Make it so y axis label is not covering tick numbers.
         viewer.figure.axes[1].label_offset = "-50"
@@ -903,11 +903,9 @@ class Application(VuetifyTemplate, HubListener):
         # Sets the plot axes labels to be the units of the most recently
         # active data.
         if len(active_data_labels) > 0:
-            print("In set axes labels")
             active_data = self.data_collection[active_data_labels[0]]
             if hasattr(active_data, "_preferred_translation") \
                     and active_data._preferred_translation is not None:
-                print("running set plot axes labels")
                 self._set_plot_axes_labels(active_data.get_object(), viewer_id)
 
     def _on_data_added(self, msg):

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -11,6 +11,16 @@ __all__ = ['CubeVizImageView']
 class CubeVizImageView(BqplotImageView):
     default_class = None
 
+    def set_plot_axes(self):
+        self.figure.axes[1].tick_format = None
+        self.figure.axes[0].tick_format = None
+
+        self.figure.axes[1].label = "y: pixels"
+        self.figure.axes[0].label = "x: pixels"
+
+        # Make it so y axis label is not covering tick numbers.
+        self.figure.axes[1].label_offset = "-50"
+
     def data(self, cls=None):
         return [layer_state.layer #.get_object(cls=cls or self.default_class)
                 for layer_state in self.state.layers

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -7,6 +7,8 @@ from glue_jupyter.bqplot.profile import BqplotProfileView
 from astropy import table
 from specutils import Spectrum1D
 from matplotlib.colors import cnames
+from astropy import units as u
+
 
 from jdaviz.core.registries import viewer_registry
 from jdaviz.core.spectral_line import SpectralLine
@@ -367,3 +369,24 @@ class SpecvizProfileView(BqplotProfileView):
 
             # We added an extra trace. Get pointer to it.
             self.error_trace_pointer = len(self.figure.marks) - 1
+
+    def set_plot_axes(self):
+        # Get data to be used for axes labels
+        data = self.data()[0]
+
+        # Set axes labels for the spectrum viewer
+
+        spectral_axis_unit_type = data.spectral_axis.unit.physical_type.title()
+        # flux_unit_type = data.flux.unit.physical_type.title()
+        flux_unit_type = "Flux density"
+
+        if data.spectral_axis.unit.is_equivalent(u.m):
+            spectral_axis_unit_type = "Wavelength"
+        elif data.spectral_axis.unit.is_equivalent(u.pixel):
+            spectral_axis_unit_type = "pixel"
+
+        self.figure.axes[0].label = f"{spectral_axis_unit_type} [{data.spectral_axis.unit.to_string()}]"
+        self.figure.axes[1].label = f"{flux_unit_type} [{data.flux.unit.to_string()}]"
+
+        # Make it so y axis label is not covering tick numbers.
+        self.figure.axes[1].label_offset = "-50"

--- a/notebooks/concepts/MOSviz overplot slit example.ipynb
+++ b/notebooks/concepts/MOSviz overplot slit example.ipynb
@@ -9,22 +9,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/javerbukh/anaconda3/envs/specviz_uc_bug/lib/python3.8/site-packages/glue/external/echo/__init__.py:3: UserWarning: glue.external.echo is deprecated, import from echo directly instead\n",
+      "  warnings.warn('glue.external.echo is deprecated, import from echo directly instead')\n"
+     ]
+    }
+   ],
    "source": [
     "from jdaviz.configs.mosviz.helper import MosViz"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d036ec3e07de4f599df80df924642df3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Application(components={'g-viewer-tab': '<template>\\n  <component :is=\"stack.container\">\\n    <g-viewer-tab\\n …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "mosviz = MosViz()\n",
     "mosviz.app"
@@ -270,7 +294,11 @@
    "outputs": [],
    "source": [
     "fig_image = mosviz.app.get_viewer(\"image-viewer\").figure\n",
-    "print(fig_image.interaction)"
+    "fig_image.axes[1].tick_format = None\n",
+    "fig_image.axes[0].tick_format = None\n",
+    "\n",
+    "fig_image.axes[1].label = \"y: pixels\"\n",
+    "fig_image.axes[0].label = \"x: pixels\""
    ]
   },
   {
@@ -307,7 +335,53 @@
    "outputs": [],
    "source": [
     "spec1d = mosviz.app.get_viewer(\"spectrum-viewer\")\n",
-    "spec1d.scales"
+    "spec1d.figure.axes[1].tick_format = \"font_size: 6\"\n",
+    "spec1d.figure.axes[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spec2d = mosviz.app.get_viewer(\"spectrum-2d-viewer\")\n",
+    "spec2d.figure.axes[0].visible = False\n",
+    "spec2d.figure.axes[1].label = \"y: pixel\"\n",
+    "spec2d.figure.axes[1].tick_format = None\n",
+    "spec2d.figure.axes[1].label_location = 'start'\n",
+    "\n",
+    "spec2d.figure.min_aspect_ratio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = mosviz.app.get_viewer(\"image-viewer\").data()\n",
+    "data[0].get_object().meta"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spec2d_data = spec2d.data()[0]\n",
+    "spec2d_data.wcs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spec1d_data = spec1d.data()[0]\n",
+    "spec1d_data.unit"
    ]
   },
   {


### PR DESCRIPTION
Set axes labels to look better and more accurately represent data. Currently the axes labels for some viewers are hard coded (such as "x: pixels" and "y: pixels" for the image viewer), but once header information is being passed through the `meta` attribute and being used in the plot, we can set these values to be more accurate.

Some examples of how the plots look now:
<img width="996" alt="Screen Shot 2020-09-08 at 9 43 19 AM" src="https://user-images.githubusercontent.com/7179333/92485345-d18a4e00-f1b8-11ea-8687-b5bf2964a2d4.png">

After readjusting the size of the viewers:
<img width="995" alt="Screen Shot 2020-09-08 at 9 43 39 AM" src="https://user-images.githubusercontent.com/7179333/92485394-e1099700-f1b8-11ea-8014-58537d44959b.png">
(The spectrum viewer says "Flux Density [Jy]". Once Unit Conversion is usable in mosviz, the user can change the units to mJy so that the numbers are not blocking the y axis label)

I would suggest in the documentation to mention that removing the axes labels all together is an option under the viewer tab, since this looks much better!
<img width="998" alt="Screen Shot 2020-09-08 at 9 47 40 AM" src="https://user-images.githubusercontent.com/7179333/92485564-1ca46100-f1b9-11ea-9e9c-719a8ad97883.png">
