### PR TITLE
Cubeviz: Allow model fitting to operate on spectral Subset

### DIFF
--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -49,6 +49,7 @@ class Collapse(TemplateMixin):
                            handler=self._on_data_updated)
 
         self._selected_data = None
+        self._spectral_subsets = {}
         self._label_counter = 0
 
     def _on_data_updated(self, msg):
@@ -68,6 +69,7 @@ class Collapse(TemplateMixin):
 
         # Also set the spectral min and max to default to the full range
         cube = self._selected_data.get_object(cls=SpectralCube)
+        self.selected_subset = "None"
         self.spectral_min = cube.spectral_axis[0].value
         self.spectral_max = cube.spectral_axis[-1].value
         self.spectral_unit = str(cube.spectral_axis.unit)
@@ -77,13 +79,12 @@ class Collapse(TemplateMixin):
     @observe("selected_subset")
     def _on_subset_selected(self, event):
         # If "None" selected, reset based on bounds of selected data
-        self._selected_subset = self.selected_subset
-        if self._selected_subset == "None":
+        if self.selected_subset == "None":
             cube = self._selected_data.get_object(cls=SpectralCube)
             self.spectral_min = cube.spectral_axis[0].value
             self.spectral_max = cube.spectral_axis[-1].value
         else:
-            spec_sub = self._spectral_subsets[self._selected_subset]
+            spec_sub = self._spectral_subsets[self.selected_subset]
             unit = u.Unit(self.spectral_unit)
             spec_reg = SpectralRegion.from_center(spec_sub.center.x * unit,
                                                   spec_sub.width * unit)
@@ -94,15 +95,13 @@ class Collapse(TemplateMixin):
         """Populate the spectral subset selection dropdown"""
         temp_subsets = self.app.get_subsets_from_viewer("spectrum-viewer",
                                                         subset_type="spectral")
-        temp_list = ["None"]
         temp_dict = {}
         # Attempt to filter out spatial subsets
         for key, region in temp_subsets.items():
             if type(region) == RectanglePixelRegion:
                 temp_dict[key] = region
-                temp_list.append(key)
         self._spectral_subsets = temp_dict
-        self.spectral_subset_items = temp_list
+        self.spectral_subset_items = ["None"] + sorted(temp_dict.keys())
 
     def vue_collapse(self, *args, **kwargs):
         try:

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -12,6 +12,7 @@ from specutils import Spectrum1D, SpectralRegion
 from specutils.utils import QuantityModel
 from traitlets import Any, Bool, Int, List, Unicode, observe
 from glue.core.data import Data
+from glue.core.subset import Subset, RangeSubsetState
 
 from jdaviz.core.events import AddDataMessage, RemoveDataMessage, SnackbarMessage
 from jdaviz.core.registries import tray_registry
@@ -122,7 +123,8 @@ class ModelFitting(TemplateMixin):
 
         self.dc_items = [layer_state.layer.label
                          for layer_state in viewer.state.layers
-                         if isinstance(layer_state.layer, Data)]
+                         if (not isinstance(layer_state.layer, Subset)
+                             or not isinstance(layer_state.layer.subset_state, RangeSubsetState))]
 
     def _param_units(self, param, order=0):
         """Helper function to handle units that depend on x and y"""

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -375,7 +375,10 @@ class ModelFitting(TemplateMixin):
 
         if self._warn_if_no_equation():
             return
-        data = self.app.data_collection[self._selected_data_label]
+        if self._selected_data_label in self.app.data_collection.labels:
+            data = self.app.data_collection[self._selected_data_label]
+        else:  # User selected some subset from spectrum viewer, just use original cube
+            data = self.app.data_collection[0]
 
         # First, ensure that the selected data is cube-like. It is possible
         # that the user has selected a pre-existing 1d data object.

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -8,10 +8,9 @@ from glue.core.message import (SubsetCreateMessage,
                                SubsetDeleteMessage,
                                SubsetUpdateMessage)
 from regions import RectanglePixelRegion
-from spectral_cube import SpectralCube
 from specutils import Spectrum1D, SpectralRegion
 from specutils.utils import QuantityModel
