### PR TITLE
Fixing bug introduced by add_data override in spectrum viewer

### DIFF
--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -259,8 +259,6 @@ class SpecvizProfileView(BqplotProfileView):
         # trace representing the spectrum itself.
         result = super().add_data(data, color, alpha, **layer_state)
 
-        #self._temp_data = data
-
         # Index of spectrum trace plotted by the super class. It is
         # for now, always the last in the array of marks. This will
         # have to be reworked once multiple spectra can be over-plotted.

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -235,7 +235,7 @@ class SpecvizProfileView(BqplotProfileView):
         if hasattr(self, 'error_line_mark') and self.error_line_mark is not None:
             marks.remove(self.error_line_mark)
             self.error_line_mark = None
-            self.uncert_trace_pointer = None
+            self.error_trace_pointer = None
 
     def add_data(self, data, color=None, alpha=None, **layer_state):
         """
@@ -259,7 +259,7 @@ class SpecvizProfileView(BqplotProfileView):
         # trace representing the spectrum itself.
         result = super().add_data(data, color, alpha, **layer_state)
 
-        self._data = data
+        #self._temp_data = data
 
         # Index of spectrum trace plotted by the super class. It is
         # for now, always the last in the array of marks. This will
@@ -268,7 +268,7 @@ class SpecvizProfileView(BqplotProfileView):
         # eventual upgrade.
         self.data_trace_pointer = len(self.figure.marks) - 1
 
-        self.uncert_trace_pointer = None
+        self.error_trace_pointer = None
         self.mask_trace_pointer = None
 
         # Color and opacity are taken from the already plotted trace,
@@ -292,7 +292,7 @@ class SpecvizProfileView(BqplotProfileView):
 
     def _plot_mask(self):
 
-        _data = self._data
+        _data = self._data[0]
         _data_trace = self.data_trace_pointer
 
         if 'mask' in _data.components and self.display_mask:
@@ -332,11 +332,11 @@ class SpecvizProfileView(BqplotProfileView):
 
     def _plot_uncertainties(self):
 
-        _data = self._data
+        _data = self._data[0]
         _data_trace = self.data_trace_pointer
 
         if 'uncertainty' in _data.components and self.display_uncertainties:
-            error = _data['uncertainty'].data
+            error = np.array(_data['uncertainty'].data)
 
             # If uncertainties were already plotted, remove them.
             if hasattr(self,'error_trace_pointer') and \
@@ -368,4 +368,4 @@ class SpecvizProfileView(BqplotProfileView):
             self.figure.marks = list(self.figure.marks) + [self.error_line_mark]
 
             # We added an extra trace. Get pointer to it.
-            self.uncert_trace_pointer = len(self.figure.marks) - 1
+            self.error_trace_pointer = len(self.figure.marks) - 1


### PR DESCRIPTION
The mask/uncertainty plotting overrode the specviz viewer's `_data` property and thus broke the region -> subset operation. This fixes that.

This currently doesn't seem to be plotting the uncertainties for me, but I checked and the master branch doesn't seem to be plotting the uncertainties anymore either. Masks work fine. Can someone else confirm/help figure out if I somehow broke the uncertainty plotting here?

I'll also be making a followup issue for a bug I saw, where the uncertainty line mark (that I somehow can't see as mentioned above) gets duplicated if the displayed data is deselected and reselected without doing `viewer.clean()` before the deselection.