### PR TITLE
Attempting to fix cubeviz load data bug

### DIFF
--- a/docs/data_prep.rst
+++ b/docs/data_prep.rst
@@ -14,12 +14,7 @@ Loading a cube
 
 We'll use the example cube data found in the ``spectral-cube`` package, and
 load the data from the repository directly into a new :class:`~spectral_cube.SpectralCube`
-object
-
-.. plot::
-    :include-source:
-    :align: center
-    :context: close-figs
+object::
 
     >>> from astropy.utils.data import download_file
     >>> from spectral_cube import SpectralCube
@@ -30,37 +25,37 @@ object
     n_y:      4  type_y: DEC--ARC  unit_y: deg    range:    31.243639 deg:   31.243739 deg
     n_s:      7  type_s: VRAD      unit_s: m / s  range:    14322.821 m / s:   14944.909 m / s
 
-    We see that the example cube is small, with a shape of ``(7, 3, 4)``; two
-    spatial axes ``RA`` and ``DEC``, and one spectral axis that's in velocity
-    units.
+We see that the example cube is small, with a shape of ``(7, 3, 4)``; two
+spatial axes ``RA`` and ``DEC``, and one spectral axis that's in velocity
+units.
 
-    Extracting the spectral data
-    ============================
+Extracting the spectral data
+============================
 
-    Now that we have a data cube, our mission is to collapse this cube along the
-    two spatial axes to get the representative spectral data. We can then parse the
-    result into a :class:`~specutils.Spectrum1D` object. ``SpectralCube`` can take
-    and apply arbitrary functions over axes of the data, in this case we can apply
-    a simple median function over the spatial axes
+Now that we have a data cube, our mission is to collapse this cube along the
+two spatial axes to get the representative spectral data. We can then parse the
+result into a :class:`~specutils.Spectrum1D` object. ``SpectralCube`` can take
+and apply arbitrary functions over axes of the data, in this case we can apply
+a simple median function over the spatial axes::
 
     >>> import numpy as np
     >>> sc_spec = sc.apply_numpy_function(np.mean, axis=(1,2), projection=True)
     >>> sc_spec.shape
     (7,)
 
-    The ``projection`` keyword returns a lower dimesional object that retains the WCS
-    information that we'll need to use when constructing the `Spectrum1D` object.
+The ``projection`` keyword returns a lower dimesional object that retains the WCS
+information that we'll need to use when constructing the `Spectrum1D` object.
 
-    Creating a spectrum object
-    ==========================
+Creating a spectrum object
+==========================
 
-    With our data parsed and extracted, let's go ahead and create our
-    :class:`~specutils.Spectrum1D` object
+With our data parsed and extracted, let's go ahead and create our
+:class:`~specutils.Spectrum1D` object::
 
     >>> from specutils import Spectrum1D
     >>> spec = Spectrum1D(flux=sc_spec.data[:] * sc_spec.unit, wcs=sc_spec.wcs)
 
-    Let's plot and see what this resulting spectrum looks like
+Let's plot and see what this resulting spectrum looks like::
 
     >>> from matplotlib import pyplot as plt
     >>> from astropy.visualization import quantity_support

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -90,21 +90,21 @@ def _parse_hdu(app, hdulist, file_name=None):
         if hdu.data is None:
             continue
 
-        # This will fail on attempting to load anything that
-        # isn't cube-shaped
+        # This is supposed to fail on attempting to load anything that
+        # isn't cube-shaped. But it's not terribly reliable
         try:
             sc = SpectralCube.read(hdu, format='fits')
-        except ValueError:
+        except (ValueError, OSError):
             # This will fail if the parsing of the wcs does not provide
             # proper celestial axes
             try:
                 hdu.header.update(wcs.to_header())
                 sc = SpectralCube.read(hdu)
-            except ValueError as e:
-                logging.error(e)
+            except (ValueError, AttributeError) as e:
+                logging.warn(e)
                 continue
         except FITSReadError as e:
-            logging.error(e)
+            logging.warn(e)
             continue
 
         app.data_collection[data_label] = sc

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -76,7 +76,7 @@ def _parse_hdu(app, hdulist, file_name=None):
             continue
 
         try:
-            sc = SpectralCube.read(hdu)
+            sc = SpectralCube.read(hdulist, format='fits')
             wcs = sc.wcs
         except (ValueError, FITSReadError):
             continue
@@ -93,7 +93,7 @@ def _parse_hdu(app, hdulist, file_name=None):
         # This will fail on attempting to load anything that
         # isn't cube-shaped
         try:
-            sc = SpectralCube.read(hdu)
+            sc = SpectralCube.read(hdu, format='fits')
         except ValueError:
             # This will fail if the parsing of the wcs does not provide
             # proper celestial axes

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,17 +20,17 @@ setup_requires = setuptools_scm
 install_requires =
     pytest<6.0
     astropy
-    glue-core @ git+https://github.com/glue-viz/glue.git
-    glue-jupyter @ git+https://github.com/glue-viz/glue-jupyter.git
-    echo @ git+https://github.com/glue-viz/echo.git
+    glue-core>=1.0.0
+    glue-jupyter>=0.2.0
+    echo>=0.5.0
     ipyvue==1.3.4
     ipyvuetify==1.4.1
     ipysplitpanes
     ipygoldenlayout==0.3.0
     voila<0.2
     pyyaml
-    specutils>=1.0
-    glue-astronomy @ git+https://github.com/glue-viz/glue-astronomy.git
+    specutils
+    glue-astronomy
     click
     spectral-cube
     asteval

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     specutils
     glue-astronomy
     click
-    spectral-cube
+    spectral-cube>=0.5
     asteval
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,10 +23,10 @@ install_requires =
     glue-core>=1.0.0
     glue-jupyter>=0.2.0
     echo>=0.5.0
-    ipyvue==1.3.4
-    ipyvuetify==1.4.1
+    ipyvue>=1.3.4
+    ipyvuetify>=1.4.1
     ipysplitpanes
-    ipygoldenlayout==0.3.0
+    ipygoldenlayout>=0.3.0
     voila<0.2
     pyyaml
     specutils


### PR DESCRIPTION
Gearing up for `jdaviz` v1.0 release, spectral-cube 0.5 is not compatabile with the current state of the app. With this PR, cubeviz can at least run, however one test is not passing and there is a traceback in cubeviz when loading data.

Fixes #296 