### PR TITLE
Unit conversion refactor

### DIFF
--- a/docs/specviz/plugins.rst
+++ b/docs/specviz/plugins.rst
@@ -64,8 +64,7 @@ Unit Conversion
 
 The spectral flux density and spectral axis units can be converted
 using the Unit Conversion plugin.  The Spectrum1D object to be
-converted is selected in the spectrum viewer :guilabel:`gear-->Data` tab.
-It is not currently possible to select the data within the Plugin.
+converted is the currently selected spectrum in the spectrum viewer :guilabel:`gear-->Data` tab.
 
 Select the frequency, wavelength, or energy unit in the
 :guilabel:`New Spectral Axis Unit` pulldown
@@ -75,8 +74,9 @@ Select the flux density unit in the :guilabel:`New Flux Unit` pulldown
 (e.g. Jansky, W/(Hz/m2), ph/(Angstrom cm2 s)).
 
 The :guilabel:`Apply` button will convert the flux density and/or
-spectral axis units and create a new Spectrum1D object that appears
-and can be selected in the spectrum viewer Data tab.
+spectral axis units and create a new Spectrum1D object that can
+be selected in the spectrum viewer Data tab. The name of the new Spectrum1D
+object is "_units_copy_" plus the flux and spectral units of the spectrum.
 
 Line Lists
 ==========

--- a/docs/specviz/plugins.rst
+++ b/docs/specviz/plugins.rst
@@ -74,9 +74,10 @@ Select the flux density unit in the :guilabel:`New Flux Unit` pulldown
 (e.g. Jansky, W/(Hz/m2), ph/(Angstrom cm2 s)).
 
 The :guilabel:`Apply` button will convert the flux density and/or
-spectral axis units and create a new Spectrum1D object that can
-be selected in the spectrum viewer Data tab. The name of the new Spectrum1D
-object is "_units_copy_" plus the flux and spectral units of the spectrum.
+spectral axis units and create a new Spectrum1D object that
+is automatically switched to in the spectrum viewer.
+The name of the new Spectrum1D object is "_units_copy_" plus
+the flux and spectral units of the spectrum.
 
 Line Lists
 ==========

--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -1,0 +1,81 @@
+import astropy.modeling.models as models
+import astropy.units as u
+import numpy as np
+from specutils.spectra import Spectrum1D
+
+from .. import unit_conversion as uc
+
+
+SPECTRUM_SIZE = 10 # length of spectrum
+
+
+def build_spectrum(sigma=0.1):
+    g1 = models.Gaussian1D(1, 4.6, 0.2)
+    g2 = models.Gaussian1D(2.5, 5.5, 0.1)
+    g3 = models.Gaussian1D(-1.7, 8.2, 0.1)
+
+    x = np.linspace(0, 10, SPECTRUM_SIZE)
+    y = g1(x) + g2(x) + g3(x)
+
+    noise = np.random.normal(4., sigma, x.shape)
+
+    return x, y + noise
+
+def test_spectral_axis_conversion():
+    np.random.seed(42)
+
+    x, y = build_spectrum()
+
+    spectrum = Spectrum1D(flux=y*u.Jy, spectral_axis=x*u.um)
+    new_spectral_axis = "micron"
+
+    converted_spectrum = uc.UnitConversion.process_unit_conversion(uc.UnitConversion,
+                                                                   spectrum=spectrum,
+                                                                   new_spectral_axis=new_spectral_axis)
+
+    result_spectral_axis = [ 0, 1.11111111, 2.22222222, 3.33333333,
+                             4.44444444, 5.55555556, 6.66666667, 7.77777778, 8.88888889, 10]
+
+
+    assert np.allclose(converted_spectrum.spectral_axis.value, result_spectral_axis, atol=1e-5)
+
+def test_flux_conversion():
+
+    np.random.seed(42)
+
+    x, y = build_spectrum()
+
+    spectrum = Spectrum1D(flux=y*u.Jy, spectral_axis=x*u.um)
+    new_flux = "erg / (s cm2 um)"
+
+    converted_spectrum = uc.UnitConversion.process_unit_conversion(uc.UnitConversion,
+                                                                   spectrum=spectrum,
+                                                                   new_flux=new_flux)
+
+    # result_flux = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    result_flux = [9.67970066e-09, 2.46763877e-09, 1.12034621e-09, 7.15682642e-10, 5.94364037e-10, 2.80465524e-10, 2.02021996e-10, 1.49988629e-10, 1.21543537e-10]
+
+    # TODO: first element is `inf`, why is this?
+    assert np.allclose(converted_spectrum.flux.value[1:], result_flux, atol=1e-5)
+
+def test_both_conversion():
+    np.random.seed(42)
+
+    x, y = build_spectrum()
+
+    spectrum = Spectrum1D(flux=y*u.Jy, spectral_axis=x*u.um)
+    new_spectral_axis = "micron"
+    new_flux = "erg / (s cm2 um)"
+
+    converted_spectrum = uc.UnitConversion.process_unit_conversion(uc.UnitConversion,
+                                                                   spectrum=spectrum,
+                                                                   new_flux=new_flux,
+                                                                   new_spectral_axis=new_spectral_axis)
+
+    result_spectral_axis = [ 0, 1.11111111, 2.22222222, 3.33333333,
+                             4.44444444, 5.55555556, 6.66666667, 7.77777778, 8.88888889, 10]
+    result_flux = [9.67970066e-09, 2.46763877e-09, 1.12034621e-09, 7.15682642e-10, 5.94364037e-10, 2.80465524e-10, 2.02021996e-10, 1.49988629e-10, 1.21543537e-10]
+
+    # TODO: first element is `inf`, why is this?
+    assert np.allclose(converted_spectrum.flux.value[1:], result_flux, atol=1e-5)
+    assert np.allclose(converted_spectrum.spectral_axis.value, result_spectral_axis, atol=1e-5)

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -151,10 +151,23 @@ class UnitConversion(TemplateMixin):
 
             new_label = selected_data_label_split[0] + label
 
