### PR TITLE
Imviz: astrowidgets + Ginga

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,21 +25,22 @@ repository.
 
 ``jdaviz`` provides data viewers and analysis plugins that can be flexibly
 combined as desired to create interactive applications that fit your workflow.
-Three named preset configurations for common use cases are provided. **Specviz**
-is a tool for visualization and quick-look analysis of 1D astronomical spectra.
-**MOSviz** is a visualization tool for many astronomical spectra,
-typically the output of a multi-object spectrograph (e.g., JWST
-NIRSpec), and includes viewers for 1D and 2D spectra as well as
-contextual information like on-sky views of the spectrograph slit.
-**Cubeviz** provides a view of spectroscopic data cubes (like those to be
-produced by JWST MIRI), along with 1D spectra extracted from the cube.
+Several named preset configurations for common use cases are provided:
+
+* **Specviz**: Visualization and quick-look analysis of 1D astronomical spectra.
+* **MOSviz**: Visualization tool for many astronomical spectra,
+  typically the output of a multi-object spectrograph (e.g., JWST
+  NIRSpec), and includes viewers for 1D and 2D spectra as well as
+  contextual information like on-sky views of the spectrograph slit.
+* **Cubeviz**: View of spectroscopic data cubes (like those to be
+  produced by JWST MIRI), along with 1D spectra extracted from the cube.
+* **Imviz**: Visualization and quick-look analysis of 2D astronomical images.
 
 
 Installing
 ----------
 For details on installing and using JDAViz, see the
 `Jdaviz documentation <https://jdaviz.readthedocs.io/en/latest/>`_.
-
 
 
 License

--- a/docs/imviz/index.rst
+++ b/docs/imviz/index.rst
@@ -1,0 +1,30 @@
+(TODO: Nice logo here.)
+
+.. _imviz:
+
+#####
+Imviz
+#####
+
+Imviz is a tool for visualization and quick-look analysis of 2D astronomical
+images. Like the rest of `jdaviz`, it is written in the Python programming
+language, and therefore can be run anywhere Python is supported
+(see :doc:`../installation`). Imviz is built on top of the
+`astrowidgets <https://astrowidgets.readthedocs.io>`_ using
+`Ginga <https://ginga.readthedocs.io>`_ backend, providing a visual,
+interactive interface to the analysis capabilities in that library.
+
+Imviz allows images to be easily displayed and examined. It supports WCS,
+GWCS, ASDF, and so on. (TODO: Add content.)
+
+
+Using Imviz
+-----------
+
+To run Imviz in a notebook::
+
+    from jdaviz import Imviz
+    imviz = Imviz()
+    imviz.app
+
+(TODO: Add content.)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ Using Jdaviz
   specviz/index.rst
   cubeviz/index.rst
   mosviz/index.rst
+  imviz/index.rst
 
 Reference/API
 =============

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -40,4 +40,4 @@ or simply start a new Jupyter notebook and run the following in a cell::
     app
 
 To learn more about the various ``jdaviz`` application configurations and loading data, see the :ref:`cubeviz`,
-:ref:`specviz`, or :ref:`mosviz` tools.
+:ref:`specviz`, :ref:`mosviz`, or :ref:`imviz` tools.

--- a/jdaviz/__init__.py
+++ b/jdaviz/__init__.py
@@ -12,3 +12,4 @@ from jdaviz.configs.specviz import SpecViz
 from jdaviz.configs.specviz2d import Specviz2d
 from jdaviz.configs.mosviz import MosViz
 from jdaviz.configs.cubeviz import CubeViz
+from jdaviz.configs.imviz import Imviz

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -912,6 +912,10 @@ class Application(VuetifyTemplate, HubListener):
                                               sender=self)
             self.hub.broadcast(add_data_message)
 
+        # Temporary workaround since ImageWidget doesn't have a state attribute
+        if not hasattr(viewer, "state"):
+            return
+
         # Remove any deselected data objects from viewer
         viewer_data = [layer_state.layer
                        for layer_state in viewer.state.layers

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -912,10 +912,6 @@ class Application(VuetifyTemplate, HubListener):
                                               sender=self)
             self.hub.broadcast(add_data_message)
 
