### PR TITLE
box zoom: ignore click without drag events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,7 @@ Bug Fixes
 - Model plugin now respects fixed parameters when applying model to cube, and retains
   parameter units in that case. [#1026]
 - Model plugin polynomial order now avoids traceback when clearing input. [#1041]
+- Box zoom silently ignores click without drag events. [#1105]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/core/tools.py
+++ b/jdaviz/core/tools.py
@@ -72,6 +72,11 @@ class BoxZoom(_BaseSelectZoom):
                              color=INTERACT_COLOR)
 
     def on_update_zoom(self):
+        if self.interact.selected_x is None or self.interact.selected_y is None:
+            # a valid box was not drawn, perhaps just a click with no drag!
+            # let's ignore and reset the tool
+            return
+
         self.viewer.state.x_min, self.viewer.state.x_max = self.interact.selected_x
         self.viewer.state.y_min, self.viewer.state.y_max = self.interact.selected_y
 
@@ -88,4 +93,9 @@ class XRangeZoom(_BaseSelectZoom):
                                      color=INTERACT_COLOR)
 
     def on_update_zoom(self):
+        if self.interact.selected is None:
+            # a valid region was not drawn, perhaps just a click with no drag!
+            # let's ignore and reset the tool
+            return
+
         self.viewer.state.x_min, self.viewer.state.x_max = self.interact.selected


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request silently ignores clicks (without drags) when using box or xrange zoom.  Previously this would result in a TypeError traceback.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
