### PR TITLE
FEAT: Radial profile in Imviz simple aperture photometry plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ New Features
 ------------
 
 - There are now ``show_in_sidecar`` and ``show_in_new_tab`` methods on all the
-  helpers that display the viewers in separate JupyterLab windows from the 
+  helpers that display the viewers in separate JupyterLab windows from the
   notebook. [#952]
 
 Cubeviz
@@ -15,6 +15,8 @@ Imviz
 ^^^^^
 
 - New metadata viewer plugin. [#1035]
+
+- New radial profile plot in the simple aperture photometry plugin. [#1030]
 
 Mosviz
 ^^^^^^

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -79,7 +79,7 @@ an interactively selected region. A typical workflow is as follows:
     However, if NaN exists in data, it will be treated as 0.
 
 When calculation is complete, a plot would show the radial profile
-and the results are displayed under the
+of the background subtracted data and the photometry results are displayed under the
 :guilabel:`CALCULATE` button. You can also retrieve the results as
 `~astropy.table.QTable` as follows, assuming ``imviz`` is the instance
 of your Imviz application::

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -78,7 +78,8 @@ an interactively selected region. A typical workflow is as follows:
     Masking and weights by uncertainty are currently not supported.
     However, if NaN exists in data, it will be treated as 0.
 
-When calculation is complete, the results are displayed under the
+When calculation is complete, a plot would show the radial profile
+and the results are displayed under the
 :guilabel:`CALCULATE` button. You can also retrieve the results as
 `~astropy.table.QTable` as follows, assuming ``imviz`` is the instance
 of your Imviz application::

--- a/docs/known_bugs.rst
+++ b/docs/known_bugs.rst
@@ -106,6 +106,14 @@ to show the markers, or not at all. This is a known bug reported in
 https://github.com/glue-viz/glue-jupyter/issues/243 . If you encounter this,
 try a different OS/browser combo.
 
+Simple Aperture Photometry Plugin and dithered images
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Due to a known bug reported in https://github.com/glue-viz/glue-astronomy/issues/52 ,
+aperture photometry and radial profile will report inaccurate results when you
+calculate them on dithered images linked by WCS *unless* you are on the reference image
+(this is usually the first loaded image).
+
 .. _known_issues_specviz:
 
 Specviz

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1022,6 +1022,14 @@ class Application(VuetifyTemplate, HubListener):
 
         resize(self.state.stack_items)
 
+        # resize tray items
+        for tray_item in self.state.tray_items:
+            # access the actual plugin object (there is no store for plugins)
+            tray_obj = self.widgets.get(tray_item['widget'].split('IPY_MODEL_')[1])
+            for bqplot_fig in tray_obj.bqplot_figs_resize:
+                bqplot_fig.layout.height = '99.9%'
+                bqplot_fig.layout.height = '100&'
+
     def vue_destroy_viewer_item(self, cid):
         """
         Callback for when viewer area tabs are destroyed. Finds the viewer item

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1028,7 +1028,7 @@ class Application(VuetifyTemplate, HubListener):
             tray_obj = self.widgets.get(tray_item['widget'].split('IPY_MODEL_')[1])
             for bqplot_fig in tray_obj.bqplot_figs_resize:
                 bqplot_fig.layout.height = '99.9%'
-                bqplot_fig.layout.height = '100&'
+                bqplot_fig.layout.height = '100%'
 
     def vue_destroy_viewer_item(self, cid):
         """

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -255,7 +255,7 @@ class SimpleAperturePhotometry(TemplateMixin):
                 y_label = 'Value'
             fig = bqplt.figure(1, title='Radial profile from Subset center',
                                title_style={'font-size': '12px'})  # TODO: Jenn wants title at bottom. # noqa
-            bqplt.plot(radial_r, y_data, 'ko', figure=fig, default_size=1)
+            bqplt.plot(radial_r, y_data, 'go', figure=fig, default_size=1)
             bqplt.xlabel(label='pix', mark=fig.marks[-1], figure=fig)
             bqplt.ylabel(label=y_label, mark=fig.marks[-1], figure=fig)
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -253,7 +253,9 @@ class SimpleAperturePhotometry(TemplateMixin):
             else:
                 y_data = radial_img
                 y_label = 'Value'
+            # NOTE: default margin in bqplot is 60 in all directions
             fig = bqplt.figure(1, title='Radial profile from Subset center',
+                               fig_margin={'top': 60, 'bottom': 60, 'left': 40, 'right': 10},
                                title_style={'font-size': '12px'})  # TODO: Jenn wants title at bottom. # noqa
             bqplt.plot(radial_r, y_data, 'go', figure=fig, default_size=1)
             bqplt.xlabel(label='pix', mark=fig.marks[-1], figure=fig)
@@ -294,7 +296,7 @@ class SimpleAperturePhotometry(TemplateMixin):
             self.results = tmp
             self.result_available = True
             self.radial_plot = fig
-            self.bqplot_figs_resize.append(fig)
+            self.bqplot_figs_resize = [fig]
             self.plot_available = True
 
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -294,6 +294,7 @@ class SimpleAperturePhotometry(TemplateMixin):
             self.results = tmp
             self.result_available = True
             self.radial_plot = fig
+            self.bqplot_figs_resize.append(fig)
             self.plot_available = True
 
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -38,12 +38,9 @@ class SimpleAperturePhotometry(TemplateMixin):
 
         self.hub.subscribe(self, AddDataMessage, handler=self._on_viewer_data_changed)
         self.hub.subscribe(self, RemoveDataMessage, handler=self._on_viewer_data_changed)
-        self.hub.subscribe(self, SubsetCreateMessage,
-                           handler=lambda x: self._on_viewer_data_changed())
-        self.hub.subscribe(self, SubsetDeleteMessage,
-                           handler=lambda x: self._on_viewer_data_changed())
-        self.hub.subscribe(self, SubsetUpdateMessage,
-                           handler=lambda x: self._on_viewer_data_changed())
+        self.hub.subscribe(self, SubsetCreateMessage, handler=self._on_viewer_data_changed)
+        self.hub.subscribe(self, SubsetDeleteMessage, handler=self._on_viewer_data_changed)
+        self.hub.subscribe(self, SubsetUpdateMessage, handler=self._on_viewer_data_changed)
 
         # TODO: Allow switching viewer in the future. Need new "messages" to subscribe
         #       to in viewer create/destroy events.

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -250,6 +250,7 @@ class SimpleAperturePhotometry(TemplateMixin):
             else:
                 y_data = radial_img
                 y_label = 'Value'
+            bqplt.clear()
             # NOTE: default margin in bqplot is 60 in all directions
             fig = bqplt.figure(1, title='Radial profile from Subset center',
                                fig_margin={'top': 60, 'bottom': 60, 'left': 40, 'right': 10},

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -70,7 +70,12 @@
       <v-btn color="primary" text @click="do_aper_phot">Calculate</v-btn>
     </v-row>
 
-    <jupyter-widget v-if="plot_available" :widget="radial_plot" style="width: 100%; height: 250px" />
+    <v-row>
+      <!-- NOTE: the internal bqplot widget defaults to 480 pixels, so if choosing something else,
+           we will likely need to override that with custom CSS rules in order to avoid the initial
+           rendering of the plot from overlapping with content below -->
+      <jupyter-widget v-if="plot_available" :widget="radial_plot" style="width: 100%; height: 480px" />
+    </v-row>
 
     <div v-if="result_available">
       <j-plugin-section-header>Results</j-plugin-section-header>

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -70,7 +70,7 @@
       <v-btn color="primary" text @click="do_aper_phot">Calculate</v-btn>
     </v-row>
 
-    <img v-if="radial_plot" :src="`data:image/png;base64,${radial_plot}`" border="0"/>
+    <jupyter-widget v-if="plot_available" :widget="radial_plot" style="width: 100%" />
 
     <div v-if="result_available">
       <j-plugin-section-header>Results</j-plugin-section-header>

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -70,7 +70,7 @@
       <v-btn color="primary" text @click="do_aper_phot">Calculate</v-btn>
     </v-row>
 
-    <jupyter-widget v-if="plot_available" :widget="radial_plot" style="width: 100%" />
+    <jupyter-widget v-if="plot_available" :widget="radial_plot" style="width: 100%; height: 250px" />
 
     <div v-if="result_available">
       <j-plugin-section-header>Results</j-plugin-section-header>

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -70,16 +70,18 @@
       <v-btn color="primary" text @click="do_aper_phot">Calculate</v-btn>
     </v-row>
 
+    <img v-if="radial_plot" :src="`data:image/png;base64,${radial_plot}`" border="0"/>
 
     <div v-if="result_available">
       <j-plugin-section-header>Results</j-plugin-section-header>
-      <v-row>
+      <v-row no-gutters>
         <v-col cols=6><U>Result</U></v-col>
         <v-col cols=6><U>Value</U></v-col>
       </v-row>
       <v-row
         v-for="item in results"
-        :key="item.function">
+        :key="item.function"
+        no-gutters>
         <v-col cols=6>
           {{  item.function  }}
         </v-col>

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -25,6 +25,7 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         assert not phot_plugin.result_available
         assert len(phot_plugin.results) == 0
         assert self.imviz.get_aperture_photometry_results() is None
+        assert not phot_plugin.plot_available
         assert phot_plugin.radial_plot == ''
 
         # Perform photometry on both images using same Subset.
@@ -37,6 +38,7 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         assert_allclose(phot_plugin.counts_factor, 0)
         assert_allclose(phot_plugin.pixel_area, 0)
         assert_allclose(phot_plugin.flux_scaling, 0)
+        assert phot_plugin.plot_available
         assert phot_plugin.radial_plot != ''  # Does not check content
 
         # Check photometry results.

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -25,6 +25,7 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         assert not phot_plugin.result_available
         assert len(phot_plugin.results) == 0
         assert self.imviz.get_aperture_photometry_results() is None
+        assert phot_plugin.radial_plot == ''
 
         # Perform photometry on both images using same Subset.
         phot_plugin.vue_data_selected('has_wcs_1[SCI,1]')
@@ -36,6 +37,7 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         assert_allclose(phot_plugin.counts_factor, 0)
         assert_allclose(phot_plugin.pixel_area, 0)
         assert_allclose(phot_plugin.flux_scaling, 0)
+        assert phot_plugin.radial_plot != ''  # Does not check content
 
         # Check photometry results.
         tbl = self.imviz.get_aperture_photometry_results()

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -28,6 +28,9 @@ class TemplateMixin(VuetifyTemplate, HubListener):
         # give the vue templates access to jdaviz version
         obj.vdocs = 'latest' if 'dev' in __version__ else 'v'+__version__
 
+        # store references to all bqplot widgets that need to handle resizing
+        obj.bqplot_figs_resize = []
+
         return obj
 
     @property


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to add radial plot to simple aperture photometry plugin in Imviz.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Close #962

[🐱](https://jira.stsci.edu/browse/JDAT-2055)

### TODO

- [x] Replace `matplotlib` with `bqplot`. ~Awaiting~ Use findings from @kecnry .
- [x] Fix bqplot figure not resizing.
- [x] Ensure reasonable dark mode support.

### Screenshots (bqplot)

HST/ACS data (dark mode):

![Screenshot 2022-02-02 151539](https://user-images.githubusercontent.com/2090236/152230498-ef2af0b0-1126-4e86-a501-c9e6449e3e29.png)

JWST simulated data:

![Screenshot 2022-02-02 150931](https://user-images.githubusercontent.com/2090236/152230533-116169e2-1ae0-40cb-a211-e06e04a7ec9c.png)

`photutils` example data (no WCS nor unit):

![Screenshot 2022-02-02 151239](https://user-images.githubusercontent.com/2090236/152230575-bd1515eb-6f38-4121-9572-d7e1eb76ab14.png)

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
