### PR TITLE
Imviz parser

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -37,10 +37,11 @@ jobs:
             toxenv: securityaudit
             allow_failure: false
 
-          - name: Python 3.8 with coverage checking
+          - name: Python 3.8 with coverage checking, all deps, and remote data
             os: ubuntu-latest
             python: 3.8
-            toxenv: py38-test-cov
+            toxenv: py38-test-alldeps-cov
+            toxposargs: --remote-data
             allow_failure: false
 
           - name: OS X - Python 3.8
@@ -70,7 +71,7 @@ jobs:
         python -m pip install tox codecov
     - name: Test/run with tox
       run: |
-        tox -e ${{ matrix.toxenv }}
+        tox -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
     # Activate your repo on codecov.io first.
     - name: Upload coverage to codecov
       if: "contains(matrix.toxenv, '-cov')"

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -260,7 +260,7 @@ class Application(VuetifyTemplate, HubListener):
                 self.data_collection.add_link(LinkSame(wc_old[0], wc_new[0]))
                 break
 
-    def load_data(self, file_obj, parser_reference=None, **kwargs):
+    def load_data(self, file_obj, parser_reference=None, skip_checks=False, **kwargs):
         """
         Provided a path to a data file, open and parse the data into the
         `~glue.core.DataCollection` for this session. This also attempts to
@@ -271,13 +271,22 @@ class Application(VuetifyTemplate, HubListener):
         ----------
         file_obj : str or file-like
             File object for the data to be loaded.
+
+        parser_reference
+
+        skip_checks : bool
+            If `True`, do not try to vet the given ``file_obj`` and rely on
+            lower level parser to handle invalid input.
+
+        kwargs : dict
+
         """
         self.loading = True
         try:
             try:
                 # Properly form path and check if a valid file
                 file_obj = pathlib.Path(file_obj)
-                if not file_obj.exists():
+                if not skip_checks and not file_obj.exists():
                     msg_text = "Error: File {} does not exist".format(file_obj)
                     snackbar_message = SnackbarMessage(msg_text, sender=self,
                                                        color='error')

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -260,7 +260,7 @@ class Application(VuetifyTemplate, HubListener):
                 self.data_collection.add_link(LinkSame(wc_old[0], wc_new[0]))
                 break
 
-    def load_data(self, file_obj, parser_reference=None, skip_checks=False, **kwargs):
+    def load_data(self, file_obj, parser_reference=None, **kwargs):
         """
         Provided a path to a data file, open and parse the data into the
         `~glue.core.DataCollection` for this session. This also attempts to
@@ -271,22 +271,13 @@ class Application(VuetifyTemplate, HubListener):
         ----------
         file_obj : str or file-like
             File object for the data to be loaded.
-
-        parser_reference
-
-        skip_checks : bool
-            If `True`, do not try to vet the given ``file_obj`` and rely on
-            lower level parser to handle invalid input.
-
-        kwargs : dict
-
         """
         self.loading = True
         try:
             try:
                 # Properly form path and check if a valid file
                 file_obj = pathlib.Path(file_obj)
-                if not skip_checks and not file_obj.exists():
+                if not file_obj.exists():
                     msg_text = "Error: File {} does not exist".format(file_obj)
                     snackbar_message = SnackbarMessage(msg_text, sender=self,
                                                        color='error')

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -63,6 +63,8 @@ def split_filename_with_fits_ext(filename):
             ext = ext.split(',')
             ext[1] = int(ext[1])
             ext = tuple(ext)
+        elif not re.match(r'\D+', ext):
+            ext = int(ext)
 
     filepath = f'{s[0]}{sfx}'
     data_label = os.path.basename(s[0])

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -4,3 +4,7 @@ from jdaviz.core.helpers import ConfigHelper
 class Imviz(ConfigHelper):
     """Imviz Helper class"""
     _default_configuration = 'imviz'
+
+    def load_data(self, data, parser_reference=None, **kwargs):
+        self.app.load_data(data, parser_reference=parser_reference,
+                           skip_checks=True, **kwargs)

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -14,9 +14,13 @@ class Imviz(ConfigHelper):
         if isinstance(data, str):
             filepath, ext, data_label = split_filename_with_fits_ext(data)
 
-            # These will overwrite inputs, if any.
-            kwargs['ext'] = ext
-            kwargs['data_label'] = data_label
+            # This, if valid, will overwrite input.
+            if ext is not None:
+                kwargs['ext'] = ext
+
+            # This will only overwrite if not provided.
+            if 'data_label' not in kwargs:
+                kwargs['data_label'] = data_label
 
         self.app.load_data(filepath, parser_reference=parser_reference, **kwargs)
 
@@ -51,15 +55,17 @@ def split_filename_with_fits_ext(filename):
     if ext_match is None:
         sfx = s[1]
         ext = None
+        label_sfx = ''
     else:
         sfx = ext_match.group(1)
         ext = ext_match.group(2)
+        label_sfx = f'[{ext.upper()}]'
         if ',' in ext:
             ext = ext.split(',')
             ext[1] = int(ext[1])
             ext = tuple(ext)
 
     filepath = f'{s[0]}{sfx}'
-    data_label = f'{os.path.basename(s[0])}[{ext.upper()}]'
+    data_label = f'{os.path.basename(s[0])}{label_sfx}'
 
     return filepath, ext, data_label

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -1,4 +1,9 @@
+import os
+import re
+
 from jdaviz.core.helpers import ConfigHelper
