### PR TITLE
TST: Fix test header for CI, add more info

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,23 +1,4 @@
-# This file is used to configure the behavior of pytest when using the Astropy
-# test infrastructure. It needs to live inside the package in order for it to
-# get picked up when running the tests inside an interpreter using
-# packagename.test
-
-import pytest
-
-from astropy.wcs import WCS
-
 from jdaviz import __version__
-
-
-@pytest.fixture
-def spectral_cube_wcs(request):
-    # A simple spectral cube WCS used by some tests
-    wcs = WCS(naxis=3)
-    wcs.wcs.ctype = 'RA---TAN', 'DEC--TAN', 'FREQ'
-    wcs.wcs.set()
-    return wcs
-
 
 try:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
@@ -26,6 +7,8 @@ except ImportError:
     TESTED_VERSIONS = {}
 
 
+# This is repeated from jdaviz/conftest.py because tox cannot grab test
+# header from that file.
 def pytest_configure(config):
     PYTEST_HEADER_MODULES['astropy'] = 'astropy'
     PYTEST_HEADER_MODULES['pyyaml'] = 'yaml'
@@ -52,10 +35,3 @@ def pytest_configure(config):
     PYTEST_HEADER_MODULES['jwst'] = 'jwst'
 
     TESTED_VERSIONS['jdaviz'] = __version__
-
-# TODO: Need to handle warnings properly first before we can enable this. See
-# https://github.com/spacetelescope/jdaviz/issues/478
-# Uncomment the last two lines in this block to treat all DeprecationWarnings as
-# exceptions.
-# from astropy.tests.helper import enable_deprecations_as_exceptions  # noqa
-# enable_deprecations_as_exceptions()

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ testpaths = "jdaviz" "docs"
 astropy_header = true
 doctest_plus = enabled
 text_file_format = rst
-addopts = --doctest-rst -Wignore
+addopts = --doctest-rst --import-mode=append -Wignore
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
Fix test header for CI. Also add more info.

This is part of #476 that deals with test header. Close #628.

# Python 3.8 with coverage checking, all deps, and remote data

## Before this patch

```
============================= test session starts ==============================
platform linux -- Python 3.8.9, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
cachedir: .tox/py38-test-alldeps-cov/.pytest_cache

Running tests with Astropy version 4.2.1.
Running tests in jdaviz docs.

Date: 2021-04-28T20:52:17

Platform: Linux-5.4.0-1046-azure-x86_64-with-glibc2.2.5

Executable: /home/runner/work/jdaviz/jdaviz/.tox/py38-test-alldeps-cov/bin/python

Full Python Version: 
3.8.9 (default, Apr  8 2021, 12:01:33) 
[GCC 9.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.20.2
Scipy: 1.6.3
Matplotlib: 3.4.1
h5py: 3.2.1
Pandas: 1.2.4

Using Astropy options: remote_data: any.
```

## With this patch

```
============================= test session starts ==============================
platform linux -- Python 3.8.9, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
cachedir: .tox/py38-test-alldeps-cov/.pytest_cache

Running tests with jdaviz version 1.2.dev104+g9c7b696.
Running tests in jdaviz docs.

Date: 2021-04-29T21:15:43

Platform: Linux-5.4.0-1046-azure-x86_64-with-glibc2.2.5

Executable: /home/runner/work/jdaviz/jdaviz/.tox/py38-test-alldeps-cov/bin/python

Full Python Version: 
3.8.9 (default, Apr  8 2021, 12:01:33) 
[GCC 9.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.20.2
Scipy: 1.6.3
Matplotlib: 3.4.1
h5py: 3.2.1
Pandas: 1.2.4
astropy: 4.2.1
pyyaml: 5.4.1
specutils: 1.2
spectral-cube: 0.5.0
asteval: 0.9.23
click: 7.1.2
echo: 0.5
idna: 2.10
traitlets: 5.0.5
bqplot: 0.12.26
bqplot-image-gl: 1.3.2
glue-core: 1.0.1
glue-jupyter: 0.4
glue-astronomy: 0.1
ipyvue: 1.5.0
ipyvuetify: 1.6.2
ipysplitpanes: 0.2.0
ipygoldenlayout: 0.4.0
voila: 0.2.10
vispy: 0.6.6
gwcs: 0.16.1
asdf: 2.7.3
jwst: 1.1.0

Using Astropy options: remote_data: any.
```