### PR TITLE
Fix figure marks index error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,7 @@ Bug Fixes
   parameter units in that case. [#1026]
 - Model plugin polynomial order now avoids traceback when clearing input. [#1041]
 - Box zoom silently ignores click without drag events. [#1105]
+- Fixes index error when plotting new data/model. [#1120]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -342,12 +342,16 @@ class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
         # trace representing the spectrum itself.
         result = super().add_data(data, color, alpha, **layer_state)
 
-        # Index of spectrum trace plotted by the super class. It is
-        # for now, always the last in the array of marks. This will
-        # have to be reworked once multiple spectra can be over-plotted.
-        # The uncert and mask trace pointers are meant to facilitate this
-        # eventual upgrade.
-        self.data_trace_pointer = len(self.figure.marks) - 1
+        # Index of spectrum trace plotted by the super class. It is the
+        # **latest** item in figure.marks that is a Line instance
+        for ind, mark in reversed(list(enumerate(self.figure.marks))):
+            # we'll use __class__.__name__ since other entries (spectral lines,
+            # etc) defined in jdaviz.core.marks inherit from Lines
+            if mark.__class__.__name__ == 'Lines':
+                self.data_trace_pointer = ind
+                break
+        else:
+            raise ValueError("could not find mark for added data")
 
         self.error_trace_pointer = None
         self.mask_trace_pointer = None

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -350,7 +350,7 @@ class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
             if mark.__class__.__name__ == 'Lines':
                 self.data_trace_pointer = ind
                 break
-        else:
+        else:  # pragma: no cover
             raise ValueError("could not find mark for added data")
 
         self.error_trace_pointer = None


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request removes the index error caused by #1060 and reported in #1113, but also occurring before (#908, #1010) by ensuring the index to `figure.marks` is pointing to a `Lines` object rather than other marks added (spectral lines, continuum indicator, etc).

The full intention of the `self.data_trace_pointer` is a little unclear to me and may need to be revisited in the future.  But this PR attempts to reproduce the original intent of updating the index with the latest data entry in `self.figure.marks` by searching that list in reverse order and taking the first that is an actual `Lines` object instead of one of our custom marks that might be appended later.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #908 #1113

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
