### PR TITLE
MNT: Ignore FITS from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ htmlcov
 .coverage
 MANIFEST
 .ipynb_checkpoints
+notebooks/*.fits
 
 # Sphinx
 docs/api


### PR DESCRIPTION
Notebook added in #429 downloads two FITS files into `notebooks` directory. If not ignored, someone can accidentally add them into version control in the future.