### PR TITLE
Use linename index for plot_spectral_line string input case

### DIFF
--- a/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+from glue.core import Data
+import astropy.units as u
+from astropy.table import QTable
+from jdaviz import SpecViz
+from specutils import Spectrum1D
+
+from ..line_lists import LineListTool
+
+def test_line_lists():
+    viz = SpecViz()
+    spec = Spectrum1D(flux=np.random.rand(100)*u.Jy,
+                      spectral_axis=np.arange(6000,7000,10)*u.AA)
+    viz.load_spectrum(spec)
+
+    lt = QTable()
+    lt['linename'] = ['O III','Halpha']
+    lt['rest'] = [5007, 6563]*u.AA
+    lt['redshift'] = u.Quantity(0.046)
+    viz.load_line_list(lt)
+
+    assert len(viz.spectral_lines) == 2
+    assert viz.spectral_lines.loc["linename","Halpha"]["listname"] == "Custom"
+    assert np.all(viz.spectral_lines["show"] == True)
+
+    viz.erase_spectral_lines()
+
+    assert np.all(viz.spectral_lines["show"] == False)
+
+    viz.plot_spectral_line("Halpha")
+    viz.plot_spectral_line("O III 5007.0")
+
+    assert np.all(viz.spectral_lines["show"] == True)

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -191,7 +191,11 @@ class SpecvizProfileView(BqplotProfileView):
 
     def plot_spectral_line(self, line, scales=None, plot_units=None, **kwargs):
         if type(line) == str:
-            line = self.spectral_lines.loc[line]
+            # Try the full index first (for backend calls), otherwise name only
+            try:
+                line = self.spectral_lines.loc[line]
+            except KeyError:
+                line = self.spectral_lines.loc["linename", line]
         if plot_units is None:
             plot_units = self.data()[0].spectral_axis.unit
         if scales is None:


### PR DESCRIPTION
The `plot_spectral_line` method of the spectrum viewer wasn't behaving correctly, since the primary key on the `spectral_lines` table is now a combination of line name and wavelength rather than just the line name. This PR ensures that users can input the line name to the `plot_spectral_line` method as expected.