### PR TITLE
Add --version to CLI

### DIFF
--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -9,9 +9,12 @@ import click
 from voila.app import Voila
 from voila.configuration import VoilaConfiguration
 
+from jdaviz import __version__
+
 CONFIGS_DIR = os.path.join(os.path.dirname(__file__), 'configs')
 
 
+@click.version_option(__version__)
 @click.command()
 @click.argument('filename', nargs=1, type=click.Path(exists=True))
 @click.option('--layout',


### PR DESCRIPTION
With this patch, you will see something like this:

```
$ jdaviz --version
jdaviz, version 1.0.4.dev505+g3568f7c.d20210429
```

Fix #576 and fix #378