### PR TITLE
BUG: Fix Mosviz parser to support loading native Spectrum1D objects directly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,9 @@ Imviz
 Mosviz
 ^^^^^^
 
+- Mosviz no longer crashes when loading 1D and 2D spectra (without images)
+  directly. [#1045]
+
 Specviz
 ^^^^^^^
 

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -457,8 +457,11 @@ class Mosviz(ConfigHelper):
             self.load_metadata(spectra_2d, spectra=True)
 
         elif spectra_1d is not None and spectra_2d is not None:
-            self.load_2d_spectra(spectra_2d, spectra_2d_label, format=format_2d, show_in_viewer=True)
-            self.load_1d_spectra(spectra_1d, spectra_1d_label, format=format_1d, show_in_viewer=True)
+            # we'll delay showing the data until setting the first (0) row to be highlighted
+            self.load_2d_spectra(spectra_2d, spectra_2d_label,
+                                 format=format_2d, show_in_viewer=False)
+            self.load_1d_spectra(spectra_1d, spectra_1d_label,
+                                 format=format_1d, show_in_viewer=False)
             self.load_metadata(spectra_2d, spectra=True)
             self.load_metadata(spectra_1d, spectra=True, sp1d=True, ids=spectra_1d)
 

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -379,7 +379,7 @@ class Mosviz(ConfigHelper):
 
     def load_data(self, spectra_1d=None, spectra_2d=None, images=None,
                   spectra_1d_label=None, spectra_2d_label=None,
-                  images_label=None, *args, **kwargs):
+                  images_label=None, format_1d=None, format_2d=None, *args, **kwargs):
         """
         Load and parse a set of MOS spectra and images
 
@@ -414,6 +414,9 @@ class Mosviz(ConfigHelper):
             String representing the label for the data item loaded via
             ``images``. Can be a list of strings representing data labels
             for each item in ``images`` if  ``images`` is a list.
+
+        format_1d, format_2d : str or `None`
+            Format for ``specutils`` data loader, if it cannot guess automatically.
         """
         # Link data after everything is loaded
         self.app.auto_link = False
@@ -454,8 +457,8 @@ class Mosviz(ConfigHelper):
             self.load_metadata(spectra_2d, spectra=True)
 
         elif spectra_1d is not None and spectra_2d is not None:
-            self.load_2d_spectra(spectra_2d, spectra_2d_label, show_in_viewer=True)
-            self.load_1d_spectra(spectra_1d, spectra_1d_label, show_in_viewer=True)
+            self.load_2d_spectra(spectra_2d, spectra_2d_label, format=format_2d, show_in_viewer=True)
+            self.load_1d_spectra(spectra_1d, spectra_1d_label, format=format_1d, show_in_viewer=True)
             self.load_metadata(spectra_2d, spectra=True)
             self.load_metadata(spectra_1d, spectra=True, sp1d=True, ids=spectra_1d)
 
@@ -553,7 +556,7 @@ class Mosviz(ConfigHelper):
         self.app.load_data(data_obj, ids=ids, spectra=spectra, sp1d=sp1d,
                            parser_reference="mosviz-metadata-parser")
 
-    def load_1d_spectra(self, data_obj, data_labels=None, show_in_viewer=False):
+    def load_1d_spectra(self, data_obj, data_labels=None, show_in_viewer=False, format=None):
         """
         Load and parse a set of 1D spectra objects.
 
@@ -571,10 +574,10 @@ class Mosviz(ConfigHelper):
             Show the first spectrum in viewer.
         """
         super().load_data(data_obj, parser_reference="mosviz-spec1d-parser",
-                          data_labels=data_labels, show_in_viewer=show_in_viewer)
+                          data_labels=data_labels, show_in_viewer=show_in_viewer, format=format)
         self._add_redshift_column()
 
-    def load_2d_spectra(self, data_obj, data_labels=None, show_in_viewer=False):
+    def load_2d_spectra(self, data_obj, data_labels=None, show_in_viewer=False, format=None):
         """
         Load and parse a set of 2D spectra objects.
 
@@ -592,7 +595,7 @@ class Mosviz(ConfigHelper):
             Show the data in viewer.
         """
         super().load_data(data_obj, parser_reference="mosviz-spec2d-parser",
-                          data_labels=data_labels, show_in_viewer=show_in_viewer)
+                          data_labels=data_labels, show_in_viewer=show_in_viewer, format=format)
         self._add_redshift_column()
 
     def load_niriss_data(self, data_obj, data_labels=None):

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -189,7 +189,7 @@ def mos_nirspec_directory_parser(app, data_obj, data_labels=None):
 
 
 @data_parser_registry("mosviz-spec1d-parser")
