### PR TITLE
Viewers now have human-readable IDs

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -721,9 +721,29 @@ class Application(VuetifyTemplate, HubListener):
             if data_item['name'] == label:
                 return data_item['id']
 
-    def get_viewer_ids(self):
-        """Return a list of available viewer IDs."""
-        return sorted(self._viewer_store.keys())
+    def get_viewer_ids(self, prefix=None):
+        """Return a list of available viewer IDs.
+
+        Parameters
+        ----------
+        prefix : str or `None`
+            If not `None`, only return viewer IDs with given prefix
+            (case-sensitive). Otherwise, all viewer IDs are returned.
+
+        Returns
+        -------
+        vids : list of str
+            Sorted list of viewer IDs.
+
+        """
+        all_keys = sorted(self._viewer_store.keys())
+
+        if isinstance(prefix, str):
+            vids = [k for k in all_keys if k.startswith(prefix)]
+        else:
+            vids = all_keys
+
+        return vids
 
     def get_viewer_reference_names(self):
         """Return a list of available viewer reference names."""
@@ -1044,8 +1064,8 @@ class Application(VuetifyTemplate, HubListener):
             'children': children,
             'viewers': viewers}
 
-    def _next_viewer_num(self):
-        all_vids = self.get_viewer_ids()
+    def _next_viewer_num(self, prefix):
+        all_vids = self.get_viewer_ids(prefix=prefix)
         if len(all_vids) == 0:
             return 0
 
@@ -1077,8 +1097,9 @@ class Application(VuetifyTemplate, HubListener):
         tools.borderless = True
         tools.tile = True
 
