### PR TITLE
Increase glue-jupyter dep to 0.2.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     pytest<6.0
     astropy
     glue-core>=1.0.0
-    glue-jupyter>=0.2.0
+    glue-jupyter>=0.2.1
     echo>=0.5.0
     ipyvue>=1.3.4
     ipyvuetify>=1.4.1


### PR DESCRIPTION
Glue-jupyter [#204](https://github.com/glue-viz/glue-jupyter/pull/204) has been merged and Tom has done a bug release, so the current version is 0.2.1. This PR updates `setup.cfg` to point to that version in order to fix #295 in jdaviz.