### PR TITLE
TST: Add more deps to devdeps, fix test header and matrix

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -43,17 +43,25 @@ jobs:
             toxenv: py38-test-cov
             allow_failure: false
 
-          - name: OS X - Python 3.8
+          - name: OS X - Python 3.7
             os: macos-latest
-            python: 3.8
-            toxenv: py38-test
+            python: 3.7
+            toxenv: py37-test
             allow_failure: false
 
-          - name: Windows - Python 3.8
+          - name: Windows - Python 3.9
             os: windows-latest
-            python: 3.8
-            toxenv: py38-test
+            python: 3.9
+            toxenv: py39-test
             allow_failure: false
+
+          # This also runs on cron but we want to make sure new changes
+          # won't break this job at the PR stage.
+          - name: Python 3.9 with latest dev versions of key dependencies
+            os: ubuntu-latest
+            python: 3.9
+            toxenv: py39-test-devdeps
+            allow_failure: true
 
     steps:
     - name: Checkout code

--- a/conftest.py
+++ b/conftest.py
@@ -1,22 +1,6 @@
-# This file is used to configure the behavior of pytest when using the Astropy
-# test infrastructure. It needs to live inside the package in order for it to
-# get picked up when running the tests inside an interpreter using
-# packagename.test
-
-import pytest
+# This copies over some pytest setup from jdaviz/conftest.py so tox can see it.
 
 from astropy.tests.helper import enable_deprecations_as_exceptions
-from astropy.wcs import WCS
-
-
-@pytest.fixture
-def spectral_cube_wcs(request):
-    # A simple spectral cube WCS used by some tests
-    wcs = WCS(naxis=3)
-    wcs.wcs.ctype = 'RA---TAN', 'DEC--TAN', 'FREQ'
-    wcs.wcs.set()
-    return wcs
-
 
 try:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
@@ -51,7 +35,7 @@ def pytest_configure(config):
         PYTEST_HEADER_MODULES['voila'] = 'voila'
         PYTEST_HEADER_MODULES['vispy'] = 'vispy'
 
-        from . import __version__
+        from jdaviz import __version__
         TESTED_VERSIONS['jdaviz'] = __version__
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,5 @@
 # This copies over some pytest setup from jdaviz/conftest.py so tox can see it.
 
-from astropy.tests.helper import enable_deprecations_as_exceptions
-
 try:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
     ASTROPY_HEADER = True
@@ -41,4 +39,5 @@ def pytest_configure(config):
 
 # Uncomment the last two lines in this block to treat all DeprecationWarnings as
 # exceptions.
-enable_deprecations_as_exceptions()
+# from astropy.tests.helper import enable_deprecations_as_exceptions
+# enable_deprecations_as_exceptions()

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -5,7 +5,6 @@
 
 import pytest
 
-from astropy.tests.helper import enable_deprecations_as_exceptions
 from astropy.wcs import WCS
 
 
@@ -57,4 +56,5 @@ def pytest_configure(config):
 
 # Uncomment the last two lines in this block to treat all DeprecationWarnings as
 # exceptions.
-enable_deprecations_as_exceptions()
+# from astropy.tests.helper import enable_deprecations_as_exceptions
+# enable_deprecations_as_exceptions()

--- a/tox.ini
+++ b/tox.ini
@@ -59,10 +59,19 @@ deps =
     astropylts: astropy==4.0.*
     astropylts: gwcs>=0.14,<0.15
 
+    # NOTE: Add/remove as needed
     devdeps: :NIGHTLY:numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
+    devdeps: git+https://github.com/astropy/specutils.git
+    devdeps: git+https://github.com/radio-astro-tools/spectral-cube.git
+    devdeps: git+https://github.com/voila-dashboards/voila.git
+    devdeps: git+https://github.com/glue-viz/bqplot-image-gl.git
+    devdeps: git+https://github.com/glue-viz/glue-jupyter.git
+    devdeps: git+https://github.com/glue-viz/glue-astronomy.git
 
-# The following indicates which extras_require from setup.cfg will be installed
+# The following indicates which extras_require from setup.cfg will be installed.
+# TODO: Before you can use alldeps, you need to define "all" in
+#       [options.extras_require] in setup.cfg first.
 extras =
     test
     alldeps: all


### PR DESCRIPTION
This PR is a follow up of #442 and fixes #449 . This PR contains the following:

* Add more deps to `devdeps` job. (Though I don't think testing against numpy-dev is necessary but removing it is out of scope.)
* Have CI cross-test against different Python versions.
* Have a `conftest.py` at root level to fix test header in CI. If you look in the log, it is currently nonsensical, e.g., `Running tests with Astropy version 4.2.` when it is supposed to be reporting `jdaviz` version under test.
* Remove test header compatibility for `astropy<3`.
* ~Turn all deprecation warnings into exceptions. (If this spits out too many failures, I will revert it.)~ (2 failures, 557 warnings... reverted) See #478

# TODO

- [ ] Fix devdeps job failures.