### PR TITLE
Cubeviz parser: Refactor parser, add ndarray support, metadata viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ New Features
 Cubeviz
 ^^^^^^^
 
+- Cubeviz can now load 3D ndarray (or equivalent) and data without WCS. However,
+  when WCS is not present, not all plugins will work as intended. [#1040]
+
+- New metadata viewer plugin. [#1040]
+
 Imviz
 ^^^^^
 
@@ -21,6 +26,8 @@ API Changes
 
 Cubeviz
 ^^^^^^^
+
+- Cubeviz parser is refactored for better support across all supported data formats. [#1040]
 
 Imviz
 ^^^^^
@@ -86,11 +93,6 @@ Cubeviz
 
 - Move slice slider to the plugin tray and add capability for selecting by wavelength as well as
   through a tool in the spectrum viewer. [#1013]
-
-- Cubeviz can now load 3D ndarray (or equivalent) and data without WCS. However,
-  when WCS is not present, not all plugins will work as intended. [#1040]
-
-- New metadata viewer plugin. [#1040]
 
 Imviz
 ^^^^^
@@ -165,8 +167,6 @@ Cubeviz
 - Moment Map plugin no longer crashes when writing out to FITS file. [#1099]
 
 - Moment Maps result is no longer rotated w.r.t. original data. [#1104]
-
-- Cubeviz parser is refactored for better support across all supported data formats. [#1040]
 
 Imviz
 ^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -87,7 +87,10 @@ Cubeviz
 - Move slice slider to the plugin tray and add capability for selecting by wavelength as well as
   through a tool in the spectrum viewer. [#1013]
 
-- Cubeviz can now load 3D ndarray. [#1040]
+- Cubeviz can now load 3D ndarray (or equivalent) and data without WCS. However,
+  when WCS is not present, not all plugins will work as intended. [#1040]
+
+- New metadata viewer plugin. [#1040]
 
 Imviz
 ^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -87,6 +87,8 @@ Cubeviz
 - Move slice slider to the plugin tray and add capability for selecting by wavelength as well as
   through a tool in the spectrum viewer. [#1013]
 
+- Cubeviz can now load 3D ndarray. [#1040]
+
 Imviz
 ^^^^^
 
@@ -160,6 +162,8 @@ Cubeviz
 - Moment Map plugin no longer crashes when writing out to FITS file. [#1099]
 
 - Moment Maps result is no longer rotated w.r.t. original data. [#1104]
+
+- Cubeviz parser is refactored for better support across all supported data formats. [#1040]
 
 Imviz
 ^^^^^

--- a/docs/cubeviz/displaycubes.rst
+++ b/docs/cubeviz/displaycubes.rst
@@ -14,7 +14,7 @@ function. The indicators that the load machinery looks for in each HDU to
 populate the viewers are below (note that in all cases, header values are
 converted to lower case):
 
-    - Flux viewer: ``hdu.name`` is in the set ``['flux', 'sci']``
+    - Flux viewer: ``hdu.name`` is in the set ``['flux', 'sci', 'primary']``
     - Uncertainty viewer: ``hdu.header.keys()`` includes "errtype" or ``hdu.name``
       is in the set ``['ivar', 'err', 'var', 'uncert']``
     - Mask viewer: ``hdu.data.dtype`` is `int`, `numpy.uint` or `numpy.uint32`, or
@@ -24,7 +24,7 @@ If any viewer fails to populate automatically, or if displaying
 different data is desired, the user can manually select data for each viewer
 as described in the next section. Different statistics for collapsing the 
 spectrum displayed in the spectrum viewer can be chosen as described in 
-:ref:`Display Settings<display-settings>`. Note that any spatial subsets will 
+:ref:`Display Settings <display-settings>`. Note that any spatial subsets will
 also be collapsed into a spectrum using the same statistic and displayed in 
 the spectrum viewer along with the spectrum resulting from collapsing all the
 data in each spectral slice.

--- a/docs/cubeviz/import_data.rst
+++ b/docs/cubeviz/import_data.rst
@@ -12,8 +12,8 @@ application:
 
 Cubeviz supports loading the following data formats:
 
-* FITS file, `~astropy.io.fits.HDUList`, `~fits.hdu.hdulist.ImageHDU`, or
-  `~fits.hdu.hdulist.PrimaryHDU` that can be parsed as
+* FITS file, `~astropy.io.fits.HDUList`, `~astropy.io.fits.ImageHDU`, or
+  `~astropy.io.fits.PrimaryHDU` that can be parsed as
   `~specutils.Spectrum1D` 3D object, in which case the application
   will attempt to automatically parse the data into the viewers as described
   in :ref:`cubeviz-display-cubes`. This support includes the ASDF-in-FITS
@@ -66,7 +66,7 @@ method, which takes as input either the name of a local file or a
     >>> cubeviz.load_data("/Users/demouser/data/cube_file.fits")  # doctest: +SKIP
 
 Theoretically, mix-and-match loading might be possible. For instance,
-you may choose to load `~specutils.Spectrum1D` into one viewer, `~fits.hdu.hdulist.ImageHDU`
+you may choose to load `~specutils.Spectrum1D` into one viewer, `~astropy.io.fits.ImageHDU`
 into another, and Numpy array into the third one. However, user must ensure their
 data units and WCS's are compatible. Therefore, while possible, it is not recommended unless
 you know what you are doing.

--- a/docs/cubeviz/import_data.rst
+++ b/docs/cubeviz/import_data.rst
@@ -5,10 +5,30 @@ Import Data
 ***********
 
 There are two primary ways in which you can load your data into the Cubeviz
-application. Cubeviz supports loading FITS files that can be parsed as 
-:class:`~specutils.Spectrum1D` objects, in which case the application will
-attempt to automatically parse the data into the viewers as described in 
-:ref:`cubeviz-display-cubes`, including the 1D spectrum viewer.
+application:
+
+* :ref:`gui-import-cubeviz`
+* :ref:`api-import-cubeviz`
+
+Cubeviz supports loading the following data formats:
+
+* FITS file, `~astropy.io.fits.HDUList`, `~fits.hdu.hdulist.ImageHDU`, or
+  `~fits.hdu.hdulist.PrimaryHDU` that can be parsed as
+  `~specutils.Spectrum1D` 3D object, in which case the application
+  will attempt to automatically parse the data into the viewers as described
+  in :ref:`cubeviz-display-cubes`. This support includes the ASDF-in-FITS
+  format for JWST but the ASDF/GWCS extension will be ignored.
+* If a `~specutils.Spectrum1D` 3D object is passed in directly, it will
+  be loaded into the different viewers based on its ``flux``, ``mask``,
+  or ``uncertainty`` attributes.
+* If a `~specutils.Spectrum1D` 1D object is passed in directly, it will
+  be loaded into the 1D spectrum viewer even though for this use case,
+  :ref:`specviz` is better suited instead of Cubeviz.
+* If a 3D Numpy array is passed in directly, a dummy WCS will be assigned.
+  It will be loaded into the flux viewer unless an extra keyword option,
+  ``data_type`` is provided to indicate ``'mask'`` or ``'uncert'``.
+
+.. _gui-import-cubeviz:
 
 Importing data through the GUI
 ------------------------------
@@ -26,6 +46,9 @@ application. A green success message will appear if the data import
 was successful. Afterward, the new data set can be found in the :guilabel:`Data` 
 tab of each viewer's options menu as described in :ref:`cubeviz-selecting-data`.
 
+Due to the limitations of GUI interactions, only filenames are accepted as inputs.
+If you wish to load native Python objects, see :ref:`api-import-cubeviz`.
+
 .. _api-import-cubeviz:
 
 Importing data via the API
@@ -41,3 +64,12 @@ method, which takes as input either the name of a local file or a
     >>> from jdaviz import Cubeviz
     >>> cubeviz = Cubeviz()
     >>> cubeviz.load_data("/Users/demouser/data/cube_file.fits")  # doctest: +SKIP
+
+Theoretically, mix-and-match loading might be possible. For instance,
+you may choose to load `~specutils.Spectrum1D` into one viewer, `~fits.hdu.hdulist.ImageHDU`
+into another, and Numpy array into the third one. However, user must ensure their
+data units and WCS's are compatible. Therefore, while possible, it is not recommended unless
+you know what you are doing.
+
+For more examples on loading different formats, see
+``notebooks/concepts/cubeviz_parser_showcase.ipynb``.

--- a/docs/cubeviz/index.rst
+++ b/docs/cubeviz/index.rst
@@ -40,12 +40,11 @@ Future functionality will include the ability to:
 
 * save and restore a session,
 
-
 * create RGB images from regions collapsed in wavelength space (i.e., linemaps),
 
-* output python scripts for making figures,
+* output Python scripts for making figures,
 
-* output astropy commands,
+* output ``astropy`` commands,
 
 * match spatial resolution among selected data cubes,
 

--- a/docs/cubeviz/notebook.rst
+++ b/docs/cubeviz/notebook.rst
@@ -24,8 +24,13 @@ attribute of the `~jdaviz.configs.cubeviz.helper.Cubeviz` helper class. For exam
      cubeviz.app.get_data_from_viewer('flux-viewer')
 
 This code can be used to access data from the different viewers, which is returned as a dictionary.
-The viewer options in the Cubeviz configuration are ``spectrum-viewer``, ``flux-viewer``,
-``uncert-viewer``, and ``mask-viewer``.
+The viewer options in the Cubeviz configuration are:
+
+* ``flux-viewer`` (top left)
+* ``uncert-viewer`` (top center)
+* ``mask-viewer`` (top right)
+* ``spectrum-viewer`` (bottom)
+
 Using the appropriate data label, the data in its native type can be returned from this dictionary like
 so::
 

--- a/docs/cubeviz/plugins.rst
+++ b/docs/cubeviz/plugins.rst
@@ -9,6 +9,13 @@ more detail under :ref:`Specviz: Data Analysis Plugins <specviz-plugins>`.  All 
 are accessed via the :guilabel:`plugin` icon in the upper right corner
 of the Cubeviz application.
 
+.. _cubeviz-metadata-viewer:
+
+Metadata Viewer
+===============
+
+This plugin allows viewing of any metadata associated with the selected data.
+
 .. _cubeviz-export-plot:
 
 Export Plot

--- a/docs/notebook/import_data.rst
+++ b/docs/notebook/import_data.rst
@@ -1,3 +1,5 @@
+.. _notebook_import_data:
+
 ***********************************
 Import Data From Notebook to Jdaviz
 ***********************************

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -27,17 +27,10 @@ In a Jupyter Notebook
 ---------------------
 
 ``jdaviz`` provides a directory of sample notebooks to test the application, located in the ``notebooks`` sub-directory
-of the git repository.  ``Example.ipynb`` is provided as an example that loads a SDSS MaNGA IFU data cube with the
-``Cubeviz`` configuration.  To run the provided example, start the jupyter kernel with the notebook path::
+of the Git repository.  For instance, the following example loads a SDSS MaNGA IFU data cube with the
+Cubeviz configuration.  To run it, start the Jupyter kernel with the notebook path::
 
-    jupyter notebook /path/to/jdaviz/notebooks/Example.ipynb
+    jupyter notebook /path/to/jdaviz/notebooks/CubevizExample.ipynb
 
-or simply start a new Jupyter notebook and run the following in a cell::
-
-    from jdaviz import Application
-
-    app = Application()
-    app
-
-To learn more about the various ``jdaviz`` application configurations and loading data, see the :ref:`cubeviz`,
-:ref:`specviz`, :ref:`mosviz`, or :ref:`imviz` tools.
+To learn more about the various ``jdaviz`` application configurations and loading data, see
+:ref:`notebook_import_data`, :ref:`cubeviz`, :ref:`specviz`, :ref:`mosviz`, or :ref:`imviz`.

--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -15,6 +15,7 @@ toolbar:
   - g-data-tools
   - g-subset-tools
 tray:
+  - g-metadata-viewer
   - g-export-plot
   - g-plot-options
   - cubeviz-slice

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -111,7 +111,7 @@ def _parse_hdulist(app, hdulist, base_data_label):
         data_label = f"{base_data_label}[{hdu.name.upper()}]"
         try:
             data_type = _parse_hdu(app, hdu, data_label, hdulist=hdulist, show_in_viewer=False)
-        except Exception:
+        except Exception:  # nosec
             continue
         if data_type and data_type not in viewer_cache:
             _show_data_in_cubeviz_viewer(app, data_label, data_type)

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -23,7 +23,7 @@ def parse_data(app, file_obj, data_type=None, data_label=None):
     ----------
     app : `~jdaviz.app.Application`
         The application-level object used to reference the viewers.
-    file_obj : str, `~fits.hdu.hdulist.ImageHDU`, `~fits.hdu.hdulist.PrimaryHDU`, `~fits.hdu.hdulist.HDUList`, `~specutils.Spectrum1D`, or ndarray
+    file_obj : str, `~astropy.io.fits.ImageHDU`, `~astropy.io.fits.PrimaryHDU`, `~astropy.io.fits.HDUList`, `~specutils.Spectrum1D`, or ndarray
         The path to a cube-like data FITS file or the data object to be loaded.
     data_type : {'flux', 'uncert', 'mask', `None`}
         The data type used to explicitly differentiate parsed data.

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -329,7 +329,8 @@ def _parse_ndarray_3d(app, file_obj, data_label, data_type):
     else:
         flux_unit = u.count
     flux = file_obj << flux_unit
-    fake_wcs = generate_dummy_fits_wcs_3d()
-    sc = Spectrum1D(flux, wcs=fake_wcs)
+    # fake_wcs = generate_dummy_fits_wcs_3d()
+    idx = np.arange(flux.shape[-1]) * u.pix
+    sc = Spectrum1D(spectral_axis=idx, flux=flux)
     app.add_data(sc, data_label)
     _show_data_in_cubeviz_viewer(app, data_label, data_type)

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -91,6 +91,8 @@ def parse_data(app, file_obj, data_type=None, data_label=None):
     elif isinstance(file_obj, np.ndarray):
         if data_label is None:
             data_label = f'ndarray|{str(base64.b85encode(uuid.uuid4().bytes), "utf-8")}'
+        if data_type is None:
+            data_type = 'flux'
 
         if file_obj.ndim == 3:
             _parse_ndarray_3d(app, file_obj, data_label, data_type)

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -151,16 +151,6 @@ def _get_flux_unit_from_hdu_header(app, hdr, data_label, strict=False):
     return flux_unit
 
 
-def generate_dummy_fits_wcs_3d():
-    """Generate a dummy 3D FITS WCS for Cubeviz."""
-    dummy_wcs = WCS(naxis=3)
-    dummy_wcs.wcs.ctype[2] = 'WAVE'
-    dummy_wcs.wcs.cunit[2] = u.m
-    dummy_wcs.wcs.crval[2] = 0
-    dummy_wcs.wcs.cdelt[2] = 1
-    return dummy_wcs
-
-
 def _get_wcs_from_hdu_header(app, hdr, data_label, hdulist=None):
     is_bad = ''
 
@@ -176,7 +166,7 @@ def _get_wcs_from_hdu_header(app, hdr, data_label, hdulist=None):
         app.hub.broadcast(SnackbarMessage(
             f"Invalid WCS for {data_label}: {is_bad}",
             color="warning", timeout=8000, sender=app))
-        wcs = generate_dummy_fits_wcs_3d()
+        wcs = None
 
     return wcs
 
@@ -329,8 +319,6 @@ def _parse_ndarray_3d(app, file_obj, data_label, data_type):
     else:
         flux_unit = u.count
     flux = file_obj << flux_unit
-    # fake_wcs = generate_dummy_fits_wcs_3d()
-    idx = np.arange(flux.shape[-1]) * u.pix
-    sc = Spectrum1D(spectral_axis=idx, flux=flux)
+    sc = Spectrum1D(flux=flux)
     app.add_data(sc, data_label)
     _show_data_in_cubeviz_viewer(app, data_label, data_type)

--- a/jdaviz/configs/cubeviz/plugins/tests/test_data_retrieval.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_data_retrieval.py
@@ -12,18 +12,18 @@ from astropy.utils.data import download_file
 
 @pytest.mark.filterwarnings('ignore')
 @pytest.mark.remote_data
-def test_data_retrieval(cubeviz_app):
+def test_data_retrieval(cubeviz_helper):
     # This file is originally from
     # https://data.sdss.org/sas/dr14/manga/spectro/redux/v2_1_2/7495/stack/manga-7495-12704-LOGCUBE.fits.gz
     URL = 'https://stsci.box.com/shared/static/28a88k1qfipo4yxc4p4d40v4axtlal8y.fits'
 
     fn = download_file(URL, cache=True)
-    cubeviz_app.load_data(fn)
+    cubeviz_helper.load_data(fn)
 
     # two ways of retrieving data from the viewer.
     # They should return the same spectral values
-    a1 = cubeviz_app.app.get_viewer('spectrum-viewer').data()
-    a2 = cubeviz_app.app.get_data_from_viewer("spectrum-viewer")
+    a1 = cubeviz_helper.app.get_viewer('spectrum-viewer').data()
+    a2 = cubeviz_helper.app.get_data_from_viewer("spectrum-viewer")
 
     test_value_1 = a1[0].data
     test_value_2 = list(a2.values())[0].data

--- a/jdaviz/configs/cubeviz/plugins/tests/test_data_retrieval.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_data_retrieval.py
@@ -1,15 +1,3 @@
-import pytest
-import numpy as np
-
-from astropy.utils.data import download_file
-
-from jdaviz.app import Application
-
-# This file is originally from
-# https://data.sdss.org/sas/dr14/manga/spectro/redux/v2_1_2/7495/stack/manga-7495-12704-LOGCUBE.fits.gz
-URL = 'https://stsci.box.com/shared/static/28a88k1qfipo4yxc4p4d40v4axtlal8y.fits'
-
-
 """ The purpose of this test is to check that both methods:
 
       - app.get_viewer('spectrum-viewer').data()
@@ -17,24 +5,25 @@ URL = 'https://stsci.box.com/shared/static/28a88k1qfipo4yxc4p4d40v4axtlal8y.fits
 
       return the same spectrum values.
 """
-
-
-@pytest.fixture
-def jdaviz_app():
-    return Application(configuration='cubeviz')
+import numpy as np
+import pytest
+from astropy.utils.data import download_file
 
 
 @pytest.mark.filterwarnings('ignore')
 @pytest.mark.remote_data
-def test_data_retrieval(jdaviz_app):
+def test_data_retrieval(cubeviz_app):
+    # This file is originally from
+    # https://data.sdss.org/sas/dr14/manga/spectro/redux/v2_1_2/7495/stack/manga-7495-12704-LOGCUBE.fits.gz
+    URL = 'https://stsci.box.com/shared/static/28a88k1qfipo4yxc4p4d40v4axtlal8y.fits'
 
     fn = download_file(URL, cache=True)
-    jdaviz_app.load_data(fn)
+    cubeviz_app.load_data(fn)
 
     # two ways of retrieving data from the viewer.
     # They should return the same spectral values
-    a1 = jdaviz_app.get_viewer('spectrum-viewer').data()
-    a2 = jdaviz_app.get_data_from_viewer("spectrum-viewer")
+    a1 = cubeviz_app.app.get_viewer('spectrum-viewer').data()
+    a2 = cubeviz_app.app.get_data_from_viewer("spectrum-viewer")
 
     test_value_1 = a1[0].data
     test_value_2 = list(a2.values())[0].data

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -72,5 +72,6 @@ def test_spectrum1d_parse(spectrum1d, cubeviz_helper):
 
 
 def test_numpy_cube(cubeviz_helper):
-    with pytest.raises(NotImplementedError, match='Unsupported data format'):
-        cubeviz_helper.load_data(np.ones(27).reshape((3, 3, 3)))
+    cubeviz_helper.load_data(np.ones(27).reshape((3, 3, 3)))
+    assert len(cubeviz_helper.app.data_collection) == 1
+    assert cubeviz_helper.app.data_collection[0].label.endswith('[FLUX]')

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -2,20 +2,30 @@ import numpy as np
 import pytest
 from astropy import units as u
 from astropy.io import fits
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.wcs import WCS
+from numpy.testing import assert_array_equal, assert_allclose
 from specutils import Spectrum1D
+
+from jdaviz.configs.cubeviz.plugins.parsers import parse_data, _fix_jwst_s3d_sci_header
 
 
 @pytest.fixture
 def image_hdu_obj():
-    flux_hdu = fits.ImageHDU(np.ones((10, 10, 10), dtype=np.float32))
+    flux_hdu = fits.ImageHDU(np.ones((5, 8, 10), dtype=np.float32))  # X=10 Y=10 WAVE=5
     flux_hdu.name = 'FLUX'
 
-    uncert_hdu = fits.ImageHDU(np.ones((10, 10, 10), dtype=np.float32))
+    uncert_hdu = fits.ImageHDU(np.ones((5, 8, 10), dtype=np.float32))
     uncert_hdu.name = 'ERR'
 
-    mask_hdu = fits.ImageHDU(np.zeros((10, 10, 10), dtype=np.int32))
+    mask_hdu = fits.ImageHDU(np.zeros((5, 8, 10), dtype=np.int32))
     mask_hdu.name = 'MASK'
+
+    invalid_hdu_1 = fits.ImageHDU(np.zeros((2, 2), dtype=np.int16))
+    invalid_hdu_1.name = 'WRONGDIM'
+
+    invalid_hdu_2 = fits.ImageHDU(np.ones((5, 8, 10), dtype=np.float32))
+    invalid_hdu_2.name = 'NOTCUBEVIZCUBE'
 
     wcs_header = {
         'WCSAXES': 3, 'CRPIX1': 38.0, 'CRPIX2': 38.0, 'CRPIX3': 1.0,
@@ -31,47 +41,188 @@ def image_hdu_obj():
     flux_hdu.header.update(wcs_header)
     flux_hdu.header['BUNIT'] = '1E-17 erg*s^-1*cm^-2*Angstrom^-1*pix^-1'
 
-    return fits.HDUList([fits.PrimaryHDU(), flux_hdu, uncert_hdu, mask_hdu])
+    return fits.HDUList([fits.PrimaryHDU(), flux_hdu, uncert_hdu, mask_hdu,
+                         invalid_hdu_1, invalid_hdu_2])
+
+
+@pytest.mark.filterwarnings('ignore')
+def test_fits_image_hdulist_parse(image_hdu_obj, cubeviz_helper):
+    cubeviz_helper.load_data(image_hdu_obj, data_label='my_hdu')
+    assert len(cubeviz_helper.app.data_collection) == 3
+
+    data = cubeviz_helper.app.data_collection[0]
+    flux = data.get_component('flux')
+    data_unit = '1e-17 erg / (Angstrom cm2 pix s)'
+    assert data.label == 'my_hdu[FLUX]'
+    assert data.shape == (5, 8, 10)
+    assert isinstance(data.coords, WCS)
+    assert_array_equal(flux.data, 1)
+    assert flux.units == data_unit
+
+    data = cubeviz_helper.app.data_collection[1]
+    flux = data.get_component('flux')
+    assert data.label == 'my_hdu[ERR]'
+    assert data.shape == (5, 8, 10)
+    assert isinstance(data.coords, WCS)  # Inherited
+    assert_array_equal(flux.data, 1)
+    assert flux.units == data_unit  # Inherited
+
+    data = cubeviz_helper.app.data_collection[2]
+    flux = data.get_component('flux')
+    assert data.label == 'my_hdu[MASK]'
+    assert data.shape == (5, 8, 10)
+    assert isinstance(data.coords, WCS)   # Inherited
+    assert_array_equal(flux.data, 0)
+    assert flux.units == ''  # Mask should be unitless
+
+    spec = cubeviz_helper.app.get_data_from_viewer('spectrum-viewer', 'my_hdu[FLUX]')
+    assert_quantity_allclose(spec.flux, 1 * u.Unit(data_unit))
+    assert_quantity_allclose(spec.spectral_axis.radial_velocity, 0 * (u.km / u.s))
+    assert_quantity_allclose(spec.spectral_axis.redshift, 0)
+    assert_quantity_allclose(spec.spectral_axis.si, [3.62159598e-07, 3.62242998e-07, 3.62326418e-07,
+                                                     3.62409856e-07, 3.62493313e-07] * u.m)
 
 
 @pytest.mark.filterwarnings('ignore')
 def test_fits_image_hdu_parse(image_hdu_obj, cubeviz_helper):
-    cubeviz_helper.load_data(image_hdu_obj)
-
+    cubeviz_helper.load_data(image_hdu_obj['FLUX'], data_label='myhdu[left]')
+    cubeviz_helper.load_data(image_hdu_obj['ERR'], data_label='myhdu[center]')
+    cubeviz_helper.load_data(image_hdu_obj['MASK'], data_label='myhdu[right]')
     assert len(cubeviz_helper.app.data_collection) == 3
-    assert cubeviz_helper.app.data_collection[0].label.endswith('[FLUX]')
+
+    data = cubeviz_helper.app.data_collection[0]
+    flux = data.get_component('flux')
+    data_unit = '1e-17 erg / (Angstrom cm2 pix s)'
+    assert data.label == 'myhdu[left]'
+    assert data.shape == (5, 8, 10)
+    assert isinstance(data.coords, WCS)
+    assert_array_equal(flux.data, 1)
+    assert flux.units == data_unit
+
+    data = cubeviz_helper.app.data_collection[1]
+    flux = data.get_component('flux')
+    assert data.label == 'myhdu[center]'
+    assert data.shape == (5, 8, 10)
+    assert isinstance(data.coords, WCS)
+    assert list(data.coords.wcs.ctype) == ['', '', 'WAVE']  # Dummy
+    assert_array_equal(flux.data, 1)
+    assert flux.units == 'ct'  # Fallback unit
+
+    data = cubeviz_helper.app.data_collection[2]
+    flux = data.get_component('flux')
+    assert data.label == 'myhdu[right]'
+    assert data.shape == (5, 8, 10)
+    assert isinstance(data.coords, WCS)
+    assert list(data.coords.wcs.ctype) == ['', '', 'WAVE']  # Dummy
+    assert_array_equal(flux.data, 0)
+    assert flux.units == ''  # Mask should be unitless
+
+    spec = cubeviz_helper.app.get_data_from_viewer('spectrum-viewer', 'myhdu[left]')
+    assert_quantity_allclose(spec.flux, 1 * u.Unit(data_unit))
+    assert_quantity_allclose(spec.spectral_axis.radial_velocity, 0 * (u.km / u.s))
+    assert_quantity_allclose(spec.spectral_axis.redshift, 0)
+    assert_quantity_allclose(spec.spectral_axis.si, [3.62159598e-07, 3.62242998e-07, 3.62326418e-07,
+                                                     3.62409856e-07, 3.62493313e-07] * u.m)
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_fits_image_hdu_parse_from_file(tmpdir, image_hdu_obj, cubeviz_helper):
-    f = tmpdir.join("test_fits_image.fits")
-    path = f.strpath
+def test_fits_image_hdulist_parse_from_file(tmpdir, image_hdu_obj, cubeviz_helper):
+    path = tmpdir.join("test_fits_image.fits").strpath
     image_hdu_obj.writeto(path, overwrite=True)
-    cubeviz_helper.load_data(path)
 
+    cubeviz_helper.load_data(path)
     assert len(cubeviz_helper.app.data_collection) == 3
-    assert cubeviz_helper.app.data_collection[0].label.endswith('[FLUX]')
+
+    # Contents already tested in test_fits_image_hdulist_parse()
+    assert cubeviz_helper.app.data_collection[0].label == 'test_fits_image.fits[FLUX]'
+    assert cubeviz_helper.app.data_collection[1].label == 'test_fits_image.fits[ERR]'
+    assert cubeviz_helper.app.data_collection[2].label == 'test_fits_image.fits[MASK]'
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_spectrum3d_parse(image_hdu_obj, cubeviz_helper):
-    flux = image_hdu_obj[1].data << u.Unit(image_hdu_obj[1].header['BUNIT'])
-    wcs = WCS(image_hdu_obj[1].header, image_hdu_obj)
-    sc = Spectrum1D(flux=flux, wcs=wcs)
-    cubeviz_helper.load_data(sc)
+def test_spectrum3d_parse(spectrum1d_cube, cubeviz_helper):
+    cubeviz_helper.load_data(spectrum1d_cube)
+    assert len(cubeviz_helper.app.data_collection) == 3
 
-    assert len(cubeviz_helper.app.data_collection) == 1
-    assert cubeviz_helper.app.data_collection[0].label.endswith('[FLUX]')
+    data = cubeviz_helper.app.data_collection[0]
+    flux = data.get_component('flux')
+    data_unit = 'Jy'
+    wcs_ctypes = ['RA---TAN', 'DEC--TAN', 'WAVE-LOG']
+    assert data.label.endswith('[FLUX]')
+    assert data.shape == (2, 2, 4)
+    assert list(data.coords.wcs.ctype) == wcs_ctypes
+    assert flux.units == data_unit
+
+    data = cubeviz_helper.app.data_collection[1]
+    flux = data.get_component('flux')
+    assert data.label.endswith('[UNCERTAINTY]')
+    assert data.shape == (2, 2, 4)
+    assert list(data.coords.wcs.ctype) == wcs_ctypes
+    assert flux.units == data_unit
+
+    data = cubeviz_helper.app.data_collection[2]
+    flux = data.get_component('flux')
+    assert data.label.endswith('[MASK]')
+    assert data.shape == (2, 2, 4)
+    assert list(data.coords.wcs.ctype) == wcs_ctypes
+    assert flux.units == ''  # Mask should be unitless
 
 
 def test_spectrum1d_parse(spectrum1d, cubeviz_helper):
     cubeviz_helper.load_data(spectrum1d)
-
     assert len(cubeviz_helper.app.data_collection) == 1
     assert cubeviz_helper.app.data_collection[0].label.endswith('[FLUX]')
 
 
-def test_numpy_cube(cubeviz_helper):
-    cubeviz_helper.load_data(np.ones(27).reshape((3, 3, 3)))
+@pytest.mark.parametrize(('data_type', 'label_suffix', 'flux_unit'),
+                         [(None, '[FLUX]', 'ct'),
+                          ('uncert', '[UNCERT]', 'ct'),
+                          ('mask', '[MASK]', '')])
+def test_numpy_cube(cubeviz_helper, data_type, label_suffix, flux_unit):
+    cubeviz_helper.load_data(np.ones(24).reshape((2, 3, 4)), data_type=data_type)
     assert len(cubeviz_helper.app.data_collection) == 1
-    assert cubeviz_helper.app.data_collection[0].label.endswith('[FLUX]')
+
+    data = cubeviz_helper.app.data_collection[0]
+    flux = data.get_component('flux')
+    assert data.label.endswith(label_suffix)
+    assert data.shape == (2, 3, 4)
+    assert list(data.coords.wcs.ctype) == ['', '', 'WAVE']  # Dummy
+    assert flux.units == flux_unit
+
+
+def test_invalid_data_types(cubeviz_helper):
+    with pytest.raises(FileNotFoundError, match='Could not locate file'):
+        cubeviz_helper.load_data('foo')
+
+    with pytest.raises(ValueError, match='data_type must be one of'):
+        cubeviz_helper.load_data(np.ones((2, 2, 2)), data_type='bar')
+
+    with pytest.raises(NotImplementedError, match='Unsupported data format'):
+        cubeviz_helper.load_data(Spectrum1D(flux=np.ones((2, 2)) * u.nJy))
+
+    with pytest.raises(NotImplementedError, match='Unsupported data format'):
+        cubeviz_helper.load_data(np.ones((2, )))
+
+    with pytest.raises(NotImplementedError, match='Unsupported data format'):
+        cubeviz_helper.load_data(fits.TableHDU())
+
+    # Lower level parsing logic.
+
+    with pytest.raises(ValueError, match='HDU is not supported as data cube'):
+        parse_data(cubeviz_helper.app, fits.PrimaryHDU(), 'flux')
+
+    with pytest.raises(ValueError, match='Unsupported extname'):
+        parse_data(cubeviz_helper.app, fits.ImageHDU(np.ones((2, 2, 2)), name='bar'))
+
+
+@pytest.mark.parametrize(('date_key', 'date_val'),
+                         [('MJD-BEG', 59573.0),
+                          ('DATE-OBS', '2021-12-25')])
+def test_fix_invalid_jwst_s3d_sci_header(date_key, date_val):
+    extname = 'SCI'
+    sci_hdu = fits.ImageHDU()
+    sci_hdu.name = extname
+    sci_hdu.header[date_key] = date_val
+    hdu_list = fits.HDUList([sci_hdu])
+    _fix_jwst_s3d_sci_header(hdu_list)
+    assert_allclose(hdu_list[extname].header['MJD-OBS'], 59573)

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -1,4 +1,3 @@
-import gwcs
 import numpy as np
 import pytest
 from astropy import units as u
@@ -139,7 +138,7 @@ def test_fits_image_hdu_parse_4d(cubeviz_helper):
     assert_array_equal(flux.data, 1)
     assert flux.units == 'ct'
 
-    with pytest.raises(NotImplementedError, match='Unsupported data format'):
+    with pytest.raises(ValueError, match='HDU is not supported as data cube'):
         cubeviz_helper.load_data(fits.ImageHDU(np.ones(48).reshape((2, 2, 3, 4)), name='SCI'))
 
 
@@ -196,8 +195,9 @@ def test_spectrum3d_no_wcs_parse(cubeviz_helper):
     flux = data.get_component('flux')
     assert data.label.endswith('[FLUX]')
     assert data.shape == (2, 3, 4)
-    assert isinstance(data.coords, gwcs.WCS)
-    assert_quantity_allclose(flux, 1 * u.nJy)
+    assert isinstance(data.coords, PaddedSpectrumWCS)
+    assert_array_equal(flux.data, 1)
+    assert flux.units == 'nJy'
 
 
 def test_spectrum1d_parse(spectrum1d, cubeviz_helper):

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -8,16 +8,16 @@ from specutils import Spectrum1D
 
 @pytest.fixture
 def image_hdu_obj():
-    flux_hdu = fits.ImageHDU(np.ones((10, 10, 10)))
+    flux_hdu = fits.ImageHDU(np.ones((10, 10, 10), dtype=np.float32))
     flux_hdu.name = 'FLUX'
 
-    mask_hdu = fits.ImageHDU(np.zeros((10, 10, 10)))
-    mask_hdu.name = 'MASK'
-
-    uncert_hdu = fits.ImageHDU(np.ones((10, 10, 10)))
+    uncert_hdu = fits.ImageHDU(np.ones((10, 10, 10), dtype=np.float32))
     uncert_hdu.name = 'ERR'
 
-    wcs = WCS(header={
+    mask_hdu = fits.ImageHDU(np.zeros((10, 10, 10), dtype=np.int32))
+    mask_hdu.name = 'MASK'
+
+    wcs_header = {
         'WCSAXES': 3, 'CRPIX1': 38.0, 'CRPIX2': 38.0, 'CRPIX3': 1.0,
         'PC1_1 ': -0.000138889, 'PC2_2 ': 0.000138889,
         'PC3_3 ': 8.33903304339E-11, 'CDELT1': 1.0, 'CDELT2': 1.0,
@@ -26,16 +26,12 @@ def image_hdu_obj():
         'CRVAL1': 205.4384, 'CRVAL2': 27.004754, 'CRVAL3': 3.62159598486E-07,
         'LONPOLE': 180.0, 'LATPOLE': 27.004754, 'MJDREFI': 0.0,
         'MJDREFF': 0.0, 'DATE-OBS': '2014-03-30',
-        'RADESYS': 'FK5', 'EQUINOX': 2000.0
-    })
+        'RADESYS': 'FK5', 'EQUINOX': 2000.0}
 
-    flux_hdu.header.update(wcs.to_header())
+    flux_hdu.header.update(wcs_header)
     flux_hdu.header['BUNIT'] = '1E-17 erg*s^-1*cm^-2*Angstrom^-1*pix^-1'
 
-    mask_hdu.header.update(wcs.to_header())
-    uncert_hdu.header.update(wcs.to_header())
-
-    return fits.HDUList([fits.PrimaryHDU(), flux_hdu, mask_hdu, uncert_hdu])
+    return fits.HDUList([fits.PrimaryHDU(), flux_hdu, uncert_hdu, mask_hdu])
 
 
 @pytest.mark.filterwarnings('ignore')

--- a/jdaviz/configs/default/plugins/collapse/tests/test_collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/tests/test_collapse.py
@@ -8,7 +8,8 @@ from jdaviz.configs.default.plugins.collapse.collapse import Collapse
 
 @pytest.mark.filterwarnings('ignore')
 def test_linking_after_collapse(cubeviz_helper, spectral_cube_wcs):
-    cubeviz_helper.load_data(Spectrum1D(flux=np.ones((3, 4, 5)) * u.nJy, wcs=spectral_cube_wcs))
+    cubeviz_helper.load_data(Spectrum1D(flux=np.ones((3, 4, 5)) * u.nJy, wcs=spectral_cube_wcs),
+                             data_label='Unknown spectrum object')
     dc = cubeviz_helper.app.data_collection
 
     coll = Collapse(app=cubeviz_helper.app)

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.vue
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.vue
@@ -14,7 +14,9 @@
         ></v-select>
       </v-row>
 
-      <v-row v-if="show_modes">
+      <div v-if="disabled">The selected data does not have spectral WCS</div>
+
+      <v-row v-if="!disabled && show_modes">
         <v-select
           :items="smooth_modes"
           v-model="selected_mode"
@@ -24,7 +26,7 @@
         ></v-select>
       </v-row>
 
-      <v-row>
+      <v-row v-if="!disabled">
         <v-text-field
           ref="stddev"
           label="Standard deviation"
@@ -36,7 +38,7 @@
         ></v-text-field>
       </v-row>
 
-      <v-row v-if="selected_data && stddev > 0">
+      <v-row v-if="!disabled && selected_data && stddev > 0">
         <v-select v-if="config=='cubeviz'"
           :items="viewers"
           v-model="selected_viewer"
@@ -51,7 +53,7 @@
         </v-switch>
       </v-row>
 
-      <v-row justify="end">
+      <v-row justify="end" v-if="!disabled">
         <j-tooltip v-if="selected_mode=='Spectral'" tipid='plugin-gaussian-apply'>
           <v-btn :disabled="stddev <= 0 || selected_data == ''"
             color="accent" text 

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -129,6 +129,11 @@ class LineListTool(PluginTemplateMixin):
         if viewer_data is None:
             return
 
+        if viewer_data.spectral_axis.unit.is_equivalent(u.pixel):
+            self.disabled_msg = 'Data does not have spectral WCS'
+        else:
+            self.disabled_msg = ''
+
         self._units["x"] = str(viewer_data.spectral_axis.unit)
         self._units["y"] = str(viewer_data.flux.unit)
 

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -36,7 +36,7 @@
       ></v-text-field>
     </v-row>
 
-    <v-row>
+    <v-row v-if="spectral_axis_unit_equivalencies.length > 0">
       <v-combobox
         label="New Spectral Axis Unit"
         :items="spectral_axis_unit_equivalencies"
@@ -49,7 +49,7 @@
       ></v-text-field>
     </v-row>
 
-    <v-row>
+    <v-row v-if="flux_unit_equivalencies.length > 0">
       <v-combobox
         label="New Flux Unit"
         :items="flux_unit_equivalencies"
@@ -61,7 +61,7 @@
       ></v-text-field>
     </v-row>
 
-    <v-row justify="end">
+    <v-row justify="end" v-if="spectral_axis_unit_equivalencies.length > 0 || flux_unit_equivalencies.length > 0">
       <j-tooltip tipid='plugin-unit-conversion-apply'>
         <v-btn :disabled="selected_data == ''"
         color="accent" text @click="unit_conversion">Apply</v-btn>

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -476,8 +476,13 @@ class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
         elif data.spectral_axis.unit.is_equivalent(u.pixel):
             spectral_axis_unit_type = "pixel"
 
-        label_0 = f"{spectral_axis_unit_type} [{data.spectral_axis.unit.to_string()}]"
-        self.figure.axes[0].label = label_0
+        if spectral_axis_unit_type == "pixel" and self.session.jdaviz_app.config == 'cubeviz':
+            self.figure.axes[0].label = "Slice"
+            self.figure.axes[0].tick_values = data.spectral_axis.value
+        else:
+            label_0 = f"{spectral_axis_unit_type} [{data.spectral_axis.unit.to_string()}]"
+            self.figure.axes[0].label = label_0
+
         self.figure.axes[1].label = f"{flux_unit_type} [{data.flux.unit.to_string()}]"
 
         # Make it so y axis label is not covering tick numbers.

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -51,11 +51,10 @@ def spectral_cube_wcs(request):
 
 @pytest.fixture
 def spectrum1d_cube_wcs(request):
-    # A simple spectrum1D WCS used by some tests
-    wcs = WCS(naxis=3)
-    wcs.wcs.ctype = 'RA---TAN', 'DEC--TAN', 'WAVE-LOG'
-    wcs.wcs.set()
-    return wcs
+    return WCS({"CTYPE1": "RA---TAN", "CTYPE2": "DEC--TAN", "CTYPE3": "WAVE-LOG",
+                "CRVAL1": 205, "CRVAL2": 27, "CRVAL3": 4.622e-7,
+                "CDELT1": -0.0001, "CDELT2": 0.0001, "CDELT3": 8e-11,
+                "CRPIX1": 0, "CRPIX2": 0, "CRPIX3": 0})
 
 
 @pytest.fixture
@@ -72,17 +71,12 @@ def spectrum1d():
 
 
 @pytest.fixture
-def spectrum1d_cube():
+def spectrum1d_cube(spectrum1d_cube_wcs):
     flux = np.arange(16).reshape((2, 2, 4)) * u.Jy
-    wcs_dict = {"CTYPE1": "RA---TAN", "CTYPE2": "DEC--TAN", "CTYPE3": "WAVE-LOG",
-                "CRVAL1": 205, "CRVAL2": 27, "CRVAL3": 4.622e-7,
-                "CDELT1": -0.0001, "CDELT2": 0.0001, "CDELT3": 8e-11,
-                "CRPIX1": 0, "CRPIX2": 0, "CRPIX3": 0}
-    w = WCS(wcs_dict)
-
-    spec = Spectrum1D(flux=flux, wcs=w)
-
-    return spec
+    uncert = StdDevUncertainty()
+    uncert.array = np.ones(flux.shape, dtype=np.float32)
+    mask = np.zeros(flux.shape, dtype=np.int16)
+    return Spectrum1D(flux=flux, uncertainty=uncert, mask=mask, wcs=spectrum1d_cube_wcs)
 
 
 try:

--- a/jdaviz/core/validunits.py
+++ b/jdaviz/core/validunits.py
@@ -31,6 +31,9 @@ def create_spectral_equivalencies_list(spectrum,
     """
     Gets all possible conversions from current spectral_axis_unit.
     """
+    if spectrum.spectral_axis.unit == u.pix:
+        return []
+
     # Get unit equivalencies.
     curr_spectral_axis_unit_equivalencies = u.Unit(
         spectrum.spectral_axis.unit).find_equivalent_units(
@@ -60,6 +63,9 @@ def create_flux_equivalencies_list(spectrum):
     """
     Gets all possible conversions for flux from current flux units.
     """
+    if spectrum.spectral_axis.unit == u.pix:
+        return []
+
     # Get unit equivalencies.
     curr_flux_unit_equivalencies = u.Unit(
         spectrum.flux.unit).find_equivalent_units(

--- a/notebooks/CubevizExample.ipynb
+++ b/notebooks/CubevizExample.ipynb
@@ -76,7 +76,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -90,7 +90,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/concepts/cubeviz_parser_showcase.ipynb
+++ b/notebooks/concepts/cubeviz_parser_showcase.ipynb
@@ -18,7 +18,7 @@
     "import numpy as np\n",
     "from astropy import units as u\n",
     "from astropy.io import fits\n",
-    "from astropy.nddata import StdDevUncertainty\n",
+    "from astropy.nddata import NDData, StdDevUncertainty\n",
     "from astropy.utils.data import download_file\n",
     "from astropy.wcs import WCS\n",
     "from specutils import Spectrum1D\n",
@@ -292,6 +292,72 @@
    "source": [
     "viz = Cubeviz()\n",
     "viz.load_data(sp, data_label='spec-1323-52797-0012')\n",
+    "viz.app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ac6405d",
+   "metadata": {},
+   "source": [
+    "# NDData (3D)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f08cee4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arr = np.random.random((5, 10, 10))\n",
+    "uncert = StdDevUncertainty(np.sqrt(arr))\n",
+    "mask = np.random.randint(0, 2, size=arr.shape).astype(bool)\n",
+    "ndd = NDData(arr, mask=mask, uncertainty=uncert, unit=u.nJy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a67ff01e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz = Cubeviz()\n",
+    "viz.load_data(ndd, data_label='ndd_3d')\n",
+    "viz.app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f420874",
+   "metadata": {},
+   "source": [
+    "# NDData (2D)\n",
+    "\n",
+    "Needed for Moment plugin, maybe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4028dc8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arr = np.random.random((10, 10))\n",
+    "ndd = NDData(arr, unit=u.nJy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d3fc1bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz = Cubeviz()\n",
+    "viz.load_data(ndd, data_label='ndd_2d', data_type='mask')\n",
     "viz.app"
    ]
   },

--- a/notebooks/concepts/cubeviz_parser_showcase.ipynb
+++ b/notebooks/concepts/cubeviz_parser_showcase.ipynb
@@ -137,6 +137,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "02057a9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# BUG: Transpose is needed because specutils assumes\n",
+    "# spectral axis is in a different place when no WCS\n",
+    "uncert_hdu.data = uncert_hdu.data.T\n",
+    "mask_hdu.data = mask_hdu.data.T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "5952d20c",
    "metadata": {},
    "outputs": [],
@@ -179,25 +192,15 @@
     "sci_unit = u.electron / u.s  # From BUNIT but its value is invalid for astropy.units\n",
     "err_unit = sci_unit  # Assume the same\n",
     "\n",
+    "# BUG: Transpose is needed because specutils assumes\n",
+    "# spectral axis is in a different place when no WCS\n",
     "with fits.open(wfc3ir_file) as pf:\n",
-    "    sci_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'SCI']) * sci_unit\n",
-    "    err_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'ERR']) * err_unit\n",
-    "    dq_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'DQ']) * u.dimensionless_unscaled\n",
+    "    sci_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'SCI']).T * sci_unit\n",
+    "    err_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'ERR']).T * err_unit\n",
+    "    dq_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'DQ']).T * u.dimensionless_unscaled\n",
     "    \n",
     "uncertainty = StdDevUncertainty()\n",
     "uncertainty.array = err_cube"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "46bc1a96",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Assign dummy WCS for now. Constructing actual WCS is out of scope here.\n",
-    "from jdaviz.configs.cubeviz.plugins.parsers import generate_dummy_fits_wcs_3d\n",
-    "fake_wcs = generate_dummy_fits_wcs_3d()"
    ]
   },
   {
@@ -207,7 +210,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc = Spectrum1D(flux=sci_cube, uncertainty=uncertainty, mask=dq_cube, wcs=fake_wcs)"
+    "sc = Spectrum1D(flux=sci_cube, uncertainty=uncertainty, mask=dq_cube)"
    ]
   },
   {
@@ -314,7 +317,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sci_arr = np.random.random((5, 10, 10))\n",
+    "# BUG: The shape is because specutils assumes\n",
+    "# spectral axis is in a different place when no WCS\n",
+    "sci_arr = np.random.random((10, 10, 5))\n",
     "err_arr = np.sqrt(sci_arr)"
    ]
   },

--- a/notebooks/concepts/cubeviz_parser_showcase.ipynb
+++ b/notebooks/concepts/cubeviz_parser_showcase.ipynb
@@ -136,29 +136,9 @@
    "source": [
     "# FITS Data Cube (Individual HDUs)\n",
     "\n",
-    "This uses HDUs similar as above but without the WCS. Instead of passing in HDUList, we load one HDU at a time."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "34b22117-a5ab-48d4-b0a9-85a22476f7c1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# ***** NOTE *****\n",
-    "# Without WCS, specutils will not try to reorder the axes,\n",
-    "# so we put \"5\" (the spectral axis length) in the opposite\n",
-    "# shape position w.r.t. the example above with WCS.\n",
-    "flux_hdu = fits.ImageHDU(np.random.random((10, 10, 5)).astype(np.float32))\n",
-    "flux_hdu.name = 'FLUX'\n",
-    "flux_hdu.header['BUNIT'] = '1E-17 erg*s^-1*cm^-2*Angstrom^-1*pix^-1'\n",
+    "This reuses HDUs from above. Instead of passing in HDUList, we load one HDU at a time.\n",
     "\n",
-    "uncert_hdu = fits.ImageHDU(np.sqrt(flux_hdu.data))\n",
-    "uncert_hdu.name = 'ERR'\n",
-    "\n",
-    "mask_hdu = fits.ImageHDU(np.random.randint(0, 16, (10, 10, 5), dtype=np.int32))\n",
-    "mask_hdu.name = 'MASK'"
+    "*Note: Because we pass in individual HDUs instead of a HDUList, `uncert_hdu` and `mask_hdu` will not be aware of the WCS that is in `flux_hdu`.*"
    ]
   },
   {
@@ -206,14 +186,11 @@
     "sci_unit = u.electron / u.s  # From BUNIT but its value is invalid for astropy.units\n",
     "err_unit = sci_unit  # Assume the same\n",
     "\n",
-    "# ***** NOTE *****\n",
-    "# Transpose is needed here because of the lack of WCS;\n",
-    "# specutils will not try to reorder the axes, so we have to\n",
-    "# manually do it so spectral axis is where specutils expects it.\n",
     "with fits.open(wfc3ir_file) as pf:\n",
-    "    sci_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'SCI']).T * sci_unit\n",
-    "    err_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'ERR']).T * err_unit\n",
-    "    dq_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'DQ']).T * u.dimensionless_unscaled\n",
+    "    primary_header = pf[0].header\n",
+    "    sci_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'SCI']) * sci_unit\n",
+    "    err_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'ERR']) * err_unit\n",
+    "    dq_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'DQ']) * u.dimensionless_unscaled\n",
     "    \n",
     "uncertainty = StdDevUncertainty()\n",
     "uncertainty.array = err_cube"
@@ -226,7 +203,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc = Spectrum1D(flux=sci_cube, uncertainty=uncertainty, mask=dq_cube)"
+    "sc = Spectrum1D(flux=sci_cube, uncertainty=uncertainty, mask=dq_cube, meta=primary_header)"
    ]
   },
   {
@@ -333,11 +310,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ***** NOTE *****\n",
-    "# Without WCS, specutils will not try to reorder the axes,\n",
-    "# so we put \"5\" (the spectral axis length) in the opposite\n",
-    "# shape position w.r.t. the example above with WCS.\n",
-    "sci_arr = np.random.random((10, 10, 5))\n",
+    "sci_arr = np.random.random((5, 10, 10))\n",
     "err_arr = np.sqrt(sci_arr)"
    ]
   },

--- a/notebooks/concepts/cubeviz_parser_showcase.ipynb
+++ b/notebooks/concepts/cubeviz_parser_showcase.ipynb
@@ -1,0 +1,395 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1cbc8201",
+   "metadata": {},
+   "source": [
+    "This notebook showcases all the things that Cubeviz can load."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bcd50736",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from astropy import units as u\n",
+    "from astropy.io import fits\n",
+    "from astropy.nddata import StdDevUncertainty\n",
+    "from astropy.utils.data import download_file\n",
+    "from astropy.wcs import WCS\n",
+    "from specutils import Spectrum1D\n",
+    "\n",
+    "from jdaviz import Cubeviz"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52b8ba99",
+   "metadata": {},
+   "source": [
+    "# FITS Data Cube (FITS File)\n",
+    "\n",
+    "This file is from Cubeviz example notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8082be4e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "manga_logcube = download_file('https://stsci.box.com/shared/static/28a88k1qfipo4yxc4p4d40v4axtlal8y.fits', cache=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4cc8660d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fits.info(manga_logcube)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b00d92a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz = Cubeviz()\n",
+    "viz.load_data(manga_logcube, data_label='manga-7495-12704-LOGCUBE')\n",
+    "viz.app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6e34e6a",
+   "metadata": {},
+   "source": [
+    "# FITS Data Cube (HDUList)\n",
+    "\n",
+    "This is a test case adapted from Cubeviz parser test fixture, `image_hdu_obj`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6b3aa91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flux_hdu = fits.ImageHDU(np.random.random((5, 10, 10)).astype(np.float32))\n",
+    "flux_hdu.name = 'FLUX'\n",
+    "\n",
+    "uncert_hdu = fits.ImageHDU(np.sqrt(flux_hdu.data))\n",
+    "uncert_hdu.name = 'ERR'\n",
+    "\n",
+    "mask_hdu = fits.ImageHDU(np.random.randint(0, 16, (5, 10, 10), dtype=np.int32))\n",
+    "mask_hdu.name = 'MASK'\n",
+    "\n",
+    "wcs_header = {\n",
+    "    'WCSAXES': 3, 'CRPIX1': 38.0, 'CRPIX2': 38.0, 'CRPIX3': 1.0,\n",
+    "    'PC1_1 ': -0.000138889, 'PC2_2 ': 0.000138889,\n",
+    "    'PC3_3 ': 8.33903304339E-11, 'CDELT1': 1.0, 'CDELT2': 1.0,\n",
+    "    'CDELT3': 1.0, 'CUNIT1': 'deg', 'CUNIT2': 'deg', 'CUNIT3': 'm',\n",
+    "    'CTYPE1': 'RA---TAN', 'CTYPE2': 'DEC--TAN', 'CTYPE3': 'WAVE-LOG',\n",
+    "    'CRVAL1': 205.4384, 'CRVAL2': 27.004754, 'CRVAL3': 3.62159598486E-07,\n",
+    "    'LONPOLE': 180.0, 'LATPOLE': 27.004754, 'MJDREFI': 0.0,\n",
+    "    'MJDREFF': 0.0, 'DATE-OBS': '2014-03-30',\n",
+    "    'RADESYS': 'FK5', 'EQUINOX': 2000.0}\n",
+    "\n",
+    "flux_hdu.header.update(wcs_header)\n",
+    "flux_hdu.header['BUNIT'] = '1E-17 erg*s^-1*cm^-2*Angstrom^-1*pix^-1'\n",
+    "\n",
+    "hdu_list = fits.HDUList([fits.PrimaryHDU(), flux_hdu, uncert_hdu, mask_hdu])\n",
+    "hdu_list.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d821921",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz = Cubeviz()\n",
+    "viz.load_data(hdu_list, data_label='mycube')\n",
+    "viz.app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "adfac3f8",
+   "metadata": {},
+   "source": [
+    "# FITS Data Cube (Individual HDUs)\n",
+    "\n",
+    "This reuses HDUs created above. Instead of passing in HDUList, we load one HDU at a time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5952d20c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz = Cubeviz()\n",
+    "viz.load_data(flux_hdu, data_label='myhdu[left]')\n",
+    "viz.load_data(uncert_hdu, data_label='myhdu[center]')\n",
+    "viz.load_data(mask_hdu, data_label='myhdu[right]')\n",
+    "viz.app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31e763d4",
+   "metadata": {},
+   "source": [
+    "# HST WFC3/IR Ramp (Spectrum1D, 3D)\n",
+    "\n",
+    "This is a little more complicated because we need to stack all the different 2D extensions into respective cubes. We do not attempt to recreate a composite WCS here, but rather just use a dummy one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7abb0ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wfc3ir_file = download_file('https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HST/product/icgk01a8q_ima.fits', cache=True)\n",
+    "fits.info(wfc3ir_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "faf326e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sci_unit = u.electron / u.s  # From BUNIT but its value is invalid for astropy.units\n",
+    "err_unit = sci_unit  # Assume the same\n",
+    "\n",
+    "with fits.open(wfc3ir_file) as pf:\n",
+    "    sci_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'SCI']) * sci_unit\n",
+    "    err_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'ERR']) * err_unit\n",
+    "    dq_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'DQ']) * u.dimensionless_unscaled\n",
+    "    \n",
+    "uncertainty = StdDevUncertainty()\n",
+    "uncertainty.array = err_cube"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46bc1a96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Assign dummy WCS for now. Constructing actual WCS is out of scope here.\n",
+    "from jdaviz.configs.cubeviz.plugins.parsers import generate_dummy_fits_wcs_3d\n",
+    "fake_wcs = generate_dummy_fits_wcs_3d()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba5101df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc = Spectrum1D(flux=sci_cube, uncertainty=uncertainty, mask=dq_cube, wcs=fake_wcs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68425d14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz = Cubeviz()\n",
+    "viz.load_data(sc, data_label='icgk01a8q_ima.fits')\n",
+    "viz.app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f6fd792",
+   "metadata": {},
+   "source": [
+    "# JWST s3d (FITS File)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4d1a89f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Ask Brian Cherinka if you want the file.\n",
+    "s3d_filename = 'jw00619-o094_t001_miri_ch1-long_s3d.fits'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6582f964",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz = Cubeviz()\n",
+    "viz.load_data(s3d_filename)\n",
+    "viz.app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95ee7ede",
+   "metadata": {},
+   "source": [
+    "# Spectrum1D (1D)\n",
+    "\n",
+    "This is from `specutils` example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "617939c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sp_filename = download_file('https://data.sdss.org/sas/dr16/sdss/spectro/redux/26/spectra/1323/spec-1323-52797-0012.fits', cache=True)\n",
+    "fits.info(sp_filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b774dc4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with fits.open(sp_filename) as pf:\n",
+    "    lamb = 10 ** pf[1].data['loglam'] * u.AA \n",
+    "    flux = pf[1].data['flux'] * 10**-17 * u.Unit('erg cm-2 s-1 AA-1')\n",
+    "    sp = Spectrum1D(spectral_axis=lamb, flux=flux)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d7e3cf5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz = Cubeviz()\n",
+    "viz.load_data(sp, data_label='spec-1323-52797-0012')\n",
+    "viz.app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbfe1ef5",
+   "metadata": {},
+   "source": [
+    "# Numpy Array (3D)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0dad5c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sci_arr = np.random.random((5, 10, 10))\n",
+    "err_arr = np.sqrt(sci_arr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d99959f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz = Cubeviz()\n",
+    "viz.load_data(sci_arr, data_type='flux', data_label='myarray[SCI]')\n",
+    "viz.load_data(err_arr, data_type='uncert', data_label='myarray[ERR]')\n",
+    "viz.app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28868502",
+   "metadata": {},
+   "source": [
+    "# Invalid Data\n",
+    "\n",
+    "Cubeviz now should throw exception instead of giving misleading success message."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b45194f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image2d = np.random.random((10, 10))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3842ca8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz = Cubeviz()\n",
+    "viz.load_data(image2d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05bd2a58",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/concepts/cubeviz_parser_showcase.ipynb
+++ b/notebooks/concepts/cubeviz_parser_showcase.ipynb
@@ -87,6 +87,7 @@
    "source": [
     "flux_hdu = fits.ImageHDU(np.random.random((5, 10, 10)).astype(np.float32))\n",
     "flux_hdu.name = 'FLUX'\n",
+    "flux_hdu.header['BUNIT'] = '1E-17 erg*s^-1*cm^-2*Angstrom^-1*pix^-1'\n",
     "\n",
     "uncert_hdu = fits.ImageHDU(np.sqrt(flux_hdu.data))\n",
     "uncert_hdu.name = 'ERR'\n",
@@ -94,6 +95,12 @@
     "mask_hdu = fits.ImageHDU(np.random.randint(0, 16, (5, 10, 10), dtype=np.int32))\n",
     "mask_hdu.name = 'MASK'\n",
     "\n",
+    "# ***** NOTE *****\n",
+    "# This WCS assigns NAXIS3 as the spatial axis and specutils will\n",
+    "# issue warning to swap things around, so long story short, \"5\" in the\n",
+    "# HDU data shape above is the spatial axis length.\n",
+    "# When passed into Cubeviz as HDUList, ERR and MASK extensions would\n",
+    "# inherit the WCS from FLUX extension.\n",
     "wcs_header = {\n",
     "    'WCSAXES': 3, 'CRPIX1': 38.0, 'CRPIX2': 38.0, 'CRPIX3': 1.0,\n",
     "    'PC1_1 ': -0.000138889, 'PC2_2 ': 0.000138889,\n",
@@ -104,9 +111,7 @@
     "    'LONPOLE': 180.0, 'LATPOLE': 27.004754, 'MJDREFI': 0.0,\n",
     "    'MJDREFF': 0.0, 'DATE-OBS': '2014-03-30',\n",
     "    'RADESYS': 'FK5', 'EQUINOX': 2000.0}\n",
-    "\n",
     "flux_hdu.header.update(wcs_header)\n",
-    "flux_hdu.header['BUNIT'] = '1E-17 erg*s^-1*cm^-2*Angstrom^-1*pix^-1'\n",
     "\n",
     "hdu_list = fits.HDUList([fits.PrimaryHDU(), flux_hdu, uncert_hdu, mask_hdu])\n",
     "hdu_list.info()"
@@ -131,20 +136,29 @@
    "source": [
     "# FITS Data Cube (Individual HDUs)\n",
     "\n",
-    "This reuses HDUs created above. Instead of passing in HDUList, we load one HDU at a time."
+    "This uses HDUs similar as above but without the WCS. Instead of passing in HDUList, we load one HDU at a time."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02057a9e",
+   "id": "34b22117-a5ab-48d4-b0a9-85a22476f7c1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# BUG: Transpose is needed because specutils assumes\n",
-    "# spectral axis is in a different place when no WCS\n",
-    "uncert_hdu.data = uncert_hdu.data.T\n",
-    "mask_hdu.data = mask_hdu.data.T"
+    "# ***** NOTE *****\n",
+    "# Without WCS, specutils will not try to reorder the axes,\n",
+    "# so we put \"5\" (the spectral axis length) in the opposite\n",
+    "# shape position w.r.t. the example above with WCS.\n",
+    "flux_hdu = fits.ImageHDU(np.random.random((10, 10, 5)).astype(np.float32))\n",
+    "flux_hdu.name = 'FLUX'\n",
+    "flux_hdu.header['BUNIT'] = '1E-17 erg*s^-1*cm^-2*Angstrom^-1*pix^-1'\n",
+    "\n",
+    "uncert_hdu = fits.ImageHDU(np.sqrt(flux_hdu.data))\n",
+    "uncert_hdu.name = 'ERR'\n",
+    "\n",
+    "mask_hdu = fits.ImageHDU(np.random.randint(0, 16, (10, 10, 5), dtype=np.int32))\n",
+    "mask_hdu.name = 'MASK'"
    ]
   },
   {
@@ -168,7 +182,7 @@
    "source": [
     "# HST WFC3/IR Ramp (Spectrum1D, 3D)\n",
     "\n",
-    "This is a little more complicated because we need to stack all the different 2D extensions into respective cubes. We do not attempt to recreate a composite WCS here, but rather just use a dummy one."
+    "This is a little more complicated because we need to stack all the different 2D extensions into respective cubes. We do not attempt to recreate a composite WCS here."
    ]
   },
   {
@@ -192,8 +206,10 @@
     "sci_unit = u.electron / u.s  # From BUNIT but its value is invalid for astropy.units\n",
     "err_unit = sci_unit  # Assume the same\n",
     "\n",
-    "# BUG: Transpose is needed because specutils assumes\n",
-    "# spectral axis is in a different place when no WCS\n",
+    "# ***** NOTE *****\n",
+    "# Transpose is needed here because of the lack of WCS;\n",
+    "# specutils will not try to reorder the axes, so we have to\n",
+    "# manually do it so spectral axis is where specutils expects it.\n",
     "with fits.open(wfc3ir_file) as pf:\n",
     "    sci_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'SCI']).T * sci_unit\n",
     "    err_cube = np.stack([hdu.data for hdu in pf if hdu.name == 'ERR']).T * err_unit\n",
@@ -317,8 +333,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# BUG: The shape is because specutils assumes\n",
-    "# spectral axis is in a different place when no WCS\n",
+    "# ***** NOTE *****\n",
+    "# Without WCS, specutils will not try to reorder the axes,\n",
+    "# so we put \"5\" (the spectral axis length) in the opposite\n",
+    "# shape position w.r.t. the example above with WCS.\n",
     "sci_arr = np.random.random((10, 10, 5))\n",
     "err_arr = np.sqrt(sci_arr)"
    ]
@@ -331,8 +349,8 @@
    "outputs": [],
    "source": [
     "viz = Cubeviz()\n",
-    "viz.load_data(sci_arr, data_type='flux', data_label='myarray[SCI]')\n",
-    "viz.load_data(err_arr, data_type='uncert', data_label='myarray[ERR]')\n",
+    "viz.load_data(sci_arr, data_type='flux', data_label='myarray')\n",
+    "viz.load_data(err_arr, data_type='uncert', data_label='myarray')\n",
     "viz.app"
    ]
   },

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     voila>=0.2.4
     pyyaml>=5.4.1
     specutils>=1.7.0
-    glue-astronomy>=0.3.2
+    glue-astronomy@git+https://github.com/rosteen/glue-astronomy.git@spec3d-bugfix
     click>=7.1.2
     asteval>=0.9.23
     idna


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to:

* Refactor Cubeviz parser backend so it is easier to maintain going forward.
* Add support for generic 3D Numpy array for better software flexibility. (If you have a crazy data format, grab the Numpy array and we will be able to load it instead of us having to write a special parser for you.)
* Fix #840 by getting rid of useless logging and fail fast and hard when parser encounters errors.
* Enables #1035 for Cubeviz
* ~Fix moment map result that is rotated.~ Moved to #1104 
* Also goes with #1085 (xref #1084)

### TODO

- [x] Ensure no regression of #690 
- [x] Add tests for better coverage.
- [x] Update both API and user-facing documentation.
- [x] Remove usage of dummy WCS, needs:
  - glue-viz/glue-astronomy#61
  - #1006
- [x] Think about how to handle astropy/specutils#923 and fix the CI. 
- [x] Change "no WCS" spectral axis unit from `u.pix` to "slice". Upstream still uses pixel but the plot won't say that. 
- [x] Add NDData support (similar to pure 3D numpy array) for Moment plugin. xref #1154
- [ ] Run Cubeviz example notebook with plugins. Do they still work even with no WCS and unitless mask? From code review 2022-02-23: Kyle will try to provide framework to disable some plugins if spectral axis has no real WCS (see #1106 but maybe wait for #1130 to be merged first). ~If that does not happen in time, then PL will emit warning on load for those data and we can defer fixing plugins as future work.~
  - [x]  Fix Collapse: astropy/specutils#924 ~(or maybe defer as future PR)~
  - [x] Gaussian Smooth: Crashes but only when in spatial + plot in viewer combo (works if you do not enable plot in viewer). Disabled plugin for pixel case.
  - [x] Unit Conversion: Pull down menus will be empty but does not stop people from typing in garbage and then crash. Disabled dropdown when no entries.
  - [x] Line Lists: This plugin just won't work with pixel unit by design; it will crash. Disabled plugin for pixel case.
- [x] ~Are people happy with hacky way to assign dummy WCS? Is there a better way?~
- [x] Wait for `specutils` release.
- [ ] Wait for `glue-astronomy` release. Or copy the code we need over where if it is not going to happen soon?
- [ ] Remove temporary commit that pins to glue-viz/glue-astronomy#61
- [ ] Squash all the commits.
- [ ] Open follow-up issue to adjust spectral axis to integer tick labels only when it is in "no WCS" mode. Have to ensure this works well with Units Conversion plugin, etc. @kecnry said there is already some existing code in Jdaviz to do "world axis override."

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-2085) [🐱](https://jira.stsci.edu/browse/JDAT-1741)