-from traitlets import Any, Bool, Int, List, Unicode, observe
+from traitlets import Bool, Float, Int, List, Unicode, observe
 from glue.core.data import Data
 
 from jdaviz.core.events import AddDataMessage, RemoveDataMessage, SnackbarMessage
@@ -39,8 +38,8 @@ class ModelFitting(TemplateMixin):
     template = load_template("model_fitting.vue", __file__).tag(sync=True)
     dc_items = List([]).tag(sync=True)
 
-    spectral_min = Any().tag(sync=True)
-    spectral_max = Any().tag(sync=True)
+    spectral_min = Float().tag(sync=True)
+    spectral_max = Float().tag(sync=True)
     spectral_unit = Unicode().tag(sync=True)
     spectral_subset_items = List(["None"]).tag(sync=True)
     selected_subset = Unicode("None").tag(sync=True)
@@ -274,10 +273,9 @@ class ModelFitting(TemplateMixin):
     def _on_subset_selected(self, event):
         # If "None" selected, reset based on bounds of selected data
         if self.selected_subset == "None":
-            cube = self._spectrum1d.get_object(cls=SpectralCube)
             self._window = None
-            self.spectral_min = cube.spectral_axis[0].value
-            self.spectral_max = cube.spectral_axis[-1].value
+            self.spectral_min = self._spectrum1d.spectral_axis[0].value
+            self.spectral_max = self._spectrum1d.spectral_axis[-1].value
         else:
             spec_sub = self._spectral_subsets[self.selected_subset]
             unit = u.Unit(self.spectral_unit)

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -7,9 +7,11 @@ from astropy.wcs import WCSSUB_SPECTRAL
 from glue.core.message import (SubsetCreateMessage,
                                SubsetDeleteMessage,
                                SubsetUpdateMessage)
-from specutils import Spectrum1D
+from regions import RectanglePixelRegion
+from spectral_cube import SpectralCube
+from specutils import Spectrum1D, SpectralRegion
 from specutils.utils import QuantityModel
-from traitlets import Bool, Int, List, Unicode
+from traitlets import Any, Bool, Int, List, Unicode, observe
 from glue.core.data import Data
 
 from jdaviz.core.events import AddDataMessage, RemoveDataMessage, SnackbarMessage
@@ -37,6 +39,12 @@ class ModelFitting(TemplateMixin):
     template = load_template("model_fitting.vue", __file__).tag(sync=True)
     dc_items = List([]).tag(sync=True)
 
+    spectral_min = Any().tag(sync=True)
+    spectral_max = Any().tag(sync=True)
+    spectral_unit = Unicode().tag(sync=True)
+    spectral_subset_items = List(["None"]).tag(sync=True)
+    selected_subset = Unicode("None").tag(sync=True)
+
     model_label = Unicode().tag(sync=True)
     cube_fit = Bool(False).tag(sync=True)
     temp_name = Unicode().tag(sync=True)
@@ -63,6 +71,8 @@ class ModelFitting(TemplateMixin):
         self._display_order = False
         self.model_label = "Model"
         self._selected_data_label = None
+        self._spectral_subsets = {}
+        self._window = None
         if self.app.state.settings.get("configuration") == "cubeviz":
             self.cube_fit = True
 
@@ -112,7 +122,8 @@ class ModelFitting(TemplateMixin):
         viewer = self.app.get_viewer('spectrum-viewer')
 
         self.dc_items = [layer_state.layer.label
-                         for layer_state in viewer.state.layers]
+                         for layer_state in viewer.state.layers
+                         if isinstance(layer_state.layer, Data)]
 
     def _param_units(self, param, order=0):
         """Helper function to handle units that depend on x and y"""
@@ -240,6 +251,42 @@ class ModelFitting(TemplateMixin):
 
         self._spectrum1d = selected_spec
 
