### PR TITLE
TST: Ignore numpy.ufunc size warning in cron job CI

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -3,6 +3,7 @@
 name: Cron Scheduled CI Tests
 
 on:
+  workflow_dispatch:
   schedule:
     # run at 9am UTC on Mondays
     - cron: '0 9 * * 1'

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,7 @@ text_file_format = rst
 addopts = --doctest-rst --import-mode=append
 filterwarnings =
     error
+    ignore:numpy\.ufunc size changed:RuntimeWarning
     ignore:numpy\.ndarray size changed:RuntimeWarning
     ignore:Numpy has detected that you:DeprecationWarning
     ignore:Passing unrecognized arguments to super:DeprecationWarning


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to fix the failing cron job in CI, and also allow manual trigger on a as-needed basis, given the scheduled job only runs weekly.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
