### PR TITLE
Astrowidgets API: Allow unfilled circles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ Cubeviz
 Imviz
 ^^^^^
 
+- ``viewer.marker`` dictionary now accepts ``fill`` as an option, settable to
+  ``True`` (default) or ``False``; the latter draws unfilled circle. [#1101]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/core/astrowidgets_api.py
+++ b/jdaviz/core/astrowidgets_api.py
@@ -356,7 +356,7 @@ class AstrowidgetsImageViewerMixin:
         # Validation: Ideally Glue should do this but we have to due to
         # https://github.com/glue-viz/glue/issues/2203
         given = set(val.keys())
-        allowed = set(('color', 'alpha', 'markersize'))
+        allowed = set(('color', 'alpha', 'markersize', 'fill'))
         if not given.issubset(allowed):
             raise KeyError(f'Invalid attribute(s): {given - allowed}')
         if 'color' in val:
@@ -370,6 +370,10 @@ class AstrowidgetsImageViewerMixin:
             size = val['markersize']
             if not isinstance(size, (int, float)):
                 raise ValueError(f'Invalid marker size: {size}')
+        if 'fill' in val:
+            fill = val['fill']
+            if not isinstance(fill, bool):
+                raise ValueError(f'Invalid fill: {fill}')
 
         # Only set this once we have successfully validated a marker.
         # Those not set here use Glue defaults.
@@ -419,6 +423,8 @@ class AstrowidgetsImageViewerMixin:
             Invalid marker name.
 
         """
+        from glue_jupyter.bqplot.scatter.layer_artist import BqplotScatterLayerState
+
         if marker_name is None:
             marker_name = self._default_mark_tag_name
 
@@ -454,8 +460,14 @@ class AstrowidgetsImageViewerMixin:
         else:
             # Only can set alpha and color using self.add_data(), so brute force here instead.
             # https://github.com/glue-viz/glue/issues/2201
-            for key, val in self.marker.items():
-                setattr(jglue.data_collection[jglue.data_collection.labels.index(marker_name)].style, key, val)  # noqa
+            for lyr in self.state.layers:
+                if isinstance(lyr, BqplotScatterLayerState) and lyr.layer.label == marker_name:
+                    for key, val in self.marker.items():
+                        if key == 'markersize':  # Named a little differently in state.layers
+                            k = 'size'
+                        else:
+                            k = key
+                        setattr(lyr, k, val)
 
             self._marktags.add(marker_name)
 

--- a/jdaviz/core/astrowidgets_api.py
+++ b/jdaviz/core/astrowidgets_api.py
@@ -465,7 +465,6 @@ class AstrowidgetsImageViewerMixin:
                     for key, val in self.marker.items():
                         setattr(lyr, {'markersize': 'size'}.get(key, key), val)
 
-
             self._marktags.add(marker_name)
 
     def remove_markers(self, marker_name=None):

--- a/jdaviz/core/astrowidgets_api.py
+++ b/jdaviz/core/astrowidgets_api.py
@@ -463,11 +463,8 @@ class AstrowidgetsImageViewerMixin:
             for lyr in self.state.layers:
                 if isinstance(lyr, BqplotScatterLayerState) and lyr.layer.label == marker_name:
                     for key, val in self.marker.items():
-                        if key == 'markersize':  # Named a little differently in state.layers
-                            k = 'size'
-                        else:
-                            k = key
-                        setattr(lyr, k, val)
+                        setattr(lyr, {'markersize': 'size'}.get(key, key), val)
+
 
             self._marktags.add(marker_name)
 

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -552,7 +552,7 @@
    "id": "f1c1aa0d-46b7-42f6-b6d7-395305c15f91",
    "metadata": {},
    "source": [
-    "You could customize marker color, alpha, and size with values that Glue supports."
+    "You could customize marker color, alpha, size, and fill with values that Glue supports."
    ]
   },
   {
@@ -562,7 +562,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer.marker = {'color': 'green', 'alpha': 0.8, 'markersize': 10}"
+    "viewer.marker = {'color': 'green', 'alpha': 0.8, 'markersize': 10, 'fill': False}"
    ]
   },
   {


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to allow unfilled circles in marker API for astrowidgets.

![Screenshot 2022-03-04 113544](https://user-images.githubusercontent.com/2090236/156802719-b1c0c475-f354-4d6a-a527-2af7c6f0a5a7.png)

Needs:

* glue-viz/glue-jupyter#292

Blocked by:

* #1117

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #713 

### TODO

- [x] Wait for `glue-jupyter` release with the patch above.
- [x] Rerun CI on this PR with that new release.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
