### PR TITLE
fix redshift RV input float parsing

### DIFF
--- a/jdaviz/configs/default/plugins/line_lists/line_lists.vue
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.vue
@@ -55,6 +55,7 @@
       <v-col>
         <v-text-field
           v-model="rs_rv"
+          @input='setRVFloat'
           @blur="unpause_tables"
           :step="rs_redshift_step"
           class="mt-0 pt-0"
@@ -273,6 +274,9 @@
       },
       this.setRedshiftFloat = (v) => {
         this.rs_redshift = parseFloat(v)
+      }
+      this.setRVFloat = (v) => {
+        this.rs_rv = parseFloat(v)
       }
     }
   }


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes a UI bug when entering RV manually.  This was inadvertently introduced in #1036 (https://github.com/spacetelescope/jdaviz/pull/1036/commits/953d9d16b192778578bd8144ad1b2df077bbd700).  The change to use `FloatHandleEmpty` instead of `Any` requires string->float casting to be done within JS.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