+        # Also set the spectral min and max to default to the full range
+        cube = self._spectrum1d.get_object(cls=SpectralCube)
+        self.selected_subset = "None"
+        self._window = None
+        self.spectral_min = cube.spectral_axis[0].value
+        self.spectral_max = cube.spectral_axis[-1].value
+        self.spectral_unit = str(cube.spectral_axis.unit)
+
+    def vue_list_subsets(self, event):
+        """Populate the spectral subset selection dropdown"""
+        temp_subsets = self.app.get_subsets_from_viewer("spectrum-viewer",
+                                                        subset_type="spectral")
+        temp_dict = {}
+        # Attempt to filter out spatial subsets
+        for key, region in temp_subsets.items():
+            if type(region) == RectanglePixelRegion:
+                temp_dict[key] = region
+        self._spectral_subsets = temp_dict
+        self.spectral_subset_items = ["None"] + sorted(temp_dict.keys())
+
+    @observe("selected_subset")
+    def _on_subset_selected(self, event):
+        # If "None" selected, reset based on bounds of selected data
+        if self.selected_subset == "None":
+            cube = self._spectrum1d.get_object(cls=SpectralCube)
+            self._window = None
+            self.spectral_min = cube.spectral_axis[0].value
+            self.spectral_max = cube.spectral_axis[-1].value
+        else:
+            spec_sub = self._spectral_subsets[self.selected_subset]
+            unit = u.Unit(self.spectral_unit)
+            self._window = SpectralRegion.from_center(spec_sub.center.x * unit,
+                                                      spec_sub.width * unit)
+            self.spectral_min = self._window.lower.value
+            self.spectral_max = self._window.upper.value
+
     def vue_model_selected(self, event):
         # Add the model selected to the list of models
         self.temp_model = event
@@ -349,7 +396,8 @@ class ModelFitting(TemplateMixin):
                 self._spectrum1d,
                 models_to_fit,
                 self.model_equation,
-                run_fitter=True)
+                run_fitter=True,
+                window=self._window)
         except AttributeError:
             msg = SnackbarMessage("Unable to fit: model equation may be invalid",
                                   color="error", sender=self)
@@ -375,10 +423,7 @@ class ModelFitting(TemplateMixin):
 
         if self._warn_if_no_equation():
             return
-        if self._selected_data_label in self.app.data_collection.labels:
-            data = self.app.data_collection[self._selected_data_label]
-        else:  # User selected some subset from spectrum viewer, just use original cube
-            data = self.app.data_collection[0]
+        data = self.app.data_collection[self._selected_data_label]
 
         # First, ensure that the selected data is cube-like. It is possible
         # that the user has selected a pre-existing 1d data object.
@@ -438,7 +483,8 @@ class ModelFitting(TemplateMixin):
                 spec,
                 models_to_fit,
                 self.model_equation,
-                run_fitter=True)
+                run_fitter=True,
+                window=self._window)
         except ValueError:
             snackbar_message = SnackbarMessage(
                 "Cube fitting failed",
@@ -492,7 +538,8 @@ class ModelFitting(TemplateMixin):
         else:
             model, spectrum = fit_model_to_spectrum(self._spectrum1d,
                                                     self._initialized_models.values(),
-                                                    self.model_equation)
+                                                    self.model_equation,
+                                                    window=self._window)
 
         self.n_models += 1
         label = self.model_label

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -252,12 +252,11 @@ class ModelFitting(TemplateMixin):
         self._spectrum1d = selected_spec
 
         # Also set the spectral min and max to default to the full range
-        cube = self._spectrum1d.get_object(cls=SpectralCube)
         self.selected_subset = "None"
         self._window = None
-        self.spectral_min = cube.spectral_axis[0].value
-        self.spectral_max = cube.spectral_axis[-1].value
-        self.spectral_unit = str(cube.spectral_axis.unit)
+        self.spectral_min = selected_spec.spectral_axis[0].value
+        self.spectral_max = selected_spec.spectral_axis[-1].value
+        self.spectral_unit = str(selected_spec.spectral_axis.unit)
 
     def vue_list_subsets(self, event):
         """Populate the spectral subset selection dropdown"""

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -423,7 +423,10 @@ class ModelFitting(TemplateMixin):
 
         if self._warn_if_no_equation():
             return
