### PR TITLE
MNT: Temporarily pin maxversion of jwst

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ docs =
     sphinx-rtd-theme
     sphinx-astropy
 all =
-    jwst
+    jwst<=1.1.0
 
 [options.package_data]
 jdaviz =


### PR DESCRIPTION
Temporarily pin maxversion of `jwst` until they release hotfix for their pytest plugin entrypoint. Otherwise, you will see this error followed by a bunch of `INTERNALERROR` in the `alldeps` job:

```
CRDS - ERROR -  (FATAL) CRDS server connection and cache load FAILED.  Cannot continue.
 See https://hst-crds.stsci.edu/docs/cmdline_bestrefs/ or https://jwst-crds.stsci.edu/docs/cmdline_bestrefs/
 for more information on configuring CRDS,  particularly CRDS_PATH and CRDS_SERVER_URL. :
 [Errno 2] No such file or directory: '/grp/crds/cache/config/jwst/server_config'
```

After this is merged, I will open a follow-up issue to unpin in the future.