### PR TITLE
Mosviz: redshift column in table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Mosviz
 - New toggle button to lock/unlock viewer settings (x-limits in 1d and 2d spectrum viewers and 
   stretch and percentile for 2d spectrum and image viewers). [#918]
 
+- Ability to add custom columns and change visibility of columns in the table. [#961]
+
 Specviz
 ^^^^^^^
 

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -673,29 +673,10 @@ class Mosviz(ConfigHelper):
         """
         return np.asarray(deepcopy(self.app.data_collection['MOS Table'].get_component(column_name).data)) # noqa
 
-    def add_column(self, column_name, data=None, show=True):
-        """
-        Add a new data column to the table or update the data in an existing column.
+    def _add_or_update_column(self, column_name, data=None, show=True):
+        if not isinstance(column_name, str):
+            raise TypeError("column_name must be of type str")
 
-        If ``column_name`` is 'Redshift', the column will be synced with the redshift
-        in the respective spectrum objects.
-
-        Parameters
-        ----------
-        column_name : str
-            Header string to be shown in the table.  If already exists as a column in
-            the table, the data for that column will be updated.
-        data : array-like
-            Array-like set of data values, e.g. redshifts, RA, DEC, etc.
-        show: bool or None
-            Whether to show the column in the table (defaults to True).  If None, will
-            show if the column is new, otherwise will leave at current state.
-
-        Returns
-        -------
-        array
-            copy of the data in the added or edited column.
-        """
         table_data = self.app.data_collection['MOS Table']
 
         if data is None:
@@ -719,6 +700,34 @@ class Mosviz(ConfigHelper):
             self._apply_redshift_from_table()
 
         return self.get_column(column_name)
+
+    def add_column(self, column_name, data=None, show=True):
+        """
+        Add a new data column to the table.
+
+        If ``column_name`` is 'Redshift', the column will be synced with the redshift
+        in the respective spectrum objects.
+
+        Parameters
+        ----------
+        column_name : str
+            Header string to be shown in the table.  If already exists as a column in
+            the table, the data for that column will be updated.
+        data : array-like
+            Array-like set of data values, e.g. redshifts, RA, DEC, etc.
+        show: bool or None
+            Whether to show the column in the table (defaults to True).  If None, will
+            show if the column is new, otherwise will leave at current state.
+
+        Returns
+        -------
+        array
+            copy of the data in the added or edited column.
+        """
+        if column_name in self.get_column_names():
+            raise ValueError(f"{column_name} already exists.  Use update_column to update contents")
+
+        return self._add_or_update_column(column_name, data, show=show)
 
     def update_column(self, column_name, data, row=None):
         """
@@ -756,7 +765,7 @@ class Mosviz(ConfigHelper):
 
             data[row] = replace_value
 
-        return self.add_column(column_name, data, show=None)
+        return self._add_or_update_column(column_name, data, show=None)
 
     def to_table(self):
         """

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -587,6 +587,26 @@ class Mosviz(ConfigHelper):
             table_data.add_component(data, column_name)
         return self.get_column(column_name)
 
+    def update_column(self, data, column_name, row=None):
+        """
+        """
+        table_data = self.app.data_collection['MOS Table']
+
+        if column_name not in [comp.label for comp in table_data.components]:
+            raise ValueError(f"{column_name} is not an existing column label")
+
+        if row is not None:
+            replace_value = data
+            data = self.get_column(column_name)
+            if not isinstance(row, int):
+                raise TypeError("row must be an integer or None")
+            if row < 0 or row >= len(data):
+                raise ValueError("row out of range of table")
+
+            data[row] = replace_value
+
+        return self.add_column(data, column_name)
+
     def to_table(self):
         """
         Creates an astropy `~astropy.table.QTable` object from the MOS table

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -642,7 +642,7 @@ class Mosviz(ConfigHelper):
         if column_name not in column_names:
             raise ValueError(f"{column_name} not in available columns ({column_names})")
         new_column_names = [cn for cn in self.get_column_names(True)
-                                if cn not in column_name]
+                            if cn not in column_name]
         return self.set_visible_columns(new_column_names)
 
     def show_column(self, column_name):

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -694,6 +694,14 @@ class Mosviz(ConfigHelper):
         if len(data) != table_data.size:
             raise ValueError(f"data must have length {table_data.size} (rows in table)")
 
+        if column_name == 'Redshift':
+            # then we should raise errors in advance if the values would fail
+            # when applied to the spectra
+            try:
+                _ = u.Quantity(data)
+            except TypeError:
+                raise TypeError("Redshift values must be floats or quantity objects")
+
         if column_name in self.get_column_names():
             table_data.update_components({table_data.get_component(column_name): data})
         else:

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -657,12 +657,13 @@ class Mosviz(ConfigHelper):
         if not isinstance(column_name, str):
             raise TypeError("column_name must be of type str")
 
-        column_names = self.get_column_names(True)
-        if column_name not in column_names:
-            if column_name in self.get_column_names():
-                return self.set_visible_columns(column_names+[column_name])
+        vis_column_names = self.get_column_names(True)
+        if column_name not in vis_column_names:
+            all_column_names = self.get_column_names()
+            if column_name in all_column_names:
+                return self.set_visible_columns(vis_column_names+[column_name])
             else:
-                raise ValueError(f"{column_name} not in available columns ({column_names})")
+                raise ValueError(f"{column_name} not in available columns ({all_column_names})")
 
     def get_column(self, column_name):
         """

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -70,6 +70,8 @@ class Mosviz(ConfigHelper):
 
         self._update_in_progress = False
 
+        self._default_visible_columns = []
+
     def _on_row_selected_begin(self):
         if not self.app.state.settings.get('freeze_states_on_row_change'):
             return
@@ -444,6 +446,8 @@ class Mosviz(ConfigHelper):
         loaded_msg = SnackbarMessage("MOS data loaded successfully", color="success", sender=self)
         self.app.hub.broadcast(loaded_msg)
 
+        self._default_visible_columns = self.get_column_names(True)
+
     def link_table_data(self, data_obj):
         """
         Batch link data in the Mosviz table rather than doing it on
@@ -599,15 +603,18 @@ class Mosviz(ConfigHelper):
         else:
             raise ValueError("visible must be one of None, True, or False.")
 
-    def set_visible_columns(self, column_names):
+    def set_visible_columns(self, column_names=None):
         """
         Set the columns to be visible in the table.
 
         Parameters
         ----------
-        column_names: list
-            list of columns to be visible in the table.
+        column_names: list or None
+            list of columns to be visible in the table.  If None, will default to original
+            visible columns.
         """
+        if column_names is None:
+            column_names = self._default_visible_columns
         if not isinstance(column_names, list):
             raise TypeError("column_names must be of type list")
         avail_names = self.get_column_names()

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -631,8 +631,12 @@ class Mosviz(ConfigHelper):
         if not isinstance(column_name, str):
             raise TypeError("column_name must be of type str")
 
-        column_names = [cn for cn in self.get_column_names(True) if cn not in column_name]
-        return self.set_visible_columns(column_names)
+        column_names = self.get_column_names()
+        if column_name not in column_names:
+            raise ValueError(f"{column_name} not in available columns ({column_names})")
+        new_column_names = [cn for cn in self.get_column_names(True)
+                                if cn not in column_name]
+        return self.set_visible_columns(new_column_names)
 
     def show_column(self, column_name):
         """

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -669,7 +669,7 @@ class Mosviz(ConfigHelper):
         """
         return np.asarray(deepcopy(self.app.data_collection['MOS Table'].get_component(column_name).data)) # noqa
 
-    def add_column(self, column_name, data, show=True):
+    def add_column(self, column_name, data=None, show=True):
         """
         Add a new data column to the table or update the data in an existing column.
 
@@ -685,7 +685,7 @@ class Mosviz(ConfigHelper):
             Array-like set of data values, e.g. redshifts, RA, DEC, etc.
         show: bool or None
             Whether to show the column in the table (defaults to True).  If None, will
-            leave at current state.
+            show if the column is new, otherwise will leave at current state.
 
         Returns
         -------

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -11,7 +11,7 @@ from echo import delay_callback
 from copy import deepcopy
 
 from jdaviz.core.helpers import ConfigHelper
-from jdaviz.core.events import SnackbarMessage, TableClickMessage
+from jdaviz.core.events import SnackbarMessage, TableClickMessage, RedshiftMessage
 from jdaviz.configs.specviz import Specviz
 from jdaviz.configs.mosviz.plugins import jwst_header_to_skyregion
 
@@ -56,6 +56,10 @@ class Mosviz(ConfigHelper):
         self.app.hub.subscribe(self, TableClickMessage,
                                handler=self._row_click_message_handler)
 
+        # Listen for new redshifts from the redshift slider (NOT YET IMPLEMENTED)
+        self.app.hub.subscribe(self, RedshiftMessage,
+                               handler=self._redshift_listener)
+
         self._shared_image = False
 
         self._scales1d = spec1d.scales['x']
@@ -97,6 +101,8 @@ class Mosviz(ConfigHelper):
         # callbacks may have been made while limits were frozen.  This is
         # especially important for NIRISS data.
         self._update_spec2d_x_axis()
+
+        self._apply_redshift_from_table()
 
     def _extend_world(self, spec1d, ext):
         # Extend 1D spectrum world axis to enable panning (within reason) past
@@ -180,6 +186,23 @@ class Mosviz(ConfigHelper):
             self._scales1d.max = world[idx_max]
 
         self._update_in_progress = False
+
+    def _redshift_listener(self, msg):
+        '''Save new redshifts (including from the helper itself)'''
+        if msg.param == "redshift":
+            row = self.app.get_viewer('table-viewer').widget_table.highlighted
+            # NOTE: this updates the value in the table for the current row.  This
+            # in turn will feedback to call _apply_redshift_from_table and set
+            # the internal value.  When implementing the slider itself, this logic
+            # may need to be changed slightly to avoid a race condition.
+            self.update_column('Redshift', msg.value, row=row)
+
+    def _apply_redshift_from_table(self):
+        # NOTE: this only applies to mosviz.specviz.get_spectra(...)
+        # not mosviz.app.get_data_from_viewer(...).  This should be
+        # cleaned up when the slider is implemented in mosviz.
+        row = self.app.get_viewer('table-viewer').widget_table.highlighted
+        self.specviz._redshift = self.get_column('Redshift')[row]
 
     def _show_panning_warning(self):
         now = time()
@@ -379,6 +402,33 @@ class Mosviz(ConfigHelper):
 
         self.link_table_data(None)
 
+        # Parse any information from the files into columns in the table
+        def _get_sp_attribute(table_data, row, attr, fill=None):
+            sp1_name = table_data['1D Spectra'][row]
+            sp1 = self.app.data_collection[sp1_name].get_object()
+            sp1_val = getattr(sp1, attr, None)
+
+            sp2_name = table_data['2D Spectra'][row]
+            sp2 = self.app.data_collection[sp2_name].get_object()
+            sp2_val = getattr(sp2, attr, sp1_val)
+
+            if sp1_val is not None and sp1_val != sp2_val:
+                # then there was a conflict
+                msg = f"Warning: value for {attr} in row {row} in disagreement between Spectrum1D and Spectrum2D" # noqa
+                logging.warning(msg)
+                msg = SnackbarMessage(msg, color='warning', sender=self)
+                self.app.hub.broadcast(msg)
+
+            if sp2_val is None:
+                return fill
+
+            return sp2_val
+
+        table_data = self.app.data_collection['MOS Table']
+        redshifts = np.asarray([_get_sp_attribute(table_data, row, 'redshift', 0)
+                                for row in range(table_data.size)])
+        self.add_column(column_name='Redshift', data=redshifts, show=np.any(redshifts != 0))
+
         # Any subsequently added data will automatically be linked
         # with data already loaded in the app
         self.app.auto_link = True
@@ -529,34 +579,84 @@ class Mosviz(ConfigHelper):
         super().load_data(data_obj, parser_reference="mosviz-image-parser",
                           data_labels=data_labels, share_image=share_image)
 
-
-    def get_redshift_column(self):
+    def get_column_names(self, visible=None):
         """
-        """
-        return self.get_column(column_name='Redshift')
-
-    def add_redshift_column(self, data=None):
-        """
-        Add a redshift column to the table labeled "Redshift".
+        List the names of the columns in the table.
 
         Parameters
         ----------
-        data: array-like or None
-            Array-like set of data values for redshifts.  If None or not provided,
-            will default to a list of Nones.  Otherwise must be the same length as
-            there are rows in the table.
+        visible: bool or None
+            If None (default): will show all available column names.
+            If True: will only show columns names currently shown in the table.
+            If False: will only show column names currently not shown in the table.
         """
-        return self.add_column(data, column_name='Redshift')
+        if visible is None:
+            return [c.label for c in self.app.data_collection['MOS Table'].components]
+        elif visible is True:
+            return [h['value'] for h in self.app.get_viewer('table-viewer').widget_table.headers]
+        elif visible is False:
+            return [cn for cn in self.get_column_names() if cn not in self.get_column_names(True)]
+        else:
+            raise ValueError("visible must be one of None, True, or False.")
 
-    def update_redshift_column(self, data, row=None):
+    def set_visible_columns(self, column_names):
         """
+        Set the columns to be visible in the table.
+
+        Parameters
+        ----------
+        column_names: list
+            list of columns to be visible in the table.
         """
-        return self.update_column(data, column_name='Redshift', row=row)
+        if not isinstance(column_names, list):
+            raise TypeError("column_names must be of type list")
+        avail_names = self.get_column_names()
+        if not np.all([c in avail_names for c in column_names]):
+            raise ValueError("not all entries of column_names are valid")
+        is_sortable = ['Redshift']
+        headers = [{'text': cn, 'value': cn, 'sortable': cn in is_sortable} for cn in column_names]
+        wt = self.app.get_viewer('table-viewer').widget_table
+        wt.set_state({'headers': headers})
+        wt.send_state()
+
+    def hide_column(self, column_name):
+        """
+        Hide a single column in the table.
+
+        Parameters
+        ----------
+        column_name: str
+            Name of the column to hide
+        """
+        if not isinstance(column_name, str):
+            raise TypeError("column_name must be of type str")
+
+        column_names = [cn for cn in self.get_column_names(True) if cn not in column_name]
+        return self.set_visible_columns(column_names)
+
+    def show_column(self, column_name):
+        """
+        Show a hidden column in the table.
+
+        Parameters
+        ----------
+        column_name: str
+            Name of the column to show
+        """
+        if not isinstance(column_name, str):
+            raise TypeError("column_name must be of type str")
+
+        column_names = self.get_column_names(True)
+        if column_name not in column_names:
+            if column_name in self.get_column_names():
+                return self.set_visible_columns(column_names+[column_name])
+            else:
+                raise ValueError(f"{column_name} not in available columns ({column_names})")
 
     def get_column(self, column_name):
         """
         Get the data from a column in the table.
-        
+
         Parameters
         ----------
         column_name: str
@@ -569,21 +669,23 @@ class Mosviz(ConfigHelper):
         """
         return np.asarray(deepcopy(self.app.data_collection['MOS Table'].get_component(column_name).data)) # noqa
 
-
-    def add_column(self, data, column_name):
+    def add_column(self, column_name, data, show=True):
         """
         Add a new data column to the table or update the data in an existing column.
-        
+
         If ``column_name`` is 'Redshift', the column will be synced with the redshift
         in the respective spectrum objects.
 
         Parameters
         ----------
-        data : array-like
-            Array-like set of data values, e.g. redshifts, RA, DEC, etc.
         column_name : str
             Header string to be shown in the table.  If already exists as a column in
             the table, the data for that column will be updated.
+        data : array-like
+            Array-like set of data values, e.g. redshifts, RA, DEC, etc.
+        show: bool or None
+            Whether to show the column in the table (defaults to True).  If None, will
+            leave at current state.
 
         Returns
         -------
@@ -599,37 +701,45 @@ class Mosviz(ConfigHelper):
         if len(data) != table_data.size:
             raise ValueError(f"data must have length {table_data.size} (rows in table)")
 
-        if column_name == 'Redshift':
-            # Then any non-provided values should default to those in the
-            # underlying Spectrum1D objects.  And any provided values should
-            # be pushed to the Spectrum1D and Spectrum 2D objects.
-            for row, d in enumerate(data):
-                sp1_name = table_data['1D Spectra'][row]
-                sp1 = self.app.data_collection[sp1_name].get_object()
-                sp2_name = table_data['2D Spectra'][row]
-                sp2 = self.app.data_collection[sp2_name].get_object()
-
-                if d is not None:
-                    # then push to the spectrum1D/2D
-                    sp1.redshift = d
-                    sp2.redshift = d
-                else:
-                    # then pull from the spectrum1D
-                    # TODO: should we check for consistency with the Spectrum2D?
-                    data[row] = sp1.redshift
-
-        if column_name in [comp.label for comp in table_data.components]:
+        if column_name in self.get_column_names():
             table_data.update_components({table_data.get_component(column_name): data})
         else:
             table_data.add_component(data, column_name)
+        if show is True:
+            self.show_column(column_name)
+        elif not show and show is not None:
+            self.hide_column(column_name)
+
+        if column_name == 'Redshift':
+            # apply the value in the current row to the specviz object
+            self._apply_redshift_from_table()
+
         return self.get_column(column_name)
 
-    def update_column(self, data, column_name, row=None):
+    def update_column(self, column_name, data, row=None):
         """
-        """
-        table_data = self.app.data_collection['MOS Table']
+        Update the data in an existing column.
 
-        if column_name not in [comp.label for comp in table_data.components]:
+        If ``column_name`` is 'Redshift', the column will be synced with the redshift
+        in the respective spectrum objects.
+
+        Parameters
+        ----------
+        column_name: str
+            Name of the existing column to update
+        data: array-like or float/int/string
+            Array-like set of data values or value at a single index (in which
+            case ``row`` must be provided)
+        row: None or int
+            Index of the row to replace.  If None, will replace entire column
+            and ``data`` must be array-like with the appropriate length.
+
+        Returns
+        -------
+        array
+            copy of the data in the edited column
+        """
+        if column_name not in self.get_column_names():
             raise ValueError(f"{column_name} is not an existing column label")
 
         if row is not None:
@@ -642,7 +752,7 @@ class Mosviz(ConfigHelper):
 
             data[row] = replace_value
 
-        return self.add_column(data, column_name)
+        return self.add_column(column_name, data, show=None)
 
     def to_table(self):
         """

--- a/jdaviz/configs/mosviz/tests/test_helper.py
+++ b/jdaviz/configs/mosviz/tests/test_helper.py
@@ -350,3 +350,8 @@ def test_custom_columns(mosviz_app, image, spectrum1d, spectrum2d):
                 ValueError,
                 match="data must have length 2 \\(rows in table\\)"):
         mosviz_app.add_column('custom_name_2', [0.1])
