### PR TITLE
Imviz: Add zoom and zoom_level API

### DIFF
--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -220,7 +220,7 @@ class Imviz(ConfigHelper):
 
         """
         viewer = self.app.get_viewer("viewer-1")
-        if viewer.shape is None:
+        if viewer.shape is None:  # pragma: no cover
             raise ValueError('Viewer is still loading, try again later')
 
         screenx = viewer.shape[1]
@@ -240,7 +240,7 @@ class Imviz(ConfigHelper):
         viewer = self.app.get_viewer("viewer-1")
         image = viewer.state.reference_data
         if (image is None or viewer.shape is None or
-                viewer.state.x_att is None or viewer.state.y_att is None):
+                viewer.state.x_att is None or viewer.state.y_att is None):  # pragma: no cover
             return
 
         # Zoom on X and Y will auto-adjust.

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -220,13 +220,13 @@ class Imviz(ConfigHelper):
 
         """
         viewer = self.app.get_viewer("viewer-1")
-        image = viewer.state.reference_data
+        if viewer.shape is None:
+            raise ValueError('Viewer is still loading, try again later')
 
-        # TODO: Need to fix formula to use "real pixel size"
-        nx = image.shape[viewer.state.x_att.axis]
-        ny = image.shape[viewer.state.y_att.axis]
-        zoom_x = nx / (viewer.state.x_max - viewer.state.x_min)
-        zoom_y = ny / (viewer.state.y_max - viewer.state.y_min)
+        screenx = viewer.shape[1]
+        screeny = viewer.shape[0]
+        zoom_x = screenx / (viewer.state.x_max - viewer.state.x_min)
+        zoom_y = screeny / (viewer.state.y_max - viewer.state.y_min)
 
         return max(zoom_x, zoom_y)  # Similar to Ginga get_scale()
 
@@ -239,20 +239,18 @@ class Imviz(ConfigHelper):
 
         viewer = self.app.get_viewer("viewer-1")
         image = viewer.state.reference_data
-        if image is None or viewer.state.x_att is None or viewer.state.y_att is None:
+        if (image is None or viewer.shape is None or
+                viewer.state.x_att is None or viewer.state.y_att is None):
             return
 
         # Zoom on X and Y will auto-adjust.
-        nx = image.shape[viewer.state.x_att.axis]
-
         if val == 'fit':
             # Similar to ImageViewerState.reset_limits() in Glue.
             new_x_min = 0
-            new_x_max = nx
+            new_x_max = image.shape[viewer.state.x_att.axis]
         else:
-            # TODO: Need to fix formula to use "real pixel size"
             cur_xcen = (viewer.state.x_min + viewer.state.x_max) * 0.5
-            new_dx = nx * 0.5 / val
+            new_dx = viewer.shape[1] * 0.5 / val
             new_x_min = cur_xcen - new_dx
             new_x_max = cur_xcen + new_dx
 

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -252,8 +252,7 @@ class Imviz(ConfigHelper):
             new_x_min = 0
             new_x_max = nx
         else:
-            width = viewer.state.x_max - viewer.state.x_min
-            cur_xcen = viewer.state.x_min + (width * 0.5)
+            cur_xcen = (viewer.state.x_min + viewer.state.x_max) * 0.5
             new_dx = nx * 0.5 / val
             new_x_min = cur_xcen - new_dx
             new_x_max = cur_xcen + new_dx

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -216,12 +216,13 @@ class Imviz(ConfigHelper):
         * 1 means real-pixel-size.
         * 2 means zoomed in by a factor of 2.
         * 0.5 means zoomed out by a factor of 2.
