### PR TITLE
Fix gaussian smooth bug

### DIFF
--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -75,7 +75,16 @@ class GaussianSmooth(TemplateMixin):
         # define a standard deviation for gaussian smoothing
         spec_smoothed = gaussian_smooth(spec, stddev=size)
 
-        label = f"Smoothed {self._selected_data.label}"
+        label = f"Smoothed {self._selected_data.label} stddev {size}"
+
+        if label in self.data_collection:
+            snackbar_message = SnackbarMessage(
+                "Data with selected stddev already exists, canceling operation.",
+                color="error",
+                sender=self)
+            self.hub.broadcast(snackbar_message)
+
+            return
 
         self.data_collection[label] = spec_smoothed
 
@@ -112,7 +121,16 @@ class GaussianSmooth(TemplateMixin):
                                mask=cube.mask, meta=cube.meta,
                                fill_value=cube.fill_value)
 
-        label = f"Smoothed {self._selected_data.label}"
+        label = f"Smoothed {self._selected_data.label} spatial stddev {size}"
+
+        if label in self.data_collection:
+            snackbar_message = SnackbarMessage(
+                "Data with selected stddev already exists, canceling operation.",
+                color="error",
+                sender=self)
+            self.hub.broadcast(snackbar_message)
+
+            return
 
         self.data_collection[label] = newcube
 

--- a/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
@@ -20,7 +20,7 @@ def test_linking_after_spectral_smooth(spectral_cube_wcs):
     gs.vue_spectral_smooth()
 
     assert len(dc) == 2
-    assert dc[1].label == 'Smoothed test'
+    assert dc[1].label == 'Smoothed test stddev 3.2'
     assert len(dc.external_links) == 1
 
     assert dc.external_links[0].cids1[0] is dc[0].world_component_ids[0]
@@ -39,5 +39,5 @@ def test_spatial_convolution(spectral_cube_wcs):
     gs.vue_spatial_convolution()
 
     assert len(dc) == 2
-    assert dc[1].label == "Smoothed test"
-    assert dc["Smoothed test"].get_object(cls=SpectralCube).shape == (3, 4, 5)
+    assert dc[1].label == "Smoothed test spatial stddev 3.0"
+    assert dc["Smoothed test spatial stddev 3.0"].get_object(cls=SpectralCube).shape == (3, 4, 5)


### PR DESCRIPTION
Fixes #438 

The solution adds the standard deviation and type of smoothing to the label, and cancels the smoothing operation if that label already exists. This way, the user can use Gaussian Smooth multiple times and not crash the application.