### PR TITLE
Fix bug with None uncertainty in unit conversion

### DIFF
--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -143,14 +143,18 @@ class UnitConversion(TemplateMixin):
                 return
 
         # Uncertainty converted to new flux units
-        temp_uncertainty = self.spectrum.uncertainty.quantity.to(u.Unit(set_flux_unit.unit),
-                                                      equivalencies=u.spectral_density(set_spectral_axis_unit))
+        if self.spectrum.uncertainty is not None:
+            temp_uncertainty = self.spectrum.uncertainty.quantity.to(u.Unit(set_flux_unit.unit),
+                                    equivalencies=u.spectral_density(set_spectral_axis_unit))
+            temp_uncertainty = self.spectrum.uncertainty.__class__(temp_uncertainty.value)
+        else:
+            temp_uncertainty = None
 
         # Create new spectrum with new units.
         converted_spec = self.spectrum._copy(flux=set_flux_unit,
                                              spectral_axis=set_spectral_axis_unit,
                                              unit=set_flux_unit.unit,
-                                             uncertainty=self.spectrum.uncertainty.__class__(temp_uncertainty.value)
+                                             uncertainty=temp_uncertainty
                                              )
 
         # Finds the '_units_copy_' spectrum and does unit conversions in that copy.


### PR DESCRIPTION
I noticed while testing unit conversion in Cubeviz that if the spectrum had no uncertainty attached, the unit conversion plugin would error out. This fixes that by propagating through a `None` uncertainty properly. Note that actually adding the plugin to the Cubeviz and Mosviz configs is included in #274 .