### PR TITLE
consistent plugin padding & styling

### DIFF
--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -10,5 +10,6 @@ Here is some documentation specific for developers.
   release
   infrastructure
   ui_description
+  ui_style_guide
   specviz_selection
   links

--- a/docs/dev/ui_style_guide.rst
+++ b/docs/dev/ui_style_guide.rst
@@ -13,6 +13,8 @@ try to adhere to the following principles:
   ``j-tray-plugin`` stylesheet (``jdaviz/components/tray_plugin.vue``).
 * Each item should be wrapped in a ``v-row``, but avoid any unnecessary additional wrapping-components
   (``v-card-*``, ``v-container``, etc).
+* The first entry should be a ``j-docs-link`` component which provides a quick overview of the 
+  plugin functionality and a link to the relevant content in the online docs.
 * Only use ``v-col`` components (within the ``<v-row class="row-no-outside-padding">``) if multiple 
   components are necessary in a single row.  Always emphasize readability at the default/minimum
   width of the plugin tray, rather than using columns that result in a ton of text overflow.
@@ -29,7 +31,7 @@ try to adhere to the following principles:
     <template>
       <j-tray-plugin>
         <v-row>
-          <j-docs-link> ... </j-docs-link>
+          <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#plugin-name'">Quick overview of plugin functionality.</j-docs-link>
         </v-row>
 
         <v-row>

--- a/docs/dev/ui_style_guide.rst
+++ b/docs/dev/ui_style_guide.rst
@@ -1,0 +1,39 @@
+***************************
+UI/UX Style Guide
+***************************
+
+Tray Plugins
+-------------
+
+In order to be consistent with layout, styling, and spacing, UI development on plugins should
+try to adhere to the following principles.
+
+* any tray plugin should utilize ``<j-tray-plugin>`` as the outer-container (which provides consistent 
+  styling rules).  Any changes to style across all plugins should then take place in the 
+  ``j-tray-plugin`` stylesheet (``tray_plugin.vue``).
+* each item should be wrapped in a ``v-row``, but avoid any unnecessary additional wrapping-components
+  (``v-card-*``, ``v-container``, etc).
+* only use ``v-col`` components (within the ``<v-row class="row-no-outside-padding">``) if multiple 
+  components are necessary in a single row.  Always emphasize readability at the default/minimum
+  width of the plugin tray, rather than using columns that result in a ton of text overflow.
+* action buttons should have ``color="primary"`` if it loads something into the plugin, or 
+  ``color="accent"`` if applying something to the viewers/apps/data.
+* to remove vertical padding from rows (i.e., two successive buttons stacked vertically), use 
+  ``<v-row class="row-min-bottom-padding">``.
+* use ``<v-row justify="end">`` to align content to the right (such as action buttons).
+* use new ``<j-plugin-section-header>Header Text</j-plugin-section-header>`` to separate content 
+  within a plugin (instead of nested cards, ``v-card-subtitle``, etc).
+
+.. code::
+
+    <template>
+      <j-tray-plugin>
+        <v-row>
+          <j-docs-link> ... </j-docs-link>
+        </v-row>
+
+        <v-row>
+          ....
+        </v-row>
+      </j-tray-plugin>
+    </template>

--- a/docs/dev/ui_style_guide.rst
+++ b/docs/dev/ui_style_guide.rst
@@ -1,27 +1,27 @@
-***************************
+*****************
 UI/UX Style Guide
-***************************
+*****************
 
 Tray Plugins
--------------
+------------
 
 In order to be consistent with layout, styling, and spacing, UI development on plugins should
-try to adhere to the following principles.
+try to adhere to the following principles:
 
