### PR TITLE
Pin GWCS for astropy 4.0.3 compatibility in tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,9 +54,9 @@ deps =
 
     astropy30: astropy==3.0.*
     astropy40: astropy==4.0.*
-    astropy40: gwcs==0.14
+    astropy40: gwcs>=0.14,<0.15
     astropylts: astropy==4.0.*
-    astropylts: gwcs==0.14
+    astropylts: gwcs>=0.14,<0.15
 
     devdeps: :NIGHTLY:numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy

--- a/tox.ini
+++ b/tox.ini
@@ -53,8 +53,10 @@ deps =
     numpy118: numpy==1.18.*
 
     astropy30: astropy==3.0.*
-    astropy40: astropy==4.0.* gwcs==0.14
-    astropylts: astropy==4.0.* gwcs==0.14
+    astropy40: astropy==4.0.*
+    astropy40: gwcs==0.14
+    astropylts: astropy==4.0.*
+    astropylts: gwcs==0.14
 
     devdeps: :NIGHTLY:numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy

--- a/tox.ini
+++ b/tox.ini
@@ -53,8 +53,8 @@ deps =
     numpy118: numpy==1.18.*
 
     astropy30: astropy==3.0.*
-    astropy40: astropy==4.0.*
-    astropylts: astropy==4.0.*
+    astropy40: astropy==4.0.* gwcs==0.14
+    astropylts: astropy==4.0.* gwcs==0.14
 
     devdeps: :NIGHTLY:numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy


### PR DESCRIPTION
Edits the tox config to fix compatibility failure.