### PR TITLE
Move snackbar message to the top of the UI

### DIFF
--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -55,6 +55,7 @@
       v-model="state.snackbar.show"
       :timeout="state.snackbar.timeout"
       :color="state.snackbar.color"
+      :top=true
       absolute
     >
       {{ state.snackbar.text }}


### PR DESCRIPTION
<img width="1009" alt="Screen Shot 2020-12-07 at 6 45 36 PM" src="https://user-images.githubusercontent.com/7179333/101418632-422a2f00-38bc-11eb-8e20-b889c35642e7.png">

More information on editing the Snackbar message can be found here: https://vuetifyjs.com/en/api/v-snackbar/