### PR TITLE
Add ability to retrieve only spectral or spatial subsets

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -474,6 +474,10 @@ class Application(VuetifyTemplate, HubListener):
         data_label : str, optional
             Optionally provide a label to retrieve a specific data set from the
             viewer instance.
+        subset_type : str, optional
+            Optionally specify either "spectral" or "spatial" to return only
+            subsets created in a profile (spectrum) viewer or image viewer,
+            respectively.
 
         Returns
         -------

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -22,7 +22,7 @@ from glue.core.link_helpers import LinkSame
 from glue.core.message import (DataCollectionAddMessage,
                                DataCollectionDeleteMessage)
 from glue.core.state_objects import State
-from glue.core.subset import Subset
+from glue.core.subset import Subset, RangeSubsetState, RoiSubsetState
 from glue_jupyter.app import JupyterApplication
 from glue_jupyter.state_traitlets_helpers import GlueState
 from ipyvuetify import VuetifyTemplate
@@ -453,7 +453,7 @@ class Application(VuetifyTemplate, HubListener):
 
         return data
 
-    def get_subsets_from_viewer(self, viewer_reference, data_label=None):
+    def get_subsets_from_viewer(self, viewer_reference, data_label=None, subset_type=None):
         """
         Returns the subsets of a specified viewer converted to astropy regions
         objects.
@@ -496,6 +496,12 @@ class Application(VuetifyTemplate, HubListener):
                 # TODO: Remove this when Imviz support round-tripping, see
                 # https://github.com/spacetelescope/jdaviz/pull/721
                 if viewer_reference == 'viewer-1' and not key.startswith('Subset'):
+                    continue
+
+                # Skip spatial or spectral subsets if only the other is wanted
+                if subset_type == "spectral" and isinstance(value.subset_state, RoiSubsetState):
+                    continue
+                elif subset_type == "spatial" and isinstance(value.subset_state, RangeSubsetState):
                     continue
 
                 # Range selection on a profile is currently not supported in

--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -92,7 +92,8 @@ class Collapse(TemplateMixin):
 
     def vue_list_subsets(self, event):
         """Populate the spectral subset selection dropdown"""
-        temp_subsets = self.app.get_subsets_from_viewer("spectrum-viewer")
+        temp_subsets = self.app.get_subsets_from_viewer("spectrum-viewer",
+                                                        subset_type="spectral")
         temp_list = ["None"]
         temp_dict = {}
         # Attempt to filter out spatial subsets

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -75,7 +75,7 @@ class SpecViz(ConfigHelper, LineListMixin):
             Mapping from the names of the subsets to the subsets expressed
             as `specutils.SpectralRegion` objects.
         """
-        regions = self.app.get_subsets_from_viewer("spectrum-viewer")
+        regions = self.app.get_subsets_from_viewer("spectrum-viewer", subset_type="spectral")
 
         spec_regs = {}
 

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -18,17 +18,12 @@ def test_region_from_subset_2d(jdaviz_app):
     data = Data(flux=np.ones((128, 128)), label='Test 2D Flux')
     jdaviz_app.data_collection.append(data)
 
-    subset_state = RoiSubsetState(data.pixel_component_ids[1],
-                                  data.pixel_component_ids[0],
-                                  RectangularROI(1, 3.5, -0.2, 3.3))
-
     jdaviz_app.add_data_to_viewer('flux-viewer', 'Test 2D Flux')
 
-    jdaviz_app.data_collection.new_subset_group(
-        subset_state=subset_state, label='rectangular')
+    jdaviz_app.get_viewer('flux-viewer').apply_roi(RectangularROI(1, 3.5, -0.2, 3.3))
 
     subsets = jdaviz_app.get_subsets_from_viewer('flux-viewer')
-    reg = subsets.get('rectangular')
+    reg = subsets.get('Subset 1')
 
     assert len(subsets) == 1
     assert isinstance(reg, RectanglePixelRegion)
@@ -44,17 +39,12 @@ def test_region_from_subset_3d(jdaviz_app):
     data = Data(flux=np.ones((256, 128, 128)), label='Test 3D Flux')
     jdaviz_app.data_collection.append(data)
 
-    subset_state = RoiSubsetState(data.pixel_component_ids[1],
-                                  data.pixel_component_ids[0],
-                                  RectangularROI(1, 3.5, -0.2, 3.3))
-
     jdaviz_app.add_data_to_viewer('flux-viewer', 'Test 3D Flux')
 
-    jdaviz_app.data_collection.new_subset_group(
-        subset_state=subset_state, label='rectangular')
+    jdaviz_app.get_viewer('flux-viewer').apply_roi(RectangularROI(1, 3.5, -0.2, 3.3))
 
     subsets = jdaviz_app.get_subsets_from_viewer('flux-viewer')
