### PR TITLE
Snackbar fix

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -33,7 +33,7 @@ from .core.events import (LoadDataMessage, NewViewerMessage, AddDataMessage,
                           AddDataToViewerMessage, RemoveDataFromViewerMessage)
 from .core.registries import (tool_registry, tray_registry, viewer_registry,
                               data_parser_registry)
-from .utils import load_template
+from .utils import load_template, SnackbarQueue
 
 __all__ = ['Application']
 
@@ -71,6 +71,8 @@ class ApplicationState(State):
         'timeout': 3000,
         'loading': False
     }, docstring="State of the quick toast messages.")
+
+    snackbar_queue = SnackbarQueue()
 
     settings = DictCallbackProperty({
         'data': {
@@ -233,12 +235,16 @@ class Application(VuetifyTemplate, HubListener):
             The Glue snackbar message containing information about displaying
             the message box.
         """
-        self.state.snackbar['show'] = False
-        self.state.snackbar['text'] = msg.text
-        self.state.snackbar['color'] = msg.color
-        self.state.snackbar['timeout'] = msg.timeout
-        self.state.snackbar['loading'] = msg.loading
-        self.state.snackbar['show'] = True
+        # if self.state.snackbar_queue.queue.empty():
+        #     self.state.snackbar['show'] = False
+        #     self.state.snackbar['text'] = msg.text
+        #     self.state.snackbar['color'] = msg.color
+        #     self.state.snackbar['timeout'] = msg.timeout
+        #     self.state.snackbar['loading'] = msg.loading
+        #     self.state.snackbar['show'] = True
+
+        self.state.snackbar_queue.put(self.state, msg)
+
 
     def _link_new_data(self):
         """

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -900,9 +900,6 @@ class Application(VuetifyTemplate, HubListener):
         """
         Callback to close a message in the snackbar when the "close"
         button is clicked.
-
-        Still need to find out how to perform the same action, but
-        triggered by a snackbar message timeout.
         """
         self.state.snackbar_queue.close_current_message(self.state)
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -245,7 +245,6 @@ class Application(VuetifyTemplate, HubListener):
 
         self.state.snackbar_queue.put(self.state, msg)
 
-
     def _link_new_data(self):
         """
         When additional data is loaded, check to see if the spectral axis of
@@ -904,6 +903,16 @@ class Application(VuetifyTemplate, HubListener):
             viewer.figure.save_png()
         elif filetype == "svg":
             viewer.figure.save_svg()
+
+    def vue_close_snackbar_message(self, event):
+        """
+        Callback to close a message in the snackbar when the "close"
+        button is clicked.
+
+        Still need to find out how to perform the same action, but
+        triggered by a snackbar message timeout.
+        """
+        self.state.snackbar_queue.close_event_handler(self.state)
 
     def _update_selected_data_items(self, viewer_id, selected_items):
         # Find the active viewer

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -235,14 +235,6 @@ class Application(VuetifyTemplate, HubListener):
             The Glue snackbar message containing information about displaying
             the message box.
         """
-        # if self.state.snackbar_queue.queue.empty():
-        #     self.state.snackbar['show'] = False
-        #     self.state.snackbar['text'] = msg.text
-        #     self.state.snackbar['color'] = msg.color
-        #     self.state.snackbar['timeout'] = msg.timeout
-        #     self.state.snackbar['loading'] = msg.loading
-        #     self.state.snackbar['show'] = True
-
         self.state.snackbar_queue.put(self.state, msg)
 
     def _link_new_data(self):

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -912,7 +912,7 @@ class Application(VuetifyTemplate, HubListener):
         Still need to find out how to perform the same action, but
         triggered by a snackbar message timeout.
         """
-        self.state.snackbar_queue.close_event_handler(self.state)
+        self.state.snackbar_queue.close_current_message(self.state)
 
     def _update_selected_data_items(self, viewer_id, selected_items):
         # Find the active viewer

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -68,7 +68,7 @@
       <v-btn
               v-if="!state.snackbar.loading"
               text
-              @click="state.snackbar.show = false"
+              @click="close_snackbar_message($event)"
       >
         Close
       </v-btn>

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -142,7 +142,7 @@ def _parse_image(app, file_obj, data_label, show_in_viewer, ext=None):
 
 def _info_nextensions(app, file_obj):
     if _count_image2d_extensions(file_obj) > 1:
-        info_msg = SnackbarMessage(INFO_MSG, color="info", timeout=15000, sender=app)
+        info_msg = SnackbarMessage(INFO_MSG, color="info", timeout=8000, sender=app)
         app.hub.broadcast(info_msg)
 
 

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -1,5 +1,10 @@
 import os
+from queue import Queue
+
 from traitlets import Unicode
+
+from echo import DictCallbackProperty
+
 
 __all__ = ['load_template']
 
@@ -31,3 +36,21 @@ def load_template(file_name, path=None, traitlet=True):
         return Unicode(TEMPLATE)
 
     return TEMPLATE
+
+
+class SnackbarQueue:
+
+    def __init__(self):
+        self.queue = Queue()
+
+    def put(self, state, msg):
+
+        if self.queue.empty():
+            state.snackbar['show'] = False
+            state.snackbar['text'] = msg.text
+            state.snackbar['color'] = msg.color
+            state.snackbar['timeout'] = msg.timeout
+            state.snackbar['loading'] = msg.loading
+            state.snackbar['show'] = True
+
+        self.queue.put(msg)

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -54,3 +54,25 @@ class SnackbarQueue:
             state.snackbar['show'] = True
 
         self.queue.put(msg)
+
+    def close_event_handler(self, state):
+
+        # turn off snackbar and remove corresponding
+        # message from  queue.
+        state.snackbar['show'] = False
+        self.queue.get()
+
+        # in case there are messages in the queue still,
+        # display the next.
+        if not self.queue.empty():
+            msg = self.queue.get()
+            self.queue.put(msg)
+            state.snackbar['show'] = False
+            state.snackbar['text'] = msg.text
+            state.snackbar['color'] = msg.color
+            state.snackbar['timeout'] = msg.timeout
+            state.snackbar['loading'] = msg.loading
+            state.snackbar['show'] = True
+
+
+

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -73,7 +73,7 @@ class SnackbarQueue:
         state.snackbar['show'] = False
         state.snackbar['text'] = msg.text
         state.snackbar['color'] = msg.color
-        state.snackbar['timeout'] = 0 # timeout controlled by thread
+        state.snackbar['timeout'] = 0  # timeout controlled by thread
         state.snackbar['loading'] = msg.loading
         state.snackbar['show'] = True
 
@@ -98,4 +98,3 @@ class SnackbarQueue:
                              args=(timeout,),
                              daemon=True)
         x.start()
-

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -46,16 +46,11 @@ class SnackbarQueue:
     def put(self, state, msg):
 
         if self.queue.empty():
-            state.snackbar['show'] = False
-            state.snackbar['text'] = msg.text
-            state.snackbar['color'] = msg.color
-            state.snackbar['timeout'] = msg.timeout
-            state.snackbar['loading'] = msg.loading
-            state.snackbar['show'] = True
+            _write_message(state, msg)
 
         self.queue.put(msg)
 
-    def close_event_handler(self, state):
+    def close_current_message(self, state):
 
         # turn off snackbar and remove corresponding
         # message from  queue.
@@ -67,12 +62,15 @@ class SnackbarQueue:
         if not self.queue.empty():
             msg = self.queue.get()
             self.queue.put(msg)
-            state.snackbar['show'] = False
-            state.snackbar['text'] = msg.text
-            state.snackbar['color'] = msg.color
-            state.snackbar['timeout'] = msg.timeout
-            state.snackbar['loading'] = msg.loading
-            state.snackbar['show'] = True
+            _write_message(state, msg)
 
+
+def _write_message(state, msg):
+    state.snackbar['show'] = False
+    state.snackbar['text'] = msg.text
+    state.snackbar['color'] = msg.color
+    state.snackbar['timeout'] = msg.timeout
+    state.snackbar['loading'] = msg.loading
+    state.snackbar['show'] = True
 
 

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -48,11 +48,11 @@ class SnackbarQueue:
         self.first = True
 
     def put(self, state, msg):
-
         if len(self.queue) == 0:
             self._write_message(state, msg)
 
-        self.queue.appendleft(msg)
+        if not msg.loading:
+            self.queue.appendleft(msg)
 
     def close_current_message(self, state):
 
@@ -76,6 +76,9 @@ class SnackbarQueue:
         state.snackbar['timeout'] = 0  # timeout controlled by thread
         state.snackbar['loading'] = msg.loading
         state.snackbar['show'] = True
+
+        if msg.loading:
+            return
 
         # timeout of the first message needs to be increased by a
         # few seconds to account for the time spent in page rendering.


### PR DESCRIPTION
Attempt at fixing ticket JDAT-1559: stacking snackbar messages.

Snackbar vuetify elements (\<v-snackbar \>) cannot be drawn at arbitrary places on screen; they just support `top`, `bottom`, `left`, `right` properties. Thus there is no way to stack them say, as a column on screen. People found a solution via a `VSnackbarQueue` that displays snackbar messages one after the other, as the `Close` button is clicked, or each message times out in turn. Unfortunately, this class is not implemented in `ipyvuetify`.

As a stopgap solution, I implemented a queuing mechanism here.