### PR TITLE
TST: Add approval check

### DIFF
--- a/.github/workflows/pr_approvals.yml
+++ b/.github/workflows/pr_approvals.yml
@@ -1,0 +1,43 @@
+name: Approvals
+
+on:
+  pull_request:
+    types: [opened, reopened]
+  pull_request_review:
+
+jobs:
+  approvals:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Count approvals
+      uses: actions/github-script@v4
+      with:
+        script: |
+          const pr = context.payload.pull_request;
+          if (pr.labels.find(lbl => lbl.name === 'trivial')) {
+            core.info(`This PR will follow default repo approval rule, skipping check.`);
+            return;
+          }
+
+          const approvedResponse = await github.graphql(`
+            query($name: String!, $owner: String!, $pull_number: Int!) {
+              repository(name: $name, owner: $owner) {
+                pullRequest(number: $pull_number) {
+                  reviews(states: APPROVED) {
+                    totalCount
+                  }
+                }
+              }
+            }
+          `, {
+            name: context.repo.repo,
+            owner: context.repo.owner,
+            pull_number: context.issue.number
+          });
+          const approvalsRequired = 2;
+          const approvals = approvedResponse.repository.pullRequest.reviews.totalCount;
+          if (approvals < approvalsRequired) {
+            core.setFailed(`Needs ${approvalsRequired} approvals but only has ${approvals}`);
+          } else {
+            core.info(`Needs ${approvalsRequired} approvals and has ${approvals}`);
+          }

--- a/.github/workflows/pr_approvals.yml
+++ b/.github/workflows/pr_approvals.yml
@@ -1,6 +1,8 @@
 name: Approvals
 
 on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
   pull_request_review:
 
 jobs:

--- a/.github/workflows/pr_approvals.yml
+++ b/.github/workflows/pr_approvals.yml
@@ -2,7 +2,7 @@ name: Approvals
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, labeled, unlabeled]
   pull_request_review:
 
 jobs:

--- a/.github/workflows/pr_approvals.yml
+++ b/.github/workflows/pr_approvals.yml
@@ -2,7 +2,7 @@ name: Approvals
 
 on:
   pull_request:
-    types: [opened, reopened, labeled, unlabeled]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
   pull_request_review:
 
 jobs:

--- a/.github/workflows/pr_approvals.yml
+++ b/.github/workflows/pr_approvals.yml
@@ -1,8 +1,6 @@
 name: Approvals
 
 on:
-  pull_request:
-    types: [opened, reopened, labeled, unlabeled, synchronize]
   pull_request_review:
 
 jobs:


### PR DESCRIPTION
Motivation: Repo admin setting to require 2 approvals for all PRs is blocking some trivial PRs from being merged with only one approval. Giving everyone admin powers to overwrite that setting is too dangerous. Duy has relaxed admin setting but desires an optional check to still require 2 approvals unless a PR is labeled as "trivial".

Once this PR is merged, this new check can be made mandatory, so that 2 approvals are still required unless the PR is labeled as "trivial". I already created the "trivial" label.

p.s. Hard to test this but I think the logic works. We can fix as needed later.

References:

* https://docs.github.com/en/actions/reference/events-that-trigger-workflows
* https://stackoverflow.com/questions/66699962/github-api-get-approved-pull-request-reviews-list
* https://github.com/actions/github-script

Downside: `pull_request` and `pull_request_review` do not update the same status.

![Screenshot 2021-06-16 143519](https://user-images.githubusercontent.com/2090236/122274099-2e393880-ceb0-11eb-8b4e-174fc44b3aa7.jpg)
