### PR TITLE
Imviz: astrowidgets markers API

### DIFF
--- a/docs/known_bugs.rst
+++ b/docs/known_bugs.rst
@@ -83,6 +83,15 @@ has the unintended consequence of changing the contrast of the image displayed
 in the Cubeviz cube viewer.
 
 
+Imviz add_markers may not show markers
+--------------------------------------
+
+In some OS/browser combo, ``imviz.add_markers(...)`` might take a few tries
+to show the markers, or not at all. This is a known bug reported in
+https://github.com/glue-viz/glue-jupyter/issues/243 . If you encounter this,
+try a different OS/browser combo.
+
+
 Reporting a bug
 ---------------
 

--- a/docs/known_bugs.rst
+++ b/docs/known_bugs.rst
@@ -86,7 +86,7 @@ in the Cubeviz cube viewer.
 Imviz add_markers may not show markers
 --------------------------------------
 
-In some OS/browser combo, ``imviz.add_markers(...)`` might take a few tries
+In some OS/browser combinations, ``imviz.add_markers(...)`` might take a few tries
 to show the markers, or not at all. This is a known bug reported in
 https://github.com/glue-viz/glue-jupyter/issues/243 . If you encounter this,
 try a different OS/browser combo.

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -247,6 +247,8 @@ class Imviz(ConfigHelper):
         """Creates markers w.r.t. the reference image at given points
         in the table.
 
+        .. note:: Use `marker` to change marker appearance.
+
         Parameters
         ----------
         table : `~astropy.table.Table`

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -205,7 +205,7 @@ class Imviz(ConfigHelper):
             {'color': '#ff0000', 'alpha': 0.5, 'markersize': 10}
             {'color': (1, 0, 0)}
 
-        Also see: https://docs.glueviz.org/en/stable/api/glue.core.visual.VisualAttributes.html
+        The valid properties for markers in imviz are listed at  https://docs.glueviz.org/en/stable/api/glue.core.visual.VisualAttributes.html
 
         """
         return self._marker_dict

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -205,7 +205,8 @@ class Imviz(ConfigHelper):
             {'color': '#ff0000', 'alpha': 0.5, 'markersize': 10}
             {'color': (1, 0, 0)}
 
