### PR TITLE
Make sure we remove the right patch from the image viewer when removing the slit overlay

### DIFF
--- a/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
@@ -55,6 +55,8 @@ class SlitOverlay(TemplateMixin):
         table = self.app.get_viewer("table-viewer")
         table.figure_widget.observe(self.place_slit_overlay, names=['highlighted'])
 
+        self._slit_overlay_mark = None
+
     def vue_change_visible(self, *args, **kwargs):
         if self.visible:
             self.place_slit_overlay()
@@ -114,6 +116,8 @@ class SlitOverlay(TemplateMixin):
                 # Visualize slit on the figure
                 fig_image.marks = fig_image.marks + [patch2]
 
+                self._slit_overlay_mark = patch2
+
             else:
                 self.visible = False
                 snackbar_message = SnackbarMessage(
@@ -126,5 +130,7 @@ class SlitOverlay(TemplateMixin):
             self.hub.broadcast(snackbar_message)
 
     def remove_slit_overlay(self):
-        image_figure = self.app.get_viewer("image-viewer").figure
-        image_figure.marks = [image_figure.marks[0]]
+        if self._slit_overlay_mark is not None:
+            image_figure = self.app.get_viewer("image-viewer").figure
+            image_figure.marks.remove(self._slit_overlay_mark)
+            self._slit_overlay_mark = None

--- a/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
@@ -132,5 +132,10 @@ class SlitOverlay(TemplateMixin):
     def remove_slit_overlay(self):
         if self._slit_overlay_mark is not None:
             image_figure = self.app.get_viewer("image-viewer").figure
-            image_figure.marks.remove(self._slit_overlay_mark)
+            # We need to do the following instead of just removing directly on
+            # the marks otherwise traitlets doesn't register a change in the
+            # marks.
+            marks = image_figure.marks.copy()
+            marks.remove(self._slit_overlay_mark)
+            image_figure.marks = marks
             self._slit_overlay_mark = None


### PR DESCRIPTION

### Description

While testing out https://github.com/spacetelescope/jdaviz/pull/762 I ran across a bug which was that the code to remove the slit overlay was assuming things about the order and number of marks in the figure, which caused an error of the type ``x not in list``. This PR should fix it by making sure we remove the right mark.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
