### PR TITLE
Link model fitting results so they plot in Mosviz

### DIFF
--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -13,6 +13,7 @@ from specutils.utils import QuantityModel
 from traitlets import Any, Bool, Int, List, Unicode, observe
 from glue.core.data import Data
 from glue.core.subset import Subset, RangeSubsetState
+from glue.core.link_helpers import LinkSame
 
 from jdaviz.core.events import AddDataMessage, RemoveDataMessage, SnackbarMessage
 from jdaviz.core.registries import tray_registry
@@ -550,6 +551,13 @@ class ModelFitting(TemplateMixin):
             self.app.remove_data_from_viewer('spectrum-viewer', label)
             # Remove the actual Glue data object from the data_collection
             self.data_collection.remove(self.data_collection[label])
-        self.data_collection[label] = spectrum
+
+        self.app.add_data(spectrum, label)
+
+        # Make sure we link the result spectrum to the data we're fitting
+        data_fitted = self.app.session.data_collection[self._selected_data_label]
+        data_id = data_fitted.world_component_ids[0]
+        model_id = self.app.session.data_collection[label].world_component_ids[0]
+        self.app.session.data_collection.add_link(LinkSame(data_id, model_id))
 
         self.app.add_data_to_viewer('spectrum-viewer', label)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Our reductions in linking in Mosviz seem to have left fitted models out in the rain. This fixes it so that they once more plot over the selected data in the 1D spectrum viewer automatically after being fit. Seems a bit slower than I expected at the moment, but I think that's a separate issue.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
