### PR TITLE
MNT: Bump Python minversion based on astropy>=4.2, remove outdated test config

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -43,11 +43,6 @@ jobs:
             python: 3.9
             toxenv: py39-test-devdeps
 
-          - name: Python 3.6 astropy LTS and Numpy 1.16
-            os: ubuntu-latest
-            python: 3.6
-            toxenv: py36-test-astropylts-numpy116
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -6,7 +6,6 @@
 import os
 import pytest
 
-from astropy.version import version as astropy_version
 from astropy.wcs import WCS
 
 
@@ -19,43 +18,29 @@ def spectral_cube_wcs(request):
     return wcs
 
 
-# For Astropy 3.0 and later, we can use the standalone pytest plugin
-if astropy_version < '3.0':
-    from astropy.tests.pytest_plugins import *  # noqa
-    del pytest_report_header
-    ASTROPY_HEADER = True
-else:
-    try:
-        from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
-        ASTROPY_HEADER = True
-    except ImportError:
-        ASTROPY_HEADER = False
+try:
+    from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+except ImportError:
+    PYTEST_HEADER_MODULES = {}
+    TESTED_VERSIONS = {}
 
 
 def pytest_configure(config):
+    config.option.astropy_header = True
 
-    if ASTROPY_HEADER:
+    # Customize the following lines to add/remove entries from the list of
+    # packages for which version numbers are displayed when running the tests.
+    PYTEST_HEADER_MODULES.pop('Pandas', None)
+    PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
 
-        config.option.astropy_header = True
+    from . import __version__
+    packagename = os.path.basename(os.path.dirname(__file__))
+    TESTED_VERSIONS[packagename] = __version__
 
-        # Customize the following lines to add/remove entries from the list of
-        # packages for which version numbers are displayed when running the tests.
-        PYTEST_HEADER_MODULES.pop('Pandas', None)
-        PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
 
-        from . import __version__
-        packagename = os.path.basename(os.path.dirname(__file__))
-        TESTED_VERSIONS[packagename] = __version__
-
+# TODO: Need to handle warnings properly first before we can enable this. See
+# https://github.com/spacetelescope/jdaviz/issues/478
 # Uncomment the last two lines in this block to treat all DeprecationWarnings as
-# exceptions. For Astropy v2.0 or later, there are 2 additional keywords,
-# as follow (although default should work for most cases).
-# To ignore some packages that produce deprecation warnings on import
-# (in addition to 'compiler', 'scipy', 'pygments', 'ipykernel', and
-# 'setuptools'), add:
-#     modules_to_ignore_on_import=['module_1', 'module_2']
-# To ignore some specific deprecation warning messages for Python version
-# MAJOR.MINOR or later, add:
-#     warnings_to_ignore_by_pyver={(MAJOR, MINOR): ['Message to ignore']}
+# exceptions.
 # from astropy.tests.helper import enable_deprecations_as_exceptions  # noqa
 # enable_deprecations_as_exceptions()

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ github_project = spacetelescope/jdaviz
 zip_safe = False
 packages = find:
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     astropy>=4.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{36,37,38,39}-test{,-alldeps,-devdeps}{,-cov}
-    py{36,37,38,39}-test-astropy{30,40,lts}-numpy{116,117,118}
+    py{37,38,39}-test{,-alldeps,-devdeps}{,-cov}
+    py{37,38,39}-test-astropy{lts}-numpy{117,118}
     build_docs
     linkcheck
     codestyle
@@ -39,23 +39,17 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy116: with numpy 1.16.*
     numpy117: with numpy 1.17.*
     numpy118: with numpy 1.18.*
-    astropy30: with astropy 3.0.*
-    astropy40: with astropy 4.0.*
     astropylts: with the latest astropy LTS
 
 # The following provides some specific pinnings for key packages
 deps =
 
-    numpy116: numpy==1.16.*
     numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
 
-    astropy30: astropy==3.0.*
-    astropy40: astropy==4.0.*
-    astropy40: gwcs>=0.14,<0.15
+    # We don't support 4.0.x but let's keep this for when LTS changes
     astropylts: astropy==4.0.*
     astropylts: gwcs>=0.14,<0.15
 


### PR DESCRIPTION
You currently have:

https://github.com/spacetelescope/jdaviz/blob/3568f7ce49c3dcae03e9ce2ae1d6d08e9fdd87bf/setup.cfg#L21

* Bumps Python minversion to 3.7 to match `astropy>=4.2`.
* Drops test matrix for Numpy 1.16 to match `astropy>=4.2`.
* Drops test matrix for `astropy<4.2`.
* Remove dead code and outdated comments from `jdaviz/conftest.py` due to `astropy>=4.2`.