### PR TITLE
Fix model parameter updating after fit for compound models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Bug Fixes
 ---------
 
 - Model plugin now validates component names to avoid equation failing. [#1020]
+- Model plugin properly updates parameters after fit for compound models. [#1023]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -160,7 +160,11 @@ class ModelFitting(TemplateMixin):
         for m in self.component_models:
             name = m["id"]
             if hasattr(self._fitted_model, "submodel_names"):
-                m_fit = self._fitted_model[name]
+                try:
+                    m_fit = self._fitted_model[name]
+                except IndexError:
+                    # This component model wasn't actually used in the model equation
+                    continue
             elif self._fitted_model.name == name:
                 m_fit = self._fitted_model
             else:

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -160,10 +160,9 @@ class ModelFitting(TemplateMixin):
         for m in self.component_models:
             name = m["id"]
             if hasattr(self._fitted_model, "submodel_names"):
-                try:
+                if name in self._fitted_model.submodel_names:
                     m_fit = self._fitted_model[name]
-                except IndexError:
-                    # This component model wasn't actually used in the model equation
+                else:
                     continue
             elif self._fitted_model.name == name:
                 m_fit = self._fitted_model

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -159,7 +159,7 @@ class ModelFitting(TemplateMixin):
         """Insert the results of the model fit into the component_models"""
         for m in self.component_models:
             name = m["id"]
-            if hasattr(self._fitted_model, name):
+            if hasattr(self._fitted_model, "submodel_names"):
                 m_fit = self._fitted_model[name]
             elif self._fitted_model.name == name:
                 m_fit = self._fitted_model


### PR DESCRIPTION
Fixes #1022 , ended up being very simple. The displayed parameters for models with multiple components now update properly with the fitted values again. 