### PR TITLE
MNT: Remove jwst as dependency for Imviz

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -33,6 +33,5 @@ def pytest_configure(config):
     PYTEST_HEADER_MODULES['vispy'] = 'vispy'
     PYTEST_HEADER_MODULES['gwcs'] = 'gwcs'
     PYTEST_HEADER_MODULES['asdf'] = 'asdf'
-    PYTEST_HEADER_MODULES['jwst'] = 'jwst'
 
     TESTED_VERSIONS['jdaviz'] = __version__

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -51,7 +51,7 @@ class Imviz(ConfigHelper):
             * ``'filename.fits[SCI,2]'`` (loads the second SCI extension)
             * ``'filename.jpg'`` (requires ``scikit-image``; grayscale only)
             * ``'filename.png'`` (requires ``scikit-image``; grayscale only)
-            * JWST ASDF-in-FITS file (requires ``jwst``; ``data`` or given
+            * JWST ASDF-in-FITS file (requires ``asdf`` and ``gwcs``; ``data`` or given
               ``ext`` + GWCS)
             * ``astropy.io.fits.HDUList`` object (first image extension found
               is loaded unless ``ext`` keyword is also given)

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -9,7 +9,8 @@ from astropy.nddata import NDData
 from astropy.wcs import WCS
 from glue.core.data import Component, Data
 try:
-    from jwst import datamodels
+    import gwcs  # noqa
+    from asdf.fits_embed import AsdfInFits
     HAS_JWST_ASDF = True
 except ImportError:
     HAS_JWST_ASDF = False
@@ -89,7 +90,7 @@ def _parse_image(app, file_obj, data_label, show_in_viewer, ext=None):
                     _info_nextensions(app, file_obj)
 
             else:
-                raise ImportError('jwst package is missing')
+                raise ImportError('asdf or gwcs package is missing')
 
         elif ext == '*':  # Load all extensions
             data_iter = _hdus_to_glue_data(file_obj, data_label)
@@ -215,18 +216,21 @@ def _jwst2data(file_obj, ext, data_label):
     unit_attr = f'bunit_{ext}'
 
     # This is very specific to JWST pipeline image output.
-    with datamodels.open(file_obj) as dm:
-        if (unit_attr in dm.meta and
-                _validate_bunit(getattr(dm.meta, unit_attr), raise_error=False)):
-            bunit = getattr(dm.meta, unit_attr)
+    with AsdfInFits.open(file_obj) as af:
+        dm = af.tree
+        dm_meta = af.tree["meta"]
+
+        if (unit_attr in dm_meta and
+                _validate_bunit(dm_meta[unit_attr], raise_error=False)):
+            bunit = dm_meta[unit_attr]
         else:
             bunit = ''
 
         # This is instance of gwcs.WCS, not astropy.wcs.WCS
-        if hasattr(dm.meta, 'wcs'):
-            data.coords = dm.meta.wcs
+        if 'wcs' in dm_meta:
+            data.coords = dm_meta['wcs']
 
-        imdata = getattr(dm, ext)
+        imdata = dm[ext]
         component = Component.autotyped(imdata, units=bunit)
         data.add_component(component=component, label=comp_label)
 

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -174,15 +174,15 @@ class TestParseImage:
         with pytest.raises(ValueError, match='Do not manually overwrite data_label'):
             imviz_app.load_data(flist, data_label='foo', show_in_viewer=False)
 
-    @pytest.mark.skipif(HAS_JWST_ASDF, reason='jwst is installed')
+    @pytest.mark.skipif(HAS_JWST_ASDF, reason='asdf and gwcs are installed')
     @pytest.mark.remote_data
     def test_parse_jwst_nircam_level2_no_jwst(self, imviz_app):
         filename = download_file(self.jwst_asdf_url_1, cache=True)
-        with pytest.raises(ImportError, match='jwst package is missing'):
+        with pytest.raises(ImportError, match='asdf or gwcs package is missing'):
             parse_data(imviz_app.app, filename, data_label='foo',
                        show_in_viewer=False)
 
-    @pytest.mark.skipif(not HAS_JWST_ASDF, reason='jwst not installed')
+    @pytest.mark.skipif(not HAS_JWST_ASDF, reason='asdf and gwcs not installed')
     @pytest.mark.remote_data
     def test_parse_jwst_nircam_level2(self, imviz_app):
         from gwcs import WCS as GWCS

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -58,7 +58,7 @@ def test_validate_bunit():
 
 class TestParseImage:
     def setup_class(self):
-        self.jwst_asdf_url_1 = 'https://data.science.stsci.edu/redirect/JWST/jwst-data_analysis_tools/stellar_photometry/jw01072001001_01101_00001_nrcb1_cal.fits'  # noqa: E501
+        self.jwst_asdf_url_1 = 'https://data.science.stsci.edu/redirect/JWST/jwst-data_analysis_tools/imviz_test_data/jw00042001001_01101_00001_nrcb5_cal.fits'  # noqa: E501
 
     def test_no_data_label(self):
         with pytest.raises(NotImplementedError, match='should be set'):
@@ -243,7 +243,7 @@ class TestParseImage:
             assert data.labels[6].endswith('[VAR_FLAT]')
 
         # Invalid ASDF attribute (extension)
-        with pytest.raises(AttributeError, match='No attribute'):
+        with pytest.raises(KeyError, match='does_not_exist'):
             parse_data(imviz_app.app, filename, ext='DOES_NOT_EXIST',
                        data_label='foo', show_in_viewer=False)
 

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -93,7 +93,6 @@ def pytest_configure(config):
     PYTEST_HEADER_MODULES['vispy'] = 'vispy'
     PYTEST_HEADER_MODULES['gwcs'] = 'gwcs'
     PYTEST_HEADER_MODULES['asdf'] = 'asdf'
-    PYTEST_HEADER_MODULES['jwst'] = 'jwst'
 
     TESTED_VERSIONS['jdaviz'] = __version__
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,8 @@ all =
     scikit-image
     regions
     photutils
-    jwst>=1.2.1
+    asdf>=2.7.4
+    gwcs>=0.16.1
 
 [options.package_data]
 jdaviz =

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,8 @@ deps =
     devdeps: :NIGHTLY:numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
     devdeps: git+https://github.com/astropy/specutils.git
+    devdeps: git+https://github.com/spacetelescope/gwcs.git
+    devdeps: git+https://github.com/asdf-format/asdf.git
     devdeps: git+https://github.com/radio-astro-tools/spectral-cube.git
     devdeps: git+https://github.com/bqplot/bqplot.git
     devdeps: git+https://github.com/voila-dashboards/voila.git


### PR DESCRIPTION
Fix #725 

<details>
<summary>This is no longer an issue.</summary>

But I am not convinced this works because I get this error locally. Test image is https://data.science.stsci.edu/redirect/JWST/jwst-data_analysis_tools/stellar_photometry/jw01072001001_01101_00001_nrcb1_cal.fits

```
...
gwcs: 0.16.1
asdf: 2.7.3
...
_____________________________________ TestParseImage.test_parse_jwst_nircam_level2 _____________________________________

    @pytest.mark.skipif(not HAS_JWST_ASDF, reason='asdf and gwcs not installed')
    @pytest.mark.remote_data
    def test_parse_jwst_nircam_level2(self, imviz_app):
        from gwcs import WCS as GWCS

        filename = download_file(self.jwst_asdf_url_1, cache=True)

        # Default behavior: Science image
>       parse_data(imviz_app.app, filename, show_in_viewer=False)

jdaviz/configs/imviz/tests/test_parser.py:193:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
jdaviz/configs/imviz/plugins/parsers.py:65: in parse_data
    _parse_image(app, pf, data_label, show_in_viewer, ext=ext)
jdaviz/configs/imviz/plugins/parsers.py:133: in _parse_image
    for data, data_label in data_iter:
jdaviz/configs/imviz/plugins/parsers.py:207: in _jwst_to_glue_data
    data, new_data_label = _jwst2data(file_obj, ext, data_label)
jdaviz/configs/imviz/plugins/parsers.py:219: in _jwst2data
    with asdf.open(file_obj) as af:
.../asdf/asdf.py:1480: in open_asdf
    return AsdfFile._open_impl(instance,
.../asdf/asdf.py:719: in _open_impl
    return fits_embed.AsdfInFits._open_impl(fd, uri=uri,
.../asdf/fits_embed.py:266: in _open_impl
    return cls._open_asdf(self, buff, uri=uri, mode='r',
.../asdf/asdf.py:693: in _open_asdf
    tree = yamlutil.tagged_tree_to_custom_tree(tree, self, _force_raw_types)
.../asdf/yamlutil.py:287: in tagged_tree_to_custom_tree
    return treeutil.walk_and_modify(
.../asdf/treeutil.py:406: in walk_and_modify
    return _recurse(top)
.../asdf/treeutil.py:387: in _recurse
    result = _handle_children(node, json_id)
.../asdf/treeutil.py:365: in _handle_children
    return _handle_generator(result)
.../asdf/treeutil.py:263: in _handle_generator
    result = next(generator)
.../asdf/treeutil.py:291: in _handle_mapping
    value = _recurse(value, json_id)
.../asdf/treeutil.py:387: in _recurse
    result = _handle_children(node, json_id)
.../asdf/treeutil.py:365: in _handle_children
    return _handle_generator(result)
.../asdf/treeutil.py:263: in _handle_generator
    result = next(generator)
.../asdf/treeutil.py:291: in _handle_mapping
    value = _recurse(value, json_id)
.../asdf/treeutil.py:388: in _recurse
    result = _handle_callback(result, json_id)
.../asdf/treeutil.py:270: in _handle_callback
    result = callback(node)
.../asdf/yamlutil.py:279: in walker
    return tag_type.from_tree_tagged(node, ctx)
.../asdf/types.py:407: in from_tree_tagged
    return cls.from_tree(tree.data, ctx)
.../gwcs/tags/wcs.py:29: in from_tree
    steps = [(x.frame, x.transform) for x in node['steps']]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

.0 = <list_iterator object at ...>

>   steps = [(x.frame, x.transform) for x in node['steps']]
E   AttributeError: 'TaggedDict' object has no attribute 'frame'

.../gwcs/tags/wcs.py:29: AttributeError
```

</details>

cc @jdavies-st