### PR TITLE
Imviz: Aperture photometry plugin with viewer-agnostic data/subset dropdown menus

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,9 @@ Imviz
 
 - Imviz no longer loads incompatible data from ASDF-in-FITS file. [#1056]
 
+- Simple Aperture Photometry plugin now shows the entire data collection
+  for the application, not just selected data/subset for the default viewer. [#1096]
+
 Mosviz
 ^^^^^^
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

As pointed out by @orifox , Simple Aperture Photometry plugin should not depend on what is shown in the default viewer because it should work for data shown on any viewer. To avoid overcomplicating the logic, I am simply displaying data and subsets across the whole app, not depending on the viewer anymore. So now the plugin should even work if no data is displayed as long as it is loaded, but why would anyone do that... who knows?

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