+
+    mosviz_app.show_column("Redshift")
+    assert "Redshift" in mosviz_app.get_column_names(True)
+    mosviz_app.set_visible_columns()
+    assert "Redshift" not in mosviz_app.get_column_names(True)

--- a/jdaviz/configs/mosviz/tests/test_helper.py
+++ b/jdaviz/configs/mosviz/tests/test_helper.py
@@ -296,12 +296,12 @@ def test_table_scrolling(mosviz_app, image, spectrum1d, spectrum2d):
     # (otherwise it would be None which is a case not handled)
     table.widget_table.highlighted = 0
     table.next_row()
-    assert(table.widget_table.highlighted == 1)
+    assert table.widget_table.highlighted == 1
     table.next_row()
     # with only 2 rows, this should wrap back to 0
-    assert(table.widget_table.highlighted == 0)
+    assert table.widget_table.highlighted == 0
     table.prev_row()
-    assert(table.widget_table.highlighted == 1)
+    assert table.widget_table.highlighted == 1
 
 
 @pytest.mark.filterwarnings('ignore')
@@ -316,15 +316,15 @@ def test_column_visibility(mosviz_app, image, spectrum1d, spectrum2d):
                 match="visible must be one of None, True, or False."):
         mosviz_app.get_column_names(visible='string')
 
