### PR TITLE
spectrum-2d-viewer: set custom toolbar tools

### DIFF
--- a/jdaviz/configs/mosviz/plugins/viewers.py
+++ b/jdaviz/configs/mosviz/plugins/viewers.py
@@ -82,7 +82,14 @@ class MosvizProfile2DView(BqplotImageView):
     #  axes, the default conversion class must handle cubes
     default_class = Spectrum1D
 
-    tools = ['bqplot:panzoom_x']
+    # replace the default tools (which include rect and circle region)
+    # with only the tools we want (likely the same as in SpecvizProfileView)
+    inherit_tools = False
+    tools = ['bqplot:home',
+             'bqplot:panzoom',
+             'bqplot:panzoom_x',
+             'bqplot:panzoom_y',
+             'bqplot:xrange']
 
     _state_cls = FreezableBqplotImageViewerState
 


### PR DESCRIPTION


<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request sets the toolbar tools on the spectrum-2d-viewer (in both mosviz and specviz2d) to match those in spectrum-viewer (1d and 2d pan/zoom, but only xrange region selection).  This was a blocker for #776 and confirms that that is still a remaining issue even with xrange subsets.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
