### PR TITLE
Change default data layer opacity to 1

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -15,7 +15,8 @@ from traitlets import Dict, Bool
 from regions import RectanglePixelRegion, PixCoord
 from specutils import Spectrum1D
 
-from glue.config import data_translator, settings
+from glue.config import data_translator
+from glue.config import settings as glue_settings
 from glue.core import BaseData, HubListener, Data, DataCollection
 from glue.core.link_helpers import LinkSame
 from glue.core.message import (DataCollectionAddMessage,
@@ -47,7 +48,7 @@ EXT_TYPES = dict(flux=['flux', 'sci'],
 
 # Set default opacity for data layers to 1 instead of 0.8 in
 # some glue-core versions
-settings.DATA_ALPHA = 1
+glue_settings.DATA_ALPHA = 1
 
 
 class ApplicationState(State):

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -15,7 +15,7 @@ from traitlets import Dict, Bool
 from regions import RectanglePixelRegion, PixCoord
 from specutils import Spectrum1D
 
-from glue.config import data_translator
+from glue.config import data_translator, settings
 from glue.core import BaseData, HubListener, Data, DataCollection
 from glue.core.link_helpers import LinkSame
 from glue.core.message import (DataCollectionAddMessage,
@@ -43,6 +43,11 @@ CONTAINER_TYPES = dict(row='gl-row', col='gl-col', stack='gl-stack')
 EXT_TYPES = dict(flux=['flux', 'sci'],
                  uncert=['ivar', 'err', 'var', 'uncert'],
                  mask=['mask', 'dq'])
+
+
+# Set default opacity for data layers to 1 instead of 0.8 in
+# some glue-core versions
+settings.DATA_ALPHA = 1
 
 
 class ApplicationState(State):


### PR DESCRIPTION
In glue, the default opacity for data layers is 0.8 - while it might make sense to change the default there, for now the quickest and most past- and future-proof fix is to simply set the default for jdaviz here.

Fixes https://github.com/spacetelescope/jdaviz/issues/535
Fixes https://github.com/spacetelescope/jdaviz/issues/537