### PR TITLE
fix: don't show the scrollbar in the app template

### DIFF
--- a/share/jupyter/nbconvert/templates/jdaviz-default/index.html.j2
+++ b/share/jupyter/nbconvert/templates/jdaviz-default/index.html.j2
@@ -10,6 +10,12 @@
         <link href='{{resources.base_url}}voila/static/theme-light.css' rel="stylesheet">
         <script src="{{resources.base_url}}voila/static/require.min.js" integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA=" crossorigin="anonymous"></script>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui">
+        <style>
+            /* override vuetify style which causes the scrollbar to always show */
+            html {
+                overflow-y: hidden;
+            }
+        </style>
     </head>
 
     <body data-base-url="{{resources.base_url}}voila/">


### PR DESCRIPTION
See #666

Before:
<img width="100" alt="Screenshot 2021-06-08 at 21 52 32" src="https://user-images.githubusercontent.com/46192475/121248665-fcb6e080-c8a3-11eb-915a-d496eeed11bc.png">

After:
<img width="62" alt="Screenshot 2021-06-08 at 21 52 43" src="https://user-images.githubusercontent.com/46192475/121248687-02acc180-c8a4-11eb-890a-b5664e52b70a.png">

I never saw this issue because I have scroll bars turned off. To see the difference in MacOS "Show scroll bars" has to be set to "Always":
<img width="544" alt="Screenshot 2021-06-08 at 21 55 37" src="https://user-images.githubusercontent.com/46192475/121248930-4a334d80-c8a4-11eb-8712-73136f68bfcf.png">
