### PR TITLE
Link subsequent data world coords to only the first compatible

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -236,13 +236,18 @@ class Application(VuetifyTemplate, HubListener):
         """
         new_len = len(self.data_collection)
         # Can't link if there's no world_component_ids
-        if self.data_collection[new_len-1].world_component_ids == []:
+        wc_new = self.data_collection[new_len-1].world_component_ids
+        if wc_new == []:
             return
+
+        # Link to the first dataset with compatible coordinates
         for i in range(0, new_len-1):
-            if self.data_collection[i].world_component_ids == []:
+            wc_old = self.data_collection[i].world_component_ids
+            if wc_old == []:
                 continue
-            self.data_collection.add_link(LinkSame(self.data_collection[i].world_component_ids[0],
-                                          self.data_collection[new_len-1].world_component_ids[0]))
+            else:
+                self.data_collection.add_link(LinkSame(wc_old[0], wc_new[0]))
+                break
 
     def load_data(self, file_obj, parser_reference=None, **kwargs):
         """

--- a/jdaviz/configs/default/plugins/collapse/tests/test_collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/tests/test_collapse.py
@@ -33,21 +33,21 @@ def test_linking_after_collapse(spectral_cube_wcs):
 
     assert len(dc) == 3
     assert dc[2].label == 'Collapsed 2 test'
-    assert len(dc.external_links) == 7
+    assert len(dc.external_links) == 6
 
-    assert dc.external_links[5].cids1[0] is dc[0].pixel_component_ids[0]
-    assert dc.external_links[5].cids2[0] is dc[2].pixel_component_ids[0]
-    assert dc.external_links[6].cids1[0] is dc[0].pixel_component_ids[2]
-    assert dc.external_links[6].cids2[0] is dc[2].pixel_component_ids[1]
+    assert dc.external_links[4].cids1[0] is dc[0].pixel_component_ids[0]
+    assert dc.external_links[4].cids2[0] is dc[2].pixel_component_ids[0]
+    assert dc.external_links[5].cids1[0] is dc[0].pixel_component_ids[2]
+    assert dc.external_links[5].cids2[0] is dc[2].pixel_component_ids[1]
 
     coll.selected_axis = 2
     coll.vue_collapse()
 
     assert len(dc) == 4
     assert dc[3].label == 'Collapsed 3 test'
-    assert len(dc.external_links) == 12
+    assert len(dc.external_links) == 9
 
-    assert dc.external_links[10].cids1[0] is dc[0].pixel_component_ids[0]
-    assert dc.external_links[10].cids2[0] is dc[3].pixel_component_ids[0]
-    assert dc.external_links[11].cids1[0] is dc[0].pixel_component_ids[1]
-    assert dc.external_links[11].cids2[0] is dc[3].pixel_component_ids[1]
+    assert dc.external_links[7].cids1[0] is dc[0].pixel_component_ids[0]
+    assert dc.external_links[7].cids2[0] is dc[3].pixel_component_ids[0]
+    assert dc.external_links[8].cids1[0] is dc[0].pixel_component_ids[1]
+    assert dc.external_links[8].cids2[0] is dc[3].pixel_component_ids[1]


### PR DESCRIPTION
Thanks to @astrofrog for pointing out that we don't need to link every dataset to every other dataset, we can just link all subsequent data to the first. This change makes the performance scale linearly instead of exponentially as more datasets are added, which vastly improves the behavior of #394 and also helps in cases of loading large quantities of data into Specviz. We'll likely want to do some follow up work to further restrict when things get linked, since I don't think we need to link the spectra at all in the Mosviz case. 