### PR TITLE
Specviz Spectral Region Getter falls back to reference data units

### DIFF
--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -80,7 +80,18 @@ class SpecViz(ConfigHelper, LineListMixin):
         spec_regs = {}
 
         for name, reg in regions.items():
-            unit = reg.meta.get("spectral_axis_unit", u.Unit("Angstrom"))
+            try:
+                # Use the region's unit. If N/A, use the reference_data's
+                unit = reg.meta.get("spectral_axis_unit",
+                                    self.get_spectra(
+                                        self.app.get_viewer("spectrum-viewer"
+                                                            ).state.reference_data.label,
+                                        apply_slider_redshift=False
+                                        ).spectral_axis.unit
+                                    )
+            except (KeyError, LookupError, AttributeError):
+                unit = u.Unit('count')
+
             spec_reg = SpectralRegion.from_center(reg.center.x * unit,
                                                   reg.width * unit)
 

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -90,7 +90,7 @@ class SpecViz(ConfigHelper, LineListMixin):
                                         ).spectral_axis.unit
                                     )
             except (KeyError, LookupError, AttributeError):
-                unit = u.Unit('pixel')
+                unit = u.dimensionless_unscaled
 
             spec_reg = SpectralRegion.from_center(reg.center.x * unit,
                                                   reg.width * unit)

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -87,7 +87,7 @@ class SpecViz(ConfigHelper, LineListMixin):
                                                         ).state.reference_data.label,
                                     apply_slider_redshift=False
                                     ).spectral_axis.unit
-                                    )
+                                )
 
             spec_reg = SpectralRegion.from_center(reg.center.x * unit,
                                                   reg.width * unit)

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -80,17 +80,14 @@ class SpecViz(ConfigHelper, LineListMixin):
         spec_regs = {}
 
         for name, reg in regions.items():
-            try:
-                # Use the region's unit. If N/A, use the reference_data's
-                unit = reg.meta.get("spectral_axis_unit",
-                                    self.get_spectra(
-                                        self.app.get_viewer("spectrum-viewer"
-                                                            ).state.reference_data.label,
-                                        apply_slider_redshift=False
-                                        ).spectral_axis.unit
+            # Use the region's unit. If N/A, use the reference_data's
+            unit = reg.meta.get("spectral_axis_unit",
+                                self.get_spectra(
+                                    self.app.get_viewer("spectrum-viewer"
+                                                        ).state.reference_data.label,
+                                    apply_slider_redshift=False
+                                    ).spectral_axis.unit
                                     )
-            except (KeyError, LookupError, AttributeError):
-                unit = u.dimensionless_unscaled
 
             spec_reg = SpectralRegion.from_center(reg.center.x * unit,
                                                   reg.width * unit)

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -90,7 +90,7 @@ class SpecViz(ConfigHelper, LineListMixin):
                                         ).spectral_axis.unit
                                     )
             except (KeyError, LookupError, AttributeError):
-                unit = u.Unit('count')
+                unit = u.Unit('pixel')
 
             spec_reg = SpectralRegion.from_center(reg.center.x * unit,
                                                   reg.width * unit)

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -1,9 +1,11 @@
 import pytest
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
-
+from glue.core.roi import XRangeROI
+import numpy as np
 from specutils import Spectrum1D
 
+from ..plugins.unit_conversion import unit_conversion as uc
 
 class TestSpecvizHelper:
     @pytest.fixture(autouse=True)
@@ -76,3 +78,39 @@ def test_get_spectra_no_spectra_label_redshift_error(specviz_app, spectrum1d):
     label = "label"
     with pytest.raises(AttributeError):
         specviz_app.get_spectra(data_label=label, apply_slider_redshift=True)
