### PR TITLE
Imviz: Load 3D slices, enable delayed_linking

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,9 @@ Imviz
 - New radial profile plot in the simple aperture photometry plugin. [#1030]
 
 - New plugin to display compass for image with WCS and also zoom box. [#983]
-- Imviz now loads 3D Numpy array as individual slices at ``axis=0``. [#1056]
+
+- Imviz now loads 3D Numpy array as individual slices at ``axis=0``.
+  Also supports higher dimension as long as the array can be squeezed into 3D. [#1056]
 
 - New ``do_link`` keyword for ``Imviz.load_data()``. Set it to ``False``
   when loading multiple dataset in a loop but ``Imviz.link_data()`` must be
@@ -79,6 +81,8 @@ Imviz
 ^^^^^
 
 - Imviz no longer crashes when configuration is overwritten by MAST. [#1038]
+
+- Imviz no longer loads incompatible data from ASDF-in-FITS file. [#1056]
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@ Imviz
 - New radial profile plot in the simple aperture photometry plugin. [#1030]
 
 - New plugin to display compass for image with WCS and also zoom box. [#983]
+- Imviz now loads 3D Numpy array as individual slices at ``axis=0``. [#1056]
+
+- New ``do_link`` keyword for ``Imviz.load_data()``. Set it to ``False``
+  when loading multiple dataset in a loop but ``Imviz.link_data()`` must be
+  run at the end manually afterwards. [#1056]
 
 - New ``imviz.load_static_regions_from_file()`` method to load region file
   via API. [#1066]

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -75,7 +75,7 @@ class Imviz(ConfigHelper):
             raise ValueError(f"Default viewer '{viewer_id}' cannot be destroyed")
         self.app.vue_destroy_viewer_item(viewer_id)
 
-    def load_data(self, data, parser_reference=None, **kwargs):
+    def load_data(self, data, parser_reference=None, do_link=True, **kwargs):
         """Load data into Imviz.
 
         Parameters
@@ -97,10 +97,16 @@ class Imviz(ConfigHelper):
             * `~astropy.io.fits.ImageHDU` object
             * `~astropy.nddata.NDData` object (2D only but may have unit,
               mask, or uncertainty attached)
-            * Numpy array (2D only)
+            * Numpy array (2D or 3D); if 3D, it will treat each slice at
+              ``axis=0`` as a separate image.
 
         parser_reference
             This is used internally by the app.
+
+        do_link : bool
+            Link the data after parsing. Set this to `False` if you want to
+            load a lot of data back-to-back but you must remember to run
+            :meth:`link_data` manually at the end.
 
         kwargs : dict
             Extra keywords to be passed into app-level parser.
@@ -139,9 +145,22 @@ class Imviz(ConfigHelper):
                 self.app.load_data(
                     filepath, parser_reference=parser_reference, **kw)
 
+        elif isinstance(data, np.ndarray) and data.ndim == 3:
+            for i in range(data.shape[0]):
+                kw = deepcopy(kwargs)
+
+                # This will only append index to data label if provided.
+                if 'data_label' in kw:
+                    kw['data_label'] = f'{kwargs["data_label"]}_{i}'
+
+                self.app.load_data(data[i, :, :], parser_reference=parser_reference, **kw)
+
         else:
             self.app.load_data(
                 data, parser_reference=parser_reference, **kwargs)
+
+        if do_link:
+            self.link_data(link_type='pixels', error_on_fail=False)
 
     def link_data(self, **kwargs):
         """(Re)link loaded data in Imviz with the desired link type.

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -145,7 +145,12 @@ class Imviz(ConfigHelper):
                 self.app.load_data(
                     filepath, parser_reference=parser_reference, **kw)
 
-        elif isinstance(data, np.ndarray) and data.ndim == 3:
+        elif isinstance(data, np.ndarray) and data.ndim >= 3:
+            if data.ndim > 3:
+                data = data.squeeze()
+                if data.ndim != 3:
+                    raise ValueError(f'Imviz cannot load this array with ndim={data.ndim}')
+
             for i in range(data.shape[0]):
                 kw = deepcopy(kwargs)
 

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -162,10 +162,14 @@ def _count_image2d_extensions(file_obj):
 def _validate_fits_image2d(hdu, raise_error=True):
     valid = hdu.data is not None and hdu.is_image and hdu.data.ndim == 2
     if not valid and raise_error:
+        if hdu.data is not None and hdu.is_image:
+            ndim = hdu.data.ndim
+        else:
+            ndim = None
         raise ValueError(
             f'Imviz cannot load this HDU ({hdu}): '
             f'has_data={hdu.data is not None}, is_image={hdu.is_image}, '
-            f'name={hdu.name}, ver={hdu.ver}')
+            f'name={hdu.name}, ver={hdu.ver}, ndim={ndim}')
     return valid
 
 
@@ -206,13 +210,18 @@ def _jwst_to_glue_data(file_obj, ext, data_label):
     # Translate FITS extension into JWST ASDF convention.
     if ext is None:
         ext = 'data'
+        fits_ext = 'sci'
     else:
         if isinstance(ext, tuple):
             ext = ext[0]  # EXTVER means nothing in ASDF
         ext = ext.lower()
         if ext in ('sci', 'asdf'):
             ext = 'data'
+            fits_ext = 'sci'
+        else:
+            fits_ext = ext
 
+    _validate_fits_image2d(file_obj[fits_ext])
     data, new_data_label = _jwst2data(file_obj, ext, data_label)
 
     yield data, new_data_label

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -10,7 +10,6 @@ from astropy.nddata import NDData
 from astropy.wcs import WCS
 from glue.core.data import Component, Data
 
-from jdaviz.configs.imviz.helper import link_image_data
 from jdaviz.core.registries import data_parser_registry
 from jdaviz.core.events import SnackbarMessage
 
@@ -143,7 +142,7 @@ def _parse_image(app, file_obj, data_label, show_in_viewer, ext=None):
     if len(app.data_collection) <= 1:  # No need to link, we are done.
         return
 
-    link_image_data(app, link_type='pixels', error_on_fail=False)
+    # Do not run link_image_data here. We do it at the end in Imviz.load_data()
 
 
 def _info_nextensions(app, file_obj):

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -76,7 +76,7 @@ class TestParseImage:
         with pytest.raises(NotImplementedError, match='Imviz does not support'):
             parse_data(imviz_helper.app, some_obj, show_in_viewer=False)
 
-    def test_parse_numpy_array(self, imviz_helper):
+    def test_parse_numpy_array_1d_2d(self, imviz_helper):
         with pytest.raises(ValueError, match='Imviz cannot load this array with ndim=1'):
             parse_data(imviz_helper.app, np.zeros(2), show_in_viewer=False)
 
@@ -87,6 +87,23 @@ class TestParseImage:
         assert data.label == 'some_array'
         assert data.shape == (2, 2)
         assert comp.data.shape == (2, 2)
+
+    def test_parse_numpy_array_3d(self, imviz_helper):
+        # This data has values in axis=0 that correspond to axis num.
+        n_slices = 5
+        slice_shape = (2, 3)
+        arr = np.stack([np.zeros(slice_shape) + i for i in range(n_slices)])
+
+        # We use higher level load_data() here to make sure linking does not crash.
+        imviz_helper.load_data(arr, data_label='my_slices')
+        assert len(imviz_helper.app.data_collection) == n_slices
+
+        for i in range(n_slices):
+            data = imviz_helper.app.data_collection[i]
+            comp = data.get_component('DATA')
+            assert data.label == f'my_slices_{i}'
+            assert data.shape == slice_shape
+            assert_array_equal(comp.data, i)
 
     def test_parse_nddata_simple(self, imviz_helper):
         with pytest.raises(ValueError, match='Imviz cannot load this NDData with ndim=1'):

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -88,15 +88,23 @@ class TestParseImage:
         assert data.shape == (2, 2)
         assert comp.data.shape == (2, 2)
 
-    def test_parse_numpy_array_3d(self, imviz_helper):
+    @pytest.mark.parametrize('manual_loop', [False, True])
+    def test_parse_numpy_array_3d(self, imviz_helper, manual_loop):
         # This data has values in axis=0 that correspond to axis num.
         n_slices = 5
         slice_shape = (2, 3)
         arr = np.stack([np.zeros(slice_shape) + i for i in range(n_slices)])
 
-        # We use higher level load_data() here to make sure linking does not crash.
-        imviz_helper.load_data(arr, data_label='my_slices')
+        if not manual_loop:
+            # We use higher level load_data() here to make sure linking does not crash.
+            imviz_helper.load_data(arr, data_label='my_slices')
+        else:
+            for i in range(n_slices):
+                imviz_helper.load_data(arr[i, :, :], data_label=f'my_slices_{i}', do_link=False)
+            imviz_helper.link_data(error_on_fail=True)
+
         assert len(imviz_helper.app.data_collection) == n_slices
+        assert len(imviz_helper.app.data_collection.links) == 8
 
         for i in range(n_slices):
             data = imviz_helper.app.data_collection[i]

--- a/notebooks/concepts/imviz_load_3d_slices.ipynb
+++ b/notebooks/concepts/imviz_load_3d_slices.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "852e11d6",
+   "metadata": {},
+   "source": [
+    "# Imviz: Load 3D cube as 2D slices\n",
+    "\n",
+    "This showcases how Imviz can load 3D cube as 2D slices at `axis=0`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "662e9783",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from jdaviz import Imviz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2e74c3a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate the cube.\n",
+    "arr = np.stack([np.random.random((10, 10)) for _ in range(5)])\n",
+    "arr.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e75f616e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz = Imviz()\n",
+    "imviz.load_data(arr, data_label='my_slices')\n",
+    "imviz.app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05c24b87",
+   "metadata": {},
+   "source": [
+    "## You can also load it one slice at a time...\n",
+    "\n",
+    "But remember to manually link it at the end."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b07b7fd2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz2 = Imviz()\n",
+    "imviz2.app"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d38aa230",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(arr.shape[0]):\n",
+    "    data = arr[i, :, :]\n",
+    "    imviz2.load_data(data, data_label=f'a_{i}', do_link=False)\n",
+    "\n",
+    "imviz2.link_data(error_on_fail=True)  # Link them!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11626756",
+   "metadata": {},
+   "source": [
+    "## This is not Cubeviz, so...\n",
+    "\n",
+    "You have to plot the line profile manually, as follows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa2ede51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f18e7353",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collapsed_mean = arr.mean(axis=(1, 2))\n",
+    "collapsed_mean.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ea2c32e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(collapsed_mean, '-o')\n",
+    "plt.title('Mean across slices')\n",
+    "plt.xlabel('Slice index')\n",
+    "plt.ylabel('Value');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1abe2b74",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/concepts/imviz_load_3d_slices.ipynb
+++ b/notebooks/concepts/imviz_load_3d_slices.ipynb
@@ -128,9 +128,82 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "8b692944-ec27-4e72-9601-114ba040f6e7",
+   "metadata": {},
+   "source": [
+    "## What else can you do doo doo doo doo?\n",
+    "\n",
+    "This requires `PIL` package to be installed."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1abe2b74",
+   "id": "e8d9092e-86c3-489d-b48c-e103d276eae0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.utils.data import download_file\n",
+    "from PIL import Image, ImageSequence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "006260b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz3 = Imviz(verbosity='warning')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f01e094-785d-4a15-a90b-b65e10d69fff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gif_file = download_file('https://media4.giphy.com/media/J5pnZ53pj4cmu30Rx5/giphy.gif', cache=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce2667c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im = Image.open(gif_file)\n",
+    "i = 0\n",
+    "\n",
+    "for frame in ImageSequence.Iterator(im):\n",
+    "    if i % 10 != 0:  # Skip some\n",
+    "        i += 1\n",
+    "        continue\n",
+    "    data = np.asarray(frame)[::-1, :]\n",
+    "    imviz3.load_data(data, data_label=f'frame_{i}')\n",
+    "    i += 1\n",
+    "\n",
+    "# Might take a while if loaded too many.\n",
+    "imviz3.link_data(error_on_fail=True)  # Link them, doo doo doo doo!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb573f18-970b-4555-9ca7-4156b99a7b57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz3.app"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "698fe1cf",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/concepts/imviz_load_3d_slices.ipynb
+++ b/notebooks/concepts/imviz_load_3d_slices.ipynb
@@ -183,7 +183,7 @@
     "        i += 1\n",
     "        continue\n",
     "    data = np.asarray(frame)[::-1, :]\n",
-    "    imviz3.load_data(data, data_label=f'frame_{i}')\n",
+    "    imviz3.load_data(data, data_label=f'frame_{i}', do_link=False)\n",
     "    i += 1\n",
     "\n",
     "# Might take a while if loaded too many.\n",
@@ -203,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "698fe1cf",
+   "id": "7f408020",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to enable:

* Loading a data cube as individual 2D slices at `axis=0`.
* Enable option to disable linking at every iteration when user wants to call `imviz.load_data(...)` in a loop.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1055

Fixes #1058

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
