### PR TITLE
subscribe to subset messages from glue

### DIFF
--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -3,6 +3,8 @@ import logging
 import astropy.units as u
 from specutils import SpectralRegion, Spectrum1D
 
+from glue.core.message import SubsetMessage, SubsetCreateMessage, SubsetUpdateMessage
+
 from jdaviz.core.helpers import ConfigHelper
 from jdaviz.core.events import RedshiftMessage
 from jdaviz.configs.default.plugins.line_lists.line_list_mixin import LineListMixin
@@ -22,6 +24,18 @@ class Specviz(ConfigHelper, LineListMixin):
         # Listen for new redshifts from the redshift slider
         self.app.hub.subscribe(self, RedshiftMessage,
                                handler=self._redshift_listener)
+
+        self.app.session.hub.subscribe(self, SubsetMessage,
+                              handler=self._on_subset_msg)
+
+        self.app.session.hub.subscribe(self, SubsetCreateMessage,
+                              handler=self._on_subset_msg)
+
+        self.app.session.hub.subscribe(self, SubsetUpdateMessage,
+                              handler=self._on_subset_msg)
+
+    def _on_subset_msg(self, msg):
+        print("*** _on_subset_msg", msg)
 
     def load_spectrum(self, data, data_label=None, format=None, show_in_viewer=True):
         super().load_data(data,


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This draft pull request attempts to subscribe to subset messages from glue (creation or update) and print a debugging message (eventually to be replaced by overriding subset thickness, etc).  However, the glue messages don't seem to be sent when creating a subset region in jdaviz (in specviz).

Open specviz example notebook, create a new subset.  Print message would show if the messages from glue were being sent and appropriately received, but currently are not.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
