### PR TITLE
Use ipyfilechooser for file dialog

### DIFF
--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -55,6 +55,10 @@ def main(filename, layout='default', browser='default'):
 
     start_dir = os.path.abspath('.')
 
+    # Keep track of start directory in environment variable so that it can be
+    # easily accessed e.g. in the file load dialog.
+    os.environ['JDAVIZ_START_DIR'] = start_dir
+
     nbdir = tempfile.mkdtemp()
 
     with open(os.path.join(nbdir, 'notebook.ipynb'), 'w') as nbf:

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.py
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.py
@@ -19,7 +19,12 @@ class DataTools(TemplateMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._file_upload = FileChooser(os.path.abspath(os.path.curdir))
+        if 'JDAVIZ_START_DIR' in os.environ:
+            start_path = os.environ['JDAVIZ_START_DIR']
+        else:
+            start_path = os.path.abspath(os.path.curdir)
+
+        self._file_upload = FileChooser(start_path)
 
         self.components = {'g-file-import': self._file_upload}
 

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.py
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.py
@@ -12,7 +12,6 @@ __all__ = ['DataTools']
 @tool_registry('g-data-tools')
 class DataTools(TemplateMixin):
     template = load_template("data_tools.vue", __file__).tag(sync=True)
-    file_path = Unicode("").tag(sync=True)
     dialog = Bool(False).tag(sync=True)
     valid_path = Bool(True).tag(sync=True)
     error_message = Unicode().tag(sync=True)
@@ -26,9 +25,13 @@ class DataTools(TemplateMixin):
 
         self._file_upload.register_callback(self._on_file_path_changed)
 
+    @property
+    def file_path(self):
+        return self._file_upload.selected
+
     @observe("file_path")
     def _on_file_path_changed(self, event):
-        if not os.path.exists(event['new']) or not os.path.isfile(event['new']):
+        if not os.path.exists(self.file_path) or not os.path.isfile(self.file_path):
             self.error_message = "No file exists at given path"
             self.valid_path = False
         else:

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.py
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.py
@@ -19,7 +19,7 @@ class DataTools(TemplateMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._file_upload = FileChooser(os.path.expanduser('~'), use_dir_icons=True)
+        self._file_upload = FileChooser(os.path.abspath(os.path.curdir))
 
         self.components = {'g-file-import': self._file_upload}
 

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.py
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.py
@@ -1,7 +1,7 @@
 from jdaviz.core.template_mixin import TemplateMixin
 from jdaviz.utils import load_template
 from jdaviz.core.events import LoadDataMessage
-from traitlets import Unicode, Bool, observe
+from traitlets import Unicode, Bool
 import os
 from jdaviz.configs.default.plugins.data_tools.file_chooser import FileChooser
 from jdaviz.core.registries import tool_registry

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.py
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.py
@@ -19,10 +19,7 @@ class DataTools(TemplateMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if 'JDAVIZ_START_DIR' in os.environ:
-            start_path = os.environ['JDAVIZ_START_DIR']
-        else:
-            start_path = os.path.abspath(os.path.curdir)
+        start_path = os.environ.get('JDAVIZ_START_DIR', os.path.curdir)
 
         self._file_upload = FileChooser(start_path)
 

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.py
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.py
@@ -39,7 +39,14 @@ class DataTools(TemplateMixin):
             self.valid_path = True
 
     def vue_load_data(self, *args, **kwargs):
-        if os.path.exists(self.file_path):
-            load_data_message = LoadDataMessage(self.file_path, sender=self)
-            self.hub.broadcast(load_data_message)
-            self.dialog = False
+        if self.file_path is None:
+            self.error_message = "No file selected"
+        elif os.path.exists(self.file_path):
+            try:
+                load_data_message = LoadDataMessage(self.file_path, sender=self)
+                self.hub.broadcast(load_data_message)
+            except Exception:
+                self.error_message = "An error occurred when loading the file"
+            else:
+                self.dialog = False
+                self._file_upload.reset()

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.py
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.py
@@ -20,14 +20,21 @@ class DataTools(TemplateMixin):
         super().__init__(*args, **kwargs)
 
         self._file_upload = FileChooser(os.path.expanduser('~'), use_dir_icons=True)
+        self._file_upload._show_dialog()
+        self._file_upload._select.layout.visibility = 'hidden'
+        self._file_upload._cancel.layout.visibility = 'hidden'
+        self._file_upload._label.layout.visibility = 'hidden'
 
         self.components = {'g-file-import': self._file_upload}
 
-        self._file_upload.register_callback(self._on_file_path_changed)
+        self._file_upload._filename.observe(self._on_file_path_changed, names='value')
 
     @property
     def file_path(self):
-        return self._file_upload.selected
+        return os.path.join(
+            self._file_upload._pathlist.value,
+            self._file_upload._filename.value
+        )
 
     @observe("file_path")
     def _on_file_path_changed(self, event):
@@ -49,4 +56,3 @@ class DataTools(TemplateMixin):
                 self.error_message = "An error occurred when loading the file"
             else:
                 self.dialog = False
-                self._file_upload.reset()

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.py
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.py
@@ -3,6 +3,7 @@ from jdaviz.utils import load_template
 from jdaviz.core.events import LoadDataMessage
 from traitlets import Unicode, Bool, observe
 import os
+from ipyfilechooser import FileChooser
 from jdaviz.core.registries import tool_registry
 
 __all__ = ['DataTools']
@@ -15,6 +16,15 @@ class DataTools(TemplateMixin):
     dialog = Bool(False).tag(sync=True)
     valid_path = Bool(True).tag(sync=True)
     error_message = Unicode().tag(sync=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._file_upload = FileChooser(os.path.expanduser('~'), use_dir_icons=True)
+
+        self.components = {'g-file-import': self._file_upload}
+
+        self._file_upload.register_callback(self._on_file_path_changed)
 
     @observe("file_path")
     def _on_file_path_changed(self, event):

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.vue
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.vue
@@ -16,8 +16,8 @@
           <v-container>
             <v-row>
               <v-col>
-                <span>{{ error_message }}</span>
                 <g-file-import id="file-uploader"></g-file-import>
+                <span style="color: red;">{{ error_message }}</span>
               </v-col>
             </v-row>
           </v-container>

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.vue
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.vue
@@ -1,6 +1,6 @@
 <template>
   <v-toolbar-items>
-    <v-dialog v-model="dialog" width="500" @keydown.stop>
+    <v-dialog v-model="dialog" height="400" width="600">
       <template v-slot:activator="{ on }">
         <v-btn tile depressed v-on="on" color="accent">
           Import
@@ -16,7 +16,8 @@
           <v-container>
             <v-row>
               <v-col>
-                <g-file-import id="file-uploader" :error-messages="error_message"></g-file-import>
+                <span>{{ error_message }}</span>
+                <g-file-import id="file-uploader"></g-file-import>
               </v-col>
             </v-row>
           </v-container>

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.vue
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.vue
@@ -1,6 +1,6 @@
 <template>
   <v-toolbar-items>
-    <v-dialog v-model="dialog" width="500" persistent>
+    <v-dialog v-model="dialog" width="500" @keydown.stop>
       <template v-slot:activator="{ on }">
         <v-btn tile depressed v-on="on" color="accent">
           Import
@@ -9,39 +9,26 @@
       </template>
 
       <v-card>
+
         <v-card-title class="headline" color="primary" primary-title>Import Data</v-card-title>
+
         <v-card-text>
           <v-container>
             <v-row>
               <v-col>
-                <!-- <v-file-input v-model="files" label="File input"></v-file-input> -->
-                <v-text-field
-                  label="File Path"
-                  placeholder="/path/to/data/file"
-                  v-model="file_path"
-                  :error-messages="error_message"
-                ></v-text-field>
+                <g-file-import id="file-uploader" :error-messages="error_message"></g-file-import>
               </v-col>
             </v-row>
           </v-container>
         </v-card-text>
-        <!-- <v-divider></v-divider> -->
+
         <v-card-actions>
           <div class="flex-grow-1"></div>
           <v-btn color="primary" text @click="dialog = false">Cancel</v-btn>
           <v-btn color="primary" text @click="load_data" :disabled="!valid_path">Import</v-btn>
         </v-card-actions>
+
       </v-card>
     </v-dialog>
-
-    <v-tooltip bottom>
-      <template v-slot:activator="{ on }">
-        <v-btn disabled v-on="on" icon tile>
-          <v-icon>mdi-format-blank</v-icon>
-        </v-btn>
-      </template>
-      <span>Spacer</span>
-    </v-tooltip>
-    <!-- <v-divider vertical></v-divider> -->
   </v-toolbar-items>
 </template>

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.vue
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.vue
@@ -13,6 +13,7 @@
         <v-card-title class="headline" color="primary" primary-title>Import Data</v-card-title>
 
         <v-card-text>
+          Single click to select directory. Select and click "IMPORT" to open a file.
           <v-container>
             <v-row>
               <v-col>

--- a/jdaviz/configs/default/plugins/data_tools/file_chooser.py
+++ b/jdaviz/configs/default/plugins/data_tools/file_chooser.py
@@ -90,7 +90,11 @@ def get_dir_contents(
     if prepend_icons:
         return prepend_dir_icons(sorted(dirs)) + sorted(files)
     else:
-        return sorted(dirs) + sorted(files)
+        return add_trailing_slash(sorted(dirs)) + sorted(files)
+
+
+def add_trailing_slash(dir_list):
+    return [dirname + '/' for dirname in dir_list]
 
 
 def prepend_dir_icons(dir_list):
@@ -123,10 +127,7 @@ class FileChooser(VBox, ValueWidget):
             self,
             path=os.getcwd(),
             filename='',
-            select_desc='Select',
-            change_desc='Change',
             show_hidden=False,
-            select_default=False,
             use_dir_icons=False,
             filter_pattern=None,
             **kwargs):
@@ -134,8 +135,6 @@ class FileChooser(VBox, ValueWidget):
         self._default_path = path.rstrip(os.path.sep)
         self._default_filename = filename
         self._show_hidden = show_hidden
-        self._select_desc = select_desc
-        self._change_desc = change_desc
         self._use_dir_icons = use_dir_icons
         self._filter_pattern = filter_pattern
 

--- a/jdaviz/configs/default/plugins/data_tools/file_chooser.py
+++ b/jdaviz/configs/default/plugins/data_tools/file_chooser.py
@@ -1,0 +1,462 @@
+# The code in this file has been forked from the ipyfilechooser package which
+# was originally released under the following license:
+#
+# MIT License
+#
+# Copyright (c) 2019 Thomas Bouve
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# This was forked to enable us to use our own buttons for the dialog and use
+# this just for the file browser view, but we could switch back to using the
+# main released version of ipyfilechooser if it was possible to toggle this via
+# public API. However for now this is sufficient until we know whether we are
+# going to try and implement a native file picker instead.
+
+
+import fnmatch
+import os
+import string
+import sys
+
+from traitlets import Unicode
+
+from ipywidgets import Dropdown, Select, Layout, GridBox, VBox, ValueWidget
+
+__all__ = ['FileChooser']
+
+
+def get_subpaths(path):
+    """Walk a path and return a list of subpaths."""
+    if os.path.isfile(path):
+        path = os.path.dirname(path)
+
+    paths = [path]
+    path, tail = os.path.split(path)
+
+    while tail:
+        paths.append(path)
+        path, tail = os.path.split(path)
+
+    try:
+        # Add Windows drive letters, but remove the current drive
+        drives = get_drive_letters()
+        drives.remove(paths[-1])
+        paths.extend(drives)
+    except ValueError:
+        pass
+    return paths
+
+
+def has_parent(path):
+    """Check if a path has a parent folder."""
+    return os.path.basename(path) != ''
+
+
+def match_item(item, filter_pattern):
+    """Check if a string matches one or more fnmatch patterns."""
+    if isinstance(filter_pattern, str):
+        filter_pattern = [filter_pattern]
+
+    idx = 0
+    found = False
+
+    while idx < len(filter_pattern) and not found:
+        found |= fnmatch.fnmatch(item, filter_pattern[idx])
+        idx += 1
+
+    return found
+
+
+def get_dir_contents(
+        path,
+        show_hidden=False,
+        prepend_icons=False,
+        filter_pattern=None):
+    """Get directory contents."""
+    files = list()
+    dirs = list()
+
+    if os.path.isdir(path):
+        for item in os.listdir(path):
+            append = True
+            if item.startswith('.') and not show_hidden:
+                append = False
+            full_item = os.path.join(path, item)
+            if append and os.path.isdir(full_item):
+                dirs.append(item)
+            elif append:
+                if filter_pattern:
+                    if match_item(item, filter_pattern):
+                        files.append(item)
+                else:
+                    files.append(item)
+        if has_parent(path):
+            dirs.insert(0, '..')
+    if prepend_icons:
+        return prepend_dir_icons(sorted(dirs)) + sorted(files)
+    else:
+        return sorted(dirs) + sorted(files)
+
+
+def prepend_dir_icons(dir_list):
+    """Prepend unicode folder icon to directory names."""
+    return ['\U0001F4C1 ' + dirname for dirname in dir_list]
+
+
+def get_drive_letters():
+    """Get drive letters."""
+    if sys.platform == 'win32':
+        # Windows has drive letters
+        return [
+            '%s:\\' % d for d in string.ascii_uppercase
+            if os.path.exists('%s:' % d)
+        ]
+    else:
+        # Unix does not have drive letters
+        return []
+
+
+class FileChooser(VBox, ValueWidget):
+    """FileChooser class."""
+
+    _LBL_TEMPLATE = '<span style="margin-left:10px; color:{1};">{0}</span>'
+    _LBL_NOFILE = 'No file selected'
+
+    file_path = Unicode(allow_none=True)
+
+    def __init__(
+            self,
+            path=os.getcwd(),
+            filename='',
+            select_desc='Select',
+            change_desc='Change',
+            show_hidden=False,
+            select_default=False,
+            use_dir_icons=False,
+            filter_pattern=None,
+            **kwargs):
+        """Initialize FileChooser object."""
+        self._default_path = path.rstrip(os.path.sep)
+        self._default_filename = filename
+        self._show_hidden = show_hidden
+        self._select_desc = select_desc
+        self._change_desc = change_desc
+        self._use_dir_icons = use_dir_icons
+        self._filter_pattern = filter_pattern
+
+        # Widgets
+
+        self._pathlist = Dropdown(
+            description="",
+            layout=Layout(
+                width='auto',
+                grid_area='pathlist'
+            )
+        )
+
+        self._dircontent = Select(
+            rows=8,
+            layout=Layout(
+                width='auto',
+                grid_area='dircontent'
+            )
+        )
+
+        # Widget observe handlers
+        self._pathlist.observe(
+            self._on_pathlist_select,
+            names='value'
+        )
+        self._dircontent.observe(
+            self._on_dircontent_select,
+            names='value'
+        )
+       # Layout
+        self._gb = GridBox(
+            children=[
+                self._pathlist,
+                self._dircontent
+            ],
+            layout=Layout(
+                width='500px',
+                grid_gap='0px 0px',
+                grid_template_rows='auto auto',
+                grid_template_columns='60% 40%',
+                grid_template_areas='''
+                    'pathlist pathlist'
+                    'dircontent dircontent'
+                    '''
+            )
+        )
+
+        # Call setter to set initial form values
+        self._set_form_values(
+            self._default_path,
+            self._default_filename
+        )
+
+        self._initialize_form_values()
+
+        # Call VBox super class __init__
+        super().__init__(
+            children=[self._gb],
+            layout=Layout(width='auto'),
+            **kwargs
+        )
+
+    def _set_form_values(self, path, filename):
+        """Set the form values."""
+        # Disable triggers to prevent selecting an entry in the Select
+        # box from automatically triggering a new event.
+        self._pathlist.unobserve(
+            self._on_pathlist_select,
+            names='value'
+        )
+        self._dircontent.unobserve(
+            self._on_dircontent_select,
+            names='value'
+        )
+
+        # Set form values
+        self._pathlist.options = get_subpaths(path)
+        self._pathlist.value = path
+
+        # file/folder real names
+        dircontent_real_names = get_dir_contents(
+            path,
+            show_hidden=self._show_hidden,
+            prepend_icons=False,
+            filter_pattern=self._filter_pattern
+        )
+
+        # file/folder display names
+        dircontent_display_names = get_dir_contents(
+            path,
+            show_hidden=self._show_hidden,
+            prepend_icons=self._use_dir_icons,
+            filter_pattern=self._filter_pattern
+        )
+
+        # Dict to map real names to display names
+        self._map_name_to_disp = {
+            real_name: disp_name
+            for real_name, disp_name in zip(
+                dircontent_real_names,
+                dircontent_display_names
+            )
+        }
+
+        # Dict to map display names to real names
+        self._map_disp_to_name = dict(
+            reversed(item) for item in self._map_name_to_disp.items()
+        )
+
+        # Set _dircontent form value to display names
+        self._dircontent.options = dircontent_display_names
+
+        # If the value in the filename Text box equals a value in the
+        # Select box and the entry is a file then select the entry.
+        if ((filename in dircontent_real_names) and
+                os.path.isfile(os.path.join(path, filename))):
+            self._dircontent.value = self._map_name_to_disp[filename]
+        else:
+            self._dircontent.value = None
+
+        # Reenable triggers again
+        self._pathlist.observe(
+            self._on_pathlist_select,
+            names='value'
+        )
+        self._dircontent.observe(
+            self._on_dircontent_select,
+            names='value'
+        )
+
+        self._update_file_path()
+
+    def _on_pathlist_select(self, change):
+        """Handle selecting a path entry."""
+        self._set_form_values(
+            change['new'],
+            self._selected_filename
+        )
+
+    def _on_dircontent_select(self, change):
+        """Handle selecting a folder entry."""
+        new_path = os.path.realpath(
+            os.path.join(
+                self._selected_path,
+                self._map_disp_to_name[change['new']]
+            )
+        )
+
+        # Check if folder or file
+        if os.path.isdir(new_path):
+            path = new_path
+            filename = None
+        elif os.path.isfile(new_path):
+            path = self._selected_path
+            filename = self._map_disp_to_name[change['new']]
+
+        self._set_form_values(
+            path,
+            filename
+        )
+
+    def _initialize_form_values(self):
+        """Show the dialog."""
+
+        # Show the form with the correct path and filename
+        if ((self._selected_path is not None) and
+                (self._selected_filename is not None)):
+            path = self._selected_path
+            filename = self._selected_filename
+        else:
+            path = self._default_path
+            filename = self._default_filename
+
+        self._set_form_values(path, filename)
+
+    @property
+    def _selected_path(self):
+        return self._pathlist.value
+
+    @property
+    def _selected_filename(self):
+        if self._dircontent.value is None:
+            return None
+        else:
+            return self._map_disp_to_name[self._dircontent.value]
+
+    def _update_file_path(self):
+        if self._selected_filename is None or self._selected_path is None:
+            self.file_path = None
+        else:
+            self.file_path = os.path.join(self._selected_path,
+                                          self._selected_filename)
+
+    def refresh(self):
+        """Re-render the form."""
+        self._set_form_values(
+            self._selected_path,
+            self._selected_filename
+        )
+
+    @property
+    def show_hidden(self):
+        """Get _show_hidden value."""
+        return self._show_hidden
+
+    @show_hidden.setter
+    def show_hidden(self, hidden):
+        """Set _show_hidden value."""
+        self._show_hidden = hidden
+        self.refresh()
+
+    @property
+    def use_dir_icons(self):
+        """Get _use_dir_icons value."""
+        return self._use_dir_icons
+
+    @use_dir_icons.setter
+    def use_dir_icons(self, dir_icons):
+        """Set _use_dir_icons value."""
+        self._use_dir_icons = dir_icons
+        self.refresh()
+
+    @property
+    def rows(self):
+        """Get current number of rows."""
+        return self._dircontent.rows
+
+    @rows.setter
+    def rows(self, rows):
+        """Set number of rows."""
+        self._dircontent.rows = rows
+
+    @property
+    def default_path(self):
+        """Get the default_path value."""
+        return self._default_path
+
+    @default_path.setter
+    def default_path(self, path):
+        """Set the default_path."""
+        self._default_path = path.rstrip(os.path.sep)
+        self._set_form_values(
+            self._default_path,
+            self._selected_filename
+        )
+
+    @property
+    def default_filename(self):
+        """Get the default_filename value."""
+        return self._default_filename
+
+    @default_filename.setter
+    def default_filename(self, filename):
+        """Set the default_filename."""
+        self._default_filename = filename
+        self._set_form_values(
+            self._selected_path,
+            self._default_filename
+        )
+
+    @property
+    def filter_pattern(self):
+        """Get file name filter pattern."""
+        return self._filter_pattern
+
+    @filter_pattern.setter
+    def filter_pattern(self, filter_pattern):
+        """Set file name filter pattern."""
+        self._filter_pattern = filter_pattern
+        self.refresh()
+
+    @property
+    def selected(self):
+        """Get selected value."""
+        try:
+            return os.path.join(
+                self._selected_path,
+                self._selected_filename
+            )
+        except TypeError:
+            return None
+
+    def __repr__(self):
+        """Build string representation."""
+        str_ = (
+            "FileChooser("
+            "path='{0}', "
+            "filename='{1}', "
+            "show_hidden='{3}', "
+            "use_dir_icons='{4}', "
+            "select_desc='{6}', "
+            "change_desc='{7}')"
+        ).format(
+            self._default_path,
+            self._default_filename,
+            self._show_hidden,
+            self._use_dir_icons,
+            self._select_desc,
+            self._change_desc
+        )
+        return str_

--- a/jdaviz/configs/default/plugins/data_tools/file_chooser.py
+++ b/jdaviz/configs/default/plugins/data_tools/file_chooser.py
@@ -188,7 +188,8 @@ class FileChooser(VBox, ValueWidget):
             self._on_dircontent_select,
             names='value'
         )
-       # Layout
+
+        # Layout
         self._gb = GridBox(
             children=[
                 self._pathlist,
@@ -440,23 +441,3 @@ class FileChooser(VBox, ValueWidget):
             )
         except TypeError:
             return None
-
-    def __repr__(self):
-        """Build string representation."""
-        str_ = (
-            "FileChooser("
-            "path='{0}', "
-            "filename='{1}', "
-            "show_hidden='{3}', "
-            "use_dir_icons='{4}', "
-            "select_desc='{6}', "
-            "change_desc='{7}')"
-        ).format(
-            self._default_path,
-            self._default_filename,
-            self._show_hidden,
-            self._use_dir_icons,
-            self._select_desc,
-            self._change_desc
-        )
-        return str_

--- a/jdaviz/configs/default/plugins/data_tools/file_chooser.py
+++ b/jdaviz/configs/default/plugins/data_tools/file_chooser.py
@@ -1,27 +1,5 @@
 # The code in this file has been forked from the ipyfilechooser package which
-# was originally released under the following license:
-#
-# MIT License
-#
-# Copyright (c) 2019 Thomas Bouve
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# was originally released under the license in licenses/IPYFILECHOOSER_LICENSE.rst
 #
 # This was forked to enable us to use our own buttons for the dialog and use
 # this just for the file browser view, but we could switch back to using the

--- a/licenses/IPYFILECHOOSER_LICENSE.rst
+++ b/licenses/IPYFILECHOOSER_LICENSE.rst
@@ -1,0 +1,26 @@
+This package includes code adapted from the ipyfilechooser package, released
+under the following license.
+
+---
+
+MIT License
+
+Copyright (c) 2019 Thomas Bouve
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     click>=7.1.2
     spectral-cube>=0.5
     asteval>=0.9.23
-    ipyfilechooser
+    ipyfilechooser>=0.4.3
     # Some users were experiencing a version conflict for idna
     idna<3.0
     # vispy is an indirect dependency, but older vispy's don't play nice with jdaviz install

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     click>=7.1.2
     spectral-cube>=0.5
     asteval>=0.9.23
+    ipyfilechooser
     # Some users were experiencing a version conflict for idna
     idna<3.0
     # vispy is an indirect dependency, but older vispy's don't play nice with jdaviz install

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ install_requires =
     click>=7.1.2
     spectral-cube>=0.5
     asteval>=0.9.23
-    ipyfilechooser>=0.4.3
     # Some users were experiencing a version conflict for idna
     idna<3.0
     # vispy is an indirect dependency, but older vispy's don't play nice with jdaviz install


### PR DESCRIPTION
This is an experiment with using ipyfilechooser as the file dialog, which allows us to select file paths on disk as opposed to having to upload the data as #186 does. This does mean the file browser is not 'native' but instead implemented using ipywidgets, so it is not as pretty, but on the other hand it is better than passing a file path! Here is a preview:

![Peek 2021-04-27 17-05](https://user-images.githubusercontent.com/314716/116274800-e719ab80-a77a-11eb-9d43-79ec1d50c25f.gif)

I had to hack around and use private API on ipyfilechooser to hide some of their buttons so this should be treated as experimental. If people like this I can work on trying to expose what we need in a public API in ipyfilechooser or in the worst case forking it and bundling the modified version here (it is pretty simple code)

This should otherwise be functional so feel free to try it out!

Fix #156, fix #546
