### PR TITLE
fix: scientific notation of Y-axis not shown on first load

### DIFF
--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -328,12 +328,12 @@ class Mosviz(ConfigHelper):
         # with data already loaded in the app
         self.app.auto_link = True
 
-        # Load the first object into the viewers automatically
-        self.app.get_viewer("table-viewer").figure_widget.highlighted = 0
-
-        # Manually set viewer options after loading first object
+        # Manually set viewer options
         self.app.get_viewer("spectrum-viewer").figure.axes[1].tick_format = '0.1e'
         self.app.get_viewer("image-viewer").figure.axes[1].label_offset = "-50"
+
+        # Load the first object into the viewers automatically
+        self.app.get_viewer("table-viewer").figure_widget.highlighted = 0
 
         # Notify the user that this all loaded successfully
         loaded_msg = SnackbarMessage("MOS data loaded successfully", color="success", sender=self)


### PR DESCRIPTION
Sometimes the scientific notation for the Y-axis is not applied.
When it happens, it's resolved by resizing the browser window,
which causes a re-render of bqplot, so looks to me like bqplot is
sometimes not re-rendering when the tick_format is changed.

To work around this, set the tick_format before the plot is
rendered with the first data.

See: #865

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
