### PR TITLE
Vispy fix update

### DIFF
--- a/docs/known_bugs.rst
+++ b/docs/known_bugs.rst
@@ -4,7 +4,7 @@ Known Issues
 On some platforms, install fails due to `vispy`
 -----------------------------------------------
 
-The 0.6.4 version of `vispy` at fails to build for some combinations of
+The 0.6.4 version of `vispy` fails to build for some combinations of
 platform/OS and Python versions.  `vispy` 0.6.5 has resolved this, but a
 workaround if you have an older version of vispy is to ensure you have a
 compatible version:

--- a/docs/known_bugs.rst
+++ b/docs/known_bugs.rst
@@ -4,14 +4,14 @@ Known Issues
 On some platforms, install fails due to `vispy`
 -----------------------------------------------
 
-The latest version of `vispy` at the time of this release fails to build for
-some combinations of platform/OS and Python versions.  While a new `vispy`
-release should address this, in the meantime the workaround is to install
-from the development version of vispy like this::
+The 0.3.4 version of `vispy` at fails to build for some combinations of
+platform/OS and Python versions.  `vispy` 0.3.5 has resolved this, but a
+workaround if you have an older version of vispy is to ensure you have a
+compatible version:
 
   % conda create -n jdaviz python=3.8
   % conda activate jdaviz
-  % pip install git+https://github.com/vispy/vispy.git
+  % pip install vispy>=0.3.5
   % pip install jdaviz --no-cache-dir
 
 See `Issue #305 <https://github.com/spacetelescope/jdaviz/issues/305>`_ for

--- a/docs/known_bugs.rst
+++ b/docs/known_bugs.rst
@@ -4,14 +4,14 @@ Known Issues
 On some platforms, install fails due to `vispy`
 -----------------------------------------------
 
-The 0.3.4 version of `vispy` at fails to build for some combinations of
-platform/OS and Python versions.  `vispy` 0.3.5 has resolved this, but a
+The 0.6.4 version of `vispy` at fails to build for some combinations of
+platform/OS and Python versions.  `vispy` 0.6.5 has resolved this, but a
 workaround if you have an older version of vispy is to ensure you have a
 compatible version:
 
   % conda create -n jdaviz python=3.8
   % conda activate jdaviz
-  % pip install vispy>=0.3.5
+  % pip install vispy>=0.6.5
   % pip install jdaviz --no-cache-dir
 
 See `Issue #305 <https://github.com/spacetelescope/jdaviz/issues/305>`_ for

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     spectral-cube>=0.5
     asteval
     # vispy is an indirect dependency, but older vispy's don't play nice with jdaviz install
-    vispy>=0.3.5
+    vispy>=0.6.5
 
 [options.extras_require]
 test =

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,8 @@ install_requires =
     click
     spectral-cube>=0.5
     asteval
+    # vispy is an indirect dependency, but older vispy's don't play nice with jdaviz install
+    vispy>=0.3.5
 
 [options.extras_require]
 test =


### PR DESCRIPTION
This PR fixes #305 by requiring the latest version of vispy which has fixed the install issue (and also giving an recommended workaround that we can leave in for a few versions for anyone who might already have hit #305 and wants to know how to work around it).