### PR TITLE
perf: use entrypoints package which is 10x faster

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -8,10 +8,10 @@ from inspect import isclass
 import ipywidgets as w
 import numpy as np
 from astropy import units as u
-import pkg_resources
 from astropy.nddata import CCDData
 from spectral_cube import SpectralCube
 from echo import CallbackProperty, DictCallbackProperty, ListCallbackProperty
+import entrypoints
 from ipygoldenlayout import GoldenLayout
 from ipysplitpanes import SplitPanes
 from traitlets import Dict
@@ -139,7 +139,7 @@ class Application(VuetifyTemplate, HubListener):
         plugins = {
             entry_point.name: entry_point.load()
             for entry_point
-            in pkg_resources.iter_entry_points(group='jdaviz_plugins')}
+            in entrypoints.get_group_all(group='jdaviz_plugins')}
 
         # Create a dictionary for holding non-ipywidget viewer objects so we
         #  can reference their state easily since glue does not store viewers

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     asteval
     # vispy is an indirect dependency, but older vispy's don't play nice with jdaviz install
     vispy>=0.6.5
+    entrypoints
 
 [options.extras_require]
 test =


### PR DESCRIPTION
`pkg_resoruces.iter_entry_points` is quite slow, and the entrypoints is a replacement package that performs much better:

Profiled using:
```python
with VizTracer(output_file="cubeviz-no-notebook.html"):
    app = Application(configuration='cubeviz')
```
We see before we spend 1.3 seconds on loading the entry points (0.66 without the overhead of VizTracer):
![image](https://user-images.githubusercontent.com/1765949/108498548-55d71600-72ad-11eb-9966-b6f27302a666.png)
(Note that viztracer discarded the data in the beginning, since it overflowed the ring buffer)

Using entrypoints less than 0.175 seconds, since we now see overhead of other things in the constructor:
![image](https://user-images.githubusercontent.com/1765949/108499215-3ee4f380-72ae-11eb-8718-1cb79a24cf89.png)

This makes loading the plugins about 10x faster.
