### PR TITLE
TST: Suppress warnings in test logs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ testpaths = "jdaviz" "docs"
 astropy_header = true
 doctest_plus = enabled
 text_file_format = rst
-addopts = --doctest-rst
+addopts = --doctest-rst -Wignore
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
Until we are ready to deal with #478 , this will suppress all the warnings in test logs. Otherwise, it is annoying to scroll up to get to the parts of the logs that matter.

If this is merged, #478 should be updated with a reminder to undo this change.

# Before

```
...
..\..\docs\specviz\notebook.rst .                                        [100%]

============================== warnings summary ===============================

(a lot of stuff)

  d:\a\jdaviz\jdaviz\.tox\py38-test\lib\site-packages\glue\core\data.py:1803: FutureWarning: ...
    full_result[result_slices] = result

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================= 44 passed, 566 warnings in 81.25s (0:01:21) =================
___________________________________ summary ___________________________________
  py38-test: commands succeeded
  congratulations :)
```

# After

```
...
..\..\docs\specviz\notebook.rst .                                        [100%]

======================== 44 passed in 87.57s (0:01:27) ========================
___________________________________ summary ___________________________________
  py38-test: commands succeeded
  congratulations :)
```