-* any tray plugin should utilize ``<j-tray-plugin>`` as the outer-container (which provides consistent 
+* Any tray plugin should utilize ``<j-tray-plugin>`` as the outer-container (which provides consistent 
   styling rules).  Any changes to style across all plugins should then take place in the 
-  ``j-tray-plugin`` stylesheet (``tray_plugin.vue``).
-* each item should be wrapped in a ``v-row``, but avoid any unnecessary additional wrapping-components
+  ``j-tray-plugin`` stylesheet (``jdaviz/components/tray_plugin.vue``).
+* Each item should be wrapped in a ``v-row``, but avoid any unnecessary additional wrapping-components
   (``v-card-*``, ``v-container``, etc).
-* only use ``v-col`` components (within the ``<v-row class="row-no-outside-padding">``) if multiple 
+* Only use ``v-col`` components (within the ``<v-row class="row-no-outside-padding">``) if multiple 
   components are necessary in a single row.  Always emphasize readability at the default/minimum
   width of the plugin tray, rather than using columns that result in a ton of text overflow.
-* action buttons should have ``color="primary"`` if it loads something into the plugin, or 
+* Action buttons should have ``color="primary"`` if it loads something into the plugin, or 
   ``color="accent"`` if applying something to the viewers/apps/data.
-* to remove vertical padding from rows (i.e., two successive buttons stacked vertically), use 
+* To remove vertical padding from rows (i.e., two successive buttons stacked vertically), use 
   ``<v-row class="row-min-bottom-padding">``.
-* use ``<v-row justify="end">`` to align content to the right (such as action buttons).
-* use new ``<j-plugin-section-header>Header Text</j-plugin-section-header>`` to separate content 
+* Use ``<v-row justify="end">`` to align content to the right (such as action buttons).
+* Use new ``<j-plugin-section-header>Header Text</j-plugin-section-header>`` to separate content 
   within a plugin (instead of nested cards, ``v-card-subtitle``, etc).
 
 .. code::

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -62,6 +62,15 @@ ipyvue.register_component_from_file(None, 'j-external-link',
 ipyvue.register_component_from_file(None, 'j-docs-link',
                                     os.path.join(os.path.dirname(__file__),
                                                  'components/docs_link.vue'))
+
+ipyvue.register_component_from_file(None, 'j-tray-plugin',
+                                    os.path.join(os.path.dirname(__file__),
+                                                 'components/tray_plugin.vue'))
+
+ipyvue.register_component_from_file(None, 'j-plugin-section-header',
+                                    os.path.join(os.path.dirname(__file__),
+                                                 'components/plugin_section_header.vue'))
+
 # Register pure vue component. This allows us to do recursive component instantiation only in the
 # vue component file
 ipyvue.register_component_from_file('g-viewer-tab', "container.vue", __file__)

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -44,7 +44,7 @@
             </golden-layout>
           </pane>
           <pane size="25" min-size="25" v-if="state.drawer" style="background-color: #fafbfc;">
-            <v-card flat tile class="overflow-y-auto fill-height" color="#f8f8f8">
+            <v-card flat tile class="overflow-y-auto fill-height" style="overflow-x: hidden" color="#f8f8f8">
               <v-expansion-panels accordion multiple focusable flat tile v-model="state.tray_items_open">
                 <v-expansion-panel v-for="(tray, index) in state.tray_items" :key="index">
                   <v-expansion-panel-header>

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -43,7 +43,7 @@
               </gl-row>
             </golden-layout>
           </pane>
-          <pane size="25" v-if="state.drawer" style="background-color: #fafbfc;">
+          <pane size="25" min-size="25" v-if="state.drawer" style="background-color: #fafbfc;">
             <v-card flat tile class="overflow-y-auto fill-height" color="#f8f8f8">
               <v-expansion-panels accordion multiple focusable flat tile v-model="state.tray_items_open">
                 <v-expansion-panel v-for="(tray, index) in state.tray_items" :key="index">
@@ -52,7 +52,7 @@
                       {{ tray.label }}
                     </j-tooltip>
                   </v-expansion-panel-header>
-                  <v-expansion-panel-content>
+                  <v-expansion-panel-content style="margin-left: -12px; margin-right: -12px">
                     <jupyter-widget :widget="tray.widget"></jupyter-widget>
                   </v-expansion-panel-content>
                 </v-expansion-panel>
@@ -201,21 +201,6 @@ div.output_wrapper {
 
 .lm_header ul {
   padding-left: 0;
-}
-
-.v-expansion-panel-content__wrap {
-  padding: 0px;
-  margin: 0px;
-}
-
-.v-expansion-panel__header {
-  padding: 0px;
-  margin: 0px;
-}
-
-.v-expansion-panel-content__wrap {
-  padding: 0px;
-  margin: 0px;
 }
 
 .v-toolbar__items .v-btn {

--- a/jdaviz/components/docs_link.vue
+++ b/jdaviz/components/docs_link.vue
@@ -2,7 +2,7 @@
   <div class="v-messages">
     <div class="v-messages__wrapper" style="margin-top: 2px; margin-bottom: 2px">
       <div class="v-messages__message">
-        <p style="margin-bottom: 8px">
+        <p style="margin-bottom: 8px; color: rgba(0, 0, 0, 0.6)">
           <slot></slot>
         </p>
         <div v-if="link">

--- a/jdaviz/components/docs_link.vue
+++ b/jdaviz/components/docs_link.vue
@@ -1,10 +1,8 @@
 <template>
   <div class="v-messages">
     <div class="v-messages__wrapper" style="margin-top: 2px; margin-bottom: 2px">
-      <div class="v-messages__message">
-        <p style="margin-bottom: 8px; color: rgba(0, 0, 0, 0.6)">
+      <div class="v-messages__message text--secondary" style="margin-bottom: 8px">
           <slot></slot>
-        </p>
         <div v-if="link">
           <j-external-link :link="link" :linktext="linktext"/>
         </div>

--- a/jdaviz/components/plugin_section_header.vue
+++ b/jdaviz/components/plugin_section_header.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="strike">
+     <span>
+       <slot></slot>
+     </span>
+  </div>
+</template>
+
+
+<style scoped>
+.strike {
+    display: block;
+    text-align: center;
+    overflow: hidden;
+    white-space: nowrap; 
+    margin-left: -12px;
+    margin-right: -12px;
+    margin-top: 40px;
+    margin-bottom: 8px;
+    color: rgba(0, 0, 0, 0.6) !important;
+}
+
+.strike > span {
+    position: relative;
+    display: inline-block;
+}
+
+.strike > span:before,
+.strike > span:after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    width: 9999px;
+    height: 1px;
+    background: rgba(0, 0, 0, 0.15);
+}
+
+.strike > span:before {
+    right: 100%;
+    margin-right: 15px;
+}
+
+.strike > span:after {
+    left: 100%;
+    margin-left: 15px;
+}
+</style>

--- a/jdaviz/components/plugin_section_header.vue
+++ b/jdaviz/components/plugin_section_header.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="strike">
+  <div class="strike text--secondary">
      <span>
        <slot></slot>
      </span>
@@ -17,7 +17,6 @@
     margin-right: -12px;
     margin-top: 40px;
     margin-bottom: 8px;
-    color: rgba(0, 0, 0, 0.6) !important;
 }
 
 .strike > span {

--- a/jdaviz/components/tooltip.vue
+++ b/jdaviz/components/tooltip.vue
@@ -56,7 +56,7 @@ const tooltips = {
   'plugin-model-fitting-fit': 'Fit the model to the data',
   'plugin-model-fitting-apply': 'Fit the model to every spaxel in the cube',
   'plugin-unit-conversion-apply': 'Apply unit conversion',
-  'plugin-line-lists-load': 'Load list into tool',
+  'plugin-line-lists-load': 'Load list into "Loaded Lines" section of plugin',
   'plugin-line-lists-plot-all-in-list': 'Plot all lines in this list',
   'plugin-line-lists-erase-all-in-list': 'Hide all lines in this list',
   'plugin-line-lists-plot-all': 'Plot all lines from every loaded list',
@@ -67,6 +67,7 @@ const tooltips = {
   'plugin-line-lists-line-visible': 'Check to plot the line in the spectrum viewer',
   'plugin-moment-maps-calculate': 'Calculate moment map',
   'plugin-moment-save-fits': 'Save moment map as FITS file',
+  'plugin-link-apply': 'Apply linking to data',
 }
 
 

--- a/jdaviz/components/tray_plugin.vue
+++ b/jdaviz/components/tray_plugin.vue
@@ -22,11 +22,16 @@ module.exports = {
     margin-bottom: 4px !important;
   }
 
-  .row-no-outside-padding :first-child {
+  .row-no-outside-padding .col:first-of-type {
     padding-left: 0px !important;
   }
 
-  .row-no-outside-padding :last-child {
+  .row-no-outside-padding .col:last-of-type {
+    padding-right: 0px !important;
+  }
+
+  .row-no-padding > .col {
+    padding-left: 0px !important;
     padding-right: 0px !important;
   }
 

--- a/jdaviz/components/tray_plugin.vue
+++ b/jdaviz/components/tray_plugin.vue
@@ -1,0 +1,44 @@
+<template>
+  <v-container>
+    <slot>
+    </slot>
+  </v-container>
+</template>
+
+<script>
+module.exports = {
+  props: {docslink: String, 
+          docstext: String
+        },
+};
+</script>
+
+<style scoped>
+  .row {
+    margin-bottom: 12px !important;
+  }
+
+  .row-min-bottom-padding {
+    margin-bottom: 4px !important;
+  }
+
+  .row-no-outside-padding :first-child {
+    padding-left: 0px !important;
+  }
+
+  .row-no-outside-padding :last-child {
+    padding-right: 0px !important;
+  }
+
+  .v-expansion-panel-header {
+    /* tighten default padding on any sub expansion headers */
+    padding: 6px !important;
+  }
+  
+  .v-expansion-panel-header .row {
+    /* override margin from above and replace with equal top and bottom margins
+    for the text in the panel header */
+    margin-top: 2px !important;
+    margin-bottom: 2px !important;
+  }
+</style>

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
@@ -1,103 +1,102 @@
 <template>
-  <v-card flat tile>
-    <v-container>
+  <j-tray-plugin>
+    <v-row>
       <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#moment-maps'">Create a 2D image from a data cube</j-docs-link>
-      <v-row>
-        <v-col>
-          <v-select
-            :items="dc_items"
-            v-model="selected_data"
-            label="Data"
-            hint="Select the data set."
-            persistent-hint
-          ></v-select>
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col>
-          <v-select
-            :items="spectral_subset_items"
-            v-model="selected_subset"
-            label="Spectral Region"
-            hint="Optional: limit to a spectral region defined in the spectrum viewer."
-            persistent-hint
-            @click="list_subsets"
-          ></v-select>
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col>
-          <v-text-field
-            label="Lower spectral bound"
-            v-model="spectral_min"
-            hint="Lower bound of spectral region"
-            persistent-hint
-          >
-          </v-text-field>
-        </v-col>
-        <v-col cols = 2>
-          <span>{{ spectral_unit }}</span>
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col>
-          <v-text-field
-            label="Upper spectral bound"
-            v-model="spectral_max"
-            hint="Lower bound of spectral region"
-            persistent-hint
-          >
-          </v-text-field>
-        </v-col>
-        <v-col cols = 2>
-          <span>{{ spectral_unit }}</span>
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-select
-          :items="viewers"
-          v-model="selected_viewer"
-          label='Plot in Viewer'
-          hint='Moment map will replace plot in the specified viewer.  Will also be available in the data dropdown in all image viewers.'
-          persistent-hint
-        ></v-select>
-      </v-row>
-    </v-container>
-    <!-- <v-divider></v-divider> -->
+    </v-row>
 
-    <v-card-actions>
+    <v-row>
+      <v-select
+        :items="dc_items"
+        v-model="selected_data"
+        label="Data"
+        hint="Select the data set."
+        persistent-hint
+      ></v-select>
+    </v-row>
+
+    <v-row>
+      <v-select
+        :items="spectral_subset_items"
+        v-model="selected_subset"
+        label="Spectral Region"
+        hint="Optional: limit to a spectral region defined in the spectrum viewer."
+        persistent-hint
+        @click="list_subsets"
+      ></v-select>
+    </v-row>
+
+    <v-row class="row-no-outside-padding">
+      <v-col>
+        <v-text-field
+          label="Lower spectral bound"
+          v-model="spectral_min"
+          hint="Lower bound of spectral region"
+          persistent-hint
+        >
+        </v-text-field>
+      </v-col>
+      <v-col cols = 2>
+        <span>{{ spectral_unit }}</span>
+      </v-col>
+    </v-row>
+
+    <v-row class="row-no-outside-padding">
+      <v-col>
+        <v-text-field
+          label="Upper spectral bound"
+          v-model="spectral_max"
+          hint="Lower bound of spectral region"
+          persistent-hint
+        >
+        </v-text-field>
+      </v-col>
+      <v-col cols = 2>
+        <span>{{ spectral_unit }}</span>
+      </v-col>
+    </v-row>
+
+    <v-row>
+      <v-select
+        :items="viewers"
+        v-model="selected_viewer"
+        label='Plot in Viewer'
+        hint='Moment map will replace plot in the specified viewer.  Will also be available in the data dropdown in all image viewers.'
+        persistent-hint
+      ></v-select>
+    </v-row>
+
+    <v-row class="row-no-outside-padding">
+      <v-col>
+        <v-text-field
+          ref="n_moment"
+          label="Moment"
+          v-model="n_moment"
+          hint="The desired moment."
+          persistent-hint
+          :rules="[() => !!n_moment || 'This field is required']"
+        ></v-text-field>
+      </v-col>
+      <v-col>
+        <j-tooltip tipid='plugin-moment-maps-calculate'>
+          <v-btn color="primary" text @click="calculate_moment">Calculate</v-btn>
+        </j-tooltip>
+      </v-col>
+    </v-row>
+
+    <div v-if="moment_available">
+      <j-plugin-section-header>Results</j-plugin-section-header>
       <v-row>
-        <v-col>
-          <v-text-field
-            ref="n_moment"
-            label="Moment"
-            v-model="n_moment"
-            hint="The desired moment."
-            persistent-hint
-            :rules="[() => !!n_moment || 'This field is required']"
-          ></v-text-field>
-        </v-col>
-        <v-col>
-          <j-tooltip tipid='plugin-moment-maps-calculate'>
-            <v-btn color="primary" text @click="calculate_moment">Calculate</v-btn>
-          </j-tooltip>
-        </v-col>
-    </v-card-actions>
-    <v-card-actions>
-      <v-row v-if="moment_available">
-        <v-col>
           <v-text-field
            v-model="filename"
            label="Filename"
            :rules="[() => !!filename || 'This field is required']">
           </v-text-field>
-        </v-col>
-        <v-col>
-          <j-tooltip tipid='plugin-moment-save-fits'>
-            <v-btn color="primary" text @click="save_as_fits">Save as FITS</v-btn>
-          </j-tooltip>
-        </v-col>
       </v-row>
-    </v-card-actions>
-  </v-card>
+      <v-row justify="end">
+        <j-tooltip tipid='plugin-moment-save-fits'>
+          <v-btn color="primary" text @click="save_as_fits">Save as FITS</v-btn>
+        </j-tooltip>
+      </v-row>
+    </div>
+  </j-tray-plugin>
 </template>

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
@@ -35,7 +35,7 @@
         >
         </v-text-field>
       </v-col>
-      <v-col cols = 2>
+      <v-col cols=2 style="padding-top: 32px">
         <span>{{ spectral_unit }}</span>
       </v-col>
     </v-row>
@@ -50,7 +50,7 @@
         >
         </v-text-field>
       </v-col>
-      <v-col cols = 2>
+      <v-col cols=2 style="padding-top: 32px">
         <span>{{ spectral_unit }}</span>
       </v-col>
     </v-row>
@@ -65,22 +65,21 @@
       ></v-select>
     </v-row>
 
-    <v-row class="row-no-outside-padding">
-      <v-col>
-        <v-text-field
-          ref="n_moment"
-          label="Moment"
-          v-model="n_moment"
-          hint="The desired moment."
-          persistent-hint
-          :rules="[() => !!n_moment || 'This field is required']"
-        ></v-text-field>
-      </v-col>
-      <v-col>
-        <j-tooltip tipid='plugin-moment-maps-calculate'>
-          <v-btn color="primary" text @click="calculate_moment">Calculate</v-btn>
-        </j-tooltip>
-      </v-col>
+    <v-row>
+      <v-text-field
+        ref="n_moment"
+        label="Moment"
+        v-model="n_moment"
+        hint="The desired moment."
+        persistent-hint
+        :rules="[() => !!n_moment || 'This field is required']"
+      ></v-text-field>
+    </v-row>
+
+    <v-row justify="end">
+      <j-tooltip tipid='plugin-moment-maps-calculate'>
+        <v-btn color="primary" text @click="calculate_moment">Calculate</v-btn>
+      </j-tooltip>
     </v-row>
 
     <div v-if="moment_available">

--- a/jdaviz/configs/default/plugins/collapse/collapse.vue
+++ b/jdaviz/configs/default/plugins/collapse/collapse.vue
@@ -1,53 +1,52 @@
 <template>
-  <v-card flat tile>
-    <v-container>
-      <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#collapse'">Collapse a spectral cube along one axis</j-docs-link>
+  <j-tray-plugin>
+    <v-row>
+      <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#collapse'">Collapse a spectral cube along one axis.</j-docs-link>
+    </v-row>
+
+    <v-row>
+      <v-select
+        :items="data_items"
+        v-model="selected_data_item"
+        label="Data"
+        hint="Select the data set to use in collapse."
+        persistent-hint
+      ></v-select>
+    </v-row>
+
+    <v-row>
+      <v-select
+        :items="axes"
+        v-model="selected_axis"
+        label="Axis"
+        hint="Select the axis along which the data will be collapsed."
+        persistent-hint
+      ></v-select>
+    </v-row>
+
+    <v-row>
+      <v-select
+        :items="funcs"
+        v-model="selected_func"
+        label="Method"
+        hint="Select the method to use in the collapse."
+        persistent-hint
+      ></v-select>
+    </v-row>
+
+    <div v-if="selected_axis==0">
       <v-row>
-        <v-col class="py-0">
-          <v-select
-            :items="data_items"
-            v-model="selected_data_item"
-            label="Data"
-            hint="Select the data set to use in collapse."
-            persistent-hint
-          ></v-select>
-        </v-col>
+        <v-select
+          :items="spectral_subset_items"
+          v-model="selected_subset"
+          label="Spectral Region"
+          hint="Select spectral region to apply the collapse."
+          persistent-hint
+          @click="list_subsets"
+        ></v-select>
       </v-row>
-      <v-row>
-        <v-col>
-          <v-select
-            :items="axes"
-            v-model="selected_axis"
-            label="Axis"
-            hint="Select the axis along which the data will be collapsed."
-            persistent-hint
-          ></v-select>
-        </v-col>
-        <v-col>
-          <v-select
-            :items="funcs"
-            v-model="selected_func"
-            label="Method"
-            hint="Select the method to use in the collapse."
-            persistent-hint
-          ></v-select>
-        </v-col>
-      </v-row>
-    </v-container>
-    <v-container v-if="selected_axis == 0">
-      <v-row>
-        <v-col>
-          <v-select
-            :items="spectral_subset_items"
-            v-model="selected_subset"
-            label="Spectral Region"
-            hint="Select spectral region to apply the collapse."
-            persistent-hint
-            @click="list_subsets"
-          ></v-select>
-        </v-col>
-      </v-row>
-      <v-row>
+
+      <v-row class="row-no-outside-padding">
         <v-col>
           <v-text-field
             label="Lower spectral bound"
@@ -61,7 +60,8 @@
           <span>{{ spectral_unit }}</span>
         </v-col>
       </v-row>
-      <v-row>
+
+      <v-row class="row-no-outside-padding">
         <v-col>
           <v-text-field
             label="Upper spectral bound"
@@ -75,6 +75,7 @@
           <span>{{ spectral_unit }}</span>
         </v-col>
       </v-row>
+
       <v-row>
         <v-select
           :items="viewers"
@@ -84,22 +85,23 @@
           persistent-hint
         ></v-select>
       </v-row>
-    </v-container>
-    <v-container v-else>
-      <v-switch
-        label="Plot Results"
-        hint="Collapsed spectrum will immediately plot in the spectral viewer.  Will also be available in the data menu of each spectral viewer."
-        v-model="add_replace_results"
-        persistent-hint>
-      </v-switch>
-    </v-container>
-    <!-- <v-divider></v-divider> -->
 
-    <v-card-actions>
-      <div class="flex-grow-1"></div>
+    </div>
+    <div v-else>
+      <v-row>
+        <v-switch
+          label="Plot Results"
+          hint="Collapsed spectrum will immediately plot in the spectral viewer.  Will also be available in the data menu of each spectral viewer."
+          v-model="add_replace_results"
+          persistent-hint>
+        </v-switch>
+      </v-row>
+    </div>
+
+    <v-row justify="end">
       <j-tooltip tipid='plugin-collapse-apply'>
         <v-btn color="accent" text @click="collapse">Apply</v-btn>
       </j-tooltip>
-    </v-card-actions>
-  </v-card>
+    </v-row>
+  </j-tray-plugin>
 </template>

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.vue
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.vue
@@ -1,43 +1,42 @@
 <template>
-  <v-card flat tile>
-    <v-container>
-      <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#gaussian-smooth'">Smooth your data in xy or wavelength with a Gaussian kernel</j-docs-link>
+    <j-tray-plugin>
       <v-row>
-        <v-col class="py-0">
-          <v-select
-            :items="dc_items"
-            v-model="selected_data"
-            label="Data"
-            hint="Select the data set to be smoothed."
-            persistent-hint
-          ></v-select>
-        </v-col>
+        <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#gaussian-smooth'">Smooth your data in xy or wavelength with a Gaussian kernel</j-docs-link>
       </v-row>
+
+      <v-row>
+        <v-select
+          :items="dc_items"
+          v-model="selected_data"
+          label="Data"
+          hint="Select the data set to be smoothed."
+          persistent-hint
+        ></v-select>
+      </v-row>
+
       <v-row v-if="show_modes">
-        <v-col>
-          <v-select
-            :items="smooth_modes"
-            v-model="selected_mode"
-            label="Smoothing Type"
-            hint="Smooth data spectrally or spatially."
-            persistent-hint
-          ></v-select>
-        </v-col>
+        <v-select
+          :items="smooth_modes"
+          v-model="selected_mode"
+          label="Smoothing Type"
+          hint="Smooth data spectrally or spatially."
+          persistent-hint
+        ></v-select>
       </v-row>
+
       <v-row>
-        <v-col>
-          <v-text-field
-            ref="stddev"
-            label="Standard deviation"
-            v-model="stddev"
-            type="number"
-            hint="The stddev of the kernel, in pixels."
-            persistent-hint
-            :rules="[() => !!stddev || 'This field is required', () => stddev > 0 || 'Kernel must be greater than zero']"
-          ></v-text-field>
-        </v-col>
+        <v-text-field
+          ref="stddev"
+          label="Standard deviation"
+          v-model="stddev"
+          type="number"
+          hint="The stddev of the kernel, in pixels."
+          persistent-hint
+          :rules="[() => !!stddev || 'This field is required', () => stddev > 0 || 'Kernel must be greater than zero']"
+        ></v-text-field>
       </v-row>
-      <v-row v-if="selected_data">
+
+      <v-row v-if="selected_data && stddev > 0">
         <v-select v-if="config=='cubeviz'"
           :items="viewers"
           v-model="selected_viewer"
@@ -50,26 +49,22 @@
           v-model="add_replace_results"
           persistent-hint>
         </v-switch>
-        </div>
       </v-row>
-    </v-container>
-    <!-- <v-divider></v-divider> -->
 
-    <v-card-actions>
-      <div class="flex-grow-1"></div>
-      <j-tooltip v-if="selected_mode=='Spectral'" tipid='plugin-gaussian-apply'>
-        <v-btn :disabled="stddev <= 0 || selected_data == ''"
-          color="accent" text 
-          @click="spectral_smooth"
-        >Apply</v-btn>
-      </j-tooltip>
-      <j-tooltip v-else tipid='plugin-gaussian-apply'>
-        <v-btn 
-          :disabled="stddev <= 0 || selected_data == ''"
-          color="accent" text
-          @click="spatial_convolution"
-        >Apply</v-btn>
-      </j-tooltip>
-    </v-card-actions>
-  </v-card>
+      <v-row justify="end">
+        <j-tooltip v-if="selected_mode=='Spectral'" tipid='plugin-gaussian-apply'>
+          <v-btn :disabled="stddev <= 0 || selected_data == ''"
+            color="accent" text 
+            @click="spectral_smooth"
+          >Apply</v-btn>
+        </j-tooltip>
+        <j-tooltip v-else tipid='plugin-gaussian-apply'>
+          <v-btn 
+            :disabled="stddev <= 0 || selected_data == ''"
+            color="accent" text
+            @click="spatial_convolution"
+          >Apply</v-btn>
+        </j-tooltip>
+      </v-row>
+    </j-tray-plugin>
 </template>

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.vue
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.vue
@@ -1,180 +1,174 @@
 <template>
-  <v-card flat tile>
-    <v-card>
-      <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#line-lists'">Plot lines from preset or custom line lists</j-docs-link>
-      <v-card-subtitle>Preset Line Lists</v-card-subtitle>
-      <v-card-text>
-        <v-container>
-          <v-row
-            align="start"
-          >
-            <v-col>
-              <v-select
-                :items="available_lists"
-                @change="list_selected"
-                label="Available Line Lists"
-                hint="Select a line list to load"
-                persistent-hint
-              ></v-select>
-            </v-col>
-          </v-row>
-          <v-row
-            justify="end"
-          >
-            <j-tooltip tipid='plugin-line-lists-load'>
-              <v-btn color="primary" text @click="load_list">Load List</v-btn>
-            </j-tooltip>
-          </v-row>
-        </v-container>
-      </v-card-text>
-      <v-divider></v-divider>
+  <j-tray-plugin>
+    <v-row>
+      <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#line-lists'">Plot lines from preset or custom line lists.</j-docs-link>
+    </v-row>
+  
+    <j-plugin-section-header>Preset Line Lists</j-plugin-section-header>
+    <v-row>
+      <v-select
+        :items="available_lists"
+        @change="list_selected"
+        label="Available Line Lists"
+        hint="Select a line list to load"
+        persistent-hint
+      ></v-select>
+    </v-row>
 
-      <v-card-subtitle>Loaded Lines</v-card-subtitle>
-      <v-card-text>
-        <v-expansion-panels>
-          <v-expansion-panel v-for="item in loaded_lists" key=":item">
-            <v-expansion-panel-header v-slot="{ open }">
-              <v-row no-gutters align="center">
-                <v-col cols=1>
-                  <v-btn 
-                    v-if="item != 'Custom'" 
-                    @click.native.stop="remove_list(item)" 
-                    icon
-                  >
-                    <v-icon>mdi-close-circle</v-icon>
-                  </v-btn>
-                </v-col>
-                <v-col cols=2></v-col>
-                <v-col cols=8 class="text--secondary">
+    <v-row justify="end">
+      <j-tooltip tipid='plugin-line-lists-load'>
+        <v-btn color="primary" text @click="load_list">Load List</v-btn>
+      </j-tooltip>
+    </v-row>
+
+
+    <j-plugin-section-header>Loaded Lines</j-plugin-section-header>
+    <v-row>
+      <v-expansion-panels accordion>
+        <v-expansion-panel v-for="item in loaded_lists" key=":item">
+          <v-expansion-panel-header v-slot="{ open }">
+            <v-row no-gutters align="center">
+              <v-col cols=3>
+                <v-btn 
+                  v-if="item != 'Custom'" 
+                  @click.native.stop="remove_list(item)" 
+                  icon
+                  style="width: 60%"
+                >
+                  <v-icon>mdi-close-circle</v-icon>
+                </v-btn>
+              </v-col>
+              <v-col cols=9 class="text--secondary">
+                <v-row>
                   <span>{{ item }}</span>
-                </v-col>
-              </v-row>
-            </v-expansion-panel-header>
-            <v-expansion-panel-content>
-              <v-row 
-                v-if="item == 'Custom'"
-                align="center"
-                justify="center"
-              >
-                <v-col>
+                </v-row>
+              </v-col>
+            </v-row>
+          </v-expansion-panel-header>
+          <v-expansion-panel-content style="padding-left: 0px">
+
+            <v-row justify="space-around" style="padding-top: 16px">
+              <v-color-picker
+                hide-inputs
+                mode="hexa"
+                width="200px"
+                flat
+                @update:color="set_color({listname:item, color: $event.hexa})">
+              </v-color-picker>
+            </v-row>
+
+            <div v-if="item == 'Custom'" style="padding-top: 16px">
+              <v-row class="row-min-bottom-padding" style="display: block">
                   <j-tooltip tipid='plugin-line-lists-line-name'>
                     <v-text-field
                       label="Line Name"
                       v-model="custom_name"
+                      dense
                     >
                     </v-text-field>
                   </j-tooltip>
-                </v-col>
-                <v-col>
-                  <j-tooltip tipid='plugin-line-lists-custom-rest'>
-                    <v-text-field
-                      label="Rest Value"
-                      v-model="custom_rest"
-                    >
-                    </v-text-field>
-                  </j-tooltip>
-                </v-col>
-                <v-col>
+              </v-row>
+
+              <v-row class="row-min-bottom-padding" style="display: block">
+                <j-tooltip tipid='plugin-line-lists-custom-rest'>
+                  <v-text-field
+                    label="Rest Value"
+                    v-model="custom_rest"
+                    dense
+                  >
+                  </v-text-field>
+                </j-tooltip>
+              </v-row>
+
+              <v-row class="row-min-bottom-padding" style="display: block">
+                <j-tooltip tipid='plugin-line-lists-custom-unit'>
                   <v-text-field
                     label="Unit"
                     v-model="custom_unit"
+                    dense
                   >
                   </v-text-field>
-                </v-col>
-                <v-col>
-                  <j-tooltip tipid='plugin-line-lists-add-custom-line'>
-                    <v-btn color="primary" text @click="add_custom_line">Add Line</v-btn>
-                  </j-tooltip>
-                </v-col>
-              </v-row>
-              <v-row justify="space-around">
-                <v-color-picker
-                  hide-inputs
-                  mode="hexa"
-                  flat
-                  @update:color="set_color({listname:item, color: $event.hexa})">
-                </v-color-picker>
-              </v-row
-                align="center"
-                justify="center"
-              >
-                <j-tooltip tipid='plugin-line-lists-plot-all-in-list'>
-                  <v-btn 
-                   color="primary" 
-                   text @click="show_all_in_list(item)">Plot All</v-btn>
                 </j-tooltip>
-                <j-tooltip tipid='plugin-line-lists-erase-all-in-list'>
-                  <v-btn 
-                   color="primary" 
-                   text @click="hide_all_in_list(item)">Erase All</v-btn>
-                </j-tooltip>
-              <v-row>
               </v-row>
+
+              <v-row justify="end">
+                <j-tooltip tipid='plugin-line-lists-add-custom-line'>
+                  <v-btn color="primary" text @click="add_custom_line">Add Line</v-btn>
+                </j-tooltip>
+              </v-row>
+            </div>
+
+            <v-row justify="end" style="margin-bottom: 0px !important">
+              <j-tooltip tipid='plugin-line-lists-plot-all-in-list'>
+                <v-btn 
+                 color="accent" 
+                 text @click="show_all_in_list(item)">Plot All</v-btn>
+              </j-tooltip>
+            </v-row>
+            <v-row justify="end">
+              <j-tooltip tipid='plugin-line-lists-erase-all-in-list'>
+                <v-btn 
+                 color="accent" 
+                 text @click="hide_all_in_list(item)">Erase All</v-btn>
+              </j-tooltip>
+            </v-row>
+
+            <div 
+              v-if="list_contents[item].lines.length" 
+              style="margin-left: -10px; margin-right: -12px"
+            >
               <v-row
                 justify="center"
                 align="center"
-                no-gutters
+                classname="row-no-outside-padding"
               >
-                <v-col cols=1></v-col>
-                <v-col cols=3>
-                  <p class="font-weight-bold">Line Name</p>
+                <v-col cols=5>
+                  <p class="font-weight-bold">Name</p>
                 </v-col>
-                <v-col cols=3>
+                <v-col cols=7> <!-- covers rest value and unit cols below -->
                   <p class="font-weight-bold">Rest Value</p>
                 </v-col>
-                <v-col cols=3>
-                  <p class="font-weight-bold">Unit</p>
-                </v-col>
-                <v-col cols=2>
-                  <j-tooltip tipid='plugin-line-lists-line-visible'>
-                    <p class="font-weight-bold">Visible</p>
-                  </j-tooltip>
-                </v-col>
               </v-row>
               <v-row
                 justify="center"
                 align="center"
-                no-gutters
+                class="row-no-outside-padding"
                 v-for="line in list_contents[item].lines"
               >
-                <v-col cols=1></v-col>
-                <v-col cols = 3>
-                  {{ line.linename }}
-                </v-col>
-                <v-col cols = 3>
-                  {{ line.rest }}
-                </v-col>
-                <v-col cols=3>
-                  {{ line.unit }}
-                </v-col>
-                <v-col cols=2>
+                <v-col cols=5>
                   <j-tooltip tipid='plugin-line-lists-line-visible'>
                     <v-checkbox v-model="line.show" @change="change_visible(line)">
+                      <template v-slot:label>
+                        <span style="overflow-wrap: anywhere; color: rgba(0, 0, 0, 0.87); font-size: 10pt">
+                          {{line.linename}}
+                        </span>
+                      </template>
                     </v-checkbox>
                   </j-tooltip>
                 </v-col>
+                <v-col cols=4 style="font-size: 10pt">
+                  {{ line.rest }}
+                </v-col>
+                <v-col cols=3 style="font-size: 10pt">
+                  {{ line.unit.replace("Angstrom", "&#8491;") }}
+                </v-col>
               </v-row>
-            </v-expansion-panel-content>
-          <v-expansion-panel>
-        </v-expansion-panels>
-      </v-card-text>
-      <v-divider></v-divider>
+            </div>
+          </v-expansion-panel-content>
+        <v-expansion-panel>
+      </v-expansion-panels>
+    </v-row>
 
-      <v-card-text>
-        <v-container>
-          <v-row
-            justify="left"
-            align="center"
-            no-gutters>
-            <j-tooltip tipid='plugin-line-lists-plot-all'>
-              <v-btn color="primary" text @click="plot_all_lines">Plot All</v-btn>
-            </j-tooltip>
-            <j-tooltip tipid='plugin-line-lists-erase-all'>
-              <v-btn color="primary" text @click="erase_all_lines">Erase All</v-btn>
-            </j-tooltip>
-          </v-row>
-        </v-container>
-      </v-card-text>
-    </v-card>
-  </v-card>
+    <v-row justify="end" style="margin-bottom: 0px !important">
+      <j-tooltip tipid='plugin-line-lists-plot-all'>
+        <v-btn color="accent" text @click="plot_all_lines">Plot All</v-btn>
+      </j-tooltip>
+    </v-row>
+    <v-row justify="end">
+      <j-tooltip tipid='plugin-line-lists-erase-all'>
+        <v-btn color="accent" text @click="erase_all_lines">Erase All</v-btn>
+      </j-tooltip>
+    </v-row>
+
+  </j-tray-plugin>
 </template>

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.vue
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.vue
@@ -98,19 +98,23 @@
               </v-row>
             </div>
 
-            <v-row justify="end" style="margin-bottom: 0px !important">
-              <j-tooltip tipid='plugin-line-lists-plot-all-in-list'>
-                <v-btn 
-                 color="accent" 
-                 text @click="show_all_in_list(item)">Plot All</v-btn>
-              </j-tooltip>
-            </v-row>
-            <v-row justify="end">
-              <j-tooltip tipid='plugin-line-lists-erase-all-in-list'>
-                <v-btn 
-                 color="accent" 
-                 text @click="hide_all_in_list(item)">Erase All</v-btn>
-              </j-tooltip>
+            <v-row class="row-no-padding">
+              <v-col cols=6>
+                <j-tooltip tipid='plugin-line-lists-erase-all-in-list'>
+                  <v-btn 
+                   color="accent" 
+                   style="padding-left: 8px; padding-right: 8px;"
+                   text @click="hide_all_in_list(item)">Erase All</v-btn>
+                </j-tooltip>
+              </v-col>
+              <v-col cols=6 style="text-align: right">
+                <j-tooltip tipid='plugin-line-lists-plot-all-in-list'>
+                  <v-btn 
+                   color="accent"
+                   style="padding-left: 8px; padding-right: 8px;"
+                   text @click="show_all_in_list(item)">Plot All</v-btn>
+                </j-tooltip>
+              </v-col>
             </v-row>
 
             <div 
@@ -159,15 +163,24 @@
       </v-expansion-panels>
     </v-row>
 
-    <v-row justify="end" style="margin-bottom: 0px !important">
-      <j-tooltip tipid='plugin-line-lists-plot-all'>
-        <v-btn color="accent" text @click="plot_all_lines">Plot All</v-btn>
-      </j-tooltip>
-    </v-row>
-    <v-row justify="end">
-      <j-tooltip tipid='plugin-line-lists-erase-all'>
-        <v-btn color="accent" text @click="erase_all_lines">Erase All</v-btn>
-      </j-tooltip>
+    <v-row class="row-no-padding">
+      <v-col cols=6>
+        <j-tooltip tipid='plugin-line-lists-erase-all'>
+          <v-btn 
+            color="accent"
+            style="padding-left: 8px; padding-right: 8px;"
+            text @click="erase_all_lines">Erase All</v-btn>
+        </j-tooltip>
+      </v-col>
+      <v-col cols=6 style="text-align: right">
+        <j-tooltip tipid='plugin-line-lists-plot-all'>
+          <v-btn 
+            color="accent"
+            style="padding-left: 8px; padding-right: 8px;"
+            text @click="plot_all_lines">Plot All</v-btn>
+        </j-tooltip>
+      </v-col>
+
     </v-row>
 
   </j-tray-plugin>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -1,111 +1,92 @@
 <template>
-  <v-card flat tile>
-    <v-card>
-      <v-card-text>
-        <v-container>
-          <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#model-fitting'">Fit an analytic model to data or a subset.</j-docs-link>
-          <v-row>
-            <v-col>
-              <v-select
-                :items="dc_items"
-                @change="data_selected"
-                label="Data"
-                hint="Select the data set to be fitted."
-                persistent-hint
-              ></v-select>
-            </v-col>
-          </v-row>
-        </v-container>
-        <v-container>
-          <v-row>
-            <v-col>
-              <v-select
-                :items="spectral_subset_items"
-                v-model="selected_subset"
-                label="Spectral Region"
-                hint="Select spectral region to fit."
-                persistent-hint
-                @click="list_subsets"
-              ></v-select>
-            </v-col>
-          </v-row>
-        </v-container>
-      </v-card-text>
-      <v-divider></v-divider>
+  <j-tray-plugin>
+    <v-row>
+      <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#model-fitting'">Fit an analytic model to data or a subset.</j-docs-link>
+    </v-row>
 
-      <v-card-text>
-        <v-container>
-          <v-row
-          align="start"
-          >
-            <v-col>
-              <v-select
-                :items="available_models"
-                @change="model_selected"
-                label="Model"
-                hint="Select a model to fit."
-                persistent-hint
-              ></v-select>
-            </v-col>
-            <v-col>
-              <v-text-field
-                label="Model ID"
-                v-model="temp_name"
-                hint="A unique string label for this component model."
-                persistent-hint
-                :rules="[() => !!temp_name || 'This field is required']"
-              >
-              </v-text-field>
-            </v-col>
-            <v-col v-if="display_order">
-              <v-text-field
-                label="Order"
-                type="number"
-                v-model.number="poly_order"
-                hint="Order of polynomial to fit."
-                persistent-hint
-              >
-              </v-text-field>
-            </v-col>
-          </v-row>
-          <v-row
-          justify="end">
-            <j-tooltip tipid='plugin-model-fitting-add-model'>
-              <v-btn color="primary" text @click="add_model">Add Model</v-btn>
-            </j-tooltip>
-          </v-row>
-        </v-container>
-      </v-card-text>
-      <v-divider></v-divider>
+    <v-row>
+      <v-select
+        :items="dc_items"
+        @change="data_selected"
+        label="Data"
+        hint="Select the data set to be fitted."
+        persistent-hint
+      ></v-select>
+    </v-row>
 
-      <v-card-subtitle>Model Parameters</v-card-subtitle>
-      <v-card-text>
-        <v-container>
-        <v-expansion-panels>
+    <v-row>
+      <v-select
+        :items="spectral_subset_items"
+        v-model="selected_subset"
+        label="Spectral Region"
+        hint="Select spectral region to fit."
+        persistent-hint
+        @click="list_subsets"
+      ></v-select>
+    </v-row>
+
+    <j-plugin-section-header>Model Components</j-plugin-section-header>
+    <v-row>
+      <v-select
+        :items="available_models"
+        @change="model_selected"
+        label="Model"
+        hint="Select a model to fit."
+        persistent-hint
+      ></v-select>
+    </v-row>
+
+    <v-row>
+      <v-text-field
+        label="Model ID"
+        v-model="temp_name"
+        hint="A unique string label for this component model."
+        persistent-hint
+        :rules="[() => !!temp_name || 'This field is required']"
+      >
+      </v-text-field>
+    </v-row>
+
+    <v-row v-if="display_order">
+      <v-text-field
+        label="Order"
+        type="number"
+        v-model.number="poly_order"
+        hint="Order of polynomial to fit."
+        persistent-hint
+      >
+      </v-text-field>
+    </v-row>
+
+    <v-row justify="end">
+      <j-tooltip tipid='plugin-model-fitting-add-model'>
+        <v-btn color="primary" text @click="add_model">Add Component</v-btn>
+      </j-tooltip>
+    </v-row>
+
+    <div v-if="component_models.length">
+      <j-plugin-section-header>Model Parameters</j-plugin-section-header>
+      <v-row>
+        <v-expansion-panels accordion>
           <v-expansion-panel
             v-for="item in component_models" :key="item.id"
           >
             <v-expansion-panel-header v-slot="{ open }">
-              <v-row no-gutters>
-                <v-col cols=1>
-                  <v-btn @click.native.stop="remove_model(item.id)" icon>
+              <v-row no-gutters align="center">
+                <v-col cols=3>
+                  <v-btn @click.native.stop="remove_model(item.id)" icon style="width: 60%">
                     <v-icon>mdi-close-circle</v-icon>
                   </v-btn>
                 </v-col>
-                <v-col cols="3">{{ item.id }} ({{ item.model_type }})</v-col>
-                <v-col cols="8" class="text--secondary">
-                  <v-fade-transition leave-absolute>
-                    <span v-if="open">Enter parameters for model initialization</span>
-                    <v-row
-                      v-else
-                      no-gutters
-                      style="width: 100%"
-                    >
-                      <v-col cols="4" v-for="param in item.parameters">
-                      {{ param.name }} : {{ param.value }}
-                      </v-col>
-                    </v-row>
-                  </v-fade-transition>
+                <v-col cols=9 class="text--secondary">
+                  <v-row>
+                    <b>{{ item.id }}</b>&nbsp;({{ item.model_type }})
+                  </v-row>
+                  <v-row v-for="param in item.parameters">
+                    <span style="white-space: nowrap; overflow-x: hidden; width: calc(100% - 24px); margin-right: -48px">
+                      {{ param.name }} = {{ param.value }}                      
+                    </span>
+                  </v-row>
                 </v-col>
               </v-row>
             </v-expansion-panel-header>
@@ -113,107 +94,98 @@
               <v-row
                 justify="left"
                 align="center"
-                no-gutters
+                class="row-no-outside-padding"
               >
-                <v-col cols=2>
-                  <p class="font-weight-bold">Parameter</p>
-                </v-col>
-                <v-col cols=3>
-                  <p class="font-weight-bold">Value</p>
-                </v-col>
                 <v-col cols=4>
-                  <p class="font-weight-bold">Unit</p>
+                  <p class="font-weight-bold">Param</p>
                 </v-col>
-                <v-col cols=2>
-                  <j-tooltip tipid='plugin-model-fitting-param-fixed'>
-                    <p class="font-weight-bold">Fixed?</p>
-                  </j-tooltip>
+                <v-col cols=8> <!-- covers value and unit in rows -->
+                  <p class="font-weight-bold">Value</p>
                 </v-col>
               </v-row>
               <v-row
                 justify="left"
                 align="center"
-                no-gutters
+                class="row-no-outside-padding"
                 v-for="param in item.parameters"
               >
-                <v-col cols = 2>
-                  {{ param.name }}
+                <v-col cols=4>
+                  <j-tooltip tipid='plugin-model-fitting-param-fixed'>
+                    <v-checkbox v-model="param.fixed">
+                      <template v-slot:label>
+                        <span style="overflow-wrap: anywhere; color: black; font-size: 10pt">
+                          {{param.name}}
+                        </span>
+                      </template>
+                    </v-checkbox>
+                  </j-tooltip>
                 </v-col>
-                <v-col cols = 2>
+                <v-col cols=4>
                   <v-text-field
                     v-model="param.value"
                   >
                   </v-text-field>
                 </v-col>
-                <v-col cols=1></v-col>
-                <v-col cols=3>
-                  {{ param.unit }}
-                </v-col>
-                <v-col cols=1></v-col>
-                <v-col cols=2>
-                  <j-tooltip tipid='plugin-model-fitting-param-fixed'>
-                    <v-checkbox v-model="param.fixed">
-                    </v-checkbox>
-                  </j-tooltip>
+                <v-col cols=4 style="font-size: 10pt">
+                  {{ param.unit.replace("Angstrom", "&#8491;") }}
                 </v-col>
               </v-row>
             </v-expansion-panel-content>
           </v-expansion-panel>
         </v-expansion-panels>
-        </v-container>
-      </v-card-text>
-      <v-divider></v-divider>
+      </v-row>
+    </div>
 
-      <v-card-subtitle>Model Equation Editor</v-card-subtitle>
-      <v-card-text>
-        <v-container>
-          <v-text-field
-            v-model="model_equation"
-            hint="Enter an equation specifying how to combine the component models, using their model IDs and basic arithmetic operators (ex. component1+component2)."
-            persistent-hint
-            :rules="[() => !!model_equation || 'This field is required']"
-            @change="equation_changed"
-            :error="eq_error"
-          >
-          </v-text-field>
-        </v-container>
-      </v-card-text>
-      <v-divider></v-divider>
-
-      <v-card-actions>
-        <div class="flex-grow-1"></div>
+    <div v-if="component_models.length">
+      <j-plugin-section-header>Equation Editor</j-plugin-section-header>
+      <v-row>
         <v-text-field
-          v-model="model_label"
-          label="Model Label"
-          hint="Label for the resulting modeled spectrum/cube."
+          v-model="model_equation"
+          hint="Enter an equation specifying how to combine the component models, using their model IDs and basic arithmetic operators (ex. component1+component2)."
           persistent-hint
+          :rules="[() => !!model_equation || 'This field is required']"
+          @change="equation_changed"
+          :error="eq_error"
         >
         </v-text-field>
-      </v-card-actions>
-      <v-divider></v-divider>
-      <v-card-actions>
-        <v-switch
-          label="Plot Results"
-          hint="Model will immediately be plotted in the spectral viewer.  Will also be available in the data menu of each spectral viewer."
-          v-model="add_replace_results"
-          persistent-hint>
-        </v-switch>
-      </v-card-actions>
-      <v-card-actions>
-        <div class="flex-grow-1"></div>
-        <v-row
-          justify="left"
-          align="center"
-          no-gutters
-        >
-          <j-tooltip tipid='plugin-model-fitting-fit'>
-            <v-btn color="primary" text @click="model_fitting">Fit</v-btn>
-          </j-tooltip>
-        </v-row>
-      </v-card-actions>
-      
-      <v-divider v-if="cube_fit"></v-divider>
-      <v-card-actions v-if="cube_fit">
+      </v-row>
+    </div>
+
+    <j-plugin-section-header>Fit Model</j-plugin-section-header>
+    <v-row>
+      <v-text-field
+        v-model="model_label"
+        label="Model Label"
+        hint="Label for the resulting modeled spectrum/cube."
+        persistent-hint
+      >
+      </v-text-field>
+    </v-row>
+
+    <v-row>
+      <v-switch
+        label="Plot Results"
+        hint="Model will immediately be plotted in the spectral viewer.  Will also be available in the data menu of each spectral viewer."
+        v-model="add_replace_results"
+        persistent-hint>
+      </v-switch>
+    </v-row>
+
+    <v-row justify="end">
+      <j-tooltip tipid='plugin-model-fitting-fit'>
+        <v-btn color="accent" text @click="model_fitting">Fit</v-btn>
+      </j-tooltip>
+    </v-row>
+
+    <v-row>
+      <span class="vuetify-styles v-messages v-messages__message" style="color: rgba(0, 0, 0, 0.6)">
+          If fit is not sufficiently converged, try clicking fitting again to complete additional iterations.
+      </span>
+    </v-row>
+
+    <div v-if="cube_fit">
+      <j-plugin-section-header>Cube Fit</j-plugin-section-header>
+      <v-row>
         <v-select
           :items="viewers"
           v-model="selected_viewer"
@@ -221,24 +193,14 @@
           hint='Cube results will replace plot in the specified viewer. Will also be available in the data dropdown in all image viewers.'
           persistent-hint
         ></v-select>
-      </v-card-actions>
-      <v-card-actions v-if="cube_fit">
-        <div class="flex-grow-1"></div>
-        <v-row
-          justify="left"
-          align="center"
-          no-gutters
-        >
-          <j-tooltip tipid='plugin-model-fitting-apply'>
-            <v-btn color="primary" text @click="fit_model_to_cube">Apply to Cube</v-btn>
-          </j-tooltip>
-        </v-row>
-      </v-card-actions>
-      <v-card-actions>
-        <span class="vuetify-styles v-messages">
-            If fit is not sufficiently converged, try clicking fitting again to complete additional iterations.
-        </span>
-      </v-card-actions>
-    </v-card>
-  </v-card>
+      </v-row>
+
+      <v-row justify="end">
+        <j-tooltip tipid='plugin-model-fitting-apply'>
+          <v-btn color="accent" text @click="fit_model_to_cube">Apply to Cube</v-btn>
+        </j-tooltip>
+      </v-row>
+    </div>
+
+  </j-tray-plugin>
 </template>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -173,12 +173,12 @@
 
     <v-row justify="end">
       <j-tooltip tipid='plugin-model-fitting-fit'>
-        <v-btn color="accent" text @click="model_fitting">Fit</v-btn>
+        <v-btn color="accent" text @click="model_fitting">Fit Model</v-btn>
       </j-tooltip>
     </v-row>
 
     <v-row>
-      <span class="vuetify-styles v-messages v-messages__message text--secondary">
+      <span class="v-messages v-messages__message text--secondary">
           If fit is not sufficiently converged, try clicking fitting again to complete additional iterations.
       </span>
     </v-row>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -178,7 +178,7 @@
     </v-row>
 
     <v-row>
-      <span class="vuetify-styles v-messages v-messages__message" style="color: rgba(0, 0, 0, 0.6)">
+      <span class="vuetify-styles v-messages v-messages__message text--secondary">
           If fit is not sufficiently converged, try clicking fitting again to complete additional iterations.
       </span>
     </v-row>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -83,7 +83,7 @@
                     <b>{{ item.id }}</b>&nbsp;({{ item.model_type }})
                   </v-row>
                   <v-row v-for="param in item.parameters">
-                    <span style="white-space: nowrap; overflow-x: hidden; width: calc(100% - 24px); margin-right: -48px">
+                    <span style="white-space: nowrap; overflow-x: clip; width: calc(100% - 24px); margin-right: -48px">
                       {{ param.name }} = {{ param.value }}                      
                     </span>
                   </v-row>

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -1,110 +1,90 @@
 <template>
-  <v-card flat tile>
-    <v-card>
-      <v-card-text>
-        <v-container>
-          <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#aper-phot-simple'">
-            Perform aperture photometry for a single region.
-          </j-docs-link>
-          <v-row>
-            <v-col>
-              <v-select
-                :items="dc_items"
-                @change="data_selected"
-                label="Data"
-                hint="Select data for photometry."
-                persistent-hint
-              ></v-select>
-            </v-col>
-          </v-row>
-          <v-row>
-            <v-col>
-              <v-select
-                :items="subset_items"
-                @change="subset_selected"
-                label="Subset"
-                hint="Select subset region for photometry."
-                persistent-hint
-              ></v-select>
-            </v-col>
-          </v-row>
-          <v-row>
-            <v-col>
-              <v-text-field
-                label="Background value"
-                v-model="background_value"
-                hint="Background to subtract, same unit as data"
-                persistent-hint
-              >
-              </v-text-field>
-            </v-col>
-          </v-row>
-          <v-row>
-            <v-col>
-              <v-text-field
-                label="Pixel area"
-                v-model="pixel_area"
-                hint="Pixel area in arcsec squared, only used if sr in data unit"
-                persistent-hint
-              >
-              </v-text-field>
-            </v-col>
-          </v-row>
-          <v-row>
-            <v-col>
-              <v-text-field
-                label="Counts conversion factor"
-                v-model="counts_factor"
-                hint="Factor to convert data unit to counts, in unit of flux/counts"
-                persistent-hint
-              >
-              </v-text-field>
-            </v-col>
-          </v-row>
-          <v-row>
-            <v-col>
-              <v-text-field
-                label="Flux scaling"
-                v-model="flux_scaling"
-                hint="Same unit as data, used in -2.5 * log(flux / flux_scaling)"
-                persistent-hint
-              >
-              </v-text-field>
-            </v-col>
-          </v-row>
-        </v-container>
-      </v-card-text>
-      <v-divider></v-divider>
+  <j-tray-plugin>
+    <v-row>
+      <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#aper-phot-simple'">
+        Perform aperture photometry for a single region.
+      </j-docs-link>
+    </v-row>
 
-      <v-card-actions>
-        <div class="flex-grow-1"></div>
-        <v-row
-          justify="left"
-          align="center"
-          no-gutters
-        >
-          <v-btn color="primary" text @click="do_aper_phot">Calculate</v-btn>
-        </v-row>
-      </v-card-actions>
-      <v-divider></v-divider>
+    <v-row>
+      <v-select
+        :items="dc_items"
+        @change="data_selected"
+        label="Data"
+        hint="Select data for photometry."
+        persistent-hint
+      ></v-select>
+    </v-row>
 
-      <v-card-text v-if="result_available">
-        <v-container>
-          <v-row>
-            <v-col cols=6><U>Result</U></v-col>
-            <v-col cols=6><U>Value</U></v-col>
-          </v-row>
-          <v-row
-            v-for="item in results"
-            :key="item.function">
-            <v-col cols=6>
-              {{  item.function  }}
-            </v-col>
-            <v-col cols=6>{{ item.result }}</v-col>
-          </v-row>
-        </v-container>
-      </v-card-text>
-      <v-divider></v-divider>
-    </v-card>
-  </v-card>
+    <v-row>
+      <v-select
+        :items="subset_items"
+        @change="subset_selected"
+        label="Subset"
+        hint="Select subset region for photometry."
+        persistent-hint
+      ></v-select>
+    </v-row>
+
+    <v-row>
+      <v-text-field
+        label="Background value"
+        v-model="background_value"
+        hint="Background to subtract, same unit as data"
+        persistent-hint
+      >
+      </v-text-field>
+    </v-row>
+
+    <v-row>
+      <v-text-field
+        label="Pixel area"
+        v-model="pixel_area"
+        hint="Pixel area in arcsec squared, only used if sr in data unit"
+        persistent-hint
+      >
+      </v-text-field>
+    </v-row>
+
+    <v-row>
+      <v-text-field
+        label="Counts conversion factor"
+        v-model="counts_factor"
+        hint="Factor to convert data unit to counts, in unit of flux/counts"
+        persistent-hint
+      >
+      </v-text-field>
+    </v-row>
+
+    <v-row>
+      <v-text-field
+        label="Flux scaling"
+        v-model="flux_scaling"
+        hint="Same unit as data, used in -2.5 * log(flux / flux_scaling)"
+        persistent-hint
+      >
+      </v-text-field>
+    </v-row>
+
+    <v-row justify="end">
+      <v-btn color="primary" text @click="do_aper_phot">Calculate</v-btn>
+    </v-row>
+
+
+    <div v-if="result_available">
+      <j-plugin-section-header>Results</j-plugin-section-header>
+      <v-row>
+        <v-col cols=6><U>Result</U></v-col>
+        <v-col cols=6><U>Value</U></v-col>
+      </v-row>
+      <v-row
+        v-for="item in results"
+        :key="item.function">
+        <v-col cols=6>
+          {{  item.function  }}
+        </v-col>
+        <v-col cols=6>{{ item.result }}</v-col>
+      </v-row>
+    </div>
+  </j-tray-plugin>
 </template>

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -1,60 +1,49 @@
 <template>
-  <v-card flat tile>
-    <v-card>
-      <v-card-text>
-        <v-container>
-          <v-row>
-            <v-col>
-              <v-radio-group 
-                label="Link type"
-                hint="Type of linking to be done."
-                v-model="link_type"
-                persistent-hint
-                row>
-                <v-radio
-                  v-for="item in link_types"
-                  :key="item"
-                  :label="item"
-                  :value="item"
-                ></v-radio>
-               </v-radio-group>
-            </v-col>
-          </v-row>
-          <v-row v-if="false">
-            <v-col>
-              <v-switch
-                label="Fallback on Pixels"
-                hint="If WCS linking fails, fallback to linking by pixels."
-                v-model="wcs_use_fallback"
-                persistent-hint>
-              </v-switch>
-            </v-col>
-          </v-row>
-          <v-row v-if="link_type == 'WCS'">
-            <v-col>
-              <v-switch
-                label="Fast approximation"
-                hint="Use fast approximation for image alignment if possible (accurate to <1 pixel)."
-                v-model="wcs_use_affine"
-                persistent-hint>
-              </v-switch>
-            </v-col>
-          </v-row>
-        </v-container>
-      </v-card-text>
-      <v-divider></v-divider>
-      <v-card-actions>
-        <div class="flex-grow-1"></div>
-        <v-row
-          justify="left"
-          align="center"
-          no-gutters
-        >
-        <v-btn color="primary" text @click="do_link">Link</v-btn>
-        </v-row>
-      </v-card-actions>
-    </v-card>
-  </v-card>
+  <j-tray-plugin>
+    <v-row>
+      <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#link-control'">Re-link images by WCS or pixels.</j-docs-link>
+    </v-row>
+
+    <v-row>
+      <v-radio-group 
+        label="Link type"
+        hint="Type of linking to be done."
+        v-model="link_type"
+        persistent-hint
+        row>
+        <v-radio
+          v-for="item in link_types"
+          :key="item"
+          :label="item"
+          :value="item"
+        ></v-radio>
+       </v-radio-group>
+    </v-row>
+
+    <v-row v-if="false">
+      <v-switch
+        label="Fallback on Pixels"
+        hint="If WCS linking fails, fallback to linking by pixels."
+        v-model="wcs_use_fallback"
+        persistent-hint>
+      </v-switch>
+    </v-row>
+
+    <v-row v-if="link_type == 'WCS'">
+      <v-switch
+        label="Fast approximation"
+        hint="Use fast approximation for image alignment if possible (accurate to <1 pixel)."
+        v-model="wcs_use_affine"
+        persistent-hint>
+      </v-switch>
+    </v-row>
+
+    <v-row justify="end">
+      <j-tooltip tipid='plugin-link-apply'>
+        <v-btn color="accent" text @click="do_link">Link</v-btn>
+      </j-tooltip>
+    </v-row>
+  </j-tray-plugin>
 </template>
 
 <style>

--- a/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.vue
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.vue
@@ -1,26 +1,17 @@
 <template>
-  <v-card flat tile>
-    <!-- <v-divider></v-divider> -->
-    <v-container>
+  <j-tray-plugin>
+    <v-row>
       <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#slit-overlay'">Add a slit to the image viewer</j-docs-link>
-      <v-row>
-        <v-col>
-          <v-card-actions>
-            <div class="flex-grow-1">
-              <v-row>
-                <v-switch
-                  label="Visible"
-                  hint="Show slit in the image viewer."
-                  v-model="visible"
-                  @click.native="change_visible"
-                  persistent-hint>
-                </v-switch>
-              </v-row>
-            </div>
-          </v-card-actions>
-        </v-col>
-      </v-row>
-    </v-container>
+    </v-row>
 
-  </v-card>
+    <v-row>
+      <v-switch
+        label="Visible"
+        hint="Show slit in the image viewer."
+        v-model="visible"
+        @click.native="change_visible"
+        persistent-hint>
+      </v-switch>
+    </v-row>
+  </j-tray-plugin>
 </template>

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -1,50 +1,42 @@
 <template>
-  <v-card flat tile>
-    <v-card>
-      <v-card-text>
-        <v-container>
-          <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#line-analysis'">
-            Return statistics for a single spectral line.  The results are meaningful only when the continuum is properly normalized or subtracted, depending on the function you are interested in. See the <j-external-link link="https://specutils.readthedocs.io/en/stable/analysis.html" linktext="specutils docs"/> for more details.
-          </j-docs-link>
-          <v-row>
-            <v-col>
-              <v-select
-                :items="dc_items"
-                @change="data_selected"
-                label="Data"
-                hint="Select the data set to be fitted."
-                persistent-hint
-              ></v-select>
-            </v-col>
-          </v-row>
-        </v-container>
-      </v-card-text>
-      <v-divider></v-divider>
+  <j-tray-plugin>
+    <v-row>
+      <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#line-analysis'">
+        Return statistics for a single spectral line.  The results are meaningful only when the continuum is properly normalized or subtracted, depending on the function you are interested in. See the <j-external-link link="https://specutils.readthedocs.io/en/stable/analysis.html" linktext="specutils docs"/> for more details.
+      </j-docs-link>
+    </v-row>
 
-      <v-card-text v-if="result_available">
-        <v-container>
-          <v-row>
-            <v-col cols=6><U>Function</U></v-col>
-            <v-col cols=6><U>Result</U></v-col>
-          </v-row>
-          <v-row 
-            v-for="item in results"
-            :key="item.function">
-            <v-col cols=6>
-              {{  item.function  }}
-              <j-tooltip :tooltipcontent="'specutils '+item.function+' documentation'">
-                <a v-bind:href="'https://specutils.readthedocs.io/en/stable/api/specutils.analysis.'+item.function.toLowerCase().replaceAll(' ', '_')+'.html'" 
-                  target="__blank" 
-                  style="color: #A75000">
-                  <v-icon x-small color="#A75000">mdi-open-in-new</v-icon>
-                </a> 
-              </j-tooltip>
-            </v-col>
-            <v-col cols=6>{{ item.result }}</v-col>
-          </v-row>
-        </v-container>
-      </v-card-text>
-      <v-divider></v-divider>
-    </v-card>
-  </v-card>
+    <v-row>
+      <v-select
+        :items="dc_items"
+        @change="data_selected"
+        label="Data"
+        hint="Select the data set to be fitted."
+        persistent-hint
+      ></v-select>
+    </v-row>
+
+    <div v-if="result_available">
+      <j-plugin-section-header>Results</j-plugin-section-header>
+      <v-row>
+        <v-col cols=6><U>Function</U></v-col>
+        <v-col cols=6><U>Result</U></v-col>
+      </v-row>
+      <v-row 
+        v-for="item in results"
+        :key="item.function">
+        <v-col cols=6>
+          {{  item.function  }}
+          <j-tooltip :tooltipcontent="'specutils '+item.function+' documentation'">
+            <a v-bind:href="'https://specutils.readthedocs.io/en/stable/api/specutils.analysis.'+item.function.toLowerCase().replaceAll(' ', '_')+'.html'" 
+              target="__blank" 
+              style="color: #A75000">
+              <v-icon x-small color="#A75000">mdi-open-in-new</v-icon>
+            </a> 
+          </j-tooltip>
+        </v-col>
+        <v-col cols=6>{{ item.result }}</v-col>
+      </v-row>
+    </div>
+  </j-tray-plugin>
 </template>

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -1,78 +1,72 @@
 <template>
-  <v-card flat tile>
-    <v-container>
-      <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#unit-conversion'">Convert the spectral flux density and spectral axis units</j-docs-link>
-      <v-row>
-        <v-col class="py-0">
-          <v-text-field
-            v-model="selected_data"
-            label="Data"
-            hint="Data to be converted."
-            disabled="True"
-            persistent-hint
-          ></v-text-field>
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col>
-          <v-text-field
-            ref="current_spectral_axis_unit"
-            label="Current Spectral Axis Unit"
-            v-model="current_spectral_axis_unit"
-            hint="The spectral axis unit of the currently selected data."
-            persistent-hint
-            disabled="True"
-          ></v-text-field>
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col>
-          <v-text-field
-            ref="current_flux_unit"
-            label="Current Flux Unit"
-            v-model="current_flux_unit"
-            hint="The flux unit of the currently selected data."
-            persistent-hint
-            disabled="True"
-          ></v-text-field>
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col>
-          <v-combobox
-            label="New Spectral Axis Unit"
-            :items="spectral_axis_unit_equivalencies"
-            v-model="new_spectral_axis_unit"
-            @input.native="new_spectral_axis_unit=$event.srcElement.value"
-            return-object
-            hide-no-data="True"
-            hint="The spectral axis unit the currently selected data will be converted to."
-            persistent-hint
-          ></v-text-field>
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col>
-          <v-combobox
-            label="New Flux Unit"
-            :items="flux_unit_equivalencies"
-            v-model="new_flux_unit"
-            @input.native="new_flux_unit=$event.srcElement.value"
-            return-object
-            hint="The flux unit the currently selected data will be converted to."
-            persistent-hint
-          ></v-text-field>
-        </v-col>
-      </v-row>
-    </v-container>
-    <!-- <v-divider></v-divider> -->
+  <j-tray-plugin>
+    <v-row>
+      <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#unit-conversion'">Convert the spectral flux density and spectral axis units.</j-docs-link>
+    </v-row>
 
-    <v-card-actions>
-      <div class="flex-grow-1"></div>
+    <v-row>
+      <v-text-field
+        v-model="selected_data"
+        label="Data"
+        hint="Data to be converted."
+        disabled="True"
+        persistent-hint
+      ></v-text-field>
+    </v-row>
+
+    <v-row>
+      <v-text-field
+        ref="current_spectral_axis_unit"
+        label="Current Spectral Axis Unit"
+        v-model="current_spectral_axis_unit"
+        hint="The spectral axis unit of the currently selected data."
+        persistent-hint
+        disabled="True"
+      ></v-text-field>
+    </v-row>
+
+    <v-row>
+      <v-text-field
+        ref="current_flux_unit"
+        label="Current Flux Unit"
+        v-model="current_flux_unit"
+        hint="The flux unit of the currently selected data."
+        persistent-hint
+        disabled="True"
+      ></v-text-field>
+    </v-row>
+
+    <v-row>
+      <v-combobox
+        label="New Spectral Axis Unit"
+        :items="spectral_axis_unit_equivalencies"
+        v-model="new_spectral_axis_unit"
+        @input.native="new_spectral_axis_unit=$event.srcElement.value"
+        return-object
+        hide-no-data="True"
+        hint="The spectral axis unit the currently selected data will be converted to."
+        persistent-hint
+      ></v-text-field>
+    </v-row>
+
+    <v-row>
+      <v-combobox
+        label="New Flux Unit"
+        :items="flux_unit_equivalencies"
+        v-model="new_flux_unit"
+        @input.native="new_flux_unit=$event.srcElement.value"
+        return-object
+        hint="The flux unit the currently selected data will be converted to."
+        persistent-hint
+      ></v-text-field>
+    </v-row>
+
+    <v-row justify="end">
       <j-tooltip tipid='plugin-unit-conversion-apply'>
         <v-btn :disabled="selected_data == ''"
-        color="primary" text @click="unit_conversion">Apply</v-btn>
+        color="accent" text @click="unit_conversion">Apply</v-btn>
       </j-tooltip>
-    </v-card-actions>
-  </v-card>
+    </v-row>
+
+  </j-tray-plugin>
 </template>


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request attempts to minimize padding (i.e., maximize usable space) in plugins and create a consistent styling across all plugins.

If accepted and merged, all future plugin work should adopt the [new style guide](https://github.com/kecnry/jdaviz/blob/plugin-styling/docs/dev/ui_style_guide.rst) (also added to the docs as part of this PR/review).

The screenshots below show a few places with noticeable changes at the default plugin tray width (which also becomes the **minimum allowed width in a default notebook** in this PR) and with the cell extended to 100% width (with the plugin tray still at 25%). 

Changes that *might* be controversial:
* model fitting & line lists: move check boxes from right to left and remove column headers
* model fitting: rename "add model" button to "add component" to be consistent with section headers
* model fitting: keep header the same when expanding a model component
* line lists: for custom line list, move color box to top above "add new line"

Note about the minimum tray width:
* splitpanes only allows setting a minimum width in percentages (not pixels).  So here the tray always opens at 25% and has that set as a minimum.  For large standalone apps or when overriding the cell width in jupyter, this might not be ideal, but it does prevent shrinking the tray below "supported" levels in the default notebook environment.

**NOTE**: screenshots are slightly outdated, but changes are minimal.  Overall padding on the left and right of content has been halved, and the header on model components has been improved.


| Before | After | After 100% |
| --- | --- | --- |
| <img width="200" src="https://user-images.githubusercontent.com/877591/146564381-547aff61-5171-4cd1-a66d-14a3edd97add.png"> | <img width="200" src="https://user-images.githubusercontent.com/877591/146564760-96645761-1b29-41c9-aa19-39c6d993ae44.png"> | <img width="320" src="https://user-images.githubusercontent.com/877591/146601068-94384155-93ac-4e29-8078-bcb77b9af19f.png"> |
| <img width="200" src="https://user-images.githubusercontent.com/877591/146564468-fbfcbf2d-279b-44b7-8e8c-7ab2d872465b.png"> | <img width="200" src="https://user-images.githubusercontent.com/877591/146564828-b15da9ab-140d-4f62-a9b2-e0f06f0e8ced.png"> | <img width="320" src="https://user-images.githubusercontent.com/877591/146601160-6f0ff4cf-5b9e-4fbe-900a-8da0b3c120d6.png"> |
| <img width="200" src="https://user-images.githubusercontent.com/877591/146564523-2a82ba1a-3346-4590-9461-1d1a554376cd.png"> | <img width="200" src="https://user-images.githubusercontent.com/877591/146564873-d71f9a7f-632d-4f06-b8a1-09a016ac1cd6.png"> |  <img width="320" src="https://user-images.githubusercontent.com/877591/146601199-b8c002d1-b748-4134-b603-2c95006747e5.png"> |
| <img width="200" src="https://user-images.githubusercontent.com/877591/146564561-df06da69-cefb-4b60-b8fe-5e7114725d98.png"> | <img width="200" src="https://user-images.githubusercontent.com/877591/146564915-34cf1121-3a81-4811-b3f6-aa670561ecc8.png"> | <img width="320" src="https://user-images.githubusercontent.com/877591/146601585-225e78bc-248e-43bd-a55c-eebae0116a7b.png"> |
| <img width="200" src="https://user-images.githubusercontent.com/877591/146564605-e197ac09-c73b-4133-8165-bef30aa15b7d.png"> | <img width="200" src="https://user-images.githubusercontent.com/877591/146564944-43ac72df-82bd-479a-bb7a-f5da40ad347c.png"> | <img width="320" src="https://user-images.githubusercontent.com/877591/146601428-a1403b1f-da23-456a-b9b3-2050b7226b41.png"> |
| <img width="200" src="https://user-images.githubusercontent.com/877591/146564643-c56805b1-c1d0-4e97-afc7-265f32313287.png"> | <img width="200" src="https://user-images.githubusercontent.com/877591/146564986-088272be-e4c1-425a-a0c2-8e0d83011676.png"> | <img width="320" src="https://user-images.githubusercontent.com/877591/146601453-741a054d-237d-480f-8b0d-f4fa5ca038e9.png"> |


**TODO**
- [x] fix text color of docs link text (alpha=0.6 to match other gray text)
- [x] remove padding around outside of columns (but not between)
- [ ] ~try to improve responsiveness of remaining use of columns~
- [x] improve color picker size in line lists plugin
- [x] improve model components expansion panel in model fitting plugin
- [x] improve layout of line lists expansion panel
- [x] iterate styling with Jenn and get approval
  * standards for action buttons (color, placement, justification)
  * styling of divider
  * padding sizes (in general)
- [x] document style guide somewhere in dev docs
- [x] test layout in notebook, lab, voila, embedded
  * embedded version still needs some styling help, but nothing new seems broken
- [x] check if this magically fixes #1005 🤞  (it did not)
- [x] test plugins (ensure significant changes to vue files don't break functionality anywhere - all /seem/ to work, but extra tests during review never hurts!)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
