### PR TITLE
BUG: Fix loading of HLA product in Imviz

### DIFF
--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -175,10 +175,7 @@ def _hdu_to_glue_data(hdu, data_label, hdulist=None):
     comp_label = f'{hdu.name.upper()},{hdu.ver}'
     data_label = f'{data_label}[{comp_label}]'
     data = Data(label=data_label)
-    if hdulist is None:
-        data.coords = WCS(hdu.header)
-    else:
-        data.coords = WCS(hdu.header, hdulist)
+    data.coords = WCS(hdu.header, hdulist)
     component = Component.autotyped(hdu.data, units=bunit)
     data.add_component(component=component, label=comp_label)
     yield data, data_label


### PR DESCRIPTION
Apparently, HLA pipeline adds a lot of distortion info as separate FITS extensions, so you need to pass in the whole `HDUList` into the `WCS` constructor. This patch is possible thanks to advice from @mcara .

Example file extensions:

```
Filename: jbt7a3k7q_flc.fits
No.    Name      Ver    Type      Cards   Dimensions   Format
  0  PRIMARY       1 PrimaryHDU     281   ()      
  1  SCI           1 ImageHDU       249   (4096, 2048)   float32   
  2  ERR           1 ImageHDU        56   (4096, 2048)   float32   
  3  DQ            1 ImageHDU        48   (4096, 2048)   int16   
  4  SCI           2 ImageHDU       245   (4096, 2048)   float32   
  5  ERR           2 ImageHDU        56   (4096, 2048)   float32   
  6  DQ            2 ImageHDU        48   (4096, 2048)   int16   
  7  HDRLET        1 NonstandardExtHDU     22   (60480,)      
  8  HDRLET        2 NonstandardExtHDU     22   (60480,)      
  9  HDRLET        3 NonstandardExtHDU     26   (112320,)      
 10  HDRLET        4 NonstandardExtHDU     26   (112320,)      
 11  HDRLET        5 NonstandardExtHDU     26   (112320,)      
 12  WCSCORR       1 BinTableHDU     59   14R x 24C   [40A, I, A, 24A, 24A, 24A, 24A, D, D, D, D, D, D, D, D, 24A, 24A, D, D, D, D, J, 40A, 128A]   
 13  WCSDVARR      1 ImageHDU        15   (64, 32)   float32   
 14  WCSDVARR      2 ImageHDU        15   (64, 32)   float32   
 15  D2IMARR       1 ImageHDU        15   (64, 32)   float32   
 16  D2IMARR       2 ImageHDU        15   (64, 32)   float32   
 17  WCSDVARR      3 ImageHDU        15   (64, 32)   float32   
 18  WCSDVARR      4 ImageHDU        15   (64, 32)   float32   
 19  D2IMARR       3 ImageHDU        15   (64, 32)   float32   
 20  D2IMARR       4 ImageHDU        15   (64, 32)   float32   
 21  HDRLET        6 NonstandardExtHDU     26   (112320,)      
 22  HDRLET        7 NonstandardExtHDU     26   (112320,)      
 23  HDRLET        8 NonstandardExtHDU     26   (112320,) 
```

Distantly related to #600 . Follow-up of #541 .