### PR TITLE
update the first cell of the example notebooks to be consistent

### DIFF
--- a/notebooks/CubevizExample.ipynb
+++ b/notebooks/CubevizExample.ipynb
@@ -1,6 +1,15 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cubeviz Demonstration Notebook\n",
+    "\n",
+    "This notebook demonstrates the Cubeviz API in the Notebook setting. UI equivalents for these actions, as well as additional documentation about Cubeviz, can be found here: https://jdaviz.readthedocs.io/en/latest/cubeviz/"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -29,13 +38,6 @@
     "fn = download_file('https://stsci.box.com/shared/static/28a88k1qfipo4yxc4p4d40v4axtlal8y.fits', cache=True)\n",
     "viz.load_data(fn)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -54,7 +56,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -5,7 +5,10 @@
    "id": "17b4af6f",
    "metadata": {},
    "source": [
-    "# Proof of concept of Imviz requirements using glupyter/bqplot"
+    "# Imviz Demonstration Notebook\n",
+    "\n",
+    "\n",
+    "This notebook demonstrates the Imviz API in the Notebook setting. UI equivalents for these actions, as well as additional documentation about Imviz, can be found here: https://jdaviz.readthedocs.io/en/latest/imviz/"
    ]
   },
   {
@@ -646,7 +649,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/MosvizExample.ipynb
+++ b/notebooks/MosvizExample.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Mosviz example notebook"
+    "# Mosviz Demonstration Notebook\n",
+    "\n",
+    "This notebook demonstrates the Mosviz API in the Notebook setting. UI equivalents for these actions, as well as additional documentation about Mosviz, can be found here: https://jdaviz.readthedocs.io/en/latest/mosviz/"
    ]
   },
   {
@@ -270,7 +272,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -284,7 +286,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/SpecvizExample.ipynb
+++ b/notebooks/SpecvizExample.ipynb
@@ -4,8 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Specviz Demo Notebook\n",
+    "# Specviz Demonstration Notebook\n",
     "This notebook demonstrates the Specviz API in the Notebook setting. UI equivalents for these actions, as well as additional documentation about Specviz, can be found here: https://jdaviz.readthedocs.io/en/latest/specviz/\n",
+    "\n",
     "## Setup"
    ]
   },
@@ -243,7 +244,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This is a quick PR that does exactly what it says: updates all the example notebooks to use the same structure.

(Also has the unintended but I guess good side-effect of making the kernels all consistent).