-        The valid properties for markers in imviz are listed at  https://docs.glueviz.org/en/stable/api/glue.core.visual.VisualAttributes.html
+        The valid properties for markers in imviz are listed at
+        https://docs.glueviz.org/en/stable/api/glue.core.visual.VisualAttributes.html
 
         """
         return self._marker_dict

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -1,10 +1,8 @@
 import numpy as np
 
-from astropy.wcs.wcsapi import BaseHighLevelWCS
-
-from glue.core import BaseData
 from glue_jupyter.bqplot.image import BqplotImageView
 
+from jdaviz.configs.imviz.helper import data_has_valid_wcs, layer_is_image_data
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import viewer_registry
 
@@ -74,7 +72,7 @@ class ImvizImageView(BqplotImageView):
 
             self.label_mouseover.pixel = (fmt.format(x, y))
 
-            if hasattr(image, 'coords') and isinstance(image.coords, BaseHighLevelWCS):
+            if data_has_valid_wcs(image):
                 # Convert these to a SkyCoord via WCS - note that for other datasets
                 # we aren't actually guaranteed to get a SkyCoord out, just for images
                 # with valid celestial WCS
@@ -116,7 +114,7 @@ class ImvizImageView(BqplotImageView):
 
         # Exclude Subsets: They are global
         valid = [ilayer for ilayer, layer in enumerate(self.state.layers)
-                 if isinstance(layer.layer, BaseData)]
+                 if layer_is_image_data(layer.layer)]
         n_layers = len(valid)
 
         if n_layers == 1:
@@ -156,4 +154,4 @@ class ImvizImageView(BqplotImageView):
         return [layer_state.layer  # .get_object(cls=cls or self.default_class)
                 for layer_state in self.state.layers
                 if hasattr(layer_state, 'layer') and
-                isinstance(layer_state.layer, BaseData)]
+                layer_is_image_data(layer_state.layer)]

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -1,41 +1,12 @@
-import numpy as np
 import pytest
 from astropy import units as u
-from astropy.io import fits
-from astropy.wcs import WCS
+from astropy.table import Table
 from numpy.testing import assert_allclose
 
+from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_NoWCS
 
-class TestAstrowidgetsAPI:
-    @pytest.fixture(autouse=True)
-    def setup_class(self, imviz_app):
-        hdu = fits.ImageHDU(np.zeros((10, 10)), name='SCI')
 
-        # Apply some celestial WCS from
-        # https://learn.astropy.org/rst-tutorials/celestial_coords1.html
-        hdu.header.update({'CTYPE1': 'RA---TAN',
-                           'CUNIT1': 'deg',
-                           'CDELT1': -0.0002777777778,
-                           'CRPIX1': 1,
-                           'CRVAL1': 337.5202808,
-                           'NAXIS1': 10,
-                           'CTYPE2': 'DEC--TAN',
-                           'CUNIT2': 'deg',
-                           'CDELT2': 0.0002777777778,
-                           'CRPIX2': 1,
-                           'CRVAL2': -20.833333059999998,
-                           'NAXIS2': 10})
-
-        # Data with WCS
-        imviz_app.load_data(hdu, data_label='has_wcs')
-
-        # Data without WCS
-        imviz_app.load_data(hdu, data_label='no_wcs')
-        imviz_app.app.data_collection[1].coords = None
-
-        self.wcs = WCS(hdu.header)
-        self.imviz = imviz_app
-        self.viewer = imviz_app.app.get_viewer('viewer-1')
+class TestCenterOffset(BaseImviz_WCS_NoWCS):
 
     def test_center_offset_pixel(self):
         self.imviz.center_on((0, 1))
@@ -84,3 +55,79 @@ class TestAstrowidgetsAPI:
 
         with pytest.raises(AttributeError, match='does not have a valid WCS'):
             self.imviz.offset_to(dsky, dsky, skycoord_offset=True)
+
+
+class TestMarkers(BaseImviz_WCS_NoWCS):
+
+    def test_invalid_markers(self):
+        with pytest.raises(KeyError, match='Invalid attribute'):
+            self.imviz.marker = {'foo': 'bar', 'alpha': 0.8}
+        with pytest.raises(ValueError, match='Invalid RGBA argument'):
+            self.imviz.marker = {'color': 'greenfishbluefish'}
+        with pytest.raises(ValueError, match='Invalid alpha'):
+            self.imviz.marker = {'alpha': '1'}
+        with pytest.raises(ValueError, match='Invalid alpha'):
+            self.imviz.marker = {'alpha': 42}
+        with pytest.raises(ValueError, match='Invalid marker size'):
+            self.imviz.marker = {'markersize': '1'}
+
+    def test_mvp_markers(self):
+        x_pix = (0, 0)
+        y_pix = (0, 1)
+        sky = self.wcs.pixel_to_world(x_pix, y_pix)
+        tbl = Table({'x': x_pix, 'y': y_pix, 'coord': sky})
+
+        self.imviz.add_markers(tbl)
+        data = self.imviz.app.data_collection[2]
+        assert data.label == 'default-marker-name'
+        assert data.style.color == 'red'
+        assert data.style.marker == 'o'
+        assert_allclose(data.style.markersize, 5)
+        assert_allclose(data.style.alpha, 1)
+        assert_allclose(data.get_component('x').data, x_pix)
+        assert_allclose(data.get_component('y').data, y_pix)
+
+        # Table with only sky coordinates but no use_skycoord=True
+        with pytest.raises(KeyError):
+            self.imviz.add_markers(tbl[('coord', )])
+
+        # Cannot use reserved marker name
+        with pytest.raises(ValueError, match='not allowed'):
+            self.imviz.add_markers(tbl, use_skycoord=True, marker_name='all')
+
+        self.imviz.marker = {'color': (0, 1, 0), 'alpha': 0.8}
+
+        self.imviz.add_markers(tbl, use_skycoord=True, marker_name='my_sky')
+        data = self.imviz.app.data_collection[3]
+        assert data.label == 'my_sky'
+        assert data.style.color == (0, 1, 0)  # green
+        assert data.style.marker == 'o'
+        assert_allclose(data.style.markersize, 3)  # Glue default
+        assert_allclose(data.style.alpha, 0.8)
+        assert_allclose(data.get_component('ra').data, sky.ra.deg)
+        assert_allclose(data.get_component('dec').data, sky.dec.deg)
+
+        # TODO: How to check imviz.app.data_collection.links is correct?
+        assert len(self.imviz.app.data_collection.links) == 12
+
+        # Remove markers with default name.
+        self.imviz.remove_markers()
+        assert self.imviz.app.data_collection.labels == [
+            'has_wcs[SCI,1]', 'no_wcs[SCI,1]', 'my_sky']
+
+        # Reset markers (runs remove_markers with marker_name set)
+        self.imviz.reset_markers()
+        assert self.imviz.app.data_collection.labels == [
+            'has_wcs[SCI,1]', 'no_wcs[SCI,1]']
+
+        assert len(self.imviz.app.data_collection.links) == 8
+
+        # NOTE: This changes the state of self.imviz for this test class!
+
+        self.imviz.app.data_collection.remove(self.imviz.app.data_collection[0])
+        with pytest.raises(AttributeError, match='does not have a valid WCS'):
+            self.imviz.add_markers(tbl, use_skycoord=True, marker_name='my_sky')
+
+        self.imviz.app.data_collection.clear()
+        with pytest.raises(AttributeError, match='does not have a valid WCS'):
+            self.imviz.add_markers(tbl, use_skycoord=True, marker_name='my_sky')

--- a/jdaviz/configs/imviz/tests/utils.py
+++ b/jdaviz/configs/imviz/tests/utils.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+from astropy.io import fits
+from astropy.wcs import WCS
+
+__all__ = ['BaseImviz_WCS_NoWCS']
+
+
+class BaseImviz_WCS_NoWCS:
+    @pytest.fixture(autouse=True)
+    def setup_class(self, imviz_app):
+        hdu = fits.ImageHDU(np.zeros((10, 10)), name='SCI')
+
+        # Apply some celestial WCS from
+        # https://learn.astropy.org/rst-tutorials/celestial_coords1.html
+        hdu.header.update({'CTYPE1': 'RA---TAN',
+                           'CUNIT1': 'deg',
+                           'CDELT1': -0.0002777777778,
+                           'CRPIX1': 1,
+                           'CRVAL1': 337.5202808,
+                           'NAXIS1': 10,
+                           'CTYPE2': 'DEC--TAN',
+                           'CUNIT2': 'deg',
+                           'CDELT2': 0.0002777777778,
+                           'CRPIX2': 1,
+                           'CRVAL2': -20.833333059999998,
+                           'NAXIS2': 10})
+
+        # Data with WCS
+        imviz_app.load_data(hdu, data_label='has_wcs')
+
+        # Data without WCS
+        imviz_app.load_data(hdu, data_label='no_wcs')
+        imviz_app.app.data_collection[1].coords = None
+
+        self.wcs = WCS(hdu.header)
+        self.imviz = imviz_app
+        self.viewer = imviz_app.app.get_viewer('viewer-1')

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -46,14 +46,46 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "7c73155f-c062-461a-8ca7-0891ce142901",
+   "metadata": {},
+   "source": [
+    "Import modules needed for this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0915bde6-e3cc-4038-aca1-c2ae852f7a69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from astropy import units as u\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from astropy.table import Table\n",
+    "from astropy.utils.data import download_file\n",
+    "from glue.plugins.wcs_autolinking.wcs_autolinking import wcs_autolink, WCSLink\n",
+    "\n",
+    "from jdaviz import Imviz"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60eb5782-264f-4af4-bb6e-ae583398277d",
+   "metadata": {},
+   "source": [
+    "Download some data. In this example, we use two 47 Tuc observations from HST/ACS."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "bccca7f4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from astropy.utils.data import download_file\n",
-    "\n",
     "acs_47tuc_1 = download_file('https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HST/product/jbqf03gjq_flc.fits', cache=True)\n",
     "acs_47tuc_2 = download_file('https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HST/product/jbqf03h1q_flc.fits', cache=True)"
    ]
@@ -73,11 +105,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import matplotlib.pyplot as plt\n",
-    "from glue.plugins.wcs_autolinking.wcs_autolinking import wcs_autolink, WCSLink\n",
-    "\n",
-    "from jdaviz import Imviz\n",
-    "\n",
     "imviz = Imviz()\n",
     "imviz.load_data(acs_47tuc_1, data_label='acs_47tuc_1')\n",
     "imviz.load_data(acs_47tuc_2, data_label='acs_47tuc_2')\n",
@@ -161,7 +188,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer.state.layers[0].percentile = 95"
+    "viewer.state.layers[0].percentile = 95\n",
+    "\n",
+    "# Do this for the second image too.\n",
+    "viewer.state.layers[1].percentile = 95"
    ]
   },
   {
@@ -295,8 +325,6 @@
    "outputs": [],
    "source": [
     "# Center the image on given sky coordinates.\n",
-    "from astropy.coordinates import SkyCoord\n",
-    "\n",
     "sky = SkyCoord('00h24m07.33s -71d52m50.71s')\n",
     "imviz.center_on(sky)"
    ]
@@ -309,8 +337,6 @@
    "outputs": [],
    "source": [
     "# Move the image with the given sky offsets.\n",
-    "from astropy import units as u\n",
-    "\n",
     "imviz.offset_to(0.5 * u.arcsec, -1.5 * u.arcsec, skycoord_offset=True)"
    ]
   },
@@ -329,18 +355,86 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "from astropy.table import Table\n",
-    "\n",
-    "t = Table({'x': np.random.randint(0, 500, 100),\n",
-    "           'y': np.random.randint(0, 500, 100)})\n",
-    "imviz.add_markers(t)"
+    "# Add 100 randomly generated X,Y (0-indexed) w.r.t. reference image\n",
+    "# using default marker properties.\n",
+    "t_xy = Table({'x': np.random.randint(0, 4096, 100),\n",
+    "              'y': np.random.randint(0, 2048, 100)})\n",
+    "imviz.add_markers(t_xy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1c1aa0d-46b7-42f6-b6d7-395305c15f91",
+   "metadata": {},
+   "source": [
+    "You could customize marker color and alpha with values that Glue supports."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "07088bc0-3963-4230-8eb7-40109e10123c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz.marker = {'color': '#4b0082', 'alpha': 0.8}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ecfd0f9-da9e-419b-99a8-cc6efc20568f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Mark some sky coordinates using updated marker properties.\n",
+    "t_sky = Table({'coord': [SkyCoord('00h24m07.33s -71d52m50.71s'),\n",
+    "                         SkyCoord('00h24m01.57s -71d53m17.77s'),\n",
+    "                         SkyCoord('00h24m11.70s -71d52m29.21s'),\n",
+    "                         SkyCoord('00h24m22.29s -71d53m28.04s')]})\n",
+    "imviz.add_markers(t_sky, use_skycoord=True, marker_name='my_sky')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf02dfc5-088b-4745-8dbc-2de1106c53ea",
+   "metadata": {},
+   "source": [
+    "When you do not need the markers anymore, you could remove them by name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "776c3b75-a1a9-4141-9d6d-8aa766c58d21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz.remove_markers(marker_name='my_sky')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "594e8b67-6725-416b-814e-8d49055821f2",
+   "metadata": {},
+   "source": [
+    "You can also remove all the markers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "046641de-b173-4377-92d3-344bd4ba48f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz.reset_markers()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebd78f30-7d53-4d66-85c2-502c207bedf9",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -362,7 +456,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -315,6 +315,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "11fab067-7428-4ce4-bc9b-f5462fe52e2a",
+   "metadata": {},
+   "source": [
+    "It is also possible to programmatically add non-interactive markers to the image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "270a6dd2-ce21-457f-845e-19cf5405fee7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from astropy.table import Table\n",
+    "\n",
+    "t = Table({'x': np.random.randint(0, 500, 100),\n",
+    "           'y': np.random.randint(0, 500, 100)})\n",
+    "imviz.add_markers(t)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "07088bc0-3963-4230-8eb7-40109e10123c",

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -367,17 +367,17 @@
    "id": "f1c1aa0d-46b7-42f6-b6d7-395305c15f91",
    "metadata": {},
    "source": [
-    "You could customize marker color and alpha with values that Glue supports."
+    "You could customize marker color, alpha, and size with values that Glue supports."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "07088bc0-3963-4230-8eb7-40109e10123c",
+   "id": "7c8edb6f-c928-4aee-8e64-73a34ab020d0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "imviz.marker = {'color': '#4b0082', 'alpha': 0.8}"
+    "imviz.marker = {'color': 'green', 'alpha': 0.8, 'markersize': 50}"
    ]
   },
   {
@@ -434,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ebd78f30-7d53-4d66-85c2-502c207bedf9",
+   "id": "ea66062b-a546-4d77-8119-b3f59d3c2104",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Fix #662 

MVP markers portion of #632 .

![Screenshot 2021-06-23 180904](https://user-images.githubusercontent.com/2090236/123175051-1ed96280-d44f-11eb-9572-62afec99f701.jpg)

Also see https://github.com/astropy/astrowidgets/blob/main/astrowidgets/core.py

# TODO

- [x] Do we need markers to appear on all the images or just the displayed? We will just make it global like Subset.
- [x] How do we make this work with blinking? (Maybe checking against `Data.ndim` is enough to not include marker tables.)
- [x] Do we need to handle out of bounds markers or is Glue smart enough?
- [x] Implement the rest of the stuff (MVP APIs, sky coordinates support)
- [x] Add tests
- [x] Update notebook
- [ ] Address TODO notes (need SME input): Would be nice to address but I don't think they are part of MVP, so not blockers.
- [x] Linking/unlinking markers have noticeable lag: Is this a problem? Duy said no.