### PR TITLE
Line analysis subsets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ New Features
 
 - Box and xrange zoom tools for all applicable viewers. [#997]
 
+- Data and Subset selection are now separate in the Line Analysis plugin, to
+  handle the case of multiple datasets affected by a subset. [#1012]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -82,14 +82,14 @@ class LineAnalysis(TemplateMixin):
 
         if len(self.dc_items) == 0:
             self.selected_spectrum = ""
+            self.selected_subset = "Entire Spectrum"
             self.result_available = False
 
     @observe("selected_subset", "selected_spectrum")
-    def _run_functions(self, *args, **kwargs):
+    def _calculate_statistics(self, *args, **kwargs):
         """
-        Run fitting on the initialized models, fixing any parameters marked
-        as such by the user, then update the displauyed parameters with fit
-        values
+        Run the line analysis functions on the selected data/subset and
+        display the results.
         """
         if self.selected_spectrum == "":
             self.result_available = False
@@ -119,5 +119,6 @@ class LineAnalysis(TemplateMixin):
                 temp_result = FUNCTIONS[function](self._spectrum1d)
 
             temp_results.append({'function': function, 'result': str(temp_result)})
-        self.result_available = True
+
         self.results = temp_results
+        self.result_available = True

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -1,6 +1,5 @@
 import numpy as np
-from glue.core.message import (SubsetCreateMessage,
-                               SubsetDeleteMessage,
+from glue.core.message import (SubsetDeleteMessage,
                                SubsetUpdateMessage)
 from traitlets import Bool, List, Unicode, observe
 from specutils import analysis, SpectralRegion
@@ -44,11 +43,6 @@ class LineAnalysis(TemplateMixin):
         self.hub.subscribe(self, RemoveDataMessage,
                            handler=self._on_viewer_data_changed)
 
-        # It seems like SubsetUpdate always gets called after SubsetCreate, so
-        # we wait until after creation is complete to handle it on SubsetUpdate.
-        #self.hub.subscribe(self, SubsetCreateMessage,
-        #                   handler=self._on_viewer_data_changed)
-
         self.hub.subscribe(self, SubsetDeleteMessage,
                            handler=self._on_viewer_data_changed)
 
@@ -76,12 +70,11 @@ class LineAnalysis(TemplateMixin):
         viewer = self.app.get_viewer('spectrum-viewer')
 
         self._spectral_subsets = self.app.get_subsets_from_viewer("spectrum-viewer",
-                                                                   subset_type="spectral")
+                                                                  subset_type="spectral")
         self.spectral_subset_items = ["None"] + sorted(self._spectral_subsets.keys())
 
         self.dc_items = [layer_state.layer.label for layer_state in viewer.state.layers
                          if layer_state.layer.label not in self.spectral_subset_items]
-
 
     @observe("selected_subset", "selected_spectrum")
     def _run_functions(self, *args, **kwargs):
@@ -92,10 +85,11 @@ class LineAnalysis(TemplateMixin):
         """
         if self.selected_spectrum == "":
             return
+
         self._spectrum1d = self.app.get_data_from_viewer("spectrum-viewer",
                                                          data_label=self.selected_spectrum)
 
-        if self.selected_subset is not "None":
+        if self.selected_subset != "None":
             mask = self.app.get_data_from_viewer("spectrum-viewer",
                                                  data_label=self.selected_subset).mask
             self._spectrum1d.mask = mask

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -2,7 +2,7 @@ import numpy as np
 from glue.core.message import (SubsetCreateMessage,
                                SubsetDeleteMessage,
                                SubsetUpdateMessage)
-from traitlets import Bool, List, Unicode
+from traitlets import Bool, List, Unicode, observe
 from specutils import analysis, SpectralRegion
 
 from jdaviz.core.events import AddDataMessage, RemoveDataMessage
@@ -23,8 +23,9 @@ class LineAnalysis(TemplateMixin):
     dialog = Bool(False).tag(sync=True)
     template_file = __file__, "line_analysis.vue"
     dc_items = List([]).tag(sync=True)
-    temp_function = Unicode().tag(sync=True)
-    available_functions = List(list(FUNCTIONS.keys())).tag(sync=True)
+    spectral_subset_items = List(["None"]).tag(sync=True)
+    selected_spectrum = Unicode("").tag(sync=True)
+    selected_subset = Unicode("None").tag(sync=True)
     result_available = Bool(False).tag(sync=True)
     results = List().tag(sync=True)
 
@@ -33,6 +34,7 @@ class LineAnalysis(TemplateMixin):
 
         self._viewer_spectra = None
         self._spectrum1d = None
+        self._viewer_id = self.app._viewer_item_by_reference('spectrum-viewer').get('id')
         self._units = {}
         self.result_available = False
 
@@ -42,14 +44,16 @@ class LineAnalysis(TemplateMixin):
         self.hub.subscribe(self, RemoveDataMessage,
                            handler=self._on_viewer_data_changed)
 
-        self.hub.subscribe(self, SubsetCreateMessage,
-                           handler=lambda x: self._on_viewer_data_changed())
+        # It seems like SubsetUpdate always gets called after SubsetCreate, so
+        # we wait until after creation is complete to handle it on SubsetUpdate.
+        #self.hub.subscribe(self, SubsetCreateMessage,
+        #                   handler=self._on_viewer_data_changed)
 
         self.hub.subscribe(self, SubsetDeleteMessage,
-                           handler=lambda x: self._on_viewer_data_changed())
+                           handler=self._on_viewer_data_changed)
 
         self.hub.subscribe(self, SubsetUpdateMessage,
-                           handler=lambda x: self._on_viewer_data_changed())
+                           handler=self._on_viewer_data_changed)
 
     def _on_viewer_data_changed(self, msg=None):
         """
@@ -69,59 +73,33 @@ class LineAnalysis(TemplateMixin):
         msg : `glue.core.Message`
             The glue message passed to this callback method.
         """
-        self._viewer_id = self.app._viewer_item_by_reference(
-            'spectrum-viewer').get('id')
-
-        # Subsets are global and are not linked to specific viewer instances,
-        # so it's not required that we match any specific ids for that case.
-        # However, if the msg is not none, check to make sure that it's the
-        # viewer we care about.
-        if msg is not None and msg.viewer_id != self._viewer_id:
-            return
-
         viewer = self.app.get_viewer('spectrum-viewer')
 
-        self.dc_items = [layer_state.layer.label
-                         for layer_state in viewer.state.layers]
+        self._spectral_subsets = self.app.get_subsets_from_viewer("spectrum-viewer",
+                                                                   subset_type="spectral")
+        self.spectral_subset_items = ["None"] + sorted(self._spectral_subsets.keys())
 
-    def vue_data_selected(self, event):
-        """
-        Callback method for when the user has selected data from the drop down
-        in the front-end. It is here that we actually parse and create a new
-        data object from the selected data. From this data object, unit
-        information is scraped, and the selected spectrum is stored for later
-        use in fitting.
+        self.dc_items = [layer_state.layer.label for layer_state in viewer.state.layers
+                         if layer_state.layer.label not in self.spectral_subset_items]
 
-        Parameters
-        ----------
-        event : str
-            IPyWidget callback event object. In this case, represents the data
-            label of the data collection object selected by the user.
-        """
-        selected_spec = self.app.get_data_from_viewer("spectrum-viewer",
-                                                      data_label=event)
 
-        if self._units == {}:
-            self._units["x"] = str(
-                selected_spec.spectral_axis.unit)
-            self._units["y"] = str(
-                selected_spec.flux.unit)
-
-        for label in self.dc_items:
-            if label in self.data_collection:
-                self._label_to_link = label
-                break
-
-        self._spectrum1d = selected_spec
-
-        self._run_functions()
-
+    @observe("selected_subset", "selected_spectrum")
     def _run_functions(self, *args, **kwargs):
         """
         Run fitting on the initialized models, fixing any parameters marked
         as such by the user, then update the displauyed parameters with fit
         values
         """
+        if self.selected_spectrum == "":
+            return
+        self._spectrum1d = self.app.get_data_from_viewer("spectrum-viewer",
+                                                         data_label=self.selected_spectrum)
+
+        if self.selected_subset is not "None":
+            mask = self.app.get_data_from_viewer("spectrum-viewer",
+                                                 data_label=self.selected_subset).mask
+            self._spectrum1d.mask = mask
+
         temp_results = []
         for function in FUNCTIONS:
             # Centroid function requires a region argument, create one to pass

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -69,8 +69,12 @@ class LineAnalysis(TemplateMixin):
         """
         viewer = self.app.get_viewer('spectrum-viewer')
 
-        self._spectral_subsets = self.app.get_subsets_from_viewer("spectrum-viewer",
-                                                                  subset_type="spectral")
+        try:
+            self._spectral_subsets = self.app.get_subsets_from_viewer("spectrum-viewer",
+                                                                      subset_type="spectral")
+        except ValueError:
+            pass
+
         self.spectral_subset_items = ["Entire Spectrum"] + sorted(self._spectral_subsets.keys())
 
         self.dc_items = [layer_state.layer.label for layer_state in viewer.state.layers

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -22,9 +22,9 @@ class LineAnalysis(TemplateMixin):
     dialog = Bool(False).tag(sync=True)
     template_file = __file__, "line_analysis.vue"
     dc_items = List([]).tag(sync=True)
-    spectral_subset_items = List(["None"]).tag(sync=True)
+    spectral_subset_items = List(["Entire Spectrum"]).tag(sync=True)
     selected_spectrum = Unicode("").tag(sync=True)
-    selected_subset = Unicode("None").tag(sync=True)
+    selected_subset = Unicode("Entire Spectrum").tag(sync=True)
     result_available = Bool(False).tag(sync=True)
     results = List().tag(sync=True)
 
@@ -71,10 +71,14 @@ class LineAnalysis(TemplateMixin):
 
         self._spectral_subsets = self.app.get_subsets_from_viewer("spectrum-viewer",
                                                                   subset_type="spectral")
-        self.spectral_subset_items = ["None"] + sorted(self._spectral_subsets.keys())
+        self.spectral_subset_items = ["Entire Spectrum"] + sorted(self._spectral_subsets.keys())
 
         self.dc_items = [layer_state.layer.label for layer_state in viewer.state.layers
                          if layer_state.layer.label not in self.spectral_subset_items]
+
+        if len(self.dc_items) == 0:
+            self.selected_spectrum = ""
+            self.result_available = False
 
     @observe("selected_subset", "selected_spectrum")
     def _run_functions(self, *args, **kwargs):
@@ -84,12 +88,13 @@ class LineAnalysis(TemplateMixin):
         values
         """
         if self.selected_spectrum == "":
+            self.result_available = False
             return
 
         self._spectrum1d = self.app.get_data_from_viewer("spectrum-viewer",
                                                          data_label=self.selected_spectrum)
 
-        if self.selected_subset != "None":
+        if self.selected_subset != "Entire Spectrum":
             mask = self.app.get_data_from_viewer("spectrum-viewer",
                                                  data_label=self.selected_subset).mask
             self._spectrum1d.mask = mask

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -9,9 +9,19 @@
     <v-row>
       <v-select
         :items="dc_items"
-        @change="data_selected"
+        v-model="selected_spectrum"
         label="Data"
         hint="Select the data set to be fitted."
+        persistent-hint
+      ></v-select>
+    </v-row>
+
+    <v-row>
+      <v-select
+        :items="spectral_subset_items"
+        v-model="selected_subset"
+        label="Spectral Region"
+        hint="Select spectral region to apply the collapse."
         persistent-hint
       ></v-select>
     </v-row>


### PR DESCRIPTION
Separates out the Subset selection from the Data selection in the Line Analysis plugin, in case there are multiple datasets that a subset might be applied to. Also removes some defunct code that was still there, probably from an older version that did things differently.

I'll note here, because it's given us problems before, that I ended up removing the `SubsetCreate` message handling entirely. There is no guarantee of which order message handlers will be executed in in Glue, so I was hitting an error where the handler was getting called (and trying to retrieve the created subset) before the handler that actually adds the subset to the viewer, which is apparently also triggered off the `SubsetCreate` message. As far as I can tell, the `SubsetUpdate` message always gets triggered after a subset is created, and it works to trigger the behavior we need here only off of that message instead. 