### PR TITLE
TST: Mark test_data_retrieval to require remote_data

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/tests/test_data_retrieval.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_data_retrieval.py
@@ -24,6 +24,7 @@ def jdaviz_app():
     return Application(configuration='cubeviz')
 
 
+@pytest.mark.remote_data
 def test_data_retrieval(jdaviz_app):
 
     fn = download_file(URL, cache=True)


### PR DESCRIPTION
`test_data_retrieval` in Cubeviz accesses Internet. It should only run in a job that enables `--remote-data`. Otherwise, you'll hit timeout a lot when all the jobs hit the server at once and you get marked as spammer.