### PR TITLE
Rename helper test fixtures from 'app' to 'helper'

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -5,8 +5,8 @@ from jdaviz.configs.cubeviz.plugins.moment_maps.moment_maps import MomentMap
 
 
 @pytest.mark.filterwarnings('ignore:No observer defined on WCS')
-def test_moment_calculation(cubeviz_app, spectrum1d_cube):
-    app = cubeviz_app.app
+def test_moment_calculation(cubeviz_helper, spectrum1d_cube):
+    app = cubeviz_helper.app
     dc = app.data_collection
     app.add_data(spectrum1d_cube, 'test')
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -39,42 +39,42 @@ def image_hdu_obj():
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_fits_image_hdu_parse(image_hdu_obj, cubeviz_app):
-    cubeviz_app.load_data(image_hdu_obj)
+def test_fits_image_hdu_parse(image_hdu_obj, cubeviz_helper):
+    cubeviz_helper.load_data(image_hdu_obj)
 
-    assert len(cubeviz_app.app.data_collection) == 3
-    assert cubeviz_app.app.data_collection[0].label.endswith('[FLUX]')
+    assert len(cubeviz_helper.app.data_collection) == 3
+    assert cubeviz_helper.app.data_collection[0].label.endswith('[FLUX]')
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_fits_image_hdu_parse_from_file(tmpdir, image_hdu_obj, cubeviz_app):
+def test_fits_image_hdu_parse_from_file(tmpdir, image_hdu_obj, cubeviz_helper):
     f = tmpdir.join("test_fits_image.fits")
     path = f.strpath
     image_hdu_obj.writeto(path, overwrite=True)
-    cubeviz_app.load_data(path)
+    cubeviz_helper.load_data(path)
 
-    assert len(cubeviz_app.app.data_collection) == 3
-    assert cubeviz_app.app.data_collection[0].label.endswith('[FLUX]')
+    assert len(cubeviz_helper.app.data_collection) == 3
+    assert cubeviz_helper.app.data_collection[0].label.endswith('[FLUX]')
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_spectrum3d_parse(image_hdu_obj, cubeviz_app):
+def test_spectrum3d_parse(image_hdu_obj, cubeviz_helper):
     flux = image_hdu_obj[1].data << u.Unit(image_hdu_obj[1].header['BUNIT'])
     wcs = WCS(image_hdu_obj[1].header, image_hdu_obj)
     sc = Spectrum1D(flux=flux, wcs=wcs)
-    cubeviz_app.load_data(sc)
+    cubeviz_helper.load_data(sc)
 
-    assert len(cubeviz_app.app.data_collection) == 1
-    assert cubeviz_app.app.data_collection[0].label.endswith('[FLUX]')
-
-
-def test_spectrum1d_parse(spectrum1d, cubeviz_app):
-    cubeviz_app.load_data(spectrum1d)
-
-    assert len(cubeviz_app.app.data_collection) == 1
-    assert cubeviz_app.app.data_collection[0].label.endswith('[FLUX]')
+    assert len(cubeviz_helper.app.data_collection) == 1
+    assert cubeviz_helper.app.data_collection[0].label.endswith('[FLUX]')
 
 
-def test_numpy_cube(cubeviz_app):
+def test_spectrum1d_parse(spectrum1d, cubeviz_helper):
+    cubeviz_helper.load_data(spectrum1d)
+
+    assert len(cubeviz_helper.app.data_collection) == 1
+    assert cubeviz_helper.app.data_collection[0].label.endswith('[FLUX]')
+
+
+def test_numpy_cube(cubeviz_helper):
     with pytest.raises(NotImplementedError, match='Unsupported data format'):
-        cubeviz_app.load_data(np.ones(27).reshape((3, 3, 3)))
+        cubeviz_helper.load_data(np.ones(27).reshape((3, 3, 3)))

--- a/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
@@ -33,16 +33,16 @@ def test_line_lists():
     assert np.all(viz.spectral_lines["show"])
 
 
-def test_redshift(specviz_app, spectrum1d):
+def test_redshift(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
     # test that helper functions run, we'll test functionality at the plugin level
-    specviz_app.set_redshift(0.1)
-    specviz_app.set_redshift_slider_bounds(range=0.5, step=0.01)
-    specviz_app.set_redshift_slider_bounds(range='auto', step='auto')
+    specviz_helper.set_redshift(0.1)
+    specviz_helper.set_redshift_slider_bounds(range=0.5, step=0.01)
+    specviz_helper.set_redshift_slider_bounds(range='auto', step='auto')
 
-    ll_plugin = line_lists.LineListTool(app=specviz_app.app)
+    ll_plugin = line_lists.LineListTool(app=specviz_helper.app)
     ll_plugin.rs_redshift = 0.1
     assert ll_plugin.rs_rv == 28487.06614479641
 

--- a/jdaviz/configs/default/plugins/metadata_viewer/tests/test_metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/tests/test_metadata_viewer.py
@@ -4,17 +4,17 @@ from astropy.nddata import NDData
 from jdaviz.configs.default.plugins.metadata_viewer.metadata_viewer import MetadataViewer
 
 
-def test_view_dict(imviz_app):
-    mv = MetadataViewer(app=imviz_app.app)
+def test_view_dict(imviz_helper):
+    mv = MetadataViewer(app=imviz_helper.app)
     ndd_1 = NDData(np.zeros((2, 2)), meta={
         'EXTNAME': 'SCI', 'EXTVER': 1, 'BAR': 10.0,
         'FOO': '', 'COMMENT': 'a test', 'BOZO': None})
     ndd_2 = NDData(np.ones((2, 2)), meta={
         'EXTNAME': 'ASDF', 'REF': {'bar': 10.0, 'foo': {'1': '', '2': [1, 2]}}})
     arr = np.zeros((2, 2))
-    imviz_app.load_data(ndd_1, data_label='has_simple_meta')
-    imviz_app.load_data(ndd_2, data_label='has_nested_meta')
-    imviz_app.load_data(arr, data_label='no_meta')
+    imviz_helper.load_data(ndd_1, data_label='has_simple_meta')
+    imviz_helper.load_data(ndd_2, data_label='has_nested_meta')
+    imviz_helper.load_data(arr, data_label='no_meta')
     assert mv.dc_items == ['has_simple_meta[DATA]', 'has_nested_meta[DATA]', 'no_meta']
 
     mv.selected_data = 'has_simple_meta[DATA]'
@@ -34,8 +34,8 @@ def test_view_dict(imviz_app):
     assert mv.metadata == []
 
 
-def test_view_invalid(imviz_app):
-    mv = MetadataViewer(app=imviz_app.app)
+def test_view_invalid(imviz_helper):
+    mv = MetadataViewer(app=imviz_helper.app)
     assert mv.dc_items == []
 
     # Should not even happen but if it does, do not crash.

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -155,13 +155,13 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
             self.viewer.get_link_type('foo')
 
 
-def test_imviz_no_data(imviz_app):
+def test_imviz_no_data(imviz_helper):
     with pytest.raises(ValueError, match='No valid reference data'):
-        get_reference_image_data(imviz_app.app)
+        get_reference_image_data(imviz_helper.app)
 
-    imviz_app.link_data(error_on_fail=True)  # Just no-op, do not crash
-    links = imviz_app.app.data_collection.external_links
+    imviz_helper.link_data(error_on_fail=True)  # Just no-op, do not crash
+    links = imviz_helper.app.data_collection.external_links
     assert len(links) == 0
 
     with pytest.raises(ValueError, match='No reference data for link look-up'):
-        imviz_app.default_viewer.get_link_type('foo')
+        imviz_helper.default_viewer.get_link_type('foo')

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -66,40 +66,40 @@ class TestParseImage:
         with pytest.raises(NotImplementedError, match='should be set'):
             _parse_image(None, None, None, False)
 
-    def test_hdulist_no_image(self, imviz_app):
+    def test_hdulist_no_image(self, imviz_helper):
         hdulist = fits.HDUList([fits.PrimaryHDU()])
         with pytest.raises(ValueError, match='does not have any FITS image'):
-            parse_data(imviz_app.app, hdulist, show_in_viewer=False)
+            parse_data(imviz_helper.app, hdulist, show_in_viewer=False)
 
     @pytest.mark.parametrize('some_obj', (WCS(), [[1, 2], [3, 4]]))
-    def test_invalid_file_obj(self, imviz_app, some_obj):
+    def test_invalid_file_obj(self, imviz_helper, some_obj):
         with pytest.raises(NotImplementedError, match='Imviz does not support'):
-            parse_data(imviz_app.app, some_obj, show_in_viewer=False)
+            parse_data(imviz_helper.app, some_obj, show_in_viewer=False)
 
-    def test_parse_numpy_array(self, imviz_app):
+    def test_parse_numpy_array(self, imviz_helper):
         with pytest.raises(ValueError, match='Imviz cannot load this array with ndim=1'):
-            parse_data(imviz_app.app, np.zeros(2), show_in_viewer=False)
+            parse_data(imviz_helper.app, np.zeros(2), show_in_viewer=False)
 
-        parse_data(imviz_app.app, np.zeros((2, 2)), data_label='some_array',
+        parse_data(imviz_helper.app, np.zeros((2, 2)), data_label='some_array',
                    show_in_viewer=False)
-        data = imviz_app.app.data_collection[0]
+        data = imviz_helper.app.data_collection[0]
         comp = data.get_component('DATA')
         assert data.label == 'some_array'
         assert data.shape == (2, 2)
         assert comp.data.shape == (2, 2)
 
-    def test_parse_nddata_simple(self, imviz_app):
+    def test_parse_nddata_simple(self, imviz_helper):
         with pytest.raises(ValueError, match='Imviz cannot load this NDData with ndim=1'):
-            parse_data(imviz_app.app, NDData([1, 2, 3, 4]), show_in_viewer=False)
+            parse_data(imviz_helper.app, NDData([1, 2, 3, 4]), show_in_viewer=False)
 
         ndd = NDData([[1, 2], [3, 4]])
-        parse_data(imviz_app.app, ndd, data_label='some_data', show_in_viewer=False)
-        data = imviz_app.app.data_collection[0]
+        parse_data(imviz_helper.app, ndd, data_label='some_data', show_in_viewer=False)
+        data = imviz_helper.app.data_collection[0]
         comp = data.get_component('DATA')
         assert data.label == 'some_data[DATA]'
         assert data.shape == (2, 2)
         assert comp.data.shape == (2, 2)
-        assert len(imviz_app.app.data_collection) == 1
+        assert len(imviz_helper.app.data_collection) == 1
 
     @pytest.mark.parametrize(
         ('ndd', 'attributes'),
@@ -107,23 +107,23 @@ class TestParseImage:
           ['DATA', 'MASK']),
          (NDData([[1, 2], [3, 4]], uncertainty=StdDevUncertainty([[0.1, 0.2], [0.3, 0.4]])),
           ['DATA', 'UNCERTAINTY'])])
