### PR TITLE
ENH: verbosity to control snackbar messages

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -131,9 +131,7 @@ class Application(VuetifyTemplate, HubListener):
 
     def __init__(self, configuration=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        # verbosity: viola will set it via env var that is already validated
-        self._verbosity = os.environ.get('JDAVIZ_VERBOSITY', 'info')
+        self._verbosity = 'info'
 
         # Generate a state object for this application to maintain the state of
         #  the user interface.

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -132,6 +132,9 @@ class Application(VuetifyTemplate, HubListener):
     def __init__(self, configuration=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # verbosity: viola will set it via env var that is already validated
+        self._verbosity = os.environ.get('JDAVIZ_VERBOSITY', 'info')
+
         # Generate a state object for this application to maintain the state of
         #  the user interface.
         self.state = ApplicationState()
@@ -225,10 +228,26 @@ class Application(VuetifyTemplate, HubListener):
         """
         return self._application_handler.data_collection
 
+    @property
+    def verbosity(self):
+        """
+        Verbosity of the application, choose from ``'debug'``, ``'info'`` (default),
+        ``'warning'``, or ``'error'``.
+        """
+        return self._verbosity
+
+    @verbosity.setter
+    def verbosity(self, val):
+        if val not in ('debug', 'info', 'warning', 'error'):
+            raise ValueError(f'Invalid verbosity: {val}')
+        self._verbosity = val
+
     def _on_snackbar_message(self, msg):
         """
         Displays a toast message with an editable message that be dismissed
         manually or will dismiss automatically after a timeout.
+
+        This is also controlled by ``self.verbosity``.
 
         Parameters
         ----------
@@ -236,7 +255,23 @@ class Application(VuetifyTemplate, HubListener):
             The Glue snackbar message containing information about displaying
             the message box.
         """
-        self.state.snackbar_queue.put(self.state, msg)
+        # https://material-ui.com/customization/palette/ provides these options:
+        #   success, info, warning, error, secondary, primary
+        # We have these options:
+        #   debug, info, warning, error
+        # Therefore:
+        # * debug is not used, it is more for the future if we also have a logger.
+        # * info lets everything through
+        # * success, secondary, and primary are treated as info (not sure what they are used for)
+        # * None is also treated as info (when color is not set)
+        ignored = []
+        if self.verbosity in ('warning', 'error'):
+            ignored += ['success', 'info', 'secondary', 'primary', None]
+            if self.verbosity == 'error':
+                ignored.append('warning')
+
+        if msg.color not in ignored:
+            self.state.snackbar_queue.put(self.state, msg)
 
     def _link_new_data(self):
         """

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -78,13 +78,10 @@ def main(filename, layout='default', browser='default', theme='light', verbosity
     # easily accessed e.g. in the file load dialog.
     os.environ['JDAVIZ_START_DIR'] = start_dir
 
-    # Also keep track of desired verbosity.
-    os.environ['JDAVIZ_VERBOSITY'] = verbosity
-
     nbdir = tempfile.mkdtemp()
 
     with open(os.path.join(nbdir, 'notebook.ipynb'), 'w') as nbf:
-        nbf.write(notebook_template.replace('DATA_FILENAME', filepath).strip())
+        nbf.write(notebook_template.replace('DATA_FILENAME', filepath).replace('JDAVIZ_VERBOSITY', verbosity).strip())  # noqa: E501
 
     os.chdir(nbdir)
 

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -37,7 +37,13 @@ CONFIGS_DIR = os.path.join(os.path.dirname(__file__), 'configs')
               show_default=True,
               type=click.Choice(['light', 'dark']),
               help="Theme to use for application")
-def main(filename, layout='default', browser='default', theme='light'):
+@click.option('--verbosity',
+              default='info',
+              nargs=1,
+              show_default=True,
+              type=click.Choice(['debug', 'info', 'warning', 'error']),
+              help="Verbosity of the application")
+def main(filename, layout='default', browser='default', theme='light', verbosity='info'):
     """
     Start a JDAViz application instance with data loaded from FILENAME.\f
 
@@ -51,6 +57,8 @@ def main(filename, layout='default', browser='default', theme='light'):
         Path to browser executable.
     theme : {'light', 'dark'}
         Theme to use for Voila app or Jupyter Lab.
+    verbosity : {'debug', 'info', 'warning', 'error'}
+        Verbosity of the application.
     """
     # Tornado Webserver py3.8 compatibility hotfix for windows
     if sys.platform == 'win32':
@@ -69,6 +77,9 @@ def main(filename, layout='default', browser='default', theme='light'):
     # Keep track of start directory in environment variable so that it can be
     # easily accessed e.g. in the file load dialog.
     os.environ['JDAVIZ_START_DIR'] = start_dir
+
+    # Also keep track of desired verbosity.
+    os.environ['JDAVIZ_VERBOSITY'] = verbosity
 
     nbdir = tempfile.mkdtemp()
 

--- a/jdaviz/configs/cubeviz/cubeviz.ipynb
+++ b/jdaviz/configs/cubeviz/cubeviz.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "from jdaviz import CubeViz\n",
     "\n",
-    "cubeviz = CubeViz()\n",
+    "cubeviz = CubeViz(verbosity='JDAVIZ_VERBOSITY')\n",
     "cubeviz.load_data('DATA_FILENAME')\n",
     "cubeviz.app"
    ]

--- a/jdaviz/configs/default/default.ipynb
+++ b/jdaviz/configs/default/default.ipynb
@@ -42,6 +42,7 @@
    "source": [
     "from jdaviz.app import Application\n",
     "app = Application(configuration='default')\n",
+    "app.verbosity = 'JDAVIZ_VERBOSITY'\n",
     "app.load_data('DATA_FILENAME')\n",
     "app"
    ]

--- a/jdaviz/configs/imviz/imviz.ipynb
+++ b/jdaviz/configs/imviz/imviz.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "from jdaviz import Imviz\n",
     "\n",
-    "imviz = Imviz()\n",
+    "imviz = Imviz(verbosity='JDAVIZ_VERBOSITY')\n",
     "imviz.load_data('DATA_FILENAME')\n",
     "imviz.app"
    ]