+
+__all__ = ['Imviz']
 
 
 class Imviz(ConfigHelper):
@@ -6,5 +11,55 @@ class Imviz(ConfigHelper):
     _default_configuration = 'imviz'
 
     def load_data(self, data, parser_reference=None, **kwargs):
-        self.app.load_data(data, parser_reference=parser_reference,
-                           skip_checks=True, **kwargs)
+        if isinstance(data, str):
+            filepath, ext, data_label = split_filename_with_fits_ext(data)
+
+            # These will overwrite inputs, if any.
+            kwargs['ext'] = ext
+            kwargs['data_label'] = data_label
+
+        self.app.load_data(filepath, parser_reference=parser_reference, **kwargs)
+
+
+def split_filename_with_fits_ext(filename):
+    """Split a ``filename[ext]`` input into filename and FITS extension.
+
+    Parameters
+    ----------
+    filename : str
+        Can be a plain filename or ``filename[ext]``. The latter is a form
+        of input that is commonly used by DS9. Example values:
+
+        * ``'myimage.fits'``
+        * ``'myimage.fits[SCI]'`` (assumes ``EXTVER=1``)
+        * ``'myimage.fits[SCI,1]'``
+
+    Returns
+    -------
+    filepath : str
+        Path to the file, without extension.
+
+    ext : str, tuple, or `None`
+        FITS extension, if given. Examples: ``'SCI'`` or ``('SCI', 1)``
+
+    data_label : str
+        Human-readable data label for Glue.
+
+    """
+    s = os.path.splitext(filename)
+    ext_match = re.match(r'(.+)\[(.+)\]', s[1])
+    if ext_match is None:
+        sfx = s[1]
+        ext = None
+    else:
+        sfx = ext_match.group(1)
+        ext = ext_match.group(2)
+        if ',' in ext:
+            ext = ext.split(',')
+            ext[1] = int(ext[1])
+            ext = tuple(ext)
+
+    filepath = f'{s[0]}{sfx}'
+    data_label = f'{os.path.basename(s[0])}[{ext.upper()}]'
+
+    return filepath, ext, data_label

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -47,7 +47,8 @@ def split_filename_with_fits_ext(filename):
         FITS extension, if given. Examples: ``'SCI'`` or ``('SCI', 1)``
 
     data_label : str
-        Human-readable data label for Glue.
+        Human-readable data label for Glue. Extension info will be added
+        later in the parser.
 
     """
     s = os.path.splitext(filename)
@@ -55,17 +56,15 @@ def split_filename_with_fits_ext(filename):
     if ext_match is None:
         sfx = s[1]
         ext = None
-        label_sfx = ''
     else:
         sfx = ext_match.group(1)
         ext = ext_match.group(2)
-        label_sfx = f'[{ext.upper()}]'
         if ',' in ext:
             ext = ext.split(',')
             ext[1] = int(ext[1])
             ext = tuple(ext)
 
     filepath = f'{s[0]}{sfx}'
-    data_label = f'{os.path.basename(s[0])}{label_sfx}'
+    data_label = os.path.basename(s[0])
 
     return filepath, ext, data_label

--- a/jdaviz/configs/imviz/imviz.yaml
+++ b/jdaviz/configs/imviz/imviz.yaml
@@ -2,6 +2,7 @@ settings:
   configuration: imviz
   data:
     auto_populate: true
+    parser: imviz-data-parser
   visible:
     menu_bar: false
     toolbar: true

--- a/jdaviz/configs/imviz/plugins/__init__.py
+++ b/jdaviz/configs/imviz/plugins/__init__.py
@@ -1,3 +1,4 @@
 from .tools import *  # noqa
 from .viewers import *  # noqa
 from .image_viewer_creator import *  # noqa
+from .parsers import *  # noqa

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -92,12 +92,15 @@ def _parse_image(app, file_obj, data_label, show_in_viewer, ext=None):
 def _validate_image2d(hdu, raise_error=True):
     valid = hdu.data is not None and hdu.is_image and hdu.data.ndim == 2
     if not valid and raise_error:
-        raise ValueError(f'Imviz cannot load this HDU ({hdu}): '
-                         f'is_image={hdu.is_image}, data={hdu.data}')
+        raise ValueError(
+            f'Imviz cannot load this HDU ({hdu}): '
+            f'has_data={hdu.data is not None}, is_image={hdu.is_image}, '
+            f'name={hdu.name}, ver={hdu.ver}')
     return valid
 
 
 def _validate_bunit(bunit, raise_error=True):
+    # TODO: Do we want to handle weird FITS BUNIT values here?
     try:
         u.Unit(bunit)
     except Exception:

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -126,11 +126,13 @@ def _jwst_to_glue_data(file_obj, ext, data_label):
     comp_label = ext.upper()
     data_label = f'{data_label}[{comp_label}]'
     data = Data(label=data_label)
+    unit_attr = f'bunit_{ext}'
 
     # This is very specific to JWST pipeline image output.
     with datamodels.open(file_obj) as dm:
-        if 'bunit' in dm.meta and _validate_bunit(dm.meta.bunit, raise_error=False):
-            bunit = dm.meta.bunit
+        if (unit_attr in dm.meta and
+                _validate_bunit(getattr(dm.meta, unit_attr), raise_error=False)):
+            bunit = getattr(dm.meta, unit_attr)
         else:
             bunit = 'count'
 

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -39,7 +39,6 @@ def parse_data(app, file_obj, ext=None, data_label=None, show_in_viewer=True):
         Show data in viewer.
 
     """