-    def test_parse_nddata_with_one_only(self, imviz_app, ndd, attributes):
-        parse_data(imviz_app.app, ndd, data_label='some_data', show_in_viewer=False)
+    def test_parse_nddata_with_one_only(self, imviz_helper, ndd, attributes):
+        parse_data(imviz_helper.app, ndd, data_label='some_data', show_in_viewer=False)
         for i, attrib in enumerate(attributes):
-            data = imviz_app.app.data_collection[i]
+            data = imviz_helper.app.data_collection[i]
             comp = data.get_component(attrib)
             assert data.label == f'some_data[{attrib}]'
             assert data.shape == (2, 2)
             assert comp.data.shape == (2, 2)
-        assert len(imviz_app.app.data_collection) == 2
+        assert len(imviz_helper.app.data_collection) == 2
 
-    def test_parse_nddata_with_everything(self, imviz_app):
+    def test_parse_nddata_with_everything(self, imviz_helper):
         ndd = NDData([[1, 2], [3, 4]], mask=[[True, False], [False, False]],
                      uncertainty=StdDevUncertainty([[0.1, 0.2], [0.3, 0.4]]),
                      unit=u.MJy/u.sr, wcs=WCS(naxis=2), meta={'name': 'my_ndd'})
-        parse_data(imviz_app.app, ndd, data_label='some_data', show_in_viewer=False)
+        parse_data(imviz_helper.app, ndd, data_label='some_data', show_in_viewer=False)
         for i, attrib in enumerate(['DATA', 'MASK', 'UNCERTAINTY']):
-            data = imviz_app.app.data_collection[i]
+            data = imviz_helper.app.data_collection[i]
             comp = data.get_component(attrib)
             assert data.label == f'some_data[{attrib}]'
             assert data.shape == (2, 2)
@@ -134,11 +134,11 @@ class TestParseImage:
                 assert comp.units == ''
             else:
                 assert comp.units == 'MJy / sr'
-        assert len(imviz_app.app.data_collection) == 3
+        assert len(imviz_helper.app.data_collection) == 3
 
     @pytest.mark.filterwarnings('ignore:.* is a low contrast image')
     @pytest.mark.parametrize('format', ('jpg', 'png'))
-    def test_parse_rgba(self, imviz_app, tmp_path, format):
+    def test_parse_rgba(self, imviz_helper, tmp_path, format):
         if format == 'png':  # Cross-test PNG with RGBA
             a = np.zeros((10, 10, 4), dtype='uint8')
         else:  # Cross-test JPG with RGB only
@@ -147,12 +147,12 @@ class TestParseImage:
         filename = str(tmp_path / f'myimage.{format}')
         imsave(filename, a)
 
-        parse_data(imviz_app.app, filename, show_in_viewer=False)
-        data = imviz_app.app.data_collection[0]
+        parse_data(imviz_helper.app, filename, show_in_viewer=False)
+        data = imviz_helper.app.data_collection[0]
         assert data.label == 'myimage'
         assert data.shape == (10, 10)
 
-    def test_filelist(self, imviz_app, tmp_path):
+    def test_filelist(self, imviz_helper, tmp_path):
         flist = []
 
         # Generate some files to parse.
@@ -164,10 +164,10 @@ class TestParseImage:
             hdu.writeto(fpath, overwrite=True)
 
         flist = ','.join(flist)
-        imviz_app.load_data(flist, show_in_viewer=False)
+        imviz_helper.load_data(flist, show_in_viewer=False)
 
         for i in range(2):
-            data = imviz_app.app.data_collection[i]
+            data = imviz_helper.app.data_collection[i]
             comp = data.get_component('PRIMARY,1')
             assert data.label == f'myfits_{i}[PRIMARY,1]'
             assert data.shape == (2, 2)
@@ -175,15 +175,15 @@ class TestParseImage:
             np.testing.assert_allclose(comp.data.mean(), i)
 
         with pytest.raises(ValueError, match='Do not manually overwrite data_label'):
-            imviz_app.load_data(flist, data_label='foo', show_in_viewer=False)
+            imviz_helper.load_data(flist, data_label='foo', show_in_viewer=False)
 
     @pytest.mark.remote_data
-    def test_parse_jwst_nircam_level2(self, imviz_app):
+    def test_parse_jwst_nircam_level2(self, imviz_helper):
         filename = download_file(self.jwst_asdf_url_1, cache=True)
 
         # Default behavior: Science image
-        parse_data(imviz_app.app, filename, show_in_viewer=True)
-        data = imviz_app.app.data_collection[0]
+        parse_data(imviz_helper.app, filename, show_in_viewer=True)
+        data = imviz_helper.app.data_collection[0]
         comp = data.get_component('DATA')
         assert data.label == 'contents[DATA]'  # download_file returns cache loc
         assert data.shape == (2048, 2048)
@@ -194,13 +194,13 @@ class TestParseImage:
         # --- Since download is expensive, we attach GWCS-specific tests here. ---
 
         # Ensure interactive region supports GWCS. Also see test_regions.py
-        imviz_app._apply_interactive_region('bqplot:circle', (965, 1122), (976.9, 1110.1))  # Star
-        subsets = imviz_app.get_interactive_regions()
+        imviz_helper._apply_interactive_region('bqplot:circle', (965, 1122), (976.9, 1110.1))  # Star
+        subsets = imviz_helper.get_interactive_regions()
         assert list(subsets.keys()) == ['Subset 1'], subsets
         assert isinstance(subsets['Subset 1'], CirclePixelRegion)
 
         # Test simple aperture photometry plugin.
-        phot_plugin = SimpleAperturePhotometry(app=imviz_app.app)
+        phot_plugin = SimpleAperturePhotometry(app=imviz_helper.app)
         phot_plugin._on_viewer_data_changed()
         phot_plugin.vue_data_selected('contents[DATA]')
         phot_plugin.vue_subset_selected('Subset 1')
@@ -211,7 +211,7 @@ class TestParseImage:
         assert_allclose(phot_plugin.counts_factor, 0.0036385915646798953)
         phot_plugin.flux_scaling = 1  # Simple mag, no zeropoint
         phot_plugin.vue_do_aper_phot()
-        tbl = imviz_app.get_aperture_photometry_results()
+        tbl = imviz_helper.get_aperture_photometry_results()
         assert_quantity_allclose(tbl[0]['xcenter'], 970.95 * u.pix)
         assert_quantity_allclose(tbl[0]['ycenter'], 1116.05 * u.pix)
         sky = tbl[0]['sky_center']
@@ -236,10 +236,10 @@ class TestParseImage:
         # --- Back to parser testing below. ---
 
         # Request specific extension (name + ver, but ver is not used), use given label