-    assert('Redshift' not in mosviz_app.get_column_names(True))
-    assert('Redshift' in mosviz_app.get_column_names(False))
-    assert('Redshift' in mosviz_app.get_column_names())
+    assert 'Redshift' not in mosviz_app.get_column_names(True)
+    assert 'Redshift' in mosviz_app.get_column_names(False)
+    assert 'Redshift' in mosviz_app.get_column_names()
 
     mosviz_app.show_column('Redshift')
-    assert('Redshift' in mosviz_app.get_column_names(True))
+    assert 'Redshift' in mosviz_app.get_column_names(True)
 
     mosviz_app.hide_column('Redshift')
-    assert('Redshift' not in mosviz_app.get_column_names(True))
+    assert 'Redshift' not in mosviz_app.get_column_names(True)
 
 
 @pytest.mark.filterwarnings('ignore')
@@ -335,11 +335,11 @@ def test_custom_columns(mosviz_app, image, spectrum1d, spectrum2d):
     mosviz_app.load_data(spectra1d, spectra2d, images=image)
 
     mosviz_app.add_column('custom_name')
-    assert('custom_name' in mosviz_app.get_column_names(True))
-    assert(len(mosviz_app.get_column('custom_name')) == 2)
+    assert 'custom_name' in mosviz_app.get_column_names(True)
+    assert len(mosviz_app.get_column('custom_name')) == 2
 
     mosviz_app.update_column('custom_name', 0.1, row=1)
