### PR TITLE
Imviz: Load NDData and ndarray

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,7 @@ except ImportError:
 def pytest_configure(config):
     PYTEST_HEADER_MODULES['astropy'] = 'astropy'
     PYTEST_HEADER_MODULES['pyyaml'] = 'yaml'
+    PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
     PYTEST_HEADER_MODULES['specutils'] = 'specutils'
     PYTEST_HEADER_MODULES['spectral-cube'] = 'spectral_cube'
     PYTEST_HEADER_MODULES['asteval'] = 'asteval'

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -43,6 +43,14 @@ class Imviz(ConfigHelper):
             extension format supported by ``astropy.io.fits``) and
             ``show_in_viewer`` (bool).
 
+        Notes
+        -----
+        When loading image formats that support RGB color like jpg or png, the
+        files are  converted to greyscale. This is done following the algorithm
+        of `skimage.color.rgb2grey`, which involves weighting the channels as
+        ``0.2125 R + 0.7154 G + 0.0721 B``. If you prefer a different weighting,
+        you can use `skimage.io.imread` and from that produce your own greyscale
+        image.
         """
         if isinstance(data, str):
             filepath, ext, data_label = split_filename_with_fits_ext(data)

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -45,12 +45,12 @@ class Imviz(ConfigHelper):
 
         Notes
         -----
-        When loading image formats that support RGB color like jpg or png, the
-        files are  converted to greyscale. This is done following the algorithm
-        of `skimage.color.rgb2grey`, which involves weighting the channels as
+        When loading image formats that support RGB color like JPG or PNG, the
+        files are converted to greyscale. This is done following the algorithm
+        of ``skimage.color.rgb2grey``, which involves weighting the channels as
         ``0.2125 R + 0.7154 G + 0.0721 B``. If you prefer a different weighting,
-        you can use `skimage.io.imread` and from that produce your own greyscale
-        image.
+        you can use ``skimage.io.imread`` to produce your own greyscale
+        image as Numpy array and load the latter instead.
         """
         if isinstance(data, str):
             filepath, ext, data_label = split_filename_with_fits_ext(data)

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -11,6 +11,39 @@ class Imviz(ConfigHelper):
     _default_configuration = 'imviz'
 
     def load_data(self, data, parser_reference=None, **kwargs):
+        """Load data into Imviz.
+
+        Parameters
+        ----------
+        data : obj or str
+            File name or object to be loaded. Supported formats include:
+
+            * ``'filename.fits'`` (or any extension that ``astropy.io.fits``
+              supports; first image extension found is loaded unless ``ext``
+              keyword is also given)
+            * ``'filename.fits[SCI]'`` (loads only first SCI extension)
+            * ``'filename.fits[SCI,2]'`` (loads the second SCI extension)
+            * ``'filename.jpg'`` (requires ``scikit-image``; grayscale only)
+            * ``'filename.png'`` (requires ``scikit-image``; grayscale only)
+            * JWST ASDF-in-FITS file (requires ``jwst``; ``data`` or given
+              ``ext`` + GWCS)
+            * ``astropy.io.fits.HDUList`` object (first image extension found
+              is loaded unless ``ext`` keyword is also given)
+            * ``astropy.io.fits.ImageHDU`` object
+            * ``astropy.nddata.NDData`` object (2D only but may have unit,
+              mask, or uncertainty attached)
+            * Numpy array (2D only)
+
+        parser_reference
+            This is used internally by the app.
+
+        kwargs : dict
+            Extra keywords to be passed into app-level parser.
+            The only one you might call directly here is ``ext`` (any FITS
+            extension format supported by ``astropy.io.fits``) and
+            ``show_in_viewer`` (bool).
+
+        """
         if isinstance(data, str):
             filepath, ext, data_label = split_filename_with_fits_ext(data)
 

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -44,7 +44,7 @@ def parse_data(app, file_obj, ext=None, data_label=None, show_in_viewer=True):
     if isinstance(file_obj, str):
         if data_label is None:
             data_label = os.path.splitext(os.path.basename(file_obj))[0]
-        if file_obj.lower().endswith(('.jpg', '.jpeg', '.png')):  # pragma: no cover
+        if file_obj.lower().endswith(('.jpg', '.jpeg', '.png')):
             from skimage.io import imread
             from skimage.color import rgb2gray, rgba2rgb
             im = imread(file_obj)

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -2,8 +2,10 @@ import base64
 import os
 import uuid
 
+import numpy as np
 from astropy import units as u
 from astropy.io import fits
+from astropy.nddata import NDData
 from astropy.wcs import WCS
 from glue.core.data import Component, Data
 try:
