### PR TITLE
add Imviz_RadialPlot_Example.ipynb

### DIFF
--- a/notebooks/concepts/Imviz_RadialPlot_Example.ipynb
+++ b/notebooks/concepts/Imviz_RadialPlot_Example.ipynb
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "a4b3aee3",
    "metadata": {},
    "outputs": [],
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "53fb47da-0427-4a43-9d11-39567a12cdb0",
    "metadata": {},
    "outputs": [],
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "0915bde6-e3cc-4038-aca1-c2ae852f7a69",
    "metadata": {},
    "outputs": [],
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "0e81c635-97eb-459c-bfc0-3136839c2844",
    "metadata": {},
    "outputs": [],
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "bccca7f4",
    "metadata": {},
    "outputs": [],
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "77c97590",
    "metadata": {},
    "outputs": [],
@@ -164,25 +164,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "229d64f3-843f-4a7f-ac98-989f2a95d4c1",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1e1c5d5e2c804bd1adb4d0a9a47a05ac",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Application(components={'g-viewer-tab': '<template>\\n  <component :is=\"stack.container\">\\n    <g-viewer-tab\\n …"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "imviz.app"
    ]
@@ -197,13 +182,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "77d5c1d4",
    "metadata": {},
    "outputs": [],
    "source": [
     "glue_app = imviz.app._application_handler\n",
-    "imdata = glue_app.data_collection[0]"
+    "d = glue_app.data_collection[0]"
    ]
   },
   {
@@ -250,6 +235,119 @@
   },
   {
    "cell_type": "markdown",
+   "id": "394bb604",
+   "metadata": {},
+   "source": [
+    "# From simple aperture photometry plugin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9439d322",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jdaviz.configs.imviz.plugins.aper_phot_simple.aper_phot_simple import SimpleAperturePhotometry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a345924",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plg = SimpleAperturePhotometry(app=imviz.app)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8902b9ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plg.vue_data_selected('acs_47tuc_1[SCI,1]')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ee18830",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plg.vue_subset_selected('Subset 1')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "536226a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This code is already inside the plugin\n",
+    "self = plg\n",
+    "data = self._selected_data\n",
+    "reg = self._selected_subset\n",
+    "comp = data.get_component(data.main_components[0])\n",
+    "bg = 0\n",
+    "comp_no_bg = comp.data - bg\n",
+    "aper_mask = reg.to_mask(mode='subpixels', subpixels=32)  # rectangle\n",
+    "img = aper_mask.get_values(comp_no_bg, mask=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f1ebf3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sanity check: Should match Imviz viewer selection above.\n",
+    "plt.imshow(img.reshape(aper_mask.shape), vmin=46, vmax=287, origin='lower')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2760cfc2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is new code that we need to add\n",
+    "reg_bb = reg.bounding_box\n",
+    "xx = np.ogrid[reg_bb.iymin:reg_bb.iymax, reg_bb.ixmin:reg_bb.ixmax]\n",
+    "dx = xx[1] - reg.center.x\n",
+    "dy = xx[0] - reg.center.y\n",
+    "r = np.hypot(dx, dy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cebe4a5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We can use the glue_app stuff here, but I just want to\n",
+    "# see if we get the same result in Matplotlib.\n",
+    "# Should look the same as \"Subset based selection\" below.\n",
+    "#\n",
+    "# Kyle, this is what will get sent to the frontend:\n",
+    "#      r.ravel(), img\n",
+    "#\n",
+    "# Frontend consideration: I don't think we can use\n",
+    "# glue_app.add_data() because we do not want to flood\n",
+    "# the app data collection with temporary buffer.\n",
+    "# Would be nice to have a plot-and-forget way to do this.\n",
+    "plt.plot(r.ravel(), img, 'k.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ec99610f",
    "metadata": {},
    "source": [
@@ -258,13 +356,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "fcc6bfbc",
    "metadata": {},
    "outputs": [],
    "source": [
     "glue_app = imviz.app._application_handler\n",
     "imdata = glue_app.data_collection[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "293fe111",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imdata.subsets"
    ]
   },
   {
@@ -344,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 158,
+   "execution_count": null,
    "id": "9b1da905",
    "metadata": {},
    "outputs": [],
@@ -356,27 +464,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 168,
+   "execution_count": null,
    "id": "37a6a8c9",
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8cd8dd4bb0fe4881ad242eebc4aeaaa3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Application(components={'g-viewer-tab': '<template>\\n  <component :is=\"stack.container\">\\n    <g-viewer-tab\\n …"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "imviz = Imviz()\n",
     "viewer = imviz.default_viewer\n",
@@ -471,25 +564,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 169,
+   "execution_count": null,
    "id": "b57aafb2",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3c1637cc35254da9bd0f19feb361e751",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "rpl.output"
    ]
@@ -504,21 +582,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": null,
    "id": "aa1340e6",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<bound method JupyterApplication.new_data_viewer of <glue_jupyter.app.JupyterApplication object at 0x7f26b5281d90>>"
-      ]
-     },
-     "execution_count": 178,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "glue_app.new_data_viewer"
    ]
@@ -596,7 +663,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/notebooks/concepts/Imviz_RadialPlot_Example.ipynb
+++ b/notebooks/concepts/Imviz_RadialPlot_Example.ipynb
@@ -204,9 +204,9 @@
     "boxrad = 3\n",
     "msk = (slice(y0-boxrad, y0+boxrad), slice(x0-boxrad, x0+boxrad))\n",
     "\n",
-    "dx = imdata.get_data(d.components[1])[msk] - x0\n",
-    "dy = imdata.get_data(d.components[0])[msk] - y0\n",
-    "dat = imdata.get_data(d.components[-1])[msk]\n",
+    "dx = d.get_data(d.components[1])[msk] - x0\n",
+    "dy = d.get_data(d.components[0])[msk] - y0\n",
+    "dat = d.get_data(d.components[-1])[msk]\n",
     "r = np.hypot(dx, dy)"
    ]
   },

