### PR TITLE
POC: disable plugins with message

### DIFF
--- a/docs/dev/ui_style_guide.rst
+++ b/docs/dev/ui_style_guide.rst
@@ -8,8 +8,9 @@ Tray Plugins
 In order to be consistent with layout, styling, and spacing, UI development on plugins should
 try to adhere to the following principles:
 
-* Any tray plugin should utilize ``<j-tray-plugin>`` as the outer-container (which provides consistent 
-  styling rules).  Any changes to style across all plugins should then take place in the 
+* Any tray plugin should utilize ``<j-tray-plugin :disabled_msg='disabled_msg'>`` as the 
+  outer-container (which provides consistent styling rules).  Any changes to style 
+  across all plugins should then take place in the 
   ``j-tray-plugin`` stylesheet (``jdaviz/components/tray_plugin.vue``).
 * Each item should be wrapped in a ``v-row``, but avoid any unnecessary additional wrapping-components
   (``v-card-*``, ``v-container``, etc).

--- a/jdaviz/components/tray_plugin.vue
+++ b/jdaviz/components/tray_plugin.vue
@@ -1,15 +1,24 @@
 <template>
   <v-container>
-    <slot>
+    <v-row v-if="isDisabled()">
+      <span> {{ getDisabledMsg() }}</span>
+    </v-row>
+    <slot v-else>
     </slot>
   </v-container>
 </template>
 
 <script>
 module.exports = {
-  props: {docslink: String, 
-          docstext: String
-        },
+  props: ['disabled_msg'],
+  methods: {
+    isDisabled() {
+      return this.getDisabledMsg().length > 0
+    },
+    getDisabledMsg() {
+      return this.disabled_msg || ''
+    },
+  }
 };
 </script>
 

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -14,7 +14,7 @@ from jdaviz.core.events import (AddDataMessage,
                                 SnackbarMessage,
                                 RedshiftMessage)
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import TemplateMixin
+from jdaviz.core.template_mixin import PluginTemplateMixin
 from jdaviz.core.linelists import load_preset_linelist
 from jdaviz.core.marks import SpectralLine
 from jdaviz.core.validunits import create_spectral_equivalencies_list
@@ -23,7 +23,7 @@ __all__ = ['LineListTool']
 
 
 @tray_registry('g-line-list', label="Line Lists")
-class LineListTool(TemplateMixin):
+class LineListTool(PluginTemplateMixin):
     dialog = Bool(False).tag(sync=True)
     template_file = __file__, "line_lists.vue"
 

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.vue
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.vue
@@ -1,5 +1,5 @@
 <template>
-  <j-tray-plugin>
+  <j-tray-plugin :disabled_msg="disabled_msg">
     <v-row>
       <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#line-lists'">Plot lines from preset or custom line lists.</j-docs-link>
     </v-row>

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -4,7 +4,7 @@ from traitlets import Unicode
 
 from jdaviz import __version__
 
-__all__ = ['TemplateMixin']
+__all__ = ['TemplateMixin', 'PluginTemplateMixin']
 
 
 class TemplateMixin(VuetifyTemplate, HubListener):
@@ -53,3 +53,7 @@ class TemplateMixin(VuetifyTemplate, HubListener):
     @property
     def data_collection(self):
         return self._app.session.data_collection
+
+
+class PluginTemplateMixin(TemplateMixin):
+    disabled_msg = Unicode("").tag(sync=True)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements infrastructure so we can disable plugins (with a message in their place) depending on conditions (spectral data not including units, for example).

how to use:
* plugin class should inherit from PluginTemplateMixin (instead of TemplateMixin) - done for line list plugin in this PR
* plugin template must pass `:disabled_msg="disabled_msg"` on to the `j-tray-plugin` component - done for line list plugin in this PR
* listen to any necessary events/messages and set `self.disabled_msg` to a non-empty string.  The plugin contents will then be replaced by the string itself.

how to test without implementing:
* load specviz
* set `specviz.app.get_tray_item_from_name('g-line-list').disabled_msg = 'plugin disabled message here'`

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