-def mos_spec1d_parser(app, data_obj, data_labels=None, show_in_viewer=False):
+def mos_spec1d_parser(app, data_obj, data_labels=None, show_in_viewer=False, format=None):
     """
     Attempts to parse a 1D spectrum object.
 
@@ -204,6 +204,8 @@ def mos_spec1d_parser(app, data_obj, data_labels=None, show_in_viewer=False):
         The label applied to the glue data component.
     show_in_viewer : bool
         Show the first spectrum in viewer.
+    format : str or `None`
+        Format for ``specutils`` loader if filename is provided.
     """
 
     if isinstance(data_labels, str):
@@ -213,7 +215,7 @@ def mos_spec1d_parser(app, data_obj, data_labels=None, show_in_viewer=False):
     if not isinstance(data_obj, (list, tuple, SpectrumCollection)):
         data_obj = [data_obj]
 
-    data_obj = [Spectrum1D.read(x) if _check_is_file(x) else x for x in data_obj]
+    data_obj = [Spectrum1D.read(x, format=format) if _check_is_file(x) else x for x in data_obj]
 
     if data_labels is None:
         data_labels = [f"1D Spectrum {i}" for i in range(len(data_obj))]
@@ -236,7 +238,7 @@ def mos_spec1d_parser(app, data_obj, data_labels=None, show_in_viewer=False):
 
 @data_parser_registry("mosviz-spec2d-parser")
 def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
-                      show_in_viewer=False):
+                      show_in_viewer=False, format=None):
     """
     Attempts to parse a 2D spectrum object.
 
@@ -256,6 +258,8 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
         The label applied to the glue data component.
     show_in_viewer : bool
         Show the data in viewer.
+    format : str or `None`
+        Format for ``specutils`` loader if filename is provided.
     """
     def _parse_as_spectrum1d(path):
         # Parse as a FITS file and assume the WCS is correct
@@ -289,7 +293,7 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
             # FITS file.
             if _check_is_file(data):
                 try:
-                    data = Spectrum1D.read(data)
+                    data = Spectrum1D.read(data, format=format)
                 except IORegistryError:
                     data = _parse_as_spectrum1d(data)
 
@@ -312,9 +316,7 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
             _add_to_table(app, data_labels, '2D Spectra')
 
     if show_in_viewer:
-        if len(data_labels) > 1:
-            raise ValueError("More than one data label provided, unclear " +
-                             "which to show in viewer")
+        # Just show the first one
         app.add_data_to_viewer("spectrum-2d-viewer", data_labels[0])
 
 

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -128,7 +128,7 @@ def link_data_in_table(app, data_obj=None):
             wc_spec_1d = app.session.data_collection[spec_1d].world_component_ids
             wc_spec_2d = app.session.data_collection[spec_2d].world_component_ids
 
-            wc_spec_ids.append(LinkSame(wc_spec_1d[0], wc_spec_2d[1]))
+            wc_spec_ids.append(LinkSame(wc_spec_1d[0], wc_spec_2d[-1]))
 
         # Link each 1D spectrum to all other 1D spectra
         first_spec_1d = spectra_1d[0]
@@ -189,7 +189,7 @@ def mos_nirspec_directory_parser(app, data_obj, data_labels=None):
 
 
 @data_parser_registry("mosviz-spec1d-parser")
-def mos_spec1d_parser(app, data_obj, data_labels=None):
+def mos_spec1d_parser(app, data_obj, data_labels=None, show_in_viewer=False):
     """
     Attempts to parse a 1D spectrum object.
 
@@ -202,6 +202,8 @@ def mos_spec1d_parser(app, data_obj, data_labels=None):
         the mosviz table.
     data_labels : str, optional
         The label applied to the glue data component.
+    show_in_viewer : bool
+        Show the first spectrum in viewer.
     """
 
     if isinstance(data_labels, str):
@@ -227,6 +229,10 @@ def mos_spec1d_parser(app, data_obj, data_labels=None):
 
         _add_to_table(app, data_labels, '1D Spectra')
 
+    if show_in_viewer:
+        # Just show the first one.
+        app.add_data_to_viewer("spectrum-viewer", data_labels[0])
+
 
 @data_parser_registry("mosviz-spec2d-parser")
 def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
@@ -248,6 +254,8 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
         the mosviz table.
     data_labels : str, optional
         The label applied to the glue data component.
+    show_in_viewer : bool
+        Show the data in viewer.
     """
     def _parse_as_spectrum1d(path):
         # Parse as a FITS file and assume the WCS is correct


### PR DESCRIPTION
### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Mosviz parser theoretically has logic to load a list of 1D `Spectrum1D` objects and a list of 2D `Spectrum1D` objects directly but I suspect no one ever tried to use it until now and it has never worked. This patch enables loading them to the point they show up, but the table columns is still messed up, probably due to the lack of expected metadata.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Kyle, does this fix any open issue?

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
