### PR TITLE
Fix custom data labels in cubeviz filename/HDUList parsing

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -62,7 +62,7 @@ def parse_data(app, file_obj, data_type=None, data_label=None):
 
 
 def _parse_hdu(app, hdulist, file_name=None):
-    if filename is None:
+    if file_name is None:
         if hasattr(hdulist, 'file_name'):
             file_name = hdulist.file_name
 

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -44,13 +44,13 @@ def parse_data(app, file_obj, data_type=None, data_label=None):
     #  generic enough to work with other file types (e.g. ASDF). For now, this
     #  supports MaNGA and JWST data.
     if isinstance(file_obj, fits.hdu.hdulist.HDUList):
-        _parse_hdu(app, file_obj)
+        _parse_hdu(app, file_obj, file_name=data_label)
     elif isinstance(file_obj, str) and os.path.exists(file_obj):
         file_name = os.path.basename(file_obj)
 
         with fits.open(file_obj) as hdulist:
             hdulist = fits.open(file_obj)
-            _parse_hdu(app, hdulist, file_name)
+            _parse_hdu(app, hdulist, file_name=data_label or file_name)
 
     # If the data types are custom data objects, use explicit parsers. Note
     #  that this relies on the glue-astronomy machinery to turn the data object
@@ -62,8 +62,9 @@ def parse_data(app, file_obj, data_type=None, data_label=None):
 
 
 def _parse_hdu(app, hdulist, file_name=None):
-    if hasattr(hdulist, 'file_name'):
-        file_name = hdulist.file_name
+    if filename is None:
+        if hasattr(hdulist, 'file_name'):
+            file_name = hdulist.file_name
 
     file_name = file_name or "Unknown HDU object"
 


### PR DESCRIPTION
Closes #312 by applying the `data_label` argument of `load_data` to the created Glue Data objects in the case of Cubeviz parsing string filenames or astropy `HDUList` objects. 