### PR TITLE
Fix for parsing of cube extensions

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -73,14 +73,15 @@ def _parse_hdu(app, hdulist, file_name=None):
     wcs = None
 
     for hdu in hdulist:
-        if hdu.data is None:
+        if hdu.data is None or not hdu.is_image:
             continue
 
         try:
-            sc = SpectralCube.read(hdulist, format='fits')
-            wcs = sc.wcs
+            sc = SpectralCube.read(hdu, format='fits')
         except (ValueError, FITSReadError):
             continue
+        else:
+            wcs = sc.wcs
 
     # Now loop through and attempt to parse the fits extensions as spectral
     #  cube object. If the wcs fails to parse in any case, use the wcs
@@ -88,7 +89,7 @@ def _parse_hdu(app, hdulist, file_name=None):
     for hdu in hdulist:
         data_label = f"{file_name}[{hdu.name}]"
 
-        if hdu.data is None:
+        if hdu.data is None or not hdu.is_image:
             continue
 
         # This is supposed to fail on attempting to load anything that


### PR DESCRIPTION
This PR fixes #322.   It changes the first loop that assigns finds the wcs to use the individual hdu.   To both loops, it also adds an additional check to skip extensions when they are not image extensions, e.g. BinTable HDUs.  I believe those extensions currently cannot be parsed and loaded into an image viewer.