### PR TITLE
Standardize/improve list coercion in Mosviz parsers

### DIFF
--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -11,7 +11,7 @@ from astropy.wcs import WCS
 from glue.core.data import Data
 from glue.core.link_helpers import LinkSame
 from spectral_cube import SpectralCube
-from specutils import Spectrum1D, SpectrumList
+from specutils import Spectrum1D, SpectrumList, SpectrumCollection
 
 from jdaviz.configs.imviz.plugins.parsers import get_image_data_iterator
 from jdaviz.core.registries import data_parser_registry

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -181,21 +181,15 @@ def mos_spec1d_parser(app, data_obj, data_labels=None):
     data_labels : str, optional
         The label applied to the glue data component.
     """
-    # If providing a file path, parse it using the specutils io tooling
-    if _check_is_file(data_obj):
-        data_obj = [Spectrum1D.read(data_obj)]
 
     if isinstance(data_labels, str):
         data_labels = [data_labels]
 
-    # Coerce into list-like object. This works because `Spectrum1D` objects
-    #  don't have a length dunder method.
-    if not hasattr(data_obj, '__len__'):
+    # Coerce into list if needed
+    if not isinstance(data_obj, (list, tuple, SpectrumCollection)):
         data_obj = [data_obj]
-    else:
-        data_obj = [Spectrum1D.read(x)
-                    if _check_is_file(x) else x
-                    for x in data_obj]
+
+    data_obj = [Spectrum1D.read(x) if _check_is_file(x) else x for x in data_obj]
 
     if data_labels is None:
         data_labels = [f"1D Spectrum {i}" for i in range(len(data_obj))]
@@ -286,19 +280,14 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
 
         return SpectralCube(new_data, wcs=wcs, meta=meta)
 
-    if _check_is_file(data_obj):
-        data_obj = [_parse_as_cube(data_obj)]
-
     if isinstance(data_labels, str):
         data_labels = [data_labels]
 
-    # Coerce into list-like object
-    if not isinstance(data_obj, (list, set)):
+    # Coerce into list if needed
+    if not isinstance(data_obj, (list, tuple, SpectrumCollection)):
         data_obj = [data_obj]
-    else:
-        data_obj = [_parse_as_cube(x)
-                    if _check_is_file(x) else x
-                    for x in data_obj]
+
+    data_obj = [_parse_as_cube(x) if _check_is_file(x) else x for x in data_obj]
 
     if data_labels is None:
         data_labels = [f"2D Spectrum {i}" for i in range(len(data_obj))]
@@ -422,14 +411,11 @@ def mos_meta_parser(app, data_obj):
     if data_obj is None:
         return
 
-    # Coerce into list-like object
-    if not hasattr(data_obj, '__len__'):
+    # Coerce into list if needed
+    if not isinstance(data_obj, (list, tuple, SpectrumCollection)):
         data_obj = [data_obj]
-    elif isinstance(data_obj, str):
-        data_obj = [fits.open(data_obj)]
-    else:
-        data_obj = [fits.open(x) if _check_is_file(x)
-                    else x for x in data_obj]
+
+    data_obj = [fits.open(x) if _check_is_file(x) else x for x in data_obj]
 
     if np.all([isinstance(x, fits.HDUList) for x in data_obj]):
         ra = [x[0].header.get("OBJ_RA", float("nan")) for x in data_obj]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Removes checking for `__len__` attribute and uses `isinstance` instead. Also some other minor related code efficiency improvements. Fixes #314 .

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
