### PR TITLE
Fix setting 'show' column to False when hiding lists

### DIFF
--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -160,9 +160,14 @@ class SpecvizProfileView(BqplotProfileView):
                 self.spectral_lines["show"] = False
         else:
             temp_marks = []
-            # Toggle "show" value in main astropy table
+            # Toggle "show" value in main astropy table. The astropy table
+            # machinery only allows updating a single row at a time.
             if name_rest is not None:
-                self.spectral_lines.loc[name_rest]["show"] = False
+                if type(name_rest) == str:
+                    self.spectral_lines.loc[name_rest]["show"] = False
+                elif type(name_rest) == list:
+                    for nr in name_rest:
+                        self.spectral_lines.loc[nr]["show"] = False
             # Get rid of the marks we no longer want
             for x in fig.marks:
                 if type(x) == SpectralLine:
@@ -171,7 +176,6 @@ class SpecvizProfileView(BqplotProfileView):
                         if x.name == name:
                             continue
                     else:
-                        self.spectral_lines.loc[name_rest]["show"] = False
                         if type(name_rest) == str:
                             if x.table_index == name_rest:
                                 continue


### PR DESCRIPTION
Closes #381. Lines hidden by the list "Hide All" button no longer get replotted when using the "Show All" button in another list or when calling `specviz.plot_spectral_lines()`. The cause here was that setting a new column value for multiple rows at a time in an astropy Table silently fails.