### PR TITLE
close plot tools menu when opening layer/viewer menu

### DIFF
--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -56,14 +56,21 @@
               <v-spacer></v-spacer>
                <v-toolbar-items>
                <j-tooltip tipid='viewer-toolbar-figure'>
+                 <!-- NOTE: since this is just a btn, not a toggle or menu, we cannot use v-model
+                      but instead will use @click to toggle the state AND close any other active
+                      toolbar menus (that won't already by close-on-content-click)-->
                  <v-btn icon @click="viewer.tools_open = !viewer.tools_open" :class="{active: viewer.tools_open}" color="white">
                    <v-icon>mdi-hammer-screwdriver</v-icon>
                  </v-btn>
                </j-tooltip>
                <j-tooltip tipid='viewer-toolbar-menu'>
+                 <!-- NOTE: this case uses v-menu, so we'll control the active state with v-model
+                      on that component, but close any other active toolbar menus (that won't already
+                      with close-on-content-click with the @click on the underlying button component  
+                  -->
                 <v-menu offset-y :close-on-content-click="false" style="z-index: 10" v-model="viewer.layer_viewer_open">
                   <template v-slot:activator="{ on }">
-                    <v-btn icon v-on="on" :class="{active : viewer.layer_viewer_open}" color="white">
+                    <v-btn icon v-on="on" :class="{active : viewer.layer_viewer_open}" color="white" @click="viewer.tools_open=false">
                       <v-icon>tune</v-icon>
                     </v-btn>
                   </template>


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request ensures that the tools menu closes when opening the layer/viewer menu (the opposite was already the case as the layer/viewer menu closes on any click away from the menu, whereas the plot tools must remain open in order to function).  This can be extended to any future menu (i.e. the currently empty "more" menu), or to the data button on the left (which is currently excluded).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #791 (note: there was an issue opened upstream.  Not sure if that should be closed or left for consideration within glue itself)

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
