### PR TITLE
Parse NIRISS data files by header instead of name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Imviz
 
 Mosviz
 ^^^^^^
+- NIRISS parser now sorts FITS files by header instead of file name. [#819]
 
 Specviz
 ^^^^^^^
@@ -64,8 +65,6 @@ Cubeviz
 
 Mosviz
 ^^^^^^
-- NIRISS parser now sorts FITS files by header instead of file name. [#819]
-
 - Added ``--instrument`` CLI option to support NIRISS data loading in Mosviz. [#1488]
 
 Bug Fixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,7 @@ Cubeviz
 
 Mosviz
 ^^^^^^
+- NIRISS parser now sorts FITS files by header instead of file name. [#819]
 
 - Added ``--instrument`` CLI option to support NIRISS data loading in Mosviz. [#1488]
 

--- a/docs/mosviz/import_data.rst
+++ b/docs/mosviz/import_data.rst
@@ -4,8 +4,8 @@
 Importing Data into Mosviz
 **************************
 
-Mosviz provides two different ways to load data: Auto-recognition directory loading
-or manual loading:
+Mosviz provides two different ways to load data: auto-recognition directory
+loading and manual loading.
 
 Automatic Directory Loading
 ---------------------------

--- a/docs/mosviz/import_data.rst
+++ b/docs/mosviz/import_data.rst
@@ -18,7 +18,7 @@ time, Mosviz supports automatic parsing for the following instruments:
 The NIRISS parser expects a directory with the following types of files:
 
 * ``*_i2d.fits`` : Level 3 2D images from the ``calwebb_image3`` imaging pipeline
-* ``*_cat.ecsv`` : Level 3 Source catalog from the ``calwebb_image3`` imaging pipeline **(For best performance, it's recommended that your directory only contain one.)**
+* ``*_cat.ecsv`` : Level 3 source catalog from the ``calwebb_image3`` imaging pipeline **(For best performance, it's recommended that your directory only contain one.)**
 * ``*_cal.fits`` : Level 2 2D spectra in vertical (R) and horizontal (C) orientations from the ``calwebb_spec2`` spectroscopic pipeline *(C spectra are shown first in 2D viewer by default.)*
 * ``*_x1d.fits`` : Level 2 1D spectra in vertical (R) and horizontal (C) orientations from the ``calwebb_spec2`` spectroscopic pipeline *(C spectra are shown first in 1D viewer by default.)*
 

--- a/docs/mosviz/import_data.rst
+++ b/docs/mosviz/import_data.rst
@@ -15,6 +15,13 @@ time, Mosviz supports automatic parsing for the following instruments:
 * JWST NIRSpec
 * JWST NIRISS
 
+The NIRISS parser expects a directory with the following types of files:
+
+* `*_i2d.fits` : Direct 2D images
+* `*_cat.ecsv` : Source catalog **(For best performance, it's recommended that your directory only contain one.)**
+* `*_cal.fits` : 2D spectra in vertical (R) and horizontal (C) orientations *(C spectra are shown first in 2D viewer by default.)*
+* `*_x1d.fits` : 1D spectra in vertical (R) and horizontal (C) orientations *(C spectra are shown first in 1D viewer by default.)*
+
 In a Jupyter context (notebook or Lab), you can specify the instrument with a directory
 as such::
 
@@ -42,8 +49,8 @@ Manual Loading
 
 If an automatic parser is not provided yet for your data, Mosviz provides manual loading by
 specifying which files are which, and the associations between them. This is done by
-generating three lists containing the filenames for the 1D spectra, 
-2D spectra, and images in your dataset. These three lists are taken as arguments 
+generating three lists containing the filenames for the 1D spectra,
+2D spectra, and images in your dataset. These three lists are taken as arguments
 by :meth:`~jdaviz.configs.mosviz.helper.Mosviz.load_data`. The association between files is
 assumed to be the order of each list (e.g., the first object consists of the first filename
 specified in each list, the second target is the second in each list, and so forth).

--- a/docs/mosviz/import_data.rst
+++ b/docs/mosviz/import_data.rst
@@ -17,10 +17,10 @@ time, Mosviz supports automatic parsing for the following instruments:
 
 The NIRISS parser expects a directory with the following types of files:
 
-* `*_i2d.fits` : Direct 2D images
-* `*_cat.ecsv` : Source catalog **(For best performance, it's recommended that your directory only contain one.)**
-* `*_cal.fits` : 2D spectra in vertical (R) and horizontal (C) orientations *(C spectra are shown first in 2D viewer by default.)*
-* `*_x1d.fits` : 1D spectra in vertical (R) and horizontal (C) orientations *(C spectra are shown first in 1D viewer by default.)*
+* ``*_i2d.fits`` : Level 3 2D images from the ``calwebb_image3`` imaging pipeline
+* ``*_cat.ecsv`` : Level 3 Source catalog from the ``calwebb_image3`` imaging pipeline **(For best performance, it's recommended that your directory only contain one.)**
+* ``*_cal.fits`` : Level 2 2D spectra in vertical (R) and horizontal (C) orientations from the ``calwebb_spec2`` spectroscopic pipeline *(C spectra are shown first in 2D viewer by default.)*
+* ``*_x1d.fits`` : Level 2 1D spectra in vertical (R) and horizontal (C) orientations from the ``calwebb_spec2`` spectroscopic pipeline *(C spectra are shown first in 1D viewer by default.)*
 
 In a Jupyter context (notebook or Lab), you can specify the instrument with a directory
 as such::

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -718,8 +718,10 @@ def mos_niriss_parser(app, data_dir):
                 orientation = f[-1]
 
                 for spec in specs:
-                    if ( spec.meta['header']['SPORDER'] == 1
-                         and spec.meta['header']['EXTNAME'] == 'EXTRACT1D'):
+                    if (
+                        spec.meta['header']['SPORDER'] == 1
+                        and spec.meta['header']['EXTNAME'] == 'EXTRACT1D'
+                    ):
 
                         label = (f"{filter_name} Source "
                                  f"{spec.meta['header']['SOURCEID']} spec1d "

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -518,16 +518,18 @@ def _get_source_identifiers_by_hdu(hdus, filepaths=None, header_keys=['SOURCEID'
 @data_parser_registry("mosviz-niriss-parser")
 def mos_niriss_parser(app, data_dir):
     """
-    Attempts to parse all data for a NIRISS dataset in the specified
+    Attempts to parse all data for a NIRISS dataset in a single
     directory, which should include:
-    - *_direct_*_cal.fits : Direct 2D image
-    - *_direct_*_cat.ecsv : Source catalog
-    - *_WFSSR_*_cal.fits : 2D spectra in first orientation
-    - *_WFSSC_*_cal.fits : 2D spectra in second orientation
-    - *_WFSSR_*_x1d.fits : 1D spectra in first orientation
-    - *_WFSSC_*_x1d.fits : 1D spectra in second orientation
-    The spectra from the "C" files (horizontal orientation) are shown
-    in the viewers by default.
+
+    - *_i2d.fits : Direct 2D images
+    - *_cat.ecsv : Source catalog
+    - *_cal.fits : 2D spectra in vertical (R) and horizontal (C)
+        orientations. C spectra are shown first in viewers by default
+    - *_x1d.fits : 1D spectra in vertical (R) and horizontal (C)
+        orientations. C spectra are shown first in viewers by default
+
+    NOTE: For best performance, it's recommended that your directory
+    only contain one source catalog and its associated images/spectra.
 
     Parameters
     ----------
@@ -713,6 +715,7 @@ def mos_niriss_parser(app, data_dir):
 
                         filters.append(filter)
 
+    # Parse 1D spectra
     file_labels_1d = [k for k in file_lists.keys() if k.startswith("1D")]
     spec_labels_1d = []
     for f in file_labels_1d:

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -624,6 +624,7 @@ def mos_niriss_parser(app, data_dir):
     # Set up a dictionary of datasets to add to glue
     add_to_glue = {}
 
+    # Parse images
     print("Loading: Images")
     for image_file in file_lists["Direct Image"]:
         im_split = image_file.split("/")[-1].split("_")
@@ -704,8 +705,9 @@ def mos_niriss_parser(app, data_dir):
                                  f"{orientation}")  # noqa
 
                         ra, dec = pupil_id_dict[filter_name][temp[sci].header["SOURCEID"]]
+                        # still needed? also defined above loop
                         # source_ids.append(f"Source Catalog: {filter_name} "
-                        #                   f"Source ID: {temp[sci].header['SOURCEID']}") # still needed?
+                        #                   f"Source ID: {temp[sci].header['SOURCEID']}")
                         ras.append(ra)
                         decs.append(dec)
                         image_add.append(image_dict[filter_name])

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -557,11 +557,11 @@ def mos_niriss_parser(app, data_dir, obs_label=""):
             datamodl = header.get('DATAMODL')
 
             # infer the dispersion direction of 1D and 2D spectra by the last
-            # letter of their filter values (e.g., "GR150C" or "GR150R")
+            # letter of their filter values (e.g., "C" from GR150C")
             try:
                 dispersion = header.get('FILTER')[-1]
             except TypeError:
-                dispersion = None # could be cleaner...
+                dispersion = None
 
             # distinguish image files from counts files -- only the former go
             # through the "Assign World Coordinate System" calibration step

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -2,8 +2,6 @@ from collections.abc import Iterable
 import csv
 import glob
 import os
-import re
-from collections import defaultdict
 from pathlib import Path
 import warnings
 
@@ -678,7 +676,7 @@ def mos_niriss_parser(app, data_dir):
                     if "EXTNAME" in temp[i].header:
                         if (temp[i].header["EXTNAME"] == "SCI"
                             and temp[i].header["SOURCEID"] in cat_id_dict.keys()
-                        ):
+                            ):
                             sci_hdus.append(i)
                             wav_hdus[i] = ('WAVELENGTH',
                                            temp[i].header['EXTVER'])
@@ -726,7 +724,7 @@ def mos_niriss_parser(app, data_dir):
                 for hdu in temp:
                     if ("SRCTYPE" in hdu.header
                         and (hdu.header["SRCTYPE"] in ("POINT", "EXTENDED"))
-                    ):
+                        ):
                         pass
                     else:
                         hdu.header["SRCTYPE"] = "EXTENDED"

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -672,8 +672,8 @@ def mos_niriss_parser(app, data_dir):
                         filter = temp[0].header["FILTER"]
                     if "EXTNAME" in temp[i].header:
                         if (temp[i].header["EXTNAME"] == "SCI"
-                            and temp[i].header["SOURCEID"] in cat_id_dict.keys()
-                            ):
+                                and (temp[i].header["SOURCEID"]
+                                     in cat_id_dict.keys())):
                             sci_hdus.append(i)
                             wav_hdus[i] = ('WAVELENGTH',
                                            temp[i].header['EXTVER'])
@@ -720,8 +720,7 @@ def mos_niriss_parser(app, data_dir):
                 # TODO: Remove this once valid SRCTYPE values are present in all headers
                 for hdu in temp:
                     if ("SRCTYPE" in hdu.header
-                        and (hdu.header["SRCTYPE"] in ("POINT", "EXTENDED"))
-                        ):
+                            and (hdu.header["SRCTYPE"] in ("POINT", "EXTENDED"))):
                         pass
                     else:
                         hdu.header["SRCTYPE"] = "EXTENDED"

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -594,13 +594,7 @@ def mos_niriss_parser(app, data_dir, obs_label=""):
     _warn_if_not_found(app, file_lists)
 
     # Parse relevant information from source catalog
-    # TEMP NOTE: the ecsv table in the example directory has one column with
-    # sky centroid info given as an RA/Dec tuple instead of two columns with
-    # separate floats. i tried to support both schemas.
-    cat_fields = ['id', 'sky_centroid']
-    if 'sky_centroid' not in file_lists['Source Catalog'][0]:
-        cat_fields.pop()
-        cat_fields.extend(['sky_centroid.ra', 'sky_centroid.dec']) # old style
+    cat_fields = ['id', 'sky_centroid.ra', 'sky_centroid.dec']
 
     source_ids = []
     ras = []
@@ -619,14 +613,8 @@ def mos_niriss_parser(app, data_dir, obs_label=""):
 
         pupil_id_dict[pupil] = {}
 
-        if len(cat_fields) == 2: # new style
-            for row in parsed_cat_fields:
-                pupil_id_dict[pupil][int(row[0])] = (row[1][0], row[1][1])
-        elif len(cat_fields) == 3: # old style
-            for row in parsed_cat_fields:
-                pupil_id_dict[pupil][int(row[0])] = (row[1], row[2])
-        else:
-            raise Exception("Unexpected cat_fields length")
+        for row in parsed_cat_fields:
+            pupil_id_dict[pupil][int(row[0])] = (row[1], row[2])
 
     # Read in direct image filters
     image_dict = {}

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -623,7 +623,6 @@ def mos_niriss_parser(app, data_dir):
 
     # Parse images
     image_dict = {}
-    filter_wcs = {} # NEEDED? HAS VALUE ASSIGNED LATER BUT NEVER USED OTHERWISE
 
     print("Loading: Images")
     for image_file in file_lists["Direct Image"]:
@@ -640,8 +639,6 @@ def mos_niriss_parser(app, data_dir):
             data_obj = [d[0] for d in data_iter]  # We do not use the generated labels
             image_data = data_obj[0]  # Grab the first one.
             # TODO: Error if multiple found?
-
-            filter_wcs[pupil] = temp[1].header # NEEDED?
 
         image_data.label = image_label
         add_to_glue[image_label] = image_data

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -622,9 +622,8 @@ def mos_niriss_parser(app, data_dir):
     # Set up a dictionary of datasets to add to glue
     add_to_glue = {}
 
+    print("Loading: Images")
     for image_file in file_lists["Direct Image"]:
-        print("Loading: Images")
-
         im_split = image_file.split("/")[-1].split("_")
         pupil = fits.getheader(image_file, ext=0).get('PUPIL')
 
@@ -744,7 +743,7 @@ def mos_niriss_parser(app, data_dir):
 
                         label = (f"{filter_name} Source "
                                  f"{spec.meta['header']['SOURCEID']} spec1d "
-                                 f"orientation")
+                                 f"{orientation}")
 
                         spec_labels_1d.append(label)
                         add_to_glue[label] = spec

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -76,7 +76,7 @@ def _warn_if_not_found(app, file_lists):
     if len(found) == 0:
         raise ValueError("No valid files found in specified directory")
     if len(not_found) > 0:
-        warn_msg = f"Some files not found: {", ".join(not_found)}"
+        warn_msg = f"Some files not found: {', '.join(not_found)}"
         print(warn_msg)
         warn_msg = SnackbarMessage(warn_msg, color="warning", sender=app)
         app.hub.broadcast(warn_msg)

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -75,7 +75,6 @@ def _warn_if_not_found(app, file_lists):
         raise ValueError("No valid files found in specified directory")
     if len(not_found) > 0:
         warn_msg = f"Some files not found: {', '.join(not_found)}"
-        print(warn_msg)
         warn_msg = SnackbarMessage(warn_msg, color="warning", sender=app)
         app.hub.broadcast(warn_msg)
 

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -736,14 +736,15 @@ def mos_niriss_parser(app, data_dir):
                 # Orientation denoted by "C", "R", or "C+R" for combined spectra
                 orientation = flabel.split()[-1]
 
-                # update 1D labels for table viewer
+                # update 1D labels and standardize metadata for table viewer
                 for sp in specs_cut:
                     if (
                         sp.meta['header']['SPORDER'] == 1
                         and sp.meta['header']['EXTNAME'] == 'EXTRACT1D'
                     ):
+                        sp.meta = standardize_metadata(sp.meta)
                         label = (f"{filter_name} Source "
-                                 f"{sp.meta['header']['SOURCEID']} spec1d "
+                                 f"{sp.meta['SOURCEID']} spec1d "
                                  f"{orientation}")
 
                         spec_labels_1d.append(label)

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -552,7 +552,7 @@ def mos_niriss_parser(app, data_dir, obs_label=""):
 
         filestr = str(filepath)
 
-        if filepath.suffix == '.fits':
+        if filepath.suffix in ('.fits', '.fits.gz', '.fit', '.fit.gz'):
             # eligible files will have a DATAMODL value in their primary headers
             header = fits.getheader(filepath, ext=0)
             datamodl = header.get('DATAMODL')
@@ -570,7 +570,7 @@ def mos_niriss_parser(app, data_dir, obs_label=""):
 
             if datamodl is None:
                 continue
-            elif datamodl == 'MultiSpecModel' and dispersion == 'C':
+            if datamodl == 'MultiSpecModel' and dispersion == 'C':
                 file_lists['1D Spectra C'].append(filestr)
             elif datamodl == 'MultiSpecModel' and dispersion == 'R':
                 file_lists['1D Spectra R'].append(filestr)
@@ -583,7 +583,7 @@ def mos_niriss_parser(app, data_dir, obs_label=""):
             else:
                 # print(f"Other case: datamodl is {datamodl}; "
                 #       f"dispersion is {dispersion}")
-                pass
+                continue
 
         elif filepath.suffix == '.ecsv':
             file_lists['Source Catalog'].append(filestr)

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 import csv
 import glob
 import os
+from collections import defaultdict
 from pathlib import Path
 import warnings
 
@@ -541,9 +542,7 @@ def mos_niriss_parser(app, data_dir, obs_label=""):
     if not path.is_dir():
         raise ValueError("{} is not a valid directory path".format(data_dir))
 
-    file_types = ['Source Catalog', 'Direct Image', '2D Spectra C',
-                  '2D Spectra R', '1D Spectra C', '1D Spectra R']
-    file_lists = {k: [] for k in file_types}
+    file_lists = defaultdict(list)
 
     # use FITS header keywords to sort the directory's files
     for filepath in path.glob('*'):
@@ -591,6 +590,7 @@ def mos_niriss_parser(app, data_dir, obs_label=""):
         else:
             continue
 
+    file_lists = dict(file_lists)
     _warn_if_not_found(app, file_lists)
 
     # Parse relevant information from source catalog


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

I updated `mos_niriss_parser()` to sort files into categories (image, 1d spectrum, etc.) by examining their FITS headers instead of matching their filenames to a pattern. I chose distinctive keywords based on the headers of the current NIRISS example's data files. The `'DATAMODL'` key is particularly useful.

I can run the NIRISS example in full and don't see any glaring errors.

Open questions include:
- Are these the best ways to sort NIRISS' data files into the categories Mosviz desires?
- ~~What is the expected structure of the .ecsv source catalog? Two columns for RA and Dec or one with them in a tuple?~~
- ~~Should we still allow users to provide an `obs_label` argument to select a subset of NIRISS files in a directory? If so, what keyword is best? I left some examples in the docstring.~~

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

[🐱](https://jira.stsci.edu/browse/JDAT-1619)

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
