### PR TITLE
Use smaller images for Imviz example notebook

### DIFF
--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -76,7 +76,7 @@
    "id": "60eb5782-264f-4af4-bb6e-ae583398277d",
    "metadata": {},
    "source": [
-    "Download some data. In this example, we use two 47 Tuc observations from HST/ACS."
+    "Download some data. In this example, we use two 47 Tuc observations from HST ACS/WFC."
    ]
   },
   {
@@ -86,8 +86,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "acs_47tuc_1 = download_file('https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HST/product/jbqf03gjq_flc.fits', cache=True)\n",
-    "acs_47tuc_2 = download_file('https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HST/product/jbqf03h1q_flc.fits', cache=True)"
+    "acs_47tuc_1 = download_file('https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HST/product/jcr513hfq_flt.fits', cache=True)\n",
+    "acs_47tuc_2 = download_file('https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HST/product/jd0q13krq_flt.fits', cache=True)"
    ]
   },
   {
@@ -226,7 +226,7 @@
    "id": "5a7848d0",
    "metadata": {},
    "source": [
-    "It possible to make selections/regions in images and export these to astropy regions. Click on the viewer toolbar then click on the circular selection tool, and drag and click to select an interesting region on the sky. We can then export this region with:"
+    "It possible to make selections/regions in images and export these to astropy regions. Click on the viewer toolbar then click on the rectangular selection tool, and drag and click to select an interesting region on the sky. We can then export this region with:"
    ]
   },
   {
@@ -303,7 +303,7 @@
    "outputs": [],
    "source": [
     "# Center the image on given pixel position.\n",
-    "imviz.center_on((1173, 1013))  # X, Y (0-indexed)"
+    "imviz.center_on((170, 263))  # X, Y (0-indexed)"
    ]
   },
   {
@@ -314,7 +314,7 @@
    "outputs": [],
    "source": [
     "# Move the image with the given pixel offsets.\n",
-    "imviz.offset_to(500, -100)  # dX, dY"
+    "imviz.offset_to(50, -100)  # dX, dY"
    ]
   },
   {
@@ -325,7 +325,7 @@
    "outputs": [],
    "source": [
     "# Center the image on given sky coordinates.\n",
-    "sky = SkyCoord('00h24m07.33s -71d52m50.71s')\n",
+    "sky = SkyCoord('00h22m43.88s -72d01m53.23s')\n",
     "imviz.center_on(sky)"
    ]
   },
@@ -357,8 +357,8 @@
    "source": [
     "# Add 100 randomly generated X,Y (0-indexed) w.r.t. reference image\n",
     "# using default marker properties.\n",
-    "t_xy = Table({'x': np.random.randint(0, 4096, 100),\n",
-    "              'y': np.random.randint(0, 2048, 100)})\n",
+    "t_xy = Table({'x': np.random.randint(0, 511, 100),\n",
+    "              'y': np.random.randint(0, 511, 100)})\n",
     "imviz.add_markers(t_xy)"
    ]
   },
@@ -377,7 +377,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imviz.marker = {'color': 'green', 'alpha': 0.8, 'markersize': 50}"
+    "imviz.marker = {'color': 'green', 'alpha': 0.8, 'markersize': 16}"
    ]
   },
   {
@@ -388,10 +388,10 @@
    "outputs": [],
    "source": [
     "# Mark some sky coordinates using updated marker properties.\n",
-    "t_sky = Table({'coord': [SkyCoord('00h24m07.33s -71d52m50.71s'),\n",
-    "                         SkyCoord('00h24m01.57s -71d53m17.77s'),\n",
-    "                         SkyCoord('00h24m11.70s -71d52m29.21s'),\n",
-    "                         SkyCoord('00h24m22.29s -71d53m28.04s')]})\n",
+    "t_sky = Table({'coord': [SkyCoord('00h22m43.88s -72d01m53.23s'),\n",
+    "                         SkyCoord('00h22m43.22s -72d02m07.42s'),\n",
+    "                         SkyCoord('00h22m41.77s -72d01m56.05s'),\n",
+    "                         SkyCoord('00h22m44.48s -72d01m46.19s')]})\n",
     "imviz.add_markers(t_sky, use_skycoord=True, marker_name='my_sky')"
    ]
   },


### PR DESCRIPTION
A workaround for lag seen in #723 by using the smallest ACS/WFC subarray exposures available (512 x 512). Even so, I think I still see some lag but not as bad as when using 2k x 4k exposures. Reviewers should double check.

Lag was a lot better using original test images from @astrofrog that were `(720, 721)` and `(149, 149)` but those sizes are a bit too unrealistic and the contents are not real science cases.

I don't know why it would matter if second image is now 512 x 512 as opposed to 149 x 149. Perhaps a discussion for glue-viz/glue#2138 in the future.