### PR TITLE
DOC: Add Imviz API documentation

### DIFF
--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -21,6 +21,7 @@ Application
 .. automodapi:: jdaviz.app
    :no-inheritance-diagram:
 
+
 Configurations
 ==============
 
@@ -28,4 +29,7 @@ Configurations
    :no-inheritance-diagram:
 
 .. automodapi:: jdaviz.configs.cubeviz.plugins
+   :no-inheritance-diagram:
+
+.. automodapi:: jdaviz.configs.imviz
    :no-inheritance-diagram:


### PR DESCRIPTION
This adds Imviz API doc in a way that is consistent with the rest of the package, except where other Viz only includes "plugins" doc, I opt to include the whole "imviz" at one level up because I want `load_data` info to show.

Out of scope: Re-organize package-level docs.

Rendered doc: https://jdaviz--647.org.readthedocs.build/en/647/reference/api.html#module-jdaviz.configs.imviz