### PR TITLE
EXP: See if we can just drop in Histogram viewer

### DIFF
--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -5,7 +5,7 @@ from bqplot.marks import Lines, Scatter
 from glue.core import BaseData
 from glue.core.subset import Subset
 from glue.config import data_translator
-from glue_jupyter.bqplot.profile import BqplotProfileView
+from glue_jupyter.bqplot.histogram import BqplotHistogramView
 from glue.core.exceptions import IncompatibleAttribute
 
 import astropy
@@ -19,14 +19,14 @@ from astropy import units as u
 from jdaviz.core.registries import viewer_registry
 from jdaviz.core.marks import SpectralLine
 from jdaviz.core.linelists import load_preset_linelist, get_available_linelists
-from jdaviz.core.freezable_state import FreezableProfileViewerState
+from jdaviz.core.freezable_state import FreezableHistogramViewerState
 from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
 
 __all__ = ['SpecvizProfileView']
 
 
 @viewer_registry("specviz-profile-viewer", label="Profile 1D (Specviz)")
-class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
+class SpecvizProfileView(BqplotHistogramView, JdavizViewerMixin):
     # Whether to inherit tools from glue-jupyter automatically. Set this to
     # False to have full control here over which tools are shown in case new
     # ones are added in glue-jupyter in future that we don't want here.
@@ -39,7 +39,7 @@ class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
 
     default_class = Spectrum1D
     spectral_lines = None
-    _state_cls = FreezableProfileViewerState
+    _state_cls = FreezableHistogramViewerState
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -1,5 +1,9 @@
+from glue.viewers.histogram.state import HistogramViewerState
 from glue.viewers.profile.state import ProfileViewerState
 from glue_jupyter.bqplot.image.state import BqplotImageViewerState
+
+__all__ = ['FreezableState', 'FreezableHistogramViewerState', 'FreezableProfileViewerState',
+           'FreezableBqplotImageViewerState']
 
 
 class FreezableState():
@@ -11,6 +15,10 @@ class FreezableState():
         elif getattr(self, k) is None:
             # still allow Nones to be updated to initial values
             super().__setattr__(k, v)
+
+
+class FreezableHistogramViewerState(HistogramViewerState, FreezableState):
+    pass
 
 
 class FreezableProfileViewerState(ProfileViewerState, FreezableState):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This is a feeble stab at #385 .

Spoiler: Does not work like I want it to. Histogram attempts to bin the flux, not plotting flux against binned wavelengths.

Also, long traceback and suggests we need to implement custom state over at `glue-jupyter` like https://github.com/glue-viz/glue-jupyter/blob/main/glue_jupyter/bqplot/image/state.py .

### Fantasy

![Screenshot 2022-02-14 214014](https://user-images.githubusercontent.com/2090236/153982291-64f59e12-4170-4ec3-9b6b-10bfa73d6aa2.png)

### Reality

![Screenshot 2022-02-14 212514](https://user-images.githubusercontent.com/2090236/153981294-9ad3638e-2d1f-45cc-ab66-ffc21e7874ec.png)

### Traceback

```
.../jdaviz/configs/specviz/helper.py in load_spectrum(self, data, data_label, format, show_in_viewer)
     39 
     40     def load_spectrum(self, data, data_label=None, format=None, show_in_viewer=True):
---> 41         super().load_data(data,
     42                           'specviz-spectrum1d-parser',
     43                           data_label=data_label,

.../jdaviz/core/helpers.py in load_data(self, data, parser_reference, **kwargs)
     67 
     68     def load_data(self, data, parser_reference=None, **kwargs):
---> 69         self.app.load_data(data, parser_reference=parser_reference, **kwargs)
     70 
     71     @property

.../jdaviz/app.py in load_data(self, file_obj, parser_reference, **kwargs)
    368                 # If the parser returns something other than known, assume it's
    369                 #  a message we want to make the user aware of.
--> 370                 msg = parser(self, file_obj, **kwargs)
    371 
    372                 if msg is not None:

.../jdaviz/configs/specviz/plugins/parsers.py in specviz_spectrum1d_parser(app, data, data_label, format, show_in_viewer)
     81             # Only auto-show the first spectrum in a list
     82             if i == 0 and show_in_viewer:
---> 83                 app.add_data_to_viewer("spectrum-viewer", data_label[i])

.../jdaviz/app.py in add_data_to_viewer(self, viewer_reference, data_path, clear_other_data, ext)
    808         if data_id is not None:
    809             data_ids.append(data_id)
--> 810             self._update_selected_data_items(viewer_item['id'], data_ids)
    811         else:
    812             raise ValueError(

.../jdaviz/app.py in _update_selected_data_items(self, viewer_id, selected_items)
   1142                                               viewer_id=viewer_id,
   1143                                               sender=self)
-> 1144             self.hub.broadcast(add_data_message)
   1145 
   1146         # Remove any deselected data objects from viewer

.../glue/core/hub.py in broadcast(self, message)
    213             logging.getLogger(__name__).info("Broadcasting %s", message)
    214             for subscriber, handler in self._find_handlers(message):
--> 215                 handler(message)
    216 
    217     def __getstate__(self):

.../jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py in _on_viewer_data_changed(self, msg)
     87                          if data is not None]
     88 
---> 89         if self.app.get_viewer("spectrum-viewer").state.reference_data is not None:
     90 
     91             data_label = self.app.get_viewer("spectrum-viewer").state.reference_data.label

AttributeError: 'FreezableHistogramViewerState' object has no attribute 'reference_data'
```

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
