### PR TITLE
Docs: Mosviz Pan/Zoom and Spectral Regions

### DIFF
--- a/docs/mosviz/displayspectra.rst
+++ b/docs/mosviz/displayspectra.rst
@@ -12,7 +12,7 @@ For an overview on general pan/zoom mechanics, please see :ref:`pan-zoom`
 Defining Spectral Regions
 =========================
 
-Coming soon
+For an overview on spectral regions, please see :ref:`spectral-regions`
 
 Plot Settings
 =============

--- a/docs/mosviz/displayspectra.rst
+++ b/docs/mosviz/displayspectra.rst
@@ -7,7 +7,7 @@ Coming soon
 Pan/Zoom
 ========
 
-Coming soon
+For an overview on general pan/zoom mechanics, please see :ref:`pan-zoom`
 
 Defining Spectral Regions
 =========================

--- a/docs/mosviz/displayspectra.rst
+++ b/docs/mosviz/displayspectra.rst
@@ -9,6 +9,13 @@ Pan/Zoom
 
 For an overview on general pan/zoom mechanics, please see :ref:`pan-zoom`
 
+Synchronous Spectral Pan/Zoom
+-----------------------------
+Mosviz assumes the 1D and 2D spectra objects share a relationship in spectral space. As a result, the 1D and 2D spectral viewers have their spectral axes (the horizontal x-axis) linked. As you pan and zoom in spectral space (horizontally) in either of the two spectral viewers, the other will follow, simultaneously panning and zooming by the same amounts.
+
+.. warning::
+    If you pan too far away from the bounds of the dataset provided in the 1D or 2D spectral viewers, a warning will be displayed to notify the user. If you go too far, there is a risk of desynchronizing the two viewers.
+
 Defining Spectral Regions
 =========================
 

--- a/docs/mosviz/displayspectra.rst
+++ b/docs/mosviz/displayspectra.rst
@@ -7,7 +7,7 @@ Coming soon
 Pan/Zoom
 ========
 
-For an overview on general pan/zoom mechanics, please see :ref:`pan-zoom`
+For an overview on general pan/zoom functionality, please see :ref:`pan-zoom`
 
 Synchronous Spectral Pan/Zoom
 -----------------------------

--- a/docs/specviz/displaying.rst
+++ b/docs/specviz/displaying.rst
@@ -31,7 +31,7 @@ Pan/Zoom
 
 Coming soon
 
-.. _spectral-regions
+.. _spectral-regions:
 
 Defining Spectral Regions
 =========================

--- a/docs/specviz/displaying.rst
+++ b/docs/specviz/displaying.rst
@@ -31,6 +31,8 @@ Pan/Zoom
 
 Coming soon
 
+.. _spectral-regions
+
 Defining Spectral Regions
 =========================
 


### PR DESCRIPTION
Some mosviz documentation for pan/zoom and spectral regions. For the most part, I just linked the specviz docs as they're basically the same with a few caveats:
1. I added special section talking about the linked 1D and 2D spectral viewers
2. I am restricting the spectral region to the 1D spectral viewer, ignoring the 2D spectral viewer and image viewer. Playing around with them, I don't think those features are finalized and I struggled to get consistent behavior to document. Also because we are considering creating a dedicated 2D spectral viewer anyways, I think we shouldn't invest too heavily into docs of the 2D spectral viewer just yet