### PR TITLE
BUG: Fix get_model_parameters for Gaussian1D

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,7 @@ Specviz
 
 Bug Fixes
 ---------
+
 - ``vue_destroy_viewer_item`` called twice on destroy event. [#676, #913]
 
 Cubeviz
@@ -66,6 +67,9 @@ Mosviz
 
 Specviz
 ^^^^^^^
+
+- Fixed a bug where ``specviz.get_model_parameters()`` crashes after fitting
+  a Gaussian model in the Model Fitting plugin. [#976]
 
 Other Changes and Additions
 ---------------------------

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -238,10 +238,7 @@ class ConfigHelper(HubListener):
                 for name in param_dict[model_name]:
                     param = getattr(models[label], name)
                     parameters_cube[model_name][name] = param.value
-                    if "amplitude" in name:
-                        param_units[model_name][name] = models[model_name].return_units
-                    elif "mean" in name or "stddev" in name:
-                        param_units[model_name][name] = models[model_name].input_units
+                    param_units[model_name][name] = param.unit
 
         # Convert values of parameters_cube[key][param_name] into u.Quantity
         # objects that contain the appropriate unit set in


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to remove special unit handling for Gaussian model because it breaks `viz.get_model_parameters`. Not sure why they were added but maybe it was needed at some point but it is no longer the case.

I cannot find any unit tests for the Model Fitting plugin, that this method is affected by. This method is also not in any other existing tests. So maybe adding a test for this fix is out of scope... 😬 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #975 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
