### PR TITLE
Fix padding above import button

### DIFF
--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -129,6 +129,7 @@ div.output_wrapper {
 .vuetify-styles .v-toolbar__content {
   padding-left: 0px;
   padding-right: 0px;
+  padding-top: 0;
 }
 
 .v-tabs-items {


### PR DESCRIPTION
Before:

![Screenshot from 2021-05-13 16-45-39](https://user-images.githubusercontent.com/314716/118150661-b4261780-b40a-11eb-86ab-b7ad9e101eb6.png)


After:
![Screenshot from 2021-05-13 16-44-23](https://user-images.githubusercontent.com/314716/118150674-b7b99e80-b40a-11eb-8afc-fe1cfa6cc915.png)

Thanks to @mariobuikhuizen for the fix!