### PR TITLE
"fix" long text in selects from pushing tray to right in lab

### DIFF
--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -43,7 +43,7 @@
               </gl-row>
             </golden-layout>
           </pane>
-          <pane size="25" min-size="25" v-if="state.drawer" style="background-color: #fafbfc;">
+          <pane size="25" min-size="25" v-if="state.drawer" class="jdaviz-plugin-tray" style="background-color: #fafbfc;">
             <v-card flat tile class="overflow-y-auto fill-height" style="overflow-x: hidden" color="#f8f8f8">
               <v-expansion-panels accordion multiple focusable flat tile v-model="state.tray_items_open">
                 <v-expansion-panel v-for="(tray, index) in state.tray_items" :key="index">
@@ -274,5 +274,14 @@ a:active {
 
 .no-hint .v-text-field__details {
   display: none !important;
+}
+
+/* fix selects causing toolbar tray pushing offscreen in lab 
+   the default flex display seems to be causing overflow on the long selection entries
+   within lab, so we'll switch to grid and manually adjust the bottom margin 
+*/
+.jdaviz-plugin-tray .v-select__selections {
+  display: grid !important;
+  margin-bottom: -32px !important;
 }
 </style>


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request prevents the plugin tray from pushing off-screen (occurred in lab only) when a select element includes long text.

Reproduce (in-lab):
* open specviz
* use unit conversion plugin to convert spectral axis (to anything)
* open plugin with data dropdown (model fitting, for example)
* select new data entry with long label
* before this would push the plugin tray out of view, now it does not

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1067 #1008

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
