### PR TITLE
Mosviz: freeze selected plot properties during row change

### DIFF
--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -31,13 +31,20 @@ class Mosviz(ConfigHelper):
         spec2d = self.app.get_viewer("spectrum-2d-viewer")
         spec2d.scales['x'].observe(self._update_spec1d_x_axis, names=['min', 'max'])
 
+        image_viewer = self.app.get_viewer("image-viewer")
+
         # Choose which viewers will have state frozen during a row change.
         # This should be a list of tuples, where each entry has the state as the
         # first item in the tuple, and a list of frozen attributes as the second.
         self._freezable_states = [(spec1d.state, ['x_min', 'x_max']),
                                   (spec2d.state, ['x_min', 'x_max']),
-                                  (self.app.get_viewer("image-viewer").state, []),
+                                  (image_viewer.state, []),
                                   ]
+
+        self._freezable_layers = [(spec1d.state, ['linewidth']),
+                                  (spec2d.state, ['stretch', 'percentile']),
+                                  (image_viewer.state, ['stretch', 'percentile'])]
+        self._frozen_layers_cache = []
 
         # Add callbacks to table-viewer to enable/disable the state freeze
         table = self.app.get_viewer("table-viewer")
@@ -59,12 +66,26 @@ class Mosviz(ConfigHelper):
         self._update_in_progress = False
 
     def _on_row_selected_begin(self):
+        # TODO: UI to toggle an option at the helper or table viewer level
+
         for state, attrs in self._freezable_states:
             state._frozen_state = attrs
+
+        # Make a copy of layer attributes (these can't be frozen since it will
+        # technically be a NEW layer instance).  Note: this assumes that
+        # layers[0] points to the data (and all other indices point to subsets)
+        self._frozen_layers_cache = [{a: getattr(state.layers[0], a) for a in attrs}
+                                     for state, attrs in self._freezable_layers if len(state.layers)]
 
     def _on_row_selected_end(self):
         for state, attrs in self._freezable_states:
             state._frozen_state = []
+
+        # Restore data-layer states from cache, then reset cache
+        for (state, attrs), cache in zip(self._freezable_layers, self._frozen_layers_cache):
+            state.layers[0].update_from_dict(cache)
+
+        self._frozen_layers_cache = []
 
     def _extend_world(self, spec1d, ext):
         # Extend 1D spectrum world axis to enable panning (within reason) past

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -19,6 +19,7 @@ from astropy import units as u
 from jdaviz.core.registries import viewer_registry
 from jdaviz.core.spectral_line import SpectralLine
 from jdaviz.core.linelists import load_preset_linelist, get_available_linelists
+from jdaviz.core.freezable_state import FreezableProfileViewerState
 
 __all__ = ['SpecvizProfileView']
 
@@ -27,6 +28,7 @@ __all__ = ['SpecvizProfileView']
 class SpecvizProfileView(BqplotProfileView):
     default_class = Spectrum1D
     spectral_lines = None
+    _state_cls = FreezableProfileViewerState
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -1,0 +1,21 @@
+from glue.viewers.profile.state import ProfileViewerState
+from glue_jupyter.bqplot.image.state import BqplotImageViewerState
+
+
+class FreezableState():
+    _frozen_state = []
+
+    def __setattr__(self, k, v):
+        if k[0] == '_' or k not in self._frozen_state:
+            super().__setattr__(k, v)
+        elif getattr(self, k) is None:
+            # still allow Nones to be updated to intial values
+            super().__setattr__(k, v)
+
+
+class FreezableProfileViewerState(ProfileViewerState, FreezableState):
+    pass
+
+
+class FreezableBqplotImageViewerState(BqplotImageViewerState, FreezableState):
+    pass


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request freezes specific plot/viewer/layer properties during a row change within mosviz, including: x-limits for 1d and 2d spectrum viewers, and stretch and percentile for 2d spectrum and image viewers. 


TODO before final review and merge:
- [ ] Implement API/UI to toggle behavior (likely as a single toggle, with the set of "frozen" properties hardcoded)
- [ ] changes.rst entry

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
