### PR TITLE
ENH: Add --browser option to CLI

### DIFF
--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -21,7 +21,13 @@ CONFIGS_DIR = os.path.join(os.path.dirname(__file__), 'configs')
               type=click.Choice(['default', 'cubeviz', 'specviz', 'mosviz'],
                                 case_sensitive=False),
               help="Configuration to use on application startup")
-def main(filename, layout='default'):
+@click.option('--browser',
+              default='default',
+              nargs=1,
+              show_default=True,
+              type=str,
+              help="Browser to use for application")
+def main(filename, layout='default', browser='default'):
     """
     Start a JDAViz application instance with data loaded from FILENAME.\f
 
@@ -31,6 +37,8 @@ def main(filename, layout='default'):
         The path to the file to be loaded into the JDAViz application.
     layout : str, optional
         Optional specification for which configuration to use on startup.
+    browser : str, optional
+        Path to browser executable.
     """
     # Tornado Webserver py3.8 compatibility hotfix for windows
     if sys.platform == 'win32':
@@ -56,6 +64,8 @@ def main(filename, layout='default'):
         Voila.notebook_path = 'notebook.ipynb'
         VoilaConfiguration.template = 'jdaviz-default'
         VoilaConfiguration.enable_nbextensions = True
+        if browser != 'default':
+            Voila.browser = browser
         sys.exit(Voila().launch_instance(argv=[]))
     finally:
         os.chdir(start_dir)


### PR DESCRIPTION
This allows user to provide non-default browser for Jdaviz to use with. Implementation based on answer from voila-dashboards/voila#843 .

For instance, I need this because WebGL doesn't work on machine's Firefox but it works on Chrome, but default browser is Firefox and I don't have enough admin access to change it.