### PR TITLE
Imviz: Add simple blink tool

### DIFF
--- a/jdaviz/configs/imviz/plugins/tools.py
+++ b/jdaviz/configs/imviz/plugins/tools.py
@@ -1,9 +1,43 @@
 from echo import delay_callback
 from glue.config import viewer_tool
-from glue_jupyter.bqplot.common.tools import InteractCheckableTool
+from glue_jupyter.bqplot.common.tools import InteractCheckableTool, Tool
 from glue.plugins.wcs_autolinking.wcs_autolinking import wcs_autolink, WCSLink
 
 __all__ = []
+
+
+@viewer_tool
+class BlinkOnce(Tool):
+    icon = 'glue_forward'
+    tool_id = 'bqplot:blinkonce'
+    action_text = 'Go to next image'
+    tool_tip = ('Click on this button to display the next image, '
+                'or you can also press the "b" key anytime')
+
+    def __init__(self, viewer, **kwargs):
+        super().__init__(viewer, **kwargs)
+
+    def activate(self):
+        # Simple blinking of images - this will make it so that only one
+        # layer is visible at a time and cycles through the layers.
+
+        state = self.viewer.state
+        n_layers = len(state.layers)
+
+        if n_layers > 1:
+
+            # If only one layer is visible, pick the next one to be visible,
+            # otherwise start from the last visible one.
+
+            visible = [ilayer for ilayer, layer in
+                       enumerate(state.layers) if layer.visible]
+
+            if len(visible) > 0:
+                next_layer = (visible[-1] + 1) % n_layers
+                state.layers[next_layer].visible = True
+                for ilayer in visible:
+                    if ilayer != next_layer:
+                        state.layers[ilayer].visible = False
 
 
 @viewer_tool

--- a/jdaviz/configs/imviz/plugins/tools.py
+++ b/jdaviz/configs/imviz/plugins/tools.py
@@ -71,6 +71,7 @@ class BqplotMatchWCS(InteractCheckableTool):
                     if (link.data1 is existing_link.data1
                             and link.data2 is existing_link.data2):
                         exists = True
+                        break
             if not exists:
                 self.viewer.session.data_collection.add_link(link)
 

--- a/jdaviz/configs/imviz/plugins/tools.py
+++ b/jdaviz/configs/imviz/plugins/tools.py
@@ -18,26 +18,7 @@ class BlinkOnce(Tool):
         super().__init__(viewer, **kwargs)
 
     def activate(self):
-        # Simple blinking of images - this will make it so that only one
-        # layer is visible at a time and cycles through the layers.
-
-        state = self.viewer.state
-        n_layers = len(state.layers)
-
-        if n_layers > 1:
-
-            # If only one layer is visible, pick the next one to be visible,
-            # otherwise start from the last visible one.
-
-            visible = [ilayer for ilayer, layer in
-                       enumerate(state.layers) if layer.visible]
-
-            if len(visible) > 0:
-                next_layer = (visible[-1] + 1) % n_layers
-                state.layers[next_layer].visible = True
-                for ilayer in visible:
-                    if ilayer != next_layer:
-                        state.layers[ilayer].visible = False
+        self.viewer.blink_once()
 
 
 @viewer_tool

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -13,7 +13,8 @@ __all__ = ['ImvizImageView']
 @viewer_registry("imviz-image-viewer", label="Image 2D (Imviz)")
 class ImvizImageView(BqplotImageView):
 
-    tools = ['bqplot:panzoom', 'bqplot:rectangle', 'bqplot:circle', 'bqplot:matchwcs']
+    tools = ['bqplot:panzoom', 'bqplot:blinkonce', 'bqplot:rectangle',
+             'bqplot:circle', 'bqplot:matchwcs']
 
     default_class = None
 
@@ -98,7 +99,9 @@ class ImvizImageView(BqplotImageView):
             # Simple blinking of images - this will make it so that only one
             # layer is visible at a time and cycles through the layers.
 
-            if len(self.state.layers) > 1:
+            n_layers = len(self.state.layers)
+
+            if n_layers > 1:
 
                 # If only one layer is visible, pick the next one to be visible,
                 # otherwise start from the last visible one.
@@ -107,7 +110,7 @@ class ImvizImageView(BqplotImageView):
                            enumerate(self.state.layers) if layer.visible]
 
                 if len(visible) > 0:
-                    next_layer = (visible[-1] + 1) % len(self.state.layers)
+                    next_layer = (visible[-1] + 1) % n_layers
                     self.state.layers[next_layer].visible = True
                     for ilayer in visible:
                         if ilayer != next_layer:

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -110,7 +110,8 @@ class ImvizImageView(BqplotImageView):
 
         if n_layers == 1:
             msg = SnackbarMessage(
-                'Nothing to blink', color='warning', sender=self)
+                'Nothing to blink. Select a second image in the Data menu to use this feature', 
+                color='warning', sender=self)
             self.session.hub.broadcast(msg)
 
         elif n_layers > 1:

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -110,7 +110,7 @@ class ImvizImageView(BqplotImageView):
 
         if n_layers == 1:
             msg = SnackbarMessage(
-                'Nothing to blink. Select a second image in the Data menu to use this feature', 
+                'Nothing to blink. Select a second image in the Data menu to use this feature.',
                 color='warning', sender=self)
             self.session.hub.broadcast(msg)
 

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -5,6 +5,7 @@ from astropy.wcs.wcsapi import BaseHighLevelWCS
 from glue.core import BaseData
 from glue_jupyter.bqplot.image import BqplotImageView
 
+from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import viewer_registry
 
 __all__ = ['ImvizImageView']
@@ -44,7 +45,6 @@ class ImvizImageView(BqplotImageView):
                 return
 
         if data['event'] == 'mousemove':
-
             # Display the current cursor coordinates (both pixel and world) as
             # well as data values. For now we use the first dataset in the
             # viewer for the data values.
@@ -63,7 +63,7 @@ class ImvizImageView(BqplotImageView):
 
             self.label_mouseover.pixel = (fmt.format(x, y))
 
-            if isinstance(image.coords, BaseHighLevelWCS):
+            if hasattr(image, 'coords') and isinstance(image.coords, BaseHighLevelWCS):
                 # Convert these to a SkyCoord via WCS - note that for other datasets
                 # we aren't actually guaranteed to get a SkyCoord out, just for images
                 # with valid celestial WCS
@@ -80,7 +80,9 @@ class ImvizImageView(BqplotImageView):
             # Extract data values at this position.
             # TODO: for now we just use the first visible layer but we should think
             # of how to display values when multiple datasets are present.
-            if x > -0.5 and y > -0.5 and x < image.shape[1] - 0.5 and y < image.shape[0] - 0.5:
+            if (x > -0.5 and y > -0.5
+                    and x < image.shape[1] - 0.5 and y < image.shape[0] - 0.5
+                    and hasattr(visible_layers[0], 'attribute')):
                 attribute = visible_layers[0].attribute
                 value = image.get_data(attribute)[int(round(y)), int(round(x))]
                 unit = image.get_component(attribute).units
@@ -94,27 +96,39 @@ class ImvizImageView(BqplotImageView):
             self.label_mouseover.world = ""
             self.label_mouseover.value = ""
 
-        if data['event'] == 'keydown' and data['key'] == 'b':
+        elif data['event'] == 'keydown' and data['key'] == 'b':
+            self.blink_once()
 
-            # Simple blinking of images - this will make it so that only one
-            # layer is visible at a time and cycles through the layers.
+    def blink_once(self):
+        # Simple blinking of images - this will make it so that only one
+        # layer is visible at a time and cycles through the layers.
 
-            n_layers = len(self.state.layers)
+        # Exclude Subsets: They are global
+        valid = [ilayer for ilayer, layer in enumerate(self.state.layers)
+                 if isinstance(layer.layer, BaseData)]
+        n_layers = len(valid)
 
-            if n_layers > 1:
+        if n_layers == 1:
+            msg = SnackbarMessage(
+                'Nothing to blink', color='warning', sender=self)
+            self.session.hub.broadcast(msg)
 
-                # If only one layer is visible, pick the next one to be visible,
-                # otherwise start from the last visible one.
+        elif n_layers > 1:
+            # If only one layer is visible, pick the next one to be visible,
+            # otherwise start from the last visible one.
 
-                visible = [ilayer for ilayer, layer in
-                           enumerate(self.state.layers) if layer.visible]
+            visible = [ilayer for ilayer in valid if self.state.layers[ilayer].visible]
+            n_visible = len(visible)
 
