### PR TITLE
DOC: Add STScI code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,54 @@
+# Spacetelescope Open Source Code of Conduct
+
+We expect all "spacetelescope" organization projects to adopt a code of conduct
+that ensures a productive, respectful environment for all open source
+contributors and participants. We are committed to providing a strong and
+enforced code of conduct and expect everyone in our community to follow these
+guidelines when interacting with others in all forums. Our goal is to keep ours
+a positive, inclusive, successful, and growing community. The community of
+participants in open source Astronomy projects is made up of members from
+around the globe with a diverse set of skills, personalities, and experiences.
+It is through these differences that our community experiences success and
+continued growth.
+
+As members of the community:
+
+- We pledge to treat all people with respect and provide a harassment-
+  and bullying-free environment, regardless of sex, sexual orientation and/or
+  gender identity, disability, physical appearance, body size, race,
+  nationality, ethnicity, and religion. In particular, sexual language and
+  imagery, sexist, racist, or otherwise exclusionary jokes are not appropriate.
+- We pledge to respect the work of others by recognizing acknowledgment/citation
+  requests of original authors. As authors, we pledge to be explicit about how
+  we want our own work to be cited or acknowledged.
+- We pledge to welcome those interested in joining the community, and realize
+  that including people with a variety of opinions and backgrounds will only
+  serve to enrich our community. In particular, discussions relating to
+  pros/cons of various technologies, programming languages, and so on are
+  welcome, but these should be done with respect, taking proactive measure to
+  ensure that all participants are heard and feel confident that they can
+  freely express their opinions.
+- We pledge to welcome questions and answer them respectfully, paying
+  particular attention to those new to the community. We pledge to provide
+  respectful criticisms and feedback in forums, especially in discussion
+  threads resulting from code contributions.
+- We pledge to be conscientious of the perceptions of the wider community and
+  to respond to criticism respectfully. We will strive to model behaviors that
+  encourage productive debate and disagreement, both within our community and
+  where we are criticized. We will treat those outside our community with the
+  same respect as people within our community.
+- We pledge to help the entire community follow the code of conduct, and to not
+  remain silent when we see violations of the code of conduct. We will take
+  action when members of our community violate this code such as such as
+  contacting conduct@stsci.edu (all emails sent to this address will be
+  treated with the strictest confidence) or talking privately with the person.
+
+This code of conduct applies to all community situations online and offline,
+including mailing lists, forums, social media, conferences, meetings,
+associated social events, and one-to-one interactions.
+
+Parts of this code of conduct have been adapted from the Astropy and NumFOCUS
+codes of conduct:
+
+- https://www.astropy.org/code_of_conduct.html
+- https://www.numfocus.org/about/code-of-conduct/


### PR DESCRIPTION
Code of conduct is from https://github.com/spacetelescope/stsci-package-template/blob/main/CODE_OF_CONDUCT.md