### PR TITLE
Multi-extension data format identification

### DIFF
--- a/jdaviz/core/data_formats.py
+++ b/jdaviz/core/data_formats.py
@@ -4,7 +4,7 @@ import pathlib
 
 import astropy.io
 from specutils.io.registers import identify_spectrum_format
-from specutils import Spectrum1D, SpectrumList
+from specutils import SpectrumList
 
 from jdaviz.core.config import list_configurations
 

--- a/jdaviz/core/data_formats.py
+++ b/jdaviz/core/data_formats.py
@@ -4,7 +4,7 @@ import pathlib
 
 import astropy.io
 from specutils.io.registers import identify_spectrum_format
-from specutils import Spectrum1D
+from specutils import Spectrum1D, SpectrumList
 
 from jdaviz.core.config import list_configurations
 
@@ -12,10 +12,13 @@ from jdaviz.core.config import list_configurations
 # create a default file format to configuration mapping
 default_mapping = {'JWST x1d': 'specviz', 'JWST s2d': 'specviz2d',
                    'JWST s3d': 'cubeviz', 'MaNGA cube': 'cubeviz',
-                   'MaNGA rss': 'imviz'}
+                   'MaNGA rss': 'specviz'}
 
-formats_table = astropy.io.registry.get_formats(data_class=Spectrum1D,
-                                                readwrite='Read')
+# get formats table for specutils objects
+formats_table = astropy.io.registry.get_formats(readwrite='Read')
+formats_table.add_index('Data class')
+formats_table = formats_table.loc[['Spectrum1D', 'SpectrumList']]
+formats_table.sort(['Data class', 'Format'])
 
 file_to_config_mapping = {i: default_mapping.get(
     i, 'specviz') for i in formats_table['Format']}
@@ -63,7 +66,7 @@ def get_valid_format(filename):
             The recommended application configuration
     """
 
-    valid_file_format = identify_spectrum_format(filename)
+    valid_file_format = identify_spectrum_format(filename, SpectrumList)
     ndim = guess_dimensionality(filename)
 
     if valid_file_format:

--- a/jdaviz/tests/test_data_formats.py
+++ b/jdaviz/tests/test_data_formats.py
@@ -41,10 +41,10 @@ def create_jwst(n_dim=None, multi=None, ext=None):
         exts.append(ex1d)
         # create two more extensions
         if multi:
-            for i in range(1,3):
+            for i in range(1, 3):
                 ex1d = _create_bintable(ext, ver=i)
                 exts.append(ex1d)
-    shape = (1,) if n_dim == 1 else (1, 2,) if n_dim == 2 else (1, 2, 3) if n_dim == 3 else (1,)
+    shape = (1,) if n_dim == 1 else (1, 2,) if n_dim == 2 else (1, 2, 3) if n_dim == 3 else (1, )
     sci.data = np.empty(shape)
     if n_dim > 1:
         exts.append(sci)


### PR DESCRIPTION
This PR expands the data format identification to include JWST multi extension data.   It expands the spectrum formats table to also include `SpectrumList` objects.  Passing `SpectrumList` into `identify_spectrum_format` is a more general solution that now allows for e.g. `JWST x1d multi` formats in addition to the standard single `JWST x1d`, `JWST s3d`, etc.  to be properly identified. 

- [ ] Need new specutils release and update minversion pin in `setup.cfg` accordingly.