### PR TITLE
fix: also set the height for the app in a lab context

### DIFF
--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -83,7 +83,8 @@
 export default {
   methods: {
     checkNotebookContext() {
-      this.notebook_context = document.getElementById("ipython-main-app");
+      this.notebook_context = document.getElementById("ipython-main-app")
+        || document.querySelector('.jp-LabShell');
       return this.notebook_context;
     }
   },


### PR DESCRIPTION
Fixes the missing content in Jupyter Lab:
<img width="1352" alt="Screenshot 2021-05-19 at 14 37 47" src="https://user-images.githubusercontent.com/46192475/118814461-77e23380-b8b0-11eb-8dee-0fe872526dd5.png">
