### PR TITLE
Add Bandit to the github actions build

### DIFF
--- a/.bandit.yaml
+++ b/.bandit.yaml
@@ -1,0 +1,2 @@
+exclude_dirs:
+  - jdaviz/tests

--- a/.bandit.yaml
+++ b/.bandit.yaml
@@ -1,2 +1,5 @@
 exclude_dirs:
   - jdaviz/tests
+
+skips: ['B101' # skip warning about asserts - they are used as behavior checks not as code tools
+       ]

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -35,7 +35,7 @@ jobs:
             os: ubuntu-latest
             python: 3.x
             toxenv: securityaudit
-            allow_failure: true
+            allow_failure: false
 
           - name: Python 3.8 with coverage checking
             os: ubuntu-latest

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -31,6 +31,12 @@ jobs:
             toxenv: pep517
             allow_failure: false
 
+          - name: Security audit
+            os: ubuntu-latest
+            python: 3.x
+            toxenv: securityaudit
+            allow_failure: true
+
           - name: Python 3.8 with coverage checking
             os: ubuntu-latest
             python: 3.8
@@ -68,7 +74,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox codecov
-    - name: Test with tox
+    - name: Test/run with tox
       run: |
         tox -e ${{ matrix.toxenv }}
     # Activate your repo on codecov.io first.

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -1,5 +1,4 @@
 import os
-import pickle
 
 import bqplot
 from bqplot.marks import Lines

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -1,5 +1,6 @@
 import os
-import pickle
+# pickle is in principle a security risk, but we use it just for dumping of a known class here
+import pickle  # nosec
 import re
 import numpy as np
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -1,5 +1,4 @@
 import os
-import pickle
 
 import numpy as np
 import astropy.units as u

--- a/tox.ini
+++ b/tox.ini
@@ -95,6 +95,13 @@ description = check code style, e.g. with flake8
 deps = flake8
 commands = flake8 jdaviz --count --max-line-length=100 --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E502,E722,E901,E902
 
+[testenv:securityaudit]
+skip_install = true
+changedir = .
+description = security audit with bandit
+deps = bandit
+commands = bandit -r jdaviz -c .bandit.yaml
+
 [testenv:pep517]
 skip_install = true
 changedir = .


### PR DESCRIPTION
This PR ~(if/when it's working...)~ should close #289 .  ~It's also built off of #369 so I'm opening it as a draft until we merge that~.

This basically just ports the bandit configuration that I discovered had already been done in spacetelescope/stsci-package-template#25 over here.  The problem is that it is currently failing for a bunch of reasons - see https://github.com/eteq/jdaviz/actions/runs/373207713 .

It's not clear to me if any of these are "real" security concerns - it's basically all about `assert` statements.  We may just want to exclude that particular check because it feels to me like whoever wrote bandit is really just asserting their opinion that `assert` is bad.  But we can discuss since this can't be merged until #369 anyway.