### PR TITLE
Refactor specviz2d parser

### DIFF
--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -92,7 +92,8 @@ def mos_spec1d_parser(app, data_obj, data_labels=None):
 
 
 @data_parser_registry("mosviz-spec2d-parser")
-def mos_spec2d_parser(app, data_obj, data_labels=None):
+def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
+                      show_in_viewer=False):
     """
     Attempts to parse a 2D spectrum object.
 
@@ -186,7 +187,14 @@ def mos_spec2d_parser(app, data_obj, data_labels=None):
     for i in range(len(data_obj)):
         app.data_collection[data_labels[i]] = data_obj[i]
 
-    _add_to_table(app, data_labels, '2D Spectra')
+    if show_in_viewer:
+        if len(data_labels) > 1:
+            raise ValueError("More than one data label provided, unclear " +
+                             "which to show in viewer")
+        app.add_data_to_viewer("spectrum-2d-viewer", data_labels[0])
+
+    if add_to_table:
+        _add_to_table(app, data_labels, '2D Spectra')
 
 
 @data_parser_registry("mosviz-image-parser")

--- a/jdaviz/configs/specviz2d/helper.py
+++ b/jdaviz/configs/specviz2d/helper.py
@@ -126,9 +126,10 @@ class Specviz2d(ConfigHelper):
             spectrum_1d_label = spectrum_2d_label.replace("2D", "1D")
 
         if spectrum_2d is not None:
-            self.app.load_data(spectrum_2d, parser_reference="spec2d-parser",
-                               data_label=spectrum_2d_label,
-                               show_in_viewer=show_in_viewer)
+            self.app.load_data(spectrum_2d, parser_reference="mosviz-spec2d-parser",
+                               data_labels=spectrum_2d_label,
+                               show_in_viewer=show_in_viewer,
+                               add_to_table=False)
             # Collapse the 2D spectrum to 1D if no 1D spectrum provided
             if spectrum_1d is None:
                 self.app.load_data(spectrum_2d,

--- a/jdaviz/configs/specviz2d/plugins/parsers.py
+++ b/jdaviz/configs/specviz2d/plugins/parsers.py
@@ -12,69 +12,10 @@ import logging
 from astropy.wcs import WCS
 from pathlib import Path
 
-__all__ = ['spec2d_parser']
+__all__ = ['spec2d_1d_parser']
 
 def _check_is_file(path):
     return isinstance(path, str) and Path(path).is_file()
-
-@data_parser_registry("spec2d-parser")
-def spec2d_parser(app, data_obj, data_label=None, show_in_viewer=True):
-    """
-    Attempts to parse a 2D spectrum object.
-
-    Notes
-    -----
-    This currently only works with JWST-type data in which the data is in the
-    second hdu of the fits file.
-
-    Parameters
-    ----------
-    app : `~jdaviz.app.Application`
-        The application-level object used to reference the viewers.
-    data_obj : str or list or spectrum-like
-        File path, list, or spectrum-like object to be read as a new row in
-        the mosviz table.
-    data_labels : str, optional
-        The label applied to the glue data component.
-    """
-    # In the case where the data object is a string, attempt to parse it as
-    #  a fits file.
-    # TODO: this current does not handle the case where the file in the path is
-    #  anything but a fits file whose wcs can be extracted.
-    def _parse_as_ccddata(path):
-        with fits.open(path) as hdulist:
-            data = hdulist[1].data
-            header = hdulist[1].header
-            data = data * u.Unit(header['BUNIT'])
-            wcs = WCS(header)
-
-        return CCDData(data, wcs=wcs)
-
-    def _parse_as_cube(path):
-        with fits.open(path) as hdulist:
-            data = hdulist[1].data
-            header = hdulist[1].header
-            if header['NAXIS'] == 2:
-                new_data = np.expand_dims(data, axis=1)
-                header['NAXIS'] = 3
-
-            header['NAXIS3'] = 1
-            header['BUNIT'] = 'dN/s'
-            header['CUNIT3'] = 'um'
-            wcs = WCS(header)
-
-            meta = {'S_REGION': header['S_REGION']}
-
-        return SpectralCube(new_data, wcs=wcs, meta=meta)
-
-    if _check_is_file(data_obj):
-        # data_obj = _parse_as_ccddata(data_obj)
-        data_obj = _parse_as_cube(data_obj)
-
-    app.data_collection[data_label] = data_obj
-
-    if show_in_viewer:
-        app.add_data_to_viewer("spectrum-2d-viewer", data_label)
 
 @data_parser_registry("spec2d-1d-parser")
 def spec2d_1d_parser(app, data_obj, data_label=None, show_in_viewer=True):


### PR DESCRIPTION
Minor edits to the Mosviz 2d parser to enable Specviz2d to use it instead of using a mostly duplicate parser, to ease maintainability and specifically enable Specviz2d to take advantage of #377 . 