### PR TITLE
adding quickstart documentation

### DIFF
--- a/docs/cubeviz/index.rst
+++ b/docs/cubeviz/index.rst
@@ -2,6 +2,8 @@
 .. image:: ../logos/cubeviz.svg
    :width: 400
 
+.. _cubeviz:
+
 #######
 Cubeviz
 #######

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ Jdaviz
 
 .. image:: logos/jdaviz.svg
    :width: 400
-   
+
 ``Jdaviz`` is a package of astronomical data analysis visualization
 tools based on the Jupyter platform.  These GUI-based tools link data
 visualization and interactive analysis.  They are designed to work
@@ -29,6 +29,7 @@ Using Jdaviz
   :maxdepth: 2
 
   installation.rst
+  quickstart.rst
   data_prep.rst
   specviz/index.rst
   cubeviz/index.rst
@@ -39,6 +40,6 @@ Reference/API
 
 .. toctree::
    :maxdepth: 2
-    
+
    dev/index.rst
    reference/api.rst

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,3 +1,6 @@
+
+.. _install:
+
 Installation
 ============
 
@@ -23,43 +26,4 @@ To install ``jdaviz`` for development, or from source::
    cd jdaviz
    pip install -e .
 
-
-Running Jdaviz
-==============
-
-Once installed, ``jdaviz`` can be run either as a standalone web application or in a Jupyter notebook.
-
-As a Web Application
-------------------------
-
-``jdaviz`` provides a command-line tool to start the web application. To see the syntax and usage,
-from a terminal, type::
-
-    jdaviz --help
-
-The general syntax to start the application is to provide a local filename path and an application configuration
-to load, i.e.::
-
-    jdaviz /path/to/data/file --layout=<configuration>
-
-For example, to load a SDSS MaNGA IFU data cube into ``CubeViz``, you would run the following from a terminal::
-
-    jdaviz /my/manga/cube/manga-8485-1901-LOGCUBE.fits.gz --layout=cubeviz
-
-In a Juypter Notebook
----------------------
-
-``jdaviz`` provides a directory of sample notebooks to test the application, located in the `notebooks` sub-directory
-of the git repository.  `Example.ipynb` is provided as an example that loads a SDSS MaNGA IFU data cube with the
-``CubeViz`` configuration.  To run the provided example, start the jupyter kernel with the notebook path::
-
-    jupyter notebook /path/to/jdaviz/notebooks/Example.ipynb
-
-or simply start a new Jupyter notebook and run the following in a cell::
-
-    from jdaviz import Application
-
-    app = Application()
-    app
-
-To learn more about the various ``jdaviz`` application configurations and loading data, see xxxx.
+See :ref:`quickstart` to learn how to run ``jdaviz``.

--- a/docs/mosviz/index.rst
+++ b/docs/mosviz/index.rst
@@ -2,6 +2,8 @@
 .. image:: ../logos/mosviz.svg
    :width: 400
 
+.. _mosviz:
+
 ######
 Mosviz
 ######

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,0 +1,43 @@
+
+.. _quickstart:
+
+Quickstart
+==========
+
+Once installed, ``jdaviz`` can be run either as a standalone web application or in a Jupyter notebook.
+
+As a Web Application
+------------------------
+
+``jdaviz`` provides a command-line tool to start the web application. To see the syntax and usage,
+from a terminal, type::
+
+    jdaviz --help
+
+The general syntax to start the application is to provide a local filename path and an application configuration
+to load, i.e.::
+
+    jdaviz /path/to/data/file --layout=<configuration>
+
+For example, to load a SDSS MaNGA IFU data cube into ``CubeViz``, you would run the following from a terminal::
+
+    jdaviz /my/manga/cube/manga-8485-1901-LOGCUBE.fits.gz --layout=cubeviz
+
+In a Juypter Notebook
+---------------------
+
+``jdaviz`` provides a directory of sample notebooks to test the application, located in the `notebooks` sub-directory
+of the git repository.  `Example.ipynb` is provided as an example that loads a SDSS MaNGA IFU data cube with the
+``CubeViz`` configuration.  To run the provided example, start the jupyter kernel with the notebook path::
+
+    jupyter notebook /path/to/jdaviz/notebooks/Example.ipynb
+
+or simply start a new Jupyter notebook and run the following in a cell::
+
+    from jdaviz import Application
+
+    app = Application()
+    app
+
+To learn more about the various ``jdaviz`` application configurations and loading data, see the :ref:`cubeviz`,
+:ref:`specviz`, or :ref:`mosviz` tools.

--- a/docs/specviz/index.rst
+++ b/docs/specviz/index.rst
@@ -2,6 +2,8 @@
 .. image:: ../logos/specviz.svg
    :width: 400
 
+.. _specviz:
+
 #######
 Specviz
 #######


### PR DESCRIPTION
This PR adds a new quickstart docs page, and moves the "Running Jdaviz" section from installation to the new quickstart page.