### PR TITLE
Proof of concept: transparent menu while interacting with sliders

### DIFF
--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -89,18 +89,18 @@
                     </v-btn>
                   </template>
 
-                  <v-tabs v-model="viewer.tab" grow height="36px">
+                  <v-tabs v-model="viewer.tab" grow height="36px" ref="layer_viewer_tabs">
                     <v-tab key="0">Layer</v-tab>
                     <v-tab key="1">Viewer</v-tab>
                   </v-tabs>
 
                   <!-- NOTE: v-lazy needed for initial tab underline: https://github.com/vuetifyjs/vuetify/issues/1978#issuecomment-676892274 -->
-                  <v-lazy>
+                  <v-lazy @mousedown="layer_viewer_mouse_down" @mouseup="layer_viewer_mouse_up" ref="layer_viewer_contents">
                     <v-tabs-items v-model="viewer.tab" style="max-height: 500px; width: 350px;" lazy>
 
                     <v-tab-item key="0" class="overflow-y-auto" style="height: 100%">
                       <v-sheet class="px-4">
-                        <jupyter-widget :widget="viewer.layer_options" /> 
+                        <jupyter-widget :widget="viewer.layer_options"/> 
                       </v-sheet>
                     </v-tab-item>
 
@@ -177,9 +177,21 @@ module.exports = {
   name: "g-viewer-tab",
   props: ["stack", "dataItems", "closefn"],
   created() {
+    this.layer_viewer_class = ""
     this.$parent.childMe = () => {
       return this.$children[0];
     };
+    this.layer_viewer_mouse_down = (e) => {
+      if (e.target.className.indexOf("v-slider__thumb") !== -1) {
+        // then clicked on a slider, so we want to set transparency
+        this.$refs.layer_viewer_contents[0].$el.style.opacity = 0.2
+        this.$refs.layer_viewer_tabs[0].$el.style.opacity = 0.2
+      }
+    }
+    this.layer_viewer_mouse_up = (e) => {
+      this.$refs.layer_viewer_contents[0].$el.style.opacity = 1.0
+      this.$refs.layer_viewer_tabs[0].$el.style.opacity = 1.0
+    }
   },
   methods: {
     computeChildrenPath() {


### PR DESCRIPTION


<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address the layer/viewer menu covering the image being adjusted by making it temporarily semi-transparent.  The implementation has 2 difficulties which will need to be overcome if moving forward with this solution, both of which can be seen in the recording below:
* underline on tabs can be lost
* v-slider seems to be blocking the event propagation on mouseup, so transparency can only be reset by clicking elsewhere.

https://user-images.githubusercontent.com/877591/147785345-28b662b7-d9f1-47b7-914a-90212a173e51.mov

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
