### PR TITLE
Docs: Skip rendering of specviz app

### DIFF
--- a/docs/specviz/displaying.rst
+++ b/docs/specviz/displaying.rst
@@ -56,7 +56,7 @@ The Specviz helper contains a set of convenience methods to programmatically def
 >>> # Instantiate an instance of SpecViz
 >>> SpecViz = SpecViz()
 >>> # Display SpecViz
->>> SpecViz.app
+>>> SpecViz.app #doctest: +SKIP
 
 Limit methods
 ^^^^^^^^^^^^^


### PR DESCRIPTION
Found this in helping Ricky diagnose CI failures for #344. Forgot to suppress the app rendering in the docs