### PR TITLE
Update changelog for release, pin dev version of glue-astronomy for now

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,13 +1,10 @@
-2.1 (unreleased)
+2.1 (2021-12-10)
 ================
 
 New Features
 ------------
 
-- Support for units and BlackBody in modeling plugin. [#953]
-
-Cubeviz
-^^^^^^^
+- Support for units in astropy models and BlackBody in modeling plugin. [#953]
 
 Imviz
 ^^^^^
@@ -44,25 +41,10 @@ API Changes
 
 - Removed unused ``jdaviz.core.events.AddViewerMessage``. [#939]
 
-Cubeviz
-^^^^^^^
-
-Imviz
-^^^^^
-
-Mosviz
-^^^^^^
-
-Specviz
-^^^^^^^
-
 Bug Fixes
 ---------
 
-- ``vue_destroy_viewer_item`` called twice on destroy event. [#676, #913]
-
-Cubeviz
-^^^^^^^
+- ``vue_destroy_viewer_item`` no longer called twice on destroy event. [#676, #913]
 
 Imviz
 ^^^^^
@@ -77,9 +59,6 @@ Imviz
 
 - Imviz now displays the correct pixel and sky coordinates for dithered
   images linked by WCS. [#992]
-
-Mosviz
-^^^^^^
 
 Specviz
 ^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     voila>=0.2.4
     pyyaml>=5.4.1
     specutils>=1.5.0
-    glue-astronomy>=0.3.2
+    glue-astronomy@git+https://github.com/glue-viz/glue-astronomy.git
     click>=7.1.2
     spectral-cube>=0.5
     asteval>=0.9.23


### PR DESCRIPTION
Does what it says in the title - I removed empty headings in the changelog for readability. #991 is the reminder to update the `glue-astronomy` pin once they do a release.