@@ -57,20 +59,20 @@ def _parse_image(app, file_obj, data_label, show_in_viewer, ext=None):
     if isinstance(file_obj, fits.HDUList):
         if 'ASDF' in file_obj:  # JWST ASDF-in-FITS
             if HAS_JWST_ASDF:
-                data, data_label = _jwst_to_glue_data(file_obj, ext, data_label)
+                data_iter = _jwst_to_glue_data(file_obj, ext, data_label)
             else:
                 raise ImportError('jwst package is missing')
 
         elif ext is not None:  # Load just the EXT user wants
             hdu = file_obj[ext]
-            _validate_image2d(hdu)
-            data, data_label = _hdu_to_glue_data(hdu, data_label)
+            _validate_fits_image2d(hdu)
+            data_iter = _hdu_to_glue_data(hdu, data_label)
 
         else:  # Load first image extension found
             found = False
             for hdu in file_obj:
-                if _validate_image2d(hdu, raise_error=False):
-                    data, data_label = _hdu_to_glue_data(hdu, data_label)
+                if _validate_fits_image2d(hdu, raise_error=False):
+                    data_iter = _hdu_to_glue_data(hdu, data_label)
                     found = True
                     break
             if not found:
@@ -78,18 +80,25 @@ def _parse_image(app, file_obj, data_label, show_in_viewer, ext=None):
 
     elif isinstance(file_obj, (fits.ImageHDU, fits.CompImageHDU, fits.PrimaryHDU)):
         # NOTE: ext is not used here. It only means something if HDUList is given.
-        _validate_image2d(file_obj)
-        data, data_label = _hdu_to_glue_data(file_obj, data_label)
+        _validate_fits_image2d(file_obj)
+        data_iter = _hdu_to_glue_data(file_obj, data_label)
+
+    elif isinstance(file_obj, NDData):
+        data_iter = _nddata_to_glue_data(file_obj, data_label)
+
+    elif isinstance(file_obj, np.ndarray):
+        data_iter = _ndarray_to_glue_data(file_obj, data_label)
 
     else:
         raise NotImplementedError(f'Imviz does not support {file_obj}')
 
-    app.add_data(data, data_label)
-    if show_in_viewer:
-        app.add_data_to_viewer("viewer-1", data_label)
+    for data, data_label in data_iter:
+        app.add_data(data, data_label)
+        if show_in_viewer:
+            app.add_data_to_viewer("viewer-1", data_label)
 
 
-def _validate_image2d(hdu, raise_error=True):
+def _validate_fits_image2d(hdu, raise_error=True):
     valid = hdu.data is not None and hdu.is_image and hdu.data.ndim == 2
     if not valid and raise_error:
         raise ValueError(
@@ -143,7 +152,7 @@ def _jwst_to_glue_data(file_obj, ext, data_label):
         component = Component.autotyped(imdata, units=bunit)
         data.add_component(component=component, label=comp_label)
 
-    return data, data_label
+    yield data, data_label
 
 
 def _hdu_to_glue_data(hdu, data_label):
@@ -158,4 +167,40 @@ def _hdu_to_glue_data(hdu, data_label):
     data.coords = WCS(hdu.header)
     component = Component.autotyped(hdu.data, units=bunit)
     data.add_component(component=component, label=comp_label)
-    return data, data_label
+    yield data, data_label
+
+
+def _nddata_to_glue_data(ndd, data_label):
+    if ndd.data.ndim != 2:
+        raise ValueError(f'Imviz cannot load this NDData with ndim={ndd.data.ndim}')
+
+    for attrib in ['data', 'mask', 'uncertainty']:
+        arr = getattr(ndd, attrib)
+        if arr is None:
+            continue
+        comp_label = attrib.upper()
+        cur_label = f'{data_label}[{comp_label}]'
+        cur_data = Data(label=cur_label)
+        if ndd.wcs is not None:
+            cur_data.coords = ndd.wcs
+        raw_arr = arr
+        if attrib == 'data':
+            bunit = ndd.unit or ''
+        elif attrib == 'uncertainty':
+            raw_arr = arr.array
+            bunit = arr.unit or ''
+        else:
+            bunit = ''
+        component = Component.autotyped(raw_arr, units=bunit)
+        cur_data.add_component(component=component, label=comp_label)
+        yield cur_data, cur_label
+
+
+def _ndarray_to_glue_data(arr, data_label):
+    if arr.ndim != 2:
+        raise ValueError(f'Imviz cannot load this array with ndim={arr.ndim}')
+
+    data = Data(label=data_label)
+    component = Component.autotyped(arr)
+    data.add_component(component=component, label='DATA')
+    yield data, data_label

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -44,8 +44,19 @@ def parse_data(app, file_obj, ext=None, data_label=None, show_in_viewer=True):
     if isinstance(file_obj, str):
         if data_label is None:
             data_label = os.path.splitext(os.path.basename(file_obj))[0]
-        with fits.open(file_obj) as pf:
+        if file_obj.lower().endswith(('.jpg', '.jpeg', '.png')):  # pragma: no cover
+            from skimage.io import imread
+            from skimage.color import rgb2gray, rgba2rgb
+            im = imread(file_obj)
+            if im.shape[2] == 4:
+                pf = rgb2gray(rgba2rgb(im))
+            else:  # Assume RGB
+                pf = rgb2gray(im)
+            pf = pf[::-1, :]  # Flip it
             _parse_image(app, pf, data_label, show_in_viewer, ext=ext)
+        else:  # Assume FITS
+            with fits.open(file_obj) as pf:
+                _parse_image(app, pf, data_label, show_in_viewer, ext=ext)
     else:
         if data_label is None:
             data_label = f'imviz_data|{str(base64.b85encode(uuid.uuid4().bytes), "utf-8")}'

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -143,9 +143,9 @@ class TestParseImage:
         from skimage.io import imsave
 
         if format == 'png':  # Cross-test PNG with RGBA
-            a = np.zeros((10, 10, 4))
+            a = np.zeros((10, 10, 4), dtype='uint8')
         else:  # Cross-test JPG with RGB only
-            a = np.zeros((10, 10, 3))
+            a = np.zeros((10, 10, 3), dtype='uint8')
 
         filename = tmp_path / f'myimage.{format}'
         imsave(filename, a)

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -1,11 +1,15 @@
+import numpy as np
 import pytest
+from astropy import units as u
 from astropy.io import fits
+from astropy.nddata import NDData, StdDevUncertainty
 from astropy.utils.data import download_file
 from astropy.wcs import WCS
 
 from jdaviz.configs.imviz.helper import Imviz, split_filename_with_fits_ext
 from jdaviz.configs.imviz.plugins.parsers import (
-    HAS_JWST_ASDF, parse_data, _validate_image2d, _validate_bunit, _parse_image)
+    HAS_JWST_ASDF, parse_data, _validate_fits_image2d, _validate_bunit,
+    _parse_image)
 
 
 @pytest.fixture
