### PR TITLE
TST: Update test matrix, etc

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -37,13 +37,11 @@ jobs:
             toxenv: securityaudit
             allow_failure: false
 
-          # One test times out with coverage, see
-          # https://github.com/spacetelescope/jdaviz/pull/1052
           - name: Python 3.9 with coverage checking, all deps, and remote data
             os: ubuntu-latest
             python: 3.9
             toxenv: py39-test-alldeps-cov
-            toxposargs: --remote-data -k 'not test_cube_fitting_backend'
+            toxposargs: --remote-data
             allow_failure: false
 
           - name: OS X - Python 3.7

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -37,11 +37,13 @@ jobs:
             toxenv: securityaudit
             allow_failure: false
 
-          - name: Python 3.8 with coverage checking, all deps, and remote data
+          # One test times out with coverage, see
+          # https://github.com/spacetelescope/jdaviz/pull/1052
+          - name: Python 3.9 with coverage checking, all deps, and remote data
             os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-test-alldeps-cov
-            toxposargs: --remote-data
+            python: 3.9
+            toxenv: py39-test-alldeps-cov
+            toxposargs: --remote-data -k 'not test_cube_fitting_backend'
             allow_failure: false
 
           - name: OS X - Python 3.7
@@ -58,10 +60,10 @@ jobs:
 
           # This also runs on cron but we want to make sure new changes
           # won't break this job at the PR stage.
-          - name: Python 3.9 with latest dev versions of key dependencies
+          - name: Python 3.10 with latest dev versions of key dependencies
             os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-test-devdeps
+            python: '3.10'
+            toxenv: py310-test-devdeps
             allow_failure: true
 
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,8 @@ description =
 
 # The following provides some specific pinnings for key packages
 deps =
+    # https://github.com/nedbat/coveragepy/issues/1310
+    cov: coverage==6.2.*
 
     # NOTE: Add/remove as needed
     devdeps: :NIGHTLY:numpy

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39}-test{,-alldeps,-devdeps}{,-cov}
-    py{37,38,39}-test-astropy{lts}-numpy{117,118}
+    py{37,38,39,310}-test{,-alldeps,-devdeps}{,-cov}
     build_docs
     linkcheck
     codestyle
@@ -37,21 +36,10 @@ description =
     run tests
     alldeps: with all optional dependencies
     devdeps: with the latest developer version of key dependencies
-    oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy117: with numpy 1.17.*
-    numpy118: with numpy 1.18.*
-    astropylts: with the latest astropy LTS
 
 # The following provides some specific pinnings for key packages
 deps =
-
-    numpy117: numpy==1.17.*
-    numpy118: numpy==1.18.*
-
-    # We don't support 4.0.x but let's keep this for when LTS changes
-    astropylts: astropy==4.0.*
-    astropylts: gwcs>=0.14,<0.15
 
     # NOTE: Add/remove as needed
     devdeps: :NIGHTLY:numpy
@@ -61,6 +49,7 @@ deps =
     devdeps: git+https://github.com/asdf-format/asdf.git
     devdeps: git+https://github.com/radio-astro-tools/spectral-cube.git
     #devdeps: git+https://github.com/bqplot/bqplot.git
+    devdeps: git+https://github.com/glue-viz/glue.git
     devdeps: git+https://github.com/voila-dashboards/voila.git
     devdeps: git+https://github.com/glue-viz/bqplot-image-gl.git
     devdeps: git+https://github.com/glue-viz/glue-jupyter.git


### PR DESCRIPTION
This is mainly to investigate if there is a way we can fix the remote data job timeout, which is blocking other PRs. While I am at it:

* Update test matrix
* ~Make tox verbose.~
* Delete unused tox configs.
* Fix #1053 

Note to reviewers: Ignore the yellow "Python 3.8 with coverage checking, all deps, and remote data" as the job name has changed now that I updated that job to use Python 3.9. I'll have to update branch protection rules *after* this PR is merged.

Note to self: Open follow-up issue to unpin coverage in the future.

### Todo

- [x] If the timeout is magically gone, can unpin `astropy` for `cov`. Should double check!
- [x] Redo the fix by just pinning coverage, see nedbat/coveragepy#1310

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
