### PR TITLE
Fix error trace introduced to Specviz model fitting

### DIFF
--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -282,11 +282,12 @@ class ModelFitting(TemplateMixin):
         else:
             spec_sub = self._spectral_subsets[self.selected_subset]
             unit = u.Unit(self.spectral_unit)
-            spreg = SpectralRegion.from_center(spec_sub.center.x * unit,
-                                               spec_sub.width * unit)
-            self._window = (spreg.lower, spreg.upper)
-            self.spectral_min = spreg.lower.value
-            self.spectral_max = spreg.upper.value
+            if hasattr(spec_sub, "center"):
+                spreg = SpectralRegion.from_center(spec_sub.center.x * unit,
+                                                   spec_sub.width * unit)
+                self._window = (spreg.lower, spreg.upper)
+                self.spectral_min = spreg.lower.value
+                self.spectral_max = spreg.upper.value
 
     def vue_model_selected(self, event):
         # Add the model selected to the list of models


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Fixes an error trace when selected a subset in the model fitting plugin in Specviz, introduced in #951 due to a last minute change putting code back in for Cubeviz.