### PR TITLE
Implement mechanism for helpers to create new tabs for apps.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ pip-wheel-metadata
 
 # Environments
 /env*
+/*venv

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@
 New Features
 ------------
 
+- There are now `show_in_sidecar ` and `show_in_new_tab` methdos on all the
+  helpers that display the viewers in separate jupyterlab windows from the 
+  notebook. [#952]
+
 Cubeviz
 ^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 New Features
 ------------
 
-- There are now `show_in_sidecar ` and `show_in_new_tab` methdos on all the
+- There are now `show_in_sidecar ` and `show_in_new_tab` methods on all the
   helpers that display the viewers in separate jupyterlab windows from the 
   notebook. [#952]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@
 New Features
 ------------
 
-- There are now `show_in_sidecar ` and `show_in_new_tab` methods on all the
-  helpers that display the viewers in separate jupyterlab windows from the 
+- There are now ``show_in_sidecar` ` and ``show_in_new_tab`` methods on all the
+  helpers that display the viewers in separate JupyterLab windows from the 
   notebook. [#952]
 
 Cubeviz

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -128,6 +128,11 @@ export default {
 </script>
 
 <style id="web-app">
+/* This makes the viz tools scrollable when the window is too small.  In principle this should be fixed in ipywidgets 8, but that's not out yet... (see https://github.com/spacetelescope/jdaviz/pull/952#issuecomment-1021183846) */
+.jupyterlab-sidecar .jp-OutputArea-output {
+  overflow: auto;
+}
+
 * {
   /* otherwise, voila will override box-sizing to unset which screws up layouts */
   box-sizing: border-box !important;

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -18,6 +18,8 @@ from jdaviz.core.events import AddDataMessage
 
 from IPython.display import display
 
+from sidecar import Sidecar
+
 __all__ = ['ConfigHelper']
 
 
@@ -292,8 +294,8 @@ class ConfigHelper(HubListener):
             The title of the sidecar tab.  Defaults to the name of the
             application; e.g., "specviz".
         anchor : str
-            Where the tab should appear, by default on the right.  To see all
-            options see the ``sidecar.Sidecar.anchor.values``.
+            Where the tab should appear, by default on the right. Options are:
+            {sidecar_anchor_values}.
 
         additional keywords are passed into the ``sidecar.Sidecar`` constructor.
         See ``jupyterlab-sidecar`` for the most up-to-date options.
@@ -312,8 +314,6 @@ class ConfigHelper(HubListener):
         show_in_new_tab
         show_inline
         """
-        from sidecar import Sidecar
-
         if 'title' not in kwargs:
             kwargs['title'] = self.app.config
 
@@ -322,6 +322,7 @@ class ConfigHelper(HubListener):
             display(self.app)
 
         return scar
+    show_in_sidecar.__doc__ = show_in_sidecar.__doc__.format(sidecar_anchor_values=repr(Sidecar.anchor.values)[1:-1])
 
     def show_in_new_tab(self, **kwargs):
         """

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -269,17 +269,62 @@ class ConfigHelper(HubListener):
         return parameters_cube
 
 
+    def show_inline(self):
+        """
+        Display the jdaviz application inline in a notebook.  Note this is
+        functionally equivalent to displaying the cell ``self.app`` in the
+        notebook.
+
+        See Also
+        --------
+        show_in_sidecar
+        show_in_new_tab
+        """
+        display(self.app)
+
+
     def show_in_sidecar(self, **kwargs):
         """
-        If ``title`` is not in a keyword argument, auto-generate from viz name
+        Display the jdaviz application in a "sidecar", which by default is a tab
+        on the right side of the jupyterlab  interface.
+
+        Parameters
+        ----------
+        title : str, optional
+            The title of the sidecar tab.  Defaults to the name of the
+            application - e.g. "specviz".
+        anchor : str
+            Where the tab should appear, by default on the right.  To see all
+            options see the ``sidecar.Sidecar`` documentation.
+
+        additional keywords are passed into the ``sidecar.Sidecar`` constructor.
+        See the ``jupyterlab-sidecar`` docs for the most up-to-date options.
+
+        Returns
+        -------
+        sidecar
+            The ``sidecar.Sidecar`` object used to create the tab.
+
+        Notes
+        -----
+        The ``jupyterlab-sidecar`` module needs to be installed for this method
+        to work.  ``pip install sidecar`` should suffice for most use cases.
+
+        If this method is called in the "classic" Jupyter notebook, the app will
+        appear inline, as only lab has a mechanism to have multiple tabs.
+
+        See Also
+        --------
+        show_in_new_tab
+        show_inline
         """
         try:
             from sidecar import Sidecar
-        except ImportError as e:
-            e.args[0] = (e.args[0] + ' You need to install jupyterlab-sidecar '
-                                     'to use `show_in_sidecar.  Try `pip '
-                                     'install sidecar`.')
-            raise e
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError('You need to install jupyterlab-sidecar '
+                                      'to use `show_in_sidecar`.  Try `pip '
+                                      'install sidecar` and re-start your '
+                                      'Jupyter server.') from e
 
         if 'title' not in kwargs:
             kwargs['title'] = self.app.config
@@ -292,6 +337,36 @@ class ConfigHelper(HubListener):
 
 
     def show_in_new_tab(self, **kwargs):
+        """
+        Display the jdaviz application in a new tab in Jupyterlab.
+
+        Parameters
+        ----------
+        title : str, optional
+            The title of the sidecar tab.  Defaults to the name of the
+            application - e.g. "specviz".
+
+        Additional keywords are passed into the ``sidecar.Sidecar`` constructor.
+        See the ``jupyterlab-sidecar`` docs for the most up-to-date options.
+
+        Returns
+        -------
+        sidecar
+            The ``sidecar.Sidecar`` object used to create the tab.
+
+        Notes
+        -----
+        The ``jupyterlab-sidecar`` module needs to be installed for this method
+        to work.  ``pip install sidecar`` should suffice for most use cases.
+
+        If this method is called in the "classic" Jupyter notebook, the app will
+        appear inline, as only lab has a mechanism to have multiple tabs.
+
+        See Also
+        --------
+        show_in_sidecar
+        show_inline
+        """
         if 'anchor' in kwargs:
             if 'tab' not in kwargs['anchor']:
                 raise ValueError('show_in_new_tab cannot have a non-tab anchor')

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -270,7 +270,7 @@ class ConfigHelper(HubListener):
 
     def show_inline(self):
         """
-        Display the jdaviz application inline in a notebook.  Note this is
+        Display the Jdaviz application inline in a notebook.  Note this is
         functionally equivalent to displaying the cell ``self.app`` in the
         notebook.
 
@@ -283,14 +283,14 @@ class ConfigHelper(HubListener):
 
     def show_in_sidecar(self, **kwargs):
         """
-        Display the jdaviz application in a "sidecar", which by default is a tab
-        on the right side of the jupyterlab  interface.
+        Display the Jdaviz application in a "sidecar", which by default is a tab
+        on the right side of the JupyterLab  interface.
 
         Parameters
         ----------
         title : str, optional
             The title of the sidecar tab.  Defaults to the name of the
-            application - e.g. "specviz".
+            application; e.g., "specviz".
         anchor : str
             Where the tab should appear, by default on the right.  To see all
             options see the ``sidecar.Sidecar.anchor.values``.
@@ -305,24 +305,14 @@ class ConfigHelper(HubListener):
 
         Notes
         -----
-        The ``jupyterlab-sidecar`` module needs to be installed for this method
-        to work.  ``pip install sidecar`` should suffice for most use cases.
-
         If this method is called in the "classic" Jupyter notebook, the app will
         appear inline, as only lab has a mechanism to have multiple tabs.
-
         See Also
         --------
         show_in_new_tab
         show_inline
         """
-        try:
-            from sidecar import Sidecar
-        except ModuleNotFoundError as e:
-            raise ModuleNotFoundError('You need to install jupyterlab-sidecar '
-                                      'to use `show_in_sidecar`.  Try `pip '
-                                      'install sidecar` and re-start your '
-                                      'Jupyter server.') from e
+        from sidecar import Sidecar
 
         if 'title' not in kwargs:
             kwargs['title'] = self.app.config
@@ -335,13 +325,13 @@ class ConfigHelper(HubListener):
 
     def show_in_new_tab(self, **kwargs):
         """
-        Display the jdaviz application in a new tab in Jupyterlab.
+        Display the Jdaviz application in a new tab in JupyterLab.
 
         Parameters
         ----------
         title : str, optional
             The title of the sidecar tab.  Defaults to the name of the
-            application - e.g. "specviz".
+            application; e.g., "specviz".
 
         Additional keywords are passed into the ``sidecar.Sidecar`` constructor.
         See ``jupyterlab-sidecar`` for the most up-to-date options.
@@ -353,9 +343,6 @@ class ConfigHelper(HubListener):
 
         Notes
         -----
-        The ``jupyterlab-sidecar`` module needs to be installed for this method
-        to work.  ``pip install sidecar`` should suffice for most use cases.
-
         If this method is called in the "classic" Jupyter notebook, the app will
         appear inline, as only lab has a mechanism to have multiple tabs.
 

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -295,10 +295,10 @@ class ConfigHelper(HubListener):
             application - e.g. "specviz".
         anchor : str
             Where the tab should appear, by default on the right.  To see all
-            options see the ``sidecar.Sidecar`` documentation.
+            options see the ``sidecar.Sidecar.anchor.values``.
 
         additional keywords are passed into the ``sidecar.Sidecar`` constructor.
-        See the ``jupyterlab-sidecar`` docs for the most up-to-date options.
+        See ``jupyterlab-sidecar`` for the most up-to-date options.
 
         Returns
         -------
@@ -347,7 +347,7 @@ class ConfigHelper(HubListener):
             application - e.g. "specviz".
 
         Additional keywords are passed into the ``sidecar.Sidecar`` constructor.
-        See the ``jupyterlab-sidecar`` docs for the most up-to-date options.
+        See ``jupyterlab-sidecar`` for the most up-to-date options.
 
         Returns
         -------

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -324,7 +324,8 @@ class ConfigHelper(HubListener):
             display(self.app)
 
         return scar
-    show_in_sidecar.__doc__ = show_in_sidecar.__doc__.format(sidecar_anchor_values=repr(Sidecar.anchor.values)[1:-1])
+    show_in_sidecar.__doc__ = show_in_sidecar.__doc__.format(
+        sidecar_anchor_values=repr(Sidecar.anchor.values)[1:-1])
 
     def show_in_new_tab(self, **kwargs):
         """

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -16,6 +16,8 @@ from glue.core.message import SubsetCreateMessage
 from jdaviz.app import Application
 from jdaviz.core.events import AddDataMessage
 
+from IPython.display import display
+
 __all__ = ['ConfigHelper']
 
 
@@ -265,3 +267,34 @@ class ConfigHelper(HubListener):
                     param_units[key].get(param_name, None))
 
         return parameters_cube
+
+
+    def show_in_sidecar(self, **kwargs):
+        """
+        If ``title`` is not in a keyword argument, auto-generate from viz name
+        """
+        try:
+            from sidecar import Sidecar
+        except ImportError as e:
+            e.args[0] = (e.args[0] + ' You need to install jupyterlab-sidecar '
+                                     'to use `show_in_sidecar.  Try `pip '
+                                     'install sidecar`.')
+            raise e
+
+        if 'title' not in kwargs:
+            kwargs['title'] = self.app.config
+
+        scar = Sidecar(**kwargs)
+        with scar:
+            display(self.app)
+
+        return scar
+
+
+    def show_in_new_tab(self, **kwargs):
+        if 'anchor' in kwargs:
+            if 'tab' not in kwargs['anchor']:
+                raise ValueError('show_in_new_tab cannot have a non-tab anchor')
+        else:
+            kwargs['anchor'] = 'tab-after'
+        return self.show_in_sidecar(**kwargs)

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -288,6 +288,11 @@ class ConfigHelper(HubListener):
         Display the Jdaviz application in a "sidecar", which by default is a tab
         on the right side of the JupyterLab  interface.
 
+        Additional keywords not listed here are passed into the
+        ``sidecar.Sidecar`` constructor. See
+        `jupyterlab-sidecar <https://github.com/jupyter-widgets/jupyterlab-sidecar>`_
+        for the most up-to-date options.
+
         Parameters
         ----------
         title : str, optional
@@ -296,9 +301,6 @@ class ConfigHelper(HubListener):
         anchor : str
             Where the tab should appear, by default on the right. Options are:
             {sidecar_anchor_values}.
-
-        additional keywords are passed into the ``sidecar.Sidecar`` constructor.
-        See ``jupyterlab-sidecar`` for the most up-to-date options.
 
         Returns
         -------
@@ -328,14 +330,16 @@ class ConfigHelper(HubListener):
         """
         Display the Jdaviz application in a new tab in JupyterLab.
 
+        Additional keywords not listed here are passed into the
+        ``sidecar.Sidecar`` constructor. See
+        `jupyterlab-sidecar <https://github.com/jupyter-widgets/jupyterlab-sidecar>`_
+        for the most up-to-date options.
+
         Parameters
         ----------
         title : str, optional
             The title of the sidecar tab.  Defaults to the name of the
             application; e.g., "specviz".
-
-        Additional keywords are passed into the ``sidecar.Sidecar`` constructor.
-        See ``jupyterlab-sidecar`` for the most up-to-date options.
 
         Returns
         -------

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -268,7 +268,6 @@ class ConfigHelper(HubListener):
 
         return parameters_cube
 
-
     def show_inline(self):
         """
         Display the jdaviz application inline in a notebook.  Note this is
@@ -281,7 +280,6 @@ class ConfigHelper(HubListener):
         show_in_new_tab
         """
         display(self.app)
-
 
     def show_in_sidecar(self, **kwargs):
         """
@@ -334,7 +332,6 @@ class ConfigHelper(HubListener):
             display(self.app)
 
         return scar
-
 
     def show_in_new_tab(self, **kwargs):
         """

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -1,5 +1,5 @@
-import pytest
 from jdaviz.app import Specviz
+import sidecar
 
 
 def test_show_inline():
@@ -15,7 +15,7 @@ def test_show_sidecar():
     assert isinstance(res, sidecar.Sidecar)
 
 
-def test_show_sidecar():
+def test_show_new_tab():
     specviz = Specviz()
     res = specviz.show_in_new_tab()
     assert isinstance(res, sidecar.Sidecar)

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -1,4 +1,4 @@
-from jdaviz.app import Specviz
+from jdaviz import Specviz
 import sidecar
 
 

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -1,0 +1,30 @@
+import pytest
+from jdaviz.app import Specviz
+
+HAS_SIDECAR = False
+try:
+    import sidecar
+    HAS_SIDECAR = True
+except ImportError:
+    pass  # HAS_SIDECAR = False
+
+
+def test_show_inline():
+    specviz = Specviz()
+    res = specviz.show_inline()
+
+    assert res is None
+
+
+pytest.skipif('not HAS_SIDECAR')
+def test_show_sidecar():
+    specviz = Specviz()
+    res = specviz.show_in_sidecar()
+    assert isinstance(res, sidecar.Sidecar)
+
+
+pytest.skipif('not HAS_SIDECAR')
+def test_show_sidecar():
+    specviz = Specviz()
+    res = specviz.show_in_new_tab()
+    assert isinstance(res, sidecar.Sidecar)

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -1,13 +1,6 @@
 import pytest
 from jdaviz.app import Specviz
 
-HAS_SIDECAR = False
-try:
-    import sidecar
-    HAS_SIDECAR = True
-except ImportError:
-    pass  # HAS_SIDECAR = False
-
 
 def test_show_inline():
     specviz = Specviz()
@@ -16,14 +9,12 @@ def test_show_inline():
     assert res is None
 
 
-pytest.skipif('not HAS_SIDECAR')
 def test_show_sidecar():
     specviz = Specviz()
     res = specviz.show_in_sidecar()
     assert isinstance(res, sidecar.Sidecar)
 
 
-pytest.skipif('not HAS_SIDECAR')
 def test_show_sidecar():
     specviz = Specviz()
     res = specviz.show_in_new_tab()

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -1,21 +1,17 @@
-from jdaviz import Specviz
 import sidecar
 
 
-def test_show_inline():
-    specviz = Specviz()
-    res = specviz.show_inline()
+def test_show_inline(specviz_app):
+    res = specviz_app.show_inline()
 
     assert res is None
 
 
-def test_show_sidecar():
-    specviz = Specviz()
-    res = specviz.show_in_sidecar()
+def test_show_sidecar(specviz_app):
+    res = specviz_app.show_in_sidecar()
     assert isinstance(res, sidecar.Sidecar)
 
 
-def test_show_new_tab():
-    specviz = Specviz()
-    res = specviz.show_in_new_tab()
+def test_show_new_tab(specviz_app):
+    res = specviz_app.show_in_new_tab()
     assert isinstance(res, sidecar.Sidecar)

--- a/notebooks/CubevizExample.ipynb
+++ b/notebooks/CubevizExample.ipynb
@@ -38,6 +38,40 @@
     "fn = download_file('https://stsci.box.com/shared/static/28a88k1qfipo4yxc4p4d40v4axtlal8y.fits', cache=True)\n",
     "viz.load_data(fn)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Alternate ways to show the Cubeviz UI\n",
+    "\n",
+    "The above shows the Cubeviz UI inline with the notebook.  If you are in jupyter lab you can instead have the Cubeviz UI appear in a separate tab or as a \"sidecar\" (a split UI pane to the side of the notebook).  The below should do this (but only in jupyterlab.  If you are in the \"classic\" notebook it will show the same thing as `viz.app`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz.show_in_sidecar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "miz.show_in_new_tab()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that while you can do all of these at once, this is not a recommended workflow, because the different views will all update, which will both slow down the tool and probably be confusing for you. If you instead want two *independent* Mosviz UIs you should create a second `Cubeviz()` object."
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/CubevizExample.ipynb
+++ b/notebooks/CubevizExample.ipynb
@@ -45,7 +45,7 @@
    "source": [
     "### Alternate ways to show the Cubeviz UI\n",
     "\n",
-    "The above shows the Cubeviz UI inline with the notebook.  If you are in jupyter lab you can instead have the Cubeviz UI appear in a separate tab or as a \"sidecar\" (a split UI pane to the side of the notebook).  The below should do this (but only in jupyterlab.  If you are in the \"classic\" notebook it will show the same thing as `viz.app`)"
+    "The above shows the Cubeviz UI inline with the notebook.  If you are in JupyterLab you can instead have the Cubeviz UI appear in a separate tab or as a \"sidecar\" (a split UI pane to the side of the notebook).  The below should do this (but only in JupyterLab.  If you are in the \"classic\" notebook it will show the same thing as `viz.app`)"
    ]
   },
   {

--- a/notebooks/CubevizExample.ipynb
+++ b/notebooks/CubevizExample.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "miz.show_in_new_tab()"
+    "viz.show_in_new_tab()"
    ]
   },
   {

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -191,6 +191,34 @@
   },
   {
    "cell_type": "markdown",
+   "id": "db7b63f1-ccbb-45a5-8938-961ab207cfe6",
+   "metadata": {},
+   "source": [
+    "The above will show imviz inline in the notebook.  The following two cells are alternative ways to show it in separate windows, either on the right side of the notebook or in a new tab.  (Note this will only work in Jupyterlab, *not* the \"classic\" notebook.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1b5fea5-2a66-49ab-aae5-36470a1ba13d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz.show_in_sidecar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cde72ed1-6076-4cae-9b3a-c1cf7e58834d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz.show_in_new_tab()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1abb759e",
    "metadata": {},
    "source": [

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -194,7 +194,7 @@
    "id": "db7b63f1-ccbb-45a5-8938-961ab207cfe6",
    "metadata": {},
    "source": [
-    "The above will show imviz inline in the notebook.  The following two cells are alternative ways to show it in separate windows, either on the right side of the notebook or in a new tab.  (Note this will only work in Jupyterlab, *not* the \"classic\" notebook.)"
+    "The above will show Imviz inline in the notebook.  The following two cells are alternative ways to show it in separate windows, either on the right side of the notebook or in a new tab.  (Note this will only work in JupyterLab, *not* the \"classic\" notebook.)"
    ]
   },
   {

--- a/notebooks/MosvizExample.ipynb
+++ b/notebooks/MosvizExample.ipynb
@@ -268,7 +268,7 @@
    "source": [
     "### Alternate ways to show the Mosviz UI\n",
     "\n",
-    "The above shows the mosviz UI inline with the notebook.  If you are in jupyter lab you can instead have the mosviz UI appear in a separate tab or as a \"sidecar\" (a split UI pane to the side of the notebook).  The below should do this (but only in jupyterlab.  If you are in the \"classic\" notebook it will show the same thing as `mosviz.app`)"
+    "The above shows the Mosviz UI inline with the notebook.  If you are in JupyterLab you can instead have the Mosviz UI appear in a separate tab or as a \"sidecar\" (a split UI pane to the side of the notebook).  The below should do this (but only in JupyterLab.  If you are in the \"classic\" notebook it will show the same thing as `mosviz.app`)"
    ]
   },
   {

--- a/notebooks/MosvizExample.ipynb
+++ b/notebooks/MosvizExample.ipynb
@@ -263,11 +263,38 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Alternate ways to show the Mosviz UI\n",
+    "\n",
+    "The above shows the mosviz UI inline with the notebook.  If you are in jupyter lab you can instead have the mosviz UI appear in a separate tab or as a \"sidecar\" (a split UI pane to the side of the notebook).  The below should do this (but only in jupyterlab.  If you are in the \"classic\" notebook it will show the same thing as `mosviz.app`)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "mosviz.show_in_sidecar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mosviz.show_in_new_tab()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that while you can do all of these at once, this is not a recommended workflow, because the different views will all update, which will both slow down the tool and probably be confusing for you. If you instead want two *independent* Mosviz UIs you should create a second `Mosviz()` object."
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/SpecvizExample.ipynb
+++ b/notebooks/SpecvizExample.ipynb
@@ -55,7 +55,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Display Specviz"
+    "## Display Specviz\n",
+    "\n",
+    "Note: you probably want to pick one of the three options below depending on preference. Also not the latter two will only work in Jupyterlab, not the \"classic\" notebook interface."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This option will show specviz inline in the notebook"
    ]
   },
   {
@@ -65,6 +74,38 @@
    "outputs": [],
    "source": [
     "specviz.app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This option will show specviz in a new tab on the right side of the notebook:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "specviz.show_in_sidecar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This will open specviz in a new Jupyterlab tab:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "specviz.show_in_new_tab()"
    ]
   },
   {

--- a/notebooks/SpecvizExample.ipynb
+++ b/notebooks/SpecvizExample.ipynb
@@ -57,14 +57,14 @@
    "source": [
     "## Display Specviz\n",
     "\n",
-    "Note: you probably want to pick one of the three options below depending on preference. Also not the latter two will only work in Jupyterlab, not the \"classic\" notebook interface."
+    "Note: you probably want to pick one of the three options below depending on preference. Also not the latter two will only work in JupyterLab, not the \"classic\" notebook interface."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This option will show specviz inline in the notebook"
+    "This option will show Specviz inline in the notebook"
    ]
   },
   {
@@ -96,7 +96,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This will open specviz in a new Jupyterlab tab:"
+    "This will open specviz in a new JupyterLab tab:"
    ]
   },
   {

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     gwcs>=0.16.1
     regions>=0.5
     scikit-image
+    sidecar>=0.5.1
 
 [options.extras_require]
 test =


### PR DESCRIPTION
This PR adds a methods to the `jdaviz` helpers that allow them to be popped out into new tabs in jupyterlab. This video shows the two new ways of doing it in action.


https://user-images.githubusercontent.com/346587/139784545-a1e9011c-b9f6-4263-a2eb-feb256e216c7.mp4


This works as-is, but I have several standing questions which might need implementation of something before I'm ready to call this done:

- [x] Right now the default for `show_in_sidecar` is to appear on the right. The `anchor` keyword lets you place the new tab basically anywhere - new tab before, new tab after (which is how `show_in_new_tab` works), or bottom/top split view.  Should I pick a different default?  Maybe even have it be a config-specific choice what the default is?  For example, specviz is probably better at the bottom because it's "wide", while cubeviz is more "square"... But that's a bit more work, and could always be added later.
- [x] Should we even have `show_in_new_tab` given it could also just be ``self.show_in_sidecar(anchor='tab-after')``?
- [x] Should I update *all* the example notebooks with the `show_*` options instead of just specviz?
- [x] Should I just make `sidecar` an dependency instead of the current "it doesn't work unless you have sidecar installed" error message?
- [x] Should this be implemented on the `Application` class instead of the base helper?  I feel strongly this needs to be in the helpers, *but* it might belong in the application and have the helper methods just be something like:
```
def show_in_sidecar(self, **kwargs):
    return self.app.show_in_sidecar(**kwargs)
```
- [x] Are these trivial unit tests sufficient testing for now?