### PR TITLE
Remove list of bugs from readthedocs landing page  

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,6 @@ Additional documentation
 ========================
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    known_bugs.rst


### PR DESCRIPTION
It's not good advertisement practice that a significant real estate of the landing page is occupied by a list of bugs.

This PR fixes the maximum depth in the index file for the known bugs section.

(I overlooked this when I created the list).

