### PR TITLE
MNT: Unpin pytest and move it to test requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ include_package_data = True
 python_requires = >=3.6
 setup_requires = setuptools_scm
 install_requires =
-    pytest<6.0
     astropy
     traitlets<5.0
     glue-core>=1.0.1
@@ -40,6 +39,7 @@ install_requires =
 
 [options.extras_require]
 test =
+    pytest
     pytest-astropy
     pytest-tornasync
 docs =


### PR DESCRIPTION
Fix #395