### PR TITLE
BUG: Fix displayed decimals for X/Y centers in Imviz Simple Aperture Photometry plugin

### DIFF
--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -282,7 +282,7 @@ class SimpleAperturePhotometry(TemplateMixin):
                 elif key == 'sky_center' and x is not None:
                     tmp.append({'function': 'RA center', 'result': f'{x.ra.deg:.4f} deg'})
                     tmp.append({'function': 'Dec center', 'result': f'{x.dec.deg:.4f} deg'})
-                elif key == 'npix':
+                elif key in ('xcenter', 'ycenter', 'npix'):
                     x = f'{x:.1f}'
                     tmp.append({'function': key, 'result': x})
                 elif key == 'aperture_sum_counts' and x is not None:


### PR DESCRIPTION
Fix displayed decimals for X/Y centers in Imviz Simple Aperture Photometry plugin. Pretty sure this is a regression. It used to limit the number of decimals. Not sure what happened, maybe a careless force push by me at some point. 🤷 

### Before this fix

![Screenshot 2022-02-21 123937](https://user-images.githubusercontent.com/2090236/155004862-a21b66d1-27c4-40f9-877b-eeb44e38580b.png)

### After this fix

![Screenshot 2022-02-21 124147](https://user-images.githubusercontent.com/2090236/155004873-0203fd2f-985e-4dfc-b623-700cba47ac7c.png)

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
