### PR TITLE
Mosviz: Slit overlay to use Data WCS

### DIFF
--- a/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
@@ -9,7 +9,6 @@ import numpy as np
 from regions import RectangleSkyRegion
 from astropy.coordinates import Angle, SkyCoord
 from astropy import units as u
-from astropy.wcs import WCS
 
 import bqplot
 
@@ -78,11 +77,11 @@ class SlitOverlay(TemplateMixin):
         self.remove_slit_overlay()
 
         # Get data from relevant viewers
-        image_data = self.app.get_viewer("image-viewer").data()
+        image_data = self.app.get_viewer("image-viewer").state.reference_data
         spec2d_data = self.app.get_viewer("spectrum-2d-viewer").data()
 
         # 'S_REGION' contains slit information. Bypass in case no images exist.
-        if len(image_data) > 0:
+        if image_data is not None:
             # Only use S_REGION for Nirspec data, turn the plugin off
             # if other data is loaded
             if (len(spec2d_data) > 0 and 'S_REGION' in spec2d_data[0].meta
@@ -91,8 +90,7 @@ class SlitOverlay(TemplateMixin):
                 sky_region = jwst_header_to_skyregion(header)
 
                 # Use wcs of image viewer to scale slit dimensions correctly
-                wcs_image = WCS(image_data[0].meta)
-                pixel_region = sky_region.to_pixel(wcs_image)
+                pixel_region = sky_region.to_pixel(image_data.coords)
 
                 # Create polygon region from the pixel region and set vertices
                 pix_rec = pixel_region.to_polygon()

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ docs =
     sphinx-astropy
 all =
     scikit-image
-    regions
+    regions>=0.5
     photutils
 
 [options.package_data]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to have slit overlay plugin to not try to recreate the WCS itself, but rather use the WCS or GWCS that already comes with the data object.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #849 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
