### PR TITLE
Update preset line list loading behavior

### DIFF
--- a/jdaviz/configs/default/plugins/line_lists/line_list_mixin.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_list_mixin.py
@@ -18,12 +18,14 @@ class LineListMixin:
         """
 
         # If the helper class has a global redshift (as in Specviz), use it
-        if hasattr(self, "_redshift") and "redshift" not in line_table.colnames:
-            line_table["redshift"] = u.Quantity(self._redshift)
+        if not isinstance(line_table, str):
+            if hasattr(self, "_redshift") and "redshift" not in line_table.colnames:
+                line_table["redshift"] = u.Quantity(self._redshift)
 
         lt = self.app.get_viewer('spectrum-viewer').load_line_list(line_table,
                                                                    replace=replace,
                                                                    return_table=True)
+
         # Preset lists were returning None table despite loading correctly
         if lt is None:
             if replace:

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -144,7 +144,7 @@ class LineListTool(TemplateMixin):
                          "rest": row["rest"].value,
                          "unit": str(row["rest"].unit),
                          "colors": row["colors"] if "colors" in row else "#FF0000FF",
-                         "show": True,
+                         "show": row["show"],
                          "name_rest": row["name_rest"],
                          "redshift": row["redshift"] if "redshift" in row else
                          self._global_redshift}

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -155,8 +155,10 @@ class LineListTool(TemplateMixin):
         self.list_contents = {}
         self.list_contents = list_contents
 
-        lines_loaded_message = SnackbarMessage("Spectral lines loaded from notebook",
-                                               sender=self, color="success")
+        msg_text = ("Spectral lines loaded from notebook. Lines can be hidden"
+                    "/shown in the Line Lists plugin")
+        lines_loaded_message = SnackbarMessage(msg_text, sender=self,
+                                               color="success", timeout=15000)
         self.hub.broadcast(lines_loaded_message)
 
     def update_line_mark_dict(self):

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -188,7 +188,8 @@ class LineListTool(TemplateMixin):
 
         # Load the table into the main astropy table and get it back, to make
         # sure all values match between the main table and local plugin
-        temp_table = self._viewer.load_line_list(temp_table, return_table=True)
+        temp_table = self._viewer.load_line_list(temp_table, return_table=True,
+                                                 show=False)
 
         line_list_dict = {"lines": [], "color": "#FF000080"}
         # extra_fields = [x for x in temp_table.colnames if x not in
@@ -199,7 +200,7 @@ class LineListTool(TemplateMixin):
                          "rest": row["rest"].value,
                          "unit": str(row["rest"].unit),
                          "colors": row["colors"],
-                         "show": True,
+                         "show": False,
                          "name_rest": str(row["name_rest"]),
                          "redshift": self._global_redshift}
             # for field in extra_fields:
@@ -218,8 +219,10 @@ class LineListTool(TemplateMixin):
         self._viewer.plot_spectral_lines()
         self.update_line_mark_dict()
 
-        lines_loaded_message = SnackbarMessage("Spectral lines loaded from preset",
-                                               sender=self, color="success")
+        msg_text = ("Spectral lines loaded from preset. Lines can be shown/hidden"
+                    f" in the {self.list_to_load} dropdown in the Line Lists plugin")
+        lines_loaded_message = SnackbarMessage(msg_text, sender=self,
+                                               color="success", timeout=15000)
         self.hub.broadcast(lines_loaded_message)
 
     def vue_add_custom_line(self, event):

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -70,10 +70,13 @@ class SpecvizProfileView(BqplotProfileView):
 
         return data
 
-    def load_line_list(self, line_table, replace=False, return_table=False):
+    def load_line_list(self, line_table, replace=False, return_table=False, show=True):
+        # If string, load the named preset list and don't show by default
+        # since there might be too many lines
         if type(line_table) == str:
             self.load_line_list(load_preset_linelist(line_table),
-                                replace=replace, return_table=return_table)
+                                replace=replace, return_table=return_table,
+                                show=False)
             return
         elif type(line_table) != table.QTable:
             raise TypeError("Line list must be an astropy QTable with\
@@ -89,8 +92,8 @@ class SpecvizProfileView(BqplotProfileView):
         # Make sure the redshift column is a quantity
         line_table["redshift"] = u.Quantity(line_table["redshift"])
 
-        # Set all of the lines to be shown on the plot by default on load
-        line_table["show"] = True
+        # Set whether to show all of the lines on the plot by default on load
+        line_table["show"] = show
 
         # If there is already a loaded table, convert units to match. This
         # attempts to do some sane rounding after the unit conversion.

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -93,7 +93,8 @@ class SpecvizProfileView(BqplotProfileView):
         line_table["redshift"] = u.Quantity(line_table["redshift"])
 
         # Set whether to show all of the lines on the plot by default on load
-        line_table["show"] = show
+        # We convert bool to int to work around ipywidgets json serialization
+        line_table["show"] = int(show)
 
         # If there is already a loaded table, convert units to match. This
         # attempts to do some sane rounding after the unit conversion.


### PR DESCRIPTION
No longer display all the lines of a preset line list when it's loaded, for performance reasons. I made the snackbar messages when loading presets a little more informative to point users to the plugin to display the lines. I also fixed a bug where the redshift check broke loading presets from the notebook in Specviz, although the workaround means that they aren't currently inheriting the redshift on load if it's set in the slider. I haven't decided if I want to fix that here or open another bug issue, but I'm done for the day right now.

Fixes #459 