### PR TITLE
Fix support for Windows Desktop

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -270,7 +270,7 @@ class Application(VuetifyTemplate, HubListener):
         """
         try:
             # Properly form path and check if a valid file
-            file_obj = str(pathlib.Path(file_obj))
+            file_obj = pathlib.Path(file_obj)
             if not file_obj.exists():
                 raise FileNotFoundError("Could not locate file: " + file_obj)
         except TypeError:
@@ -298,7 +298,7 @@ class Application(VuetifyTemplate, HubListener):
                 self.hub.broadcast(snackbar_message)
                 return
         else:
-            self._application_handler.load_data(file_obj)
+            self._application_handler.load_data(str(file_obj))
 
         # Send out a toast message
         snackbar_message = SnackbarMessage("Data successfully loaded.",

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -273,6 +273,9 @@ class Application(VuetifyTemplate, HubListener):
             file_obj = pathlib.Path(file_obj)
             if not file_obj.exists():
                 raise FileNotFoundError("Could not locate file: " + file_obj)
+            else:
+                # Convert path to properly formatted string (Parsers do not accept path objs)
+                file_obj = str(file_obj)
         except TypeError:
             # If it's not a str/path type, it might be a class 
             pass
@@ -298,7 +301,7 @@ class Application(VuetifyTemplate, HubListener):
                 self.hub.broadcast(snackbar_message)
                 return
         else:
-            self._application_handler.load_data(str(file_obj))
+            self._application_handler.load_data(file_obj)
 
         # Send out a toast message
         snackbar_message = SnackbarMessage("Data successfully loaded.",

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -268,6 +268,15 @@ class Application(VuetifyTemplate, HubListener):
         file_obj : str or file-like
             File object for the data to be loaded.
         """
+        try:
+            # Properly form path and check if a valid file
+            file_obj = str(pathlib.Path(file_obj))
+            if not file_obj.exists():
+                raise FileNotFoundError("Could not locate file: " + file_obj)
+        except TypeError:
+            # If it's not a str/path type, it might be a class 
+            pass
+
         # attempt to get a data parser from the config settings
         parser = None
         data = self.state.settings.get('data', None)

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -277,7 +277,8 @@ class Application(VuetifyTemplate, HubListener):
                 # Convert path to properly formatted string (Parsers do not accept path objs)
                 file_obj = str(file_obj)
         except TypeError:
-            # If it's not a str/path type, it might be a class 
+            # If it's not a str/path type, it might be a compatible class.
+            # Pass to parsers to see if they can accept it
             pass
 
         # attempt to get a data parser from the config settings

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -53,3 +53,11 @@ def main(filename, layout='default'):
         sys.exit(Voila().launch_instance(argv=[]))
     finally:
         os.chdir(start_dir)
+
+if __name__ == '__main__':
+    import sys
+
+    if sys.platform == 'win32':
+        import asyncio
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    main()

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -42,8 +42,7 @@ def main(filename, layout='default'):
     nbdir = tempfile.mkdtemp()
 
     with open(os.path.join(nbdir, 'notebook.ipynb'), 'w') as nbf:
-        nbf.write(notebook_template.replace('CONFIG_NAME', layout).replace(
-            'DATA_FILENAME', str(filepath).encode('unicode_escape').decode()).strip())
+        nbf.write(notebook_template.replace('DATA_FILENAME', str(filepath).encode('unicode_escape').decode()).strip())
 
     os.chdir(nbdir)
 

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -47,7 +47,7 @@ def main(filename, layout='default'):
     nbdir = tempfile.mkdtemp()
 
     with open(os.path.join(nbdir, 'notebook.ipynb'), 'w') as nbf:
-        nbf.write(notebook_template.replace('DATA_FILENAME', str(filepath).encode('unicode_escape').decode()).strip())
+        nbf.write(notebook_template.replace('DATA_FILENAME', str(filepath).replace('\\', '/')).strip())
 
     os.chdir(nbdir)
 

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -32,6 +32,11 @@ def main(filename, layout='default'):
     layout : str, optional
         Optional specification for which configuration to use on startup.
     """
+    # Tornado Webserver py3.8 compatibility hotfix for windows
+    if sys.platform == 'win32':
+        import asyncio
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
     filepath = pathlib.Path(filename).absolute()
 
     with open(os.path.join(CONFIGS_DIR, layout, layout + '.ipynb')) as f:
@@ -55,9 +60,4 @@ def main(filename, layout='default'):
         os.chdir(start_dir)
 
 if __name__ == '__main__':
-    import sys
-
-    if sys.platform == 'win32':
-        import asyncio
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     main()

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -1,5 +1,6 @@
 # Command-line interface for jdaviz
 
+import pathlib
 import os
 import sys
 import tempfile
@@ -31,7 +32,7 @@ def main(filename, layout='default'):
     layout : str, optional
         Optional specification for which configuration to use on startup.
     """
-    filename = os.path.abspath(filename)
+    filepath = pathlib.Path(filename).absolute()
 
     with open(os.path.join(CONFIGS_DIR, layout, layout + '.ipynb')) as f:
         notebook_template = f.read()
@@ -42,7 +43,7 @@ def main(filename, layout='default'):
 
     with open(os.path.join(nbdir, 'notebook.ipynb'), 'w') as nbf:
         nbf.write(notebook_template.replace('CONFIG_NAME', layout).replace(
-            'DATA_FILENAME', filename).strip())
+            'DATA_FILENAME', str(filepath).encode('unicode_escape').decode()).strip())
 
     os.chdir(nbdir)
 

--- a/jdaviz/configs/specviz/plugins/parsers.py
+++ b/jdaviz/configs/specviz/plugins/parsers.py
@@ -35,9 +35,9 @@ def specviz_spectrum1d_parser(app, data, data_label=None, format=None, show_in_v
         path = pathlib.Path(data)
 
         if path.is_file():
-            data = Spectrum1D.read(path, format=format)
+            data = Spectrum1D.read(str(path), format=format)
         else:
-            raise FileNotFoundError("No such file: " + path)
+            raise FileNotFoundError("No such file: " + str(path))
     # If not, it must be a Spectrum1D object. Otherwise, it's unsupported
     except TypeError:
         if type(data) is SpectrumCollection:


### PR DESCRIPTION
This PR fixes Jdaviz to support the windows desktop, along with some minor improvements to the CLI (desktop) starting behavior:

1. Primarily, it addresses [#583](https://github.com/voila-dashboards/voila/issues/583); an update to the Tornado webserver used by Voila broke support for Windows. There's a workaround that I've included that we can probably remove once Voila addresses the bug; we'll need to keep an eye on it
2. I removed the `CONFIG` keyword from the CLI starter. We have default notebooks for each configuration, so we don't actually use it anymore
3. I spent much more time than I should have struggling with path recognition. I've updated the notebooks to use python's new pathlib to do some basic path formatting for us.