### PR TITLE
Remove logging usage from Jdaviz.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,9 @@ API Changes
 - Viewers now can access the Jdaviz application using ``viewer.jdaviz_app`` and
   the helper via ``viewer.jdaviz_helper``. [#1051, #1054]
 
+- Jdaviz no longer uses Python logging to issue warning. Warning is now issued by
+  Python's ``warnings`` module. [#1085]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1,8 +1,8 @@
-import logging
 import os
 import pathlib
 import re
 import uuid
+import warnings
 from inspect import isclass
 
 import ipyvue
@@ -1128,8 +1128,8 @@ class Application(VuetifyTemplate, HubListener):
                           if x['id'] == data_id), None)
 
             if label is None:
-                logging.warning(f"No data item with id '{data_id}' found in "
-                                f"viewer '{viewer_id}'.")
+                warnings.warn(f"No data item with id '{data_id}' found in "
+                              f"viewer '{viewer_id}'.")
                 continue
 
             active_data_labels.append(label)

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -1,8 +1,7 @@
 # Command-line interface for jdaviz
 
-import logging
-import pathlib
 import os
+import pathlib
 import sys
 import tempfile
 
@@ -66,6 +65,8 @@ def main(filename, layout='default', browser='default', theme='light', verbosity
     hotreload: bool
         Whether to enable hot-reloading of the UI (for development)
     """
+    import logging  # Local import to avoid possibly messing with JWST pipeline logger.
+
     # Tornado Webserver py3.8 compatibility hotfix for windows
     if sys.platform == 'win32':
         import asyncio

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -1,15 +1,14 @@
-import logging
-
-import numpy as np
+import warnings
+from copy import deepcopy
 from pathlib import Path
 from time import time
 
-import astropy.units as u
-from astropy.table import QTable
+import numpy as np
+from astropy import units as u
 from astropy.coordinates import SkyCoord
-from glue.core.exceptions import IncompatibleAttribute
+from astropy.table import QTable
 from echo import delay_callback
-from copy import deepcopy
+from glue.core.exceptions import IncompatibleAttribute
 
 from jdaviz.core.helpers import ConfigHelper
 from jdaviz.core.events import SnackbarMessage, TableClickMessage, RedshiftMessage, RowLockMessage
@@ -357,7 +356,6 @@ class Mosviz(ConfigHelper, LineListMixin):
             if sp1_val is not None and sp1_val != sp2_val:
                 # then there was a conflict
                 msg = f"Warning: value for {attr} in row {row} in disagreement between Spectrum1D and Spectrum2D" # noqa
-                logging.warning(msg)
                 msg = SnackbarMessage(msg, color='warning', sender=self)
                 self.app.hub.broadcast(msg)
 
@@ -458,7 +456,6 @@ class Mosviz(ConfigHelper, LineListMixin):
             msg = "Warning: Please set valid values for the load_data() method"
 
         if msg:
-            logging.warning(msg)
             msg = SnackbarMessage(msg, color='warning', sender=self)
             self.app.hub.broadcast(msg)
 
@@ -927,10 +924,10 @@ class Mosviz(ConfigHelper, LineListMixin):
         else:
             redshift = self.get_column("Redshift")[row]
             if apply_slider_redshift == "Warn":
-                logging.warning("Warning: Applying the value from the redshift "
-                                "slider to the output spectra. To avoid seeing this "
-                                "warning, explicitly set the apply_slider_redshift "
-                                "argument to True or False.")
+                warnings.warn("Warning: Applying the value from the redshift "
+                              "slider to the output spectra. To avoid seeing this "
+                              "warning, explicitly set the apply_slider_redshift "
+                              "argument to True or False.")
 
             return _apply_redshift_to_spectra(spectra, redshift)
 

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterable
 import csv
 import glob
-import logging
 import os
 from pathlib import Path
 import warnings
@@ -173,10 +172,9 @@ def mos_nirspec_directory_parser(app, data_obj, data_labels=None):
             mos_meta_parser(app, images, ids=images)
             mos_image_parser(app, images)
         else:
-            msg = "The number of images in this directory does not match the" \
-                  " number of spectra 1d and 2d files, please make the " \
-                  "amounts equal or load images separately."
-            logging.warning(msg)
+            msg = ("The number of images in this directory does not match the"
+                   " number of spectra 1d and 2d files, please make the "
+                   "amounts equal or load images separately.")
             msg = SnackbarMessage(msg, color='warning', sender=app)
             app.hub.broadcast(msg)
 
@@ -449,7 +447,7 @@ def mos_meta_parser(app, data_obj, ids=None, spectra=False, sp1d=False):
     else:
         # TODO: Come up with more robust metadata parsing, perhaps from
         # the spectra files.
-        logging.warning("Could not parse metadata from input images.")
+        warnings.warn("Could not parse metadata from input images.")
         return
 
     with app.data_collection.delay_link_manager_update():

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -1,6 +1,6 @@
-import logging
+import warnings
 
-import astropy.units as u
+from astropy import units as u
 from specutils import SpectralRegion, Spectrum1D
 
 from jdaviz.core.helpers import ConfigHelper
@@ -60,10 +60,10 @@ class Specviz(ConfigHelper, LineListMixin):
                 output_spectra[key] = _apply_redshift_to_spectra(spectra[key], self._redshift)
 
             if apply_slider_redshift == "Warn":
-                logging.warning("Warning: Applying the value from the redshift "
-                                "slider to the output spectra. To avoid seeing this "
-                                "warning, explicitly set the apply_slider_redshift "
-                                "argument to True or False.")
+                warnings.warn("Applying the value from the redshift "
+                              "slider to the output spectra. To avoid seeing this "
+                              "warning, explicitly set the apply_slider_redshift "
+                              "argument to True or False.")
 
             if data_label is not None:
                 output_spectra = output_spectra[data_label]
@@ -203,7 +203,7 @@ class Specviz(ConfigHelper, LineListMixin):
 
         """
         if axis not in [0, 1]:
-            logging.warning("Please use either 0 or 1 for the axis value")
+            warnings.warn("Please use either 0 or 1 for the axis value")
             return
 
         # Examples of values for fmt are '0.1e' or '0.2f'

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -51,7 +51,8 @@ class TestSpecvizHelper:
             self.spec_app.load_spectrum(collection)
 
     def test_get_spectra(self):
-        spectra = self.spec_app.get_spectra()
+        with pytest.warns(UserWarning, match='Applying the value from the redshift slider'):
+            spectra = self.spec_app.get_spectra()
 
         assert_quantity_allclose(spectra[self.label].flux,
                                  self.spec.flux, atol=1e-5*u.Unit(self.spec.flux.unit))
@@ -75,7 +76,8 @@ class TestSpecvizHelper:
                                  self.spec.flux, atol=1e-5*u.Unit(self.spec.flux.unit))
 
     def test_get_spectra_label_redshift_warn(self):
-        spectra = self.spec_app.get_spectra(data_label=self.label, apply_slider_redshift="Warn")
+        with pytest.warns(UserWarning, match='Applying the value from the redshift slider'):
+            spectra = self.spec_app.get_spectra(data_label=self.label, apply_slider_redshift="Warn")
 
         assert_quantity_allclose(spectra.flux,
                                  self.spec.flux, atol=1e-5*u.Unit(self.spec.flux.unit))
@@ -142,7 +144,8 @@ class TestSpecvizHelper:
 
 
 def test_get_spectra_no_spectra(specviz_helper, spectrum1d):
-    spectra = specviz_helper.get_spectra()
+    with pytest.warns(UserWarning, match='Applying the value from the redshift slider'):
+        spectra = specviz_helper.get_spectra()
 
     assert spectra == {}
 


### PR DESCRIPTION
Remove logging usage from Jdaviz. Except for Cubeviz because that is being refactored anyway at #1040 . The change log here assumes both this PR and #1040 would go into the same release.

This might not fully address #1084 (or at all) but might as well, since we are not even using a proper logger instance.

[🐱](https://jira.stsci.edu/browse/JP-2280)

### Goes with

* #1040 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