-        parse_data(imviz_app.app, filename, ext=('DQ', 42),
+        parse_data(imviz_helper.app, filename, ext=('DQ', 42),
                    data_label='jw01072001001_01101_00001_nrcb1_cal',
                    show_in_viewer=False)
-        data = imviz_app.app.data_collection[1]
+        data = imviz_helper.app.data_collection[1]
         comp = data.get_component('DQ')
         assert data.label == 'jw01072001001_01101_00001_nrcb1_cal[DQ]'
         assert data.meta['aperture']['name'] == 'NRCB5_FULL'
@@ -247,29 +247,29 @@ class TestParseImage:
 
         # Pass in HDUList directly + ext (name only), use given label
         with fits.open(filename) as pf:
-            parse_data(imviz_app.app, pf, ext='SCI',
+            parse_data(imviz_helper.app, pf, ext='SCI',
                        data_label='jw01072001001_01101_00001_nrcb1_cal',
                        show_in_viewer=False)
-            data = imviz_app.app.data_collection[2]
+            data = imviz_helper.app.data_collection[2]
             comp = data.get_component('DATA')  # SCI = DATA
             assert data.label == 'jw01072001001_01101_00001_nrcb1_cal[DATA]'
             assert isinstance(data.coords, GWCS)
             assert comp.units == 'MJy/sr'
 
             # Test duplicate label functionality
-            imviz_app.app.data_collection.clear()
-            parse_data(imviz_app.app, pf, ext='SCI', show_in_viewer=False, data_label='TEST')
-            data = imviz_app.app.data_collection[0]
+            imviz_helper.app.data_collection.clear()
+            parse_data(imviz_helper.app, pf, ext='SCI', show_in_viewer=False, data_label='TEST')
+            data = imviz_helper.app.data_collection[0]
             assert data.label.endswith('[DATA]')
 
-            parse_data(imviz_app.app, pf, ext='SCI', show_in_viewer=False, data_label='TEST')
-            data = imviz_app.app.data_collection[1]
+            parse_data(imviz_helper.app, pf, ext='SCI', show_in_viewer=False, data_label='TEST')
+            data = imviz_helper.app.data_collection[1]
             assert data.label.endswith('[DATA]_2')
 
             # Load all extensions
-            imviz_app.app.data_collection.clear()
-            parse_data(imviz_app.app, pf, ext='*', show_in_viewer=False)
-            data = imviz_app.app.data_collection
+            imviz_helper.app.data_collection.clear()
+            parse_data(imviz_helper.app, pf, ext='*', show_in_viewer=False)
+            data = imviz_helper.app.data_collection
             assert len(data.labels) == 7
             assert data.labels[0].endswith('[DATA]')
             assert data.labels[1].endswith('[ERR]')
@@ -281,16 +281,16 @@ class TestParseImage:
 
         # Invalid ASDF attribute (extension)
         with pytest.raises(KeyError, match='does_not_exist'):
-            parse_data(imviz_app.app, filename, ext='DOES_NOT_EXIST',
+            parse_data(imviz_helper.app, filename, ext='DOES_NOT_EXIST',
                        data_label='foo', show_in_viewer=False)
 
     @pytest.mark.remote_data
-    def test_parse_jwst_niriss_grism(self, imviz_app):
+    def test_parse_jwst_niriss_grism(self, imviz_helper):
         """No valid image GWCS for Imviz, will fall back to FITS loading without WCS."""
         filename = download_file(self.jwst_asdf_url_2, cache=True)
 
-        parse_data(imviz_app.app, filename, show_in_viewer=False)
-        data = imviz_app.app.data_collection[0]
+        parse_data(imviz_helper.app, filename, show_in_viewer=False)
+        data = imviz_helper.app.data_collection[0]
         comp = data.get_component('SCI,1')
         assert data.label == 'contents[SCI,1]'  # download_file returns cache loc
         assert data.shape == (2048, 2048)
@@ -300,13 +300,13 @@ class TestParseImage:
         assert comp.data.shape == (2048, 2048)
 
     @pytest.mark.remote_data
-    def test_parse_hst_drz(self, imviz_app):
+    def test_parse_hst_drz(self, imviz_helper):
         url = 'https://mast.stsci.edu/api/v0.1/Download/file?bundle_name=MAST_2021-04-21T1828.sh&uri=mast:HST/product/jclj01010_drz.fits'  # noqa: E501
         filename = download_file(url, cache=True)
 
         # Default behavior: Load first image
-        parse_data(imviz_app.app, filename, show_in_viewer=True)
-        data = imviz_app.app.data_collection[0]
+        parse_data(imviz_helper.app, filename, show_in_viewer=True)
+        data = imviz_helper.app.data_collection[0]
         comp = data.get_component('SCI,1')
         assert data.label == 'contents[SCI,1]'  # download_file returns cache loc
         assert data.shape == (4300, 4219)
@@ -318,15 +318,15 @@ class TestParseImage:
         # --- Since download is expensive, we attach FITS WCS-specific tests here. ---
 
         # Test simple aperture photometry plugin.
-        imviz_app._apply_interactive_region('bqplot:ellipse', (1465, 2541), (1512, 2611))  # Galaxy
-        phot_plugin = SimpleAperturePhotometry(app=imviz_app.app)
+        imviz_helper._apply_interactive_region('bqplot:ellipse', (1465, 2541), (1512, 2611))  # Galaxy
+        phot_plugin = SimpleAperturePhotometry(app=imviz_helper.app)
         phot_plugin._on_viewer_data_changed()
         phot_plugin.vue_data_selected('contents[SCI,1]')
         phot_plugin.vue_subset_selected('Subset 1')
         phot_plugin.background_value = 0.0014  # Median on whole array
         assert_allclose(phot_plugin.pixel_area, 0.0025)  # Not used but still auto-populated
         phot_plugin.vue_do_aper_phot()
-        tbl = imviz_app.get_aperture_photometry_results()
+        tbl = imviz_helper.get_aperture_photometry_results()
         assert_quantity_allclose(tbl[0]['xcenter'], 1488.5 * u.pix)
         assert_quantity_allclose(tbl[0]['ycenter'], 2576 * u.pix)
         sky = tbl[0]['sky_center']
@@ -349,18 +349,18 @@ class TestParseImage:
         assert_quantity_allclose(tbl[0]['max'], 1.625122 * data_unit, rtol=1e-5)
 
         # Request specific extension (name only), use given label
-        parse_data(imviz_app.app, filename, ext='CTX',
+        parse_data(imviz_helper.app, filename, ext='CTX',
                    data_label='jclj01010_drz', show_in_viewer=False)
-        data = imviz_app.app.data_collection[1]
+        data = imviz_helper.app.data_collection[1]
         comp = data.get_component('CTX,1')
         assert data.label == 'jclj01010_drz[CTX,1]'
         assert data.meta['EXTNAME'] == 'CTX'
         assert comp.units == ''  # BUNIT is not set
 
         # Request specific extension (name + ver), use given label
-        parse_data(imviz_app.app, filename, ext=('WHT', 1),
+        parse_data(imviz_helper.app, filename, ext=('WHT', 1),
                    data_label='jclj01010_drz', show_in_viewer=False)
-        data = imviz_app.app.data_collection[2]
+        data = imviz_helper.app.data_collection[2]
         comp = data.get_component('WHT,1')
         assert data.label == 'jclj01010_drz[WHT,1]'
         assert data.meta['EXTNAME'] == 'WHT'
@@ -369,30 +369,30 @@ class TestParseImage:
         # Pass in file obj directly
         with fits.open(filename) as pf:
             # Default behavior: Load first image
-            parse_data(imviz_app.app, pf, show_in_viewer=False)
-            data = imviz_app.app.data_collection[3]
+            parse_data(imviz_helper.app, pf, show_in_viewer=False)
+            data = imviz_helper.app.data_collection[3]
             assert data.label.startswith('imviz_data|') and data.label.endswith('[SCI,1]')
             assert_allclose(data.meta['PHOTFLAM'], 7.8711728E-20)
             assert 'SCI,1' in data.components
 
             # Request specific extension (name only), use given label
-            parse_data(imviz_app.app, pf, ext='CTX', show_in_viewer=False)
-            data = imviz_app.app.data_collection[4]
+            parse_data(imviz_helper.app, pf, ext='CTX', show_in_viewer=False)
+            data = imviz_helper.app.data_collection[4]
             assert data.label.startswith('imviz_data|') and data.label.endswith('[CTX,1]')
             assert data.meta['EXTNAME'] == 'CTX'
             assert 'CTX,1' in data.components
 
             # Pass in HDU directly, use given label
-            parse_data(imviz_app.app, pf[2], data_label='foo', show_in_viewer=False)
-            data = imviz_app.app.data_collection[5]
+            parse_data(imviz_helper.app, pf[2], data_label='foo', show_in_viewer=False)
+            data = imviz_helper.app.data_collection[5]
             assert data.label == 'foo[WHT,1]'
             assert data.meta['EXTNAME'] == 'WHT'
             assert 'WHT,1' in data.components
 
             # Load all extensions
-            imviz_app.app.data_collection.clear()
-            parse_data(imviz_app.app, filename, ext='*', show_in_viewer=False)
-            data = imviz_app.app.data_collection
+            imviz_helper.app.data_collection.clear()
+            parse_data(imviz_helper.app, filename, ext='*', show_in_viewer=False)
+            data = imviz_helper.app.data_collection
             assert len(data.labels) == 3
             assert data.labels[0].endswith('[SCI,1]')
             assert data.labels[1].endswith('[WHT,1]')
@@ -400,25 +400,25 @@ class TestParseImage:
 
         # Cannot load non-image extension
         with pytest.raises(ValueError, match='Imviz cannot load this HDU'):
-            parse_data(imviz_app.app, filename, ext='HDRTAB',
+            parse_data(imviz_helper.app, filename, ext='HDRTAB',
                        show_in_viewer=False)
 
         # Invalid FITS extension
         with pytest.raises(KeyError, match='not found'):
-            parse_data(imviz_app.app, filename, ext='DOES_NOT_EXIST',
+            parse_data(imviz_helper.app, filename, ext='DOES_NOT_EXIST',
                        data_label='foo', show_in_viewer=False)
 
 
-def test_load_valid_not_valid(imviz_app):
+def test_load_valid_not_valid(imviz_helper):
     # Load something valid.
     arr = np.ones((5, 5))
-    imviz_app.load_data(arr, data_label='valid', show_in_viewer=False)
+    imviz_helper.load_data(arr, data_label='valid', show_in_viewer=False)
 
     # Load something invalid.
     with pytest.raises(ValueError, match='Imviz cannot load this array with ndim=1'):
-        imviz_app.load_data(np.zeros(2), show_in_viewer=False)
+        imviz_helper.load_data(np.zeros(2), show_in_viewer=False)
 
     # Make sure valid data is still there.
-    assert (len(imviz_app.app.data_collection) == 1
-            and imviz_app.app.data_collection.labels == ['valid'])
-    assert_allclose(imviz_app.app.data_collection[0].get_component('DATA').data, 1)
+    assert (len(imviz_helper.app.data_collection) == 1
+            and imviz_helper.app.data_collection.labels == ['valid'])
+    assert_allclose(imviz_helper.app.data_collection[0].get_component('DATA').data, 1)

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -194,7 +194,9 @@ class TestParseImage:
         # --- Since download is expensive, we attach GWCS-specific tests here. ---
 
         # Ensure interactive region supports GWCS. Also see test_regions.py
-        imviz_helper._apply_interactive_region('bqplot:circle', (965, 1122), (976.9, 1110.1))  # Star
+        imviz_helper._apply_interactive_region('bqplot:circle',
+                                               (965, 1122),
+                                               (976.9, 1110.1))  # Star
         subsets = imviz_helper.get_interactive_regions()
         assert list(subsets.keys()) == ['Subset 1'], subsets
         assert isinstance(subsets['Subset 1'], CirclePixelRegion)
@@ -318,7 +320,9 @@ class TestParseImage:
         # --- Since download is expensive, we attach FITS WCS-specific tests here. ---
 
         # Test simple aperture photometry plugin.
-        imviz_helper._apply_interactive_region('bqplot:ellipse', (1465, 2541), (1512, 2611))  # Galaxy
+        imviz_helper._apply_interactive_region('bqplot:ellipse',
+                                               (1465, 2541),
+                                               (1512, 2611))  # Galaxy
         phot_plugin = SimpleAperturePhotometry(app=imviz_helper.app)
         phot_plugin._on_viewer_data_changed()
         phot_plugin.vue_data_selected('contents[SCI,1]')

--- a/jdaviz/configs/imviz/tests/test_regions.py
+++ b/jdaviz/configs/imviz/tests/test_regions.py
@@ -108,12 +108,12 @@ class TestLoadStaticRegions(BaseImviz_WCS_NoWCS, BaseRegionHandler):
 
 class TestLoadStaticRegionsSkyNoWCS(BaseRegionHandler):
     @pytest.fixture(autouse=True)
-    def setup_class(self, imviz_app):
+    def setup_class(self, imviz_helper):
         # Data without WCS
-        imviz_app.load_data(np.zeros((10, 10)), data_label='no_wcs')
+        imviz_helper.load_data(np.zeros((10, 10)), data_label='no_wcs')
 
-        self.imviz = imviz_app
-        self.viewer = imviz_app.default_viewer
+        self.imviz = imviz_helper
+        self.viewer = imviz_helper.default_viewer
         self.sky = SkyCoord(ra=337.5202808, dec=-20.833333059999998, unit='deg')
 
     def test_regions_sky_no_wcs(self):

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -11,27 +11,27 @@ from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
     ('desired_name', 'actual_name'),
     [(None, 'imviz-1'),
      ('babylon-5', 'babylon-5')])
-def test_create_destroy_viewer(imviz_app, desired_name, actual_name):
-    assert imviz_app.app.get_viewer_ids() == ['imviz-0']
+def test_create_destroy_viewer(imviz_helper, desired_name, actual_name):
+    assert imviz_helper.app.get_viewer_ids() == ['imviz-0']
 
-    viewer = imviz_app.create_image_viewer(viewer_name=desired_name)
+    viewer = imviz_helper.create_image_viewer(viewer_name=desired_name)
     assert isinstance(viewer, ImvizImageView)
-    assert viewer is imviz_app.app._viewer_store.get(actual_name), list(imviz_app.app._viewer_store.keys())  # noqa
-    assert imviz_app.app.get_viewer_ids() == sorted(['imviz-0', actual_name])
+    assert viewer is imviz_helper.app._viewer_store.get(actual_name), list(imviz_helper.app._viewer_store.keys())  # noqa
+    assert imviz_helper.app.get_viewer_ids() == sorted(['imviz-0', actual_name])
 
-    imviz_app.destroy_viewer(actual_name)
-    assert imviz_app.app.get_viewer_ids() == ['imviz-0']
+    imviz_helper.destroy_viewer(actual_name)
+    assert imviz_helper.app.get_viewer_ids() == ['imviz-0']
 
 
-def test_destroy_viewer_invalid(imviz_app):
-    assert imviz_app.app.get_viewer_ids() == ['imviz-0']
+def test_destroy_viewer_invalid(imviz_helper):
+    assert imviz_helper.app.get_viewer_ids() == ['imviz-0']
 
-    imviz_app.destroy_viewer('foo')
-    assert imviz_app.app.get_viewer_ids() == ['imviz-0']
+    imviz_helper.destroy_viewer('foo')
+    assert imviz_helper.app.get_viewer_ids() == ['imviz-0']
 
     with pytest.raises(ValueError, match='cannot be destroyed'):
-        imviz_app.destroy_viewer('imviz-0')
-    assert imviz_app.app.get_viewer_ids() == ['imviz-0']
+        imviz_helper.destroy_viewer('imviz-0')
+    assert imviz_helper.app.get_viewer_ids() == ['imviz-0']
 
 
 def test_mastviz_config():

--- a/jdaviz/configs/imviz/tests/utils.py
+++ b/jdaviz/configs/imviz/tests/utils.py
@@ -8,7 +8,7 @@ __all__ = ['BaseImviz_WCS_NoWCS', 'BaseImviz_WCS_WCS']
 
 class BaseImviz_WCS_NoWCS:
     @pytest.fixture(autouse=True)
-    def setup_class(self, imviz_app):
+    def setup_class(self, imviz_helper):
         hdu = fits.ImageHDU(np.arange(100).reshape((10, 10)), name='SCI')
 
         # Apply some celestial WCS from
@@ -27,15 +27,15 @@ class BaseImviz_WCS_NoWCS:
                            'NAXIS2': 10})
 
         # Data with WCS
-        imviz_app.load_data(hdu, data_label='has_wcs')
+        imviz_helper.load_data(hdu, data_label='has_wcs')
 
         # Data without WCS
-        imviz_app.load_data(hdu, data_label='no_wcs')
-        imviz_app.app.data_collection[1].coords = None
+        imviz_helper.load_data(hdu, data_label='no_wcs')
+        imviz_helper.app.data_collection[1].coords = None
 
         self.wcs = WCS(hdu.header)
-        self.imviz = imviz_app
-        self.viewer = imviz_app.default_viewer
+        self.imviz = imviz_helper
+        self.viewer = imviz_helper.default_viewer
 
         # Since we are not really displaying, need this to test zoom.
         self.viewer.shape = (100, 100)
@@ -44,7 +44,7 @@ class BaseImviz_WCS_NoWCS:
 
 class BaseImviz_WCS_WCS:
     @pytest.fixture(autouse=True)
-    def setup_class(self, imviz_app):
+    def setup_class(self, imviz_helper):
         arr = np.ones((10, 10))
 
         # First data with WCS, same as the one in BaseImviz_WCS_NoWCS.
@@ -61,7 +61,7 @@ class BaseImviz_WCS_WCS:
                             'CRPIX2': 1,
                             'CRVAL2': -20.833333059999998,
                             'NAXIS2': 10})
-        imviz_app.load_data(hdu1, data_label='has_wcs_1')
+        imviz_helper.load_data(hdu1, data_label='has_wcs_1')
 
         # Second data with WCS, similar to above but dithered by 1 pixel in X.
         # TODO: Use GWCS when https://github.com/spacetelescope/gwcs/issues/99 is possible.
@@ -78,12 +78,12 @@ class BaseImviz_WCS_WCS:
                             'CRPIX2': 1,
                             'CRVAL2': -20.833333059999998,
                             'NAXIS2': 10})
