### PR TITLE
Imviz region setter/getter

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -591,6 +591,14 @@ class Application(VuetifyTemplate, HubListener):
             f"Data '{data_label}' successfully added.", sender=self)
         self.hub.broadcast(snackbar_message)
 
+    def add_subset(self, subset, subset_label):
+        """Add subset to Glue ``DataCollection``."""
+
+        # TODO: Need translation magic from Astropy region to Glue subset
+
+        subset_label = subset_label or "New Subset"
+        self.data_collection.new_subset_group(subset_label, subset)
+
     @staticmethod
     def _build_data_label(path, ext=None):
         """ Build a data label from a filename and data extension

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -489,13 +489,18 @@ class Application(VuetifyTemplate, HubListener):
 
         for key, value in data.items():
             if isinstance(value, Subset):
+                # TODO: Remove this when you support round-tripping, see
+                # https://github.com/spacetelescope/jdaviz/pull/630
+                if not key.startswith('Subset'):
+                    continue
+
                 # Range selection on a profile is currently not supported in
                 #  the glue translation machinery for astropy regions, so we
                 #  have to do it manually. Only data that is 2d is supported,
                 #  therefore, if the data is already 2d, simply use as is.
                 if value.data.ndim == 2:
                     region = value.data.get_selection_definition(
-                        format='astropy-regions')
+                        subset_id=key, format='astropy-regions')
                     regions[key] = region
                     continue
                 # There is a special case for 1d data (which is also not

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -489,9 +489,9 @@ class Application(VuetifyTemplate, HubListener):
 
         for key, value in data.items():
             if isinstance(value, Subset):
-                # TODO: Remove this when you support round-tripping, see
+                # TODO: Remove this when Imviz support round-tripping, see
                 # https://github.com/spacetelescope/jdaviz/pull/630
-                if not key.startswith('Subset'):
+                if viewer_reference == 'viewer-1' and not key.startswith('Subset'):
                     continue
 
                 # Range selection on a profile is currently not supported in

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -591,14 +591,6 @@ class Application(VuetifyTemplate, HubListener):
             f"Data '{data_label}' successfully added.", sender=self)
         self.hub.broadcast(snackbar_message)
 
-    def add_subset(self, subset, subset_label):
-        """Add subset to Glue ``DataCollection``."""
-
-        # TODO: Need translation magic from Astropy region to Glue subset
-
-        subset_label = subset_label or "New Subset"
-        self.data_collection.new_subset_group(subset_label, subset)
-
     @staticmethod
     def _build_data_label(path, ext=None):
         """ Build a data label from a filename and data extension

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -79,6 +79,32 @@ class Imviz(ConfigHelper):
             self.app.load_data(
                 data, parser_reference=parser_reference, **kwargs)
 
+    def load_regions(self, regions):
+        """Load a given region into viewer.
+
+        Parameters
+        ----------
+        regions : dict
+            Dictionary mapping desired region names to respective Astropy
+            region objects.
+
+        """
+        for key, val in regions.items():
+            self.app.add_subset(val, key)
+
+    def get_regions(self):
+        """Return regions defined in the viewer.
+
+        Returns
+        -------
+        regions : dict
+            Dictionary mapping defined region names to respective Astropy
+            region objects.
+
+        """
+        # TODO: Is there a simpler way to do this?
+        return self.app.get_subsets_from_viewer('viewer-1')
+
 
 def split_filename_with_fits_ext(filename):
     """Split a ``filename[ext]`` input into filename and FITS extension.

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -119,7 +119,7 @@ class Imviz(ConfigHelper):
 
         for subset_label, region in regions.items():
             if subset_label.startswith('Subset'):
-                warnings.warn(f'{subset_label} is now allowed, skipping. '
+                warnings.warn(f'{subset_label} is not allowed, skipping. '
                               'Do not use region name that starts with Subset.')
                 continue
 

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -2,9 +2,8 @@ import os
 import re
 from copy import deepcopy
 
-import numpy as np
 from glue.core import BaseData
-from glue.core.subset import ElementSubsetState
+from glue.core.subset import MaskSubsetState
 
 from jdaviz.core.helpers import ConfigHelper
 
@@ -124,10 +123,11 @@ class Imviz(ConfigHelper):
             mask = region.to_mask(**kwargs)
             im = mask.to_image(data.shape)
 
-            # TODO: This is not registering to GUI. Also breaks get_regions().
-            # ValueError: Several subsets are present, specify which one to retrieve with subset_id=
-            state = ElementSubsetState(indices=np.where((im > 0).flat)[0])
-            data.new_subset(state, label=subset_label)
+            # TODO: This breaks get_regions() in 2 ways.
+            # ValueError: Several subsets are present, specify which one to retrieve with subset_id
+            # NotImplementedError: Subset states of type MaskSubsetState are not supported
+            state = MaskSubsetState(im, data.pixel_component_ids)
+            self.app.data_collection.new_subset_group(subset_label, state)
 
     def get_regions(self):
         """Return regions defined in the viewer.

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -6,7 +6,7 @@ from astropy.nddata import NDData, StdDevUncertainty
 from astropy.utils.data import download_file
 from astropy.wcs import WCS
 
