### PR TITLE
Model Fitting Cleanup

### DIFF
--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -1,5 +1,3 @@
-# pickle is in principle a security risk, but we use it just for dumping of a known class here
-import pickle  # nosec
 import re
 import numpy as np
 
@@ -367,7 +365,6 @@ class ModelFitting(TemplateMixin):
             self._update_parameters_from_QM()
         else:
             self._update_parameters_from_fit()
-
 
     def vue_fit_model_to_cube(self, *args, **kwargs):
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -470,4 +470,4 @@ class ModelFitting(TemplateMixin):
             self.data_collection.remove(self.data_collection[label])
         self.data_collection[label] = spectrum
 
-        # self.app.add_data_to_viewer('spectrum-viewer', label)
+        self.app.add_data_to_viewer('spectrum-viewer', label)

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -40,9 +40,7 @@ class ModelFitting(TemplateMixin):
     template = load_template("model_fitting.vue", __file__).tag(sync=True)
     dc_items = List([]).tag(sync=True)
 
-    save_enabled = Bool(False).tag(sync=True)
     model_label = Unicode().tag(sync=True)
-    model_save_path = Unicode().tag(sync=True)
     temp_name = Unicode().tag(sync=True)
     temp_model = Unicode().tag(sync=True)
     model_equation = Unicode().tag(sync=True)
@@ -65,7 +63,6 @@ class ModelFitting(TemplateMixin):
         self.component_models = []
         self._initialized_models = {}
         self._display_order = False
-        self.model_save_path = os.getcwd()
         self.model_label = "Model"
         self._selected_data_label = None
 
@@ -331,15 +328,6 @@ class ModelFitting(TemplateMixin):
                                  if x["id"] != event]
         del(self._initialized_models[event])
 
-    def vue_save_model(self, event):
-        if self.model_save_path[-1] == "/":
-            connector = ""
-        else:
-            connector = "/"
-        full_path = self.model_save_path + connector + self.model_label + ".pkl"
-        with open(full_path, 'wb') as f:
-            pickle.dump(self._fitted_model, f)
-
     def vue_equation_changed(self, event):
         # Length is a dummy check to test the infrastructure
         if len(self.model_equation) > 20:
@@ -378,7 +366,6 @@ class ModelFitting(TemplateMixin):
         else:
             self._update_parameters_from_fit()
 
-        self.save_enabled = True
 
     def vue_fit_model_to_cube(self, *args, **kwargs):
 
@@ -482,6 +469,5 @@ class ModelFitting(TemplateMixin):
             # Remove the actual Glue data object from the data_collection
             self.data_collection.remove(self.data_collection[label])
         self.data_collection[label] = spectrum
-        self.save_enabled = True
 
         # self.app.add_data_to_viewer('spectrum-viewer', label)

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -1,4 +1,3 @@
-import os
 # pickle is in principle a security risk, but we use it just for dumping of a known class here
 import pickle  # nosec
 import re
@@ -41,6 +40,7 @@ class ModelFitting(TemplateMixin):
     dc_items = List([]).tag(sync=True)
 
     model_label = Unicode().tag(sync=True)
+    cube_fit = Bool(False).tag(sync=True)
     temp_name = Unicode().tag(sync=True)
     temp_model = Unicode().tag(sync=True)
     model_equation = Unicode().tag(sync=True)
@@ -65,6 +65,8 @@ class ModelFitting(TemplateMixin):
         self._display_order = False
         self.model_label = "Model"
         self._selected_data_label = None
+        if self.app.state.settings.get("configuration") == "cubeviz":
+            self.cube_fit = True
 
         self.hub.subscribe(self, AddDataMessage,
                            handler=self._on_viewer_data_changed)

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -176,7 +176,7 @@
           no-gutters
         >
         <v-btn color="primary" text @click="model_fitting">Fit</v-btn>
-        <v-btn color="primary" text @click="fit_model_to_cube">Apply to Cube</v-btn>
+        <v-btn v-if="cube_fit" color="primary" text @click="fit_model_to_cube">Apply to Cube</v-btn>
         </v-row>
       </v-card-actions>
     </v-card>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -167,14 +167,6 @@
           persistent-hint
         >
         </v-text-field>
-        <c-col cols=1><v-col>
-        <v-text-field
-          v-model="model_save_path"
-          label="Filepath"
-          hint="Path to save output file [Model Label].pkl"
-          persistent-hint
-        >
-        </v-text-field>
       </v-card-actions>
       <v-card-actions>
         <div class="flex-grow-1"></div>
@@ -186,12 +178,6 @@
         <v-btn color="primary" text @click="model_fitting">Fit</v-btn>
         <v-btn color="primary" text @click="fit_model_to_cube">Apply to Cube</v-btn>
         <v-btn color="primary" text @click="register_spectrum">Add to Viewer</v-btn>
-        <v-btn
-           color="primary"
-           text
-           @click="save_model">
-           Save to File
-         </v-btn>
         </v-row>
       </v-card-actions>
     </v-card>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -177,7 +177,6 @@
         >
         <v-btn color="primary" text @click="model_fitting">Fit</v-btn>
         <v-btn color="primary" text @click="fit_model_to_cube">Apply to Cube</v-btn>
-        <v-btn color="primary" text @click="register_spectrum">Add to Viewer</v-btn>
         </v-row>
       </v-card-actions>
     </v-card>


### PR DESCRIPTION
With the introduction of #456, we now have a good foundation for some cleanup of the model fitting plugin. This PR implements the following changes:
1) The model can be automatically added to the spectral viewers immediately without fear of this looping bug that's been plaguing us
2) The "Apply to Cube" option only applies to the "Cubeviz" configuration, and therefore is only visible in Cubeviz
3) With the introduction of #458, we can now extract models via code. This, combined with MAST's request that we don't allow saving to local resources in anticipation of Cloud Hosting, means the "Save to Disk" button is removed

I reviewed the docs, and these changes aren't actually mentioned in the docs, so there's nothing to change as far as I can see