-        imviz_app.load_data(hdu2, data_label='has_wcs_2')
+        imviz_helper.load_data(hdu2, data_label='has_wcs_2')
 
         self.wcs_1 = WCS(hdu1.header)
         self.wcs_2 = WCS(hdu2.header)
-        self.imviz = imviz_app
-        self.viewer = imviz_app.default_viewer
+        self.imviz = imviz_helper
+        self.viewer = imviz_helper.default_viewer
 
         # Since we are not really displaying, need this to test zoom.
         self.viewer.shape = (100, 100)

--- a/jdaviz/configs/mosviz/tests/test_helper.py
+++ b/jdaviz/configs/mosviz/tests/test_helper.py
@@ -11,7 +11,7 @@ from specutils import Spectrum1D, SpectrumCollection
 
 
 @pytest.fixture
-def mosviz_app():
+def mosviz_helper():
     return Mosviz()
 
 
@@ -112,89 +112,89 @@ RADESYS = 'ICRS'               / Equatorial coordinate system
     return ccd_data
 
 
-def test_load_spectrum1d(mosviz_app, spectrum1d):
+def test_load_spectrum1d(mosviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    mosviz_app.load_1d_spectra(spectrum1d, data_labels=label)
+    mosviz_helper.load_1d_spectra(spectrum1d, data_labels=label)
 
-    assert len(mosviz_app.app.data_collection) == 2
-    assert mosviz_app.app.data_collection[0].label == label
+    assert len(mosviz_helper.app.data_collection) == 2
+    assert mosviz_helper.app.data_collection[0].label == label
 
-    table = mosviz_app.app.get_viewer('table-viewer')
+    table = mosviz_helper.app.get_viewer('table-viewer')
     table.widget_table.vue_on_row_clicked(0)
 
-    data = mosviz_app.app.get_data_from_viewer('spectrum-viewer')
+    data = mosviz_helper.app.get_data_from_viewer('spectrum-viewer')
 
     assert isinstance(list(data.values())[0], Spectrum1D)
     assert list(data.keys())[0] == label
 
     with pytest.raises(TypeError):
-        mosviz_app.load_1d_spectra([1, 2, 3])
+        mosviz_helper.load_1d_spectra([1, 2, 3])
 
 
-def test_load_spectrum_collection(mosviz_app, spectrum_collection):
+def test_load_spectrum_collection(mosviz_helper, spectrum_collection):
     labels = [f"Test Spectrum Collection {i}" for i in range(5)]
-    mosviz_app.load_1d_spectra(spectrum_collection, data_labels=labels)
+    mosviz_helper.load_1d_spectra(spectrum_collection, data_labels=labels)
 
-    assert len(mosviz_app.app.data_collection) == 6
-    assert mosviz_app.app.data_collection[0].label == labels[0]
+    assert len(mosviz_helper.app.data_collection) == 6
+    assert mosviz_helper.app.data_collection[0].label == labels[0]
 
-    table = mosviz_app.app.get_viewer('table-viewer')
+    table = mosviz_helper.app.get_viewer('table-viewer')
     table.widget_table.vue_on_row_clicked(0)
 
-    data = mosviz_app.app.get_data_from_viewer('spectrum-viewer')
+    data = mosviz_helper.app.get_data_from_viewer('spectrum-viewer')
 
     assert isinstance(list(data.values())[0], Spectrum1D)
     assert list(data.keys())[0] == labels[0]
 
 
-def test_load_list_of_spectrum1d(mosviz_app, spectrum1d):
+def test_load_list_of_spectrum1d(mosviz_helper, spectrum1d):
     spectra = [spectrum1d]*3
 
     labels = [f"Test Spectrum 1D {i}" for i in range(3)]
-    mosviz_app.load_1d_spectra(spectra, data_labels=labels)
+    mosviz_helper.load_1d_spectra(spectra, data_labels=labels)
 
-    assert len(mosviz_app.app.data_collection) == 4
-    assert mosviz_app.app.data_collection[0].label == labels[0]
+    assert len(mosviz_helper.app.data_collection) == 4
+    assert mosviz_helper.app.data_collection[0].label == labels[0]
 
-    table = mosviz_app.app.get_viewer('table-viewer')
+    table = mosviz_helper.app.get_viewer('table-viewer')
     table.widget_table.vue_on_row_clicked(0)
 
-    data = mosviz_app.app.get_data_from_viewer('spectrum-viewer')
+    data = mosviz_helper.app.get_data_from_viewer('spectrum-viewer')
 
     assert isinstance(list(data.values())[0], Spectrum1D)
     assert list(data.keys())[0] == labels[0]
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_load_spectrum2d(mosviz_app, spectrum2d):
+def test_load_spectrum2d(mosviz_helper, spectrum2d):
 
     label = "Test 2D Spectrum"
-    mosviz_app.load_2d_spectra(spectrum2d, data_labels=label)
+    mosviz_helper.load_2d_spectra(spectrum2d, data_labels=label)
 
-    assert len(mosviz_app.app.data_collection) == 2
-    assert mosviz_app.app.data_collection[0].label == label
+    assert len(mosviz_helper.app.data_collection) == 2
+    assert mosviz_helper.app.data_collection[0].label == label
 
-    table = mosviz_app.app.get_viewer('table-viewer')
+    table = mosviz_helper.app.get_viewer('table-viewer')
     table.widget_table.vue_on_row_clicked(0)
 
-    data = mosviz_app.app.get_data_from_viewer('spectrum-2d-viewer')
+    data = mosviz_helper.app.get_data_from_viewer('spectrum-2d-viewer')
 
     assert list(data.values())[0].shape == (1024, 15)
     assert list(data.keys())[0] == label
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_load_image(mosviz_app, image):
+def test_load_image(mosviz_helper, image):
     label = "Test Image"
-    mosviz_app.load_images(image, data_labels=label)
+    mosviz_helper.load_images(image, data_labels=label)
 
-    assert len(mosviz_app.app.data_collection) == 2
-    assert mosviz_app.app.data_collection[0].label == f"{label} 0"
+    assert len(mosviz_helper.app.data_collection) == 2
+    assert mosviz_helper.app.data_collection[0].label == f"{label} 0"
 
-    table = mosviz_app.app.get_viewer('table-viewer')
+    table = mosviz_helper.app.get_viewer('table-viewer')
     table.widget_table.vue_on_row_clicked(0)
 
-    data = mosviz_app.app.get_data_from_viewer('image-viewer')
+    data = mosviz_helper.app.get_data_from_viewer('image-viewer')
 
     assert isinstance(list(data.values())[0], CCDData)
     assert list(data.values())[0].shape == (55, 55)
@@ -203,21 +203,21 @@ def test_load_image(mosviz_app, image):
 
 @pytest.mark.filterwarnings('ignore')
 @pytest.mark.parametrize('label', [None, "Test Label"])
-def test_load_single_image_multi_spec(mosviz_app, image, spectrum1d, spectrum2d, label):
+def test_load_single_image_multi_spec(mosviz_helper, image, spectrum1d, spectrum2d, label):
     spectra1d = [spectrum1d] * 3
     spectra2d = [spectrum2d] * 3
 
     # Test that loading is still possible after previous crash:
     # https://github.com/spacetelescope/jdaviz/issues/364
     with pytest.raises(ValueError, match='The dimensions of component 2D Spectra are incompatible'):
-        mosviz_app.load_data(spectra1d, spectra2d, images=[])
+        mosviz_helper.load_data(spectra1d, spectra2d, images=[])
 
-    mosviz_app.load_data(spectra1d, spectra2d, images=image, images_label=label)
+    mosviz_helper.load_data(spectra1d, spectra2d, images=image, images_label=label)
 
-    assert mosviz_app.app.get_viewer("table-viewer").figure_widget.highlighted == 0
-    assert len(mosviz_app.app.data_collection) == 8
+    assert mosviz_helper.app.get_viewer("table-viewer").figure_widget.highlighted == 0
+    assert len(mosviz_helper.app.data_collection) == 8
 
-    qtable = mosviz_app.to_table()
+    qtable = mosviz_helper.to_table()
     if label is None:
         assert np.all(qtable["Images"] == "Shared Image")
     else:
@@ -227,17 +227,17 @@ def test_load_single_image_multi_spec(mosviz_app, image, spectrum1d, spectrum2d,
 
 @pytest.mark.filterwarnings('ignore')
 @pytest.mark.parametrize('label', [None, "Test Label"])
-def test_load_multi_image_spec(mosviz_app, image, spectrum1d, spectrum2d, label):
+def test_load_multi_image_spec(mosviz_helper, image, spectrum1d, spectrum2d, label):
     spectra1d = [spectrum1d]*3
     spectra2d = [spectrum2d]*3
     images = [image]*3
 
-    mosviz_app.load_data(spectra1d, spectra2d, images=images, images_label=label)
+    mosviz_helper.load_data(spectra1d, spectra2d, images=images, images_label=label)
 
-    assert mosviz_app.app.get_viewer("table-viewer").figure_widget.highlighted == 0
-    assert len(mosviz_app.app.data_collection) == 10
+    assert mosviz_helper.app.get_viewer("table-viewer").figure_widget.highlighted == 0
+    assert len(mosviz_helper.app.data_collection) == 10
 
-    qtable = mosviz_app.to_table()
+    qtable = mosviz_helper.to_table()
     if label is None:
         assert qtable["Images"][0] == "Image 0"
     else:
@@ -245,18 +245,18 @@ def test_load_multi_image_spec(mosviz_app, image, spectrum1d, spectrum2d, label)
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_viewer_axis_link(mosviz_app, spectrum1d, spectrum2d):
+def test_viewer_axis_link(mosviz_helper, spectrum1d, spectrum2d):
     label1d = "Test 1D Spectrum"
-    mosviz_app.load_1d_spectra(spectrum1d, data_labels=label1d)
+    mosviz_helper.load_1d_spectra(spectrum1d, data_labels=label1d)
 
     label2d = "Test 2D Spectrum"
-    mosviz_app.load_2d_spectra(spectrum2d, data_labels=label2d)
+    mosviz_helper.load_2d_spectra(spectrum2d, data_labels=label2d)
 
-    table = mosviz_app.app.get_viewer('table-viewer')
+    table = mosviz_helper.app.get_viewer('table-viewer')
     table.widget_table.vue_on_row_clicked(0)
 
-    scale_2d = mosviz_app.app.get_viewer('spectrum-2d-viewer').scales['x']
-    scale_1d = mosviz_app.app.get_viewer('spectrum-viewer').scales['x']
+    scale_2d = mosviz_helper.app.get_viewer('spectrum-2d-viewer').scales['x']
+    scale_1d = mosviz_helper.app.get_viewer('spectrum-viewer').scales['x']
 
     scale_2d.min = 200.0
     assert scale_1d.min == spectrum1d.spectral_axis.value[200]
@@ -265,11 +265,11 @@ def test_viewer_axis_link(mosviz_app, spectrum1d, spectrum2d):
     assert scale_2d.max == 800.0
 
 
-def test_to_csv(tmp_path, mosviz_app, spectrum_collection):
+def test_to_csv(tmp_path, mosviz_helper, spectrum_collection):
     labels = [f"Test Spectrum Collection {i}" for i in range(5)]
-    mosviz_app.load_1d_spectra(spectrum_collection, data_labels=labels)
+    mosviz_helper.load_1d_spectra(spectrum_collection, data_labels=labels)
 
-    mosviz_app.to_csv(filename=str(tmp_path / "MOS_data.csv"))
+    mosviz_helper.to_csv(filename=str(tmp_path / "MOS_data.csv"))
 
     found_rows = 0
     found_index_label = False
@@ -287,13 +287,13 @@ def test_to_csv(tmp_path, mosviz_app, spectrum_collection):
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_table_scrolling(mosviz_app, image, spectrum1d, spectrum2d):
+def test_table_scrolling(mosviz_helper, image, spectrum1d, spectrum2d):
     spectra1d = [spectrum1d] * 2
     spectra2d = [spectrum2d] * 2
 
-    mosviz_app.load_data(spectra1d, spectra2d, images=image)
+    mosviz_helper.load_data(spectra1d, spectra2d, images=image)
 
-    table = mosviz_app.app.get_viewer('table-viewer')
+    table = mosviz_helper.app.get_viewer('table-viewer')
     # first row is automatically selected in the UI
     # (otherwise it would be None which is a case not handled)
     table.widget_table.highlighted = 0
@@ -307,68 +307,68 @@ def test_table_scrolling(mosviz_app, image, spectrum1d, spectrum2d):
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_column_visibility(mosviz_app, image, spectrum1d, spectrum2d):
+def test_column_visibility(mosviz_helper, image, spectrum1d, spectrum2d):
     spectra1d = [spectrum1d] * 2
     spectra2d = [spectrum2d] * 2
 
-    mosviz_app.load_data(spectra1d, spectra2d, images=image)
+    mosviz_helper.load_data(spectra1d, spectra2d, images=image)
 
     with pytest.raises(
                 ValueError,
                 match="visible must be one of None, True, or False."):
-        mosviz_app.get_column_names(visible='string')
+        mosviz_helper.get_column_names(visible='string')
 
-    assert 'Redshift' not in mosviz_app.get_column_names(True)
-    assert 'Redshift' in mosviz_app.get_column_names(False)
-    assert 'Redshift' in mosviz_app.get_column_names()
+    assert 'Redshift' not in mosviz_helper.get_column_names(True)
+    assert 'Redshift' in mosviz_helper.get_column_names(False)
+    assert 'Redshift' in mosviz_helper.get_column_names()
 
-    mosviz_app.show_column('Redshift')
-    assert 'Redshift' in mosviz_app.get_column_names(True)
+    mosviz_helper.show_column('Redshift')
+    assert 'Redshift' in mosviz_helper.get_column_names(True)
 
-    mosviz_app.hide_column('Redshift')
-    assert 'Redshift' not in mosviz_app.get_column_names(True)
+    mosviz_helper.hide_column('Redshift')
+    assert 'Redshift' not in mosviz_helper.get_column_names(True)
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_custom_columns(mosviz_app, image, spectrum1d, spectrum2d):
+def test_custom_columns(mosviz_helper, image, spectrum1d, spectrum2d):
     spectra1d = [spectrum1d] * 2
     spectra2d = [spectrum2d] * 2
 
-    mosviz_app.load_data(spectra1d, spectra2d, images=image)
+    mosviz_helper.load_data(spectra1d, spectra2d, images=image)
 
-    mosviz_app.add_column('custom_name')
-    assert 'custom_name' in mosviz_app.get_column_names(True)
-    assert len(mosviz_app.get_column('custom_name')) == 2
+    mosviz_helper.add_column('custom_name')
+    assert 'custom_name' in mosviz_helper.get_column_names(True)
+    assert len(mosviz_helper.get_column('custom_name')) == 2
 
-    mosviz_app.update_column('custom_name', 0.1, row=1)
-    assert mosviz_app.get_column('custom_name')[1] == 0.1
+    mosviz_helper.update_column('custom_name', 0.1, row=1)
+    assert mosviz_helper.get_column('custom_name')[1] == 0.1
 
     with pytest.raises(
                 ValueError,
                 match="row out of range of table"):
-        mosviz_app.update_column('custom_name', 0.3, row=3)
+        mosviz_helper.update_column('custom_name', 0.3, row=3)
 
     with pytest.raises(
                 ValueError,
                 match="data must have length 2 \\(rows in table\\)"):
-        mosviz_app.add_column('custom_name_2', [0.1])
+        mosviz_helper.add_column('custom_name_2', [0.1])
 
-    mosviz_app.show_column("Redshift")
-    assert "Redshift" in mosviz_app.get_column_names(True)
-    mosviz_app.set_visible_columns()
-    assert "Redshift" not in mosviz_app.get_column_names(True)
+    mosviz_helper.show_column("Redshift")
+    assert "Redshift" in mosviz_helper.get_column_names(True)
+    mosviz_helper.set_visible_columns()
+    assert "Redshift" not in mosviz_helper.get_column_names(True)
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_redshift_column(mosviz_app, image, spectrum1d, spectrum2d):
+def test_redshift_column(mosviz_helper, image, spectrum1d, spectrum2d):
     spectra1d = [spectrum1d] * 2
     spectra2d = [spectrum2d] * 2
 
-    mosviz_app.load_data(spectra1d, spectra2d, images=image)
+    mosviz_helper.load_data(spectra1d, spectra2d, images=image)
 
-    mosviz_app.update_column("Redshift", 0.1, row=0)
-    assert_allclose(list(mosviz_app.specviz.get_spectra().values())[0].redshift.value, 0.1)
-    assert isinstance(mosviz_app.specviz2d, Specviz2d)
-    assert_allclose(mosviz_app.get_spectrum_1d().redshift.value, 0.1)
-    assert_allclose(mosviz_app.get_spectrum_2d().redshift.value, 0.1)
-    assert_allclose(mosviz_app.get_spectrum_1d(row=1).redshift.value, 0.0)
+    mosviz_helper.update_column("Redshift", 0.1, row=0)
+    assert_allclose(list(mosviz_helper.specviz.get_spectra().values())[0].redshift.value, 0.1)
+    assert isinstance(mosviz_helper.specviz2d, Specviz2d)
+    assert_allclose(mosviz_helper.get_spectrum_1d().redshift.value, 0.1)
+    assert_allclose(mosviz_helper.get_spectrum_2d().redshift.value, 0.1)
+    assert_allclose(mosviz_helper.get_spectrum_1d(row=1).redshift.value, 0.0)

--- a/jdaviz/configs/mosviz/tests/test_parsers.py
+++ b/jdaviz/configs/mosviz/tests/test_parsers.py
@@ -6,7 +6,7 @@ from astropy.utils.data import download_file
 
 
 @pytest.mark.remote_data
-def test_niriss_parser(mosviz_app, tmpdir):
+def test_niriss_parser(mosviz_helper, tmpdir):
 
     test_data = 'https://stsci.box.com/shared/static/l2azhcqd3tvzhybdlpx2j2qlutkaro3z.zip'
     fn = download_file(test_data, cache=True, timeout=30)
@@ -17,8 +17,8 @@ def test_niriss_parser(mosviz_app, tmpdir):
 
     data_dir = level3_path
 
-    mosviz_app.load_niriss_data(data_dir)
+    mosviz_helper.load_niriss_data(data_dir)
 
-    assert len(mosviz_app.app.data_collection) == 80
-    assert mosviz_app.app.data_collection[0].label == "Image canucs F150W"
-    assert mosviz_app.app.data_collection[-1].label == "MOS Table"
+    assert len(mosviz_helper.app.data_collection) == 80
+    assert mosviz_helper.app.data_collection[0].label == "Image canucs F150W"
+    assert mosviz_helper.app.data_collection[-1].label == "MOS Table"

--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -26,41 +26,41 @@ RESULT_UNCERTAINTY = [3.85914248e-09, 3.60631495e-09, 1.74661581e-09,
     [("fail", "erg / (s cm2 um)"),
      ("None", "fail"),
      ("micron", "fail")])
-def test_value_error_exception(specviz_app, spectrum1d, new_spectral_axis, new_flux):
+def test_value_error_exception(specviz_helper, spectrum1d, new_spectral_axis, new_flux):
     label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
     conv_func = uc.UnitConversion.process_unit_conversion
-    converted_spectrum = conv_func(specviz_app.app, spectrum=spectrum1d,
+    converted_spectrum = conv_func(specviz_helper.app, spectrum=spectrum1d,
                                    new_flux=new_flux,
                                    new_spectral_axis=new_spectral_axis)
 
     assert converted_spectrum is None
 
 
-def test_no_spec_no_flux_no_uncert(specviz_app, spectrum1d):
+def test_no_spec_no_flux_no_uncert(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
     spectrum1d.uncertainty = None
 
     conv_func = uc.UnitConversion.process_unit_conversion
-    converted_spectrum = conv_func(specviz_app.app, spectrum=spectrum1d)
+    converted_spectrum = conv_func(specviz_helper.app, spectrum=spectrum1d)
 
     assert converted_spectrum.flux.unit == spectrum1d.flux.unit
     assert converted_spectrum.spectral_axis.unit == spectrum1d.spectral_axis.unit
     assert converted_spectrum.uncertainty is None
 
 
-def test_spec_no_flux_no_uncert(specviz_app, spectrum1d):
+def test_spec_no_flux_no_uncert(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
     new_spectral_axis = "micron"
     spectrum1d.uncertainty = None
 
     conv_func = uc.UnitConversion.process_unit_conversion
-    converted_spectrum = conv_func(specviz_app.app, spectrum=spectrum1d,
+    converted_spectrum = conv_func(specviz_helper.app, spectrum=spectrum1d,
                                    new_spectral_axis=new_spectral_axis)
 
     assert_quantity_allclose(converted_spectrum.spectral_axis,
@@ -70,41 +70,41 @@ def test_spec_no_flux_no_uncert(specviz_app, spectrum1d):
     assert converted_spectrum.uncertainty is None
 
 
-def test_no_spec_no_flux_uncert(specviz_app, spectrum1d):
+def test_no_spec_no_flux_uncert(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
     conv_func = uc.UnitConversion.process_unit_conversion
-    converted_spectrum = conv_func(specviz_app.app, spectrum=spectrum1d)
+    converted_spectrum = conv_func(specviz_helper.app, spectrum=spectrum1d)
 
     assert converted_spectrum.flux.unit == spectrum1d.flux.unit
 
 
-def test_no_spec_no_flux_uncert_unit_exp_none(specviz_app, spectrum1d):
+def test_no_spec_no_flux_uncert_unit_exp_none(specviz_helper, spectrum1d):
     np.random.seed(42)
     label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
     spectrum1d.uncertainty = UnknownUncertainty(np.abs(
         np.random.randn(len(spectrum1d.spectral_axis))))
 
     conv_func = uc.UnitConversion.process_unit_conversion
-    converted_spectrum = conv_func(specviz_app.app, spectrum=spectrum1d)
+    converted_spectrum = conv_func(specviz_helper.app, spectrum=spectrum1d)
 
     assert converted_spectrum.flux.unit == spectrum1d.flux.unit
     assert converted_spectrum.spectral_axis.unit == spectrum1d.spectral_axis.unit
     assert converted_spectrum.uncertainty is None
 
 
-def test_no_spec_flux_no_uncert(specviz_app, spectrum1d):
+def test_no_spec_flux_no_uncert(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
     spectrum1d.uncertainty = None
     new_flux = "erg / (s cm2 um)"
 
     conv_func = uc.UnitConversion.process_unit_conversion
-    converted_spectrum = conv_func(specviz_app.app, spectrum=spectrum1d,
+    converted_spectrum = conv_func(specviz_helper.app, spectrum=spectrum1d,
                                    new_flux=new_flux)
 
     assert_quantity_allclose(converted_spectrum.flux,
@@ -113,14 +113,14 @@ def test_no_spec_flux_no_uncert(specviz_app, spectrum1d):
     assert converted_spectrum.uncertainty is None
 
 
-def test_no_spec_flux_unit_exp_not_none(specviz_app, spectrum1d):
+def test_no_spec_flux_unit_exp_not_none(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
     new_flux = "erg / (s cm2 um)"
 
     conv_func = uc.UnitConversion.process_unit_conversion
-    converted_spectrum = conv_func(specviz_app.app, spectrum=spectrum1d,
+    converted_spectrum = conv_func(specviz_helper.app, spectrum=spectrum1d,
                                    new_flux=new_flux)
 
     assert_quantity_allclose(converted_spectrum.flux,
@@ -129,9 +129,9 @@ def test_no_spec_flux_unit_exp_not_none(specviz_app, spectrum1d):
                              RESULT_UNCERTAINTY, atol=1e-11)
 
 
-def test_spec_flux_no_uncert(specviz_app, spectrum1d):
+def test_spec_flux_no_uncert(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
     new_spectral_axis = "micron"
     new_flux = "erg / (s cm2 um)"
@@ -139,7 +139,7 @@ def test_spec_flux_no_uncert(specviz_app, spectrum1d):
     spectrum1d.uncertainty = None
 
     conv_func = uc.UnitConversion.process_unit_conversion
-    converted_spectrum = conv_func(specviz_app.app, spectrum=spectrum1d,
+    converted_spectrum = conv_func(specviz_helper.app, spectrum=spectrum1d,
                                    new_flux=new_flux,
                                    new_spectral_axis=new_spectral_axis)
 
@@ -150,10 +150,10 @@ def test_spec_flux_no_uncert(specviz_app, spectrum1d):
     assert converted_spectrum.uncertainty is None
 
 
-def test_spec_no_flux_uncert_no_unit_exp(specviz_app, spectrum1d):
+def test_spec_no_flux_uncert_no_unit_exp(specviz_helper, spectrum1d):
     np.random.seed(42)
     label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
     new_spectral_axis = "micron"
 
@@ -161,7 +161,7 @@ def test_spec_no_flux_uncert_no_unit_exp(specviz_app, spectrum1d):
         np.random.randn(len(spectrum1d.spectral_axis))))
 
     conv_func = uc.UnitConversion.process_unit_conversion
-    converted_spectrum = conv_func(specviz_app.app, spectrum=spectrum1d,
+    converted_spectrum = conv_func(specviz_helper.app, spectrum=spectrum1d,
                                    new_spectral_axis=new_spectral_axis)
 
     assert converted_spectrum.flux.unit == spectrum1d.flux.unit
@@ -170,10 +170,10 @@ def test_spec_no_flux_uncert_no_unit_exp(specviz_app, spectrum1d):
     assert converted_spectrum.uncertainty is None
 
 
-def test_no_spec_flux_uncert_no_unit_exp(specviz_app, spectrum1d):
+def test_no_spec_flux_uncert_no_unit_exp(specviz_helper, spectrum1d):
     np.random.seed(42)
     label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
     new_flux = "erg / (s cm2 um)"
 
@@ -181,7 +181,7 @@ def test_no_spec_flux_uncert_no_unit_exp(specviz_app, spectrum1d):
         np.random.randn(len(spectrum1d.spectral_axis))))
 
     conv_func = uc.UnitConversion.process_unit_conversion
-    converted_spectrum = conv_func(specviz_app.app, spectrum=spectrum1d,
+    converted_spectrum = conv_func(specviz_helper.app, spectrum=spectrum1d,
                                    new_flux=new_flux)
 
     assert converted_spectrum.spectral_axis.unit == spectrum1d.spectral_axis.unit
@@ -190,24 +190,24 @@ def test_no_spec_flux_uncert_no_unit_exp(specviz_app, spectrum1d):
     assert converted_spectrum.uncertainty is None
 
 
-def test_spec_no_flux_uncert_unit_exp(specviz_app, spectrum1d):
+def test_spec_no_flux_uncert_unit_exp(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
     new_spectral_axis = "micron"
 
     conv_func = uc.UnitConversion.process_unit_conversion
-    converted_spectrum = conv_func(specviz_app.app, spectrum=spectrum1d,
+    converted_spectrum = conv_func(specviz_helper.app, spectrum=spectrum1d,
                                    new_spectral_axis=new_spectral_axis)
 
     assert_quantity_allclose(converted_spectrum.spectral_axis,
                              RESULT_SPECTRAL_AXIS, atol=1e-5*u.um)
 
 
-def test_spec_flux_uncert_no_unit_exp(specviz_app, spectrum1d):
+def test_spec_flux_uncert_no_unit_exp(specviz_helper, spectrum1d):
     np.random.seed(42)
     label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
     new_spectral_axis = "micron"
     new_flux = "erg / (s cm2 um)"
@@ -216,7 +216,7 @@ def test_spec_flux_uncert_no_unit_exp(specviz_app, spectrum1d):
         np.random.randn(len(spectrum1d.spectral_axis))))
 
     conv_func = uc.UnitConversion.process_unit_conversion
-    converted_spectrum = conv_func(specviz_app.app, spectrum=spectrum1d,
+    converted_spectrum = conv_func(specviz_helper.app, spectrum=spectrum1d,
                                    new_flux=new_flux,
                                    new_spectral_axis=new_spectral_axis)
 
@@ -227,15 +227,15 @@ def test_spec_flux_uncert_no_unit_exp(specviz_app, spectrum1d):
                              RESULT_FLUX, atol=1e-5*u.Unit(new_flux))
 
 
-def test_spec_flux_uncert_unit_exp(specviz_app, spectrum1d):
+def test_spec_flux_uncert_unit_exp(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_app.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
     new_spectral_axis = "micron"
     new_flux = "erg / (s cm2 um)"
 
     conv_func = uc.UnitConversion.process_unit_conversion
-    converted_spectrum = conv_func(specviz_app.app, spectrum=spectrum1d,
+    converted_spectrum = conv_func(specviz_helper.app, spectrum=spectrum1d,
                                    new_flux=new_flux,
                                    new_spectral_axis=new_spectral_axis)
 

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -191,8 +191,8 @@ def test_get_spectral_regions_unit_conversion(specviz_helper, spectrum1d):
     # Add this new data and clear the other, making the converted spectrum our reference
     specviz_helper.app.add_data(converted_spectrum, "Converted Spectrum")
     specviz_helper.app.add_data_to_viewer("spectrum-viewer",
-                                       "Converted Spectrum",
-                                       clear_other_data=True)
+                                          "Converted Spectrum",
+                                          clear_other_data=True)
 
     specviz_helper.app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(0.6, 0.7))
 

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -12,8 +12,8 @@ from jdaviz.configs.specviz.helper import Specviz
 
 class TestSpecvizHelper:
     @pytest.fixture(autouse=True)
-    def setup_class(self, specviz_app, spectrum1d):
-        self.spec_app = specviz_app
+    def setup_class(self, specviz_helper, spectrum1d):
+        self.spec_app = specviz_helper
         self.spec = spectrum1d
         self.spec_list = SpectrumList([spectrum1d] * 3)
 
@@ -141,73 +141,73 @@ class TestSpecvizHelper:
             self.spec_app.get_spectral_regions()
 
 
-def test_get_spectra_no_spectra(specviz_app, spectrum1d):
-    spectra = specviz_app.get_spectra()
+def test_get_spectra_no_spectra(specviz_helper, spectrum1d):
+    spectra = specviz_helper.get_spectra()
 
     assert spectra == {}
 
 
-def test_get_spectra_no_spectra_redshift_error(specviz_app, spectrum1d):
-    spectra = specviz_app.get_spectra(apply_slider_redshift=True)
+def test_get_spectra_no_spectra_redshift_error(specviz_helper, spectrum1d):
+    spectra = specviz_helper.get_spectra(apply_slider_redshift=True)
 
     assert spectra == {}
 
 
-def test_get_spectra_no_spectra_label(specviz_app, spectrum1d):
+def test_get_spectra_no_spectra_label(specviz_helper, spectrum1d):
     label = "label"
     with pytest.raises(AttributeError):
-        specviz_app.get_spectra(data_label=label)
+        specviz_helper.get_spectra(data_label=label)
 
 
-def test_get_spectra_no_spectra_label_redshift_error(specviz_app, spectrum1d):
+def test_get_spectra_no_spectra_label_redshift_error(specviz_helper, spectrum1d):
     label = "label"
     with pytest.raises(AttributeError):
-        specviz_app.get_spectra(data_label=label, apply_slider_redshift=True)
+        specviz_helper.get_spectra(data_label=label, apply_slider_redshift=True)
 
 
-def test_get_spectral_regions_unit(specviz_app, spectrum1d):
+def test_get_spectral_regions_unit(specviz_helper, spectrum1d):
     # Ensure units we put in are the same as the units we get out
-    specviz_app.load_spectrum(spectrum1d)
-    specviz_app.app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(6200, 7000))
+    specviz_helper.load_spectrum(spectrum1d)
+    specviz_helper.app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(6200, 7000))
 
-    subsets = specviz_app.get_spectral_regions()
+    subsets = specviz_helper.get_spectral_regions()
     reg = subsets.get('Subset 1')
 
     assert spectrum1d.wavelength.unit == reg.lower.unit
     assert spectrum1d.wavelength.unit == reg.upper.unit
 
 
-def test_get_spectral_regions_unit_conversion(specviz_app, spectrum1d):
+def test_get_spectral_regions_unit_conversion(specviz_helper, spectrum1d):
     # If the reference (visible) data changes via unit conversion,
     # check that the region's units convert too
-    specviz_app.load_spectrum(spectrum1d)
+    specviz_helper.load_spectrum(spectrum1d)
 
     # Convert the wavelength axis to microns
     new_spectral_axis = "micron"
     conv_func = uc.UnitConversion.process_unit_conversion
-    converted_spectrum = conv_func(specviz_app.app, spectrum=spectrum1d,
+    converted_spectrum = conv_func(specviz_helper.app, spectrum=spectrum1d,
                                    new_spectral_axis=new_spectral_axis)
 
     # Add this new data and clear the other, making the converted spectrum our reference
-    specviz_app.app.add_data(converted_spectrum, "Converted Spectrum")
-    specviz_app.app.add_data_to_viewer("spectrum-viewer",
+    specviz_helper.app.add_data(converted_spectrum, "Converted Spectrum")
+    specviz_helper.app.add_data_to_viewer("spectrum-viewer",
                                        "Converted Spectrum",
                                        clear_other_data=True)
 
-    specviz_app.app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(0.6, 0.7))
+    specviz_helper.app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(0.6, 0.7))
 
     # Retrieve the Subset
-    subsets = specviz_app.get_spectral_regions()
+    subsets = specviz_helper.get_spectral_regions()
     reg = subsets.get('Subset 1')
 
     assert reg.lower.unit == u.Unit(new_spectral_axis)
     assert reg.upper.unit == u.Unit(new_spectral_axis)
 
 
-def test_subset_default_thickness(specviz_app, spectrum1d):
-    specviz_app.load_spectrum(spectrum1d)
+def test_subset_default_thickness(specviz_helper, spectrum1d):
+    specviz_helper.load_spectrum(spectrum1d)
 
-    sv = specviz_app.app.get_viewer('spectrum-viewer')
+    sv = specviz_helper.app.get_viewer('spectrum-viewer')
     tool = sv.toolbar.tools['bqplot:xrange']
     tool.activate()
     tool.interact.brushing = True
@@ -217,7 +217,7 @@ def test_subset_default_thickness(specviz_app, spectrum1d):
     assert sv.state.layers[-1].linewidth == 3
 
 
-def test_app_links(specviz_app, spectrum1d):
-    sv = specviz_app.app.get_viewer('spectrum-viewer')
+def test_app_links(specviz_helper, spectrum1d):
+    sv = specviz_helper.app.get_viewer('spectrum-viewer')
     assert isinstance(sv.jdaviz_app, Application)
     assert isinstance(sv.jdaviz_helper, Specviz)

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -31,7 +31,7 @@ def mosviz_app():
 
 
 @pytest.fixture
-def specviz_app():
+def specviz_helper():
     return Specviz()
 
 

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -21,7 +21,7 @@ def cubeviz_helper():
 
 
 @pytest.fixture
-def imviz_app():
+def imviz_helper():
     return Imviz()
 
 

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -26,7 +26,7 @@ def imviz_app():
 
 
 @pytest.fixture
-def mosviz_app():
+def mosviz_helper():
     return Mosviz()
 
 

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -16,7 +16,7 @@ SPECTRUM_SIZE = 10  # length of spectrum
 
 
 @pytest.fixture
-def cubeviz_app():
+def cubeviz_helper():
     return Cubeviz()
 
 

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -36,7 +36,7 @@ def specviz_helper():
 
 
 @pytest.fixture
-def specviz2d_app():
+def specviz2d_helper():
     return Specviz2d()
 
 

--- a/jdaviz/tests/test_show.py
+++ b/jdaviz/tests/test_show.py
@@ -1,17 +1,17 @@
 import sidecar
 
 
-def test_show_inline(specviz_app):
-    res = specviz_app.show_inline()
+def test_show_inline(specviz_helper):
+    res = specviz_helper.show_inline()
 
     assert res is None
 
 
-def test_show_sidecar(specviz_app):
-    res = specviz_app.show_in_sidecar()
+def test_show_sidecar(specviz_helper):
+    res = specviz_helper.show_in_sidecar()
     assert isinstance(res, sidecar.Sidecar)
 
 
-def test_show_new_tab(specviz_app):
-    res = specviz_app.show_in_new_tab()
+def test_show_new_tab(specviz_helper):
+    res = specviz_helper.show_in_new_tab()
     assert isinstance(res, sidecar.Sidecar)

--- a/jdaviz/tests/test_viewer_ids.py
+++ b/jdaviz/tests/test_viewer_ids.py
@@ -40,8 +40,8 @@ def test_default_viewer_ids_mosviz(mosviz_app):
     assert x.get_viewer_ids() == ['mosviz-0', 'mosviz-1', 'mosviz-2', 'mosviz-3']
 
 
-def test_default_viewer_ids_specviz(specviz_app):
-    x = specviz_app.app
+def test_default_viewer_ids_specviz(specviz_helper):
+    x = specviz_helper.app
     assert x.get_viewer_reference_names() == ['spectrum-viewer']
     assert x.get_viewer_ids() == ['specviz-0']
 

--- a/jdaviz/tests/test_viewer_ids.py
+++ b/jdaviz/tests/test_viewer_ids.py
@@ -2,9 +2,9 @@ from jdaviz import Application
 
 
 # This applies to all viz but testing with Imviz should be enough.
-def test_viewer_calling_app(imviz_app):
-    viewer = imviz_app.default_viewer
-    assert viewer.session.jdaviz_app is imviz_app.app
+def test_viewer_calling_app(imviz_helper):
+    viewer = imviz_helper.default_viewer
+    assert viewer.session.jdaviz_app is imviz_helper.app
 
 
 def test_default_viewer_ids_default():
@@ -22,8 +22,8 @@ def test_default_viewer_ids_cubeviz(cubeviz_helper):
     assert x.get_viewer_ids() == ['cubeviz-0', 'cubeviz-1', 'cubeviz-2', 'cubeviz-3']
 
 
-def test_default_viewer_ids_imviz(imviz_app):
-    x = imviz_app.app
+def test_default_viewer_ids_imviz(imviz_helper):
+    x = imviz_helper.app
     assert x.get_viewer_reference_names() == ['imviz-0']
     assert x.get_viewer_ids() == ['imviz-0']
     assert x.get_viewer_ids(prefix='imviz') == ['imviz-0']

--- a/jdaviz/tests/test_viewer_ids.py
+++ b/jdaviz/tests/test_viewer_ids.py
@@ -46,7 +46,7 @@ def test_default_viewer_ids_specviz(specviz_helper):
     assert x.get_viewer_ids() == ['specviz-0']
 
 
-def test_default_viewer_ids_specviz2d(specviz2d_app):
-    x = specviz2d_app.app
+def test_default_viewer_ids_specviz2d(specviz2d_helper):
+    x = specviz2d_helper.app
     assert x.get_viewer_reference_names() == ['spectrum-2d-viewer', 'spectrum-viewer']
     assert x.get_viewer_ids() == ['specviz2d-0', 'specviz2d-1']

--- a/jdaviz/tests/test_viewer_ids.py
+++ b/jdaviz/tests/test_viewer_ids.py
@@ -15,8 +15,8 @@ def test_default_viewer_ids_default():
 
 # NOTE: Unable to parametrize fixture as input.
 
-def test_default_viewer_ids_cubeviz(cubeviz_app):
-    x = cubeviz_app.app
+def test_default_viewer_ids_cubeviz(cubeviz_helper):
+    x = cubeviz_helper.app
     assert x.get_viewer_reference_names() == ['flux-viewer', 'uncert-viewer', 'mask-viewer',
                                               'spectrum-viewer']
     assert x.get_viewer_ids() == ['cubeviz-0', 'cubeviz-1', 'cubeviz-2', 'cubeviz-3']

--- a/jdaviz/tests/test_viewer_ids.py
+++ b/jdaviz/tests/test_viewer_ids.py
@@ -33,8 +33,8 @@ def test_default_viewer_ids_imviz(imviz_app):
     assert x.get_viewer_by_id('imviz-0') is viewer
 
 
-def test_default_viewer_ids_mosviz(mosviz_app):
-    x = mosviz_app.app
+def test_default_viewer_ids_mosviz(mosviz_helper):
+    x = mosviz_helper.app
     assert x.get_viewer_reference_names() == ['image-viewer', 'spectrum-2d-viewer',
                                               'spectrum-viewer', 'table-viewer']
     assert x.get_viewer_ids() == ['mosviz-0', 'mosviz-1', 'mosviz-2', 'mosviz-3']


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

I ran into a small nomenclature discrepancy with our pytest fixtures that tripped me up after returning to jdaviz in who knows how long! Our test fixtures for the viz helpers are called `<spec | cube | mos | im>viz_app` which is slightly confusing to me at least, since they are the helpers and not the underlying apps (i.e. `<spec | cube | mos | im>viz.app`). This PR renames the test fixtures to `<spec | cube | mos | im>viz_helper` to be more explicit, and substitutes this change through all the unit tests. Since this has a lot of small changes, I figured I'd put this into its own PR

This naturally impacts all the devs in writing their unit tests, so we should advertise this change to everyone, and all should rebase before we stray too far.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
