### PR TITLE
Voila styling tweaks

### DIFF
--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -134,6 +134,10 @@ export default {
 </script>
 
 <style id="web-app">
+* {
+  /* otherwise, voila will override box-sizing to unset which screws up layouts */
+  box-sizing: border-box !important;
+}
 
 /* fix for loading overlay z-index */
 div.output_wrapper {

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -201,7 +201,7 @@ div.output_wrapper {
   margin-top: 0px;
 }
 
-.vuetify-styles .lm_header ul {
+.lm_header ul {
   padding-left: 0;
 }
 
@@ -215,14 +215,14 @@ div.output_wrapper {
   margin: 0px;
 }
 
-.vuetify-styles .v-expansion-panel-content__wrap {
+.v-expansion-panel-content__wrap {
   padding: 0px;
   margin: 0px;
 }
 
 .v-toolbar__items > span > .v-btn {
   /* allow voolbar-items styling to pass through tooltip wrapping span */
-  /* css is copied from .vuetify-styles .v-toolbar__items>.v-btn */
+  /* css is copied from .v-toolbar__items>.v-btn */
   border-radius: 0;
   height: 100% !important;
   max-height: none;

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -220,11 +220,11 @@ div.output_wrapper {
   margin: 0px;
 }
 
-.vuetify-styles .v-toolbar__items>span>.v-btn {
+.v-toolbar__items > span > .v-btn {
   /* allow voolbar-items styling to pass through tooltip wrapping span */
   /* css is copied from .vuetify-styles .v-toolbar__items>.v-btn */
   border-radius: 0;
-  height: 100%!important;
+  height: 100% !important;
   max-height: none;
 }
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes some inconsistencies with CSS styling when embedded in voila, including:
* styling of toolbar buttons (circle vs rectangular highlighting)
* horizontal overflow in the plugin tray

**Before**:

<img width="400" alt="Screen Shot 2021-11-10 at 3 01 20 PM" src="https://user-images.githubusercontent.com/877591/141185183-bc198a7f-5484-429e-a173-2d832fc22347.png">

Note how the active state on the buttons are incorrect and the plugin tray has a horizontal scrollbar.  Scrolling to the far right shows just how much it overflowed:

<img width="400" alt="Screen Shot 2021-11-10 at 3 01 32 PM" src="https://user-images.githubusercontent.com/877591/141185198-2990dd34-ec7c-43d6-8828-39c3bc52d06a.png">

**After**:
<img width="400" alt="Screen Shot 2021-11-10 at 3 02 26 PM" src="https://user-images.githubusercontent.com/877591/141185224-825ce4cc-4bdb-4263-b35b-03453f69cbf7.png">




<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
