### PR TITLE
Add reference to jdaviz app in glue session object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ Specviz
 API Changes
 -----------
 
+- Viewers now can access the calling Jdaviz application using
+  ``viewer.session.jdaviz_app``. [#1051]
+
 Bug Fixes
 ---------
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -168,6 +168,11 @@ class Application(VuetifyTemplate, HubListener):
         self._application_handler = JupyterApplication(
             settings={'new_subset_on_selection_tool_change': True})
 
+        # Add a reference to this application to the Glue session object. This
+        # allows the jdaviz Application object to then be accessed via e.g.
+        # viewer.session.jdaviz_app
+        self._application_handler.session.jdaviz_app = self
+
         # Create a dictionary for holding non-ipywidget viewer objects so we
         #  can reference their state easily since glue does not store viewers
         self._viewer_store = {}

--- a/jdaviz/tests/test_viewer_ids.py
+++ b/jdaviz/tests/test_viewer_ids.py
@@ -1,6 +1,12 @@
 from jdaviz import Application
 
 
+# This applies to all viz but testing with Imviz should be enough.
+def test_viewer_calling_app(imviz_app):
+    viewer = imviz_app.default_viewer
+    assert viewer.session.jdaviz_app is imviz_app.app
+
+
 def test_default_viewer_ids_default():
     app = Application(configuration='default')
     assert app.get_viewer_reference_names() == []


### PR DESCRIPTION
### Description

This adds a reference to the global jdaviz application in the global glue session object so that the jdaviz application can be accessed e.g. in viewers using ``viewer.session.jdaviz_app``. This is needed for https://github.com/spacetelescope/jdaviz/pull/983 and supersedes https://github.com/glue-viz/glue-jupyter/pull/274 and https://github.com/glue-viz/glue/pull/2256

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
