### PR TITLE
Add Specviz plugins to Cubeviz and Mosviz

### DIFF
--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -19,6 +19,7 @@ tray:
   - g-gaussian-smooth
   - g-collapse
   - g-model-fitting
+  - g-unit-conversion
   - g-line-list
   - cubeviz-moment-maps
 viewer_area:

--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -21,6 +21,7 @@ tray:
   - g-model-fitting
   - g-unit-conversion
   - g-line-list
+  - specviz-line-analysis
   - cubeviz-moment-maps
 viewer_area:
   - container: col

--- a/jdaviz/configs/mosviz/mosviz.yaml
+++ b/jdaviz/configs/mosviz/mosviz.yaml
@@ -14,8 +14,10 @@ toolbar:
 tray:
   - g-gaussian-smooth
   - g-slit-overlay
+  - g-model-fitting
   - g-unit-conversion
   - g-line-list
+  - specviz-line-analysis
 viewer_area:
   - container: col
     children:

--- a/jdaviz/configs/mosviz/mosviz.yaml
+++ b/jdaviz/configs/mosviz/mosviz.yaml
@@ -13,8 +13,9 @@ toolbar:
   - g-subset-tools
 tray:
   - g-gaussian-smooth
-  - g-collapse
   - g-slit-overlay
+  - g-unit-conversion
+  - g-line-list
 viewer_area:
   - container: col
     children:
@@ -33,7 +34,7 @@ viewer_area:
               plot: mosviz-profile-2d-viewer
               reference: spectrum-2d-viewer
             - name: Spectrum
-              plot: mosviz-profile-viewer
+              plot: specviz-profile-viewer
               reference: spectrum-viewer
       - container: row
         viewers:

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -66,8 +66,8 @@ def test_region_from_subset_3d(jdaviz_app):
     assert_allclose(reg.height, 3.5)
 
 
-def test_region_from_subset_profile(jdaviz_app):
-    data = Data(flux=np.ones((256, 128, 128)), label='Test 1D Flux')
+def test_region_from_subset_profile(jdaviz_app, spectral_cube_wcs):
+    data = Data(flux=np.ones((256, 128, 128)), label='Test 1D Flux', coords=spectral_cube_wcs)
     jdaviz_app.data_collection.append(data)
 
     subset_state = RoiSubsetState(data.pixel_component_ids[1],


### PR DESCRIPTION
Adds Specviz plugins to the other configs, to operate on the data in their 1D spectrum viewers. Also updates the Mosviz config to use the `specviz-profile-viewer` for its 1D viewer, to enable all the associated functionality.