-    # TODO: How much support needed for URL/URI?
     if isinstance(file_obj, str):
         if data_label is None:
             data_label = os.path.splitext(os.path.basename(file_obj))[0]

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -1,6 +1,5 @@
 import base64
 import os
-import re
 import uuid
 
 from astropy.io import fits
@@ -18,7 +17,7 @@ __all__ = ['parse_data']
 
 
 @data_parser_registry("imviz-data-parser")
-def parse_data(app, file_obj, data_label=None, show_in_viewer=True):
+def parse_data(app, file_obj, ext=None, data_label=None, show_in_viewer=True):
     """Parse a data file into Imviz.
 
     Parameters
@@ -26,84 +25,52 @@ def parse_data(app, file_obj, data_label=None, show_in_viewer=True):
     app : `~jdaviz.app.Application`
         The application-level object used to reference the viewers.
 
-    file_path : str
-        The path to an image data file.
+    file_obj : str or obj
+        The path to an image data file or FITS HDUList or image object.
+
+    ext : str, tuple, or `None`, optional
+        FITS extension, if given. Examples: ``'SCI'`` or ``('SCI', 1)``
 
     data_label : str, optional
         The label to be applied to the Glue data component.
 
-    show_in_viewer : bool
+    show_in_viewer : bool, optional
         Show data in viewer.
 
     """
     # TODO: How much support needed for URL/URI?
     if isinstance(file_obj, str):
-        s = os.path.splitext(file_obj)
-        ext_match = re.match(r'(.+)\[(.+)\]', s[1])
-        if ext_match is None:
-            sfx = s[1]
-            ext = None
-        else:
-            sfx = ext_match.group(1)
-            ext = ext_match.group(2)
-            if ',' in ext:
-                ext = ext.split(',')
-                ext[1] = int(ext[1])
-                ext = tuple(ext)
         if data_label is None:
-            data_label = os.path.basename(s[0])
-        with fits.open(f'{s[0]}{sfx}') as pf:
+            data_label = os.path.splitext(os.path.basename(file_obj))[0]
+        with fits.open(file_obj) as pf:
             _parse_image(app, pf, data_label, show_in_viewer, ext=ext)
     else:
         if data_label is None:
             data_label = f'imviz_data|{str(base64.b85encode(uuid.uuid4().bytes), "utf-8")}'
-        _parse_image(app, file_obj, data_label, show_in_viewer)
+        _parse_image(app, file_obj, data_label, show_in_viewer, ext=ext)
 
 
 def _parse_image(app, file_obj, data_label, show_in_viewer, ext=None):
+    if data_label is None:
+        raise NotImplementedError('data_label should be set by now')
+
     if isinstance(file_obj, fits.HDUList):
         if 'ASDF' in file_obj:  # JWST ASDF-in-FITS
             if HAS_JWST_ASDF:
-                if ext is None:
-                    ext = 'data'
-                else:
-                    if isinstance(ext, tuple):
-                        ext = ext[0]  # EXTVER means nothing in ASDF
-                    ext = ext.lower()
-                    if ext in ('sci', 'asdf'):
-                        ext = 'data'
-
-                data_label += f'[{ext.upper()}]'
-                with datamodels.open(file_obj) as dm:
-                    if 'bunit' in dm.meta:
-                        bunit = dm.meta.bunit
-                    else:
-                        bunit = 'count'
-                    image_ccd = Data(label=data_label)
-
-                    # This is instance of gwcs.WCS, not astropy.wcs.WCS
-                    image_ccd.coords = dm.meta.wcs
-
-                    imdata = getattr(dm, ext)
-                    component = Component.autotyped(imdata, units=bunit)
-                    image_ccd.add_component(component=component, label=ext)
+                data = _jwst_to_glue_data(file_obj, ext, data_label)
             else:
                 raise ImportError('jwst package is missing')
 
         elif ext is not None:  # Load just the EXT user wants
             hdu = file_obj[ext]
-            if hdu.data is not None and hdu.is_image:
-                data_label += f'[{hdu.name},{hdu.ver}]'
-                image_ccd = _hdu_to_ccddata(hdu, data_label)
-            else:
-                raise ValueError(f'{file_obj}[{ext}] is not FITS image')
+            _validate_image2d(hdu)
+            data = _hdu_to_glue_data(hdu, data_label)
 
         else:  # Load first image extension found
             found = False
             for hdu in file_obj:
-                if hdu.data is not None and hdu.is_image:
-                    data_label += f'[{hdu.name},{hdu.ver}]'
-                    image_ccd = _hdu_to_ccddata(hdu, data_label)
+                if _validate_image2d(hdu, raise_error=False):
+                    data = _hdu_to_glue_data(hdu, data_label)
                     found = True
                     break
             if not found:
@@ -111,22 +78,58 @@ def _parse_image(app, file_obj, data_label, show_in_viewer, ext=None):
 
     elif isinstance(file_obj, (fits.ImageHDU, fits.CompImageHDU, fits.PrimaryHDU)):
         # NOTE: ext is not used here. It only means something if HDUList is given.
