### PR TITLE
Fix cube fitting failures on Polynomial and Linear models

### DIFF
--- a/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
+++ b/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
@@ -161,7 +161,6 @@ def _fit_3D(initial_model, spectrum):
         r = pool.apply_async(worker, callback=collect_result)
         results.append(r)
     for r in results:
-        r.get()
         r.wait()
 
     pool.close()
@@ -213,6 +212,7 @@ class SpaxelWorker:
             sp = Spectrum1D(spectral_axis=self.wave, flux=flux)
 
             fitted_model = fit_lines(sp, self.model)
+
             fitted_values = fitted_model(self.wave)
 
             results['x'].append(x)

--- a/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
+++ b/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
@@ -161,6 +161,7 @@ def _fit_3D(initial_model, spectrum):
         r = pool.apply_async(worker, callback=collect_result)
         results.append(r)
     for r in results:
+        r.get()
         r.wait()
 
     pool.close()
@@ -212,7 +213,6 @@ class SpaxelWorker:
             sp = Spectrum1D(spectral_axis=self.wave, flux=flux)
 
             fitted_model = fit_lines(sp, self.model)
-
             fitted_values = fitted_model(self.wave)
 
             results['x'].append(x)

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -291,6 +291,7 @@ class ModelFitting(TemplateMixin):
             for p in m["parameters"]:
                 setattr(temp_model, p["name"], p["value"])
             temp_models.append(temp_model)
+
         return temp_models
 
     def vue_add_model(self, event):
@@ -405,13 +406,42 @@ class ModelFitting(TemplateMixin):
         # Retrieve copy of the models with proper "fixed" dictionaries
         # TODO: figure out why this was causing the parallel fitting to fail
         # models_to_fit = self._reinitialize_with_fixed()
-        models_to_fit = self._initialized_models.values()
+        models_to_fit = list(self._initialized_models.values())
 
-        fitted_model, fitted_spectrum = fit_model_to_spectrum(
-            spec,
-            models_to_fit,
-            self.model_equation,
-            run_fitter=True)
+        # Remove units if necessary to work around current specutils limitations
+        removed_units = {}
+        remove_units = False
+        for m in models_to_fit:
+            if type(m) in (models.Polynomial1D, models.Linear1D):
+                remove_units = True
+                break
+        if remove_units:
+            unitless_models = []
+            for m in models_to_fit:
+                removed_units[m.name] = {}
+                if type(m) == models.Polynomial1D:
+                    temp_model = m.__class__(name=m.name, degree=m.degree)
+                else:
+                    temp_model = m.__class__(name=m.name)
+                for pname in m.param_names:
+                    p = getattr(m, pname)
+                    removed_units[m.name][pname] = p.unit
+                    setattr(temp_model, pname, p.value)
+                unitless_models.append(temp_model)
+            models_to_fit = unitless_models
+
+        try:
+            fitted_model, fitted_spectrum = fit_model_to_spectrum(
+                spec,
+                models_to_fit,
+                self.model_equation,
+                run_fitter=True)
+        except ValueError:
+            snackbar_message = SnackbarMessage(
+                "Cube fitting failed",
+                color='error', loading=False, sender=self)
+            self.hub.broadcast(snackbar_message)
+            raise
 
         # Save fitted 3D model in a way that the cubeviz
         # helper can access it.

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -412,27 +412,23 @@ class ModelFitting(TemplateMixin):
         # models_to_fit = self._reinitialize_with_fixed()
         models_to_fit = list(self._initialized_models.values())
 
-        # Remove units if necessary to work around current specutils limitations
+        # Remove units to work around current specutils/astropy modeling limitations
+        # TODO: Keep units once astropy/specutils can handle them for all models
         removed_units = {}
-        remove_units = False
+        unitless_models = []
+
         for m in models_to_fit:
-            if type(m) in (models.Polynomial1D, models.Linear1D):
-                remove_units = True
-                break
-        if remove_units:
-            unitless_models = []
-            for m in models_to_fit:
-                removed_units[m.name] = {}
-                if type(m) == models.Polynomial1D:
-                    temp_model = m.__class__(name=m.name, degree=m.degree)
-                else:
-                    temp_model = m.__class__(name=m.name)
-                for pname in m.param_names:
-                    p = getattr(m, pname)
-                    removed_units[m.name][pname] = p.unit
-                    setattr(temp_model, pname, p.value)
-                unitless_models.append(temp_model)
-            models_to_fit = unitless_models
+            removed_units[m.name] = {}
+            if type(m) == models.Polynomial1D:
+                temp_model = m.__class__(name=m.name, degree=m.degree)
+            else:
+                temp_model = m.__class__(name=m.name)
+            for pname in m.param_names:
+                p = getattr(m, pname)
+                removed_units[m.name][pname] = p.unit
+                setattr(temp_model, pname, p.value)
+            unitless_models.append(temp_model)
+        models_to_fit = unitless_models
 
         try:
             fitted_model, fitted_spectrum = fit_model_to_spectrum(

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -367,6 +367,10 @@ class ModelFitting(TemplateMixin):
         else:
             self._update_parameters_from_fit()
 
+        # Also update the _initialized_models so we can use these values
+        # as the starting point for cube fitting
+        self._update_initialized_parameters()
+
     def vue_fit_model_to_cube(self, *args, **kwargs):
 
         if self._warn_if_no_equation():

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     ipygoldenlayout>=0.3.0
     voila>=0.2.4
     pyyaml>=5.4.1
-    specutils>=1.2
+    specutils@git+https://github.com/astropy/specutils.git
     glue-astronomy>=0.1
     click>=7.1.2
     spectral-cube>=0.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     ipygoldenlayout>=0.3.0
     voila>=0.2.4
     pyyaml>=5.4.1
-    specutils@git+https://github.com/astropy/specutils.git
+    specutils>=1.3
     glue-astronomy>=0.1
     click>=7.1.2
     spectral-cube>=0.5


### PR DESCRIPTION
Now removes units from model parameters before cube fitting as the single model fit does, to avoid some problems with complex parameter units in specutils fitting. 

Depends on https://github.com/astropy/specutils/pull/823 to remove a recursion error when pickling during multiprocessing result collection. 