+            original_flux = self.data_collection[selected_data_label_split[0]].get_object().flux.unit
+            original_spectral_axis = self.data_collection[selected_data_label_split[0]].get_object().spectral_axis.unit
+
             if new_label in self.data_collection:
                 # Spectrum with these converted units already exists.
                 msg = SnackbarMessage(
                     "Spectrum with these units already exists, please check the data drop down.",
+                    color="warning",
+                    sender=self)
+                self.hub.broadcast(msg)
+
+                return
+            elif converted_spec.flux.unit == original_flux and \
+                converted_spec.spectral_axis.unit == original_spectral_axis:
+                # Check if converted units already exist in the original spectrum.
+                msg = SnackbarMessage(
+                    "These are the units of the original spectrum, please use the that spectrum instead.",
                     color="warning",
                     sender=self)
                 self.hub.broadcast(msg)

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -176,6 +176,7 @@ class UnitConversion(TemplateMixin):
             else:
                 # Add spectrum with converted units to app.
                 self.app.add_data(converted_spec, new_label)
+                self.app.add_data_to_viewer("spectrum-viewer", new_label, clear_other_data=True)
 
         else:
             new_label = self.selected_data + label
@@ -194,6 +195,7 @@ class UnitConversion(TemplateMixin):
                 # Replace old spectrum with new one with updated units.
                 self.app.add_data(converted_spec, new_label)
 