-    reg = subsets.get('rectangular')
+    reg = subsets.get('Subset 1')
 
     assert len(subsets) == 1
     assert isinstance(reg, RectanglePixelRegion)
@@ -96,6 +86,7 @@ def test_region_spectral_spatial(jdaviz_app, spectral_cube_wcs):
     jdaviz_app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(1, 3.5))
 
     flux_viewer = jdaviz_app.get_viewer("flux-viewer")
+    # We set the active tool here to trigger a reset of the Subset state to "Create new"
     flux_viewer.toolbar.active_tool = flux_viewer.toolbar.tools['bqplot:rectangle']
     flux_viewer.apply_roi(RectangularROI(1, 3.5, -0.2, 3.3))
 

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -70,17 +70,12 @@ def test_region_from_subset_profile(jdaviz_app, spectral_cube_wcs):
     data = Data(flux=np.ones((256, 128, 128)), label='Test 1D Flux', coords=spectral_cube_wcs)
     jdaviz_app.data_collection.append(data)
 
-    subset_state = RoiSubsetState(data.pixel_component_ids[1],
-                                  data.pixel_component_ids[0],
-                                  XRangeROI(1, 3.5))
-
     jdaviz_app.add_data_to_viewer('spectrum-viewer', 'Test 1D Flux')
 
-    jdaviz_app.data_collection.new_subset_group(
-        subset_state=subset_state, label='rectangular')
+    jdaviz_app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(1, 3.5))
 
-    subsets = jdaviz_app.get_subsets_from_viewer('spectrum-viewer')
-    reg = subsets.get('rectangular')
+    subsets = jdaviz_app.get_subsets_from_viewer('spectrum-viewer', subset_type='spectral')
+    reg = subsets.get('Subset 1')
 
     assert len(subsets) == 1
     assert isinstance(reg, RectanglePixelRegion)
@@ -89,3 +84,39 @@ def test_region_from_subset_profile(jdaviz_app, spectral_cube_wcs):
     assert_allclose(reg.center.y, 128)
     assert_allclose(reg.width, 2.5)
     assert_allclose(reg.height, 256)
+
+
+def test_region_spectral_spatial(jdaviz_app, spectral_cube_wcs):
+    data = Data(flux=np.ones((256, 128, 128)), label='Test Flux', coords=spectral_cube_wcs)
+    jdaviz_app.data_collection.append(data)
+
+    jdaviz_app.add_data_to_viewer('spectrum-viewer', 'Test Flux')
+    jdaviz_app.add_data_to_viewer('flux-viewer', 'Test Flux')
+
+    jdaviz_app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(1, 3.5))
+
+    flux_viewer = jdaviz_app.get_viewer("flux-viewer")
+    flux_viewer.toolbar.active_tool = flux_viewer.toolbar.tools['bqplot:rectangle']
+    flux_viewer.apply_roi(RectangularROI(1, 3.5, -0.2, 3.3))
+
+    subsets = jdaviz_app.get_subsets_from_viewer('spectrum-viewer', subset_type='spectral')
+    reg = subsets.get('Subset 1')
+
+    assert len(subsets) == 1
+    assert isinstance(reg, RectanglePixelRegion)
+
+    assert_allclose(reg.center.x, 2.25)
+    assert_allclose(reg.center.y, 128)
+    assert_allclose(reg.width, 2.5)
+    assert_allclose(reg.height, 256)
+
+    subsets = jdaviz_app.get_subsets_from_viewer('flux-viewer', subset_type='spatial')
+    reg = subsets.get('Subset 2')
+
+    assert len(subsets) == 1
+    assert isinstance(reg, RectanglePixelRegion)
+    assert_allclose(reg.center.x, 2.25)
+    assert_allclose(reg.center.x, 2.25)
+    assert_allclose(reg.center.y, 1.55)
+    assert_allclose(reg.width, 2.5)
+    assert_allclose(reg.height, 3.5)

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 from glue.core import Data
 from glue.core.roi import RectangularROI, XRangeROI
-from glue.core.subset import RoiSubsetState
 from numpy.testing import assert_allclose
 from regions import RectanglePixelRegion
 


### PR DESCRIPTION
Fixes a bug when calling `cubeviz.specviz.get_spectral_regions()` where it would crash if there were circular spatial subsets defined in the image viewer (and would return rectangular spatial subsets like they were spectral regions). 

Also prevents rectangular spatial regions from showing up as spectral regions in the Collapse plugin (see screenshot below), and opens up other usage that would require this capability. 

Someone more familiar with Glue should look at this as well in case there are any pitfalls with doing the check this way that I don't appreciate. This is the best attribute on the Subsets I could find to determine whether they are spatial or spectral. 

![Screen Shot 2021-07-20 at 11 56 09 AM](https://user-images.githubusercontent.com/39831871/126359203-88f22006-a883-425d-8cad-74ebaab61695.png)
