### PR TITLE
BUG: Imviz get_interactive_regions now supports GWCS

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -497,11 +497,6 @@ class Application(VuetifyTemplate, HubListener):
 
         for key, value in data.items():
             if isinstance(value, Subset):
-                # TODO: Remove this when Imviz support round-tripping, see
-                # https://github.com/spacetelescope/jdaviz/pull/721
-                if viewer_reference == 'viewer-1' and not key.startswith('Subset'):
-                    continue
-
                 # Skip spatial or spectral subsets if only the other is wanted
                 if subset_type == "spectral" and isinstance(value.subset_state, RoiSubsetState):
                     continue

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -530,6 +530,18 @@ class Imviz(ConfigHelper):
 
         return regions
 
+    # See https://github.com/glue-viz/glue-jupyter/issues/253
+    def _apply_interactive_region(self, toolname, from_pix, to_pix):
+        """Mimic interactive region drawing.
+        This is for internal testing only.
+        """
+        viewer = self.app.get_viewer("viewer-1")
+        tool = viewer.toolbar.tools[toolname]
+        tool.activate()
+        tool.interact.brushing = True
+        tool.interact.selected = [from_pix, to_pix]
+        tool.interact.brushing = False
+
 
 def split_filename_with_fits_ext(filename):
     """Split a ``filename[ext]`` input into filename and FITS extension.

--- a/jdaviz/configs/imviz/tests/test_regions.py
+++ b/jdaviz/configs/imviz/tests/test_regions.py
@@ -30,15 +30,6 @@ class BaseRegionHandler:
                 assert layer.visible
         assert n == count
 
-    # See https://github.com/glue-viz/glue-jupyter/issues/253
-    def apply_interactive_region(self, toolname, from_pix, to_pix):
-        """Mimic interactive region drawing."""
-        tool = self.viewer.toolbar.tools[toolname]
-        tool.activate()
-        tool.interact.brushing = True
-        tool.interact.selected = [from_pix, to_pix]
-        tool.interact.brushing = False
-
 
 class TestLoadStaticRegions(BaseImviz_WCS_NoWCS, BaseRegionHandler):
 
@@ -77,15 +68,15 @@ class TestLoadStaticRegions(BaseImviz_WCS_NoWCS, BaseRegionHandler):
                              EllipsePixelRegion)
 
         # Mimic interactive region (before)
-        self.apply_interactive_region('bqplot:circle', (1.5, 2.5), (3.6, 4.6))
+        self.imviz._apply_interactive_region('bqplot:circle', (1.5, 2.5), (3.6, 4.6))
 
         sky = SkyCoord(ra=337.5202808, dec=-20.833333059999998, unit='deg')
         my_reg_sky = CircleSkyRegion(sky, Angle(0.5, u.arcsec))
         self.imviz.load_static_regions({'my_reg_sky_1': my_reg_sky})
 
         # Mimic interactive regions (after)
-        self.apply_interactive_region('bqplot:ellipse', (-2, 0), (5, 4.5))
-        self.apply_interactive_region('bqplot:rectangle', (0, 0), (10, 10))
+        self.imviz._apply_interactive_region('bqplot:ellipse', (-2, 0), (5, 4.5))
+        self.imviz._apply_interactive_region('bqplot:rectangle', (0, 0), (10, 10))
 
         # Check interactive regions. We do not check if the translation is correct,
         # that check hopefully is already done in glue-astronomy.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to allow `imviz.get_interactive_regions()` to support GWCS. The solution here is to bypass the complicated and unnecessary processing in the high-level app level, hence removes the need for `CDDData`, which currently does not work with GWCS. The underlying Glue machinery follows Astropy APE 14, so it should be compatible with GWCS already.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #781

Follow-up of #721

p.s. I know I am supposed to wait till next sprint but it bothers me too much. 😬 

p.p.s. Apparently Windows endlines snuck into `test_regions.py`. If it bothers you, I can run `dos2unix` on it, but the result is the whole file gets diff-ed, which is hard to review. I left it alone for now.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
