### PR TITLE
Imviz: Bad unit should be unitless

### DIFF
--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -134,7 +134,7 @@ def _jwst_to_glue_data(file_obj, ext, data_label):
                 _validate_bunit(getattr(dm.meta, unit_attr), raise_error=False)):
             bunit = getattr(dm.meta, unit_attr)
         else:
-            bunit = 'count'
+            bunit = ''
 
         # This is instance of gwcs.WCS, not astropy.wcs.WCS
         data.coords = dm.meta.wcs
@@ -150,7 +150,7 @@ def _hdu_to_glue_data(hdu, data_label):
     if 'BUNIT' in hdu.header and _validate_bunit(hdu.header['BUNIT'], raise_error=False):
         bunit = hdu.header['BUNIT']
     else:
-        bunit = 'count'
+        bunit = ''
 
     comp_label = f'{hdu.name.upper()},{hdu.ver}'
     data_label = f'{data_label}[{comp_label}]'

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -100,7 +100,7 @@ class TestParseImage:
         data = imviz_app.app.data_collection[1]
         comp = data.get_component('DQ')
         assert data.label == 'jw01072001001_01101_00001_nrcb1_cal[DQ]'
-        assert comp.units == 'count'
+        assert comp.units == ''
 
         # Pass in HDUList directly + ext (name only), use given label
         with fits.open(filename) as pf:
@@ -130,7 +130,7 @@ class TestParseImage:
         assert data.label == 'contents[SCI,1]'  # download_file returns cache loc
         assert data.shape == (4300, 4219)
         assert isinstance(data.coords, WCS)
-        assert comp.units == 'count'  # "ELECTRONS/S" is not valid
+        assert comp.units == ''  # "ELECTRONS/S" is not valid
         assert comp.data.shape == (4300, 4219)
 
         # Request specific extension (name only), use given label
@@ -139,7 +139,7 @@ class TestParseImage:
         data = imviz_app.app.data_collection[1]
         comp = data.get_component('CTX,1')
         assert data.label == 'jclj01010_drz[CTX,1]'
-        assert comp.units == 'count'  # BUNIT is not set
+        assert comp.units == ''  # BUNIT is not set
 
         # Request specific extension (name + ver), use given label
         parse_data(imviz_app.app, filename, ext=('WHT', 1),
@@ -147,7 +147,7 @@ class TestParseImage:
         data = imviz_app.app.data_collection[2]
         comp = data.get_component('WHT,1')
         assert data.label == 'jclj01010_drz[WHT,1]'
-        assert comp.units == 'count'  # BUNIT is not set
+        assert comp.units == ''  # BUNIT is not set
 
         # Pass in file obj directly
         with fits.open(filename) as pf:


### PR DESCRIPTION
Follow up of #541, fix #597

The test image here is `jbt7a3020_drz.fits` that has `BUNIT='ELECTRONS/S'`, which isn't a valid `astropy.units` string. Fixing invalid `BUNIT` is out of scope here and should be a Jdaviz-wide discussion.

### Before this patch

![Screenshot 2021-05-10 143126](https://user-images.githubusercontent.com/2090236/117707570-b5520d00-b19c-11eb-8622-1362960ecf21.jpg)

### With this patch

![Screenshot 2021-05-10 152358](https://user-images.githubusercontent.com/2090236/117714107-7922aa80-b1a4-11eb-8dc6-bf9c548134f0.jpg)