### PR TITLE
Add missing statistic argument in data retrieval

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -381,12 +381,11 @@ class Application(VuetifyTemplate, HubListener):
                     if cls is not None:
                         # If data is one-dimensional, assume that it can be
                         #  collapsed via the defined statistic
-                        if len(layer_data.shape) == 1:
+                        if cls == Spectrum1D:
                             layer_data = layer_data.get_object(cls=cls,
                                                                statistic=statistic)
                         else:
-                            layer_data = layer_data.get_object(cls=cls,
-                                                               statistic=statistic)
+                            layer_data = layer_data.get_object(cls=cls)
                     # If the shape of the data is 2d, then use CCDData as the
                     #  output data type
                     elif len(layer_data.shape) == 2:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -385,7 +385,8 @@ class Application(VuetifyTemplate, HubListener):
                             layer_data = layer_data.get_object(cls=cls,
                                                                statistic=statistic)
                         else:
-                            layer_data = layer_data.get_object(cls=cls)
+                            layer_data = layer_data.get_object(cls=cls,
+                                                               statistic=statistic)
                     # If the shape of the data is 2d, then use CCDData as the
                     #  output data type
                     elif len(layer_data.shape) == 2:


### PR DESCRIPTION
We weren't passing the statistic to collapse with in one of the viewer data retrieval cases, leading to a mismatch between some fit/smoothed spectra and what was displayed in the spectrum viewer. This fixes that, so that the fits or smoothing are always performed on the spectrum shown in the viewer.