-        if hdu.data is not None and hdu.is_image:
-            data_label += f'[{hdu.name},{hdu.ver}]'
-            image_ccd = _hdu_to_ccddata(file_obj, data_label)
-        else:
-            raise ValueError(f'{file_obj} is not FITS image')
+        _validate_image2d(file_obj)
+        data = _hdu_to_glue_data(file_obj, data_label)
+
     else:
         raise NotImplementedError(f'Imviz does not support {file_obj}')
 
-    app.add_data(image_ccd, data_label)
+    app.add_data(data, data_label)
     if show_in_viewer:
         app.add_data_to_viewer("viewer-1", data_label)
 
 
-def _hdu_to_ccddata(hdu, data_label):
-    image_ccd = Data(label=data_label)
-    image_ccd.coords = WCS(hdu.header)
+def _validate_image2d(hdu, raise_error=True):
+    valid = hdu.data is not None and hdu.is_image and hdu.data.ndim == 2
+    if not valid and raise_error:
+        raise ValueError(f'Imviz cannot load this HDU ({hdu}): '
+                         f'is_image={hdu.is_image}, data={hdu.data}')
+    return valid
+
+
+def _jwst_to_glue_data(file_obj, ext, data_label):
+    # Translate FITS extension into JWST ASDF convention.
+    if ext is None:
+        ext = 'data'
+    else:
+        if isinstance(ext, tuple):
+            ext = ext[0]  # EXTVER means nothing in ASDF
+        ext = ext.lower()
+        if ext in ('sci', 'asdf'):
+            ext = 'data'
+
+    # This is very specific to JWST pipeline image output.
+    with datamodels.open(file_obj) as dm:
+        if 'bunit' in dm.meta:
+            bunit = dm.meta.bunit
+        else:
+            bunit = 'count'
+
+        data = Data(label=data_label)
+
+        # This is instance of gwcs.WCS, not astropy.wcs.WCS
+        data.coords = dm.meta.wcs
+
+        imdata = getattr(dm, ext)
+        component = Component.autotyped(imdata, units=bunit)
+        data.add_component(component=component, label=ext)
+
+    return data
+
+
+def _hdu_to_glue_data(hdu, data_label):
+    data = Data(label=data_label)
+    data.coords = WCS(hdu.header)
     component = Component.autotyped(hdu.data, units=hdu.header.get('BUNIT', 'count'))
-    image_ccd.add_component(component=component, label=f'{hdu.name},{hdu.ver}')
-    return image_ccd
+    data.add_component(component=component, label=f'{hdu.name},{hdu.ver}')
+    return data

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -1,0 +1,132 @@
+import base64
+import os
+import re
+import uuid
+
+from astropy.io import fits
+from astropy.wcs import WCS
+from glue.core.data import Component, Data
+try:
+    from jwst import datamodels
+    HAS_JWST_ASDF = True
+except ImportError:
+    HAS_JWST_ASDF = False
+
+from jdaviz.core.registries import data_parser_registry
+
+__all__ = ['parse_data']
+
+
+@data_parser_registry("imviz-data-parser")
+def parse_data(app, file_obj, data_label=None, show_in_viewer=True):
+    """Parse a data file into Imviz.
+
+    Parameters
+    ----------
+    app : `~jdaviz.app.Application`
+        The application-level object used to reference the viewers.
+
+    file_path : str
+        The path to an image data file.
+
+    data_label : str, optional
+        The label to be applied to the Glue data component.
+
+    show_in_viewer : bool
+        Show data in viewer.
+
+    """
+    # TODO: How much support needed for URL/URI?
+    if isinstance(file_obj, str):
+        s = os.path.splitext(file_obj)
+        ext_match = re.match(r'(.+)\[(.+)\]', s[1])
+        if ext_match is None:
+            sfx = s[1]
+            ext = None
+        else:
+            sfx = ext_match.group(1)
+            ext = ext_match.group(2)
+            if ',' in ext:
+                ext = ext.split(',')
+                ext[1] = int(ext[1])
+                ext = tuple(ext)
+        if data_label is None:
+            data_label = os.path.basename(s[0])
+        with fits.open(f'{s[0]}{sfx}') as pf:
+            _parse_image(app, pf, data_label, show_in_viewer, ext=ext)
+    else:
+        if data_label is None:
+            data_label = f'imviz_data|{str(base64.b85encode(uuid.uuid4().bytes), "utf-8")}'
+        _parse_image(app, file_obj, data_label, show_in_viewer)
+
+
+def _parse_image(app, file_obj, data_label, show_in_viewer, ext=None):
+    if isinstance(file_obj, fits.HDUList):
+        if 'ASDF' in file_obj:  # JWST ASDF-in-FITS
+            if HAS_JWST_ASDF:
+                if ext is None:
+                    ext = 'data'
+                else:
+                    if isinstance(ext, tuple):
+                        ext = ext[0]  # EXTVER means nothing in ASDF
+                    ext = ext.lower()
+                    if ext in ('sci', 'asdf'):
+                        ext = 'data'
+
+                data_label += f'[{ext.upper()}]'
+                with datamodels.open(file_obj) as dm:
+                    if 'bunit' in dm.meta:
+                        bunit = dm.meta.bunit
+                    else:
+                        bunit = 'count'
+                    image_ccd = Data(label=data_label)
+
+                    # This is instance of gwcs.WCS, not astropy.wcs.WCS
+                    image_ccd.coords = dm.meta.wcs
+
+                    imdata = getattr(dm, ext)
+                    component = Component.autotyped(imdata, units=bunit)
+                    image_ccd.add_component(component=component, label=ext)
+            else:
+                raise ImportError('jwst package is missing')
+
+        elif ext is not None:  # Load just the EXT user wants
+            hdu = file_obj[ext]
+            if hdu.data is not None and hdu.is_image:
+                data_label += f'[{hdu.name},{hdu.ver}]'
+                image_ccd = _hdu_to_ccddata(hdu, data_label)
+            else:
+                raise ValueError(f'{file_obj}[{ext}] is not FITS image')
+
+        else:  # Load first image extension found
+            found = False
+            for hdu in file_obj:
+                if hdu.data is not None and hdu.is_image:
+                    data_label += f'[{hdu.name},{hdu.ver}]'
+                    image_ccd = _hdu_to_ccddata(hdu, data_label)
+                    found = True
+                    break
+            if not found:
+                raise ValueError(f'{file_obj} does not have any FITS image')
+
+    elif isinstance(file_obj, (fits.ImageHDU, fits.CompImageHDU, fits.PrimaryHDU)):
+        # NOTE: ext is not used here. It only means something if HDUList is given.
+        if hdu.data is not None and hdu.is_image:
+            data_label += f'[{hdu.name},{hdu.ver}]'
+            image_ccd = _hdu_to_ccddata(file_obj, data_label)
+        else:
+            raise ValueError(f'{file_obj} is not FITS image')
+    else:
+        raise NotImplementedError(f'Imviz does not support {file_obj}')
+
+    app.add_data(image_ccd, data_label)
+    if show_in_viewer:
+        app.add_data_to_viewer("viewer-1", data_label)
+
+
+def _hdu_to_ccddata(hdu, data_label):
+    image_ccd = Data(label=data_label)
+    image_ccd.coords = WCS(hdu.header)
+    component = Component.autotyped(hdu.data, units=hdu.header.get('BUNIT', 'count'))
+    image_ccd.add_component(component=component, label=f'{hdu.name},{hdu.ver}')
+    return image_ccd

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -53,8 +53,11 @@ class ImvizImageView(BqplotImageView):
                 # Convert these to a SkyCoord via WCS - note that for other datasets
                 # we aren't actually guaranteed to get a SkyCoord out, just for images
                 # with valid celestial WCS