@@ -30,16 +34,16 @@ def test_filename_split(filename, ans):
     assert data_label == ans[2]
 
 
-def test_validate_image2d():
+def test_validate_fits_image2d():
     # Not 2D image
     hdu = fits.ImageHDU([0, 0])
-    assert not _validate_image2d(hdu, raise_error=False)
+    assert not _validate_fits_image2d(hdu, raise_error=False)
     with pytest.raises(ValueError, match='Imviz cannot load this HDU'):
-        _validate_image2d(hdu)
+        _validate_fits_image2d(hdu)
 
     # 2D Image
     hdu = fits.ImageHDU([[0, 0], [0, 0]])
-    assert _validate_image2d(hdu)
+    assert _validate_fits_image2d(hdu)
 
 
 def test_validate_bunit():
@@ -63,10 +67,69 @@ class TestParseImage:
         with pytest.raises(ValueError, match='does not have any FITS image'):
             parse_data(imviz_app.app, hdulist, show_in_viewer=False)
 
-    def test_invalid_file_obj(self, imviz_app):
-        some_obj = WCS()  # Might as well re-use existing import
+    @pytest.mark.parametrize('some_obj', (WCS(), [[1, 2], [3, 4]]))
+    def test_invalid_file_obj(self, imviz_app, some_obj):
         with pytest.raises(NotImplementedError, match='Imviz does not support'):
             parse_data(imviz_app.app, some_obj, show_in_viewer=False)
