### PR TITLE
Imviz: Support file list input in CLI

### DIFF
--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -17,7 +17,7 @@ CONFIGS_DIR = os.path.join(os.path.dirname(__file__), 'configs')
 
 @click.version_option(__version__)
 @click.command()
-@click.argument('filename', nargs=1, type=click.Path(exists=True))
+@click.argument('filename', nargs=1)
 @click.option('--layout',
               default='default',
               nargs=1,
@@ -49,7 +49,9 @@ def main(filename, layout='default', browser='default'):
         import asyncio
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
-    filepath = pathlib.Path(filename).absolute()
+    # Support comma-separate file list
+    filepath = ','.join([str(pathlib.Path(f).absolute()).replace('\\', '/')
+                         for f in filename.split(',')])
 
     with open(os.path.join(CONFIGS_DIR, layout, layout + '.ipynb')) as f:
         notebook_template = f.read()
@@ -63,8 +65,7 @@ def main(filename, layout='default', browser='default'):
     nbdir = tempfile.mkdtemp()
 
     with open(os.path.join(nbdir, 'notebook.ipynb'), 'w') as nbf:
-        nbf.write(notebook_template.replace('DATA_FILENAME',
-                                            str(filepath).replace('\\', '/')).strip())
+        nbf.write(notebook_template.replace('DATA_FILENAME', filepath).strip())
 
     os.chdir(nbdir)
 

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -1,5 +1,6 @@
 import os
 import re
+from copy import deepcopy
 
 from jdaviz.core.helpers import ConfigHelper
 
@@ -53,19 +54,30 @@ class Imviz(ConfigHelper):
         image as Numpy array and load the latter instead.
         """
         if isinstance(data, str):
-            filepath, ext, data_label = split_filename_with_fits_ext(data)
+            filelist = data.split(',')
 
-            # This, if valid, will overwrite input.
-            if ext is not None:
-                kwargs['ext'] = ext
+            if len(filelist) > 1 and 'data_label' in kwargs:
+                raise ValueError('Do not manually overwrite data_label for '
+                                 'a list of images')
 
-            # This will only overwrite if not provided.
-            if 'data_label' not in kwargs:
-                kwargs['data_label'] = data_label
+            for data in filelist:
+                kw = deepcopy(kwargs)
+                filepath, ext, data_label = split_filename_with_fits_ext(data)
+
+                # This, if valid, will overwrite input.
+                if ext is not None:
+                    kw['ext'] = ext
+
+                # This will only overwrite if not provided.
+                if 'data_label' not in kw:
+                    kw['data_label'] = data_label
+
+                self.app.load_data(
+                    filepath, parser_reference=parser_reference, **kw)
+
         else:
-            filepath = data
-
-        self.app.load_data(filepath, parser_reference=parser_reference, **kwargs)
+            self.app.load_data(
+                data, parser_reference=parser_reference, **kwargs)
 
 
 def split_filename_with_fits_ext(filename):


### PR DESCRIPTION
With this patch, the following calls are now possible:

```
jdaviz --layout=imviz s12_ch1_v0.30_sci.fits,s12_ch2_v0.30_sci.fits,s12_ch3_v0.30_sci.fits,s12_ch4_v0.30_sci.fits
```
```
jdaviz --layout=imviz "jbt7a3020_drz.fits[SCI],jbt7a3020_drz.fits[CTX]"
```

Out of scope: Wildcard matching.

### But why?

Because listing them on the terminal is faster and more reproducible than clicking through the "IMPORT" button, despite #573 .

### Will it affect other Viz?

A little, as I have to disable check for `FILENAME` at the `click` level. So if you pass in garbage, it is up to the lower level parsers to handle that as appropriate. Hopefully this is not too controversial, and the benefit outweighs the cost.