### PR TITLE
EXP: Ignore obsgeo in JWST WCS for moment 2 calculation

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -127,6 +127,7 @@ class MomentMap(TemplateMixin):
     def vue_calculate_moment(self, *args):
         # Retrieve the data cube and slice out desired region, if specified
         cube = self._selected_data.get_object(cls=Spectrum1D, statistic=None)
+        cube.wcs.wcs.obsgeo = [None] * 6  # Skip observer/target calculations in astropy SpectralCoords
         spec_min = float(self.spectral_min) * u.Unit(self.spectral_unit)
         spec_max = float(self.spectral_max) * u.Unit(self.spectral_unit)
         slab = manipulation.spectral_slab(cube, spec_min, spec_max)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

I find that I needed this patch to get past an unrelated error to get to the original error reported in #947 . Since I am not familiar with JWST WCS or `astropy`'s `SpectralCoord`, I am not sure what is really going on here.

When `obsgeo` and `mjdobs` are defined, the logic gets into this logic and crashes because either `spectralcoord.observer` or `spectralcoord.target` is missing. It is unclear to me where the real bug is.

https://github.com/astropy/astropy/blob/85da057ad4eacec2cc947efab546308fa5390fa8/astropy/wcs/wcsapi/fitswcs.py#L563

Or it could just be bad simulated data: `jw00636-o003_t002_nirspec_prism-clear_s3d`

🤷 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
