### PR TITLE
BUG: Preserve Imviz zoom level when adding markers (brute force)

### DIFF
--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -377,6 +377,12 @@ class Imviz(ConfigHelper):
         viewer = self.app.get_viewer("viewer-1")
         jglue = self.app.session.application
 
+        # Store the current zoom level so we can set back to this at the end.
+        cur_x_min = viewer.state.x_min
+        cur_y_min = viewer.state.y_min
+        cur_x_max = viewer.state.x_max
+        cur_y_max = viewer.state.y_max
+
         # TODO: How to link to invidual images separately for X/Y? add_link in loop does not work.
         # Link markers to reference image data.
         image = viewer.state.reference_data
@@ -409,6 +415,13 @@ class Imviz(ConfigHelper):
                 setattr(self.app.data_collection[self.app.data_collection.labels.index(marker_name)].style, key, val)  # noqa
 
             self._marktags.add(marker_name)
+
+        # Restore original zoom
+        with delay_callback(viewer.state, 'x_min', 'x_max', 'y_min', 'y_max'):
+            viewer.state.x_min = cur_x_min
+            viewer.state.y_min = cur_y_min
+            viewer.state.x_max = cur_x_max
+            viewer.state.y_max = cur_y_max
 
     def remove_markers(self, marker_name=None):
         """Remove some but not all of the markers by name used when

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -153,6 +153,11 @@ class TestMarkers(BaseImviz_WCS_NoWCS):
         sky = self.wcs.pixel_to_world(x_pix, y_pix)
         tbl = Table({'x': x_pix, 'y': y_pix, 'coord': sky})
 
+        # Zoom in a little to make sure zoom is preserved
+        self.imviz.zoom(2)
+        actual_viewer_limits = (self.viewer.state.x_min, self.viewer.state.x_max,
+                                self.viewer.state.y_min, self.viewer.state.y_max)
+
         self.imviz.add_markers(tbl)
         data = self.imviz.app.data_collection[2]
         assert data.label == 'default-marker-name'
@@ -162,6 +167,11 @@ class TestMarkers(BaseImviz_WCS_NoWCS):
         assert_allclose(data.style.alpha, 1)
         assert_allclose(data.get_component('x').data, x_pix)
         assert_allclose(data.get_component('y').data, y_pix)
+
+        # Make sure zoom is preserved
+        assert_allclose((self.viewer.state.x_min, self.viewer.state.x_max,
+                         self.viewer.state.y_min, self.viewer.state.y_max),
+                        actual_viewer_limits)
 
         # Table with only sky coordinates but no use_skycoord=True
         with pytest.raises(KeyError):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to preserve the zoom level in Imviz when `imviz.add_markers()` is used. Without this patch, when markers are added, the display zooms back to what you see when you first load the image. Also, *without* this patch, the test added here will fail as follows:

```
        # Make sure zoom is preserved
>       assert_allclose((self.viewer.state.x_min, self.viewer.state.x_max,
                         self.viewer.state.y_min, self.viewer.state.y_max),
                        actual_viewer_limits)
E       AssertionError:
E       Not equal to tolerance rtol=1e-07, atol=0
E
E       Mismatched elements: 4 / 4 (100%)
E       Max absolute difference: 3.
E       Max relative difference: 1.33333333
E        x: array([-0.5,  9.5, -0.5,  9.5])
E        y: array([1.5, 6.5, 2. , 7. ])
```

With this patch, it goes back to the zoom level at the time of adding markers, *but* this solution is not elegant enough because you can still see the zoom level go back and forth, especially obvious with #723 not fixed yet and still noticeable without linking.

Ideally, we have a proper upstream fix, but this might be a good stop-gap solution until upstream fix happens, if at all. If we accept this PR, we should open a follow-up issue so we don't forget to investigate upstream fix in the future.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #760 

Might be somewhat related to #335

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
