### PR TITLE
Write test file to temporary directory

### DIFF
--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -252,7 +252,7 @@ class MosViz(ConfigHelper):
 
     def to_csv(self, filename="MOS_data.csv", selected=False, overwrite=False):
         """
-        Creates a csv file with the contects of the MOS table viewer
+        Creates a csv file with the contents of the MOS table viewer
 
         Parameters
         ----------

--- a/jdaviz/configs/mosviz/tests/test_helper.py
+++ b/jdaviz/configs/mosviz/tests/test_helper.py
@@ -228,16 +228,16 @@ def test_viewer_axis_link(mosviz_app, spectrum1d, spectrum2d):
     assert scale_2d.max == 800.0
 
 
-def test_to_csv(mosviz_app, spectrum_collection):
+def test_to_csv(tmp_path, mosviz_app, spectrum_collection):
     labels = [f"Test Spectrum Collection {i}" for i in range(5)]
     mosviz_app.load_1d_spectra(spectrum_collection, data_labels=labels)
 
-    mosviz_app.to_csv()
+    mosviz_app.to_csv(filename=str(tmp_path / "MOS_data.csv"))
 
     found_rows = 0
     found_index_label = False
 
-    with open("MOS_data.csv", "r") as f:
+    with open(tmp_path / "MOS_data.csv", "r") as f:
         freader = csv.reader(f)
         for row in freader:
             if row[0] == "Table Index":


### PR DESCRIPTION
This fixes a test that was writing a file to the current directory, which meant that the tests failed the second time when run twice