### PR TITLE
Remove converted spec1ds in mosviz when row changes

### DIFF
--- a/jdaviz/configs/mosviz/plugins/viewers.py
+++ b/jdaviz/configs/mosviz/plugins/viewers.py
@@ -127,7 +127,6 @@ class MosvizTableViewer(TableViewer):
         else:
             components_str = [cid.label for cid in self.figure_widget.data.main_components]
             hidden = []
-            print(components_str)
             for colname in ['Images', '1D Spectra', '2D Spectra']:
                 if colname in components_str:
                     hidden.append(self.figure_widget.data.id[colname])
@@ -147,11 +146,19 @@ class MosvizTableViewer(TableViewer):
 
             if component.label == '1D Spectra':
                 prev_data = self._selected_data.get('spectrum-viewer')
+
                 if prev_data != selected_data:
                     if prev_data:
-                        remove_data_from_viewer_message = RemoveDataFromViewerMessage(
-                            'spectrum-viewer', prev_data, sender=self)
-                        self.session.hub.broadcast(remove_data_from_viewer_message)
+
+                        # This covers the cases where data is unit converted and the name is modified
+                        all_prev_data = [x
+                                         for x in self.session.data_collection.labels
+                                         if prev_data in x]
+                        for modified_prev_data in all_prev_data:
+                            if modified_prev_data:
+                                remove_data_from_viewer_message = RemoveDataFromViewerMessage(
+                                    'spectrum-viewer', modified_prev_data, sender=self)
+                                self.session.hub.broadcast(remove_data_from_viewer_message)
 
                     add_data_to_viewer_message = AddDataToViewerMessage(
                         'spectrum-viewer', selected_data, sender=self)

--- a/jdaviz/configs/mosviz/plugins/viewers.py
+++ b/jdaviz/configs/mosviz/plugins/viewers.py
@@ -146,11 +146,10 @@ class MosvizTableViewer(TableViewer):
 
             if component.label == '1D Spectra':
                 prev_data = self._selected_data.get('spectrum-viewer')
-
                 if prev_data != selected_data:
                     if prev_data:
-
-                        # This covers the cases where data is unit converted and the name is modified
+                        # This covers the cases where data is unit converted
+                        # and the name is modified
                         all_prev_data = [x
                                          for x in self.session.data_collection.labels
                                          if prev_data in x]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address a bug where using the Unit Conversion plugin in Mosviz will lead to the data in the spectrum viewer becoming "stuck", meaning selecting a new row will not change the data in the viewer. The table viewer code now loops through all data collection labels to find labels that contain the original Spectrum 1D label within it (Unit Conversion appends the details of the conversion to the original label).

This PR also removes a print statement that made it into main.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
