### PR TITLE
Imviz: Limit cube slices to 16

### DIFF
--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -98,8 +98,9 @@ class Imviz(ConfigHelper):
             * `~astropy.nddata.NDData` object (2D only but may have unit,
               mask, or uncertainty attached)
             * Numpy array (2D or 3D); if 3D, it will treat each slice at
-              ``axis=0`` as a separate image, however loading too many slices
-              will cause performance issue, so consider using Cubeviz instead.
+              ``axis=0`` as a separate image (limit is 16 slices), however
+              loading too many slices will cause performance issue,
+              so consider using Cubeviz instead.
 
         parser_reference
             This is used internally by the app.
@@ -152,7 +153,13 @@ class Imviz(ConfigHelper):
                 if data.ndim != 3:
                     raise ValueError(f'Imviz cannot load this array with ndim={data.ndim}')
 
+            max_n_slice = 16  # Arbitrary limit for performance reasons
             for i in range(data.shape[0]):
+                if i == max_n_slice:
+                    warnings.warn(f'{max_n_slice} or more 3D slices found, stopping; '
+                                  'please use Cubeviz')
+                    break
+
                 kw = deepcopy(kwargs)
 
                 # This will only append index to data label if provided.

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -114,6 +114,14 @@ class TestParseImage:
             assert data.shape == slice_shape
             assert_array_equal(comp.data, i)
 
+    def test_parse_numpy_array_3d_too_many(self, imviz_helper):
+        with pytest.warns(UserWarning, match='16 or more 3D slices found'):
+            imviz_helper.load_data(np.ones((17, 5, 5)))
+
+        assert len(imviz_helper.app.data_collection) == 16
+        assert imviz_helper.app.data_collection[0].shape == (5, 5)
+        assert imviz_helper.app.data_collection[15].shape == (5, 5)
+
     def test_parse_numpy_array_4d(self, imviz_helper):
         # Check logic is in higher level method.
         imviz_helper.load_data(np.ones((1, 2, 5, 5)))


### PR DESCRIPTION
Imviz: Limit cube slices to 16 for performance reasons. A direct follow-up of a yet to be released feature from #1056 , so no change log is necessary here.

This was requested by PO during sprint review on 2022-02-28.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