-                if len(visible) > 0:
-                    next_layer = (visible[-1] + 1) % n_layers
-                    self.state.layers[next_layer].visible = True
-                    for ilayer in visible:
-                        if ilayer != next_layer:
-                            self.state.layers[ilayer].visible = False
+            if n_visible == 0:
+                msg = SnackbarMessage('No visible layer to blink',
+                                      color='warning', sender=self)
+                self.session.hub.broadcast(msg)
+            elif n_visible > 0:
+                next_layer = valid[(valid.index(visible[-1]) + 1) % n_layers]
+                self.state.layers[next_layer].visible = True
+                for ilayer in (set(valid) - set([next_layer])):
+                    self.state.layers[ilayer].visible = False
 
     def set_plot_axes(self):
         self.figure.axes[1].tick_format = None

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -51,36 +51,20 @@
    },
    "outputs": [],
    "source": [
-    "from jdaviz import Imviz\n",
     "import matplotlib.pyplot as plt\n",
+    "from glue.plugins.wcs_autolinking.wcs_autolinking import wcs_autolink, WCSLink\n",
+    "\n",
+    "from jdaviz import Imviz\n",
     "\n",
     "imviz = Imviz()\n",
     "imviz.load_data(gc_2mass_j, data_label='gc_2mass_j')\n",
-    "imviz.load_data(gc_msx_e, data_label='gc_msx_e', show_in_viewer=False)\n",
+    "imviz.load_data(gc_msx_e, data_label='gc_msx_e')\n",
     "\n",
     "viewer = imviz.app.get_viewer('viewer-1')\n",
     "\n",
-    "imviz.app"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Manually link the data. We can remove this when Imviz auto-linking issue is resolved. This is necessary for blink to function properly."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from glue.plugins.wcs_autolinking.wcs_autolinking import wcs_autolink, WCSLink\n",
-    "\n",
+    "# Manually link the data. We can remove this when Imviz auto-linking issue is resolved.\n",
+    "# This is necessary for blink to function properly.\n",
     "wcs_links = wcs_autolink(viewer.session.data_collection)\n",
-    "\n",
-    "# Add only those links that don't already exist\n",
     "for link in wcs_links:\n",
     "    exists = False\n",
     "    for existing_link in viewer.session.data_collection.external_links:\n",
@@ -89,8 +73,17 @@
     "                    and link.data2 is existing_link.data2):\n",
     "                exists = True\n",
     "                break\n",
+    "    # Add only those links that don't already exist\n",
     "    if not exists:\n",
-    "        viewer.session.data_collection.add_link(link)"
+    "        viewer.session.data_collection.add_link(link)\n",
+    "\n",
+    "# Because linking happens after load, the image display is broken a little.\n",
+    "# So, please do this manually **after** running this cell.\n",
+    "#\n",
+    "# 1. Uncheck both data from Data menu.\n",
+    "# 2. Re-check  both data from Data menu.\n",
+    "\n",
+    "imviz.app"
    ]
   },
   {

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -67,6 +67,36 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Manually link the data. We can remove this when Imviz auto-linking issue is resolved. This is necessary for blink to function properly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from glue.plugins.wcs_autolinking.wcs_autolinking import wcs_autolink, WCSLink\n",
+    "\n",
+    "wcs_links = wcs_autolink(viewer.session.data_collection)\n",
+    "\n",
+    "# Add only those links that don't already exist\n",
+    "for link in wcs_links:\n",
+    "    exists = False\n",
+    "    for existing_link in viewer.session.data_collection.external_links:\n",
+    "        if isinstance(existing_link, WCSLink):\n",
+    "            if (link.data1 is existing_link.data1\n",
+    "                    and link.data2 is existing_link.data2):\n",
+    "                exists = True\n",
+    "                break\n",
+    "    if not exists:\n",
+    "        viewer.session.data_collection.add_link(link)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Panning and zooming is possible by showing the viewer toolbar and clicking on the '+'-shaped icon, then dragging around in the image and using scrolling to zoom in and out. To change the stretch and colormap, show the **Layer** options accessible through the last icon in the viewer toolbar.\n",
     "\n",
     "We can also change these programmatically, for example the stretch:"

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -81,7 +81,7 @@
     "# So, please do this manually **after** running this cell.\n",
     "#\n",
     "# 1. Uncheck both data from Data menu.\n",
-    "# 2. Re-check  both data from Data menu.\n",
+    "# 2. Re-check both data from Data menu.\n",
     "\n",
     "imviz.app"
    ]


### PR DESCRIPTION
Fix #520 

![Screenshot 2021-05-12 173424](https://user-images.githubusercontent.com/2090236/118049601-f63c5400-b34b-11eb-997a-7b3780735bab.jpg)

Out of scope: Nice UI/UX stuff.

# TODO

- [x] I simply grabbed an icon from Glue. If you have a better one, let me know.
- [x] When I blink, the second image does not show. I see a white screen where it should have been. This is the same whether I use the existing "b" key or this new button. But if I check the layers menu, the "eye" and "no eye" icon change as expected. Is it just me? (Data needs to auto-link on load, see #613)
- [x] Get approval from someone so we can merge and close this out.