### PR TITLE
Fix cubeviz unit conversion

### DIFF
--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -294,6 +294,7 @@ class UnitConversion(TemplateMixin):
 
         # Create new spectrum with new units.
         converted_spectrum = spectrum._copy(flux=set_flux_unit,
+                                            wcs=None,
                                             spectral_axis=set_spectral_axis_unit,
                                             unit=set_flux_unit.unit,
                                             uncertainty=temp_uncertainty


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

When creating the new Spectrum1D with different units, the old WCS was preserved and inconsistent with the spectral axis. I'd almost call that a Spectrum1D bug *except* that this is ``_copy`` and private API. I'd highly recommend that this be done via public API in future but for now dropping the original WCS does the trick since the WCS is then produced from the provided spectral axis.

![Screenshot from 2021-09-16 21-11-25](https://user-images.githubusercontent.com/314716/133679502-1872d877-8436-4624-8178-9dba28481c6e.png)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes https://github.com/spacetelescope/jdaviz/issues/886

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
