### PR TITLE
Fix nonexistent file load

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -276,7 +276,7 @@ class Application(VuetifyTemplate, HubListener):
                 snackbar_message = SnackbarMessage(msg_text, sender=self,
                                                    color='error')
                 self.hub.broadcast(snackbar_message)
-                return
+                raise FileNotFoundError("Could not locate file: {}".format(file_obj))
             else:
                 # Convert path to properly formatted string (Parsers do not accept path objs)
                 file_obj = str(file_obj)

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -272,7 +272,11 @@ class Application(VuetifyTemplate, HubListener):
             # Properly form path and check if a valid file
             file_obj = pathlib.Path(file_obj)
             if not file_obj.exists():
-                raise FileNotFoundError("Could not locate file: " + file_obj)
+                msg_text = "Error: File {} does not exist".format(file_obj)
+                snackbar_message = SnackbarMessage(msg_text, sender=self,
+                                                   color='error')
+                self.hub.broadcast(snackbar_message)
+                return
             else:
                 # Convert path to properly formatted string (Parsers do not accept path objs)
                 file_obj = str(file_obj)


### PR DESCRIPTION
Closes #181 . For some reason the case where the input filename didn't really exist wasn't raising the `FileNotFoundError` successfully (so the "Data Loaded" snackbar message was appearing despite no data loading). I changed that case to send an error snackbar message instead and then return.