-        * 'fit' resets the zoom.
+        * 'fit' means zoomed to fit the whole image width into display.
 
         """
         viewer = self.app.get_viewer("viewer-1")
-        i_top = get_top_layer_index(viewer)
-        image = viewer.layers[i_top].layer
+        image = viewer.state.reference_data
+
+        # TODO: Need to fix formula to use "real pixel size"
         nx = image.shape[viewer.state.x_att.axis]
         ny = image.shape[viewer.state.y_att.axis]
         zoom_x = nx / (viewer.state.x_max - viewer.state.x_min)
@@ -237,14 +238,11 @@ class Imviz(ConfigHelper):
             raise ValueError(f'Unsupported zoom level: {val}')
 
         viewer = self.app.get_viewer("viewer-1")
-        if (viewer.state.reference_data is None or viewer.state.x_att is None
-                or viewer.state.y_att is None):
+        image = viewer.state.reference_data
+        if image is None or viewer.state.x_att is None or viewer.state.y_att is None:
             return
 
-        # Want to zoom what is actually visible.
         # Zoom on X and Y will auto-adjust.
-        i_top = get_top_layer_index(viewer)
-        image = viewer.layers[i_top].layer
         nx = image.shape[viewer.state.x_att.axis]
 
         if val == 'fit':
@@ -252,6 +250,7 @@ class Imviz(ConfigHelper):
             new_x_min = 0
             new_x_max = nx
         else:
+            # TODO: Need to fix formula to use "real pixel size"
             cur_xcen = (viewer.state.x_min + viewer.state.x_max) * 0.5
             new_dx = nx * 0.5 / val
             new_x_min = cur_xcen - new_dx

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -65,6 +65,59 @@ class TestCenterOffset(BaseImviz_WCS_NoWCS):
             self.imviz.offset_by(dsky, dsky)
 
 
+class TestZoom(BaseImviz_WCS_NoWCS):
+
+    @pytest.mark.parametrize('val', (0, -0.1, 'foo', [1, 2]))
+    def test_invalid_zoom_level(self, val):
+        with pytest.raises(ValueError, match='Unsupported zoom level'):
+            self.imviz.zoom_level = val
+
+    def test_invalid_zoom(self):
+        with pytest.raises(ValueError, match='zoom only accepts int or float'):
+            self.imviz.zoom('fit')
+
+    def assert_zoom_results(self, zoom_level, x_min, x_max, y_min, y_max, dpix):
+        assert_allclose(self.imviz.zoom_level, zoom_level)
+        assert_allclose((self.viewer.state.x_min, self.viewer.state.x_max,
+                         self.viewer.state.y_min, self.viewer.state.y_max),
+                        (x_min + dpix, x_max + dpix,
+                         y_min + dpix, y_max + dpix))
+
+    @pytest.mark.parametrize('is_offcenter', (False, True))
+    def test_zoom(self, is_offcenter):
+        if is_offcenter:
+            self.imviz.center_on((0, 0))
+            dpix = -4.5
+        else:
+            self.imviz.center_on((4.5, 4.5))
+            dpix = 0
+
+        self.assert_zoom_results(10, -0.5, 9.5, -0.5, 9.5, dpix)
+
+        # NOTE: Not sure why X/Y min/max not exactly the same as aspect ratio 1
+        self.imviz.zoom_level = 1
+        self.assert_zoom_results(1, -46, 54, -45.5, 54.5, dpix)
+
+        self.imviz.zoom_level = 2
+        self.assert_zoom_results(2, -21.5, 28.5, -20.5, 29.5, dpix)
+
+        self.imviz.zoom(2)
+        self.assert_zoom_results(4, -9.5, 15.5, -8.0, 17.0, dpix)
+
+        self.imviz.zoom(0.5)
+        self.assert_zoom_results(2, -22.5, 27.5, -20.5, 29.5, dpix)
+
+        self.imviz.zoom_level = 0.5
+        self.assert_zoom_results(0.5, -98, 102, -95.5, 104.5, dpix)
+
+        # This fits the whole image on screen, regardless.
+        # NOTE: But somehow Y min/max auto-adjust does not work properly
+        # in the unit test when off-center. Works in notebook though.
+        if not is_offcenter:
+            self.imviz.zoom_level = 'fit'
+            self.assert_zoom_results(10, -0.5, 9.5, -0.5, 9.5, 0)
+
+
 class TestMarkers(BaseImviz_WCS_NoWCS):
 
     def test_invalid_markers(self):

--- a/jdaviz/configs/imviz/tests/utils.py
+++ b/jdaviz/configs/imviz/tests/utils.py
@@ -36,3 +36,7 @@ class BaseImviz_WCS_NoWCS:
         self.wcs = WCS(hdu.header)
         self.imviz = imviz_app
         self.viewer = imviz_app.app.get_viewer('viewer-1')
+
+        # Since we are not really displaying, need this to test zoom.
+        self.viewer.shape = (100, 100)
+        self.viewer.state._set_axes_aspect_ratio(1)

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -399,7 +399,7 @@
     "* 1 means real-pixel-size.\n",
     "* 2 means zoomed in by a factor of 2.\n",
     "* 0.5 means zoomed out by a factor of 2.\n",
-    "* 'fit' resets the zoom."
+    "* 'fit' means zoomed to fit the whole image width into display."
    ]
   },
   {

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -389,6 +389,54 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e2744c0c-8721-480a-811e-87904373e66f",
+   "metadata": {},
+   "source": [
+    "You can programmatically zoom in and out.\n",
+    "\n",
+    "Zoom level:\n",
+    "\n",
+    "* 1 means real-pixel-size.\n",
+    "* 2 means zoomed in by a factor of 2.\n",
+    "* 0.5 means zoomed out by a factor of 2.\n",
+    "* 'fit' resets the zoom."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1bad9bdf-b959-4b74-9a77-07212095c2ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the current zoom level.\n",
+    "imviz.zoom_level"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a834bcf-7d5a-492b-bc54-740e1500a2f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set the zoom level directly.\n",
+    "imviz.zoom_level = 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32288b81-1817-4549-b2e4-5e7f55b0ee3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set the relative zoom based on current zoom level.\n",
+    "imviz.zoom(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "11fab067-7428-4ce4-bc9b-f5462fe52e2a",
    "metadata": {},
    "source": [

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -421,7 +421,7 @@
    "outputs": [],
    "source": [
     "# Set the zoom level directly.\n",
-    "imviz.zoom_level = 2"
+    "imviz.zoom_level = 1"
    ]
   },
   {


### PR DESCRIPTION
Fix #715

# TODO

- [x] Maybe use reference image?
- [x] Clarify "fit" more.
- [x] Fix "real pixel size" logic. How to grab pixel width from figure viewer? `viewer.shape`
- [x] Add tests. Remember to test the different combos and zooming on off-center.