### PR TITLE
MNT: Add codeowners 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,6 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
+# they will be requested for
 # review when someone opens a pull request.
 *   @duytnguyendtn @rosteen @javerbukh @ibusko

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*   @duytnguyendtn @rosteen @javerbukh @ibusko


### PR DESCRIPTION
Rather than having to manually request reviews from the same people every time, this will automate that process. These are the people that I was told would review all PRs, no?

See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners