### PR TITLE
POC: Simple metadata viewer plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,8 +15,12 @@ Imviz
 Mosviz
 ^^^^^^
 
+- New metadata viewer plugin. [#1035]
+
 Specviz
 ^^^^^^^
+
+- New metadata viewer plugin. [#1035]
 
 API Changes
 -----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- New metadata viewer plugin. [#1035]
+
 Mosviz
 ^^^^^^
 

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -8,6 +8,13 @@ The Imviz data analysis plugins are meant to aid quick-look analysis
 of 2D image data. All plugins are accessed via the :guilabel:`plugin`
 icon in the upper right corner of the Imviz application.
 
+.. _metadata-viewer:
+
+Metadata Viewer
+===============
+
+This plugin allows viewing of any metadata associated with the selected data.
+
 .. _imviz-link-control:
 
 Link Control
@@ -26,7 +33,6 @@ for most cases. If approximation fails, WCS linking still automatically
 falls back to full transformation.
 
 For more details on linking, see :ref:`dev_glue_linking`.
-
 
 .. _aper-phot-simple:
 

--- a/docs/mosviz/plugins.rst
+++ b/docs/mosviz/plugins.rst
@@ -9,6 +9,12 @@ more detail under Specviz:Data Analysis Plugins.  All plugins
 are accessed via the plugin icon in the upper right corner
 of the Mosviz application.
 
+.. _mosviz-metadata-viewer:
+
+Metadata Viewer
+===============
+
+This plugin allows viewing of any metadata associated with the selected data.
 
 Gaussian Smooth
 ===============

--- a/docs/specviz/plugins.rst
+++ b/docs/specviz/plugins.rst
@@ -19,8 +19,16 @@ selected datasets.
 
 Input/Output
 ============
+
 Data to be operated on are selected in each plugin via a
 :guilabel:`Data` pulldown menu.
+
+.. _specviz-metadata-viewer:
+
+Metadata Viewer
+===============
+
+This plugin allows viewing of any metadata associated with the selected data.
 
 .. _gaussian-smooth:
 

--- a/jdaviz/configs/default/plugins/__init__.py
+++ b/jdaviz/configs/default/plugins/__init__.py
@@ -6,3 +6,4 @@ from .subset_tools.subset_tools import *  # noqa
 from .model_fitting.model_fitting import *  # noqa
 from .collapse.collapse import *  # noqa
 from .line_lists.line_lists import *  # noqa
+from .metadata_viewer.metadata_viewer import *  # noqa

--- a/jdaviz/configs/default/plugins/metadata_viewer/__init__.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/__init__.py
@@ -1,0 +1,1 @@
+from .metadata_viewer import *  # noqa

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -30,7 +30,7 @@ class MetadataViewer(TemplateMixin):
     def _show_metadata(self, event):
         try:
             data = self.app.data_collection[self.app.data_collection.labels.index(event['new'])]
-        except IndexError:
+        except ValueError:
             self.has_metadata = False
             self.metadata = []
             return
@@ -95,7 +95,7 @@ def _iteritems(asdfnode):
             for i, val in enumerate(asdfnode):
                 for x in recurse(val, path + [i]):
                     yield x
-        elif asdfnode is not None:
+        else:
             yield ('.'.join(str(x) for x in path), asdfnode)
 
     for x in recurse(asdfnode):

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -1,0 +1,49 @@
+from copy import deepcopy
+
+from traitlets import Bool, List, Unicode, observe
+
+from jdaviz.core.events import AddDataMessage, RemoveDataMessage
+from jdaviz.core.registries import tray_registry
+from jdaviz.core.template_mixin import TemplateMixin
+
+__all__ = ['MetadataViewer']
+
+
+@tray_registry('g-metadata-viewer', label="Metadata Viewer")
+class MetadataViewer(TemplateMixin):
+    template_file = __file__, "metadata_viewer.vue"
+    dc_items = List([]).tag(sync=True)
+    selected_data = Unicode("").tag(sync=True)
+    has_metadata = Bool(False).tag(sync=True)
+    metadata = List([]).tag(sync=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.hub.subscribe(self, AddDataMessage,
+                           handler=self._on_viewer_data_changed)
+        self.hub.subscribe(self, RemoveDataMessage,
+                           handler=self._on_viewer_data_changed)
+
+    def _on_viewer_data_changed(self, *args, **kwargs):
+        self.dc_items = [data.label for data in self.app.data_collection]
+
+    @observe("selected_data")
+    def _show_metadata(self, event):
+        try:
+            data = self.app.data_collection[self.app.data_collection.labels.index(event['new'])]
+        except IndexError:
+            self.has_metadata = False
+            self.metadata = []
+            return
+
+        if not hasattr(data, 'meta') or not isinstance(data.meta, dict) or len(data.meta) < 1:
+            self.has_metadata = False
+            self.metadata = []
+        else:
+            d = deepcopy(data.meta)
+            for badkey in ('COMMENT', 'HISTORY', ''):
+                if badkey in d:
+                    del d[badkey]  # ipykernel cannot clean for JSON
+            self.metadata = list(zip(d.keys(), map(str, d.values())))
+            self.has_metadata = True

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -65,15 +65,15 @@ def flatten_nested_dict(asdfnode, include_arrays=True):
     from astropy.time import Time
 
     def convert_val(val):
-        if isinstance(val, datetime.datetime):
+        if isinstance(val, datetime.datetime):  # pragma: no cover
             return val.isoformat()
-        elif isinstance(val, Time):
+        elif isinstance(val, Time):  # pragma: no cover
             return str(val)
         return val
 
     if include_arrays:
         return dict((key, convert_val(val)) for (key, val) in _iteritems(asdfnode))
-    else:
+    else:  # pragma: no cover
         return dict((key, convert_val(val)) for (key, val) in _iteritems(asdfnode)
                     if not isinstance(val, np.ndarray))
 

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -1,3 +1,4 @@
+from astropy.io.fits import Header
 from traitlets import Bool, List, Unicode, observe
 
 from jdaviz.core.events import AddDataMessage, RemoveDataMessage
@@ -39,7 +40,15 @@ class MetadataViewer(TemplateMixin):
             self.has_metadata = False
             self.metadata = []
         else:
-            d = flatten_nested_dict(data.meta)
+            if 'header' in data.meta and isinstance(data.meta['header'], (dict, Header)):
+                if isinstance(data.meta['header'], Header):  # Specviz
+                    meta = dict(data.meta['header'])
+                else:
+                    meta = data.meta['header']
+            else:
+                meta = data.meta
+
+            d = flatten_nested_dict(meta)
             for badkey in ('COMMENT', 'HISTORY', ''):
                 if badkey in d:
                     del d[badkey]  # ipykernel cannot clean for JSON

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.vue
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.vue
@@ -1,0 +1,32 @@
+<template>
+  <j-tray-plugin>
+    <v-row>
+      <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#metadata-viewer'">View metadata.</j-docs-link>
+    </v-row>
+
+    <v-row>
+      <v-select
+        :items="dc_items"
+        v-model="selected_data"
+        label="Data"
+        hint="Select the data to see metadata."
+        persistent-hint
+      ></v-select>
+    </v-row>
+
+    <div v-if="has_metadata">
+      <j-plugin-section-header>Metadata</j-plugin-section-header>
+      <v-row>
+        <v-col cols=6><U>Key</U></v-col>
+        <v-col cols=6><U>Value</U></v-col>
+      </v-row>
+      <v-row
+        v-for="item in metadata"
+        :key="item[0]">
+        <v-col cols=6>{{ item[0] }}</v-col>
+        <v-col cols=6>{{ item[1] }}</v-col>
+      </v-row>
+    </div>
+
+  </j-tray-plugin>
+</template>

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.vue
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.vue
@@ -16,13 +16,14 @@
 
     <div v-if="has_metadata">
       <j-plugin-section-header>Metadata</j-plugin-section-header>
-      <v-row>
+      <v-row no-gutters>
         <v-col cols=6><U>Key</U></v-col>
         <v-col cols=6><U>Value</U></v-col>
       </v-row>
       <v-row
         v-for="item in metadata"
-        :key="item[0]">
+        :key="item[0]"
+        no-gutters>
         <v-col cols=6>{{ item[0] }}</v-col>
         <v-col cols=6>{{ item[1] }}</v-col>
       </v-row>

--- a/jdaviz/configs/default/plugins/metadata_viewer/tests/test_metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/tests/test_metadata_viewer.py
@@ -1,0 +1,44 @@
+import numpy as np
+from astropy.nddata import NDData
+
+from jdaviz.configs.default.plugins.metadata_viewer.metadata_viewer import MetadataViewer
+
+
+def test_view_dict(imviz_app):
+    mv = MetadataViewer(app=imviz_app)
+    ndd_1 = NDData(np.zeros((2, 2)), meta={
+        'EXTNAME': 'SCI', 'EXTVER': 1, 'BAR': 10.0,
+        'FOO': '', 'COMMENT': 'a test', 'BOZO': None})
+    ndd_2 = NDData(np.ones((2, 2)), meta={
+        'EXTNAME': 'ASDF', 'REF': {'bar': 10.0, 'FOO': {'1': '', '2': [1, 2]}}})
+    arr = np.zeros((2, 2))
+    imviz_app.load_data(ndd_1, data_label='has_simple_meta')
+    imviz_app.load_data(ndd_2, data_label='has_nested_meta')
+    imviz_app.load_data(arr, data_label='no_meta')
+    assert mv.dc_items == ['has_simple_meta', 'has_nested_meta', 'no_meta']
+
+    mv.selected_data = 'has_simple_meta'
+    assert mv.has_metadata
+    assert mv.metadata == [
+        ('BAR', '10.0'), ('BOZO', 'None'), ('EXTNAME', 'SCI'),
+        ('EXTVER', '1'), ('FOO', '')]
+
+    mv.selected_data = 'has_nested_meta'
+    assert mv.has_metadata
+    assert mv.metadata == [
+        ('EXTNAME', 'ASDF'), ('REF.bar', '10.0'),
+        ('REF.FOO.1', ''), ('REF.FOO.2', '[1, 2]')]
+
+    mv.selected_data = 'no_meta'
+    assert not mv.has_metadata
+    assert mv.metadata == []
+
+
+def test_view_invalid(imviz_app):
+    mv = MetadataViewer(app=imviz_app)
+    assert mv.dc_items == []
+
+    # Should not even happen but if it does, do not crash.
+    mv.selected_data = 'foo'
+    assert not mv.has_metadata
+    assert mv.metadata == []

--- a/jdaviz/configs/default/plugins/metadata_viewer/tests/test_metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/tests/test_metadata_viewer.py
@@ -5,29 +5,29 @@ from jdaviz.configs.default.plugins.metadata_viewer.metadata_viewer import Metad
 
 
 def test_view_dict(imviz_app):
-    mv = MetadataViewer(app=imviz_app)
+    mv = MetadataViewer(app=imviz_app.app)
     ndd_1 = NDData(np.zeros((2, 2)), meta={
         'EXTNAME': 'SCI', 'EXTVER': 1, 'BAR': 10.0,
         'FOO': '', 'COMMENT': 'a test', 'BOZO': None})
     ndd_2 = NDData(np.ones((2, 2)), meta={
-        'EXTNAME': 'ASDF', 'REF': {'bar': 10.0, 'FOO': {'1': '', '2': [1, 2]}}})
+        'EXTNAME': 'ASDF', 'REF': {'bar': 10.0, 'foo': {'1': '', '2': [1, 2]}}})
     arr = np.zeros((2, 2))
     imviz_app.load_data(ndd_1, data_label='has_simple_meta')
     imviz_app.load_data(ndd_2, data_label='has_nested_meta')
     imviz_app.load_data(arr, data_label='no_meta')
-    assert mv.dc_items == ['has_simple_meta', 'has_nested_meta', 'no_meta']
+    assert mv.dc_items == ['has_simple_meta[DATA]', 'has_nested_meta[DATA]', 'no_meta']
 
-    mv.selected_data = 'has_simple_meta'
+    mv.selected_data = 'has_simple_meta[DATA]'
     assert mv.has_metadata
     assert mv.metadata == [
         ('BAR', '10.0'), ('BOZO', 'None'), ('EXTNAME', 'SCI'),
-        ('EXTVER', '1'), ('FOO', '')]
+        ('EXTVER', '1'), ('FOO', '')], mv.metadata
 
-    mv.selected_data = 'has_nested_meta'
+    mv.selected_data = 'has_nested_meta[DATA]'
     assert mv.has_metadata
     assert mv.metadata == [
         ('EXTNAME', 'ASDF'), ('REF.bar', '10.0'),
-        ('REF.FOO.1', ''), ('REF.FOO.2', '[1, 2]')]
+        ('REF.foo.1', ''), ('REF.foo.2.0', '1'), ('REF.foo.2.1', '2')], mv.metadata
 
     mv.selected_data = 'no_meta'
     assert not mv.has_metadata
@@ -35,7 +35,7 @@ def test_view_dict(imviz_app):
 
 
 def test_view_invalid(imviz_app):
-    mv = MetadataViewer(app=imviz_app)
+    mv = MetadataViewer(app=imviz_app.app)
     assert mv.dc_items == []
 
     # Should not even happen but if it does, do not crash.

--- a/jdaviz/configs/imviz/imviz.yaml
+++ b/jdaviz/configs/imviz/imviz.yaml
@@ -18,6 +18,7 @@ toolbar:
   - g-image-viewer-creator
   - g-coords-info
 tray:
+  - g-metadata-viewer
   - imviz-links-control
   - imviz-aper-phot-simple
 viewer_area:

--- a/jdaviz/configs/mosviz/mosviz.yaml
+++ b/jdaviz/configs/mosviz/mosviz.yaml
@@ -13,6 +13,7 @@ toolbar:
   - g-subset-tools
   - g-row-lock
 tray:
+  - g-metadata-viewer
   - g-gaussian-smooth
   - g-slit-overlay
   - g-model-fitting

--- a/jdaviz/configs/specviz/specviz.yaml
+++ b/jdaviz/configs/specviz/specviz.yaml
@@ -14,6 +14,7 @@ toolbar:
   - g-data-tools
   - g-subset-tools
 tray:
+  - g-metadata-viewer
   - g-gaussian-smooth
   - g-model-fitting
   - g-unit-conversion


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements a new generic plugin to display whatever metadata attached to the selected glue Data, as long as it is a dictionary. For FITS, this is the header of the loaded extension. We can make it pretty later...

Would be nice if it auto-detects which one is the actively displayed Data and just display metadata for that, but it is hard to implement because layouts allow multiple viewers.

![Screenshot 2022-01-14 105259](https://user-images.githubusercontent.com/2090236/149545298-7cbb9bf4-87ae-40fd-9238-765177ff9438.jpg)

### TODO

- [x] Should we proceed with this?
- [x] Does this work for all the Viz? Focusing on Imviz now but can try with other viz as stretch goal. Got it to work for Mosviz and Specviz. Cubeviz does not load metadata and I don't want this to conflict with #1040. We don't really use Specviz2D, so I ignored it.
- [x] Add change log.
- [x] Add user-facing doc (have to be consistent with `j-docs-link` in the plugin).
- [x] Add tests.
- [x] How to make ASDF metadata display less ugly due to nested dictionary?

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-2091)
