### PR TITLE
Pinning the traitlets requirement to <5.0 for now

### DIFF
--- a/docs/specviz/displaying.rst
+++ b/docs/specviz/displaying.rst
@@ -63,16 +63,16 @@ Limit methods
 You can use the methods :py:func:`SpecViz.x_limits()` and :py:func:`SpecViz.y_limits()` to modify the field of view of Specviz. You can provide a scalar (which assumes the units of the loaded spectra), an Astropy Quantity, or 'auto' to automatically scale
 ::
 
->>> SpecViz.x_limits()
->>> SpecViz.x_limits(650*u.nm,750*u.nm)
->>> SpecViz.y_limits('auto', 110.0)
+>>> SpecViz.x_limits() #doctest: +SKIP
+>>> SpecViz.x_limits(650*u.nm,750*u.nm) #doctest: +SKIP
+>>> SpecViz.y_limits('auto', 110.0) #doctest: +SKIP
 
 Additionally, you can provide the limit methods with a `~specutils.SpectralRegion`. Specviz shall set the bounds the upper and lower bounds of the SpectralRegion
 
 >>> from astropy import units as u
->>> from specutils.spectral import SpectralRegion
+>>> from specutils import SpectralRegion
 >>> bounds = SpectralRegion(0.45*u.nm, 0.6*u.nm)
->>> SpecViz.x_limits(bounds)
+>>> SpecViz.x_limits(bounds) #doctest: +SKIP
 
 Autoscale methods
 ^^^^^^^^^^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ setup_requires = setuptools_scm
 install_requires =
     pytest<6.0
     astropy
+    traitlets<5.0
     glue-core>=1.0.0
     glue-jupyter>=0.2.1
     echo>=0.5.0


### PR DESCRIPTION
The Traitlets 5.0 release (they are now on 5.0.5) broke all of our tests. Pinning to <5.0 for now until we figure out what needs to change to be compatible with the new version.