### PR TITLE
Automatically load first object on data load in Mosviz

### DIFF
--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -146,6 +146,9 @@ class MosViz(ConfigHelper):
         self.load_2d_spectra(spectra_2d, spectra_2d_label)
         self.load_1d_spectra(spectra_1d, spectra_1d_label)
 
+        # Load the first object into the viewers automatically
+        self.app.get_viewer("table-viewer").figure_widget.highlighted = 0
+
     def load_metadata(self, data_obj):
         """
         Load and parse a set of FITS objects to extract any relevant metadata.
@@ -196,6 +199,8 @@ class MosViz(ConfigHelper):
 
     def load_niriss_data(self, data_obj, data_labels=None):
         super().load_data(data_obj, parser_reference="mosviz-niriss-parser")
+        # Load the first object into the viewers automatically
+        self.app.get_viewer("table-viewer").figure_widget.highlighted = 0
 
     def load_images(self, data_obj, data_labels=None, share_image=0):
         """

--- a/jdaviz/configs/mosviz/tests/test_helper.py
+++ b/jdaviz/configs/mosviz/tests/test_helper.py
@@ -215,6 +215,7 @@ def test_load_single_image_multi_spec(mosviz_app, image, spectrum1d, spectrum2d,
 
     mosviz_app.load_data(spectra1d, spectra2d, images=image, images_label=label)
 
+    assert mosviz_app.app.get_viewer("table-viewer").figure_widget.highlighted == 0
     assert len(mosviz_app.app.data_collection) == 8
 
     qtable = mosviz_app.to_table()
@@ -232,6 +233,8 @@ def test_load_multi_image_spec(mosviz_app, image, spectrum1d, spectrum2d, label)
     images = [image]*3
 
     mosviz_app.load_data(spectra1d, spectra2d, images=images, images_label=label)
+
+    assert mosviz_app.app.get_viewer("table-viewer").figure_widget.highlighted == 0
     assert len(mosviz_app.app.data_collection) == 10
 
     qtable = mosviz_app.to_table()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
I didn't see an issue for this, but it seemed like the easiest thing to do out of the outstanding features from Jenn's wireframe that we haven't implemented yet so I just did it. Nice little quality of life change.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