-        # Temporary workaround since ImageWidget doesn't have a state attribute
-        if not hasattr(viewer, "state"):
-            return
-
         # Remove any deselected data objects from viewer
         viewer_data = [layer_state.layer
                        for layer_state in viewer.state.layers

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -18,8 +18,8 @@ CONFIGS_DIR = os.path.join(os.path.dirname(__file__), 'configs')
               default='default',
               nargs=1,
               show_default=True,
-              type=click.Choice(['default', 'cubeviz', 'specviz', 'mosviz'],
-                                case_sensitive=False),
+              type=click.Choice(['default', 'cubeviz', 'specviz', 'mosviz',
+                                 'imviz'], case_sensitive=False),
               help="Configuration to use on application startup")
 def main(filename, layout='default'):
     """

--- a/jdaviz/configs/__init__.py
+++ b/jdaviz/configs/__init__.py
@@ -2,3 +2,4 @@ from .cubeviz import *
 from .specviz import *
 from .default import *
 from .mosviz import *
+from .imviz import *

--- a/jdaviz/configs/imviz/__init__.py
+++ b/jdaviz/configs/imviz/__init__.py
@@ -1,0 +1,2 @@
+from .plugins import *  # noqa
+from .helper import Imviz  # noqa

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -1,0 +1,12 @@
+from jdaviz.core.helpers import ConfigHelper
+
+__all__ = ['Imviz']
+
+
+class Imviz(ConfigHelper):
+    """Imviz helper class."""
+
+    _default_configuration = "imviz"
+
+    def show(self):
+        self.app

--- a/jdaviz/configs/imviz/imviz.ipynb
+++ b/jdaviz/configs/imviz/imviz.ipynb
@@ -1,0 +1,38 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jdaviz import Imviz\n",
+    "\n",
+    "imviz = Imviz()\n",
+    "imviz.load_data('DATA_FILENAME')\n",
+    "imviz.app"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/jdaviz/configs/imviz/imviz.yaml
+++ b/jdaviz/configs/imviz/imviz.yaml
@@ -1,0 +1,20 @@
+settings:
+  configuration: imviz
+  data:
+    parser: imviz-image-parser
+  visible:
+    menu_bar: false
+    toolbar: false
+    tray: false
+    tab_headers: false
+  context:
+    notebook:
+      max_height: 600px
+viewer_area:
+  - container: col
+    children:
+      - container: row
+        viewers:
+          - name: Image
+            plot: imviz-image-viewer
+            reference: image-viewer

--- a/jdaviz/configs/imviz/imviz.yaml
+++ b/jdaviz/configs/imviz/imviz.yaml
@@ -17,4 +17,4 @@ viewer_area:
         viewers:
           - name: Image
             plot: imviz-image-viewer
-            reference: image-viewer
+            reference: imviz-image-viewer

--- a/jdaviz/configs/imviz/plugins/__init__.py
+++ b/jdaviz/configs/imviz/plugins/__init__.py
@@ -1,0 +1,2 @@
+from .viewers import *  # noqa
+from .parsers import *  # noqa

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -2,6 +2,8 @@ import base64
 import pathlib
 import uuid
 
+from astropy.nddata import CCDData
+
 from jdaviz.core.registries import data_parser_registry
 
 __all__ = ["imviz_image_parser"]
@@ -18,8 +20,7 @@ def imviz_image_parser(app, data, data_label=None, show_in_viewer=True):
     path = pathlib.Path(data)
     if path.is_file():
         # TODO: Support other image formats
-        from astropy.io import fits
-        data = fits.getdata(path)
+        data = CCDData.read(path)
     else:
         raise FileNotFoundError(f"No such file: {path}")
 

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -1,0 +1,28 @@
+import base64
+import pathlib
+import uuid
+
+from jdaviz.core.registries import data_parser_registry
+
+__all__ = ["imviz_image_parser"]
+
+
+@data_parser_registry("imviz-image-parser")
+def imviz_image_parser(app, data, data_label=None, show_in_viewer=True):
+    """Loads an image into Imviz"""
+    # If no data label is assigned, give it a unique identifier
+    if not data_label:
+        data_label = "imviz_data|" + str(
+            base64.b85encode(uuid.uuid4().bytes), "utf-8")
+
+    path = pathlib.Path(data)
+    if path.is_file():
+        # TODO: Support other image formats
+        from astropy.io import fits
+        data = fits.getdata(path)
+    else:
+        raise FileNotFoundError(f"No such file: {path}")
+
+    app.add_data(data, data_label)
+    if show_in_viewer:
+        app.add_data_to_viewer("image-viewer", data_label)

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -26,4 +26,4 @@ def imviz_image_parser(app, data, data_label=None, show_in_viewer=True):
 
     app.add_data(data, data_label)
     if show_in_viewer:
-        app.add_data_to_viewer("image-viewer", data_label)
+        app.add_data_to_viewer("imviz-image-viewer", data_label, clear_other_data=True)

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -1,5 +1,6 @@
 from astrowidgets.core import ImageWidget
 from ginga.misc.log import get_logger
+from glue.core import Data
 
 from jdaviz.core.registries import viewer_registry
 
@@ -33,6 +34,11 @@ class ImvizImageWidget(ImageWidget):
 
     def register_to_hub(self, *args, **kwargs):
         pass
+
+    def add_data(self, data):
+        if type(data) == Data:
+            data = data.get_object()
+        self.load_nddata(data)
 
     @property
     def toolbar_selection_tools(self):

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -19,8 +19,17 @@ class DummyModelID:
         self.layout = DummyLayout()
 
 
-class ImvizImageWidget(ImageWidget):
+class DummyState:
+    def __init__(self):
+        self.layers = []
+
+
+@viewer_registry("imviz-image-viewer", label="Image 2D (Imviz)")
+class ImvizImageView(ImageWidget):
     """Image widget for Imviz."""
+
+    default_class = None
+    state = DummyState()
 
     # session is a glue thing
     def __init__(self, session, *args, **kwargs):
@@ -61,7 +70,11 @@ class ImvizImageWidget(ImageWidget):
     def viewer_options(self):
         return DummyModelID()
 
+    def set_plot_axes(self, *args, **kwargs):
+        pass
 
-@viewer_registry("imviz-image-viewer", label="Image 2D (Imviz)")
-class ImvizImageView(ImvizImageWidget):
-    default_class = None
+    def data(self, cls=None):
+        return [layer_state.layer
+                for layer_state in self.state.layers
+                if hasattr(layer_state, 'layer') and
+                isinstance(layer_state.layer, BaseData)]

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -1,0 +1,61 @@
+from astrowidgets.core import ImageWidget
+from ginga.misc.log import get_logger
+
+from jdaviz.core.registries import viewer_registry
+
+__all__ = ['ImvizImageView']
+
+
+class DummyLayout:
+    def __init__(self):
+        self.height = ''
+        self.width = ''
+
+
+class DummyModelID:
+    def __init__(self):
+        self.model_id = '1234'
+        self.layout = DummyLayout()
+
+
+class ImvizImageWidget(ImageWidget):
+    """Image widget for Imviz."""
+
+    # session is a glue thing
+    def __init__(self, session, *args, **kwargs):
+        # logger needs special handling because using default logger of None
+        # will crash Ginga internals.
+        kwargs['logger'] = get_logger('imviz', log_stderr=True, log_file=None,
+                                      level=30)
+        super().__init__(*args, **kwargs)
+
+    # More glue things
+
+    def register_to_hub(self, *args, **kwargs):
+        pass
+
+    @property
+    def toolbar_selection_tools(self):
+        class Dummy(DummyModelID):
+            def __init__(self):
+                super().__init__()
+                self.borderless = False
+
+        return Dummy()
+
+    @property
+    def figure_widget(self):
+        return DummyModelID()
+
+    @property
+    def layer_options(self):
+        return DummyModelID()
+
+    @property
+    def viewer_options(self):
+        return DummyModelID()
+
+
+@viewer_registry("imviz-image-viewer", label="Image 2D (Imviz)")
+class ImvizImageView(ImvizImageWidget):
+    default_class = None

--- a/jdaviz/configs/imviz/tests/__init__.py
+++ b/jdaviz/configs/imviz/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Imviz image viewer."""