--- a/jdaviz/configs/mosviz/mosviz.ipynb
+++ b/jdaviz/configs/mosviz/mosviz.ipynb
@@ -35,7 +35,7 @@
     "for i in range(0, len(spectra_1d)):\n",
     "    images.append(str(data_path / \"mosviz_cutouts\" / \"227.fits\"))\n",
     "\n",
-    "mosviz = MosViz()\n",
+    "mosviz = MosViz(verbosity='JDAVIZ_VERBOSITY')\n",
     "mosviz.load_data(spectra_1d, spectra_2d, images)\n",
     "mosviz.app"
    ]

--- a/jdaviz/configs/specviz/specviz.ipynb
+++ b/jdaviz/configs/specviz/specviz.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "from jdaviz import SpecViz\n",
     "\n",
-    "specviz = SpecViz()\n",
+    "specviz = SpecViz(verbosity='JDAVIZ_VERBOSITY')\n",
     "specviz.load_data('DATA_FILENAME')\n",
     "specviz.app"
    ]

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -28,14 +28,17 @@ class ConfigHelper(HubListener):
     app : jdaviz.app.Application or None
         The application object, or if None, creates a new one based on the
         default configuration for this helper.
+    verbosity : {'debug', 'info', 'warning', 'error'}
+        Verbosity of the application.
     """
     _default_configuration = 'default'
 
-    def __init__(self, app=None):
+    def __init__(self, app=None, verbosity='info'):
         if app is None:
             self.app = Application(configuration=self._default_configuration)
         else:
             self.app = app
+        self.app.verbosity = verbosity
 
     def load_data(self, data, parser_reference=None, **kwargs):
         self.app.load_data(data, parser_reference=parser_reference, **kwargs)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to introduce a new option named `verbosity` to control what snackbar messages get passed through.

Motivation: When I am developing the code, I only want to see warnings or errors, not 3 "success" messages per data load.

With this patch, you can now call your favorite viz with a new `verbosity=` keyword. For example: `imviz = Imviz(verbosity='warning')`

p.s. I cannot test the `voila` option due to https://github.com/voila-dashboards/voila/issues/773#issuecomment-868593863 , though theoretically it should work but someone should test it.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