--- a/notebooks/concepts/Imviz_RadialPlot_Example.ipynb
+++ b/notebooks/concepts/Imviz_RadialPlot_Example.ipynb
@@ -5,10 +5,11 @@
    "id": "17b4af6f",
    "metadata": {},
    "source": [
-    "# Imviz Demonstration Notebook\n",
+    "# Imviz Radialplot Non-plugin plugin\n",
     "\n",
+    "This concept notebooks shows how to make a glue/bqplot-based plot in a notebook that's separate from the jdaviz interface itself.  I.e., a \"plugin without the plugin\".\n",
     "\n",
-    "This notebook demonstrates the Imviz API in the Notebook setting. UI equivalents for these actions, as well as additional documentation about Imviz, can be found here: https://jdaviz.readthedocs.io/en/latest/imviz/"
+    "The first chunk of this notebook starts up imviz, following from the `ImvizExample` notebook."
    ]
   },
   {
@@ -177,7 +178,9 @@
    "id": "9717438c",
    "metadata": {},
    "source": [
-    "# By-hand star location setting"
+    "# Glue secret sauce\n",
+    "\n",
+    "## By-hand star location setting"
    ]
   },
   {
@@ -238,7 +241,7 @@
    "id": "394bb604",
    "metadata": {},
    "source": [
-    "# From simple aperture photometry plugin"
+    "## From simple aperture photometry plugin"
    ]
   },
   {
@@ -447,7 +450,7 @@
    "id": "9c27908d",
    "metadata": {},
    "source": [
-    "# Live update from subset version "
+    "## Live update from subset version "
    ]
   },
   {
@@ -663,7 +666,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/notebooks/concepts/Imviz_RadialPlot_Example.ipynb
+++ b/notebooks/concepts/Imviz_RadialPlot_Example.ipynb
@@ -1,0 +1,618 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "17b4af6f",
+   "metadata": {},
+   "source": [
+    "# Imviz Demonstration Notebook\n",
+    "\n",
+    "\n",
+    "This notebook demonstrates the Imviz API in the Notebook setting. UI equivalents for these actions, as well as additional documentation about Imviz, can be found here: https://jdaviz.readthedocs.io/en/latest/imviz/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b0f5142",
+   "metadata": {},
+   "source": [
+    "We start off by silencing warnings that can happen when loading data as well as deprecation warnings, for clarity:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a4b3aee3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "warnings.simplefilter('ignore')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc45bbab-ddb7-4d24-8066-998a1ba17fd3",
+   "metadata": {},
+   "source": [
+    "We also need this to display Matplotlib in the notebook later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "53fb47da-0427-4a43-9d11-39567a12cdb0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c73155f-c062-461a-8ca7-0891ce142901",
+   "metadata": {},
+   "source": [
+    "Import modules needed for this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0915bde6-e3cc-4038-aca1-c2ae852f7a69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from astropy import units as u\n",
+    "from astropy.coordinates import SkyCoord, Angle\n",
+    "from astropy.table import Table\n",
+    "from astropy.utils.data import download_file\n",
+    "from photutils import CircularAperture, SkyCircularAperture\n",
+    "from regions import PixCoord, CirclePixelRegion, CircleSkyRegion\n",
+    "\n",
+    "from jdaviz import Imviz"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1120d18-65a4-41ec-b831-bc3637718b90",
+   "metadata": {},
+   "source": [
+    "We create an Imviz instance and grab the default viewer instance as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0e81c635-97eb-459c-bfc0-3136839c2844",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz = Imviz()\n",
+    "viewer = imviz.default_viewer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60eb5782-264f-4af4-bb6e-ae583398277d",
+   "metadata": {},
+   "source": [
+    "Download some data. In this example, we use two 47 Tuc observations from HST/ACS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "bccca7f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "acs_47tuc_1 = download_file('https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HST/product/jbqf03gjq_flc.fits', cache=True)\n",
+    "acs_47tuc_2 = download_file('https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HST/product/jbqf03h1q_flc.fits', cache=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ec7c554",
+   "metadata": {},
+   "source": [
+    "Load the data into Imviz. Data are linked by pixels as they load."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "77c97590",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz.load_data(acs_47tuc_1, data_label='acs_47tuc_1')\n",
+    "imviz.load_data(acs_47tuc_2, data_label='acs_47tuc_2')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f38a4e4d-d4ce-4bd6-9f6f-43eed3813f1b",
+   "metadata": {},
+   "source": [
+    "Alternately, we can also visualize some simulated JWST imager data. If you wish to do this, do not run the two ACS-related cells above; turn the following cell into code and run it instead.\n",
+    "\n",
+    "*Note: Some subsequent cells, especially those involving sky coordinates, might not work with the JWST data.*"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "855f49fc-092a-48a2-8741-a10246cb02ae",
+   "metadata": {},
+   "source": [
+    "jwf277w = download_file('https://stsci.box.com/shared/static/iao1zxtigyrhq7k3wtu5nchrxzlhj9kv.fits', cache=True)\n",
+    "jwf444w = download_file('https://stsci.box.com/shared/static/rey83o5wq6g7qd7xym6r1jq9wlsxaqnt.fits', cache=True)\n",
+    "\n",
+    "imviz.load_data(jwf277w, data_label='JWST_F277W')\n",
+    "imviz.load_data(jwf444w, data_label='JWST_F444W')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e28b9919-6f9e-410c-83f6-554631407d4b",
+   "metadata": {},
+   "source": [
+    "Then, we visualize the data and start off by looking at some of the basic features:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "229d64f3-843f-4a7f-ac98-989f2a95d4c1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1e1c5d5e2c804bd1adb4d0a9a47a05ac",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Application(components={'g-viewer-tab': '<template>\\n  <component :is=\"stack.container\">\\n    <g-viewer-tab\\n …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "imviz.app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9717438c",
+   "metadata": {},
+   "source": [
+    "# By-hand star location setting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "77d5c1d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "glue_app = imviz.app._application_handler\n",
+    "imdata = glue_app.data_collection[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "436521a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 38, 18 has a star\n",
+    "\n",
+    "x0, y0 = 38, 18\n",
+    "boxrad = 3\n",
+    "msk = (slice(y0-boxrad, y0+boxrad), slice(x0-boxrad, x0+boxrad))\n",
+    "\n",
+    "dx = imdata.get_data(d.components[1])[msk] - x0\n",
+    "dy = imdata.get_data(d.components[0])[msk] - y0\n",
+    "dat = imdata.get_data(d.components[-1])[msk]\n",
+    "r = np.hypot(dx, dy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "727a192e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "glue_app.add_data(plotdat=dict(rdat=r, dat=dat))\n",
+    "scat2d = glue_app.scatter2d(data='plotdat', x='rdat', y='dat')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96db6ced",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "scat2d.figure_widget"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec99610f",
+   "metadata": {},
+   "source": [
+    "# Subset based selection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "fcc6bfbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "glue_app = imviz.app._application_handler\n",
+    "imdata = glue_app.data_collection[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8789a764",
+   "metadata": {},
+   "source": [
+    "Draw a rectangular subset around a star or whatever"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c0ca41f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subset0 = imdata.subsets[0]\n",
+    "subset0.components"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3fe045b",
+   "metadata": {},
+   "source": [
+    "Assume the \"center\" is the middle pixel or between the two center-most pixels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd6febce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x0 = np.mean(subset0['Pixel Axis 1 [x]'])\n",
+    "y0 = np.mean(subset0['Pixel Axis 0 [y]'])\n",
+    "x0, y0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3471330",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dx = subset0['Pixel Axis 1 [x]'] - x0\n",
+    "dy = subset0['Pixel Axis 0 [y]'] - y0\n",
+    "r = np.hypot(dx, dy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f44ba00e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# remove existing subset just so we can re-run this cell if desired\n",
+    "torem = [d for d in glue_app.data_collection if d.label =='plotdat_sub']\n",
+    "for d in torem:\n",
+    "    glue_app.data_collection.remove(d)\n",
+    "\n",
+    "glue_app.add_data(plotdat_sub=dict(rdat=r, dat=subset0['SCI,1']))\n",
+    "scat2d = glue_app.scatter2d(data='plotdat_sub', x='rdat', y='dat')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c27908d",
+   "metadata": {},
+   "source": [
+    "# Live update from subset version "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 158,
+   "id": "9b1da905",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import Output\n",
+    "from glue.core import Hub, HubListener, Data, DataCollection\n",
+    "from glue.core.message import SubsetUpdateMessage, Message"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 168,
+   "id": "37a6a8c9",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8cd8dd4bb0fe4881ad242eebc4aeaaa3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Application(components={'g-viewer-tab': '<template>\\n  <component :is=\"stack.container\">\\n    <g-viewer-tab\\n …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "imviz = Imviz()\n",
+    "viewer = imviz.default_viewer\n",
+    "\n",
+    "imviz.load_data(acs_47tuc_1, data_label='acs_47tuc_1')\n",
+    "imviz.load_data(acs_47tuc_2, data_label='acs_47tuc_2')\n",
+    "\n",
+    "class RadialPlotListener(HubListener):\n",
+    "\n",
+    "    def __init__(self, glueapp, dataname, subset_data_label='plotdat_sub', data_component_label='SCI,1'):\n",
+    "        self.gapp = glueapp\n",
+    "        self.image_data_name = dataname\n",
+    "        \n",
+    "        self.radial_data_label = subset_data_label\n",
+    "        self.data_component_label = data_component_label\n",
+    "        \n",
+    "        self.last_x0 = self.last_y0 = self.radial_data = self.scatter = None\n",
+    "        \n",
+    "        self.gapp.data_collection.hub.subscribe(self, SubsetUpdateMessage, handler=self.receive_message)\n",
+    "        \n",
+    "        self.msg = []\n",
+    "        \n",
+    "        self.output = Output()\n",
+    "\n",
+    "    def receive_message(self, message):\n",
+    "        self.msg.append('msg')\n",
+    "        if message.sender.data.label == self.image_data_name:\n",
+    "            self.msg.append('inner')\n",
+    "            try:\n",
+    "                self.update_data(message.subset)\n",
+    "            except Exception as e:\n",
+    "                self.msg.append('ERR:' + str(e))\n",
+    "            self.msg.append('done')\n",
+    "        \n",
+    "    def update_data(self, subset):\n",
+    "        self.last_x0 = np.mean(subset['Pixel Axis 1 [x]'])\n",
+    "        self.last_y0 = np.mean(subset['Pixel Axis 0 [y]'])\n",
+    "        dx = subset['Pixel Axis 1 [x]'] - self.last_x0 \n",
+    "        dy = subset['Pixel Axis 0 [y]'] - self.last_y0 \n",
+    "        r = np.hypot(dx, dy)\n",
+    "        \n",
+    "        existing = [d for d in self.gapp.data_collection if d.label == self.radial_data_label]\n",
+    "        for d in existing:\n",
+    "            self.gapp.data_collection.remove(d)\n",
+    "            \n",
+    "        \n",
+    "#         self.msg.append('h')\n",
+    "#         # TODO: make it not overwrite existing plots?\n",
+    "#         existing = [d for d in self.gapp.data_collection if d.label == self.radial_data_label]\n",
+    "#         if len(existing) > 0:\n",
+    "#             self.msg.append('>0')\n",
+    "#             self.radial_data = existing[0]\n",
+    "#             if len(existing) > 1:\n",
+    "#                 self.msg.append('>1')\n",
+    "#                 for d in existing[1:]:\n",
+    "#                     self.gapp.data_collection.remove(d)\n",
+    "#             self.msg.append('>1-b')\n",
+    "                    \n",
+    "#             for comp in self.radial_data.components.copy():\n",
+    "#                 self.radial_data.remove_component(comp)\n",
+    "#             self.msg.append('postfor')\n",
+    "#             self.radial_data['rdat'] = r\n",
+    "#             self.msg.append('postfor1')\n",
+    "#             self.radial_data['dat']= subset[self.data_component_label]\n",
+    "#             self.msg.append('postfor2')\n",
+    "#         else:\n",
+    "#             self.msg.append('else')\n",
+    "        self.radial_data = self.gapp.add_data(**{self.radial_data_label:dict(rdat=r, dat=subset[self.data_component_label])})[0]\n",
+    "        self.update_plot()\n",
+    "    \n",
+    "    def update_plot(self):\n",
+    "        self.scatter = self.gapp.scatter2d(data=self.radial_data_label, x='rdat', y='dat')\n",
+    "        \n",
+    "        self.output.clear_output()\n",
+    "        with self.output:\n",
+    "            self.scatter.show()\n",
+    "            \n",
+    "        return self.output\n",
+    "    \n",
+    "rpl = RadialPlotListener(imviz.app._application_handler, 'acs_47tuc_1[SCI,1]')\n",
+    "\n",
+    "imviz.app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17412099",
+   "metadata": {},
+   "source": [
+    "Now select a subset *before* running the below cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 169,
+   "id": "b57aafb2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3c1637cc35254da9bd0f19feb361e751",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "rpl.output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5e34f40",
+   "metadata": {},
+   "source": [
+    "NOTE: There's probably a way to update the scatter plot's data without having to recreate the bqplot each time.  But I'm not sure how to do it without"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 178,
+   "id": "aa1340e6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<bound method JupyterApplication.new_data_viewer of <glue_jupyter.app.JupyterApplication object at 0x7f26b5281d90>>"
+      ]
+     },
+     "execution_count": 178,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "glue_app.new_data_viewer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e6beadc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49834de4",
+   "metadata": {},
+   "source": [
+    "Below is for debugging glue messages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70ce1cda",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "\n",
+    "outp = widgets.Output()\n",
+    "outp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6f1a4ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from glue.core import Hub, HubListener, Data, DataCollection\n",
+    "from glue.core.message import (DataMessage, Message,\n",
+    "                               DataCollectionMessage)\n",
+    "\n",
+    "class MyListener(HubListener):\n",
+    "\n",
+    "    def __init__(self, hub, output):\n",
+    "        self.output = output\n",
+    "        hub.subscribe(self, Message,\n",
+    "                      handler=self.receive_message)\n",
+    "        #hub.subscribe(self, DataMessage,\n",
+    "        #              handler=self.receive_message)\n",
+    "\n",
+    "    def receive_message(self, message):\n",
+    "        with self.output:\n",
+    "            print(\"Message received:\")\n",
+    "            print(\"{0}\".format(message))\n",
+    "            print(dir(message))\n",
+    "            \n",
+    "MyListener(glue_app.data_collection.hub, outp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b428cbfb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outp.clear_output()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This adds a concept notebook that shows how one can make a radial plot from a selection in imviz.

This is basically a concept for an imviz plugin.

One thing this does that is not idea: it creates a *new* bqplot scatter plot every time a new subset is created.  There's probably someway to re-use the plot and just change the data, but I couldn't figure out the right way to do this. The main problem is that I couldn't figure out a clean way to let a new data object be a different *size* from the previous one without re-creating the plot (and data object). @astrofrog  or @maartenbreddels may have ideas here?

[🐱](https://jira.stsci.edu/browse/JDAT-2055)