--- a/jdaviz/core/config.py
+++ b/jdaviz/core/config.py
@@ -39,6 +39,8 @@ def read_configuration(path=None):
         path = default_path / "mosviz" / "mosviz.yaml"
     elif path == 'specviz2d':
         path = default_path / "specviz2d" / "specviz2d.yaml"
+    elif path == 'imviz':
+        path = default_path / "imviz" / "imviz.yaml"
     elif not os.path.isfile(path):
         raise ValueError("Configuration must be path to a .yaml file.")
 

--- a/notebooks/concepts/Imviz concept notebook.ipynb
+++ b/notebooks/concepts/Imviz concept notebook.ipynb
@@ -1,0 +1,69 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "with warnings.catch_warnings():\n",
+    "    warnings.simplefilter('ignore')\n",
+    "\n",
+    "    from jdaviz import Imviz\n",
+    "    imviz = Imviz()\n",
+    "\n",
+    "imviz.app"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.utils.data import download_file\n",
+    "\n",
+    "filename = download_file('http://data.astropy.org/photometry/spitzer_example_image.fits', cache=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz.load_data(filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/concepts/concept_programmatic_viewers_from_blank_default.ipynb
+++ b/notebooks/concepts/concept_programmatic_viewers_from_blank_default.ipynb
@@ -8,7 +8,7 @@
     "Start with a blank default application and programmatically add views and data to those views\n",
     "\n",
     "### Use Case\n",
