### PR TITLE
Fix compound model fit failure

### DIFF
--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -1,6 +1,7 @@
 import os
 import pickle
 import re
+import numpy as np
 
 import astropy.modeling.models as models
 import astropy.units as u
@@ -221,6 +222,7 @@ class ModelFitting(TemplateMixin):
                 selected_spec.flux.unit)
 
         self._spectrum1d = selected_spec
+        print(np.nanmax(self._spectrum1d.flux))
 
     def vue_model_selected(self, event):
         # Add the model selected to the list of models

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -229,6 +229,10 @@ class ModelFitting(TemplateMixin):
         """
         selected_spec = self.app.get_data_from_viewer("spectrum-viewer",
                                                       data_label=event)
+        # Replace NaNs from collapsed SpectralCube in Cubeviz
+        # (won't affect calculations because these locations are masked)
+        selected_spec.flux[np.isnan(selected_spec.flux)] = 0.0
+
         self._selected_data_label = event
 
         if self._units == {}:

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -242,7 +242,6 @@ class ModelFitting(TemplateMixin):
                 selected_spec.flux.unit)
 
         self._spectrum1d = selected_spec
-        print(np.nanmax(self._spectrum1d.flux))
 
     def vue_model_selected(self, event):
         # Add the model selected to the list of models
@@ -371,7 +370,9 @@ class ModelFitting(TemplateMixin):
         self._fitted_spectrum = fitted_spectrum
 
         self.vue_register_spectrum({"spectrum": fitted_spectrum})
-        self.app.fitted_model = fitted_model
+        if not hasattr(self.app, "_fitted_1d_models"):
+            self.app._fitted_1d_models = {}
+        self.app._fitted_1d_models[self.model_label] = fitted_model
 
         # Update component model parameters with fitted values
         if type(self._fitted_model) == QuantityModel:


### PR DESCRIPTION
Updating the displayed parameters after fitting a compound model was failing, due to `specutils.QuantityModel` not being subscriptable with the component model names. I left in the old parameter update code to be triggered if the resulting model isn't a QuantityModel (I don't know if this will actually happen ever, but better safe than sorry). Fixes a bug raised in https://github.com/spacetelescope/jdaviz/pull/263 by @PatrickOgle that fell off my radar earlier in the year (`TypeError: 'QuantityModel' object is not subscriptable`).