### PR TITLE
active state for toolbar buttons

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1178,11 +1178,13 @@ class Application(VuetifyTemplate, HubListener):
             'name': name or vid,
             'widget': "IPY_MODEL_" + viewer.figure_widget.model_id,
             'tools': "IPY_MODEL_" + viewer.toolbar_selection_tools.model_id,
+            'tools_open': False,
             'layer_options': "IPY_MODEL_" + viewer.layer_options.model_id,
             'viewer_options': "IPY_MODEL_" + viewer.viewer_options.model_id,
+            'layer_viewer_open': False,
             'selected_data_items': [],
             'config': self.config,  # give viewer access to app config/layout
-            'collapse': True,
+            'data_open': False,
             'reference': reference}
 
     def _on_new_viewer(self, msg, vid=None, name=None):

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -6,21 +6,22 @@
       </j-tooltip>
       <v-toolbar-items>
         <j-tooltip v-if="config === 'mosviz'" tipid="lock-row-toggle">
-          <v-btn icon @click="state.settings.freeze_states_on_row_change = !state.settings.freeze_states_on_row_change">
-            <v-icon v-if="state.settings.freeze_states_on_row_change">mdi-lock</v-icon>
-            <v-icon v-else>mdi-lock-open-outline</v-icon>
+          <v-btn 
+            icon
+            @click="state.settings.freeze_states_on_row_change = !state.settings.freeze_states_on_row_change"
+            :class="{active: state.settings.freeze_states_on_row_change}">
+            <v-icon>mdi-vector-link</v-icon>
           </v-btn>
         </j-tooltip>
       </v-toolbar-items>
       <v-spacer></v-spacer>
-      <v-toolbar-items>
         <j-tooltip tipid="app-toolbar-plugins">
-          <v-btn icon @click="state.drawer = !state.drawer">
-            <v-icon v-if="state.drawer">mdi-toy-brick-remove</v-icon>
-            <v-icon v-else>mdi-toy-brick-plus</v-icon>
+          <v-toolbar-items>
+          <v-btn icon @click="state.drawer = !state.drawer" :class="{active : state.drawer}">
+            <v-icon>mdi-menu</v-icon>
           </v-btn>
+        </v-toolbar-items>
         </j-tooltip>
-      </v-toolbar-items>
     </v-app-bar>
 
     <v-content
@@ -214,6 +215,14 @@ div.output_wrapper {
   margin: 0px;
 }
 
+.vuetify-styles .v-toolbar__items>span>.v-btn {
+  /* allow voolbar-items styling to pass through tooltip wrapping span */
+  /* css is copied from .vuetify-styles .v-toolbar__items>.v-btn */
+  border-radius: 0;
+  height: 100%!important;
+  max-height: none;
+}
+
 .v-tooltip__content {
   background-color: white !important;
   border-radius: 2px !important;
@@ -235,6 +244,10 @@ a:hover {
 
 a:active {
   text-decoration: none;
+}
+
+.active {
+  background-color: #c75109 !important;
 }
 
 </style>

--- a/jdaviz/components/tooltip.vue
+++ b/jdaviz/components/tooltip.vue
@@ -2,7 +2,7 @@
   <v-tooltip v-if="getTooltipHtml()" bottom :open-delay="getOpenDelay()"
       :nudge-bottom="getNudgeBottom()">
     <template v-slot:activator="{ on, attrs }">
-      <span v-bind="attrs" v-on="on" style="height: inherit">
+      <span v-bind="attrs" v-on="on" style="height: inherit; display: inherit">
         <slot></slot>
       </span>
     </template>

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -25,7 +25,14 @@
               <j-tooltip tipid="viewer-toolbar-data">
                 <v-menu offset-y :close-on-content-click="false">
                   <template v-slot:activator="{ on, attrs }">
-                    <v-btn text elevation="3" v-bind="attrs" v-on="on" color="white">
+                    <v-btn 
+                      text 
+                      elevation="3" 
+                      v-bind="attrs" 
+                      v-on="on" 
+                      color="white"
+                      @click="viewer.data_open = !viewer.data_open"
+                      :class="{active: viewer.data_open}">
                       Data
                     </v-btn>
                   </template>
@@ -48,18 +55,16 @@
 
               </v-col>
               <v-spacer></v-spacer>
-               <v-col md="auto">
-               
+               <v-toolbar-items>
                <j-tooltip tipid='viewer-toolbar-figure'>
-                 <v-btn icon @click="viewer.collapse = !viewer.collapse" color="white">
-                   <v-icon v-if="viewer.collapse">mdi-hammer-screwdriver</v-icon>
-                   <v-icon v-else>mdi-close</v-icon>
+                 <v-btn icon @click="viewer.tools_open = !viewer.tools_open" :class="{active: viewer.tools_open}" color="white">
+                   <v-icon>mdi-hammer-screwdriver</v-icon>
                  </v-btn>
                </j-tooltip>
                <j-tooltip tipid='viewer-toolbar-menu'>
                 <v-menu offset-y :close-on-content-click="false" style="z-index: 10">
                   <template v-slot:activator="{ on }">
-                    <v-btn icon color="white" v-on="on">
+                    <v-btn icon v-on="on" @click="viewer.layer_viewer_open = !viewer.layer_viewer_open" :class="{active : viewer.layer_viewer_open}" color="white">
                       <v-icon>tune</v-icon>
                     </v-btn>
                   </template>
@@ -92,7 +97,7 @@
                   <v-icon>more_horiz</v-icon>
                 </v-btn>
                </j-tooltip>
-              </v-col>
+             </v-toolbar-items>
           </v-row>
 
         </div>
@@ -103,9 +108,9 @@
           dense
           floating
           absolute
-          :collapse="viewer.collapse"
+          :tools_open="viewer.tools_open"
           elevation="1"
-          :width="viewer.collapse ? '0px' : null"
+          :width="viewer.tools_open ? null : '0px'"
           style="right: 2px;"
         >
           <v-toolbar-items>


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request adds support for an active state (orange background) to all toolbar buttons.  In doing so, it fixes block button instead of circle styling for toolbar buttons (only visible before when hovering, but required for proper shading for new active state), replaces the plugin icon with hamburger (#527), removes the "X" icon when hammer-screwdriver button is active, and replaces the lock icon in mosviz introduced in #918 (see before and after screenshots below).

Before:
<img width="996" alt="Screen Shot 2021-10-15 at 12 16 56 PM" src="https://user-images.githubusercontent.com/877591/137798319-d569b2b5-772a-40e1-95b2-e38a46d5a3df.png">

After:
<img width="996" alt="Screen Shot 2021-10-15 at 12 13 38 PM" src="https://user-images.githubusercontent.com/877591/137798335-c6b6e92a-fba8-4a9b-a4e1-913beca201d8.png">

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #527

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
