### PR TITLE
TST: Temporarily disable bqplot dev in devdeps job.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ deps =
     devdeps: git+https://github.com/spacetelescope/gwcs.git
     devdeps: git+https://github.com/asdf-format/asdf.git
     devdeps: git+https://github.com/radio-astro-tools/spectral-cube.git
-    devdeps: git+https://github.com/bqplot/bqplot.git
+    #devdeps: git+https://github.com/bqplot/bqplot.git
     devdeps: git+https://github.com/voila-dashboards/voila.git
     devdeps: git+https://github.com/glue-viz/bqplot-image-gl.git
     devdeps: git+https://github.com/glue-viz/glue-jupyter.git


### PR DESCRIPTION
Temporarily disable bqplot dev in devdeps job so it is green again to catch other possible but unknown failures.

Related: bqplot/bqplot-gl#12 #949 #955 #966

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
