### PR TITLE
fix: make height controllable in other context

### DIFF
--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -18,7 +18,7 @@
         <splitpanes @resize="relayout">
           <pane size="75">
             <golden-layout
-              :style="checkNotebookContext() ? 'height: 100%;' : 'height: calc(100vh - 48px)'"
+              style="height: 100%"
               :has-headers="state.settings.visible.tab_headers"
             >
               <gl-row :closable="false">

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -12,13 +12,13 @@
     </v-app-bar>
 
     <v-content
-      :style="checkNotebookContext() ? 'height: ' + state.settings.context.notebook.max_height + '; border: solid 1px #e5e5e5;' : ''"
+      :style="checkNotebookContext() ? 'height: ' + state.settings.context.notebook.max_height + '; border: solid 1px #e5e5e5;' : 'max-height: calc(100% - 48px)'"
     >
       <v-container class="fill-height pa-0" fluid>
         <splitpanes @resize="relayout">
           <pane size="75">
             <golden-layout
-              style="height: 100%"
+              style="height: 100%;"
               :has-headers="state.settings.visible.tab_headers"
             >
               <gl-row :closable="false">

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app id="web-app">
+  <v-app id="web-app" class="jdaviz">
     <v-app-bar color="primary" dark dense flat app absolute clipped-right>
       <jupyter-widget :widget="item.widget" v-for="item in state.tool_items" :key="item.name"></jupyter-widget>
       <v-spacer></v-spacer>

--- a/share/jupyter/nbconvert/templates/jdaviz-default/app.html
+++ b/share/jupyter/nbconvert/templates/jdaviz-default/app.html
@@ -18,7 +18,7 @@
         </v-slide-y-transition>
         <v-slide-y-transition>
             <template v-show="!loading">
-                    <jupyter-widget-mount-point mount-id="content">
+                    <jupyter-widget-mount-point style="max-height: 100vh" mount-id="content">
                     </jupyter-widget-mount-point>
             </template>
         </v-slide-y-transition>


### PR DESCRIPTION
Using height: 100% is enough here to always take up all space of
the parent. The total height of the entire app can then be
specified elsewhere.

Part of #503