### PR TITLE
Add way to turn off slit overlay if data is not NIRSpec

### DIFF
--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -200,7 +200,7 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
 
             wcs = WCS(header)
 
-            meta = {'S_REGION': header['S_REGION']}
+            meta = {'S_REGION': header['S_REGION'], 'INSTRUME': 'nirspec'}
 
         return SpectralCube(new_data, wcs=wcs, meta=meta)
 
@@ -464,11 +464,7 @@ def mos_niriss_parser(app, data_dir, obs_label=""):
 
                         spec2d = SpectralCube(new_data, wcs=wcs, meta=meta)
 
-                        # TODO: Make slit overlay optional to avoid having to hardcode
-                        # TODO: S_REGION header
-                        spec2d.meta['S_REGION'] = 'POLYGON ICRS  5.029236065 4.992154276 ' \
-                                                  '5.029513148 4.992154276 5.029513148 ' \
-                                                  '4.992468585 5.029236065 4.992468585'
+                        spec2d.meta['INSTRUME'] = 'NIRISS'
 
                         label = "{} Source {} spec2d {}".format(filter_name,
                                                                 temp[sci].header["SOURCEID"],

--- a/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
@@ -82,9 +82,8 @@ class SlitOverlay(TemplateMixin):
         if len(image_data) > 0:
             # Only use S_REGION for Nirspec data, turn the plugin off
             # if other data is loaded
-            if len(spec2d_data) > 0 and 'S_REGION' in spec2d_data[0].meta \
-                    and 'INSTRUME' in spec2d_data[0].meta \
-                    and spec2d_data[0].meta['INSTRUME'].lower() == "nirspec":
+            if (len(spec2d_data) > 0 and 'S_REGION' in spec2d_data[0].meta
+                    and spec2d_data[0].meta.get('INSTRUME', '').lower() == "nirspec"):
                 header = spec2d_data[0].meta
                 sky_region = self.jwst_header_to_skyregion(header)
 

--- a/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
@@ -80,7 +80,11 @@ class SlitOverlay(TemplateMixin):
 
         # 'S_REGION' contains slit information. Bypass in case no images exist.
         if len(image_data) > 0:
-            if len(spec2d_data) > 0 and 'S_REGION' in spec2d_data[0].meta:
+            # Only use S_REGION for Nirspec data, turn the plugin off
+            # if other data is loaded
+            if len(spec2d_data) > 0 and 'S_REGION' in spec2d_data[0].meta \
+                    and 'INSTRUME' in spec2d_data[0].meta \
+                    and spec2d_data[0].meta['INSTRUME'].lower() == "nirspec":
                 header = spec2d_data[0].meta
                 sky_region = self.jwst_header_to_skyregion(header)
 
@@ -111,9 +115,11 @@ class SlitOverlay(TemplateMixin):
                 fig_image.marks = fig_image.marks + [patch2]
 
             else:
+                self.visible = False
                 snackbar_message = SnackbarMessage(
-                    "\'S_REGION\' not found in Spectrum 2D meta attribute",
-                    color="error",
+                    "\'S_REGION\' not found in Spectrum 2D meta attribute, "
+                    "turning slit overlay off",
+                    color="warning",
                     sender=self)
 
         if snackbar_message:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address the slit overlay plugin issuing a traceback anytime NIRISS data is loaded and different rows are selected.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #433 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
