### PR TITLE
Specify format in NIRISS parser

### DIFF
--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -535,7 +535,7 @@ def mos_niriss_parser(app, data_dir, obs_label=""):
                     else:
                         hdu.header["SRCTYPE"] = "EXTENDED"
 
-                specs = SpectrumList.read(temp)
+                specs = SpectrumList.read(temp, format="JWST x1d multi")
                 filter_name = [x
                                for x in fname.split("/")[-1].split("_")
                                if x[0] == "F" or x[0] == "f"][0]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
Fixes #816 by explicitly providing the data format to the SpectrumList loader. The most recent specutils release added handling for multiple similar JWST datasets to `SpectrumList.read` that it apparently can't automatically distinguish between (well, it at least apparently can't decide given our NIRISS data, anyway).

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
