### PR TITLE
BUG: Fix writing out moment map to FITS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,8 @@ Cubeviz
 
 - Spectral region retrieval now properly handles the case of multiple subregions. [#1046]
 
+- Moment Map plugin no longer crashes when writing out to FITS file. [#1099]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from astropy.nddata import CCDData
 
@@ -5,26 +7,35 @@ from jdaviz.configs.cubeviz.plugins.moment_maps.moment_maps import MomentMap
 
 
 @pytest.mark.filterwarnings('ignore:No observer defined on WCS')
-def test_moment_calculation(cubeviz_helper, spectrum1d_cube):
+def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     app = cubeviz_helper.app
     dc = app.data_collection
-    app.add_data(spectrum1d_cube, 'test')
+    app.add_data(spectrum1d_cube, 'test[FLUX]')
 
     mm = MomentMap(app=app)
     mm._subset_selected = 'None'
     mm._on_data_updated(None)
 
-    mm._on_data_selected({'new': 'test'})
+    mm._on_data_selected({'new': 'test[FLUX]'})
     mm._on_subset_selected({'new': None})
 
     mm.n_moment = 0  # Collapsed sum, will get back 2D spatial image
     mm.vue_calculate_moment()
 
     assert mm.moment_available
-    assert dc[1].label == 'Moment 0: test'
+    assert dc[1].label == 'Moment 0: test[FLUX]'
 
     result = dc[1].get_object(cls=CCDData)
     assert result.shape == (4, 2)
 
     # FIXME: Need spatial WCS, see https://github.com/spacetelescope/jdaviz/issues/1025
     assert dc[1].coords is None
+
+    assert mm.filename == 'moment0_test_FLUX.fits'  # Auto-populated on calculate.
+    mm.filename = str(tmpdir.join(mm.filename))  # But we want it in tmpdir for testing.
+    mm.vue_save_as_fits()
+    assert os.path.isfile(mm.filename)
+
+    # Does not allow overwrite.
+    with pytest.raises(OSError, match='already exists'):
+        mm.vue_save_as_fits()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to fix saving moment map out to FITS. Might be an oversight from spectral-cube removal campaign.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1094

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
