### PR TITLE
Fix Imviz tiling bug

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -849,20 +849,12 @@ class Application(VuetifyTemplate, HubListener):
                     if viewer['id'] == cid:
                         stack['viewers'].remove(viewer)
 
-                # If the stack is empty of viewers, also delete the stack
-                if len(stack['viewers']) == 0 and \
-                        len(stack['children']) == 0:
-                    stack_items.remove(stack)
-                    continue
-
                 if len(stack.get('children', [])) > 0:
                     stack['children'] = remove(stack['children'])
 
             return stack_items
 
         remove(self.state.stack_items)
-
-        # self.vue_relayout()
 
         # Also remove the viewer from the stored viewer instance dictionary
         # FIXME: This is getting called twice for some reason


### PR DESCRIPTION
Fix #663 

# What works

Now "x" no longer does tiling roulette.

# What does not work

- [ ] Seems to work fine for Imviz layout but not sure about the other Vizes.

<details>
  <summary>Older notes</summary>

- [x] Create new viewer button now does nothing after I click "x". (It still works but just delayed, probably because of IOPub panic.)
- [x] ~I see a lot (I mean, a lot!) of this message in notebook.~ Was deep-copying but not anymore.

```
IOPub message rate exceeded.
The notebook server will temporarily stop sending output
to the client in order to avoid crashing it.
To change this limit, set the config variable
`--NotebookApp.iopub_msg_rate_limit`.

Current values:
NotebookApp.iopub_msg_rate_limit=1000.0 (msgs/sec)
NotebookApp.rate_limit_window=3.0 (secs)
```

</details>