### PR TITLE
Fix bug for subsets not having the correct upper value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,7 @@ Bug Fixes
 - Model plugin polynomial order now avoids traceback when clearing input. [#1041]
 - Box zoom silently ignores click without drag events. [#1105]
 - Fixes index error when plotting new data/model. [#1120]
+- API calls to subset now return full region. [#1125]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -598,7 +598,7 @@ class Application(VuetifyTemplate, HubListener):
 
             # Get last region within the subset
             if current_edge != index:
-                subset_region = spec_axis_data[mask[current_edge]: mask[index]]
+                subset_region = spec_axis_data[mask[current_edge]: mask[index] + 1]
                 # No if check here because len(mask) must be greater than 1
                 # so combined_spec_region will have been instantiated in the for loop
                 if combined_spec_region is None:

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -129,7 +129,7 @@ class TestSpecvizHelper:
         assert_quantity_allclose(spec_region['Subset 1'].subregions[2][0].value,
                                  7333.33333333, atol=1e-5)
         assert_quantity_allclose(spec_region['Subset 1'].subregions[2][1].value,
-                                 7555.55555556, atol=1e-5)
+                                 7777.77777778, atol=1e-5)
 
     def test_get_spectral_regions_raise_value_error(self):
         with pytest.raises(ValueError):

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -72,9 +72,8 @@ def test_region_from_subset_profile(jdaviz_app, spectral_cube_wcs):
 
     assert len(subsets) == 1
     assert isinstance(reg, SpectralRegion)
-
     assert_quantity_allclose(reg.lower, 5.0 * u.Hz)
-    assert_quantity_allclose(reg.upper, 14.0 * u.Hz)
+    assert_quantity_allclose(reg.upper, 15.0 * u.Hz)
 
 
 def test_region_spectral_spatial(jdaviz_app, spectral_cube_wcs):
@@ -94,13 +93,11 @@ def test_region_spectral_spatial(jdaviz_app, spectral_cube_wcs):
     subsets = jdaviz_app.get_subsets_from_viewer('spectrum-viewer', subset_type='spectral')
     reg = subsets.get('Subset 1')
 
-    print(reg)
-
     assert len(subsets) == 1
     assert isinstance(reg, SpectralRegion)
 
     assert_quantity_allclose(reg.lower, 5.0 * u.Hz)
-    assert_quantity_allclose(reg.upper, 14 * u.Hz)
+    assert_quantity_allclose(reg.upper, 15 * u.Hz)
 
     subsets = jdaviz_app.get_subsets_from_viewer('flux-viewer', subset_type='spatial')
     reg = subsets.get('Subset 2')
@@ -136,4 +133,4 @@ def test_disjoint_spectral_subset(jdaviz_app, spectral_cube_wcs):
     assert_quantity_allclose(reg[0].lower, 5.0*u.Hz)
     assert_quantity_allclose(reg[0].upper, 15.0*u.Hz)
     assert_quantity_allclose(reg[1].lower, 30.0*u.Hz)
-    assert_quantity_allclose(reg[1].upper, 34.0*u.Hz)
+    assert_quantity_allclose(reg[1].upper, 35.0*u.Hz)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address the bug where the upper value of the subset is off by one index value (i.e. stops one index value short of the correct upper value for the subset). This PR also updates related tests.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1114 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
