### PR TITLE
Disable Unit Conversion plugin if Subset exists

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -111,6 +111,9 @@ Specviz
 
 - Entering line list in units that require spectral equivalencies no longer crashes Line Lists plugin. [#1079]
 
+- Unit Conversion plugin is now disabled in the presence of any Subset due to
+  incompatibility between the two. [#1130]
+
 Other Changes and Additions
 ---------------------------
 

--- a/docs/dev/ui_style_guide.rst
+++ b/docs/dev/ui_style_guide.rst
@@ -8,8 +8,9 @@ Tray Plugins
 In order to be consistent with layout, styling, and spacing, UI development on plugins should
 try to adhere to the following principles:
 
-* Any tray plugin should utilize ``<j-tray-plugin>`` as the outer-container (which provides consistent 
-  styling rules).  Any changes to style across all plugins should then take place in the 
+* Any tray plugin should utilize ``<j-tray-plugin :disabled_msg='disabled_msg'>`` as the 
+  outer-container (which provides consistent styling rules).  Any changes to style 
+  across all plugins should then take place in the 
   ``j-tray-plugin`` stylesheet (``jdaviz/components/tray_plugin.vue``).
 * Each item should be wrapped in a ``v-row``, but avoid any unnecessary additional wrapping-components
   (``v-card-*``, ``v-container``, etc).

--- a/jdaviz/components/tray_plugin.vue
+++ b/jdaviz/components/tray_plugin.vue
@@ -1,15 +1,24 @@
 <template>
   <v-container>
-    <slot>
+    <v-row v-if="isDisabled()">
+      <span> {{ getDisabledMsg() }}</span>
+    </v-row>
+    <slot v-else>
     </slot>
   </v-container>
 </template>
 
 <script>
 module.exports = {
-  props: {docslink: String, 
-          docstext: String
-        },
+  props: ['disabled_msg'],
+  methods: {
+    isDisabled() {
+      return this.getDisabledMsg().length > 0
+    },
+    getDisabledMsg() {
+      return this.disabled_msg || ''
+    },
+  }
 };
 </script>
 

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -14,7 +14,7 @@ from jdaviz.core.events import (AddDataMessage,
                                 SnackbarMessage,
                                 RedshiftMessage)
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import TemplateMixin
+from jdaviz.core.template_mixin import PluginTemplateMixin
 from jdaviz.core.linelists import load_preset_linelist
 from jdaviz.core.marks import SpectralLine
 from jdaviz.core.validunits import create_spectral_equivalencies_list
@@ -23,7 +23,7 @@ __all__ = ['LineListTool']
 
 
 @tray_registry('g-line-list', label="Line Lists")
-class LineListTool(TemplateMixin):
+class LineListTool(PluginTemplateMixin):
     dialog = Bool(False).tag(sync=True)
     template_file = __file__, "line_lists.vue"
 

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.vue
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.vue
@@ -1,5 +1,5 @@
 <template>
-  <j-tray-plugin>
+  <j-tray-plugin :disabled_msg="disabled_msg">
     <v-row>
       <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#line-lists'">Plot lines from preset or custom line lists.</j-docs-link>
     </v-row>

--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -3,6 +3,7 @@ import pytest
 from astropy import units as u
 from astropy.nddata import UnknownUncertainty
 from astropy.tests.helper import assert_quantity_allclose
+from glue.core.roi import XRangeROI
 
 from jdaviz.configs.specviz.plugins.unit_conversion import unit_conversion as uc
 
@@ -50,6 +51,14 @@ def test_no_spec_no_flux_no_uncert(specviz_helper, spectrum1d):
     assert converted_spectrum.flux.unit == spectrum1d.flux.unit
     assert converted_spectrum.spectral_axis.unit == spectrum1d.spectral_axis.unit
     assert converted_spectrum.uncertainty is None
+
+    # Test that applying and removing Subset disables and enables it, respectively.
+    conv_plugin = specviz_helper.app.get_tray_item_from_name('g-unit-conversion')
+    specviz_helper.app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(6000, 6500))
+    assert conv_plugin.disabled_msg == 'Please create Subsets only after unit conversion'
+    specviz_helper.app.data_collection.remove_subset_group(
+        specviz_helper.app.data_collection.subset_groups[0])
+    assert conv_plugin.disabled_msg == ''
 
 
 def test_spec_no_flux_no_uncert(specviz_helper, spectrum1d):

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -1,5 +1,5 @@
 <template>
-  <j-tray-plugin>
+  <j-tray-plugin :disabled_msg="disabled_msg">
     <v-row>
       <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#unit-conversion'">Convert the spectral flux density and spectral axis units.</j-docs-link>
     </v-row>

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -4,7 +4,7 @@ from traitlets import Unicode
 
 from jdaviz import __version__
 
-__all__ = ['TemplateMixin']
+__all__ = ['TemplateMixin', 'PluginTemplateMixin']
 
 
 class TemplateMixin(VuetifyTemplate, HubListener):
@@ -53,3 +53,7 @@ class TemplateMixin(VuetifyTemplate, HubListener):
     @property
     def data_collection(self):
         return self._app.session.data_collection
+
+
+class PluginTemplateMixin(TemplateMixin):
+    disabled_msg = Unicode("").tag(sync=True)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to use #1106 to disable Unit Conversion plugin if Subset exists in data collection. This is because Subset does not react well to unit conversion. This will require users to do all the unit conversion they want before they create any Subset. If they want to do Unit Conversion after creating Subset, they must first delete the Subset.

Close #1106 

### TODO

- [x] This currently breaks Subset creation (i.e., I cannot finalize a Subset selection in Specviz, it disappears). Not sure why. @kecnry , any idea? (Doh, typo!)
- [x] When it works, manually test a few scenarios in all the Viz that uses this plugin: Seems to disable/enable as I expect in Specviz and Cubeviz example notebooks, where this plugin is available.
- [x] Add change log.
- [x] Add test.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
