### PR TITLE
Expose bug in selecting wavelength for moment map

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -1,9 +1,13 @@
+from glue.core.subset import RangeSubsetState
 import numpy as np
 
 from glue.core import Data
 
 from jdaviz import Application
 from ..moment_maps import MomentMap
+
+
+URL = 'https://stsci.box.com/shared/static/28a88k1qfipo4yxc4p4d40v4axtlal8y.fits'
 
 
 def test_moment_calculation(spectral_cube_wcs):
@@ -23,3 +27,25 @@ def test_moment_calculation(spectral_cube_wcs):
     assert mm.moment_available
     assert dc[1].label == 'Moment 0: test'
     assert dc[1].get_object().shape == (4, 5)
+
+
+def test_wavelength_selection(spectral_cube_wcs):
+
+    app = Application(configuration='cubeviz')
+    # TODO: replace this by dummy data
+    from astropy.utils.data import download_file
+    fn = download_file(URL, cache=True)
+    app.load_data(fn)
+    data = app.data_collection[0]
+    # TODO: this dummy data does not work, it doesn't create viewers
+    # data = Data(x=np.ones((3, 4, 5)), label='test', coords=spectral_cube_wcs)
+    # app.add_data(data, 'test')
+
+    mm = MomentMap(app=app)
+
+    subset_state = RangeSubsetState(5e-7, 6.0e-7, data.coordinate_components[3])
+    app.data_collection.new_subset_group(subset_state=subset_state, label='x')
+    mm.vue_list_subsets(None)   # this normally gets called from the UI
+    mm.selected_subset = 'x'
+    assert abs(mm.spectral_min - 5e-7) < 1e-6
+    assert abs(mm.spectral_max - 6e-7) < 1e-6


### PR DESCRIPTION
Related #283

I haven't been able to solve #283, but managed to get a handle on where things go wrong and expose them in a unit test.

 * This issue is not related to the frontend, it happens all on the Python side
 * Putting a breakpoint at https://github.com/spacetelescope/jdaviz/blob/3edb474fc0046fbddc56f4355c0304d84956483f/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py#L101 I see that spec_sub.center.x is correctly 5.5e-7, and width is 1e-7, 

This might be an issue with specutils, or we're holding specutils wrong.