### PR TITLE
add specviz property to cubeviz/mosviz helpers

### DIFF
--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -2,6 +2,7 @@ from jdaviz.core.helpers import ConfigHelper
 from jdaviz.configs.default.plugins.line_lists.line_list_mixin import LineListMixin
 from jdaviz.configs.specviz import SpecViz
 
+
 class CubeViz(ConfigHelper, LineListMixin):
     """CubeViz Helper class"""
     _default_configuration = 'cubeviz'

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -1,7 +1,16 @@
 from jdaviz.core.helpers import ConfigHelper
-from ..default.plugins.line_lists.line_list_mixin import LineListMixin
-
+from jdaviz.configs.default.plugins.line_lists.line_list_mixin import LineListMixin
+from jdaviz.configs.specviz import SpecViz
 
 class CubeViz(ConfigHelper, LineListMixin):
     """CubeViz Helper class"""
     _default_configuration = 'cubeviz'
+
+    @property
+    def specviz(self):
+        """
+        A specviz helper for the app this helper wraps
+        """
+        if not hasattr(self, '_specviz'):
+            self._specviz = SpecViz(app=self.app)
+        return self._specviz

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -9,7 +9,8 @@ class CubeViz(ConfigHelper, LineListMixin):
     @property
     def specviz(self):
         """
-        A specviz helper for the app this helper wraps
+        A specviz helper (`~jdaviz.configs.specviz.SpecViz`) for the Jdaviz
+        application that is wrapped by cubeviz
         """
         if not hasattr(self, '_specviz'):
             self._specviz = SpecViz(app=self.app)

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -9,7 +9,6 @@ from jdaviz.core.events import SnackbarMessage
 from jdaviz.configs.specviz import SpecViz
 
 
-
 class MosViz(ConfigHelper):
     """MosViz Helper class"""
 

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -289,7 +289,8 @@ class MosViz(ConfigHelper):
     @property
     def specviz(self):
         """
-        A specviz helper for the app this helper wraps
+        A specviz helper (`~jdaviz.configs.specviz.SpecViz`) for the Jdaviz
+        application that is wrapped by mosviz
         """
         if not hasattr(self, '_specviz'):
             self._specviz = SpecViz(app=self.app)

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -1,10 +1,13 @@
 import numpy as np
 from pathlib import Path
 
-from jdaviz.core.helpers import ConfigHelper
-from jdaviz.core.events import SnackbarMessage
 from astropy.table import QTable
 import astropy.units as u
+
+from jdaviz.core.helpers import ConfigHelper
+from jdaviz.core.events import SnackbarMessage
+from jdaviz.configs.specviz import SpecViz
+
 
 
 class MosViz(ConfigHelper):
@@ -282,3 +285,12 @@ class MosViz(ConfigHelper):
         table_df = table_df.drop(labels="Pixel Axis 0 [x]", axis=1)
 
         table_df.to_csv(filename, index_label="Table Index")
+
+    @property
+    def specviz(self):
+        """
+        A specviz helper for the app this helper wraps
+        """
+        if not hasattr(self, '_specviz'):
+            self._specviz = SpecViz(app=self.app)
+        return self._specviz


### PR DESCRIPTION
This implements the feature I suggested in #329. This PR should probably also include some doc updates showing its use a la what @PatrickOgle originally was thinking about in https://github.com/spacetelescope/jdaviz/pull/257#discussion_r483014900.  The idea is that with this you can do something like:
```
cubeviz = CubeViz()
cubeviz.load_data(...)

cubeviz.specviz.some_specviz_helper(...)
```
and that should be documented as the intended approach to using specviz helpers in the cubeviz context. But I'm not doing that now because I want to make sure others are ok with this idea before I complete this. Hence the "draft" status.