### PR TITLE
Remove extraneous success messsage

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -313,10 +313,6 @@ class Application(VuetifyTemplate, HubListener):
             else:
                 self._application_handler.load_data(file_obj)
 
-            # Send out a toast message
-            snackbar_message = SnackbarMessage("Data successfully loaded.",
-                                               sender=self)
-            self.hub.broadcast(snackbar_message)
         finally:
             self.loading = False
 


### PR DESCRIPTION
There is already another success message that is more explicit here:

https://github.com/spacetelescope/jdaviz/blob/409587aba2411cf0bb752761b915042c3e7746a2/jdaviz/app.py#L587-L590

This solves the duplicate data loading success messages for Imviz. Cannot speak for other vizes.

Fix #714 