+        self.app.add_data_to_viewer("spectrum-viewer", new_label, clear_other_data=True)
         snackbar_message = SnackbarMessage(
             f"Data set '{label}' units converted successfully.",
             color="success",

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -167,8 +167,19 @@ class UnitConversion(TemplateMixin):
         else:
             new_label = self.selected_data + label
 
-            # Replace old spectrum with new one with updated units.
-            self.app.add_data(converted_spec, new_label)
+            if new_label in self.data_collection:
+                # Spectrum with these converted units already exists.
+                msg = SnackbarMessage(
+                    "Spectrum with these units already exists, please check the data drop down.",
+                    color="warning",
+                    sender=self)
+                self.hub.broadcast(msg)
+
+                return
+            else:
+
+                # Replace old spectrum with new one with updated units.
+                self.app.add_data(converted_spec, new_label)
 
         snackbar_message = SnackbarMessage(
             f"Data set '{label}' units converted successfully.",

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -3,6 +3,7 @@ from astropy.nddata import VarianceUncertainty, StdDevUncertainty, InverseVarian
 import numpy as np
 import datetime
 import time
+from regions import RectanglePixelRegion
 
 from specutils import Spectrum1D
 from traitlets import List, Unicode, Any
@@ -13,6 +14,7 @@ from jdaviz.core.template_mixin import TemplateMixin
 from jdaviz.utils import load_template
 
 
+
 __all__ = ['UnitConversion']
 
 unit_exponents = {StdDevUncertainty: 1,
@@ -21,13 +23,17 @@ unit_exponents = {StdDevUncertainty: 1,
 
 @tray_registry('g-unit-conversion', label="Unit Conversion")
 class UnitConversion(TemplateMixin):
+
     template = load_template("unit_conversion.vue", __file__).tag(sync=True)
+
     dc_items = List([]).tag(sync=True)
     selected_data = Unicode().tag(sync=True)
+
     current_flux_unit = Unicode().tag(sync=True)
     current_spectral_axis_unit = Unicode().tag(sync=True)
     new_flux_unit = Any().tag(sync=True)
     new_spectral_axis_unit = Any().tag(sync=True)
+
     spectral_axis_unit_equivalencies = List([]).tag(sync=True)
     flux_unit_equivalencies = List([]).tag(sync=True)
 
@@ -73,12 +79,23 @@ class UnitConversion(TemplateMixin):
         if msg is not None and msg.viewer_id != self._viewer_id:
             return
 
+        print(self.app.data_collection)
+
         viewer = self.app.get_viewer('spectrum-viewer')
 
-        self._viewer_data = self.app.get_data_from_viewer('spectrum-viewer')
+        # self._viewer_data = self.app.get_data_from_viewer('spectrum-viewer')
 
-        self.dc_items = [layer_state.layer.label
-                         for layer_state in viewer.state.layers]
+        self.dc_items = [data.label
+                         for data in self.app.data_collection
+                         if data is not None]
+
+        print(self.dc_items)
+
+        # self.update_ui()
+
+    def vue_data_selected(self, event):
+        self.spectrum = self.app.data_collection[event].get_object(cls=Spectrum1D)
+        self.selected_data = event
 
         self.update_ui()
 
@@ -92,9 +109,20 @@ class UnitConversion(TemplateMixin):
             self.current_spectral_axis_unit = ""
             return
 
-        self.selected_data = self.app.get_viewer("spectrum-viewer").state.reference_data.label
+        """Populate the spectral subset selection dropdown"""
+        temp_subsets = self.app.get_subsets_from_viewer("spectrum-viewer")
+        temp_list = ["None"]
+        temp_dict = {}
+        # Attempt to filter out spatial subsets
+        for key, region in temp_subsets.items():
+            if type(region) == RectanglePixelRegion:
+                temp_dict[key] = region
+                temp_list.append(key)
+        print(f"temp dict: {temp_dict} temp_list: {temp_list}")
 
-        self.spectrum = self._viewer_data[self.selected_data]
+        # self.selected_data = self.app.get_viewer("spectrum-viewer").state.reference_data.label
+
+        # self.spectrum = self._viewer_data[self.selected_data]
 
         # Set UI label to show current flux and spectral axis units.
         self.current_flux_unit = self.spectrum.flux.unit.to_string()
@@ -112,13 +140,166 @@ class UnitConversion(TemplateMixin):
 
         set_spectral_axis_unit = self.spectrum.spectral_axis
         set_flux_unit = self.spectrum.flux
+        #
+        # # Try to set new units if set and are valid.
+        # if self.new_spectral_axis_unit is not None \
+        #         and self.new_spectral_axis_unit != "" \
+        #         and self.new_spectral_axis_unit != self.current_spectral_axis_unit:
+        #     try:
+        #         set_spectral_axis_unit = self.spectrum.spectral_axis.to(u.Unit(self.new_spectral_axis_unit))
+        #     except ValueError:
+        #         snackbar_message = SnackbarMessage(
+        #             f"Unable to convert spectral axis units for selected data. Try different units.",
+        #             color="error",
+        #             sender=self)
+        #         self.hub.broadcast(snackbar_message)
+        #
+        #         return
+        #
+        # # Try to set new units if set and are valid.
+        # if self.new_flux_unit is not None \
+        #         and self.new_flux_unit != "" \
+        #         and self.new_flux_unit != self.current_flux_unit:
+        #     try:
+        #
+        #         set_flux_unit = self.spectrum.flux.to(u.Unit(self.new_flux_unit),
+        #                                               equivalencies=u.spectral_density(set_spectral_axis_unit))
+        #     except ValueError:
+        #         snackbar_message = SnackbarMessage(
+        #             f"Unable to convert flux units for selected data. Try different units.",
+        #             color="error",
+        #             sender=self)
+        #         self.hub.broadcast(snackbar_message)
+        #
+        #         return
+        #
+        # # Uncertainty converted to new flux units
+        # if self.spectrum.uncertainty is not None:
+        #     unit_exp = unit_exponents.get(self.spectrum.uncertainty.__class__)
+        #     # If uncertainty type not in our lookup, drop the uncertainty
+        #     if unit_exp is None:
+        #         msg = SnackbarMessage(
+        #             "Warning: Unrecognized uncertainty type, cannot guarantee conversion so dropping uncertainty in resulting data",
+        #             color="warning",
+        #             sender=self)
+        #         self.hub.broadcast(msg)
+        #         temp_uncertainty = None
+        #     else:
+        #         try:
+        #             # Catch and handle error trying to convert variance uncertainties
+        #             # between frequency and wavelength space.
+        #             # TODO: simplify this when astropy handles it
+        #             temp_uncertainty = self.spectrum.uncertainty.quantity**(1/unit_exp)
+        #             temp_uncertainty = temp_uncertainty.to(u.Unit(set_flux_unit.unit),
+        #                             equivalencies=u.spectral_density(set_spectral_axis_unit))
+        #             temp_uncertainty **= unit_exp
+        #             temp_uncertainty = self.spectrum.uncertainty.__class__(temp_uncertainty.value)
+        #         except u.UnitConversionError:
+        #             msg = SnackbarMessage(
+        #                 "Warning: Could not convert uncertainty, setting to None in converted data",
+        #                 color="warning",
+        #                 sender=self)
+        #             self.hub.broadcast(msg)
+        #             temp_uncertainty = None
+        # else:
+        #     temp_uncertainty = None
+        #
+        # # Create new spectrum with new units.
+        # converted_spec = self.spectrum._copy(flux=set_flux_unit,
+        #                                      spectral_axis=set_spectral_axis_unit,
+        #                                      unit=set_flux_unit.unit,
+        #                                      uncertainty=temp_uncertainty
+        #                                      )
+        converted_spec = self.process_unit_conversion(self.spectrum, self.new_flux_unit, self.new_spectral_axis_unit)
+
+        label = f"_units_copy_Flux:{set_flux_unit.unit}_SpectralAxis:{set_spectral_axis_unit.unit}"
+        new_label = ""
+
+        # Finds the '_units_copy_' spectrum and does unit conversions in that copy.
+        if "_units_copy_" in self.selected_data:
+
+
+
+            selected_data_label = self.selected_data
+            selected_data_label_split = selected_data_label.split("_units_copy_")
+            # label = selected_data_label_split[0] + "_units_copy_" + datetime.datetime.now().isoformat()
+            new_label = selected_data_label_split[0] + label
+
+            if new_label in self.data_collection:
+                # self.app.add_data_to_viewer("spectrum-viewer", new_label, clear_other_data=True)
+                print("Units converted already exists")
+            else:
+                # self.data_collection[new_label] = converted_spec
+                self.app.add_data(converted_spec, new_label)
+
+                # TODO: Fix bug that sends AddDataMessage into a loop
+                # self.app.add_data_to_viewer("spectrum-viewer", new_label, clear_other_data=True)
+
+            # # Removes the old version of the unit conversion copy and creates
+            # # a new version with the most recent conversion.
+            # if selected_data_label in self.data_collection:
+            #     self.app.remove_data_from_viewer('spectrum-viewer', selected_data_label)
+            #
+            #     # Remove the actual Glue data object from the data_collection
+            #     self.data_collection.remove(self.data_collection[selected_data_label])
+            # self.data_collection[selected_data_label] = converted_spec
+            #
+            # #TODO: Fix bug that sends AddDataMessage into a loop
+            # self.app.add_data_to_viewer("spectrum-viewer", selected_data_label, clear_other_data=True)
+
+        else:
+            # label = self.selected_data + "_units_copy_" + datetime.datetime.now().isoformat()
+            new_label = self.selected_data + label
+
+            # Replace old spectrum with new one with updated units.
+            self.app.add_data(converted_spec, new_label)
+            # self.app.add_data_to_viewer("spectrum-viewer", new_label, clear_other_data=True)
+
+        self.spectrum = converted_spec
+        self.selected_data = new_label
+
+        # Reset UI labels.
+        self.update_ui()
+        # self.new_flux_unit = ""
+        # self.new_spectral_axis_unit = ""
+
+        snackbar_message = SnackbarMessage(
+            f"Data set '{label}' units converted successfully.",
+            color="success",
+            sender=self)
+        self.hub.broadcast(snackbar_message)
+
+    def process_unit_conversion(self, spectrum, new_flux=None, new_spectral_axis=None):
+        """
+
+        Parameters
+        ----------
+        spectrum : `Spectrum1D`
+            The spectrum that will have its units converted.
+        new_flux : ``
+            The flux of spectrum will be converted to these units if they are provided.
+        new_spectral_axis : ``
+            The spectral_axis of spectrum will be converted to these units if they are provided.
+        new_uncertainty : ``
+            The uncertainty of spectrum will be converted to these units if they are provided.
+
+        Returns
+        -------
+        converted_spectrum : `Spectrum1D`
+            A new spectrum with converted units.
+        """
+        set_spectral_axis_unit = spectrum.spectral_axis
+        set_flux_unit = spectrum.flux
+
+        current_flux_unit = spectrum.flux.unit.to_string()
+        current_spectral_axis_unit = spectrum.spectral_axis.unit.to_string()
 
         # Try to set new units if set and are valid.
-        if self.new_spectral_axis_unit is not None \
-                and self.new_spectral_axis_unit != "" \
-                and self.new_spectral_axis_unit != self.current_spectral_axis_unit:
+        if new_spectral_axis is not None \
+                and new_spectral_axis != "" \
+                and new_spectral_axis != current_spectral_axis_unit:
             try:
-                set_spectral_axis_unit = self.spectrum.spectral_axis.to(u.Unit(self.new_spectral_axis_unit))
+                set_spectral_axis_unit = spectrum.spectral_axis.to(u.Unit(new_spectral_axis))
             except ValueError:
                 snackbar_message = SnackbarMessage(
                     f"Unable to convert spectral axis units for selected data. Try different units.",
@@ -129,12 +310,12 @@ class UnitConversion(TemplateMixin):
                 return
 
         # Try to set new units if set and are valid.
-        if self.new_flux_unit is not None \
-                and self.new_flux_unit != "" \
-                and self.new_flux_unit != self.current_flux_unit:
+        if new_flux is not None \
+                and new_flux != "" \
+                and new_flux != current_flux_unit:
             try:
 
-                set_flux_unit = self.spectrum.flux.to(u.Unit(self.new_flux_unit),
+                set_flux_unit = spectrum.flux.to(u.Unit(new_flux),
                                                       equivalencies=u.spectral_density(set_spectral_axis_unit))
             except ValueError:
                 snackbar_message = SnackbarMessage(
@@ -146,8 +327,8 @@ class UnitConversion(TemplateMixin):
                 return
 
         # Uncertainty converted to new flux units
-        if self.spectrum.uncertainty is not None:
-            unit_exp = unit_exponents.get(self.spectrum.uncertainty.__class__)
+        if spectrum.uncertainty is not None:
+            unit_exp = unit_exponents.get(spectrum.uncertainty.__class__)
             # If uncertainty type not in our lookup, drop the uncertainty
             if unit_exp is None:
                 msg = SnackbarMessage(
@@ -161,11 +342,11 @@ class UnitConversion(TemplateMixin):
                     # Catch and handle error trying to convert variance uncertainties
                     # between frequency and wavelength space.
                     # TODO: simplify this when astropy handles it
-                    temp_uncertainty = self.spectrum.uncertainty.quantity**(1/unit_exp)
+                    temp_uncertainty = spectrum.uncertainty.quantity**(1/unit_exp)
                     temp_uncertainty = temp_uncertainty.to(u.Unit(set_flux_unit.unit),
                                     equivalencies=u.spectral_density(set_spectral_axis_unit))
                     temp_uncertainty **= unit_exp
-                    temp_uncertainty = self.spectrum.uncertainty.__class__(temp_uncertainty.value)
+                    temp_uncertainty = spectrum.uncertainty.__class__(temp_uncertainty.value)
                 except u.UnitConversionError:
                     msg = SnackbarMessage(
                         "Warning: Could not convert uncertainty, setting to None in converted data",
@@ -177,46 +358,12 @@ class UnitConversion(TemplateMixin):
             temp_uncertainty = None
 
         # Create new spectrum with new units.
-        converted_spec = self.spectrum._copy(flux=set_flux_unit,
+        converted_spectrum = spectrum._copy(flux=set_flux_unit,
                                              spectral_axis=set_spectral_axis_unit,
                                              unit=set_flux_unit.unit,
                                              uncertainty=temp_uncertainty
                                              )
-
-        # Finds the '_units_copy_' spectrum and does unit conversions in that copy.
-        if "_units_copy_" in self.selected_data:
-            selected_data_label = self.selected_data
-            selected_data_label_split = selected_data_label.split("_units_copy_")
-            label = selected_data_label_split[0] + "_units_copy_" + datetime.datetime.now().isoformat()
-
-            # Removes the old version of the unit conversion copy and creates
-            # a new version with the most recent conversion.
-            if selected_data_label in self.data_collection:
-                self.app.remove_data_from_viewer('spectrum-viewer', selected_data_label)
-
-                # Remove the actual Glue data object from the data_collection
-                self.data_collection.remove(self.data_collection[selected_data_label])
-            self.data_collection[selected_data_label] = converted_spec
-
-            #TODO: Fix bug that sends AddDataMessage into a loop
-            self.app.add_data_to_viewer("spectrum-viewer", selected_data_label)
-
-        else:
-            label = self.selected_data + "_units_copy_" + datetime.datetime.now().isoformat()
-
-            # Replace old spectrum with new one with updated units.
-            self.app.add_data(converted_spec, label)
-            self.app.add_data_to_viewer("spectrum-viewer", label, clear_other_data=True)
-
-        # Reset UI labels.
-        self.new_flux_unit = ""
-        self.new_spectral_axis_unit = ""
-
-        snackbar_message = SnackbarMessage(
-            f"Data set '{label}' units converted successfully.",
-            color="success",
-            sender=self)
-        self.hub.broadcast(snackbar_message)
+        return converted_spectrum
 
     def create_spectral_equivalencies_list(self):
         """

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -10,6 +10,13 @@
             disabled="True"
             persistent-hint
           ></v-text-field>
+          <v-select
+                :items="dc_items"
+                @change="data_selected"
+                label="Data"
+                hint="Select the data set to be fitted."
+                persistent-hint
+           ></v-select>
         </v-col>
       </v-row>
       <v-row>

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -10,13 +10,6 @@
             disabled="True"
             persistent-hint
           ></v-text-field>
-          <v-select
-                :items="dc_items"
-                @change="data_selected"
-                label="Data"
-                hint="Select the data set to be fitted."
-                persistent-hint
-           ></v-select>
         </v-col>
       </v-row>
       <v-row>


### PR DESCRIPTION
This is the current draft of the refactor of the unit conversion plugin. I originally tried to make it as viewer agnostic as possible, but the smoothest implementation requires some reliance on the 1d spectrum viewer. This also makes it easier to make unit tests for this plugin. Some other thoughts:

1. Fixes #280 
2. The ghost bqplot marks bug appears if you create subsets for different unit versions of the same spectra and then deselect them.
3. The plugin no longer automatically switches to new units spectrum after the `apply` button is pressed. Instead, it behaves like other jdaviz plugins where the data is created and added to the drop down, along with a snackbar message notifying the user of the status of the conversion.
4. If a spectrum is converted, a "_units_copy_" version will be created with the flux and spectral axis units in the spectrum label. If the user tries to convert a variant of the original spectrum (original or any of the "units_copy" versions) into a new units combination that already exists, a snackbar message will appear to notify the user that it already exists and no other action will be taken.

Once the direction of this refactor is agreed upon, the next steps will be to create tests and to update the documentation relating to unit conversions.