### PR TITLE
Add show() method as preferred entrypoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,8 @@ API Changes
   have been renamed to "Colormap" and "Monochromatic," respectively, for all image
   viewers. [#1406]
 
+- Viz tool display changed to ``viz.show()``. [#965]
+
 Cubeviz
 ^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,7 +46,7 @@ API Changes
   have been renamed to "Colormap" and "Monochromatic," respectively, for all image
   viewers. [#1406]
 
-- Viz tool display changed to ``viz.show()``. Sidecar no longer returned by 
+- Viz tool display changed to ``viz.show()`` from ``viz.app``. Sidecar no longer returned by 
   show methods. [#965]
 
 Cubeviz

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,7 +46,8 @@ API Changes
   have been renamed to "Colormap" and "Monochromatic," respectively, for all image
   viewers. [#1406]
 
-- Viz tool display changed to ``viz.show()`` to replace ``viz.app``. [#965]
+- Viz tool display changed to ``viz.show()``. Sidecar no longer returned by 
+  show methods. [#965]
 
 Cubeviz
 ^^^^^^^

--- a/docs/notebook/display.rst
+++ b/docs/notebook/display.rst
@@ -1,0 +1,28 @@
+*******************************************
+Customizing your Visualization Tool Display
+*******************************************
+
+By default, calling `show()` will display your visualization tool *inline* in your notebook, that is the tool will show underneath the notebook cell it was called from::
+
+    from jdaviz import Imviz
+
+    imviz = Imviz()
+    imviz.show()
+    imviz.load_data('filename.fits', data_label='MyData')
+
+You can additionally specify the location with the `loc` argument. For example, `inline` can be specified manually with::
+
+    imviz.show(loc='inline')
+
+Sidecar (Jupyter Lab)
+---------------------
+
+In Jupyter Lab, `sidecar` provides additional methods to customize where to show the viewer in your workspace. The following shows `jdaviz` in the default sidecar location, to the right of the notebook::
+
+    imviz.show(loc='sidecar')
+
+To manually specify the anchor location, append the anchor to sidecar, separated by a colon::
+    
+    imviz.show(loc='sidecar:right')
+
+Other anchors include: `split-right`, `split-left`, `split-top`, `split-bottom`, `tab-before`, `tab-after`. An up-to-date list can be found at `jupyterlab-sidecar <https://github.com/jupyter-widgets/jupyterlab-sidecar>`_

--- a/docs/notebook/display.rst
+++ b/docs/notebook/display.rst
@@ -4,7 +4,8 @@
 Customizing Notebook Display Layout
 ***********************************
 
-By default, calling ``show()`` will display your visualization tool *inline* in your notebook, that is the tool will show underneath the notebook cell it was called from::
+By default, calling ``show()`` will display your visualization tool *inline* in your notebook,
+that is the tool will show underneath the notebook cell it was called from::
 
     from jdaviz import Imviz
 
@@ -12,14 +13,17 @@ By default, calling ``show()`` will display your visualization tool *inline* in 
     imviz.show()
     imviz.load_data('filename.fits')
 
-You can additionally specify the location with the ``loc`` argument. For example, ``inline`` can be specified manually with::
+You can additionally specify the location with the ``loc`` argument.
+For example, ``inline`` can be specified manually with::
 
     imviz.show(loc='inline')
 
 Sidecar (Jupyter Lab)
 ---------------------
 
-In Jupyter Lab, ``sidecar`` provides additional methods to customize where to show the viewer in your workspace. The following shows ``jdaviz`` in the default sidecar location, to the right of the notebook::
+In Jupyter Lab, ``sidecar`` provides additional methods to customize where to show the viewer
+in your workspace. The following shows ``jdaviz`` in the default sidecar location,
+to the right of the notebook::
 
     imviz.show(loc='sidecar')
 
@@ -27,4 +31,6 @@ To manually specify the anchor location, append the anchor to sidecar, separated
     
     imviz.show(loc='sidecar:right')
 
-Other anchors include: ``split-right``, ``split-left``, ``split-top``, ``split-bottom``, ``tab-before``, ``tab-after``, ``right``. An up-to-date list can be found at `jupyterlab-sidecar <https://github.com/jupyter-widgets/jupyterlab-sidecar>`_.
+Other anchors include: ``split-right``, ``split-left``, ``split-top``, ``split-bottom``,
+``tab-before``, ``tab-after``, ``right``. An up-to-date list can be found at
+`jupyterlab-sidecar <https://github.com/jupyter-widgets/jupyterlab-sidecar>`_.

--- a/docs/notebook/display.rst
+++ b/docs/notebook/display.rst
@@ -2,7 +2,7 @@
 Customizing your Visualization Tool Display
 *******************************************
 
-By default, calling `show()` will display your visualization tool *inline* in your notebook, that is the tool will show underneath the notebook cell it was called from::
+By default, calling ``show()`` will display your visualization tool *inline* in your notebook, that is the tool will show underneath the notebook cell it was called from::
 
     from jdaviz import Imviz
 
@@ -10,14 +10,14 @@ By default, calling `show()` will display your visualization tool *inline* in yo
     imviz.show()
     imviz.load_data('filename.fits', data_label='MyData')
 
-You can additionally specify the location with the `loc` argument. For example, `inline` can be specified manually with::
+You can additionally specify the location with the ``loc`` argument. For example, ``inline`` can be specified manually with::
 
     imviz.show(loc='inline')
 
 Sidecar (Jupyter Lab)
 ---------------------
 
-In Jupyter Lab, `sidecar` provides additional methods to customize where to show the viewer in your workspace. The following shows `jdaviz` in the default sidecar location, to the right of the notebook::
+In Jupyter Lab, ``sidecar`` provides additional methods to customize where to show the viewer in your workspace. The following shows ``jdaviz`` in the default sidecar location, to the right of the notebook::
 
     imviz.show(loc='sidecar')
 
@@ -25,4 +25,4 @@ To manually specify the anchor location, append the anchor to sidecar, separated
     
     imviz.show(loc='sidecar:right')
 
-Other anchors include: `split-right`, `split-left`, `split-top`, `split-bottom`, `tab-before`, `tab-after`. An up-to-date list can be found at `jupyterlab-sidecar <https://github.com/jupyter-widgets/jupyterlab-sidecar>`_
+Other anchors include: ``split-right``, ``split-left``, ``split-top``, ``split-bottom``, ``tab-before``, ``tab-after``, ``right``. An up-to-date list can be found at `jupyterlab-sidecar <https://github.com/jupyter-widgets/jupyterlab-sidecar>`_

--- a/docs/notebook/display.rst
+++ b/docs/notebook/display.rst
@@ -1,3 +1,5 @@
+.. _display:
+
 *******************************************
 Customizing your Visualization Tool Display
 *******************************************

--- a/docs/notebook/index.rst
+++ b/docs/notebook/index.rst
@@ -13,7 +13,7 @@ For example::
     # Instantiate an instance of Specviz
     myviz = Specviz()
     # Display Specviz
-    myviz.app   #doctest: +SKIP
+    myviz.show()   #doctest: +SKIP
 
 For more information on using Specviz in a notebook, see
 :ref:`specviz-notebook`.

--- a/docs/notebook/index.rst
+++ b/docs/notebook/index.rst
@@ -25,6 +25,7 @@ Using Jdaviz in a Jupyter Notebook
 .. toctree::
   :maxdepth: 2
 
+  display
   import_data
   export_data
   save_state

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -15,7 +15,7 @@ The power of Jdaviz is that it can integrated into your Jupyter notebook workflo
     from jdaviz import Imviz
 
     imviz = Imviz()
-    imviz.app
+    imviz.show()
     imviz.load_data('filename.fits', data_label='MyData')
 
 Jdaviz also provides a directory of :ref:`sample notebooks <sample_notebook>`

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -185,8 +185,6 @@ class Specviz(ConfigHelper, LineListMixin):
         scale = self.app.get_viewer("spectrum-viewer").scale_y
         self.y_limits(y_min=scale.max, y_max=scale.min)
 
-    def show(self):
-        self.app
 
     def set_spectrum_tick_format(self, fmt, axis=None):
         """

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -185,7 +185,6 @@ class Specviz(ConfigHelper, LineListMixin):
         scale = self.app.get_viewer("spectrum-viewer").scale_y
         self.y_limits(y_min=scale.max, y_max=scale.min)
 
-
     def set_spectrum_tick_format(self, fmt, axis=None):
         """
         Manually set the tick format of one of the axes of the profile viewer.

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -7,7 +7,6 @@ See also https://github.com/spacetelescope/jdaviz/issues/104 for more details
 on the motivation behind this concept.
 """
 import re
-import warnings
 
 import numpy as np
 import astropy.units as u
@@ -346,7 +345,6 @@ class ConfigHelper(HubListener):
 
         except Exception as e:
             raise RuntimeError(f'Error in displaying Jdaviz: {repr(e)}')
-
 
     def show_in_sidecar(self, anchor=None, title=None):
         """

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -286,7 +286,7 @@ class ConfigHelper(HubListener):
 
             "inline": Display the Jdaviz application inline in a notebook.
             Note this is functionally equivalent to displaying the cell
-            ``self.app``in the notebook.
+            ``self.app`` in the notebook.
 
             "sidecar": Display the Jdaviz application in a "sidecar", which
             by default is a tab on the right side of the JupyterLab  interface.

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -355,8 +355,7 @@ class ConfigHelper(HubListener):
             else:
                 raise ValueError("Unrecognized display mode: " + str(mode))
 
-        except Exception:
-            warnings.warn("Error detected in display. Falling back to IPython display",
+        except Exception as e:
+            warnings.warn(f'Error detected in display: {repr(e)}. Falling back to IPython display',
                           RuntimeWarning)
             display(self.app)
-            raise

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -345,9 +345,8 @@ class ConfigHelper(HubListener):
                 raise ValueError(f"Unrecognized display location: {loc}")
 
         except Exception as e:
-            warnings.warn(f'Error detected in display: {repr(e)}. Falling back to IPython display',
-                          RuntimeWarning)
-            display(self.app)
+            raise RuntimeError(f'Error in displaying Jdaviz: {repr(e)}')
+
 
     def show_in_sidecar(self, anchor=None, title=None):
         """

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -288,7 +288,7 @@ class ConfigHelper(HubListener):
             Note this is functionally equivalent to displaying the cell
             ``self.app`` in the notebook.
 
-            "sidecar": Display the Jdaviz application in a "sidecar", which
+            "sidecar": Display the Jdaviz application in a separate JupyterLab window from the notebook, which
             by default is a tab on the right side of the JupyterLab  interface.
 
                 Additional keywords not listed here are passed into the
@@ -316,7 +316,7 @@ class ConfigHelper(HubListener):
         Returns
         -------
         sidecar or None
-            If a sidecar was used to create the tab: ``sidecar.Sidecar`` object
+            The ``sidecar.Sidecar`` object used to create the tab or window, or None if no sidecar was created
 
         Notes
         -----

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -335,8 +335,6 @@ class ConfigHelper(HubListener):
                 with scar:
                     display(self.app)
 
-                return scar
-
             elif loc == "new browser tab":
                 raise NotImplementedError
 

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -288,8 +288,8 @@ class ConfigHelper(HubListener):
             Note this is functionally equivalent to displaying the cell
             ``self.app`` in the notebook.
 
-            "sidecar": Display the Jdaviz application in a separate JupyterLab window from the notebook, which
-            by default is a tab on the right side of the JupyterLab  interface.
+            "sidecar": Display the Jdaviz application in a separate JupyterLab window from the
+            notebook, which by default is a tab on the right side of the JupyterLab  interface.
 
                 Additional keywords not listed here are passed into the
                 ``sidecar.Sidecar`` constructor. See
@@ -316,7 +316,8 @@ class ConfigHelper(HubListener):
         Returns
         -------
         sidecar or None
-            The ``sidecar.Sidecar`` object used to create the tab or window, or None if no sidecar was created
+            The ``sidecar.Sidecar`` object used to create the tab or window or
+            None if no sidecar was created
 
         Notes
         -----

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -339,7 +339,7 @@ class ConfigHelper(HubListener):
                 raise ValueError(f"Unrecognized display location: {loc}")
 
         except Exception as e:
-            raise RuntimeError(f'Error in displaying Jdaviz: {repr(e)}')
+            raise RuntimeError('Error in displaying Jdaviz') from e
 
     def show_in_sidecar(self, anchor=None, title=None):
         """

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -292,13 +292,13 @@ class ConfigHelper(HubListener):
             notebook, the location of which is decided by the 'anchor.' right is the default
 
                 Other anchors:
-                * sidecar:right (The default, opens a tab to the right of display)
-                * sidecar:tab-before (Full-width tab before the current notebook)
-                * sidecar:tab-after (Full-width tab after the current notebook)
-                * sidecar:split-right (Split-tab in the same window right of the notebook)
-                * sidecar:split-left (Split-tab in the same window left of the notebook)
-                * sidecar:split-top (Split-tab in the same window above the notebook)
-                * sidecar:split-bottom (Split-tab in the same window below the notebook)
+                * ``sidecar:right`` (The default, opens a tab to the right of display)
+                * ``sidecar:tab-before`` (Full-width tab before the current notebook)
+                * ``sidecar:tab-after`` (Full-width tab after the current notebook)
+                * ``sidecar:split-right`` (Split-tab in the same window right of the notebook)
+                * ``sidecar:split-left`` (Split-tab in the same window left of the notebook)
+                * ``sidecar:split-top`` (Split-tab in the same window above the notebook)
+                * ``sidecar:split-bottom`` (Split-tab in the same window below the notebook)
 
                 See `jupyterlab-sidecar <https://github.com/jupyter-widgets/jupyterlab-sidecar>`_
                 for the most up-to-date options.

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -307,6 +307,7 @@ class ConfigHelper(HubListener):
             Only applicable to "sidecar"/"new jupyter tab" modes.
             The title of the sidecar tab.  Defaults to the name of the
             application; e.g., "specviz".
+
         anchor : str
             Only applicable to "sidecar" mode.
             Where the tab should appear, by default on the right. Options are:
@@ -314,9 +315,8 @@ class ConfigHelper(HubListener):
 
         Returns
         -------
-        sidecar or app
+        sidecar or Nothing
             If a sidecar was used to create the tab: ``sidecar.Sidecar`` object
-            Otherwise, ``Jdaviz.Application`` object
 
         Notes
         -----
@@ -338,7 +338,7 @@ class ConfigHelper(HubListener):
             elif mode == "new jupyter tab":
                 if 'anchor' in kwargs:
                     if 'tab' not in kwargs['anchor']:
-                        raise ValueError('show_in_new_tab cannot have a non-tab anchor')
+                        raise ValueError('new jupyter lab cannot have a non-tab anchor')
                 else:
                     kwargs['anchor'] = 'tab-after'
                 return self.show(mode="sidecar", **kwargs)
@@ -351,13 +351,12 @@ class ConfigHelper(HubListener):
 
             elif mode == "inline":
                 display(self.app)
-                return self.app
 
             else:
-                raise ValueError("Invalid display mode: " + str(mode))
+                raise ValueError("Unrecognized display mode: " + str(mode))
 
         except Exception:
-            warnings.warn("Unable to detect Jupyter interface. \
-                          Visualization may not display properly",
+            warnings.warn("Error detected in display. Falling back to IPython display",
                           RuntimeWarning)
-            return self.app
+            display(self.app)
+            raise

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -315,7 +315,7 @@ class ConfigHelper(HubListener):
 
         Returns
         -------
-        sidecar or Nothing
+        sidecar or None
             If a sidecar was used to create the tab: ``sidecar.Sidecar`` object
 
         Notes

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -274,7 +274,7 @@ class ConfigHelper(HubListener):
 
         return parameters_cube
 
-    def show(self, loc="inline", **kwargs):
+    def show(self, loc="inline", title=None):
         """
         Display the Jdaviz application
 
@@ -326,15 +326,13 @@ class ConfigHelper(HubListener):
                 display(self.app)
 
             elif loc.startswith('sidecar'):
-                if loc != 'sidecar':
-                    anchor = loc.split(':')[1]
-                    kwargs['anchor'] = anchor
+                # Use default behavior if loc is exactly 'sidecar', else split anchor from the arg
+                anchor = '' if loc == 'sidecar' else loc.split(':')[1]
 
                 # If title unset, default to the viz config
-                if 'title' not in kwargs:
-                    kwargs['title'] = self.app.config
+                title = self.app.config if title is None else title
 
-                scar = Sidecar(**kwargs)
+                scar = Sidecar(anchor=anchor, title=title)
                 with scar:
                     display(self.app)
 
@@ -354,16 +352,17 @@ class ConfigHelper(HubListener):
                           RuntimeWarning)
             display(self.app)
 
-    def show_in_sidecar(self, **kwargs):
+    def show_in_sidecar(self, anchor=None, title=None):
         """
         Preserved for backwards compatibility
         Shows Jdaviz in a sidecar with the default anchor: right
         """
-        return self.show(loc="sidecar", **kwargs)
+        location = 'sidecar' if anchor is None else ':'.join(['sidecar', anchor])
+        return self.show(loc=location, title=title)
 
-    def show_in_new_tab(self, **kwargs):
+    def show_in_new_tab(self, title=None):
         """
         Preserved for backwards compatibility
         Shows Jdaviz in a sidecar in a new tab to the right
         """
-        return self.show(loc="sidecar:tab-after", **kwargs)
+        return self.show(loc="sidecar:tab-after", title=title)

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -318,9 +318,8 @@ class ConfigHelper(HubListener):
 
         Notes
         -----
-        If "sidecar" or "new jupyter tab" modes are called in the "classic"
-        Jupyter notebook, the app will appear inline, as only lab has a mechanism
-        to have multiple tabs.
+        If "sidecar" is requested in the "classic" Jupyter notebook, the app will appear inline,
+        as only lab has a mechanism to have multiple tabs.
         """
         try:
             if loc == "inline":

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -7,6 +7,7 @@ See also https://github.com/spacetelescope/jdaviz/issues/104 for more details
 on the motivation behind this concept.
 """
 import re
+import warnings
 
 import numpy as np
 import astropy.units as u
@@ -351,6 +352,8 @@ class ConfigHelper(HubListener):
         Preserved for backwards compatibility
         Shows Jdaviz in a sidecar with the default anchor: right
         """
+        warnings.warn('show_in_sidecar has been replaced with show(loc="sidecar")',
+                      DeprecationWarning)
         location = 'sidecar' if anchor is None else f"sidecar:{anchor}"
         return self.show(loc=location, title=title)
 
@@ -359,4 +362,6 @@ class ConfigHelper(HubListener):
         Preserved for backwards compatibility
         Shows Jdaviz in a sidecar in a new tab to the right
         """
+        warnings.warn('show_in_new_tab has been replaced with show(loc="sidecar:tab-after")',
+                      DeprecationWarning)
         return self.show(loc="sidecar:tab-after", title=title)

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -309,16 +309,10 @@ class ConfigHelper(HubListener):
 
             NOTE: Only applicable to a "sidecar" display.
 
-        Returns
-        -------
-        scar : sidecar or `None`
-            The ``sidecar.Sidecar`` object used to create the tab or window or
-            None if no sidecar was created.
-
         Notes
         -----
         If "sidecar" is requested in the "classic" Jupyter notebook, the app will appear inline,
-        as only Lab has a mechanism to have multiple tabs.
+        as only JupyterLab has a mechanism to have multiple tabs.
         """
         try:
             if loc == "inline":

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -367,4 +367,4 @@ class ConfigHelper(HubListener):
         Preserved for backwards compatibility
         Shows Jdaviz in a sidecar in a new tab to the right
         """
-        return self.show(loc="sidecar:tab-right", **kwargs)
+        return self.show(loc="sidecar:tab-after", **kwargs)

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -327,7 +327,7 @@ class ConfigHelper(HubListener):
 
             elif loc.startswith('sidecar'):
                 # Use default behavior if loc is exactly 'sidecar', else split anchor from the arg
-                anchor = '' if loc == 'sidecar' else loc.split(':')[1]
+                anchor = None if loc == 'sidecar' else loc.split(':')[1]
 
                 # If title unset, default to the viz config
                 title = self.app.config if title is None else title

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -356,7 +356,7 @@ class ConfigHelper(HubListener):
         Preserved for backwards compatibility
         Shows Jdaviz in a sidecar with the default anchor: right
         """
-        location = 'sidecar' if anchor is None else ':'.join(['sidecar', anchor])
+        location = 'sidecar' if anchor is None else f"sidecar:{anchor}"
         return self.show(loc=location, title=title)
 
     def show_in_new_tab(self, title=None):

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -354,3 +354,17 @@ class ConfigHelper(HubListener):
             warnings.warn(f'Error detected in display: {repr(e)}. Falling back to IPython display',
                           RuntimeWarning)
             display(self.app)
+
+    def show_in_sidecar(self, **kwargs):
+        """
+        Preserved for backwards compatibility
+        Shows Jdaviz in a sidecar with the default anchor: right
+        """
+        return self.show(loc="sidecar", **kwargs)
+
+    def show_in_new_tab(self, **kwargs):
+        """
+        Preserved for backwards compatibility
+        Shows Jdaviz in a sidecar in a new tab to the right
+        """
+        return self.show(loc="sidecar:tab-right", **kwargs)

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -7,6 +7,7 @@ See also https://github.com/spacetelescope/jdaviz/issues/104 for more details
 on the motivation behind this concept.
 """
 import re
+import warnings
 
 import numpy as np
 import astropy.units as u
@@ -65,7 +66,17 @@ class ConfigHelper(HubListener):
                 getattr(viewer, method)(msg)
 
     def show(self):
-        return self.app
+        try:
+            # If we're in a Jupyter Notebook interface, Jupyter knows what to do.
+            # Just return the app and Jupyter will render it
+            if get_ipython().__class__.__name__ != "ZMQInteractiveShell":
+                raise RuntimeError("Unsupported Kernel")
+        except Exception:
+            warnings.warn("Unable to detect Jupyter interface. \
+                          Visualization may not display properly",
+                          RuntimeWarning)
+        finally:
+            return self.app
 
     def load_data(self, data, parser_reference=None, **kwargs):
         self.app.load_data(data, parser_reference=parser_reference, **kwargs)

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -292,13 +292,13 @@ class ConfigHelper(HubListener):
             notebook, the location of which is decided by the 'anchor.' right is the default
 
                 Other anchors:
-                sidecar:right        | The default, opens a tab to the right of display
-                sidecar:tab-before   | Full-width tab before the current notebook
-                sidecar:tab-after    | Full-width tab after the current notebook
-                sidecar:split-right  | Split-tab in the same window right of the notebook
-                sidecar:split-left   | Split-tab in the same window left of the notebook
-                sidecar:split-top    | Split-tab in the same window above the notebook
-                sidecar:split-bottom | Split-tab in the same window below the notebook
+                * sidecar:right (The default, opens a tab to the right of display)
+                * sidecar:tab-before (Full-width tab before the current notebook)
+                * sidecar:tab-after (Full-width tab after the current notebook)
+                * sidecar:split-right (Split-tab in the same window right of the notebook)
+                * sidecar:split-left (Split-tab in the same window left of the notebook)
+                * sidecar:split-top (Split-tab in the same window above the notebook)
+                * sidecar:split-bottom (Split-tab in the same window below the notebook)
 
                 See `jupyterlab-sidecar <https://github.com/jupyter-widgets/jupyterlab-sidecar>`_
                 for the most up-to-date options.

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -69,7 +69,7 @@ class ConfigHelper(HubListener):
         try:
             # If we're in a Jupyter Notebook interface, Jupyter knows what to do.
             # Just return the app and Jupyter will render it
-            if get_ipython().__class__.__name__ != "ZMQInteractiveShell":
+            if get_ipython().__class__.__name__ != "ZMQInteractiveShell": # noqa
                 raise RuntimeError("Unsupported Kernel")
         except Exception:
             warnings.warn("Unable to detect Jupyter interface. \

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -275,8 +275,7 @@ class ConfigHelper(HubListener):
         return parameters_cube
 
     def show(self, loc="inline", title=None):
-        """
-        Display the Jdaviz application.
+        """ Display the Jdaviz application.
 
         Parameters
         ----------
@@ -292,6 +291,7 @@ class ConfigHelper(HubListener):
             notebook, the location of which is decided by the 'anchor.' right is the default
 
                 Other anchors:
+
                 * ``sidecar:right`` (The default, opens a tab to the right of display)
                 * ``sidecar:tab-before`` (Full-width tab before the current notebook)
                 * ``sidecar:tab-after`` (Full-width tab after the current notebook)

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -64,6 +64,9 @@ class ConfigHelper(HubListener):
             if hasattr(viewer, method):
                 getattr(viewer, method)(msg)
 
+    def show(self):
+        return self.app
+
     def load_data(self, data, parser_reference=None, **kwargs):
         self.app.load_data(data, parser_reference=parser_reference, **kwargs)
 

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -286,32 +286,29 @@ class ConfigHelper(HubListener):
 
             "inline": Display the Jdaviz application inline in a notebook.
             Note this is functionally equivalent to displaying the cell
-            ``self.app`` in the notebook.
+            ``viz.app`` in the notebook.
 
             "sidecar": Display the Jdaviz application in a separate JupyterLab window from the
-            notebook, which by default is a tab on the right side of the JupyterLab  interface.
+            notebook, the location of which is decided by the 'anchor.' right is the default
 
-                Additional keywords not listed here are passed into the
-                ``sidecar.Sidecar`` constructor. See
-                `jupyterlab-sidecar <https://github.com/jupyter-widgets/jupyterlab-sidecar>`_
+                Other anchors:
+                sidecar:right        | The default, opens a tab to the right of display
+                sidecar:tab-before   | Full-width tab before the current notebook
+                sidecar:tab-after    | Full-width tab after the current notebook
+                sidecar:split-right  | Split-tab in the same window right of the notebook
+                sidecar:split-left   | Split-tab in the same window left of the notebook
+                sidecar:split-top    | Split-tab in the same window above the notebook
+                sidecar:split-bottom | Split-tab in the same window below the notebook
+
+                See `jupyterlab-sidecar <https://github.com/jupyter-widgets/jupyterlab-sidecar>`_
                 for the most up-to-date options.
 
-            "new jupyter tab": Display the Jdaviz application in a new tab in JupyterLab.
-
-                Additional keywords not listed here are passed into the
-                ``sidecar.Sidecar`` constructor. See
-                `jupyterlab-sidecar <https://github.com/jupyter-widgets/jupyterlab-sidecar>`_
-                for the most up-to-date options.
 
         title : str, optional
-            Only applicable to "sidecar"/"new jupyter tab" modes.
             The title of the sidecar tab.  Defaults to the name of the
             application; e.g., "specviz".
 
-        anchor : str
-            Only applicable to "sidecar" mode.
-            Where the tab should appear, by default on the right. Options are:
-            {sidecar_anchor_values}.
+            NOTE: Only applicable to a "sidecar" display.
 
         Returns
         -------
@@ -326,7 +323,15 @@ class ConfigHelper(HubListener):
         to have multiple tabs.
         """
         try:
-            if loc == "sidecar":
+            if loc == "inline":
+                display(self.app)
+
+            elif loc.startswith('sidecar'):
+                if loc != 'sidecar':
+                    anchor = loc.split(':')[1]
+                    kwargs['anchor'] = anchor
+
+                # If title unset, default to the viz config
                 if 'title' not in kwargs:
                     kwargs['title'] = self.app.config
 
@@ -336,22 +341,11 @@ class ConfigHelper(HubListener):
 
                 return scar
 
-            elif loc == "new jupyter tab":
-                if 'anchor' in kwargs:
-                    if 'tab' not in kwargs['anchor']:
-                        raise ValueError('new jupyter lab cannot have a non-tab anchor')
-                else:
-                    kwargs['anchor'] = 'tab-after'
-                return self.show(loc="sidecar", **kwargs)
-
             elif loc == "new browser tab":
                 raise NotImplementedError
 
             elif loc == "popout":
                 raise NotImplementedError
-
-            elif loc == "inline":
-                display(self.app)
 
             else:
                 raise ValueError("Unrecognized display location: " + str(loc))

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -344,7 +344,7 @@ class ConfigHelper(HubListener):
                 raise NotImplementedError
 
             else:
-                raise ValueError("Unrecognized display location: " + str(loc))
+                raise ValueError(f"Unrecognized display location: {loc}")
 
         except Exception as e:
             warnings.warn(f'Error detected in display: {repr(e)}. Falling back to IPython display',

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -274,15 +274,15 @@ class ConfigHelper(HubListener):
 
         return parameters_cube
 
-    def show(self, mode="inline", **kwargs):
+    def show(self, loc="inline", **kwargs):
         """
         Display the Jdaviz application
 
         Parameters
         ----------
-        mode : str
-            The display mode determines how to present the viz app.
-            Supported modes:
+        loc : str
+            The display location determines where to present the viz app.
+            Supported locations:
 
             "inline": Display the Jdaviz application inline in a notebook.
             Note this is functionally equivalent to displaying the cell
@@ -325,7 +325,7 @@ class ConfigHelper(HubListener):
         to have multiple tabs.
         """
         try:
-            if mode == "sidecar":
+            if loc == "sidecar":
                 if 'title' not in kwargs:
                     kwargs['title'] = self.app.config
 
@@ -335,25 +335,25 @@ class ConfigHelper(HubListener):
 
                 return scar
 
-            elif mode == "new jupyter tab":
+            elif loc == "new jupyter tab":
                 if 'anchor' in kwargs:
                     if 'tab' not in kwargs['anchor']:
                         raise ValueError('new jupyter lab cannot have a non-tab anchor')
                 else:
                     kwargs['anchor'] = 'tab-after'
-                return self.show(mode="sidecar", **kwargs)
+                return self.show(loc="sidecar", **kwargs)
 
-            elif mode == "new browser tab":
+            elif loc == "new browser tab":
                 raise NotImplementedError
 
-            elif mode == "popout":
+            elif loc == "popout":
                 raise NotImplementedError
 
-            elif mode == "inline":
+            elif loc == "inline":
                 display(self.app)
 
             else:
-                raise ValueError("Unrecognized display mode: " + str(mode))
+                raise ValueError("Unrecognized display location: " + str(loc))
 
         except Exception as e:
             warnings.warn(f'Error detected in display: {repr(e)}. Falling back to IPython display',

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -2,7 +2,7 @@ import pytest
 
 
 def test_show_popout(specviz_helper):
-    with pytest.warns(RuntimeWarning):
+    with pytest.raises(RuntimeError, match='Error in displaying Jdaviz'):
         specviz_helper.show(loc="popout")
 
 

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -11,11 +11,14 @@ def test_show_sidecar(specviz_helper):
     res = specviz_helper.show(loc='sidecar')
     assert isinstance(res, sidecar.Sidecar)
 
+
 def test_known_sidecar_anchors(specviz_helper):
-    anchors = ['split-right', 'split-left', 'split-top', 'split-bottom', 'tab-before', 'tab-after', 'right']
+    anchors = ['split-right', 'split-left', 'split-top', 'split-bottom',
+               'tab-before', 'tab-after', 'right']
     for anchor in anchors:
         res = specviz_helper.show(loc=':'.join(['sidecar', anchor]))
         assert isinstance(res, anchor)
+
 
 def test_show_new_browser_tab(specviz_helper):
     with warns(RuntimeWarning, match='Error detected in display'):

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -2,24 +2,6 @@ import sidecar
 import pytest
 
 
-def test_show_inline(specviz_helper):
-    res = specviz_helper.show(loc='inline')
-    assert res is None
-
-
-def test_show_sidecar(specviz_helper):
-    res = specviz_helper.show(loc='sidecar')
-    assert isinstance(res, sidecar.Sidecar)
-
-
-def test_known_sidecar_anchors(specviz_helper):
-    anchors = ['split-right', 'split-left', 'split-top', 'split-bottom',
-               'tab-before', 'tab-after', 'right']
-    for anchor in anchors:
-        res = specviz_helper.show(loc=f"sidecar:{anchor}")
-        assert isinstance(res, sidecar.Sidecar)
-
-
 def test_show_new_browser_tab(specviz_helper):
     with pytest.warns(RuntimeWarning, match='Error detected in display'):
         specviz_helper.show(loc="new browser tab")

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -1,4 +1,3 @@
-import sidecar
 import pytest
 
 

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -1,4 +1,6 @@
+from multiprocessing.sharedctypes import Value
 import sidecar
+from pytest import raises
 
 
 def test_show_inline(specviz_helper):
@@ -11,6 +13,21 @@ def test_show_sidecar(specviz_helper):
     assert isinstance(res, sidecar.Sidecar)
 
 
-def test_show_new_tab(specviz_helper):
+def test_show_new_jupyter_tab(specviz_helper):
     res = specviz_helper.show(mode="new jupyter tab")
     assert isinstance(res, sidecar.Sidecar)
+
+
+def test_show_new_browser_tab(specviz_helper):
+    with raises(NotImplementedError):
+        specviz_helper.show(mode="new browser tab")
+
+
+def test_show_popout(specviz_helper):
+    with raises(NotImplementedError):
+        specviz_helper.show(mode="popout")
+
+
+def test_show_invalid_mode(specviz_helper):
+    with raises(ValueError):
+        specviz_helper.show(mode="thisisnotavaliddisplaymode")

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -16,7 +16,7 @@ def test_known_sidecar_anchors(specviz_helper):
     anchors = ['split-right', 'split-left', 'split-top', 'split-bottom',
                'tab-before', 'tab-after', 'right']
     for anchor in anchors:
-        res = specviz_helper.show(loc=f"sidecar{anchor}")
+        res = specviz_helper.show(loc=f"sidecar:{anchor}")
         assert isinstance(res, sidecar.Sidecar)
 
 

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -7,6 +7,5 @@ def test_show_popout(specviz_helper):
 
 
 def test_show_invalid_mode(specviz_helper):
-    with pytest.raises(RuntimeError):
-        specviz_helper.show(loc="thisisnotavaliddisplaymode",
-                            match='Error in displaying Jdaviz')
+    with pytest.raises(RuntimeError, match='Error in displaying Jdaviz'):
+        specviz_helper.show(loc="thisisnotavaliddisplaymode")

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -11,6 +11,11 @@ def test_show_sidecar(specviz_helper):
     res = specviz_helper.show(loc='sidecar')
     assert isinstance(res, sidecar.Sidecar)
 
+def test_known_sidecar_anchors(specviz_helper):
+    anchors = ['split-right', 'split-left', 'split-top', 'split-bottom', 'tab-before', 'tab-after', 'right']
+    for anchor in anchors:
+        res = specviz_helper.show(loc=':'.join(['sidecar', anchor]))
+        assert isinstance(res, anchor)
 
 def test_show_new_browser_tab(specviz_helper):
     with warns(RuntimeWarning, match='Error detected in display'):

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -1,5 +1,5 @@
 import sidecar
-from pytest import warns
+import pytest
 
 
 def test_show_inline(specviz_helper):
@@ -21,15 +21,15 @@ def test_known_sidecar_anchors(specviz_helper):
 
 
 def test_show_new_browser_tab(specviz_helper):
-    with warns(RuntimeWarning, match='Error detected in display'):
+    with pytest.warns(RuntimeWarning, match='Error detected in display'):
         specviz_helper.show(loc="new browser tab")
 
 
 def test_show_popout(specviz_helper):
-    with warns(RuntimeWarning):
+    with pytest.warns(RuntimeWarning):
         specviz_helper.show(loc="popout")
 
 
 def test_show_invalid_mode(specviz_helper):
-    with warns(RuntimeWarning):
+    with pytest.warns(RuntimeWarning):
         specviz_helper.show(loc="thisisnotavaliddisplaymode")

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -1,5 +1,5 @@
 import sidecar
-from pytest import raises
+from pytest import warns
 
 
 def test_show_inline(specviz_helper):
@@ -18,15 +18,15 @@ def test_show_new_jupyter_tab(specviz_helper):
 
 
 def test_show_new_browser_tab(specviz_helper):
-    with raises(NotImplementedError):
+    with warns(RuntimeWarning):
         specviz_helper.show(mode="new browser tab")
 
 
 def test_show_popout(specviz_helper):
-    with raises(NotImplementedError):
+    with warns(RuntimeWarning):
         specviz_helper.show(mode="popout")
 
 
 def test_show_invalid_mode(specviz_helper):
-    with raises(ValueError):
+    with warns(RuntimeWarning):
         specviz_helper.show(mode="thisisnotavaliddisplaymode")

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -3,8 +3,7 @@ import sidecar
 
 def test_show_inline(specviz_helper):
     res = specviz_helper.show(mode='inline')
-
-    assert res is specviz_helper.app
+    assert res is None
 
 
 def test_show_sidecar(specviz_helper):

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -12,11 +12,6 @@ def test_show_sidecar(specviz_helper):
     assert isinstance(res, sidecar.Sidecar)
 
 
-def test_show_new_jupyter_tab(specviz_helper):
-    res = specviz_helper.show(loc="new jupyter tab")
-    assert isinstance(res, sidecar.Sidecar)
-
-
 def test_show_new_browser_tab(specviz_helper):
     with warns(RuntimeWarning, match='Error detected in display'):
         specviz_helper.show(loc="new browser tab")

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -16,8 +16,8 @@ def test_known_sidecar_anchors(specviz_helper):
     anchors = ['split-right', 'split-left', 'split-top', 'split-bottom',
                'tab-before', 'tab-after', 'right']
     for anchor in anchors:
-        res = specviz_helper.show(loc=':'.join(['sidecar', anchor]))
-        assert isinstance(res, anchor)
+        res = specviz_helper.show(loc=f"sidecar{anchor}")
+        assert isinstance(res, sidecar.Sidecar)
 
 
 def test_show_new_browser_tab(specviz_helper):

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -2,16 +2,16 @@ import sidecar
 
 
 def test_show_inline(specviz_helper):
-    res = specviz_helper.show_inline()
+    res = specviz_helper.show(mode='inline')
 
-    assert res is None
+    assert res is specviz_helper
 
 
 def test_show_sidecar(specviz_helper):
-    res = specviz_helper.show_in_sidecar()
+    res = specviz_helper.show(mode='sidecar')
     assert isinstance(res, sidecar.Sidecar)
 
 
 def test_show_new_tab(specviz_helper):
-    res = specviz_helper.show_in_new_tab()
+    res = specviz_helper.show(mode="new jupyter tab")
     assert isinstance(res, sidecar.Sidecar)

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -18,7 +18,7 @@ def test_show_new_jupyter_tab(specviz_helper):
 
 
 def test_show_new_browser_tab(specviz_helper):
-    with warns(RuntimeWarning):
+    with warns(RuntimeWarning, match='Error detected in display'):
         specviz_helper.show(mode="new browser tab")
 
 

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -1,4 +1,3 @@
-from multiprocessing.sharedctypes import Value
 import sidecar
 from pytest import raises
 

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -2,16 +2,12 @@ import sidecar
 import pytest
 
 
-def test_show_new_browser_tab(specviz_helper):
-    with pytest.warns(RuntimeWarning, match='Error detected in display'):
-        specviz_helper.show(loc="new browser tab")
-
-
 def test_show_popout(specviz_helper):
     with pytest.warns(RuntimeWarning):
         specviz_helper.show(loc="popout")
 
 
 def test_show_invalid_mode(specviz_helper):
-    with pytest.warns(RuntimeWarning):
-        specviz_helper.show(loc="thisisnotavaliddisplaymode")
+    with pytest.raises(RuntimeError):
+        specviz_helper.show(loc="thisisnotavaliddisplaymode",
+                            match='Error in displaying Jdaviz')

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -4,7 +4,7 @@ import sidecar
 def test_show_inline(specviz_helper):
     res = specviz_helper.show(mode='inline')
 
-    assert res is specviz_helper
+    assert res is specviz_helper.app
 
 
 def test_show_sidecar(specviz_helper):

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -3,30 +3,30 @@ from pytest import warns
 
 
 def test_show_inline(specviz_helper):
-    res = specviz_helper.show(mode='inline')
+    res = specviz_helper.show(loc='inline')
     assert res is None
 
 
 def test_show_sidecar(specviz_helper):
-    res = specviz_helper.show(mode='sidecar')
+    res = specviz_helper.show(loc='sidecar')
     assert isinstance(res, sidecar.Sidecar)
 
 
 def test_show_new_jupyter_tab(specviz_helper):
-    res = specviz_helper.show(mode="new jupyter tab")
+    res = specviz_helper.show(loc="new jupyter tab")
     assert isinstance(res, sidecar.Sidecar)
 
 
 def test_show_new_browser_tab(specviz_helper):
     with warns(RuntimeWarning, match='Error detected in display'):
-        specviz_helper.show(mode="new browser tab")
+        specviz_helper.show(loc="new browser tab")
 
 
 def test_show_popout(specviz_helper):
     with warns(RuntimeWarning):
-        specviz_helper.show(mode="popout")
+        specviz_helper.show(loc="popout")
 
 
 def test_show_invalid_mode(specviz_helper):
     with warns(RuntimeWarning):
-        specviz_helper.show(mode="thisisnotavaliddisplaymode")
+        specviz_helper.show(loc="thisisnotavaliddisplaymode")

--- a/notebooks/CubevizExample.ipynb
+++ b/notebooks/CubevizExample.ipynb
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viz.show_in_sidecar()"
+    "viz.show(loc='sidecar')"
    ]
   },
   {
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viz.show_in_new_tab()"
+    "viz.show(loc='sidecar:tab-after')"
    ]
   },
   {
@@ -86,7 +86,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/CubevizExample.ipynb
+++ b/notebooks/CubevizExample.ipynb
@@ -12,23 +12,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jdaviz import Cubeviz\n",
     "\n",
     "viz = Cubeviz()\n",
-    "viz.app"
+    "viz.show()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from astropy.utils.data import download_file\n",

--- a/notebooks/CubevizExample.ipynb
+++ b/notebooks/CubevizExample.ipynb
@@ -34,40 +34,6 @@
     "fn = download_file('https://stsci.box.com/shared/static/28a88k1qfipo4yxc4p4d40v4axtlal8y.fits', cache=True)\n",
     "viz.load_data(fn)"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Alternate ways to show the Cubeviz UI\n",
-    "\n",
-    "The above shows the Cubeviz UI inline with the notebook.  If you are in JupyterLab you can instead have the Cubeviz UI appear in a separate tab or as a \"sidecar\" (a split UI pane to the side of the notebook).  The below should do this (but only in JupyterLab.  If you are in the \"classic\" notebook it will show the same thing as `viz.app`)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "viz.show(loc='sidecar')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "viz.show(loc='sidecar:tab-after')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that while you can do all of these at once, this is not a recommended workflow, because the different views will all update, which will both slow down the tool and probably be confusing for you. If you instead want two *independent* Cubeviz UIs you should create a second `Cubeviz()` object."
-   ]
   }
  ],
  "metadata": {

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -169,7 +169,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imviz.app"
+    "imviz.show"
    ]
   },
   {

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -187,7 +187,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imviz.show_in_sidecar()"
+    "imviz.show(loc='sidecar')"
    ]
   },
   {
@@ -197,7 +197,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imviz.show_in_new_tab()"
+    "imviz.show(loc='sidecar:tab-after')"
    ]
   },
   {
@@ -772,7 +772,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -174,34 +174,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db7b63f1-ccbb-45a5-8938-961ab207cfe6",
-   "metadata": {},
-   "source": [
-    "The above will show Imviz inline in the notebook.  The following two cells are alternative ways to show it in separate windows, either on the right side of the notebook or in a new tab.  (Note this will only work in JupyterLab, *not* the \"classic\" notebook.)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e1b5fea5-2a66-49ab-aae5-36470a1ba13d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "imviz.show(loc='sidecar')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cde72ed1-6076-4cae-9b3a-c1cf7e58834d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "imviz.show(loc='sidecar:tab-after')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "1abb759e",
    "metadata": {},
    "source": [

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -169,7 +169,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imviz.show"
+    "imviz.show()"
    ]
   },
   {

--- a/notebooks/MosvizExample.ipynb
+++ b/notebooks/MosvizExample.ipynb
@@ -44,7 +44,7 @@
     "from jdaviz import Mosviz\n",
     "\n",
     "mosviz = Mosviz()\n",
-    "mosviz.app"
+    "mosviz.show()"
    ]
   },
   {
@@ -222,7 +222,7 @@
    "outputs": [],
    "source": [
     "mosviz_no_images = Mosviz()\n",
-    "mosviz_no_images.app"
+    "mosviz_no_images.show()"
    ]
   },
   {
@@ -299,7 +299,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -313,7 +313,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/MosvizNIRISSExample.ipynb
+++ b/notebooks/MosvizNIRISSExample.ipynb
@@ -47,7 +47,7 @@
     "from jdaviz import Mosviz\n",
     "\n",
     "mosviz = Mosviz()\n",
-    "mosviz.app"
+    "mosviz.show()"
    ]
   },
   {
@@ -254,7 +254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/SpecvizExample.ipynb
+++ b/notebooks/SpecvizExample.ipynb
@@ -62,7 +62,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This option will show Specviz inline in the notebook"
+    "This will show Specviz inline in the notebook"
    ]
   },
   {
@@ -72,38 +72,6 @@
    "outputs": [],
    "source": [
     "specviz.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This option will show specviz in a new tab on the right side of the notebook:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "specviz.show(loc='sidecar')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This will open specviz in a new JupyterLab tab:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "specviz.show(loc='sidecar:tab-after')"
    ]
   },
   {

--- a/notebooks/SpecvizExample.ipynb
+++ b/notebooks/SpecvizExample.ipynb
@@ -42,9 +42,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jdaviz import Specviz\n",
@@ -89,7 +87,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "specviz.show_in_sidecar()"
+    "specviz.show(loc='sidecar')"
    ]
   },
   {
@@ -105,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "specviz.show_in_new_tab()"
+    "specviz.show(loc='sidecar:tab-after')"
    ]
   },
   {
@@ -304,7 +302,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/SpecvizExample.ipynb
+++ b/notebooks/SpecvizExample.ipynb
@@ -73,7 +73,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "specviz.app"
+    "specviz.show()"
    ]
   },
   {
@@ -304,7 +304,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

## Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

### Backstory
Ok I'm going to finally admit to a nearly 18 month secret I've been hiding since I originally wrote the first helper for specviz. I've always had negative opinions about `viz.app`. I feel like it's not intuitive and not apparent to a brand new user, and almost forces them to read the documentation first before even trying to take it for a spin (which I imagine some may see as a good thing, but I'm going to argue I don't have to read Chrome's documentation when I launch it!). So I added `specviz.show()` as a wrapper to the `specviz.app` call:
https://github.com/spacetelescope/jdaviz/blob/392e1b626c2ac0dbe314bb103cadf001e1b9db4c/jdaviz/configs/specviz/helper.py#L200-L201

Here's the secret... it doesn't work. It never worked. I struggled for SO LONG at the time but I couldn't fix it; I just didn't understand what front-end wizardry made `viz.app` work.. So... I kept my mouth shut because I felt so strongly it should be there, and swore one day I would fix it. You can even see how old this is because it's only in the *Specviz* helper, and not in the base helper class; this was before I even wrote the base helper class, and the only helper we had was Specviz!

With @eteq's introduction of #952, I now further think this should be the way to show our viz tools, because a helper method would allow us to add options and arguments to a SINGLE entry point, rather than separate helpers for each launching mode (i.e. `viz.show(mode=sidecar)`, `viz.show(new_tab=True)` rather than separate `viz.show_in_new_tab()` and `viz.show_in_sidecar()`

In my review of #952, I had a real *bruhhh* moment. The reason why it never worked was because I never **returned** the app...

... They say the mistakes of the past show how much you've grown. As an optimist, I choose to view it through this lens 😅 I'm legitimately giddy seeing this PR finally in fruition. Now I can finally put this issue to rest...

As a warning, I WILL die on top of this hill!! BYOP (Bring Your Own Pitchforks!)

### tl;dr What actually changed??
This PR adds `viz.show()` as a helper method to the base ConfigHelper class, and updates all notebooks and documentation to show `viz.show()` rather than `viz.app`

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

## Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
