### PR TITLE
Move viewer/layer options to plugin tray

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -117,6 +117,8 @@ Other Changes and Additions
 
 - Line list plugin now includes a dropdown for valid units for custom lines. [#1073]
 
+- Viewer and layer options are moved from a dropdown window to the sidebar. [#1108]
+
 
 2.2 (2021-12-23)
 ================

--- a/jdaviz/components/tooltip.vue
+++ b/jdaviz/components/tooltip.vue
@@ -41,7 +41,7 @@ const tooltips = {
   'viewer-toolbar-data': 'Select dataset(s) to display',
   'viewer-toolbar-figure': 'Tools: pan, zoom, select region, save',
   'viewer-toolbar-figure-save': 'Save figure',
-  'viewer-toolbar-menu': 'Adjust display: contrast, bias, stretch',
+  'viewer-toolbar-menu': 'Open viewer display options in sidebar',
   'viewer-toolbar-more': 'More options...',
 
   'table-prev': 'Select previous row in table',

--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -15,6 +15,7 @@ toolbar:
   - g-data-tools
   - g-subset-tools
 tray:
+  - g-plot-options
   - cubeviz-slice
   - g-gaussian-smooth
   - g-collapse

--- a/jdaviz/configs/default/plugins/__init__.py
+++ b/jdaviz/configs/default/plugins/__init__.py
@@ -7,3 +7,4 @@ from .model_fitting.model_fitting import *  # noqa
 from .collapse.collapse import *  # noqa
 from .line_lists.line_lists import *  # noqa
 from .metadata_viewer.metadata_viewer import *  # noqa
+from .plot_options.plot_options import * # noqa

--- a/jdaviz/configs/default/plugins/plot_options/__init__.py
+++ b/jdaviz/configs/default/plugins/plot_options/__init__.py
@@ -1,0 +1,1 @@
+from .plot_options import *  # noqa

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -1,0 +1,84 @@
+from traitlets import Any, List, Unicode, observe
+from ipywidgets.widgets import widget_serialization
+
+from glue.core.message import (SubsetCreateMessage, SubsetUpdateMessage, SubsetDeleteMessage)
+
+from jdaviz.core.events import (ViewerAddedMessage, ViewerRemovedMessage,
+                                AddDataMessage, RemoveDataMessage,
+                                PlotOptionsSelectViewerMessage)
+from jdaviz.core.registries import tray_registry
+from jdaviz.core.template_mixin import TemplateMixin
+
+__all__ = ['PlotOptions']
+
+
+def make_layer_panel(viewer, layer_artist):
+    # modified from glue-jupyter layer_options.py
+    widget_cls = viewer._layer_style_widget_cls
+    if isinstance(widget_cls, dict):
+        return widget_cls[type(layer_artist)](layer_artist.state)
+    else:
+        return widget_cls(layer_artist.state)
+
+
+@tray_registry('g-plot-options', label="Plot Options")
+class PlotOptions(TemplateMixin):
+    template_file = __file__, "plot_options.vue"
+    viewer_items = List([]).tag(sync=True)
+    selected_viewer = Unicode("").tag(sync=True)
+    layer_items = List([]).tag(sync=True)
+    selected_layer = Unicode("").tag(sync=True)
+
+    viewer_widget = Any().tag(sync=True, **widget_serialization)
+    layer_widget = Any().tag(sync=True, **widget_serialization)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.hub.subscribe(self, ViewerAddedMessage,
+                           handler=lambda _: self._on_viewers_changed())
+        self.hub.subscribe(self, ViewerRemovedMessage,
+                           handler=lambda _: self._on_viewers_changed())
+        self.hub.subscribe(self, AddDataMessage,
+                           handler=lambda _: self._selected_viewer_changed())
+        self.hub.subscribe(self, RemoveDataMessage,
+                           handler=lambda _: self._selected_viewer_changed())
+        self.hub.subscribe(self, SubsetCreateMessage,
+                           handler=lambda _: self._selected_viewer_changed())
+        self.hub.subscribe(self, SubsetUpdateMessage,
+                           handler=lambda _: self._selected_viewer_changed())
+        self.hub.subscribe(self, SubsetDeleteMessage,
+                           handler=lambda _: self._selected_viewer_changed())
+        self.hub.subscribe(self, PlotOptionsSelectViewerMessage,
+                           handler=self._on_select_viewer_message)
+
+        # initialize viewer_items from original viewers
+        self._on_viewers_changed()
+
+    def _on_viewers_changed(self):
+        self.viewer_items = self.app.get_viewer_reference_names()
+        if self.selected_viewer not in self.viewer_items:
+            # default to first entry, will trigger _on_viewer_select to set layer defaults
+            self.selected_viewer = self.viewer_items[0] if len(self.viewer_items) else ""
+
+    def _on_select_viewer_message(self, msg):
+        # message from elsewhere requesting to change the selected viewer
+        self.selected_viewer = msg.viewer
+
+    @observe("selected_viewer")
+    def _selected_viewer_changed(self, event={}):
+        viewer = self.app.get_viewer(event.get('new', self.selected_viewer))
+        self.viewer_widget = viewer.viewer_options
+        self.layer_items = [layer.layer.label for layer in viewer.layers]
+        if self.selected_layer not in self.layer_items:
+            self.selected_layer = self.layer_items[0] if len(self.layer_items) else ""
+        else:
+            # we still need to force a refresh of the layer widget
+            self._selected_layer_changed()
+
+    @observe("selected_layer")
+    def _selected_layer_changed(self, event={}):
+        viewer = self.app.get_viewer(self.selected_viewer)
+        layer_label = event.get('new', self.selected_layer)
+        layer_artist = [layer for layer in viewer.layers if layer.layer.label == layer_label][0]
+        self.layer_widget = make_layer_panel(viewer, layer_artist)

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -1,10 +1,7 @@
 from traitlets import Any, List, Unicode, observe
 from ipywidgets.widgets import widget_serialization
 
-from glue.core.message import (SubsetCreateMessage, SubsetUpdateMessage, SubsetDeleteMessage)
-
 from jdaviz.core.events import (ViewerAddedMessage, ViewerRemovedMessage,
-                                AddDataMessage, RemoveDataMessage,
                                 PlotOptionsSelectViewerMessage)
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import TemplateMixin
@@ -12,22 +9,11 @@ from jdaviz.core.template_mixin import TemplateMixin
 __all__ = ['PlotOptions']
 
 
-def make_layer_panel(viewer, layer_artist):
-    # modified from glue-jupyter layer_options.py
-    widget_cls = viewer._layer_style_widget_cls
-    if isinstance(widget_cls, dict):
-        return widget_cls[type(layer_artist)](layer_artist.state)
-    else:
-        return widget_cls(layer_artist.state)
-
-
 @tray_registry('g-plot-options', label="Plot Options")
 class PlotOptions(TemplateMixin):
     template_file = __file__, "plot_options.vue"
     viewer_items = List([]).tag(sync=True)
     selected_viewer = Unicode("").tag(sync=True)
-    layer_items = List([]).tag(sync=True)
-    selected_layer = Unicode("").tag(sync=True)
 
     viewer_widget = Any().tag(sync=True, **widget_serialization)
     layer_widget = Any().tag(sync=True, **widget_serialization)
@@ -39,16 +25,6 @@ class PlotOptions(TemplateMixin):
                            handler=lambda _: self._on_viewers_changed())
         self.hub.subscribe(self, ViewerRemovedMessage,
                            handler=lambda _: self._on_viewers_changed())
-        self.hub.subscribe(self, AddDataMessage,
-                           handler=lambda _: self._selected_viewer_changed())
-        self.hub.subscribe(self, RemoveDataMessage,
-                           handler=lambda _: self._selected_viewer_changed())
-        self.hub.subscribe(self, SubsetCreateMessage,
-                           handler=lambda _: self._selected_viewer_changed())
-        self.hub.subscribe(self, SubsetUpdateMessage,
-                           handler=lambda _: self._selected_viewer_changed())
-        self.hub.subscribe(self, SubsetDeleteMessage,
-                           handler=lambda _: self._selected_viewer_changed())
         self.hub.subscribe(self, PlotOptionsSelectViewerMessage,
                            handler=self._on_select_viewer_message)
 
@@ -69,16 +45,4 @@ class PlotOptions(TemplateMixin):
     def _selected_viewer_changed(self, event={}):
         viewer = self.app.get_viewer(event.get('new', self.selected_viewer))
         self.viewer_widget = viewer.viewer_options
-        self.layer_items = [layer.layer.label for layer in viewer.layers]
-        if self.selected_layer not in self.layer_items:
-            self.selected_layer = self.layer_items[0] if len(self.layer_items) else ""
-        else:
-            # we still need to force a refresh of the layer widget
-            self._selected_layer_changed()
-
-    @observe("selected_layer")
-    def _selected_layer_changed(self, event={}):
-        viewer = self.app.get_viewer(self.selected_viewer)
-        layer_label = event.get('new', self.selected_layer)
-        layer_artist = [layer for layer in viewer.layers if layer.layer.label == layer_label][0]
-        self.layer_widget = make_layer_panel(viewer, layer_artist)
+        self.layer_widget = viewer.layer_options

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -1,0 +1,40 @@
+<template>
+  <j-tray-plugin>
+    <v-row>
+      <j-docs-link>Viewer and data/layer options.</j-docs-link>
+    </v-row>
+
+    <v-row v-if="viewer_items.length > 1">
+      <v-select
+        :items="viewer_items"
+        v-model="selected_viewer"
+        label="Viewer"
+        hint="Select the viewer to set options."
+        persistent-hint
+      ></v-select>
+    </v-row>
+
+    <div v-if="selected_viewer">
+      <j-plugin-section-header>Viewer Options</j-plugin-section-header>
+      <v-row class="row-no-outside-padding">
+        <jupyter-widget v-if="selected_viewer" :widget="viewer_widget"></jupyter-widget>
+      </v-row>
+      
+      <j-plugin-section-header>Layer Options</j-plugin-section-header>
+      <v-row>
+        <v-select
+          :items="layer_items"
+          v-model="selected_layer"
+          label="Layer"
+          hint="Select the data or subset to set options."
+          persistent-hint
+        ></v-select>
+      </v-row>
+      
+      <v-row class="row-no-outside-padding">
+        <jupyter-widget v-if="selected_layer" :widget="layer_widget"></jupyter-widget>
+      </v-row>
+    </div>
+
+  </j-tray-plugin>
+</template>

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -20,19 +20,9 @@
         <jupyter-widget v-if="selected_viewer" :widget="viewer_widget"></jupyter-widget>
       </v-row>
       
-      <j-plugin-section-header>Layer Options</j-plugin-section-header>
-      <v-row>
-        <v-select
-          :items="layer_items"
-          v-model="selected_layer"
-          label="Layer"
-          hint="Select the data or subset to set options."
-          persistent-hint
-        ></v-select>
-      </v-row>
-      
+      <j-plugin-section-header>Layer Options</j-plugin-section-header>      
       <v-row class="row-no-outside-padding">
-        <jupyter-widget v-if="selected_layer" :widget="layer_widget"></jupyter-widget>
+        <jupyter-widget v-if="selected_viewer" :widget="layer_widget"></jupyter-widget>
       </v-row>
     </div>
 

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -1,0 +1,14 @@
+
+def test_plugin_open(cubeviz_helper):
+    assert cubeviz_helper.app.state.drawer is False
+
+    plugin_names = [ti['name'] for ti in cubeviz_helper.app.state.tray_items]
+    plugin_index = plugin_names.index('g-plot-options')
+
+    # test opening from API
+    sv = cubeviz_helper.app.get_viewer('spectrum-viewer')
+    plugin = cubeviz_helper.app.get_tray_item_from_name('g-plot-options')
+    sv.open_plot_options()
+    assert cubeviz_helper.app.state.drawer is True
+    assert cubeviz_helper.app.state.tray_items_open == [plugin_index]
+    assert plugin.selected_viewer == 'spectrum-viewer'

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -2,6 +2,7 @@ from glue_jupyter.bqplot.profile import BqplotProfileView
 from glue_jupyter.bqplot.image import BqplotImageView
 from glue_jupyter.table import TableViewer
 
+from jdaviz.core.events import PlotOptionsSelectViewerMessage
 from jdaviz.core.registries import viewer_registry
 
 __all__ = ['JdavizViewerMixin']
@@ -21,3 +22,21 @@ class JdavizViewerMixin:
     def jdaviz_helper(self):
         """The Jdaviz configuration helper tied to the viewer."""
         return self.jdaviz_app._jdaviz_helper
+
+    @property
+    def reference_name(self):
+        # TODO: this should probably be stored instead of this hideously hacky loop
+        for reference in self.jdaviz_app.get_viewer_reference_names():
+            if self.jdaviz_app.get_viewer(reference) == self:
+                return reference
+        return None
+
+    def open_plot_options(self):
+        """Open plot options for this viewer in the app sidebar"""
+        self.jdaviz_app.state.drawer = True
+        tray_item_labels = [tray_item['label'] for tray_item in self.jdaviz_app.state.tray_items]
+        index = tray_item_labels.index('Plot Options')
+        if index not in self.jdaviz_app.state.tray_items_open:
+            self.jdaviz_app.state.tray_items_open = self.jdaviz_app.state.tray_items_open + [index]
+        msg = PlotOptionsSelectViewerMessage(sender=self, viewer=self.reference_name)
+        self.session.hub.broadcast(msg)

--- a/jdaviz/configs/imviz/imviz.yaml
+++ b/jdaviz/configs/imviz/imviz.yaml
@@ -19,6 +19,7 @@ toolbar:
   - g-coords-info
 tray:
   - g-metadata-viewer
+  - g-plot-options
   - imviz-links-control
   - imviz-compass
   - imviz-aper-phot-simple

--- a/jdaviz/configs/mosviz/mosviz.yaml
+++ b/jdaviz/configs/mosviz/mosviz.yaml
@@ -13,6 +13,7 @@ toolbar:
   - g-subset-tools
   - g-row-lock
 tray:
+  - g-plot-options
   - g-metadata-viewer
   - g-gaussian-smooth
   - g-slit-overlay

--- a/jdaviz/configs/specviz/specviz.yaml
+++ b/jdaviz/configs/specviz/specviz.yaml
@@ -15,6 +15,7 @@ toolbar:
   - g-subset-tools
 tray:
   - g-metadata-viewer
+  - g-plot-options
   - g-gaussian-smooth
   - g-model-fitting
   - g-unit-conversion

--- a/jdaviz/configs/specviz2d/specviz2d.yaml
+++ b/jdaviz/configs/specviz2d/specviz2d.yaml
@@ -12,6 +12,7 @@ toolbar:
   - g-data-tools
   - g-subset-tools
 tray:
+  - g-plot-options
   - g-gaussian-smooth
   - g-model-fitting
   - g-unit-conversion

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -78,39 +78,9 @@
                  </v-btn>
                </j-tooltip>
                <j-tooltip tipid='viewer-toolbar-menu'>
-                 <!-- NOTE: this case uses v-menu, so we'll control the active state with v-model
-                      on that component, but close any other active toolbar menus (that won't already
-                      with close-on-content-click with the @click on the underlying button component  
-                  -->
-                <v-menu offset-y :close-on-content-click="false" style="z-index: 10" v-model="viewer.layer_viewer_open">
-                  <template v-slot:activator="{ on }">
-                    <v-btn icon v-on="on" :class="{active : viewer.layer_viewer_open}" color="white" @click="viewer.tools_open=false">
-                      <v-icon>tune</v-icon>
-                    </v-btn>
-                  </template>
-
-                  <v-tabs v-model="viewer.tab" grow height="36px">
-                    <v-tab key="0">Layer</v-tab>
-                    <v-tab key="1">Viewer</v-tab>
-                  </v-tabs>
-
-                  <!-- NOTE: v-lazy needed for initial tab underline: https://github.com/vuetifyjs/vuetify/issues/1978#issuecomment-676892274 -->
-                  <v-lazy>
-                    <v-tabs-items v-model="viewer.tab" style="max-height: 500px; width: 350px;" lazy>
-
-                    <v-tab-item key="0" class="overflow-y-auto" style="height: 100%">
-                      <v-sheet class="px-4">
-                        <jupyter-widget :widget="viewer.layer_options" /> 
-                      </v-sheet>
-                    </v-tab-item>
-
-                    <v-tab-item key="1" eager class="overflow-y-auto" style="height: 100%">
-                      <v-sheet class="px-4">
-                        <jupyter-widget :widget="viewer.viewer_options" />
-                      </v-sheet>
-                    </v-tab-item>
-                  </v-tabs-items>
-                </v-menu>
+                  <v-btn icon color="white" @click="$emit('call-viewer-method', {'id': viewer.id, 'method': 'open_plot_options'})">
+                    <v-icon>tune</v-icon>
+                  </v-btn>
                </j-tooltip>
                <j-tooltip tipid='viewer-toolbar-more'>
                 <v-btn icon color="white">

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -5,7 +5,7 @@ __all__ = ['NewViewerMessage', 'ViewerAddedMessage', 'ViewerRemovedMessage', 'Lo
            'AddLineListMessage', 'RowLockMessage',
            'SliceSelectWavelengthMessage', 'SliceSelectSliceMessage',
            'SliceToolStateMessage',
-           'TableClickMessage']
+           'TableClickMessage', 'PlotOptionsSelectViewerMessage']
 
 
 class NewViewerMessage(Message):
@@ -264,3 +264,13 @@ class SliceToolStateMessage(Message):
     @property
     def change(self):
         return self._change
+
+
+class PlotOptionsSelectViewerMessage(Message):
+    def __init__(self, viewer, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._viewer = viewer
+
+    @property
+    def viewer(self):
+        return self._viewer


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request moves the viewer/layer options from a dropdown menu in the viewer into the plugin tray.  The content is still just pulled directly from glue-jupyter, with no modifications.  The old button on the viewer toolbars now becomes a shortcut to open the plugin and select that viewer.

https://user-images.githubusercontent.com/877591/155408036-85a388d1-2456-4122-bbac-441f06cb521f.mov

See also #1087, #1091, #1103 for proofs-of-concept for future expansion/modification to the plugin.

**TODO**
- [ ] test against #981

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #984

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