-    assert(mosviz_app.get_column('custom_name')[1] == 0.1)
+    assert mosviz_app.get_column('custom_name')[1] == 0.1
 
     with pytest.raises(
                 ValueError,

--- a/jdaviz/configs/mosviz/tests/test_helper.py
+++ b/jdaviz/configs/mosviz/tests/test_helper.py
@@ -302,3 +302,51 @@ def test_table_scrolling(mosviz_app, image, spectrum1d, spectrum2d):
     assert(table.widget_table.highlighted == 0)
     table.prev_row()
     assert(table.widget_table.highlighted == 1)
+
+
+@pytest.mark.filterwarnings('ignore')
+def test_column_visibility(mosviz_app, image, spectrum1d, spectrum2d):
+    spectra1d = [spectrum1d] * 2
+    spectra2d = [spectrum2d] * 2
+
+    mosviz_app.load_data(spectra1d, spectra2d, images=image)
+
+    with pytest.raises(
+                ValueError,
+                match="visible must be one of None, True, or False."):
+        mosviz_app.get_column_names(visible='string')
+
+    assert('Redshift' not in mosviz_app.get_column_names(True))
+    assert('Redshift' in mosviz_app.get_column_names(False))
+    assert('Redshift' in mosviz_app.get_column_names())
+
+    mosviz_app.show_column('Redshift')
+    assert('Redshift' in mosviz_app.get_column_names(True))
+
+    mosviz_app.hide_column('Redshift')
+    assert('Redshift' not in mosviz_app.get_column_names(True))
+
+
+@pytest.mark.filterwarnings('ignore')
+def test_custom_columns(mosviz_app, image, spectrum1d, spectrum2d):
+    spectra1d = [spectrum1d] * 2
+    spectra2d = [spectrum2d] * 2
+
+    mosviz_app.load_data(spectra1d, spectra2d, images=image)
+
+    mosviz_app.add_column('custom_name')
+    assert('custom_name' in mosviz_app.get_column_names(True))
+    assert(len(mosviz_app.get_column('custom_name')) == 2)
+
+    mosviz_app.update_column('custom_name', 0.1, row=1)
+    assert(mosviz_app.get_column('custom_name')[1] == 0.1)
+
+    with pytest.raises(
+                ValueError,
+                match="row out of range of table"):
+        mosviz_app.update_column('custom_name', 0.3, row=3)
+
+    with pytest.raises(
+                ValueError,
+                match="data must have length 2 \\(rows in table\\)"):
+        mosviz_app.add_column('custom_name_2', [0.1])


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements helper methods in mosviz to create and modify custom columns in the table.

* `mosviz.get_column`: access a copy of the array in a column from the table
* `mosviz.add_column`: existed before, but now requires column_name to be passed (instead of defaulting to None), and to overwrite the data if column_name already exists (instead of adding a duplicate column).  ~~Alternatively we could create a separate `mosviz.update_column` and raise an error in `mosviz.add_column` if the label already exists?~~  This PR also changes the order of the arguments so the column name comes first to be more intuitive and self-consistent with other new methods.
* ~~`mosviz.add_redshift_column`: wrapper around `add_column` that sets `column_name='Redshift'` so that we know the exact column name and can use internally for future plugin work, etc.~~
* ~~the data itself defaults to `[None]*nrows` and all three methods return a copy of the array (which you can then modify and pass back to `add_column` to update the existing entry).~~
* `mosviz.update_column`: allows changing the value of a single _entry_ in the column by providing the row index.
* `mosviz.get_column_names`: convenience method to access all column names (hidden, visible, or both)
* `mosviz.hide_column`, `mosviz.show_column`, `mosviz.set_visible_columns`: methods to allow changing which columns are shown in the table UI
* a "Redshift" column is now automatically populated with the redshift from the loaded spectra and is shown if any values are non-zero, otherwise is hidden by default.
* `mosviz.specviz.get_spectra()` will expose a Spectrum1D with the redshift set matching the value shown in the table for that row.  Note that `mosviz.app.get_data_from_viewer()` will **not** currently include the redshift, but this does not in specviz currently either.  May want to consider if this is expected behavior.
* `mosviz.specviz.set_redshift` will set the value for the current entry in the table (in addition to `mosviz.update_column("Redshift", value, row)`).  This provides the foundation for hooks needed for the slider, but some refactoring may be necessary to extend to the 2D spectrum and to avoid race conditions.


Example case:
* load the Mosviz example notebook
* `mosviz.show_column('Redshift')`: should show the column since it defaulted to hidden for being all 0s
* `mosviz.update_column('Redshift', 0.2, row=0)`: should change the first row to have a redshift of 0.2
* `mosviz.app.get_data_from_viewer('spectrum-viewer')['1D Spectrum 0'].redshift`: will return 0 as this does not currently listen to the set redshift
* `mosviz.specviz.get_spectra()['1D Spectrum 0'].redshift`: will return 0.2 to match the value in the table
* `mosviz.specviz.set_redshift(0.3)`: will change the value in the table to 0.3 and provides the hook for the slider functionality for the current row.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