-                celestial_coordinates = image.coords.pixel_to_world(x, y).icrs.to_string('hmsdms')
-                overlay += f' ICRS={celestial_coordinates}'
+                try:
+                    celestial_coordinates = image.coords.pixel_to_world(x, y).icrs.to_string('hmsdms')  # noqa: E501
+                    overlay += f' ICRS={celestial_coordinates}'
+                except Exception:
+                    overlay += ' ICRS=unknown'
 
             # Extract data values at this position
             if x > -0.5 and y > -0.5 and x < image.shape[1] - 0.5 and y < image.shape[0] - 0.5:

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -90,7 +90,7 @@ class TestParseImage:
         assert data.label == 'contents[DATA]'  # download_file returns cache loc
         assert data.shape == (2048, 2048)
         assert isinstance(data.coords, GWCS)
-        assert comp.units == 'count'  # dm.meta.bunit is not set
+        assert comp.units == 'MJy/sr'
         assert comp.data.shape == (2048, 2048)
 
         # Request specific extension (name + ver, but ver is not used), use given label
@@ -98,8 +98,9 @@ class TestParseImage:
                    data_label='jw01072001001_01101_00001_nrcb1_cal',
                    show_in_viewer=False)
         data = imviz_app.app.data_collection[1]
+        comp = data.get_component('DQ')
         assert data.label == 'jw01072001001_01101_00001_nrcb1_cal[DQ]'
-        assert 'DQ' in data.components
+        assert comp.units == 'count'
 
         # Pass in HDUList directly + ext (name only), use given label
         with fits.open(filename) as pf:
@@ -110,7 +111,7 @@ class TestParseImage:
             comp = data.get_component('DATA')  # SCI = DATA
             assert data.label == 'jw01072001001_01101_00001_nrcb1_cal[DATA]'
             assert isinstance(data.coords, GWCS)
