### PR TITLE
Add specviz helper tests

### DIFF
--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -40,7 +40,6 @@ def test_load_spectrum1d(specviz_app, spectrum1d):
     assert list(data.keys())[0] == label
 
 
-# 1 3 5 6 7 8 9 11
 def test_get_spectra(specviz_app, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_app.load_spectrum(spectrum1d, data_label=label)
@@ -51,7 +50,6 @@ def test_get_spectra(specviz_app, spectrum1d):
     assert spectra[label].flux.unit == spectrum1d.flux.unit
 
 
-# 1 2
 def test_get_spectra_no_redshift(specviz_app, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_app.load_spectrum(spectrum1d, data_label=label)
@@ -62,7 +60,6 @@ def test_get_spectra_no_redshift(specviz_app, spectrum1d):
     assert spectra[label].flux.unit == spectrum1d.flux.unit
 
 
-# 1 3 5 6 7 9 11
 def test_get_spectra_no_data_label(specviz_app, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_app.load_spectrum(spectrum1d, data_label=label)
@@ -73,18 +70,6 @@ def test_get_spectra_no_data_label(specviz_app, spectrum1d):
     assert spectra[label].flux.unit == spectrum1d.flux.unit
 
 
-# 1 3 5 6 7 8 9 11 DUPLICATE
-def test_get_spectra_no_label_redshift_warn(specviz_app, spectrum1d):
-    label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
-
-    spectra = specviz_app.get_spectra(data_label=None, apply_slider_redshift="Warn")
-
-    assert np.allclose(spectra[label].flux, spectrum1d.flux)
-    assert spectra[label].flux.unit == spectrum1d.flux.unit
-
-
-# 1 3 4 5 6 7 9 10 11
 def test_get_spectra_label_redshift(specviz_app, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_app.load_spectrum(spectrum1d, data_label=label)
@@ -95,7 +80,6 @@ def test_get_spectra_label_redshift(specviz_app, spectrum1d):
     assert spectra.flux.unit == spectrum1d.flux.unit
 
 
-# 1 3 4 5 6 7 8 9 10 11
 def test_get_spectra_label_redshift_warn(specviz_app, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_app.load_spectrum(spectrum1d, data_label=label)
@@ -106,28 +90,24 @@ def test_get_spectra_label_redshift_warn(specviz_app, spectrum1d):
     assert spectra.flux.unit == spectrum1d.flux.unit
 
 
-# 1 3 5 7 8 9 11
 def test_get_spectra_no_spectra(specviz_app, spectrum1d):
     spectra = specviz_app.get_spectra()
 
     assert spectra == {}
 
 
-# 1 3 5 7 9 11
 def test_get_spectra_no_spectra_redshift_error(specviz_app, spectrum1d):
     spectra = specviz_app.get_spectra(apply_slider_redshift="Error")
 
     assert spectra == {}
 
 
-# 1 3 4 5 7 8 9 10 11
 def test_get_spectra_no_spectra_label(specviz_app, spectrum1d):
     label = "label"
     with pytest.raises(AttributeError):
         spectra = specviz_app.get_spectra(data_label=label)
 
 
-# 1 3 4 5 7 9 10 11
 def test_get_spectra_no_spectra_label_redshift_error(specviz_app, spectrum1d):
     label = "label"
     with pytest.raises(AttributeError):

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pytest
+from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose
 
 from specutils import Spectrum1D
 
@@ -23,8 +25,8 @@ def test_get_spectra(specviz_app, spectrum1d):
 
     spectra = specviz_app.get_spectra()
 
-    assert np.allclose(spectra[label].flux, spectrum1d.flux)
-    assert spectra[label].flux.unit == spectrum1d.flux.unit
+    assert_quantity_allclose(spectra[label].flux,
+                             spectrum1d.flux, atol=1e-5*u.Unit(spectrum1d.flux.unit))
 
 
 def test_get_spectra_no_redshift(specviz_app, spectrum1d):
@@ -33,8 +35,8 @@ def test_get_spectra_no_redshift(specviz_app, spectrum1d):
 
     spectra = specviz_app.get_spectra(apply_slider_redshift=None)
 
-    assert np.allclose(spectra[label].flux, spectrum1d.flux)
-    assert spectra[label].flux.unit == spectrum1d.flux.unit
+    assert_quantity_allclose(spectra[label].flux,
+                             spectrum1d.flux, atol=1e-5*u.Unit(spectrum1d.flux.unit))
 
 
 def test_get_spectra_no_data_label(specviz_app, spectrum1d):
@@ -43,8 +45,8 @@ def test_get_spectra_no_data_label(specviz_app, spectrum1d):
 
     spectra = specviz_app.get_spectra(data_label=None, apply_slider_redshift="Error")
 
-    assert np.allclose(spectra[label].flux, spectrum1d.flux)
-    assert spectra[label].flux.unit == spectrum1d.flux.unit
+    assert_quantity_allclose(spectra[label].flux,
+                             spectrum1d.flux, atol=1e-5*u.Unit(spectrum1d.flux.unit))
 
 
 def test_get_spectra_label_redshift(specviz_app, spectrum1d):
@@ -53,8 +55,8 @@ def test_get_spectra_label_redshift(specviz_app, spectrum1d):
 
     spectra = specviz_app.get_spectra(data_label=label, apply_slider_redshift="Error")
 
-    assert np.allclose(spectra.flux, spectrum1d.flux)
-    assert spectra.flux.unit == spectrum1d.flux.unit
+    assert_quantity_allclose(spectra.flux,
+                             spectrum1d.flux, atol=1e-5*u.Unit(spectrum1d.flux.unit))
 
 
 def test_get_spectra_label_redshift_warn(specviz_app, spectrum1d):
@@ -63,8 +65,8 @@ def test_get_spectra_label_redshift_warn(specviz_app, spectrum1d):
 
     spectra = specviz_app.get_spectra(data_label=label, apply_slider_redshift="Warn")
 
-    assert np.allclose(spectra.flux, spectrum1d.flux)
-    assert spectra.flux.unit == spectrum1d.flux.unit
+    assert_quantity_allclose(spectra.flux,
+                             spectrum1d.flux, atol=1e-5*u.Unit(spectrum1d.flux.unit))
 
 
 def test_get_spectra_no_spectra(specviz_app, spectrum1d):

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -1,30 +1,7 @@
-import astropy.units as u
 import numpy as np
 import pytest
-from jdaviz.configs.specviz.helper import SpecViz
-from specutils import Spectrum1D, SpectrumCollection
 
-
-@pytest.fixture
-def specviz_app():
-    return SpecViz()
-
-
-@pytest.fixture
-def spectrum1d():
-    spec_axis = np.linspace(6000, 8000, 1024) * u.AA
-    flux = (np.random.randn(len(spec_axis.value)) +
-            10*np.exp(-0.001*(spec_axis.value-6563)**2) +
-            spec_axis.value/500) * u.Jy
-
-    return Spectrum1D(spectral_axis=spec_axis, flux=flux)
-
-
-@pytest.fixture
-def spectrum_collection(spectrum1d):
-    sc = [spectrum1d for _ in range(5)]
-
-    return SpectrumCollection.from_spectra(sc)
+from specutils import Spectrum1D
 
 
 def test_load_spectrum1d(specviz_app, spectrum1d):
@@ -105,10 +82,10 @@ def test_get_spectra_no_spectra_redshift_error(specviz_app, spectrum1d):
 def test_get_spectra_no_spectra_label(specviz_app, spectrum1d):
     label = "label"
     with pytest.raises(AttributeError):
-        spectra = specviz_app.get_spectra(data_label=label)
+        specviz_app.get_spectra(data_label=label)
 
 
 def test_get_spectra_no_spectra_label_redshift_error(specviz_app, spectrum1d):
     label = "label"
     with pytest.raises(AttributeError):
-        spectra = specviz_app.get_spectra(data_label=label, apply_slider_redshift="Error")
+        specviz_app.get_spectra(data_label=label, apply_slider_redshift="Error")

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -40,6 +40,7 @@ def test_load_spectrum1d(specviz_app, spectrum1d):
     assert list(data.keys())[0] == label
 
 
+# 1 3 5 6 7 8 9 11
 def test_get_spectra(specviz_app, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_app.load_spectrum(spectrum1d, data_label=label)
@@ -50,6 +51,7 @@ def test_get_spectra(specviz_app, spectrum1d):
     assert spectra[label].flux.unit == spectrum1d.flux.unit
 
 
+# 1 2
 def test_get_spectra_no_redshift(specviz_app, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_app.load_spectrum(spectrum1d, data_label=label)
@@ -60,6 +62,7 @@ def test_get_spectra_no_redshift(specviz_app, spectrum1d):
     assert spectra[label].flux.unit == spectrum1d.flux.unit
 
 
+# 1 3 5 6 7 9 11
 def test_get_spectra_no_data_label(specviz_app, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_app.load_spectrum(spectrum1d, data_label=label)
@@ -70,6 +73,7 @@ def test_get_spectra_no_data_label(specviz_app, spectrum1d):
     assert spectra[label].flux.unit == spectrum1d.flux.unit
 
 
+# 1 3 5 6 7 8 9 11 DUPLICATE
 def test_get_spectra_no_label_redshift_warn(specviz_app, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_app.load_spectrum(spectrum1d, data_label=label)
@@ -80,6 +84,7 @@ def test_get_spectra_no_label_redshift_warn(specviz_app, spectrum1d):
     assert spectra[label].flux.unit == spectrum1d.flux.unit
 
 
+# 1 3 4 5 6 7 9 10 11
 def test_get_spectra_label_redshift(specviz_app, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_app.load_spectrum(spectrum1d, data_label=label)
@@ -90,6 +95,7 @@ def test_get_spectra_label_redshift(specviz_app, spectrum1d):
     assert spectra.flux.unit == spectrum1d.flux.unit
 
 
+# 1 3 4 5 6 7 8 9 10 11
 def test_get_spectra_label_redshift_warn(specviz_app, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_app.load_spectrum(spectrum1d, data_label=label)
@@ -98,3 +104,31 @@ def test_get_spectra_label_redshift_warn(specviz_app, spectrum1d):
 
     assert np.allclose(spectra.flux, spectrum1d.flux)
     assert spectra.flux.unit == spectrum1d.flux.unit
+
+
+# 1 3 5 7 8 9 11
+def test_get_spectra_no_spectra(specviz_app, spectrum1d):
+    spectra = specviz_app.get_spectra()
+
+    assert spectra == {}
+
+
+# 1 3 5 7 9 11
+def test_get_spectra_no_spectra_redshift_error(specviz_app, spectrum1d):
+    spectra = specviz_app.get_spectra(apply_slider_redshift="Error")
+
+    assert spectra == {}
+
+
+# 1 3 4 5 7 8 9 10 11
+def test_get_spectra_no_spectra_label(specviz_app, spectrum1d):
+    label = "label"
+    with pytest.raises(AttributeError):
+        spectra = specviz_app.get_spectra(data_label=label)
+
+
+# 1 3 4 5 7 9 10 11
+def test_get_spectra_no_spectra_label_redshift_error(specviz_app, spectrum1d):
+    label = "label"
+    with pytest.raises(AttributeError):
+        spectra = specviz_app.get_spectra(data_label=label, apply_slider_redshift="Error")

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -36,13 +36,13 @@ class TestSpecvizHelper:
                                  self.spec.flux, atol=1e-5*u.Unit(self.spec.flux.unit))
 
     def test_get_spectra_no_data_label(self):
-        spectra = self.spec_app.get_spectra(data_label=None, apply_slider_redshift="Error")
+        spectra = self.spec_app.get_spectra(data_label=None, apply_slider_redshift=True)
 
         assert_quantity_allclose(spectra[self.label].flux,
                                  self.spec.flux, atol=1e-5*u.Unit(self.spec.flux.unit))
 
     def test_get_spectra_label_redshift(self):
-        spectra = self.spec_app.get_spectra(data_label=self.label, apply_slider_redshift="Error")
+        spectra = self.spec_app.get_spectra(data_label=self.label, apply_slider_redshift=True)
 
         assert_quantity_allclose(spectra.flux,
                                  self.spec.flux, atol=1e-5*u.Unit(self.spec.flux.unit))
@@ -61,7 +61,7 @@ def test_get_spectra_no_spectra(specviz_app, spectrum1d):
 
 
 def test_get_spectra_no_spectra_redshift_error(specviz_app, spectrum1d):
-    spectra = specviz_app.get_spectra(apply_slider_redshift="Error")
+    spectra = specviz_app.get_spectra(apply_slider_redshift=True)
 
     assert spectra == {}
 
@@ -75,4 +75,4 @@ def test_get_spectra_no_spectra_label(specviz_app, spectrum1d):
 def test_get_spectra_no_spectra_label_redshift_error(specviz_app, spectrum1d):
     label = "label"
     with pytest.raises(AttributeError):
-        specviz_app.get_spectra(data_label=label, apply_slider_redshift="Error")
+        specviz_app.get_spectra(data_label=label, apply_slider_redshift=True)

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -60,3 +60,41 @@ def test_get_spectra_no_redshift(specviz_app, spectrum1d):
     assert spectra[label].flux.unit == spectrum1d.flux.unit
 
 
+def test_get_spectra_no_data_label(specviz_app, spectrum1d):
+    label = "Test 1D Spectrum"
+    specviz_app.load_spectrum(spectrum1d, data_label=label)
+
+    spectra = specviz_app.get_spectra(data_label=None, apply_slider_redshift="Error")
+
+    assert np.allclose(spectra[label].flux, spectrum1d.flux)
+    assert spectra[label].flux.unit == spectrum1d.flux.unit
+
+
+def test_get_spectra_no_label_redshift_warn(specviz_app, spectrum1d):
+    label = "Test 1D Spectrum"
+    specviz_app.load_spectrum(spectrum1d, data_label=label)
+
+    spectra = specviz_app.get_spectra(data_label=None, apply_slider_redshift="Warn")
+
+    assert np.allclose(spectra[label].flux, spectrum1d.flux)
+    assert spectra[label].flux.unit == spectrum1d.flux.unit
+
+
+def test_get_spectra_label_redshift(specviz_app, spectrum1d):
+    label = "Test 1D Spectrum"
+    specviz_app.load_spectrum(spectrum1d, data_label=label)
+
+    spectra = specviz_app.get_spectra(data_label=label, apply_slider_redshift="Error")
+
+    assert np.allclose(spectra.flux, spectrum1d.flux)
+    assert spectra.flux.unit == spectrum1d.flux.unit
+
+
+def test_get_spectra_label_redshift_warn(specviz_app, spectrum1d):
+    label = "Test 1D Spectrum"
+    specviz_app.load_spectrum(spectrum1d, data_label=label)
+
+    spectra = specviz_app.get_spectra(data_label=label, apply_slider_redshift="Warn")
+
+    assert np.allclose(spectra.flux, spectrum1d.flux)
+    assert spectra.flux.unit == spectrum1d.flux.unit

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -1,0 +1,62 @@
+import astropy.units as u
+import numpy as np
+import pytest
+from jdaviz.configs.specviz.helper import SpecViz
+from specutils import Spectrum1D, SpectrumCollection
+
+
+@pytest.fixture
+def specviz_app():
+    return SpecViz()
+
+
+@pytest.fixture
+def spectrum1d():
+    spec_axis = np.linspace(6000, 8000, 1024) * u.AA
+    flux = (np.random.randn(len(spec_axis.value)) +
+            10*np.exp(-0.001*(spec_axis.value-6563)**2) +
+            spec_axis.value/500) * u.Jy
+
+    return Spectrum1D(spectral_axis=spec_axis, flux=flux)
+
+
+@pytest.fixture
+def spectrum_collection(spectrum1d):
+    sc = [spectrum1d for _ in range(5)]
+
+    return SpectrumCollection.from_spectra(sc)
+
+
+def test_load_spectrum1d(specviz_app, spectrum1d):
+    label = "Test 1D Spectrum"
+    specviz_app.load_spectrum(spectrum1d, data_label=label)
+
+    assert len(specviz_app.app.data_collection) == 1
+    assert specviz_app.app.data_collection[0].label == label
+
+    data = specviz_app.app.get_data_from_viewer('spectrum-viewer')
+
+    assert isinstance(list(data.values())[0], Spectrum1D)
+    assert list(data.keys())[0] == label
+
+
+def test_get_spectra(specviz_app, spectrum1d):
+    label = "Test 1D Spectrum"
+    specviz_app.load_spectrum(spectrum1d, data_label=label)
+
+    spectra = specviz_app.get_spectra()
+
+    assert np.allclose(spectra[label].flux, spectrum1d.flux)
+    assert spectra[label].flux.unit == spectrum1d.flux.unit
+
+
+def test_get_spectra_no_redshift(specviz_app, spectrum1d):
+    label = "Test 1D Spectrum"
+    specviz_app.load_spectrum(spectrum1d, data_label=label)
+
+    spectra = specviz_app.get_spectra(apply_slider_redshift=None)
+
+    assert np.allclose(spectra[label].flux, spectrum1d.flux)
+    assert spectra[label].flux.unit == spectrum1d.flux.unit
+
+

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -14,7 +14,6 @@ class TestSpecvizHelper:
         self.label = "Test 1D Spectrum"
         self.spec_app.load_spectrum(spectrum1d, data_label=self.label)
 
-
     def test_load_spectrum1d(self):
         assert len(self.spec_app.app.data_collection) == 1
         assert self.spec_app.app.data_collection[0].label == self.label
@@ -24,13 +23,11 @@ class TestSpecvizHelper:
         assert isinstance(list(data.values())[0], Spectrum1D)
         assert list(data.keys())[0] == self.label
 
-
     def test_get_spectra(self):
         spectra = self.spec_app.get_spectra()
 
         assert_quantity_allclose(spectra[self.label].flux,
                                  self.spec.flux, atol=1e-5*u.Unit(self.spec.flux.unit))
-
 
     def test_get_spectra_no_redshift(self):
         spectra = self.spec_app.get_spectra(apply_slider_redshift=None)
@@ -38,20 +35,17 @@ class TestSpecvizHelper:
         assert_quantity_allclose(spectra[self.label].flux,
                                  self.spec.flux, atol=1e-5*u.Unit(self.spec.flux.unit))
 
-
     def test_get_spectra_no_data_label(self):
         spectra = self.spec_app.get_spectra(data_label=None, apply_slider_redshift="Error")
 
         assert_quantity_allclose(spectra[self.label].flux,
                                  self.spec.flux, atol=1e-5*u.Unit(self.spec.flux.unit))
 
-
     def test_get_spectra_label_redshift(self):
         spectra = self.spec_app.get_spectra(data_label=self.label, apply_slider_redshift="Error")
 
         assert_quantity_allclose(spectra.flux,
                                  self.spec.flux, atol=1e-5*u.Unit(self.spec.flux.unit))
-
 
     def test_get_spectra_label_redshift_warn(self):
         spectra = self.spec_app.get_spectra(data_label=self.label, apply_slider_redshift="Warn")

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -5,67 +5,59 @@ from astropy.tests.helper import assert_quantity_allclose
 from specutils import Spectrum1D
 
 
-def test_load_spectrum1d(specviz_app, spectrum1d):
-    label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+class TestSpecvizHelper:
+    @pytest.fixture(autouse=True)
+    def setup_class(self, specviz_app, spectrum1d):
+        self.spec_app = specviz_app
+        self.spec = spectrum1d
 
-    assert len(specviz_app.app.data_collection) == 1
-    assert specviz_app.app.data_collection[0].label == label
-
-    data = specviz_app.app.get_data_from_viewer('spectrum-viewer')
-
-    assert isinstance(list(data.values())[0], Spectrum1D)
-    assert list(data.keys())[0] == label
+        self.label = "Test 1D Spectrum"
+        self.spec_app.load_spectrum(spectrum1d, data_label=self.label)
 
 
-def test_get_spectra(specviz_app, spectrum1d):
-    label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    def test_load_spectrum1d(self):
+        assert len(self.spec_app.app.data_collection) == 1
+        assert self.spec_app.app.data_collection[0].label == self.label
 
-    spectra = specviz_app.get_spectra()
+        data = self.spec_app.app.get_data_from_viewer('spectrum-viewer')
 
-    assert_quantity_allclose(spectra[label].flux,
-                             spectrum1d.flux, atol=1e-5*u.Unit(spectrum1d.flux.unit))
-
-
-def test_get_spectra_no_redshift(specviz_app, spectrum1d):
-    label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
-
-    spectra = specviz_app.get_spectra(apply_slider_redshift=None)
-
-    assert_quantity_allclose(spectra[label].flux,
-                             spectrum1d.flux, atol=1e-5*u.Unit(spectrum1d.flux.unit))
+        assert isinstance(list(data.values())[0], Spectrum1D)
+        assert list(data.keys())[0] == self.label
 
 
-def test_get_spectra_no_data_label(specviz_app, spectrum1d):
-    label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    def test_get_spectra(self):
+        spectra = self.spec_app.get_spectra()
 
-    spectra = specviz_app.get_spectra(data_label=None, apply_slider_redshift="Error")
-
-    assert_quantity_allclose(spectra[label].flux,
-                             spectrum1d.flux, atol=1e-5*u.Unit(spectrum1d.flux.unit))
+        assert_quantity_allclose(spectra[self.label].flux,
+                                 self.spec.flux, atol=1e-5*u.Unit(self.spec.flux.unit))
 
 
-def test_get_spectra_label_redshift(specviz_app, spectrum1d):
-    label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    def test_get_spectra_no_redshift(self):
+        spectra = self.spec_app.get_spectra(apply_slider_redshift=None)
 
-    spectra = specviz_app.get_spectra(data_label=label, apply_slider_redshift="Error")
-
-    assert_quantity_allclose(spectra.flux,
-                             spectrum1d.flux, atol=1e-5*u.Unit(spectrum1d.flux.unit))
+        assert_quantity_allclose(spectra[self.label].flux,
+                                 self.spec.flux, atol=1e-5*u.Unit(self.spec.flux.unit))
 
 
-def test_get_spectra_label_redshift_warn(specviz_app, spectrum1d):
-    label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    def test_get_spectra_no_data_label(self):
+        spectra = self.spec_app.get_spectra(data_label=None, apply_slider_redshift="Error")
 
-    spectra = specviz_app.get_spectra(data_label=label, apply_slider_redshift="Warn")
+        assert_quantity_allclose(spectra[self.label].flux,
+                                 self.spec.flux, atol=1e-5*u.Unit(self.spec.flux.unit))
 
-    assert_quantity_allclose(spectra.flux,
-                             spectrum1d.flux, atol=1e-5*u.Unit(spectrum1d.flux.unit))
+
+    def test_get_spectra_label_redshift(self):
+        spectra = self.spec_app.get_spectra(data_label=self.label, apply_slider_redshift="Error")
+
+        assert_quantity_allclose(spectra.flux,
+                                 self.spec.flux, atol=1e-5*u.Unit(self.spec.flux.unit))
+
+
+    def test_get_spectra_label_redshift_warn(self):
+        spectra = self.spec_app.get_spectra(data_label=self.label, apply_slider_redshift="Warn")
+
+        assert_quantity_allclose(spectra.flux,
+                                 self.spec.flux, atol=1e-5*u.Unit(self.spec.flux.unit))
 
 
 def test_get_spectra_no_spectra(specviz_app, spectrum1d):


### PR DESCRIPTION
Fixes a pytest error I was seeing in addition to specviz helper tests for `get_spectra()`.