### PR TITLE
fix active state of menu buttons when closing on click away

### DIFF
--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -23,7 +23,7 @@
           <v-row dense style="background-color: #205f76">
             <v-col md="auto">
               <j-tooltip tipid="viewer-toolbar-data">
-                <v-menu offset-y :close-on-content-click="false">
+                <v-menu offset-y :close-on-content-click="false" v-model="viewer.data_open">
                   <template v-slot:activator="{ on, attrs }">
                     <v-btn 
                       text 
@@ -31,7 +31,6 @@
                       v-bind="attrs" 
                       v-on="on" 
                       color="white"
-                      @click="viewer.data_open = !viewer.data_open"
                       :class="{active: viewer.data_open}">
                       Data
                     </v-btn>
@@ -62,9 +61,9 @@
                  </v-btn>
                </j-tooltip>
                <j-tooltip tipid='viewer-toolbar-menu'>
-                <v-menu offset-y :close-on-content-click="false" style="z-index: 10">
+                <v-menu offset-y :close-on-content-click="false" style="z-index: 10" v-model="viewer.layer_viewer_open">
                   <template v-slot:activator="{ on }">
-                    <v-btn icon v-on="on" @click="viewer.layer_viewer_open = !viewer.layer_viewer_open" :class="{active : viewer.layer_viewer_open}" color="white">
+                    <v-btn icon v-on="on" :class="{active : viewer.layer_viewer_open}" color="white">
                       <v-icon>tune</v-icon>
                     </v-btn>
                   </template>


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes the case from #940 where the active state (orange background color) of a menu button could get out of sync if the menu was closed by clicking off the menu instead of on the button itself.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