-    "Progammatically load a single FITS file, e.g. for 2d spectroscopic data, into an \"image\" viewer.  Or a 1d spectrum into a spectrum viewer.  For cases that do not fit into a given pre-made configuration. \n",
+    "Programmatically load a single FITS file, e.g. for 2d spectroscopic data, into an \"image\" viewer.  Or a 1d spectrum into a spectrum viewer.  For cases that do not fit into a given pre-made configuration. \n",
     "\n",
     "### MAST Use Case\n",
     "MAST auto-generates notebooks that when users run, needs to download the data, create the relevant jdaviz application / viewers, and load the data by default. One click run gets the user back to where they were on the web."
@@ -16,22 +16,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<style>.container { width:75% !important; }</style>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from IPython.core.display import display, HTML\n",
     "display(HTML(\"<style>.container { width:75% !important; }</style>\"))"
@@ -39,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,26 +53,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b7949170270f421ba9429cab2477b53d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Application(components={'g-viewer-tab': '<template>\\n  <component :is=\"stack.container\">\\n    <g-viewer-tab\\n …"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "app = Application('default')\n",
     "app"
@@ -100,18 +72,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/bcherinka/anaconda3/envs/havokve/lib/python3.8/site-packages/glue/core/data_factories/fits.py:152: UserWarning: Dropping column 'ASDF_METADATA' since it is not 1-dimensional\n",
-      "  warnings.warn(\"Dropping column '{0}' since it is not 1-dimensional\".format(column_name))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "app.load_data(data)\n",
     "\n",
@@ -122,25 +85,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DataCollection (5 data sets)\n",
-       "\t  0: jw00626-o030_s00000_nirspec_f170lp-g235m_s2d[SCI]\n",
-       "\t  1: jw00626-o030_s00000_nirspec_f170lp-g235m_s2d[WHT]\n",
-       "\t  2: jw00626-o030_s00000_nirspec_f170lp-g235m_s2d[CON]\n",
-       "\t  3: jw00626-o030_s00000_nirspec_f170lp-g235m_s2d[HDRTAB]\n",
-       "\t  4: jw00626-o030_s00000_nirspec_f170lp-g235m_s2d[ASDF]"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# what label did my data get?  dig around in docs to understand data_collection.  How do I define custom data labels?\n",
     "app.data_collection\n",
@@ -151,20 +98,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'jw00626-o030_s00000_nirspec_f170lp-g235m_s2d[SCI]'"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# get a label\n",
     "label = app.data_collection[0].label\n",
@@ -180,23 +116,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "'NoneType' object is not subscriptable",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-17-150964480149>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# naively try image-viewer\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mapp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_viewer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'image-viewer'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;31m# also try\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;31m#app.get_viewer('g-image-viewer')\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Work/git/havok2063/jdaviz/jdaviz/app.py\u001b[0m in \u001b[0;36mget_viewer\u001b[0;34m(self, viewer_reference)\u001b[0m\n\u001b[1;32m    322\u001b[0m             \u001b[0mThe\u001b[0m \u001b[0mviewer\u001b[0m \u001b[0;32mclass\u001b[0m \u001b[0minstance\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    323\u001b[0m         \"\"\"\n\u001b[0;32m--> 324\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_viewer_by_reference\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mviewer_reference\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    325\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    326\u001b[0m     def get_data_from_viewer(self, viewer_reference, data_label=None,\n",
-      "\u001b[0;32m~/Work/git/havok2063/jdaviz/jdaviz/app.py\u001b[0m in \u001b[0;36m_viewer_by_reference\u001b[0;34m(self, reference)\u001b[0m\n\u001b[1;32m    750\u001b[0m         \u001b[0mviewer_item\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_viewer_item_by_reference\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mreference\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    751\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 752\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_viewer_store\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mviewer_item\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'id'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    753\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    754\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_viewer_item_by_reference\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreference\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mTypeError\u001b[0m: 'NoneType' object is not subscriptable"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# naively try to get \"image-viewer\". ; throws error\n",
     "app.get_viewer('image-viewer')\n",
@@ -211,22 +133,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "'NoneType' object is not subscriptable",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-18-0f7c03d3ef26>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# let's try to add data anyways\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mapp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madd_data_to_viewer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'image-viewer'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/Work/git/havok2063/jdaviz/jdaviz/app.py\u001b[0m in \u001b[0;36madd_data_to_viewer\u001b[0;34m(self, viewer_reference, data_path, clear_other_data, ext)\u001b[0m\n\u001b[1;32m    618\u001b[0m         \u001b[0mdata_id\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_data_id_from_label\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata_label\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    619\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 620\u001b[0;31m         \u001b[0mdata_ids\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mviewer_item\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'selected_data_items'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;31m \u001b[0m\u001b[0;31m\\\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    621\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mclear_other_data\u001b[0m \u001b[0;32melse\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    622\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mTypeError\u001b[0m: 'NoneType' object is not subscriptable"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# let's try to add data anyways - throws same error\n",
     "app.add_data_to_viewer('image-viewer', data, ext='SCI')"
@@ -241,20 +150,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<jdaviz.core.registries.ViewerRegistry at 0x7ffa693f4e50>"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# look in the viewer registry\n",
     "from jdaviz.core.registries import tool_registry, viewer_registry\n",
@@ -263,37 +161,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'cubeviz-image-viewer': {'label': 'Image 2D (CubeViz)',\n",
-       "  'cls': jdaviz.configs.cubeviz.plugins.viewers.CubeVizImageView},\n",
-       " 'g-profile-viewer': {'label': 'Profile 1D',\n",
-       "  'cls': glue_jupyter.bqplot.profile.viewer.BqplotProfileView},\n",
-       " 'g-image-viewer': {'label': 'Image 2D',\n",
-       "  'cls': glue_jupyter.bqplot.image.viewer.BqplotImageView},\n",
-       " 'g-table-viewer': {'label': 'Table',\n",
-       "  'cls': glue_jupyter.table.viewer.TableViewer},\n",
-       " 'specviz-profile-viewer': {'label': 'Profile 1D (Specviz)',\n",
-       "  'cls': jdaviz.configs.specviz.plugins.viewers.SpecvizProfileView},\n",
-       " 'mosviz-profile-viewer': {'label': 'Profile 1D (MOSViz)',\n",
-       "  'cls': jdaviz.configs.mosviz.plugins.viewers.MOSVizProfileView},\n",
-       " 'mosviz-image-viewer': {'label': 'Image 2D (MOSViz)',\n",
-       "  'cls': jdaviz.configs.mosviz.plugins.viewers.MOSVizImageView},\n",
-       " 'mosviz-profile-2d-viewer': {'label': 'Spectrum 2D (MOSViz)',\n",
-       "  'cls': jdaviz.configs.mosviz.plugins.viewers.MOSVizProfile2DView},\n",
-       " 'mosviz-table-viewer': {'label': 'Table (MOSViz)',\n",
-       "  'cls': jdaviz.configs.mosviz.plugins.viewers.MOSVizTableViewer}}"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# I can find all viewers in the registry. But these dict keys are not reference names.  \n",
     "viewer_registry.members"
@@ -301,23 +171,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "'NoneType' object is not subscriptable",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-21-054cb71476e8>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# oh I see my Image 2d == \"g-image-viewer\".  Let me try that.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mapp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_viewer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'g-image-viewer'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/Work/git/havok2063/jdaviz/jdaviz/app.py\u001b[0m in \u001b[0;36mget_viewer\u001b[0;34m(self, viewer_reference)\u001b[0m\n\u001b[1;32m    322\u001b[0m             \u001b[0mThe\u001b[0m \u001b[0mviewer\u001b[0m \u001b[0;32mclass\u001b[0m \u001b[0minstance\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    323\u001b[0m         \"\"\"\n\u001b[0;32m--> 324\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_viewer_by_reference\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mviewer_reference\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    325\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    326\u001b[0m     def get_data_from_viewer(self, viewer_reference, data_label=None,\n",
-      "\u001b[0;32m~/Work/git/havok2063/jdaviz/jdaviz/app.py\u001b[0m in \u001b[0;36m_viewer_by_reference\u001b[0;34m(self, reference)\u001b[0m\n\u001b[1;32m    750\u001b[0m         \u001b[0mviewer_item\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_viewer_item_by_reference\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mreference\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    751\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 752\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_viewer_store\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mviewer_item\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'id'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    753\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    754\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_viewer_item_by_reference\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreference\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mTypeError\u001b[0m: 'NoneType' object is not subscriptable"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# oh I see my \"Image 2D\" == \"g-image-viewer\".  That must be the reference name.  Let me try that, to get the viewer.\n",
     "app.get_viewer('g-image-viewer')"
@@ -332,20 +188,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'6501402f-bb03-4fd5-b8da-1b4241daf66b': <glue_jupyter.bqplot.image.viewer.BqplotImageView at 0x7ffa6a9fd400>}"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# look up the viewer store.  I see my viewer with a viewer id. \n",
     "app._viewer_store"
@@ -353,20 +198,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<CallbackList with 1 elements>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# examine the application stack of items\n",
     "app.state.stack_items"
@@ -374,28 +208,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "item dict_keys(['id', 'container', 'children', 'viewers'])\n",
-      "viewer dict_keys(['id', 'name', 'widget', 'tools', 'layer_options', 'viewer_options', 'selected_data_items', 'collapse', 'reference', 'tab'])\n",
-      "id 6501402f-bb03-4fd5-b8da-1b4241daf66b\n",
-      "name Unnamed Viewer\n",
-      "widget IPY_MODEL_2000302c0e344576b421f3f18cf8ba6e\n",
-      "tools IPY_MODEL_f4c490d6cc2e4b31893e6c2b4c4f5062\n",
-      "layer_options IPY_MODEL_75dae667d8454464a286b39ff444a678\n",
-      "viewer_options IPY_MODEL_4772c7d7dddd428a9533f6877ac18183\n",
-      "selected_data_items <CallbackList with 0 elements>\n",
-      "collapse True\n",
-      "reference None\n",
-      "tab 0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# loop over all the items in the application stack and print the data\n",
     "for i in app.state.stack_items:\n",
@@ -408,20 +223,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<CallbackDict with 10 elements>"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# now I have the viewer, I think.  The repr here should be improved to more obvious.\n",
     "viewer"
@@ -429,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -439,22 +243,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "'NoneType' object is not subscriptable",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-26-a064275d0fa4>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# try to add data by id\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mapp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madd_data_to_viewer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mid\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlabel\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/Work/git/havok2063/jdaviz/jdaviz/app.py\u001b[0m in \u001b[0;36madd_data_to_viewer\u001b[0;34m(self, viewer_reference, data_path, clear_other_data, ext)\u001b[0m\n\u001b[1;32m    618\u001b[0m         \u001b[0mdata_id\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_data_id_from_label\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata_label\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    619\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 620\u001b[0;31m         \u001b[0mdata_ids\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mviewer_item\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'selected_data_items'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;31m \u001b[0m\u001b[0;31m\\\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    621\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mclear_other_data\u001b[0m \u001b[0;32melse\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    622\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mTypeError\u001b[0m: 'NoneType' object is not subscriptable"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# try to add data by id.  Still same error as above.\n",
     "app.add_data_to_viewer(id, label)"
@@ -462,20 +253,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<CallbackDict with 10 elements>"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# I notice in the stack that no reference name is indicated.  Let's add one.\n",
     "view = app._viewer_item_by_id(id)\n",
@@ -485,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -495,22 +275,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AttributeError",
-     "evalue": "'BqplotImageView' object has no attribute 'default_class'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-29-fbe0cf679ac6>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# can I access the data back out\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mapp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_data_from_viewer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'image-viewer'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/Work/git/havok2063/jdaviz/jdaviz/app.py\u001b[0m in \u001b[0;36mget_data_from_viewer\u001b[0;34m(self, viewer_reference, data_label, cls, include_subsets)\u001b[0m\n\u001b[1;32m    364\u001b[0m         \"\"\"\n\u001b[1;32m    365\u001b[0m         \u001b[0mviewer\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_viewer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mviewer_reference\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 366\u001b[0;31m         \u001b[0mcls\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mviewer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault_class\u001b[0m \u001b[0;32mif\u001b[0m \u001b[0mcls\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m'default'\u001b[0m \u001b[0;32melse\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    367\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    368\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mcls\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0misclass\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcls\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAttributeError\u001b[0m: 'BqplotImageView' object has no attribute 'default_class'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# can I access the data back out? \n",
     "app.get_data_from_viewer('image-viewer')"
@@ -526,24 +293,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "114e532d0e944ecc8845b0c5adeb06e9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Application(components={'g-viewer-tab': '<template>\\n  <component :is=\"stack.container\">\\n    <g-viewer-tab\\n …"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "app = Application()\n",
     "app"
@@ -558,37 +310,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'cubeviz-image-viewer': {'label': 'Image 2D (CubeViz)',\n",
-       "  'cls': jdaviz.configs.cubeviz.plugins.viewers.CubeVizImageView},\n",
-       " 'g-profile-viewer': {'label': 'Profile 1D',\n",
-       "  'cls': glue_jupyter.bqplot.profile.viewer.BqplotProfileView},\n",
-       " 'g-image-viewer': {'label': 'Image 2D',\n",
-       "  'cls': glue_jupyter.bqplot.image.viewer.BqplotImageView},\n",
-       " 'g-table-viewer': {'label': 'Table',\n",
-       "  'cls': glue_jupyter.table.viewer.TableViewer},\n",
-       " 'specviz-profile-viewer': {'label': 'Profile 1D (Specviz)',\n",
-       "  'cls': jdaviz.configs.specviz.plugins.viewers.SpecvizProfileView},\n",
-       " 'mosviz-profile-viewer': {'label': 'Profile 1D (MOSViz)',\n",
-       "  'cls': jdaviz.configs.mosviz.plugins.viewers.MOSVizProfileView},\n",
-       " 'mosviz-image-viewer': {'label': 'Image 2D (MOSViz)',\n",
-       "  'cls': jdaviz.configs.mosviz.plugins.viewers.MOSVizImageView},\n",
-       " 'mosviz-profile-2d-viewer': {'label': 'Spectrum 2D (MOSViz)',\n",
-       "  'cls': jdaviz.configs.mosviz.plugins.viewers.MOSVizProfile2DView},\n",
-       " 'mosviz-table-viewer': {'label': 'Table (MOSViz)',\n",
-       "  'cls': jdaviz.configs.mosviz.plugins.viewers.MOSVizTableViewer}}"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# how do I know what viewers are available to add?  Use the viewer registry I dug around in the code to find.\n",
     "viewer_registry.members\n",
@@ -607,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -623,18 +347,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/bcherinka/anaconda3/envs/havokve/lib/python3.8/site-packages/glue/core/data_factories/fits.py:152: UserWarning: Dropping column 'ASDF_METADATA' since it is not 1-dimensional\n",
-      "  warnings.warn(\"Dropping column '{0}' since it is not 1-dimensional\".format(column_name))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# ok, I created a viewer.  Now have same problem as option 1\n",
     "app.load_data(data)"
@@ -642,20 +357,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'c3906bad-0c1f-4e80-8be2-83984a01d3ed': <glue_jupyter.bqplot.image.viewer.BqplotImageView at 0x7ffa6ac45c10>}"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# look for the viewer in the store\n",
     "app._viewer_store"
@@ -663,22 +367,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "'NoneType' object is not subscriptable",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-35-6ac80fb87974>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mapp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madd_data_to_viewer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'image-viewer'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/Work/git/havok2063/jdaviz/jdaviz/app.py\u001b[0m in \u001b[0;36madd_data_to_viewer\u001b[0;34m(self, viewer_reference, data_path, clear_other_data, ext)\u001b[0m\n\u001b[1;32m    618\u001b[0m         \u001b[0mdata_id\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_data_id_from_label\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata_label\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    619\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 620\u001b[0;31m         \u001b[0mdata_ids\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mviewer_item\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'selected_data_items'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;31m \u001b[0m\u001b[0;31m\\\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    621\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mclear_other_data\u001b[0m \u001b[0;32melse\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    622\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mTypeError\u001b[0m: 'NoneType' object is not subscriptable"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# attempt to add the data with naive reference name\n",
     "app.add_data_to_viewer('image-viewer', data, ext='SCI') "
@@ -686,25 +377,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "id c3906bad-0c1f-4e80-8be2-83984a01d3ed\n",
-      "name Unnamed Viewer\n",
-      "widget IPY_MODEL_288b6451c3784849a16055ef99d44e41\n",
-      "tools IPY_MODEL_b01dcb73142d4970a285fe0f48a3d39d\n",
-      "layer_options IPY_MODEL_a4ee8df437514ba784c3342839b0fa63\n",
-      "viewer_options IPY_MODEL_19604f2888394ef195438de35ea9134e\n",
-      "selected_data_items <CallbackList with 0 elements>\n",
-      "collapse True\n",
-      "reference None\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# grab the viewer information\n",
     "id = next(iter(app._viewer_store))\n",
@@ -715,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -725,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -743,31 +418,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'settings': {'visible': {'menu_bar': False,\n",
-       "   'toolbar': True,\n",
-       "   'tray': True,\n",
-       "   'tab_headers': True},\n",
-       "  'context': {'notebook': {'max_height': '600px'}}},\n",
-       " 'toolbar': ['g-data-tools', 'g-viewer-creator', 'g-subset-tools'],\n",
-       " 'tray': ['g-gaussian-smooth'],\n",
-       " 'viewer_area': [{'container': 'col',\n",
-       "   'children': [{'container': 'row',\n",
-       "     'viewers': [{'name': 'Image',\n",
-       "       'plot': 'g-image-viewer',\n",
-       "       'reference': 'image-viewer'}]}]}]}"
-      ]
-     },
-     "execution_count": 39,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from jdaviz.core.helpers import ConfigHelper\n",
     "from jdaviz.core.config import get_configuration\n",
@@ -792,55 +445,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "21d269258cd84446ac013628373e76e1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Application(components={'g-viewer-tab': '<template>\\n  <component :is=\"stack.container\">\\n    <g-viewer-tab\\n …"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# set my custom config object to the default configuration.  I could also just use Application(config) so \n",
     "# what does the ConfigHelper gain me, the user?  Would be nice to have default data loading. \n",
-    "class ImViz(ConfigHelper):\n",
+    "class MyImviz(ConfigHelper):\n",
     "    _default_configuration = config\n",
     "\n",
-    "im = ImViz()\n",
+    "im = MyImviz()\n",
     "im.app"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/bcherinka/anaconda3/envs/havokve/lib/python3.8/site-packages/glue/core/data_factories/fits.py:152: UserWarning: Dropping column 'ASDF_METADATA' since it is not 1-dimensional\n",
-      "  warnings.warn(\"Dropping column '{0}' since it is not 1-dimensional\".format(column_name))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "im.load_data(data)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -875,7 +504,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ include_package_data = True
 python_requires = >=3.6
 setup_requires = setuptools_scm
 install_requires =
-    pytest<6.0
     astropy
     traitlets<5.0
     glue-core>=1.0.1
@@ -35,11 +34,13 @@ install_requires =
     click
     spectral-cube>=0.5
     asteval
+    astrowidgets
     # vispy is an indirect dependency, but older vispy's don't play nice with jdaviz install
     vispy>=0.6.5
 
 [options.extras_require]
 test =
+    pytest
     pytest-astropy
     pytest-tornasync
 docs =
@@ -60,6 +61,7 @@ jdaviz_plugins =
     cubeviz = jdaviz.configs.cubeviz
     specviz = jdaviz.configs.specviz
     mosviz = jdaviz.configs.mosviz
+    imviz = jdaviz.configs.imviz
 
 [tool:pytest]
 testpaths = "jdaviz" "docs"


### PR DESCRIPTION
For JDAT-1192 .

Current thoughts: Despite that was told, I think the `jdaviz` machinery depends too much on Glue. I am not confident that you can just drop `astrowidgets` in there without significant refactoring.

## TODO

- [x] Release new `astrowidgets` version so we can pick it off PyPI. (Released 0.2.0)
- [x] Investigate error from viewer. (See **Error** below.) -- Ricky fixed it. Thanks, Ricky!
- [x] Resolve incompatibility between dev versions of `astrowidgets` and Ginga (ejeschke/ginga#925).
- [ ] Investigate why it says data loaded but nothing is showing. Maybe some of the dummy classes need to be filled in with real code but I will need a Glue expert to help here.
- [ ] I still don't see the point of this. The data flow is too complicated: `Image -> app (Glue) -> image viewer (astrowidgets/Ginga with lots of hacks) -> Glue internals`
  - If you want the interactive portion to be handled by astrowidgets, how do you send the data back and forth? Right now, the data gets sent to Glue and then that's it. I don't know how to get it back.

### Error

<details>
  <summary>Traceback (outdated)</summary>

```
../jdaviz/core/helpers.py in load_data(self, data, parser_reference, **kwargs)
     35 
     36     def load_data(self, data, parser_reference=None, **kwargs):
---> 37         self.app.load_data(data, parser_reference=parser_reference, **kwargs)

.../jdaviz/app.py in load_data(self, file_obj, parser_reference, **kwargs)
    295             # If the parser returns something other than known, assume it's
    296             #  a message we want to make the user aware of.
--> 297             msg = parser(self, file_obj, **kwargs)
    298 
    299             if msg is not None:

.../jdaviz/configs/imviz/plugins/parsers.py in imviz_image_parser(app, data, data_label, show_in_viewer)
     24         raise FileNotFoundError(f"No such file: {path}")
     25 
---> 26     app.add_data(data, data_label)
     27     if show_in_viewer:
     28         app.add_data_to_viewer("image-viewer", data_label)

.../jdaviz/app.py in add_data(self, data, data_label)
    570         # Include the data in the data collection
    571         data_label = data_label or "New Data"
--> 572         self.data_collection[data_label] = data
    573 
    574         # Send out a toast message

.../glue/core/data_collection.py in __setitem__(self, key, data)
    380         if not isinstance(data, Data):
    381 
--> 382             handler, preferred = data_translator.get_handler_for(data)
    383 
    384             data = handler.to_data(data)

.../glue/config.py in get_handler_for(self, data_or_class)
    564                                 "type Data to {0}".format(data_or_class.__name__))
    565             else:
--> 566                 raise TypeError("Could not find a class to translate objects of "
    567                                 "type {0} to Data".format(data_or_class.__class__.__name__))
    568         return handler, preferred

TypeError: Could not find a class to translate objects of type ndarray to Data
```

</details>