### PR TITLE
BUG: Fix inaccurate coordinates info on dithered data linked by WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,9 @@ Imviz
 
 - Imviz now updates pixel value correctly during blinking. [#985]
 
+- Imviz now displays the correct pixel and sky coordinates for dithered
+  images linked by WCS. [#992]
+
 Mosviz
 ^^^^^^
 

--- a/docs/specviz/import_data.rst
+++ b/docs/specviz/import_data.rst
@@ -56,7 +56,7 @@ This method works well for data files that ``specutils`` understands.  However, 
     >>> wavelength = np.arange(5100, 5300)*u.AA
     >>> spec1d = Spectrum1D(spectral_axis=wavelength, flux=flux)
     >>> specviz = Specviz()
-    >>> specviz.load_spectrum(spec1d)
+    >>> specviz.load_spectrum(spec1d)  # doctest: +IGNORE_OUTPUT
 
 For more information about using the Specutils package, please see the
 `Specutils documentation <https://specutils.readthedocs.io>`_.

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -783,6 +783,11 @@ class Application(VuetifyTemplate, HubListener):
                 "of:\n\t" + "\n\t".join([
                     data_item['name'] for data_item in self.state.data_items]))
 
+        # TODO: We can display the active data label in GUI here.
+        # For now, we will print to debug Output widget.
+        with self._application_handler.output:
+            print(f'Visible layer changed to: {data_label}')
+
     def _set_plot_axes_labels(self, viewer_id):
         """
         Sets the plot axes labels to be the units of the data to be loaded.
@@ -1120,9 +1125,8 @@ class Application(VuetifyTemplate, HubListener):
         # active data.
         if len(active_data_labels) > 0:
             active_data = self.data_collection[active_data_labels[0]]
-            if hasattr(active_data, "_preferred_translation") \
-                    and active_data._preferred_translation is not None:
-                pass
+            if (hasattr(active_data, "_preferred_translation")
+                    and active_data._preferred_translation is not None):
                 self._set_plot_axes_labels(viewer_id)
 
     def _on_data_added(self, msg):

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -96,6 +96,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "81249347-a61b-478e-bcfc-586f0457ff4e",
+   "metadata": {},
+   "source": [
+    "This next cell is only enable for debugging. It captures outputs printed to the underlying application `Output` widget."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "d23931dc",
+   "metadata": {},
+   "source": [
+    "# This is for debugging only.\n",
+    "imviz.app._application_handler.output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "60eb5782-264f-4af4-bb6e-ae583398277d",
    "metadata": {},
    "source": [
@@ -144,7 +161,7 @@
   },
   {
    "cell_type": "raw",
-   "id": "855f49fc-092a-48a2-8741-a10246cb02ae",
+   "id": "525074e2",
    "metadata": {},
    "source": [
     "jwf277w = download_file('https://stsci.box.com/shared/static/iao1zxtigyrhq7k3wtu5nchrxzlhj9kv.fits', cache=True)\n",
@@ -729,7 +746,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -743,7 +760,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to fix inaccurate coordinates info on dithered data linked by WCS.

Also add in backend to show which data is currently visible. Adding this info to GUI is a separate ticket and directly tied to Imviz wireframe work.

Suggested workflow for review:

1. Fire up Imviz example notebook.
2. Load the ACS images.
3. Zoom in so you get a nice view of some pixels.
4. Mouse over a pixel of interest.
5. Press `b` to blink. Currently, they are linked by pixels, so X/Y should stay the same but WCS and value will change.
6. Run the cell at the bottom to link them by WCS.
7. Mouse over a pixel of interest.
8. Press `b` to blink. Now, they are linked by WCS, so X/Y and value will change, but WCS still stay the same.

If you also run with the JWST data, please note that there is upstream bug reported at spacetelescope/gwcs#392.

Also feel free to load your favorite data to test this out. Everything is linked by pixels by default (on load), so you always need to run the extra cell to link them by WCS.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #945

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
