### PR TITLE
MNT: Remove dead code from _astropy_init.py

### DIFF
--- a/jdaviz/_astropy_init.py
+++ b/jdaviz/_astropy_init.py
@@ -1,25 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import os
 
-__all__ = ['__version__']
+from astropy.tests.runner import TestRunner
 
-# this indicates whether or not we are in the package's setup.py
-try:
-    _ASTROPY_SETUP_
-except NameError:
-    import builtins
-    builtins._ASTROPY_SETUP_ = False
+__all__ = ['__version__', 'test']
 
 try:
     from .version import version as __version__
 except ImportError:
     __version__ = ''
 
-
-if not _ASTROPY_SETUP_:  # noqa
-    import os
-
-    # Create the test function for self test
-    from astropy.tests.runner import TestRunner
-    test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
-    test.__test__ = False
-    __all__ += ['test']
+# Create the test function for self test
+test = TestRunner.make_test_runner_in(os.path.dirname(__file__))


### PR DESCRIPTION
A lot of the code was leftover from `astropy_helpers` days, which you don't use. Probably inherited from old template.