-        data = self.app.data_collection[self._selected_data_label]
+        if self._selected_data_label in self.app.data_collection.labels:
+            data = self.app.data_collection[self._selected_data_label]
+        else:  # User selected some subset from spectrum viewer, just use original cube
+            data = self.app.data_collection[0]
 
         # First, ensure that the selected data is cube-like. It is possible
         # that the user has selected a pre-existing 1d data object.

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -279,10 +279,11 @@ class ModelFitting(TemplateMixin):
         else:
             spec_sub = self._spectral_subsets[self.selected_subset]
             unit = u.Unit(self.spectral_unit)
-            self._window = SpectralRegion.from_center(spec_sub.center.x * unit,
-                                                      spec_sub.width * unit)
-            self.spectral_min = self._window.lower.value
-            self.spectral_max = self._window.upper.value
+            spreg = SpectralRegion.from_center(spec_sub.center.x * unit,
+                                               spec_sub.width * unit)
+            self._window = (spreg.lower, spreg.upper)
+            self.spectral_min = spreg.lower.value
+            self.spectral_max = spreg.upper.value
 
     def vue_model_selected(self, event):
         # Add the model selected to the list of models

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -10,7 +10,7 @@ from glue.core.message import (SubsetCreateMessage,
 from regions import RectanglePixelRegion
 from specutils import Spectrum1D, SpectralRegion
 from specutils.utils import QuantityModel
-from traitlets import Bool, Float, Int, List, Unicode, observe
+from traitlets import Any, Bool, Int, List, Unicode, observe
 from glue.core.data import Data
 
 from jdaviz.core.events import AddDataMessage, RemoveDataMessage, SnackbarMessage
@@ -38,8 +38,8 @@ class ModelFitting(TemplateMixin):
     template = load_template("model_fitting.vue", __file__).tag(sync=True)
     dc_items = List([]).tag(sync=True)
 
-    spectral_min = Float().tag(sync=True)
-    spectral_max = Float().tag(sync=True)
+    spectral_min = Any().tag(sync=True)
+    spectral_max = Any().tag(sync=True)
     spectral_unit = Unicode().tag(sync=True)
     spectral_subset_items = List(["None"]).tag(sync=True)
     selected_subset = Unicode("None").tag(sync=True)

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -15,6 +15,48 @@
             </v-col>
           </v-row>
         </v-container>
+        <v-container>
+          <v-row>
+            <v-col>
+              <v-select
+                :items="spectral_subset_items"
+                v-model="selected_subset"
+                label="Spectral Region"
+                hint="Optional: limit to a spectral region defined in the spectrum viewer."
+                persistent-hint
+                @click="list_subsets"
+              ></v-select>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-text-field
+                label="Lower spectral bound"
+                v-model="spectral_min"
+                hint="Lower bound of spectral region"
+                persistent-hint
+              >
+              </v-text-field>
+            </v-col>
+            <v-col cols = 2>
+              <span>{{ spectral_unit }}</span>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-text-field
+                label="Upper spectral bound"
+                v-model="spectral_max"
+                hint="Lower bound of spectral region"
+                persistent-hint
+              >
+              </v-text-field>
+            </v-col>
+            <v-col cols = 2>
+              <span>{{ spectral_unit }}</span>
+            </v-col>
+          </v-row>
+        </v-container>
       </v-card-text>
       <v-divider></v-divider>
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to allow successful "apply to cube" operation in this workflow:

1. Load cube (left viewer)
2. Generate collapsed cube by sum (middle viewer).
3. Draw X-range region on the spectrum at bottom.
4. Use model fitting plugin, fit on SCI data, use linear model, label it "L1", add the model with default values, type "L1" in equation, label it "LinFit".
5. Select "Subset 1", click "Fit", and it should succeed as expected. See fit shown on spectrum.
6. Click "Apply to cube". Without this patch, it shows error (in notebook but not in lab). With this patch, a fitted cube is shown in right viewer without error (someone familiar with Cubeviz should check if the result is correct or not; I cannot tell).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes the second bug in https://jira.stsci.edu/browse/JDAT-1671

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