-            assert comp.units == 'count'
+            assert comp.units == 'MJy/sr'
 
         # Invalid ASDF attribute (extension)
         with pytest.raises(AttributeError, match='No attribute'):

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -1,0 +1,69 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from astropy import units as u
+from astropy.io import fits
+
+from jdaviz.configs.imviz.helper import split_filename_with_fits_ext
+from jdaviz.configs.imviz.plugins.parsers import (
+    HAS_JWST_ASDF, _validate_image2d, _validate_bunit, _parse_image)
+
+test_hook = MagicMock()
+
+
+@pytest.mark.parametrize(
+    ('filename', 'ans'),
+    [('/path/to/cache/contents', ['/path/to/cache/contents', None, 'contents']),
+     ('file://path/image.fits[SCI]', ['file://path/image.fits', 'SCI', 'image']),
+     ('image.fits[dq,2]', ['image.fits', ('dq', 2), 'image']),
+     ('/path/to/image.fits', ['/path/to/image.fits', None, 'image']),
+     ('../image.fits.gz[1]', ['../image.fits.gz', 1, 'image.fits'])])
+def test_filename_split(filename, ans):
+    filepath, ext, data_label = split_filename_with_fits_ext(filename)
+    assert filepath == ans[0]
+    if ans[1] is None:
+        assert ext is None
+    else:
+        assert ext == ans[1]
+    assert data_label == ans[2]
+
+
+def test_validate_image2d():
+    # Not 2D image
+    hdu = fits.ImageHDU([0, 0])
+    assert not _validate_image2d(hdu, raise_error=False)
+    with pytest.raises(ValueError, match='Imviz cannot load this HDU'):
+        _validate_image2d(hdu)
+
+    # 2D Image
+    hdu = fits.ImageHDU([[0, 0], [0, 0]])
+    assert _validate_image2d(hdu)
+
+
+def test_validate_bunit():
+    with pytest.raises(u.UnitsError):
+        _validate_bunit('NOT_A_UNIT')
+
+    assert not _validate_bunit('Mjy-sr', raise_error=False)  # Close but not quite
+    assert _validate_bunit('MJy/sr')
+
+
+# TODO: Write real tests
+class TestParseImage:
+    def setup_method(self, method):
+        test_hook.resetmock()
+
+    def teardown_method(self, method):
+        pass
+
+    def test_no_data_label(self):
+        with pytest.raises(NotImplementedError, match='should be set'):
+            _parse_image(None, None, None, False)
+
+    @pytest.mark.skipif(not HAS_JWST_ASDF, reason='jwst not installed')
+    @pytest.mark.remote_data
+    def test_parse_jwst_nircam_level2(self):
+        url = 'https://data.science.stsci.edu/redirect/JWST/jwst-data_analysis_tools/stellar_photometry/jw01072001001_01101_00001_nrcb1_cal.fits'  # noqa: E501
+
+    @pytest.mark.remote_data
+    def test_parse_hst_drz(self):
+        url = 'https://mast.stsci.edu/api/v0.1/Download/file?bundle_name=MAST_2021-04-21T1828.sh&uri=mast:HST/product/jclj01010_drz.fits'  # noqa: E501

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -1,13 +1,16 @@
 import pytest
-from unittest.mock import MagicMock, patch
-from astropy import units as u
 from astropy.io import fits
+from astropy.utils.data import download_file
+from astropy.wcs import WCS
 
-from jdaviz.configs.imviz.helper import split_filename_with_fits_ext
+from jdaviz.configs.imviz.helper import Imviz, split_filename_with_fits_ext
 from jdaviz.configs.imviz.plugins.parsers import (
-    HAS_JWST_ASDF, _validate_image2d, _validate_bunit, _parse_image)
+    HAS_JWST_ASDF, parse_data, _validate_image2d, _validate_bunit, _parse_image)
 
