### PR TITLE
Concept notebook for programmatic viewers from a default blank app

### DIFF
--- a/notebooks/concepts/concept_programmatic_viewers_from_blank_default.ipynb
+++ b/notebooks/concepts/concept_programmatic_viewers_from_blank_default.ipynb
@@ -1,0 +1,883 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Concept Notebook\n",
+    "Start with a blank default application and programmatically add views and data to those views\n",
+    "\n",
+    "### Use Case\n",
+    "Progammatically load a single FITS file, e.g. for 2d spectroscopic data, into an \"image\" viewer.  Or a 1d spectrum into a spectrum viewer.  For cases that do not fit into a given pre-made configuration. \n",
+    "\n",
+    "### MAST Use Case\n",
+    "MAST auto-generates notebooks that when users run, needs to download the data, create the relevant jdaviz application / viewers, and load the data by default. One click run gets the user back to where they were on the web."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>.container { width:75% !important; }</style>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.core.display import display, HTML\n",
+    "display(HTML(\"<style>.container { width:75% !important; }</style>\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jdaviz.app import Application"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# some 2d spectroscopic data\n",
+    "data = '/Users/bcherinka/Work/jwst/test/jw00626-o030_s00000_nirspec_f170lp-g235m_s2d.fits'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Option 1 - Create a default viewer with the UI and programmatically add data\n",
+    "In this option, we create jdaviz with a default configuration, and load an \"Image 2D\" viewer via the user interface, (viewer creator plugin).  We then attempt to add data to the viewer programmatically.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b7949170270f421ba9429cab2477b53d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Application(components={'g-viewer-tab': '<template>\\n  <component :is=\"stack.container\">\\n    <g-viewer-tab\\n …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "app = Application('default')\n",
+    "app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "I know I first need to load the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/bcherinka/anaconda3/envs/havokve/lib/python3.8/site-packages/glue/core/data_factories/fits.py:152: UserWarning: Dropping column 'ASDF_METADATA' since it is not 1-dimensional\n",
+      "  warnings.warn(\"Dropping column '{0}' since it is not 1-dimensional\".format(column_name))\n"
+     ]
+    }
+   ],
+   "source": [
+    "app.load_data(data)\n",
+    "\n",
+    "# running this twice loads the same data with the same labels.  Downstream analysis/plugin calls raise errors on duplicate and \n",
+    "# ambiguous data labels.  Running this twice on the same data should either not re-load it or load it with a different unique\n",
+    "# data label"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataCollection (5 data sets)\n",
+       "\t  0: jw00626-o030_s00000_nirspec_f170lp-g235m_s2d[SCI]\n",
+       "\t  1: jw00626-o030_s00000_nirspec_f170lp-g235m_s2d[WHT]\n",
+       "\t  2: jw00626-o030_s00000_nirspec_f170lp-g235m_s2d[CON]\n",
+       "\t  3: jw00626-o030_s00000_nirspec_f170lp-g235m_s2d[HDRTAB]\n",
+       "\t  4: jw00626-o030_s00000_nirspec_f170lp-g235m_s2d[ASDF]"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# what label did my data get?  dig around in docs to understand data_collection.  How do I define custom data labels?\n",
+    "app.data_collection\n",
+    "\n",
+    "# want - option to easily label or relabel incoming data.  Either as input in app.load_data or a new function, e.g. app.relabel_data()\n",
+    "# app.add_data requires data to be in a special format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'jw00626-o030_s00000_nirspec_f170lp-g235m_s2d[SCI]'"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# get a label\n",
+    "label = app.data_collection[0].label\n",
+    "label"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "I want to load the data into the viewer.  I don't know the name of the viewer I created.  How do I get a list of current viewer references?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "'NoneType' object is not subscriptable",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-17-150964480149>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# naively try image-viewer\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mapp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_viewer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'image-viewer'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;31m# also try\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;31m#app.get_viewer('g-image-viewer')\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Work/git/havok2063/jdaviz/jdaviz/app.py\u001b[0m in \u001b[0;36mget_viewer\u001b[0;34m(self, viewer_reference)\u001b[0m\n\u001b[1;32m    322\u001b[0m             \u001b[0mThe\u001b[0m \u001b[0mviewer\u001b[0m \u001b[0;32mclass\u001b[0m \u001b[0minstance\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    323\u001b[0m         \"\"\"\n\u001b[0;32m--> 324\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_viewer_by_reference\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mviewer_reference\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    325\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    326\u001b[0m     def get_data_from_viewer(self, viewer_reference, data_label=None,\n",
+      "\u001b[0;32m~/Work/git/havok2063/jdaviz/jdaviz/app.py\u001b[0m in \u001b[0;36m_viewer_by_reference\u001b[0;34m(self, reference)\u001b[0m\n\u001b[1;32m    750\u001b[0m         \u001b[0mviewer_item\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_viewer_item_by_reference\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mreference\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    751\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 752\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_viewer_store\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mviewer_item\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'id'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    753\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    754\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_viewer_item_by_reference\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreference\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: 'NoneType' object is not subscriptable"
+     ]
+    }
+   ],
+   "source": [
+    "# naively try to get \"image-viewer\". ; throws error\n",
+    "app.get_viewer('image-viewer')\n",
+    "\n",
+    "# also try \n",
+    "#app.get_viewer('g-image-viewer')\n",
+    "#app.get_viewer('flux-viewer')\n",
+    "\n",
+    "# want - to return a list of all viewer reference names for currently loaded viewers.  Pick from the list and add data.\n",
+    "# app.list_viewers()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "'NoneType' object is not subscriptable",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-18-0f7c03d3ef26>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# let's try to add data anyways\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mapp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madd_data_to_viewer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'image-viewer'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/Work/git/havok2063/jdaviz/jdaviz/app.py\u001b[0m in \u001b[0;36madd_data_to_viewer\u001b[0;34m(self, viewer_reference, data_path, clear_other_data, ext)\u001b[0m\n\u001b[1;32m    618\u001b[0m         \u001b[0mdata_id\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_data_id_from_label\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata_label\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    619\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 620\u001b[0;31m         \u001b[0mdata_ids\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mviewer_item\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'selected_data_items'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;31m \u001b[0m\u001b[0;31m\\\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    621\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mclear_other_data\u001b[0m \u001b[0;32melse\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    622\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: 'NoneType' object is not subscriptable"
+     ]
+    }
+   ],
+   "source": [
+    "# let's try to add data anyways - throws same error\n",
+    "app.add_data_to_viewer('image-viewer', data, ext='SCI')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "How can I access and inspect the available viewers?  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<jdaviz.core.registries.ViewerRegistry at 0x7ffa693f4e50>"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# look in the viewer registry\n",
+    "from jdaviz.core.registries import tool_registry, viewer_registry\n",
+    "viewer_registry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'cubeviz-image-viewer': {'label': 'Image 2D (CubeViz)',\n",
+       "  'cls': jdaviz.configs.cubeviz.plugins.viewers.CubeVizImageView},\n",
+       " 'g-profile-viewer': {'label': 'Profile 1D',\n",
+       "  'cls': glue_jupyter.bqplot.profile.viewer.BqplotProfileView},\n",
+       " 'g-image-viewer': {'label': 'Image 2D',\n",
+       "  'cls': glue_jupyter.bqplot.image.viewer.BqplotImageView},\n",
+       " 'g-table-viewer': {'label': 'Table',\n",
+       "  'cls': glue_jupyter.table.viewer.TableViewer},\n",
+       " 'specviz-profile-viewer': {'label': 'Profile 1D (Specviz)',\n",
+       "  'cls': jdaviz.configs.specviz.plugins.viewers.SpecvizProfileView},\n",
+       " 'mosviz-profile-viewer': {'label': 'Profile 1D (MOSViz)',\n",
+       "  'cls': jdaviz.configs.mosviz.plugins.viewers.MOSVizProfileView},\n",
+       " 'mosviz-image-viewer': {'label': 'Image 2D (MOSViz)',\n",
+       "  'cls': jdaviz.configs.mosviz.plugins.viewers.MOSVizImageView},\n",
+       " 'mosviz-profile-2d-viewer': {'label': 'Spectrum 2D (MOSViz)',\n",
+       "  'cls': jdaviz.configs.mosviz.plugins.viewers.MOSVizProfile2DView},\n",
+       " 'mosviz-table-viewer': {'label': 'Table (MOSViz)',\n",
+       "  'cls': jdaviz.configs.mosviz.plugins.viewers.MOSVizTableViewer}}"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# I can find all viewers in the registry. But these dict keys are not reference names.  \n",
+    "viewer_registry.members"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "'NoneType' object is not subscriptable",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-21-054cb71476e8>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# oh I see my Image 2d == \"g-image-viewer\".  Let me try that.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mapp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_viewer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'g-image-viewer'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/Work/git/havok2063/jdaviz/jdaviz/app.py\u001b[0m in \u001b[0;36mget_viewer\u001b[0;34m(self, viewer_reference)\u001b[0m\n\u001b[1;32m    322\u001b[0m             \u001b[0mThe\u001b[0m \u001b[0mviewer\u001b[0m \u001b[0;32mclass\u001b[0m \u001b[0minstance\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    323\u001b[0m         \"\"\"\n\u001b[0;32m--> 324\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_viewer_by_reference\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mviewer_reference\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    325\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    326\u001b[0m     def get_data_from_viewer(self, viewer_reference, data_label=None,\n",
+      "\u001b[0;32m~/Work/git/havok2063/jdaviz/jdaviz/app.py\u001b[0m in \u001b[0;36m_viewer_by_reference\u001b[0;34m(self, reference)\u001b[0m\n\u001b[1;32m    750\u001b[0m         \u001b[0mviewer_item\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_viewer_item_by_reference\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mreference\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    751\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 752\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_viewer_store\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mviewer_item\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'id'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    753\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    754\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_viewer_item_by_reference\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreference\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: 'NoneType' object is not subscriptable"
+     ]
+    }
+   ],
+   "source": [
+    "# oh I see my \"Image 2D\" == \"g-image-viewer\".  That must be the reference name.  Let me try that, to get the viewer.\n",
+    "app.get_viewer('g-image-viewer')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now I'm lost and don't know how to look up my viewer.  I can dig around in hidden attributes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'6501402f-bb03-4fd5-b8da-1b4241daf66b': <glue_jupyter.bqplot.image.viewer.BqplotImageView at 0x7ffa6a9fd400>}"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# look up the viewer store.  I see my viewer with a viewer id. \n",
+    "app._viewer_store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<CallbackList with 1 elements>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# examine the application stack of items\n",
+    "app.state.stack_items"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "item dict_keys(['id', 'container', 'children', 'viewers'])\n",
+      "viewer dict_keys(['id', 'name', 'widget', 'tools', 'layer_options', 'viewer_options', 'selected_data_items', 'collapse', 'reference', 'tab'])\n",
+      "id 6501402f-bb03-4fd5-b8da-1b4241daf66b\n",
+      "name Unnamed Viewer\n",
+      "widget IPY_MODEL_2000302c0e344576b421f3f18cf8ba6e\n",
+      "tools IPY_MODEL_f4c490d6cc2e4b31893e6c2b4c4f5062\n",
+      "layer_options IPY_MODEL_75dae667d8454464a286b39ff444a678\n",
+      "viewer_options IPY_MODEL_4772c7d7dddd428a9533f6877ac18183\n",
+      "selected_data_items <CallbackList with 0 elements>\n",
+      "collapse True\n",
+      "reference None\n",
+      "tab 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# loop over all the items in the application stack and print the data\n",
+    "for i in app.state.stack_items:\n",
+    "    print('item', i.keys())\n",
+    "    for viewer in i.get('viewers'):\n",
+    "        print('viewer', viewer.keys())\n",
+    "        for kk, vv in viewer.items():\n",
+    "            print(kk,vv)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<CallbackDict with 10 elements>"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# now I have the viewer, I think.  The repr here should be improved to more obvious.\n",
+    "viewer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get the viewer by id\n",
+    "id = viewer['id']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "'NoneType' object is not subscriptable",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-26-a064275d0fa4>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# try to add data by id\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mapp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madd_data_to_viewer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mid\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlabel\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/Work/git/havok2063/jdaviz/jdaviz/app.py\u001b[0m in \u001b[0;36madd_data_to_viewer\u001b[0;34m(self, viewer_reference, data_path, clear_other_data, ext)\u001b[0m\n\u001b[1;32m    618\u001b[0m         \u001b[0mdata_id\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_data_id_from_label\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata_label\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    619\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 620\u001b[0;31m         \u001b[0mdata_ids\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mviewer_item\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'selected_data_items'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;31m \u001b[0m\u001b[0;31m\\\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    621\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mclear_other_data\u001b[0m \u001b[0;32melse\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    622\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: 'NoneType' object is not subscriptable"
+     ]
+    }
+   ],
+   "source": [
+    "# try to add data by id.  Still same error as above.\n",
+    "app.add_data_to_viewer(id, label)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<CallbackDict with 10 elements>"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# I notice in the stack that no reference name is indicated.  Let's add one.\n",
+    "view = app._viewer_item_by_id(id)\n",
+    "view['reference'] = 'image-viewer'\n",
+    "view"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# now I can add data to the viewer.  Success.\n",
+    "app.add_data_to_viewer('image-viewer', data, ext='SCI')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'BqplotImageView' object has no attribute 'default_class'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-29-fbe0cf679ac6>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# can I access the data back out\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mapp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_data_from_viewer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'image-viewer'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/Work/git/havok2063/jdaviz/jdaviz/app.py\u001b[0m in \u001b[0;36mget_data_from_viewer\u001b[0;34m(self, viewer_reference, data_label, cls, include_subsets)\u001b[0m\n\u001b[1;32m    364\u001b[0m         \"\"\"\n\u001b[1;32m    365\u001b[0m         \u001b[0mviewer\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_viewer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mviewer_reference\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 366\u001b[0;31m         \u001b[0mcls\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mviewer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault_class\u001b[0m \u001b[0;32mif\u001b[0m \u001b[0mcls\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m'default'\u001b[0m \u001b[0;32melse\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    367\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    368\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mcls\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0misclass\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcls\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'BqplotImageView' object has no attribute 'default_class'"
+     ]
+    }
+   ],
+   "source": [
+    "# can I access the data back out? \n",
+    "app.get_data_from_viewer('image-viewer')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Option 2 - Create the viewer programmatically and also load some data\n",
+    "In this option, we create a blank jdaviz application with default configuration, and attempt to create a \"Image 2D\" viewer programmatically, and add data to it. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "114e532d0e944ecc8845b0c5adeb06e9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Application(components={'g-viewer-tab': '<template>\\n  <component :is=\"stack.container\">\\n    <g-viewer-tab\\n …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "app = Application()\n",
+    "app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "I don't know what viewers are available to add.  How can I find this out?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'cubeviz-image-viewer': {'label': 'Image 2D (CubeViz)',\n",
+       "  'cls': jdaviz.configs.cubeviz.plugins.viewers.CubeVizImageView},\n",
+       " 'g-profile-viewer': {'label': 'Profile 1D',\n",
+       "  'cls': glue_jupyter.bqplot.profile.viewer.BqplotProfileView},\n",
+       " 'g-image-viewer': {'label': 'Image 2D',\n",
+       "  'cls': glue_jupyter.bqplot.image.viewer.BqplotImageView},\n",
+       " 'g-table-viewer': {'label': 'Table',\n",
+       "  'cls': glue_jupyter.table.viewer.TableViewer},\n",
+       " 'specviz-profile-viewer': {'label': 'Profile 1D (Specviz)',\n",
+       "  'cls': jdaviz.configs.specviz.plugins.viewers.SpecvizProfileView},\n",
+       " 'mosviz-profile-viewer': {'label': 'Profile 1D (MOSViz)',\n",
+       "  'cls': jdaviz.configs.mosviz.plugins.viewers.MOSVizProfileView},\n",
+       " 'mosviz-image-viewer': {'label': 'Image 2D (MOSViz)',\n",
+       "  'cls': jdaviz.configs.mosviz.plugins.viewers.MOSVizImageView},\n",
+       " 'mosviz-profile-2d-viewer': {'label': 'Spectrum 2D (MOSViz)',\n",
+       "  'cls': jdaviz.configs.mosviz.plugins.viewers.MOSVizProfile2DView},\n",
+       " 'mosviz-table-viewer': {'label': 'Table (MOSViz)',\n",
+       "  'cls': jdaviz.configs.mosviz.plugins.viewers.MOSVizTableViewer}}"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# how do I know what viewers are available to add?  Use the viewer registry I dug around in the code to find.\n",
+    "viewer_registry.members\n",
+    "\n",
+    "# want - option to list/dict the available options for creating different viewers; returns a reference name, label and class.\n",
+    "# i.e. expose the registry members in a user-friendly format\n",
+    "# app.list_viewer_types()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "ok, so I know I want an Image 2d viewer, but don't know how to, or cannot, create one programmatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# want - option to create a viewer by reference name or label.  The input should check against the formatted list from the registry.\n",
+    "# app.create_viewer('image-viewer') or app.create_viewer('Image 2D')\n",
+    "\n",
+    "# hack to create a new viewer programmatically using code from the Viewer Creator plugin\n",
+    "from jdaviz.core.events import NewViewerMessage, AddViewerMessage\n",
+    "viewer_cls = viewer_registry.members['g-image-viewer']['cls']\n",
+    "new_viewer_message = NewViewerMessage(viewer_cls, data=None, sender=app)\n",
+    "app.hub.broadcast(new_viewer_message)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/bcherinka/anaconda3/envs/havokve/lib/python3.8/site-packages/glue/core/data_factories/fits.py:152: UserWarning: Dropping column 'ASDF_METADATA' since it is not 1-dimensional\n",
+      "  warnings.warn(\"Dropping column '{0}' since it is not 1-dimensional\".format(column_name))\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ok, I created a viewer.  Now have same problem as option 1\n",
+    "app.load_data(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'c3906bad-0c1f-4e80-8be2-83984a01d3ed': <glue_jupyter.bqplot.image.viewer.BqplotImageView at 0x7ffa6ac45c10>}"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# look for the viewer in the store\n",
+    "app._viewer_store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "'NoneType' object is not subscriptable",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-35-6ac80fb87974>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mapp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madd_data_to_viewer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'image-viewer'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/Work/git/havok2063/jdaviz/jdaviz/app.py\u001b[0m in \u001b[0;36madd_data_to_viewer\u001b[0;34m(self, viewer_reference, data_path, clear_other_data, ext)\u001b[0m\n\u001b[1;32m    618\u001b[0m         \u001b[0mdata_id\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_data_id_from_label\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata_label\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    619\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 620\u001b[0;31m         \u001b[0mdata_ids\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mviewer_item\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'selected_data_items'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;31m \u001b[0m\u001b[0;31m\\\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    621\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mclear_other_data\u001b[0m \u001b[0;32melse\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    622\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: 'NoneType' object is not subscriptable"
+     ]
+    }
+   ],
+   "source": [
+    "# attempt to add the data with naive reference name\n",
+    "app.add_data_to_viewer('image-viewer', data, ext='SCI') "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "id c3906bad-0c1f-4e80-8be2-83984a01d3ed\n",
+      "name Unnamed Viewer\n",
+      "widget IPY_MODEL_288b6451c3784849a16055ef99d44e41\n",
+      "tools IPY_MODEL_b01dcb73142d4970a285fe0f48a3d39d\n",
+      "layer_options IPY_MODEL_a4ee8df437514ba784c3342839b0fa63\n",
+      "viewer_options IPY_MODEL_19604f2888394ef195438de35ea9134e\n",
+      "selected_data_items <CallbackList with 0 elements>\n",
+      "collapse True\n",
+      "reference None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# grab the viewer information\n",
+    "id = next(iter(app._viewer_store))\n",
+    "view = app._viewer_item_by_id(id)\n",
+    "for k, v in view.items():\n",
+    "    print(k,v)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add valid reference name\n",
+    "view['reference'] = 'image-viewer'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# re-attempt to add the data.  success\n",
+    "app.add_data_to_viewer('image-viewer', data, ext='SCI') "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Option 3 - Create custom Helper and define a custom configuration\n",
+    "This option attempts to create a custom helper that represents my 2d spectroscopic fits file, with a single \"Image 2D viewer\".  I define a new custom configuration with the viewer I need."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'settings': {'visible': {'menu_bar': False,\n",
+       "   'toolbar': True,\n",
+       "   'tray': True,\n",
+       "   'tab_headers': True},\n",
+       "  'context': {'notebook': {'max_height': '600px'}}},\n",
+       " 'toolbar': ['g-data-tools', 'g-viewer-creator', 'g-subset-tools'],\n",
+       " 'tray': ['g-gaussian-smooth'],\n",
+       " 'viewer_area': [{'container': 'col',\n",
+       "   'children': [{'container': 'row',\n",
+       "     'viewers': [{'name': 'Image',\n",
+       "       'plot': 'g-image-viewer',\n",
+       "       'reference': 'image-viewer'}]}]}]}"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from jdaviz.core.helpers import ConfigHelper\n",
+    "from jdaviz.core.config import get_configuration\n",
+    "\n",
+    "# get a default configuration\n",
+    "config = get_configuration('default')\n",
+    "\n",
+    "# create a viewer area and viewer\n",
+    "config['viewer_area'] = [{'container': 'col', 'children': [{'container':'row', 'viewers':[]}]}]\n",
+    "viewers = {'viewers': [{'name': 'Image', 'plot': 'g-image-viewer', 'reference': 'image-viewer'}]}\n",
+    "\n",
+    "# update the default config\n",
+    "config['viewer_area'][0]['children'][0].update(viewers)\n",
+    "\n",
+    "config\n",
+    "\n",
+    "\n",
+    "# want - easier mechanism for adding viewers into a custom configuration.  Given a custom config, and a viewer \n",
+    "# reference name or label, return a properly formatted new config\n",
+    "# add_viewer_to_config(config, 'image-viewer')  or add_viewer_to_config(config, ['image-viewer', 'spectrum-viewer'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "21d269258cd84446ac013628373e76e1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Application(components={'g-viewer-tab': '<template>\\n  <component :is=\"stack.container\">\\n    <g-viewer-tab\\n …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# set my custom config object to the default configuration.  I could also just use Application(config) so \n",
+    "# what does the ConfigHelper gain me, the user?  Would be nice to have default data loading. \n",
+    "class ImViz(ConfigHelper):\n",
+    "    _default_configuration = config\n",
+    "\n",
+    "im = ImViz()\n",
+    "im.app"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/bcherinka/anaconda3/envs/havokve/lib/python3.8/site-packages/glue/core/data_factories/fits.py:152: UserWarning: Dropping column 'ASDF_METADATA' since it is not 1-dimensional\n",
+      "  warnings.warn(\"Dropping column '{0}' since it is not 1-dimensional\".format(column_name))\n"
+     ]
+    }
+   ],
+   "source": [
+    "im.load_data(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# this works cleanly since I defined a proper reference viewer in my configuration\n",
+    "im.app.add_data_to_viewer('image-viewer', data, ext='SCI')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# it would be nice if some convienence for creating data parses could live in the ConfigHelper or easily \n",
+    "# decorate / attach to the new helper class"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR adds a concept notebook highlighting a use case of creating viewers, and adding data, programmatically, starting from a blank default jdaviz application.  Or, more accurately, highlights the current failure modes and subsequent hacks to enable the use case.