### PR TITLE
Mosviz redshift slider

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ Mosviz
 
 - Ability to add custom columns and change visibility of columns in the table. [#961]
 
+- Support for redshift slider and new ``mosviz.get_spectrum_1d`` and ``mosviz.get_spectrum_2d``
+  helper methods. [#982]
+
 Specviz
 ^^^^^^^
 

--- a/docs/mosviz/index.rst
+++ b/docs/mosviz/index.rst
@@ -22,4 +22,5 @@ Using Mosviz
   navigation
   displayspectra
   plugins
+  redshift
   notebook

--- a/docs/mosviz/redshift.rst
+++ b/docs/mosviz/redshift.rst
@@ -8,7 +8,7 @@ Setting Redshift/RV
     Using the redshift slider with many active spectral lines can be slow, as
     every line gets replotted at each slider position. We recommended using 
     the slider with no more than around a dozen lines plotted. You can deselect
-    lines using e.g. the "Hide All" button in the line lists UI.
+    lines using, e.g., the "Hide All" button in the line lists UI.
 
 As in :ref:`Specviz <specviz-redshift>`, the toolbar includes a slider to adjust the redshift
 or radial velocity.  In Mosviz, this is applied to the current row in the table
@@ -18,8 +18,8 @@ From the notebook
 -----------------
 
 In the notebook, the value of the Redshift column can be changed for all rows or a single row
-using `~jdaviz.configs.mosviz.helper.Mosviz.update_column`.
+using :meth:`~jdaviz.configs.mosviz.helper.Mosviz.update_column`.
 
 The 1D and 2D spectrum objects can be retrieved (with redshift optionally applied) using
-`~jdaviz.configs.mosviz.helper.Mosviz.get_spectrum_1d` and `~jdaviz.configs.mosviz.helper.Mosviz.get_spectrum_1d`,
+:meth:`~jdaviz.configs.mosviz.helper.Mosviz.get_spectrum_1d` and :meth:`~jdaviz.configs.mosviz.helper.Mosviz.get_spectrum_2d`,
 respectively.

--- a/docs/mosviz/redshift.rst
+++ b/docs/mosviz/redshift.rst
@@ -1,0 +1,25 @@
+.. _mosviz-redshift:
+
+*******************
+Setting Redshift/RV
+*******************
+
+.. warning::
+    Using the redshift slider with many active spectral lines can be slow, as
+    every line gets replotted at each slider position. We recommended using 
+    the slider with no more than around a dozen lines plotted. You can deselect
+    lines using e.g. the "Hide All" button in the line lists UI.
+
+As in :ref:`Specviz <specviz-redshift>`, the toolbar includes a slider to adjust the redshift
+or radial velocity.  In Mosviz, this is applied to the current row in the table
+and is stored (and shown) in a column of the table.
+
+From the notebook
+-----------------
+
+In the notebook, the value of the Redshift column can be changed for all rows or a single row
+using `~jdaviz.configs.mosviz.helper.Mosviz.update_column`.
+
+The 1D and 2D spectrum objects can be retrieved (with redshift optionally applied) using
+`~jdaviz.configs.mosviz.helper.Mosviz.get_spectrum_1d` and `~jdaviz.configs.mosviz.helper.Mosviz.get_spectrum_1d`,
+respectively.

--- a/docs/specviz/redshift.rst
+++ b/docs/specviz/redshift.rst
@@ -1,3 +1,5 @@
+.. _specviz-redshift:
+
 *******************
 Setting Redshift/RV
 *******************

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -13,6 +13,8 @@ from copy import deepcopy
 from jdaviz.core.helpers import ConfigHelper
 from jdaviz.core.events import SnackbarMessage, TableClickMessage, RedshiftMessage, RowLockMessage
 from jdaviz.configs.specviz import Specviz
+from jdaviz.configs.specviz.helper import _apply_redshift_to_spectra
+from jdaviz.configs.specviz2d import Specviz2d
 from jdaviz.configs.mosviz.plugins import jwst_header_to_skyregion
 
 __all__ = ['Mosviz', 'MosViz']
@@ -79,7 +81,9 @@ class Mosviz(ConfigHelper):
     def _row_lock_changed(self, msg):
         self._freeze_states_on_row_change = msg.is_locked
 
-    def _on_row_selected_begin(self):
+    def _on_row_selected_begin(self, event):
+        self._redshift_cache = self.get_column("Redshift")[event['new']]
+
         if not self._freeze_states_on_row_change:
             return
 
@@ -93,7 +97,9 @@ class Mosviz(ConfigHelper):
                                      for state, attrs in self._freezable_layers
                                      if len(state.layers)]
 
-    def _on_row_selected_end(self):
+    def _on_row_selected_end(self, event):
+        self._apply_redshift_from_table(value=self._redshift_cache, row=None)
+
         if not self._freeze_states_on_row_change:
             return
 
@@ -110,8 +116,6 @@ class Mosviz(ConfigHelper):
         # callbacks may have been made while limits were frozen.  This is
         # especially important for NIRISS data.
         self._update_spec2d_x_axis()
-
-        self._apply_redshift_from_table()
 
     def _extend_world(self, spec1d, ext):
         # Extend 1D spectrum world axis to enable panning (within reason) past
@@ -198,20 +202,30 @@ class Mosviz(ConfigHelper):
 
     def _redshift_listener(self, msg):
         '''Save new redshifts (including from the helper itself)'''
+        if self._update_in_progress:
+            # then ignore messages for now, the final redshift will be set once the
+            # data is loaded and the row change is complete.
+            return
+
         if msg.param == "redshift":
-            row = self.app.get_viewer('table-viewer').widget_table.highlighted
+            row = self.app.get_viewer('table-viewer').current_row
             # NOTE: this updates the value in the table for the current row.  This
             # in turn will feedback to call _apply_redshift_from_table and set
-            # the internal value.  When implementing the slider itself, this logic
-            # may need to be changed slightly to avoid a race condition.
+            # the internal value.
+            if msg.value == self.get_column("Redshift")[row]:
+                # avoid race condition
+                return
             self.update_column('Redshift', msg.value, row=row)
 
-    def _apply_redshift_from_table(self):
-        # NOTE: this only applies to mosviz.specviz.get_spectra(...)
-        # not mosviz.app.get_data_from_viewer(...).  This should be
-        # cleaned up when the slider is implemented in mosviz.
-        row = self.app.get_viewer('table-viewer').widget_table.highlighted
-        self.specviz._redshift = self.get_column('Redshift')[row]
+    def _apply_redshift_from_table(self, row, value=None):
+        # apply redshift from a specific row in the table (current row)
+        # to the underlying spectrum viewers (and therefore both the
+        # redshift slider as well as exposing when accessing specviz.get_spectra(...))
+        if value is None and row is not None:
+            value = self.get_column('Redshift')[row]
+
+        if value is not None:
+            self.specviz.set_redshift(value)
 
     def _show_panning_warning(self):
         now = time()
@@ -720,7 +734,9 @@ class Mosviz(ConfigHelper):
 
         if column_name == 'Redshift':
             # apply the value in the current row to the specviz object
-            self._apply_redshift_from_table()
+            row = self.app.get_viewer('table-viewer').current_row
+            if row is not None:
+                self._apply_redshift_from_table(value=data[row], row=row)
 
         return self.get_column(column_name)
 
@@ -865,6 +881,80 @@ class Mosviz(ConfigHelper):
         if not hasattr(self, '_specviz'):
             self._specviz = Specviz(app=self.app)
         return self._specviz
+
+    @property
+    def specviz2d(self):
+        """
+        A specviz2d helper (`~jdaviz.configs.specviz2d.Specviz2d`) for the Jdaviz
+        application that is wrapped by mosviz
+        """
+        if not hasattr(self, '_specviz2d'):
+            self._specviz2d = Specviz2d(app=self.app)
+        return self._specviz2d
+
+    def _get_spectrum(self, column, row=None, apply_slider_redshift="Warn"):
+        if row is None:
+            row = self.app.get_viewer('table-viewer').current_row
+        if not isinstance(row, int):
+            raise TypeError("row not of type int")
+
+        data_labels = self.get_column(column)
+        if row < 0 or row >= len(data_labels):
+            raise ValueError(f"row must be between 0 and {len(data_labels)-1}")
+
+        data_label = data_labels[row]
+        spectra = self.app.data_collection[data_label].get_object()
+        if not apply_slider_redshift:
+            return spectra
+        else:
+            redshift = self.get_column("Redshift")[row]
+            if apply_slider_redshift == "Warn":
+                logging.warning("Warning: Applying the value from the redshift "
+                                "slider to the output spectra. To avoid seeing this "
+                                "warning, explicitly set the apply_slider_redshift "
+                                "argument to True or False.")
+
+            return _apply_redshift_to_spectra(spectra, redshift)
+
+    def get_spectrum_1d(self, row=None, apply_slider_redshift="Warn"):
+        """
+        Access a 1D spectrum for any row in the Table.
+
+        Parameters
+        ----------
+        row: int or None
+            Row index in the Table. If not provided or None, will access
+            from the currently selected row.
+        apply_slider_redshift: bool or "Warn"
+            Whether to apply the redshift in the Table to the returned
+            Spectrum.  If not provided or "Warn", will apply the redshift
+            but raise a warning.
+
+        Returns
+        -------
+        `~specutils.Spectrum1D`
+        """
+        return self._get_spectrum('1D Spectra', row, apply_slider_redshift)
+
+    def get_spectrum_2d(self, row=None, apply_slider_redshift="Warn"):
+        """
+        Access a 2D spectrum for any row in the Table.
+
+        Parameters
+        ----------
+        row: int or None
+            Row index in the Table. If not provided or None, will access
+            from the currently selected row.
+        apply_slider_redshift: bool or "Warn"
+            Whether to apply the redshift in the Table to the returned
+            Spectrum.  If not provided or "Warn", will apply the redshift
+            but raise a warning.
+
+        Returns
+        -------
+        `~specutils.Spectrum1D`
+        """
+        return self._get_spectrum('2D Spectra', row, apply_slider_redshift)
 
 
 # TODO: Officially deprecate this with coordination with JDAT notebooks team.

--- a/jdaviz/configs/mosviz/mosviz.yaml
+++ b/jdaviz/configs/mosviz/mosviz.yaml
@@ -12,6 +12,7 @@ toolbar:
   - g-data-tools
   - g-subset-tools
   - g-row-lock
+  - g-redshift-slider
 tray:
   - g-gaussian-smooth
   - g-slit-overlay

--- a/jdaviz/configs/mosviz/plugins/viewers.py
+++ b/jdaviz/configs/mosviz/plugins/viewers.py
@@ -144,6 +144,10 @@ class MosvizTableViewer(TableViewer):
     def nrows(self):
         return self.widget_table.get_state()['total_length']
 
+    @property
+    def current_row(self):
+        return self.widget_table.highlighted
+
     def select_row(self, n):
         if n < 0 or n >= self.nrows:
             raise ValueError("n must be between 0 and {}".format(self.nrows-1))
@@ -159,18 +163,18 @@ class MosvizTableViewer(TableViewer):
         self.widget_table.highlighted = n
 
     def next_row(self):
-        current_row = self.widget_table.highlighted
+        current_row = self.current_row
         new_row = 0 if current_row == self.nrows - 1 else current_row + 1
         self.select_row(new_row)
 
     def prev_row(self):
-        current_row = self.widget_table.highlighted
+        current_row = self.current_row
         new_row = self.nrows - 1 if current_row == 0 else current_row - 1
         self.select_row(new_row)
 
     def _on_row_selected(self, event):
         if self._on_row_selected_begin:
-            self._on_row_selected_begin()
+            self._on_row_selected_begin(event)
 
         self.row_selection_in_progress = True
         # Grab the index of the latest selected row
@@ -238,7 +242,7 @@ class MosvizTableViewer(TableViewer):
         self.row_selection_in_progress = False
 
         if self._on_row_selected_end:
-            self._on_row_selected_end()
+            self._on_row_selected_end(event)
 
     def set_plot_axes(self, *args, **kwargs):
         return

--- a/jdaviz/configs/mosviz/tests/test_helper.py
+++ b/jdaviz/configs/mosviz/tests/test_helper.py
@@ -2,9 +2,11 @@ import astropy.units as u
 import csv
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 from astropy.nddata import CCDData
 from astropy.wcs import WCS
 from jdaviz.configs.mosviz.helper import Mosviz
+from jdaviz.configs.specviz2d.helper import Specviz2d
 from specutils import Spectrum1D, SpectrumCollection
 
 
@@ -365,8 +367,8 @@ def test_redshift_column(mosviz_app, image, spectrum1d, spectrum2d):
     mosviz_app.load_data(spectra1d, spectra2d, images=image)
 
     mosviz_app.update_column("Redshift", 0.1, row=0)
-    assert list(mosviz_app.specviz.get_spectra().values())[0].redshift.value == pytest.approx(0.1)
-    assert mosviz_app.specviz2d.__class__.__name__ == 'Specviz2d'
-    assert mosviz_app.get_spectrum_1d().redshift.value == pytest.approx(0.1)
-    assert mosviz_app.get_spectrum_2d().redshift.value == pytest.approx(0.1)
-    assert mosviz_app.get_spectrum_1d(row=1).redshift.value == 0.0
+    assert_allclose(list(mosviz_app.specviz.get_spectra().values())[0].redshift.value, 0.1)
+    assert isinstance(mosviz_app.specviz2d, Specviz2d)
+    assert_allclose(mosviz_app.get_spectrum_1d().redshift.value, 0.1)
+    assert_allclose(mosviz_app.get_spectrum_2d().redshift.value, 0.1)
+    assert_allclose(mosviz_app.get_spectrum_1d(row=1).redshift.value, 0.0)

--- a/jdaviz/configs/mosviz/tests/test_helper.py
+++ b/jdaviz/configs/mosviz/tests/test_helper.py
@@ -355,3 +355,18 @@ def test_custom_columns(mosviz_app, image, spectrum1d, spectrum2d):
     assert "Redshift" in mosviz_app.get_column_names(True)
     mosviz_app.set_visible_columns()
     assert "Redshift" not in mosviz_app.get_column_names(True)
+
+
+@pytest.mark.filterwarnings('ignore')
+def test_redshift_column(mosviz_app, image, spectrum1d, spectrum2d):
+    spectra1d = [spectrum1d] * 2
+    spectra2d = [spectrum2d] * 2
+
+    mosviz_app.load_data(spectra1d, spectra2d, images=image)
+
+    mosviz_app.update_column("Redshift", 0.1, row=0)
+    assert list(mosviz_app.specviz.get_spectra().values())[0].redshift.value == pytest.approx(0.1)
+    assert mosviz_app.specviz2d.__class__.__name__ == 'Specviz2d'
+    assert mosviz_app.get_spectrum_1d().redshift.value == pytest.approx(0.1)
+    assert mosviz_app.get_spectrum_2d().redshift.value == pytest.approx(0.1)
+    assert mosviz_app.get_spectrum_1d(row=1).redshift.value == 0.0

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -211,7 +211,7 @@ class Specviz(ConfigHelper, LineListMixin):
         the value shown in the slider.
         '''
         if new_redshift == self._redshift:
-            # avoid sending messages that can result in race conditions`
+            # avoid sending messages that can result in race conditions
             return
         msg = RedshiftMessage("redshift", new_redshift, sender=self)
         self.app.hub.broadcast(msg)

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -10,6 +10,21 @@ from jdaviz.configs.default.plugins.line_lists.line_list_mixin import LineListMi
 __all__ = ['Specviz', 'SpecViz']
 
 
+def _apply_redshift_to_spectra(spectra, redshift):
+
+    flux = spectra.flux
+    # This is a hack around inability to input separate redshift with
+    # a SpectralAxis instance in Spectrum1D
+    spaxis = spectra.spectral_axis.value * spectra.spectral_axis.unit
+    mask = spectra.mask
+    uncertainty = spectra.uncertainty
+    output_spectra = Spectrum1D(flux, spectral_axis=spaxis,
+                                redshift=redshift, mask=mask,
+                                uncertainty=uncertainty)
+
+    return output_spectra
+
+
 class Specviz(ConfigHelper, LineListMixin):
     """Specviz Helper class."""
 
@@ -43,15 +58,8 @@ class Specviz(ConfigHelper, LineListMixin):
             if data_label is not None:
                 spectra = {data_label: spectra}
             for key in spectra.keys():
-                flux = spectra[key].flux
-                # This is a hack around inability to input separate redshift with
-                # a SpectralAxis instance in Spectrum1D
-                spaxis = spectra[key].spectral_axis.value * spectra[key].spectral_axis.unit
-                mask = spectra[key].mask
-                uncertainty = spectra[key].uncertainty
-                output_spectra[key] = Spectrum1D(flux, spectral_axis=spaxis,
-                                                 redshift=self._redshift, mask=mask,
-                                                 uncertainty=uncertainty)
+                output_spectra[key] = _apply_redshift_to_spectra(spectra[key], self._redshift)
+
             if apply_slider_redshift == "Warn":
                 logging.warning("Warning: Applying the value from the redshift "
                                 "slider to the output spectra. To avoid seeing this "
@@ -202,6 +210,9 @@ class Specviz(ConfigHelper, LineListMixin):
         Apply a redshift to any loaded spectral lines and data. Also updates
         the value shown in the slider.
         '''
+        if new_redshift == self._redshift:
+            # avoid sending messages that can result in race conditions`
+            return
         msg = RedshiftMessage("redshift", new_redshift, sender=self)
         self.app.hub.broadcast(msg)
 

--- a/jdaviz/configs/specviz/plugins/redshift_slider/redshift_slider.py
+++ b/jdaviz/configs/specviz/plugins/redshift_slider/redshift_slider.py
@@ -72,9 +72,15 @@ class RedshiftSlider(TemplateMixin):
         elif param == "slider_step":
             self.slider_step = val
         elif param == "redshift":
+            if self.slider_type == "RV (km/s)":
+                # then the input value is redshift, but we need to translate
+                # to RV before setting the slider value
+                val = self._redshift_to_velocity(val).to('km/s').value
             if val > self.max_value or val < self.min_value:
                 self._update_bounds[self.slider_type](val)
             self.slider = val
+        else:
+            raise NotImplementedError(f"RedshiftMessage with param {param} not implemented.")
 
     def _velocity_to_redshift(self, velocity):
         """


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is an extension of #961 and adds a redshift slider in Mosviz along with new `mosviz.get_spectrum_1d(row=None)` and `mosviz.get_spectrum_2d(row=None)` (defaults to the currently selected row if `row` is not provided) helper methods to access the underlying data products with their respective redshifts applied.

Note: support for RVs in the slider dropdown is supported, but roundtripping is not perfect.  Support for an RV column in the table connected to the slider is not (currently) included.

This also currently includes #980 (which would preferably be merged first and then this PR rebased onto main)

Wishlist:
- [x] fix "roundtripping" between redshift and RV (if possible)
    * roundtripping internally is confirmed to be fine.  Issue is that the _step_ of the slider itself is forcing values to round when switching between redshift and RV.  Fixing this would require a redesign of how the bounds/step of the slider are determined.  Determined to be out-of-scope (same issue existed before for specviz, just wasn't apparent since the redshift value isn't shown and it generally "rounds back" to the original value when re-selecting redshift) and filed as #987.
- [x] investigate behavior for hidden redshift column when changing slider (any changed data will automatically force that column to be shown which conflicts with the `hide_column` logic).  
    * postponing to wait for user feedback (some voted that the current behavior might actually be preferred).  Changing this will likely require storing the desired list internally and re-setting the visible columns, or overriding the behavior internal to glue.
- [x] ~if RV column is within scope: design and implement~
- [x] try to minimize/remove redshift column "flickering" when changing rows.  (Now fairly minimal but not gone.  Fixing this completely is likely a larger fix that can also cover the flickering in the viewers when changing rows and is likely out of scope)
- [x] add test coverage. (Some done, but might be able to be improved before merge)
- [x] merge #980 and rebase

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