-test_hook = MagicMock()
+
+@pytest.fixture
+def imviz_app():
+    return Imviz()
 
 
 @pytest.mark.parametrize(
@@ -40,30 +43,137 @@ def test_validate_image2d():
 
 
 def test_validate_bunit():
-    with pytest.raises(u.UnitsError):
+    with pytest.raises(ValueError):
         _validate_bunit('NOT_A_UNIT')
 
     assert not _validate_bunit('Mjy-sr', raise_error=False)  # Close but not quite
     assert _validate_bunit('MJy/sr')
 
 
-# TODO: Write real tests
 class TestParseImage:
-    def setup_method(self, method):
-        test_hook.resetmock()
-
-    def teardown_method(self, method):
-        pass
+    def setup_class(self):
+        self.jwst_asdf_url_1 = 'https://data.science.stsci.edu/redirect/JWST/jwst-data_analysis_tools/stellar_photometry/jw01072001001_01101_00001_nrcb1_cal.fits'  # noqa: E501
 
     def test_no_data_label(self):
         with pytest.raises(NotImplementedError, match='should be set'):
             _parse_image(None, None, None, False)
 
+    def test_hdulist_no_image(self, imviz_app):
+        hdulist = fits.HDUList([fits.PrimaryHDU()])
+        with pytest.raises(ValueError, match='does not have any FITS image'):
+            parse_data(imviz_app.app, hdulist, show_in_viewer=False)
+
+    def test_invalid_file_obj(self, imviz_app):
+        some_obj = WCS()  # Might as well re-use existing import
+        with pytest.raises(NotImplementedError, match='Imviz does not support'):
+            parse_data(imviz_app.app, some_obj, show_in_viewer=False)
+
+    @pytest.mark.skipif(HAS_JWST_ASDF, reason='jwst is installed')
+    @pytest.mark.remote_data
+    def test_parse_jwst_nircam_level2_no_jwst(self, imviz_app):
+        filename = download_file(self.jwst_asdf_url_1, cache=True)
+        with pytest.raises(ImportError, match='jwst package is missing'):
+            parse_data(imviz_app.app, filename, data_label='foo',
+                       show_in_viewer=False)
+
     @pytest.mark.skipif(not HAS_JWST_ASDF, reason='jwst not installed')
     @pytest.mark.remote_data
-    def test_parse_jwst_nircam_level2(self):
-        url = 'https://data.science.stsci.edu/redirect/JWST/jwst-data_analysis_tools/stellar_photometry/jw01072001001_01101_00001_nrcb1_cal.fits'  # noqa: E501
+    def test_parse_jwst_nircam_level2(self, imviz_app):
+        from gwcs import WCS as GWCS
+
+        filename = download_file(self.jwst_asdf_url_1, cache=True)
+
+        # Default behavior: Science image
+        parse_data(imviz_app.app, filename, show_in_viewer=False)
+        data = imviz_app.app.data_collection[0]
+        comp = data.get_component('DATA')
+        assert data.label == 'contents[DATA]'  # download_file returns cache loc
+        assert data.shape == (2048, 2048)
+        assert isinstance(data.coords, GWCS)
+        assert comp.units == 'count'  # dm.meta.bunit is not set
+        assert comp.data.shape == (2048, 2048)
+
+        # Request specific extension (name + ver, but ver is not used), use given label
+        parse_data(imviz_app.app, filename, ext=('DQ', 42),
+                   data_label='jw01072001001_01101_00001_nrcb1_cal',
+                   show_in_viewer=False)
+        data = imviz_app.app.data_collection[1]
+        assert data.label == 'jw01072001001_01101_00001_nrcb1_cal[DQ]'
+        assert 'DQ' in data.components
+
+        # Pass in HDUList directly + ext (name only), use given label
+        with fits.open(filename) as pf:
+            parse_data(imviz_app.app, pf, ext='SCI',
+                       data_label='jw01072001001_01101_00001_nrcb1_cal',
+                       show_in_viewer=False)
+            data = imviz_app.app.data_collection[2]
+            comp = data.get_component('DATA')  # SCI = DATA
+            assert data.label == 'jw01072001001_01101_00001_nrcb1_cal[DATA]'
+            assert isinstance(data.coords, GWCS)
+            assert comp.units == 'count'
+
+        # Invalid ASDF attribute (extension)
+        with pytest.raises(AttributeError, match='No attribute'):
+            parse_data(imviz_app.app, filename, ext='DOES_NOT_EXIST',
+                       data_label='foo', show_in_viewer=False)
 
     @pytest.mark.remote_data
-    def test_parse_hst_drz(self):
+    def test_parse_hst_drz(self, imviz_app):
         url = 'https://mast.stsci.edu/api/v0.1/Download/file?bundle_name=MAST_2021-04-21T1828.sh&uri=mast:HST/product/jclj01010_drz.fits'  # noqa: E501
+        filename = download_file(url, cache=True)
+
+        # Default behavior: Load first image
+        parse_data(imviz_app.app, filename, show_in_viewer=False)
+        data = imviz_app.app.data_collection[0]
+        comp = data.get_component('SCI,1')
+        assert data.label == 'contents[SCI,1]'  # download_file returns cache loc
+        assert data.shape == (4300, 4219)
+        assert isinstance(data.coords, WCS)
+        assert comp.units == 'count'  # "ELECTRONS/S" is not valid
+        assert comp.data.shape == (4300, 4219)
+
+        # Request specific extension (name only), use given label
+        parse_data(imviz_app.app, filename, ext='CTX',
+                   data_label='jclj01010_drz', show_in_viewer=False)
+        data = imviz_app.app.data_collection[1]
+        comp = data.get_component('CTX,1')
+        assert data.label == 'jclj01010_drz[CTX,1]'
+        assert comp.units == 'count'  # BUNIT is not set
+
+        # Request specific extension (name + ver), use given label
+        parse_data(imviz_app.app, filename, ext=('WHT', 1),
+                   data_label='jclj01010_drz', show_in_viewer=False)
+        data = imviz_app.app.data_collection[2]
+        comp = data.get_component('WHT,1')
+        assert data.label == 'jclj01010_drz[WHT,1]'
+        assert comp.units == 'count'  # BUNIT is not set
+
+        # Pass in file obj directly
+        with fits.open(filename) as pf:
+            # Default behavior: Load first image
+            parse_data(imviz_app.app, pf, show_in_viewer=False)
+            data = imviz_app.app.data_collection[3]
+            assert data.label.startswith('imviz_data|') and data.label.endswith('[SCI,1]')
+            assert 'SCI,1' in data.components
+
+            # Request specific extension (name only), use given label
+            parse_data(imviz_app.app, pf, ext='CTX', show_in_viewer=False)
+            data = imviz_app.app.data_collection[4]
+            assert data.label.startswith('imviz_data|') and data.label.endswith('[CTX,1]')
+            assert 'CTX,1' in data.components
+
+            # Pass in HDU directly, use given label
+            parse_data(imviz_app.app, pf[2], data_label='foo', show_in_viewer=False)
+            data = imviz_app.app.data_collection[5]
+            assert data.label == 'foo[WHT,1]'
+            assert 'WHT,1' in data.components
+
+        # Cannot load non-image extension
+        with pytest.raises(ValueError, match='Imviz cannot load this HDU'):
+            parse_data(imviz_app.app, filename, ext='HDRTAB',
+                       show_in_viewer=False)
+
+        # Invalid FITS extension
+        with pytest.raises(KeyError, match='not found'):
+            parse_data(imviz_app.app, filename, ext='DOES_NOT_EXIST',
+                       data_label='foo', show_in_viewer=False)

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "handed-person",
    "metadata": {},
    "source": [
     "# Proof of concept of Imviz requirements using glupyter/bqplot"
@@ -10,7 +9,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "frozen-oracle",
    "metadata": {},
    "source": [
     "We start off by silencing warnings that can happen when loading data as well as deprecation warnings, for clarity:"
@@ -19,7 +17,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "handed-chicago",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,19 +27,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "caroline-enclosure",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from urllib.request import urlretrieve\n",
+    "from astropy.utils.data import download_file\n",
     "\n",
-    "urlretrieve('http://www.astropy.org/astropy-data/galactic_center/gc_2mass_j.fits', filename='2mass_j.fits')\n",
-    "urlretrieve('http://www.astropy.org/astropy-data/galactic_center/gc_msx_e.fits', filename='msx_e.fits')"
+    "gc_2mass_j = download_file('https://www.astropy.org/astropy-data/galactic_center/gc_2mass_j.fits', cache=True)\n",
+    "gc_msx_e = download_file('https://www.astropy.org/astropy-data/galactic_center/gc_msx_e.fits', cache=True)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "advance-exhibition",
    "metadata": {},
    "source": [
     "We start off by looking at some of the basic features:"
@@ -51,7 +46,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "covered-bikini",
    "metadata": {
     "scrolled": false
    },
@@ -61,8 +55,8 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "imviz = Imviz()\n",
-    "imviz.load_data('2mass_j.fits')\n",
-    "imviz.load_data('msx_e.fits')\n",
+    "imviz.load_data(gc_2mass_j, data_label='gc_2mass_j')\n",
+    "imviz.load_data(gc_msx_e, data_label='gc_msx_e')\n",
     "\n",
     "viewer = imviz.app.get_viewer('viewer-1')\n",
     "\n",
@@ -71,7 +65,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "changing-width",
    "metadata": {},
    "source": [
     "Panning and zooming is possible by showing the viewer toolbar and clicking on the '+'-shaped icon, then dragging around in the image and using scrolling to zoom in and out. To change the stretch and colormap, show the **Layer** options accessible through the last icon in the viewer toolbar.\n",
@@ -82,7 +75,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "sonic-cuisine",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +83,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "automatic-engineer",
    "metadata": {},
    "source": [
     "the colormap:"
@@ -100,7 +91,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "authorized-liberty",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +99,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "close-picture",
    "metadata": {},
    "source": [
     "the limits via the percentile option:"
@@ -118,16 +107,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "compressed-potential",
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer.state.layers[0].percentile = 90"
+    "viewer.state.layers[0].percentile = 99"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "intimate-steam",
    "metadata": {},
    "source": [
     "or the limits directly:"
@@ -136,17 +123,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "inappropriate-holmes",
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer.state.layers[0].v_min = -10\n",
-    "viewer.state.layers[0].v_max = +100"
+    "viewer.state.layers[0].v_min = 150\n",
+    "viewer.state.layers[0].v_max = 1000"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "patent-christopher",
    "metadata": {},
    "source": [
     "Note also that in the above example there are mouse-over coordinates visible by default."
@@ -154,7 +139,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aerial-turtle",
    "metadata": {},
    "source": [
     "It possible to make selections/regions in images and export these to astropy regions. Click on the viewer toolbar then click on the circular selection tool, and drag and click to select an interesting region on the sky. We can then export this region with:"
@@ -163,7 +147,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "thousand-directory",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +156,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "solid-brother",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +164,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "decent-calibration",
    "metadata": {},
    "source": [
     "Since the region is an astropy region, we can e.g. convert it to a mask:"
@@ -191,7 +172,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "round-lotus",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,17 +181,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "smooth-chrome",
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.imshow(mask.to_image((2048, 2048)), origin='lower')"
+    "data = imviz.app.get_data_from_viewer('viewer-1', 'gc_2mass_j')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "appropriate-anatomy",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(mask.to_image(data.shape), origin='lower')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -233,7 +220,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,8 @@ test =
 docs =
     sphinx-rtd-theme
     sphinx-astropy
+all =
+    jwst
 
 [options.package_data]
 jdaviz =


### PR DESCRIPTION
Fix #510 

~I cannot test this until #540 is resolved because `jwst` is not compatible with Windows.~

Reference: https://github.com/glue-viz/glue/blob/master/glue/core/data_factories/fits.py

# Proof-of-concept

Successfully loaded the following locally in notebook:

```python
# JWST/NIRCAM ASDF-in-FITS
imviz.load_data('/path/to/jw1069001001_01203_00002_nrca1_level2_cal.fits')  # SCI
imviz.load_data('/path/to/jw1069001001_01203_00002_nrca1_level2_cal.fits[DQ,1]')
imviz.load_data('/path/to/jw1069001001_01203_00002_nrca1_level2_cal.fits[VAR_POISSON]')

# HST/ACS Drizzled FITS
imviz.load_data('/path/to/jbt7a3020_drz.fits')  # SCI
imviz.load_data('/path/to/jbt7a3020_drz.fits[WHT,1]')
imviz.load_data('/path/to/jbt7a3020_drz.fits[CTX]')
```

As you can see, JWST filenames are a little long, so I need to scroll to get the full screenshot(s).

![Screenshot 2021-04-20 155340](https://user-images.githubusercontent.com/2090236/115456907-b8875800-a1f1-11eb-8315-1b6e7d86beff.jpg)

![Screenshot 2021-04-20 155354](https://user-images.githubusercontent.com/2090236/115456917-bc1adf00-a1f1-11eb-96fa-a5f136a22648.jpg)

# TODO

- [x] Tom R, how do I know if the parser used the ASDF logic?
- [x] Tom R, how to tell it to not load extensions that don't make sense?
- [x] Tom R, why is it not auto-displaying? How to make it?
- [x] POs, where are the list of images to test against as acceptance criteria? See https://github.com/spacetelescope/jdaviz/pull/541#issuecomment-824404871
- [x] Did I break circular region selection in Tom's example notebook? (No, I didn't. See #569)
- [x] Do we need test in CI? How? (Yes, use `remote_data` and stuff from PO.)