### PR TITLE
Fix centroid error in line analysis plugin

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -477,6 +477,9 @@ class Application(VuetifyTemplate, HubListener):
                                          cls=None)
         regions = {}
 
+        if data_label is not None:
+            data = {data_label: data}
+
         for key, value in data.items():
             if isinstance(value, Subset):
                 # Range selection on a profile is currently not supported in

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -131,8 +131,8 @@ class LineAnalysis(TemplateMixin):
                 if self._spectrum1d.mask is None:
                     spec_region = SpectralRegion(spectral_axis[0], spectral_axis[-1])
                 else:
-                    spec_region = self._spectrum1d.spectral_axis[np.where(self._spectrum1d.mask is
-                                                                          False)]
+                    spec_region = self._spectrum1d.spectral_axis[np.where(
+                                                                 self._spectrum1d.mask == 0)]
                     spec_region = SpectralRegion(spec_region[0], spec_region[-1])
                 temp_result = FUNCTIONS[function](self._spectrum1d, spec_region)
             else:


### PR DESCRIPTION
It seems like a numpy update (maybe?) cause the existing syntax (`array is False`) to no longer work as it once did, which was causing the `centroid` handling in the line analysis plugin to fail. Switching to `array == 0` fixes it.

I also fixed a bug I found while testing this that caused `get_subsets_from_viewer` to fail if you called the function with a `data_label` specified. 