### PR TITLE
MNT: This shows all the PEP 8 violations, except explicitly ignored

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,8 @@ addopts = --doctest-rst
 
 [flake8]
 max-line-length = 100
-select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E502,E722,E901,E902
+# E402: Module level import not at top of file
+ignore = E402
 
 [coverage:run]
 omit =


### PR DESCRIPTION
Fix #400 and a little more.