+
+def test_get_spectral_regions_unit(specviz_app, spectrum1d):
+    # Ensure units we put in are the same as the units we get out
+    specviz_app.load_spectrum(spectrum1d)
+    specviz_app.app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(1, 3.5))
+
+    subsets = specviz_app.get_spectral_regions()
+    reg = subsets.get('Subset 1')
+    
+    assert spectrum1d.wavelength.unit == reg.lower.unit
+    assert spectrum1d.wavelength.unit == reg.upper.unit
+
+def test_get_spectral_regions_unit_conversion(specviz_app, spectrum1d):
+    # If the reference (visible) data changes via unit conversion, 
+    # check that the region's units convert too
+    specviz_app.load_spectrum(spectrum1d)
+    specviz_app.app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(1, 3.5))
+
+    # Convert the wavelength axis to microns
+    new_spectral_axis = "micron"
+    conv_func = uc.UnitConversion.process_unit_conversion
+    converted_spectrum = conv_func(specviz_app.app, spectrum=spectrum1d,
+                                   new_spectral_axis=new_spectral_axis)
+
+    # Add this new data and clear the other, making the converted spectrum our reference
+    specviz_app.app.add_data(converted_spectrum, "Converted Spectrum")
+    specviz_app.app.add_data_to_viewer("spectrum-viewer",
+                                          "Converted Spectrum",
+                                          clear_other_data=True)
+
+    # Retrieve the Subset
+    subsets = specviz_app.get_spectral_regions()
+    reg = subsets.get('Subset 1')
+
+    assert reg.lower.unit == u.Unit(new_spectral_axis)
+    assert reg.upper.unit == u.Unit(new_spectral_axis)

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -2,10 +2,10 @@ import pytest
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
 from glue.core.roi import XRangeROI
-import numpy as np
 from specutils import Spectrum1D
 
 from ..plugins.unit_conversion import unit_conversion as uc
+
 
 class TestSpecvizHelper:
     @pytest.fixture(autouse=True)
@@ -79,6 +79,7 @@ def test_get_spectra_no_spectra_label_redshift_error(specviz_app, spectrum1d):
     with pytest.raises(AttributeError):
         specviz_app.get_spectra(data_label=label, apply_slider_redshift=True)
 
+
 def test_get_spectral_regions_unit(specviz_app, spectrum1d):
     # Ensure units we put in are the same as the units we get out
     specviz_app.load_spectrum(spectrum1d)
@@ -86,12 +87,13 @@ def test_get_spectral_regions_unit(specviz_app, spectrum1d):
 
     subsets = specviz_app.get_spectral_regions()
     reg = subsets.get('Subset 1')
-    
+
     assert spectrum1d.wavelength.unit == reg.lower.unit
     assert spectrum1d.wavelength.unit == reg.upper.unit
 
+
 def test_get_spectral_regions_unit_conversion(specviz_app, spectrum1d):
-    # If the reference (visible) data changes via unit conversion, 
+    # If the reference (visible) data changes via unit conversion,
     # check that the region's units convert too
     specviz_app.load_spectrum(spectrum1d)
     specviz_app.app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(1, 3.5))
@@ -105,8 +107,8 @@ def test_get_spectral_regions_unit_conversion(specviz_app, spectrum1d):
     # Add this new data and clear the other, making the converted spectrum our reference
     specviz_app.app.add_data(converted_spectrum, "Converted Spectrum")
     specviz_app.app.add_data_to_viewer("spectrum-viewer",
-                                          "Converted Spectrum",
-                                          clear_other_data=True)
+                                       "Converted Spectrum",
+                                       clear_other_data=True)
 
     # Retrieve the Subset
     subsets = specviz_app.get_spectral_regions()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This PR addresses #738 by:
1. Falling back on the reference data's spectral_axis units or
~2. If it can't, defaults to `Counts` as the astropy unit of choice, as opposed to Angstroms.~ Found a bug for this one. Will need to address https://github.com/astropy/specutils/issues/846 and possibly https://github.com/astropy/specutils/issues/847 first. 

I would really appreciate feedback on (2), specifically. I recall us having a conversation about whether Counts are a good fallback unit or whether they actually have a very specific meaning (e.g. like in photo-multiplier tubes :/)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #738 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
