### PR TITLE
Fix bug with empty snackbar queue

### DIFF
--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -59,7 +59,8 @@ class SnackbarQueue:
         # turn off snackbar and remove corresponding
         # message from  queue.
         state.snackbar['show'] = False
-        _ = self.queue.pop()
+        if len(self.queue) > 0:
+            _ = self.queue.pop()
 
         # in case there are messages in the queue still,
         # display the next.


### PR DESCRIPTION
I just found out the bug reported by @rosteen on PR #701 (`IndexError: pop from an empty deque`). This didn't happen to me before when testing for the PR itself, but now I saw it when reviewing PR #687.

This PR fixes the bug.