-        n = self._next_viewer_num()
-        vid = f"{self.state.settings.get('configuration', 'unknown')}-{n}"
+        pfx = self.state.settings.get('configuration', str(name))
+        n = self._next_viewer_num(pfx)
+        vid = f"{pfx}-{n}"
 
         return {
             'id': vid,
@@ -1117,7 +1138,7 @@ class Application(VuetifyTemplate, HubListener):
 
         # Create the viewer item dictionary
         new_viewer_item = self._create_viewer_item(
-            viewer=viewer)
+            viewer=viewer, name=viewer.__class__.__name__)
 
         new_stack_item = self._create_stack_item(
             container='gl-stack',

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -347,6 +347,12 @@ class Application(VuetifyTemplate, HubListener):
         """
         return self._viewer_by_reference(viewer_reference)
 
+    def get_viewer_by_id(self, vid):
+        """Like :meth:`get_viewer` but use ID instead of reference name.
+        This is useful when reference name is `None`.
+        """
+        return self._viewer_store[vid]
+
     def get_data_from_viewer(self, viewer_reference, data_label=None,
                              cls='default', include_subsets=True):
         """
@@ -715,6 +721,15 @@ class Application(VuetifyTemplate, HubListener):
             if data_item['name'] == label:
                 return data_item['id']
 
+    def get_viewer_ids(self):
+        """Return a list of available viewer IDs."""
+        return sorted(self._viewer_store.keys())
+
+    def get_viewer_reference_names(self):
+        """Return a list of available viewer reference names."""
+        # Cannot sort because of None
+        return [self._viewer_item_by_id(vid)['reference'] for vid in self._viewer_store]
+
     def _viewer_by_id(self, vid):
         """
         Viewer instance by id.
@@ -1029,8 +1044,17 @@ class Application(VuetifyTemplate, HubListener):
             'children': children,
             'viewers': viewers}
 
-    @staticmethod
-    def _create_viewer_item(viewer, name=None, reference=None):
+    def _next_viewer_num(self):
+        all_vids = self.get_viewer_ids()
+        if len(all_vids) == 0:
+            return 0
+
+        # Assume name-num format
+        last_vid = all_vids[-1]
+        last_num = int(last_vid.split('-')[-1])
+        return last_num + 1
+
+    def _create_viewer_item(self, viewer, name=None, reference=None):
         """
         Convenience method for generating viewer item dictionaries.
 
@@ -1053,9 +1077,12 @@ class Application(VuetifyTemplate, HubListener):
         tools.borderless = True
         tools.tile = True
 
+        n = self._next_viewer_num()
+        vid = f"{self.state.settings.get('configuration', 'unknown')}-{n}"
+
         return {
-            'id': str(uuid.uuid4()),
-            'name': name or "Unnamed Viewer",
+            'id': vid,
+            'name': name or vid,
             'widget': "IPY_MODEL_" + viewer.figure_widget.model_id,
             'tools': "IPY_MODEL_" + viewer.toolbar_selection_tools.model_id,
             'layer_options': "IPY_MODEL_" + viewer.layer_options.model_id,

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -3,19 +3,41 @@
 # get picked up when running the tests inside an interpreter using
 # packagename.test
 
+import numpy as np
 import pytest
-
-from astropy.wcs import WCS
 from astropy import units as u
 from astropy.nddata import StdDevUncertainty
-import numpy as np
+from astropy.wcs import WCS
 from specutils import Spectrum1D
-from jdaviz.configs.specviz.helper import SpecViz
-from jdaviz.configs.imviz.helper import Imviz
+
+from jdaviz import __version__, CubeViz, Imviz, MosViz, SpecViz, Specviz2d
 
 SPECTRUM_SIZE = 10  # length of spectrum
 
-from jdaviz import __version__
+
+@pytest.fixture
+def cubeviz_app():
+    return CubeViz()
+
+
+@pytest.fixture
+def imviz_app():
+    return Imviz()
+
+
+@pytest.fixture
+def mosviz_app():
+    return MosViz()
+
+
+@pytest.fixture
+def specviz_app():
+    return SpecViz()
+
+
+@pytest.fixture
+def specviz2d_app():
+    return Specviz2d()
 
 
 @pytest.fixture
@@ -25,11 +47,6 @@ def spectral_cube_wcs(request):
     wcs.wcs.ctype = 'RA---TAN', 'DEC--TAN', 'FREQ'
     wcs.wcs.set()
     return wcs
-
-
-@pytest.fixture
-def specviz_app():
-    return SpecViz()
 
 
 @pytest.fixture
@@ -43,11 +60,6 @@ def spectrum1d():
     uncertainty = StdDevUncertainty(np.abs(np.random.randn(len(spec_axis.value))) * u.Jy)
 
     return Spectrum1D(spectral_axis=spec_axis, flux=flux, uncertainty=uncertainty)
-
-
-@pytest.fixture
-def imviz_app():
-    return Imviz()
 
 
 try:

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -13,7 +13,7 @@
     <gl-component
       v-for="(viewer, index) in stack.viewers"
       :key="index"
-      title="Viewer"
+      :title="viewer.id"
       :tab-id="viewer.id"
       @resize="$emit('resize')"
       @destroy="$emit('destroy', viewer.id)"

--- a/jdaviz/tests/test_viewer_ids.py
+++ b/jdaviz/tests/test_viewer_ids.py
@@ -1,0 +1,46 @@
+from jdaviz import Application
+
+
+def test_default_viewer_ids_default():
+    app = Application(configuration='default')
+    assert app.get_viewer_reference_names() == []
+    assert app.get_viewer_ids() == []
+
+
+# NOTE: Unable to parametrize fixture as input.
+
+def test_default_viewer_ids_cubeviz(cubeviz_app):
+    x = cubeviz_app.app
+    assert x.get_viewer_reference_names() == ['flux-viewer', 'uncert-viewer', 'mask-viewer',
+                                              'spectrum-viewer']
+    assert x.get_viewer_ids() == ['cubeviz-0', 'cubeviz-1', 'cubeviz-2', 'cubeviz-3']
+
+
+def test_default_viewer_ids_imviz(imviz_app):
+    x = imviz_app.app
+    assert x.get_viewer_reference_names() == ['viewer-1']
+    assert x.get_viewer_ids() == ['imviz-0']
+    assert x.get_viewer_ids(prefix='imviz') == ['imviz-0']
+    assert x.get_viewer_ids(prefix='specviz') == []
+
+    viewer = x.get_viewer('viewer-1')
+    assert x.get_viewer_by_id('imviz-0') is viewer
+
+
+def test_default_viewer_ids_mosviz(mosviz_app):
+    x = mosviz_app.app
+    assert x.get_viewer_reference_names() == ['image-viewer', 'spectrum-2d-viewer',
+                                              'spectrum-viewer', 'table-viewer']
+    assert x.get_viewer_ids() == ['mosviz-0', 'mosviz-1', 'mosviz-2', 'mosviz-3']
+
+
+def test_default_viewer_ids_specviz(specviz_app):
+    x = specviz_app.app
+    assert x.get_viewer_reference_names() == ['spectrum-viewer']
+    assert x.get_viewer_ids() == ['specviz-0']
+
+
+def test_default_viewer_ids_specviz2d(specviz2d_app):
+    x = specviz2d_app.app
+    assert x.get_viewer_reference_names() == ['spectrum-2d-viewer', 'spectrum-viewer']
+    assert x.get_viewer_ids() == ['specviz2d-0', 'specviz2d-1']


### PR DESCRIPTION
* Fix #372
* Fix #643 

# Proof of concept

With this patch, such a thing is now possible (though the contour stuff is another issue, see #530).

```python
>>> # After creating tiled viewers
>>> imviz.app.get_viewer_reference_names()
['viewer-1', None]
>>> imviz.app.get_viewer_ids()
['imviz-0', 'imviz-1']
>>> viewer = imviz.app.get_viewer('viewer-1')
>>> viewer2 = imviz.app.get_viewer_by_id('imviz-1')
>>> viewer2.state.layers[0].contour_lim_helper = viewer.state.layers[0].contour_lim_helper
>>> viewer2.state.layers[0].contour_visible = True
```

![Screenshot 2021-07-07 154652](https://user-images.githubusercontent.com/2090236/124821092-485cb880-df3c-11eb-83bf-3edf287b0b95.jpg)

# New viewer IDs

With this patch, this is how different layouts now behave.

```python
>>> from jdaviz.configs.cubeviz import CubeViz
>>> x = CubeViz()
>>> print('Reference names:', x.app.get_viewer_reference_names())
Reference names: ['flux-viewer', 'uncert-viewer', 'mask-viewer', 'spectrum-viewer']
>>> print('Viewer IDs:', x.app.get_viewer_ids())
Viewer IDs: ['cubeviz-0', 'cubeviz-1', 'cubeviz-2', 'cubeviz-3']
```

```python
>>> from jdaviz.configs.imviz import Imviz
>>> x = Imviz()
>>> print('Reference names:', x.app.get_viewer_reference_names())
Reference names: ['viewer-1']
>>> print('Viewer IDs:', x.app.get_viewer_ids())
Viewer IDs: ['imviz-0']
```

```python
>>> from jdaviz.configs.mosviz import MosViz
>>> x = MosViz()
>>> print('Reference names:', x.app.get_viewer_reference_names())
Reference names: ['image-viewer', 'spectrum-2d-viewer', 'spectrum-viewer', 'table-viewer']
>>> print('Viewer IDs:', x.app.get_viewer_ids())
Viewer IDs: ['mosviz-0', 'mosviz-1', 'mosviz-2', 'mosviz-3']
```

```python
>>> from jdaviz.configs.specviz import SpecViz
>>> x = SpecViz()
>>> print('Reference names:', x.app.get_viewer_reference_names())
Reference names: ['spectrum-viewer']
>>> print('Viewer IDs:', x.app.get_viewer_ids())
Viewer IDs: ['specviz-0']
```

```python
>>> from jdaviz.configs.specviz2d import Specviz2d
>>> x = Specviz2d()
>>> print('Reference names:', x.app.get_viewer_reference_names())
Reference names: ['spectrum-2d-viewer', 'spectrum-viewer']
>>> print('Viewer IDs:', x.app.get_viewer_ids())
Viewer IDs: ['specviz2d-0', 'specviz2d-1']
```

```python
>>> from jdaviz.app import Application
>>> x = Application(configuration='default')
>>> print('Reference names:', x.get_viewer_reference_names())
Reference names: []
>>> print('Viewer IDs:', x.get_viewer_ids())
Viewer IDs: []
```