### PR TITLE
Fixes for specviz2d configuration and helper

### DIFF
--- a/jdaviz/configs/specviz2d/helper.py
+++ b/jdaviz/configs/specviz2d/helper.py
@@ -11,8 +11,8 @@ class Specviz2d(ConfigHelper):
 
     _default_configuration = "specviz2d"
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         spec1d = self.app.get_viewer("spectrum-viewer")
         spec1d.scales['x'].observe(self._update_spec2d_x_axis)

--- a/jdaviz/configs/specviz2d/specviz2d.yaml
+++ b/jdaviz/configs/specviz2d/specviz2d.yaml
@@ -1,5 +1,5 @@
 settings:
-  configuration: mosviz
+  configuration: specviz2d
   visible:
     menu_bar: false
     toolbar: true


### PR DESCRIPTION
This PR fixes the `specviz2d` configuration name which was previously set as `mosviz`.  It also adds args and kwargs into the `Specviz2d` helper class to enable passing in an `app` object, similar to the other helpers.  This was useful for MAST app/helper logic.  For example
```
app = Application(configuration=custom_specviz2d_config)
helper = Specviz2d(app)
```
