### PR TITLE
MNT: Unpin max versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ python_requires = >=3.6
 setup_requires = setuptools_scm
 install_requires =
     astropy
-    traitlets<5.0
+    traitlets
     glue-core>=1.0.1
     glue-jupyter>=0.2.1
     echo>=0.5.0
@@ -27,7 +27,7 @@ install_requires =
     ipyvuetify>=1.4.1
     ipysplitpanes
     ipygoldenlayout>=0.3.0
-    voila>=0.2,<0.3
+    voila>=0.2
     pyyaml
     specutils@git+https://github.com/astropy/specutils.git@625e05499386e4c48467a4a141d6763e9147fcbc
     glue-astronomy
@@ -74,7 +74,7 @@ max-line-length = 100
 # E126: continuation line over-indented for hanging indent
 # E226: missing whitespace around arithmetic operator
 # E402: Module level import not at top of file
-# W503: line break before binary operator 
+# W503: line break before binary operator
 # W504: line break after binary operator
 ignore = E123,E126,E226,E402,W503,W504
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
     pep517
 requires =
     setuptools >= 30.3.0
-    pip >= 19.3.1, < 20.0.0
+    pip >= 19.3.1
 isolated_build = true
 indexserver =
     NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple


### PR DESCRIPTION
It is just gonna come back and bite us. Except for `traitlets`, I cannot find any documentation on why these are pinned to older versions.

As for `traitlets`, https://github.com/mariobuikhuizen/ipyvue/issues/18#issuecomment-785790175 says it is no longer a problem.

Close #345