-from jdaviz.configs.imviz.helper import Imviz, split_filename_with_fits_ext
+from jdaviz.configs.imviz.helper import split_filename_with_fits_ext
 from jdaviz.configs.imviz.plugins.parsers import (
     HAS_JWST_ASDF, parse_data, _validate_fits_image2d, _validate_bunit,
     _parse_image)
@@ -16,11 +16,6 @@ try:
     HAS_SKIMAGE = True
 except ImportError:
     HAS_SKIMAGE = False
-
-
-@pytest.fixture
-def imviz_app():
-    return Imviz()
 
 
 @pytest.mark.parametrize(

--- a/jdaviz/configs/imviz/tests/test_regions.py
+++ b/jdaviz/configs/imviz/tests/test_regions.py
@@ -1,0 +1,137 @@
+import numpy as np
+import pytest
+from astropy import units as u
+from astropy.coordinates import SkyCoord, Angle
+from astropy.io import fits
+
+try:
+    import regions  # noqa
+    HAS_REGIONS = True
+except ImportError:
+    HAS_REGIONS = False
+
+try:
+    import photutils  # noqa
+    HAS_PHOTUTILS = True
+except ImportError:
+    HAS_PHOTUTILS = False
+
+
+class TestLoadStaticRegions:
+    """Test to see if region is loaded.
+    Does not check if region is actually at the correct place in display.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_class(self, imviz_app):
+        hdu = fits.ImageHDU(np.zeros((10, 10)), name='SCI')
+
+        # Apply some celestial WCS from
+        # https://learn.astropy.org/rst-tutorials/celestial_coords1.html
+        hdu.header.update({'CTYPE1': 'RA---TAN',
+                           'CUNIT1': 'deg',
+                           'CDELT1': -0.0002777777778,
+                           'CRPIX1': 1,
+                           'CRVAL1': 337.5202808,
+                           'NAXIS1': 10,
+                           'CTYPE2': 'DEC--TAN',
+                           'CUNIT2': 'deg',
+                           'CDELT2': 0.0002777777778,
+                           'CRPIX2': 1,
+                           'CRVAL2': -20.833333059999998,
+                           'NAXIS2': 10})
+
+        # Data with WCS
+        imviz_app.load_data(hdu, data_label='has_wcs')
+
+        # Data without WCS
+        imviz_app.load_data(hdu, data_label='no_wcs')
+        imviz_app.app.data_collection[1].coords = None
+
+        self.imviz = imviz_app
+        self.viewer = imviz_app.app.get_viewer('viewer-1')
+        self.sky = SkyCoord(ra=337.5202808, dec=-20.833333059999998, unit='deg')
+
+    def teardown_method(self, method):
+        # Make sure each test method did not affect interactive region getter
+        # until we implement roundtripping.
+        assert self.imviz.get_interactive_regions() == {}
+
+    def verify_region_loaded(self, region_label, count=2):
+        n = 0
+        for layer in self.viewer.state.layers:
+            if layer.layer.label == region_label:
+                n += 1
+                assert layer.visible
+        assert n == count
+
+    def test_regions_invalid(self):
+        with pytest.raises(TypeError, match='Unsupported region type'):
+            self.imviz.load_static_regions({'reg': self.imviz}, 'has_wcs[SCI,1]')
+
+        # Does not matter if region is invalid here, it is skipped.
+        with pytest.warns(UserWarning, match='is not allowed, skipping'):
+            self.imviz.load_static_regions({'Subset 1': self.imviz}, 'has_wcs[SCI,1]')
+
+        self.verify_region_loaded('reg', count=0)
+        self.verify_region_loaded('Subset 1', count=0)
+
+    @pytest.mark.parametrize('data_label', ('has_wcs[SCI,1]', 'no_wcs[SCI,1]'))
+    def test_regions_mask(self, data_label):
+        mask = np.zeros((10, 10), dtype=np.bool_)
+        mask[0, 0] = True
+        self.imviz.load_static_regions({'my_mask': mask}, data_label)
+        self.verify_region_loaded('my_mask')
+
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is missing')
+    @pytest.mark.parametrize('data_label', ('has_wcs[SCI,1]', 'no_wcs[SCI,1]'))
+    def test_regions_pixel(self, data_label):
+        from regions import PixCoord, CirclePixelRegion
+
+        # Out-of-bounds should still overlay the overlapped part.
+        my_reg = CirclePixelRegion(center=PixCoord(x=6, y=2), radius=5)
+        self.imviz.load_static_regions({'my_reg': my_reg}, data_label)
+        self.verify_region_loaded('my_reg')
+
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is missing')
+    def test_regions_sky_has_wcs(self):
+        from regions import CircleSkyRegion
+
+        my_reg_sky = CircleSkyRegion(self.sky, Angle(0.5, u.arcsec))
+        self.imviz.load_static_regions({'my_reg_sky_1': my_reg_sky}, 'has_wcs[SCI,1]')
+        self.verify_region_loaded('my_reg_sky_1')
+
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is missing')
+    def test_regions_sky_no_wcs(self):
+        from regions import CircleSkyRegion
+
+        my_reg_sky = CircleSkyRegion(self.sky, Angle(0.5, u.arcsec))
+        with pytest.warns(UserWarning, match='data has no valid WCS'):
+            self.imviz.load_static_regions({'my_reg_sky_2': my_reg_sky}, 'no_wcs[SCI,1]')
+        self.verify_region_loaded('my_reg_sky_2', count=0)
+
+    @pytest.mark.skipif(not HAS_PHOTUTILS, reason='photutils is missing')
+    @pytest.mark.parametrize('data_label', ('has_wcs[SCI,1]', 'no_wcs[SCI,1]'))
+    def test_photutils_pixel(self, data_label):
+        from photutils import CircularAperture
+
+        my_aper = CircularAperture((5, 5), r=2)
+        self.imviz.load_static_regions({'my_aper': my_aper}, data_label)
+        self.verify_region_loaded('my_aper')
+
+    @pytest.mark.skipif(not HAS_PHOTUTILS, reason='photutils is missing')
+    def test_photutils_sky_has_wcs(self):
+        from photutils import SkyCircularAperture
+
+        my_aper_sky = SkyCircularAperture(self.sky, 0.5 * u.arcsec)
+        self.imviz.load_static_regions({'my_aper_sky_1': my_aper_sky}, 'has_wcs[SCI,1]')
+        self.verify_region_loaded('my_aper_sky_1')
+
+    @pytest.mark.skipif(not HAS_PHOTUTILS, reason='photutils is missing')
+    def test_photutils_sky_no_wcs(self):
+        from photutils import SkyCircularAperture
+
+        my_aper_sky = SkyCircularAperture(self.sky, 0.5 * u.arcsec)
+        with pytest.warns(UserWarning, match='data has no valid WCS'):
+            self.imviz.load_static_regions({'my_aper_sky_2': my_aper_sky}, 'no_wcs[SCI,1]')
+        self.verify_region_loaded('my_aper_sky_2', count=0)

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -11,7 +11,7 @@ from astropy.nddata import StdDevUncertainty
 import numpy as np
 from specutils import Spectrum1D
 from jdaviz.configs.specviz.helper import SpecViz
-
+from jdaviz.configs.imviz.helper import Imviz
 
 SPECTRUM_SIZE = 10  # length of spectrum
 
@@ -43,6 +43,11 @@ def spectrum1d():
     uncertainty = StdDevUncertainty(np.abs(np.random.randn(len(spec_axis.value))) * u.Jy)
 
     return Spectrum1D(spectral_axis=spec_axis, flux=flux, uncertainty=uncertainty)
+
+
+@pytest.fixture
+def imviz_app():
+    return Imviz()
 
 
 try:

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -233,14 +233,20 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from photutils import CircularAperture\n",
-    "from regions import PixCoord, CirclePixelRegion\n",
+    "from astropy import units as u\n",
+    "from astropy.coordinates import SkyCoord, Angle\n",
+    "from photutils import CircularAperture, SkyCircularAperture\n",
+    "from regions import PixCoord, CirclePixelRegion, CircleSkyRegion\n",
+    "\n",
+    "c = SkyCoord(ra=266.670575, dec=-29.038362, unit='deg')\n",
     "\n",
     "# photutils aperture\n",
     "my_aper = CircularAperture((600, 400), r=10)\n",
+    "my_aper_sky = SkyCircularAperture(c, 50 * u.arcsec)\n",
     "\n",
     "# regions shape\n",
     "my_reg = CirclePixelRegion(center=PixCoord(x=600, y=200), radius=20)\n",
+    "my_reg_sky = CircleSkyRegion(c, Angle(100, u.arcsec))\n",
     "\n",
     "# Numpy mask\n",
     "idx = (np.array([350, 350, 350, 350, 350, 350, 351, 351, 351, 351, 352, 352, 352,\n",
@@ -256,8 +262,10 @@
     "my_mask = np.zeros(data.shape, dtype=np.bool_)\n",
     "my_mask[idx] = True\n",
     "\n",
-    "imviz.load_static_regions(\n",
-    "    {'my_aper': my_aper, 'my_reg': my_reg, 'my_mask': my_mask}, 'gc_2mass_j[PRIMARY,1]')"
+    "my_regions = {'my_aper': my_aper, 'my_aper_sky': my_aper_sky,\n",
+    "              'my_reg': my_reg, 'my_reg_sky': my_reg_sky,\n",
+    "              'my_mask': my_mask}\n",
+    "imviz.load_static_regions(my_regions, 'gc_2mass_j[PRIMARY,1]')"
    ]
   },
   {

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -173,7 +173,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "regions = imviz.app.get_subsets_from_viewer('viewer-1')"
+    "regions = imviz.get_regions()"
    ]
   },
   {

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -220,6 +220,44 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is also possible to programatically pass a `photutils` aperture shape into Imviz."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from photutils import CircularAperture\n",
+    "\n",
+    "my_aper = CircularAperture((600, 400), r=10)\n",
+    "imviz.load_regions({'my_aper': my_aper}, 'gc_2mass_j[PRIMARY,1]')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or pass in a shape from `regions`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from regions import PixCoord, CirclePixelRegion\n",
+    "\n",
+    "my_reg = CirclePixelRegion(center=PixCoord(x=600, y=200), radius=20)\n",
+    "imviz.load_regions({'my_reg': my_reg}, 'gc_2mass_j[PRIMARY,1]')"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -173,7 +173,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "regions = imviz.get_regions()"
+    "regions = imviz.get_interactive_regions()"
    ]
   },
   {
@@ -223,7 +223,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is also possible to programatically pass a `photutils` aperture shape into Imviz."
+    "It is also possible to programatically pass a `regions` shape, a `photutils` aperture shape, or a Numpy mask into Imviz."
    ]
   },
   {
@@ -232,29 +232,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import numpy as np\n",
     "from photutils import CircularAperture\n",
-    "\n",
-    "my_aper = CircularAperture((600, 400), r=10)\n",
-    "imviz.load_regions({'my_aper': my_aper}, 'gc_2mass_j[PRIMARY,1]')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Or pass in a shape from `regions`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "from regions import PixCoord, CirclePixelRegion\n",
     "\n",
+    "# photutils aperture\n",
+    "my_aper = CircularAperture((600, 400), r=10)\n",
+    "\n",
+    "# regions shape\n",
     "my_reg = CirclePixelRegion(center=PixCoord(x=600, y=200), radius=20)\n",
-    "imviz.load_regions({'my_reg': my_reg}, 'gc_2mass_j[PRIMARY,1]')"
+    "\n",
+    "# Numpy mask\n",
+    "idx = (np.array([350, 350, 350, 350, 350, 350, 351, 351, 351, 351, 352, 352, 352,\n",
+    "                 352, 352, 352, 352, 352, 352, 352, 353, 353, 353, 353, 353, 353,\n",
+    "                 353, 353, 353, 353, 353, 353, 354, 354, 354, 354, 354, 354, 354,\n",
+    "                 354, 355, 355, 355, 355, 355, 355, 355, 355, 356, 356, 356, 356,\n",
+    "                 356, 356, 356, 357, 357, 358, 358]),\n",
+    "       np.array([353, 354, 355, 356, 357, 358, 350, 352, 359, 361, 350, 352, 353,\n",
+    "                 354, 355, 356, 357, 358, 359, 361, 350, 351, 352, 353, 354, 355,\n",
+    "                 356, 357, 358, 359, 360, 361, 351, 352, 354, 355, 356, 357, 359,\n",
+    "                 360, 352, 353, 354, 355, 356, 357, 358, 359, 352, 353, 354, 355,\n",
+    "                 356, 357, 358, 353, 358, 352, 359]))\n",
+    "my_mask = np.zeros(data.shape, dtype=np.bool_)\n",
+    "my_mask[idx] = True\n",
+    "\n",
+    "imviz.load_static_regions(\n",
+    "    {'my_aper': my_aper, 'my_reg': my_reg, 'my_mask': my_mask}, 'gc_2mass_j[PRIMARY,1]')"
    ]
   },
   {

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,8 @@ docs =
 all =
     scikit-image
     jwst<=1.1.0
+    regions
+    photutils
 
 [options.package_data]
 jdaviz =


### PR DESCRIPTION
Fix #622

Notes to self:

* http://docs.glueviz.org/en/latest/python_guide/data_tutorial.html#defining-new-subsets
* https://docs.glueviz.org/en/latest/customizing_guide/customization.html#custom-data-translation

## TODO

- [x] Make sure sky regions work
- [x] Add tests (grab examples from example notebook + sky regions with/without WCS)
- [ ] Figure out linking issues, see https://github.com/spacetelescope/jdaviz/pull/630#issuecomment-855012198 , #667
- [ ] Update code when `regions` 0.5 is released with support for GWCS, see https://github.com/astropy/regions/issues/374#issuecomment-856946637
- [ ] Update code when `photutils` is released with support for GWCS, see https://github.com/astropy/photutils/issues/1219#issuecomment-857096570
- [ ] Get approvals
- [ ] Open follow-up issues: Modifying regions, roundtripping, GWCS support...

## Proof of concept

* `my_aper` and `my_aper_sky` are from `photutils` aperture objects, from pixel and sky, respectively.
* `my_reg` and `my_reg_sky` are from `regions` objects, from pixel and sky, respectively.
* `my_mask` is from Numpy boolean array.
* `Subset 6` and `Subset 7` are from manually drawn shapes.

(I don't know what is the extra small red dot in the left image is. I swear it wasn't there when I took the screenshot!)

| ![Screenshot 2021-05-28 183956](https://user-images.githubusercontent.com/2090236/120048345-d449ff00-bfe4-11eb-8775-5d4f48c1ef30.jpg) | ![Screenshot 2021-05-28 184012](https://user-images.githubusercontent.com/2090236/120048346-d449ff00-bfe4-11eb-919b-697c49d77e25.jpg) |
| - | - |

## Problem 1: Cannot move region (out of scope? yes)

Once they are loaded, they cannot be moved around. However, I also noticed this behavior with manually drawn region, so maybe fixing this is out of scope.

With manually drawn region, you can only move it right after drawn. If you click on a different button and come back to it, you can no longer move it.

## Problem 2: When multiple regions exist, get_regions() breaks (fixed)

This is fixed for interactive regions. Because we don't have to roundtrip anymore, this does not affect `regions` regions.

<details>
    <summary>Older notes</summary>

Workflow 1: Run the notebook cell to load `my_aper`. Run the notebook cell to load `my_reg`. Run the notebook cell that calls `imviz.get_regions()`.

Workflow 2: Run the notebook cell to load `my_aper`. Manually draw another region. Run the notebook cell that calls `imviz.get_regions()`.

Traceback would look similar to this:

```
.../jdaviz/configs/imviz/helper.py in get_regions(self)
     88         """
     89         # TODO: Is there a simpler way to do this?
---> 90         return self.app.get_subsets_from_viewer('viewer-1')
     91 
     92 

.../jdaviz/app.py in get_subsets_from_viewer(self, viewer_reference, data_label)
    495                 #  therefore, if the data is already 2d, simply use as is.
    496                 if value.data.ndim == 2:
--> 497                     region = value.data.get_selection_definition(
    498                         format='astropy-regions')
    499                     regions[key] = region

.../glue/core/data.py in get_selection_definition(self, subset_id, format, **kwargs)
    357                 subset = self.subsets[0]
    358             else:
--> 359                 raise ValueError("Several subsets are present, specify which one to retrieve with subset_id= - valid options are:" + format_choices(self._subset_labels, index=True))
    360         elif isinstance(subset_id, str):
    361             matches = [subset for subset in self.subsets if subset.label == subset_id]

ValueError: Several subsets are present, specify which one to retrieve with subset_id= - valid options are:

* 0 or 'my_aper'
* 1 or 'my_reg'
```
</details>

## Problem 3: When only one region is loaded, get_regions() still breaks (won't fix)

Because we dropped the roundtripping requirement, this is no longer an issue. I am reserving "Subset N" label for interactive regions, thus in this way, I can know which one was done interactively, and which programmatically, and get around this problem.

<details>
    <summary>Older notes</summary>

Workflow 1: Run the notebook cell to load `my_aper`. Run the notebook cell that calls `imviz.get_regions()`.

Workflow 2: Run the notebook cell to load `my_reg`. Run the notebook cell that calls `imviz.get_regions()`.

Question: How do you even translate an arbitrary mask back to `regions`? Is it possible to attach meta data to `Subset` for round-tripping? See glue-viz/glue-astronomy#30

Traceback would look similar to this:

```
.../jdaviz/configs/imviz/helper.py in get_regions(self)
     89         """
     90         # TODO: Is there a simpler way to do this?
---> 91         return self.app.get_subsets_from_viewer('viewer-1')
     92 
     93 

.../jdaviz/app.py in get_subsets_from_viewer(self, viewer_reference, data_label)
    495                 #  therefore, if the data is already 2d, simply use as is.
    496                 if value.data.ndim == 2:
--> 497                     region = value.data.get_selection_definition(
    498                         format='astropy-regions')
    499                     regions[key] = region

.../glue/core/data.py in get_selection_definition(self, subset_id, format, **kwargs)
    371         handler = subset_state_translator.get_handler_for(format)
    372 
--> 373         return handler.to_object(subset, **kwargs)
    374 
    375 

.../glue_astronomy/translators/regions.py in to_object(self, subset)
    159 
    160         else:
--> 161             raise NotImplementedError("Subset states of type {0} are not supported"
    162                                       .format(subset_state.__class__.__name__))

NotImplementedError: Subset states of type MaskSubsetState are not supported
```
</details>

## Problem 4: Delete button for regions is broken (fixed)

Seems to work fine now, except for existing bug already reported to #642.

<details>
    <summary>Older notes</summary>

Workflow: Load `my_aper` and `my_reg`. Manually draw another region. Pick your favorite and click on the associated trashcan button. See the region selection menu acting weird.

In the dev version without this patch, deletion kinda works, except for #642.
</details>