### PR TITLE
TST: Test workflow clean-ups

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -44,10 +44,10 @@ jobs:
             toxposargs: --remote-data
             allow_failure: false
 
-          - name: OS X - Python 3.8
+          - name: OS X - Python 3.7
             os: macos-latest
-            python: 3.8
-            toxenv: py38-test
+            python: 3.7
+            toxenv: py37-test
             allow_failure: false
 
           - name: Windows - Python 3.8
@@ -66,13 +66,12 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install base dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox codecov
+      run: python -m pip install --upgrade pip tox
+    - name: Install codecov
+      if: "contains(matrix.toxenv, '-cov')"
+      run: python -m pip install codecov
     - name: Test/run with tox
-      run: |
-        tox -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
-    # Activate your repo on codecov.io first.
+      run: tox -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
     - name: Upload coverage to codecov
       if: "contains(matrix.toxenv, '-cov')"
       uses: codecov/codecov-action@v1

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 envlist =
-    py{36,37,38}-test{,-alldeps,-devdeps}{,-cov}
-    py{36,37,38}-test-numpy{116,117,118}
-    py{36,37,38}-test-astropy{30,40,lts}
+    py{36,37,38,39}-test{,-alldeps,-devdeps}{,-cov}
+    py{36,37,38,39}-test-astropy{30,40,lts}-numpy{116,117,118}
     build_docs
     linkcheck
     codestyle
     pep517
+    securityaudit
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
@@ -111,4 +111,4 @@ deps =
     twine
 commands =
     python -m build --sdist .
-    twine check dist/*
+    twine check dist/* --strict


### PR DESCRIPTION
* General clean-ups of CI workflow syntax.
* Update `tox` env list to be consistent with what is actually used.
* PEP 517 check now fails on warnings.
* Change OSX job to use Python 3.7 because that Python version is currently untested.

But mainly I just want to see if the labeler works... 😹 