+
+    def test_parse_numpy_array(self, imviz_app):
+        with pytest.raises(ValueError, match='Imviz cannot load this array with ndim=1'):
+            parse_data(imviz_app.app, np.zeros(2), show_in_viewer=False)
+
+        parse_data(imviz_app.app, np.zeros((2, 2)), data_label='some_array',
+                   show_in_viewer=False)
+        data = imviz_app.app.data_collection[0]
+        comp = data.get_component('DATA')
+        assert data.label == 'some_array'
+        assert data.shape == (2, 2)
+        assert comp.data.shape == (2, 2)
+
+    def test_parse_nddata_simple(self, imviz_app):
+        with pytest.raises(ValueError, match='Imviz cannot load this NDData with ndim=1'):
+            parse_data(imviz_app.app, NDData([1, 2, 3, 4]), show_in_viewer=False)
+
+        ndd = NDData([[1, 2], [3, 4]])
+        parse_data(imviz_app.app, ndd, data_label='some_data', show_in_viewer=False)
+        data = imviz_app.app.data_collection[0]
+        comp = data.get_component('DATA')
+        assert data.label == 'some_data[DATA]'
+        assert data.shape == (2, 2)
+        assert comp.data.shape == (2, 2)
+        assert len(imviz_app.app.data_collection) == 1
+
+    @pytest.mark.parametrize(
+        ('ndd', 'attributes'),
+        [(NDData([[1, 2], [3, 4]], mask=[[True, False], [False, False]]),
+          ['DATA', 'MASK']),
+         (NDData([[1, 2], [3, 4]], uncertainty=StdDevUncertainty([[0.1, 0.2], [0.3, 0.4]])),
+          ['DATA', 'UNCERTAINTY'])])
+    def test_parse_nddata_with_one_only(self, imviz_app, ndd, attributes):
+        parse_data(imviz_app.app, ndd, data_label='some_data', show_in_viewer=False)
+        for i, attrib in enumerate(attributes):
+            data = imviz_app.app.data_collection[i]
+            comp = data.get_component(attrib)
+            assert data.label == f'some_data[{attrib}]'
+            assert data.shape == (2, 2)
+            assert comp.data.shape == (2, 2)
+        assert len(imviz_app.app.data_collection) == 2
+
+    def test_parse_nddata_with_everything(self, imviz_app):
+        ndd = NDData([[1, 2], [3, 4]], mask=[[True, False], [False, False]],
+                     uncertainty=StdDevUncertainty([[0.1, 0.2], [0.3, 0.4]]),
+                     unit=u.MJy/u.sr, wcs=WCS(naxis=2))
+        parse_data(imviz_app.app, ndd, data_label='some_data', show_in_viewer=False)
+        for i, attrib in enumerate(['DATA', 'MASK', 'UNCERTAINTY']):
+            data = imviz_app.app.data_collection[i]
+            comp = data.get_component(attrib)
+            assert data.label == f'some_data[{attrib}]'
+            assert data.shape == (2, 2)
+            assert isinstance(data.coords, WCS)
+            assert comp.data.shape == (2, 2)
+            if attrib == 'MASK':
+                assert comp.units == ''
+            else:
+                assert comp.units == 'MJy / sr'
+        assert len(imviz_app.app.data_collection) == 3
 
     @pytest.mark.skipif(HAS_JWST_ASDF, reason='jwst is installed')
     @pytest.mark.remote_data

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -147,7 +147,7 @@ class TestParseImage:
         else:  # Cross-test JPG with RGB only
             a = np.zeros((10, 10, 3), dtype='uint8')
 
-        filename = tmp_path / f'myimage.{format}'
+        filename = str(tmp_path / f'myimage.{format}')
         imsave(filename, a)
 
         parse_data(imviz_app.app, filename, show_in_viewer=False)

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -55,6 +55,7 @@ except ImportError:
 def pytest_configure(config):
     PYTEST_HEADER_MODULES['astropy'] = 'astropy'
     PYTEST_HEADER_MODULES['pyyaml'] = 'yaml'
+    PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
     PYTEST_HEADER_MODULES['specutils'] = 'specutils'
     PYTEST_HEADER_MODULES['spectral-cube'] = 'spectral_cube'
     PYTEST_HEADER_MODULES['asteval'] = 'asteval'

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ docs =
     sphinx-rtd-theme
     sphinx-astropy
 all =
+    scikit-image
     jwst<=1.1.0
 
 [options.package_data]


### PR DESCRIPTION
The less controversial part of #600 (JDAT-1486). This adds support for `astropy.nddata.NDData` and `numpy.ndarray` in Imviz.

With this patch, the following is now possible (I copy-pasted the code from notebook cells):

```python
import warnings
warnings.simplefilter('ignore')
```

```python
from jdaviz import Imviz

imviz = Imviz()
viewer = imviz.app.get_viewer('viewer-1')

imviz.app
```

```python
import numpy as np
from astropy.nddata import NDData

a = np.zeros((10, 10))
a[1:-1, 1] = 1
a[1:-1, 8] = 1
a[1, 1:-1] = 1
a[8, 1:-1] = 1

imviz.load_data(a, data_label='ndarray')

b = NDData(a, mask=~a.astype(np.bool_))
imviz.load_data(b, data_label='nddata')
```

![Screenshot 2021-05-14 101032](https://user-images.githubusercontent.com/2090236/118283105-0152c980-b49d-11eb-932e-f807424d449c.jpg)

![Screenshot 2021-05-14 101105](https://user-images.githubusercontent.com/2090236/118283112-04e65080-b49d-11eb-9a07-e8dc6593a377.jpg)