### PR TITLE
Fix data linking to allow contour over-plotting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Fixed linking of data to allow contour over-plotting. [#1154]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -311,16 +311,50 @@ class Application(VuetifyTemplate, HubListener):
 
         # Can't link if there's no world_component_ids
         wc_new = self.data_collection[-1].world_component_ids
-        if wc_new == []:
-            return
+        pc_new = self.data_collection[-1].pixel_component_ids
+
+        # if wc_new == []:
+        #     return
 
         # Link to the first dataset with compatible coordinates
         for i in range(new_len - 1):
             wc_old = self.data_collection[i].world_component_ids
+            pc_old = self.data_collection[i].pixel_component_ids
+
             if wc_old == []:
                 continue
             else:
-                self.data_collection.add_link(LinkSame(wc_old[0], wc_new[0]))
+                # New data is a moment map
+                if ("Plugin" in self.data_collection[-1].meta and
+                        self.data_collection[-1].meta["Plugin"] == "Moment Map"):
+                    # Link moment maps to each other
+                    # if "Moment" in self.data_collection[i].label:
+                    if ("Plugin" in self.data_collection[i].meta and
+                            self.data_collection[i].meta["Plugin"] == "Moment Map"):
+                        links = [LinkSame(pc_old[0], pc_new[0]),
+                                 LinkSame(pc_old[1], pc_new[1])]
+
+                    # Link moment map to cube (pc_old)
+                    else:
+                        links = [LinkSame(pc_old[1], pc_new[0]),
+                                 LinkSame(pc_old[2], pc_new[1])]
+
+                # Link cubes to each other
+                elif len(pc_old) > 2 and len(pc_new) > 2:
+                    links = [LinkSame(pc_old[1], pc_new[1]),
+                             LinkSame(pc_old[2], pc_new[2]),
+                             LinkSame(wc_old[0], wc_new[0])]
+
+                # If data is neither cube nor moment map, use old linking
+                # method
+                elif len(wc_new) > 0:
+                    links = [LinkSame(wc_old[0], wc_new[0])]
+
+                else:
+                    break
+
+                self.data_collection.add_link(links)
+
                 break
 
     def load_data(self, file_obj, parser_reference=None, **kwargs):

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -313,9 +313,6 @@ class Application(VuetifyTemplate, HubListener):
         wc_new = self.data_collection[-1].world_component_ids
         pc_new = self.data_collection[-1].pixel_component_ids
 
-        # if wc_new == []:
-        #     return
-
         # Link to the first dataset with compatible coordinates
         for i in range(new_len - 1):
             wc_old = self.data_collection[i].world_component_ids
@@ -324,29 +321,13 @@ class Application(VuetifyTemplate, HubListener):
             if wc_old == []:
                 continue
             else:
-                # New data is a moment map
-                if ("Plugin" in self.data_collection[-1].meta and
-                        self.data_collection[-1].meta["Plugin"] == "Moment Map"):
-                    # Link moment maps to each other
-                    # if "Moment" in self.data_collection[i].label:
-                    if ("Plugin" in self.data_collection[i].meta and
-                            self.data_collection[i].meta["Plugin"] == "Moment Map"):
-                        links = [LinkSame(pc_old[0], pc_new[0]),
-                                 LinkSame(pc_old[1], pc_new[1])]
-
-                    # Link moment map to cube (pc_old)
-                    else:
-                        links = [LinkSame(pc_old[1], pc_new[0]),
-                                 LinkSame(pc_old[2], pc_new[1])]
-
                 # Link cubes to each other
-                elif len(pc_old) > 2 and len(pc_new) > 2:
+                if len(pc_old) > 2 and len(pc_new) > 2:
                     links = [LinkSame(pc_old[1], pc_new[1]),
                              LinkSame(pc_old[2], pc_new[2]),
                              LinkSame(wc_old[0], wc_new[0])]
 
-                # If data is neither cube nor moment map, use old linking
-                # method
+                # If data is not a cube, use old linking method
                 elif len(wc_new) > 0:
                     links = [LinkSame(wc_old[0], wc_new[0])]
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -4,6 +4,8 @@ from astropy import units as u
 from astropy.nddata import CCDData
 from glue.core.message import (DataCollectionAddMessage,
                                DataCollectionDeleteMessage)
+from glue.core.link_helpers import LinkSame
+
 from traitlets import List, Unicode, Any, Bool, observe
 from specutils import Spectrum1D, manipulation, analysis
 
@@ -126,8 +128,13 @@ class MomentMap(TemplateMixin):
         label = "Moment {}: {}".format(n_moment, self._selected_data.label)
         fname_label = self._selected_data.label.replace("[", "_").replace("]", "")
         self.filename = "moment{}_{}.fits".format(n_moment, fname_label)
+
+        # Add information to meta data that this originated from
+        # the moment map plugin. Then, link the moment map data
+        # to the existing data in data_collection
         self.moment.meta["Plugin"] = "Moment Map"
         self.app.add_data(self.moment, label)
+        self._link_moment_data()
 
         self.moment_available = True
 
@@ -148,3 +155,27 @@ class MomentMap(TemplateMixin):
         # Let the user know where we saved the file.
         self.hub.broadcast(SnackbarMessage(
             f"Moment map saved to {os.path.abspath(self.filename)}", sender=self, color="success"))
+
+    def _link_moment_data(self):
+        new_len = len(self.app.data_collection)
+
+        # Can't link if there's no world_component_ids
+        pc_new = self.app.data_collection[-1].pixel_component_ids
+
+        # Link to the first dataset with compatible coordinates
+        for i in range(new_len - 1):
+            pc_old = self.app.data_collection[i].pixel_component_ids
+            # New data is a moment map
+            if ("Plugin" in self.app.data_collection[i].meta and
+                    self.app.data_collection[i].meta["Plugin"] == "Moment Map"):
+                links = [LinkSame(pc_old[0], pc_new[0]),
+                         LinkSame(pc_old[1], pc_new[1])]
+
+            # Link moment map to cube (pc_old)
+            else:
+                links = [LinkSame(pc_old[1], pc_new[0]),
+                         LinkSame(pc_old[2], pc_new[1])]
+
+            self.app.data_collection.add_link(links)
+
+            break

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -126,7 +126,9 @@ class MomentMap(TemplateMixin):
         label = "Moment {}: {}".format(n_moment, self._selected_data.label)
         fname_label = self._selected_data.label.replace("[", "_").replace("]", "")
         self.filename = "moment{}_{}.fits".format(n_moment, fname_label)
-        self.data_collection[label] = self.moment
+        self.moment.meta["Plugin"] = "Moment Map"
+        self.app.add_data(self.moment, label)
+
         self.moment_available = True
 
         msg = SnackbarMessage("{} added to data collection".format(label),

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -25,6 +25,8 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     assert mm.moment_available
     assert dc[1].label == 'Moment 0: test[FLUX]'
 
+    assert len(dc.links) == 8
+
     result = dc[1].get_object(cls=CCDData)
     assert result.shape == (2, 4)  # Cube shape is (2, 2, 4)
 
@@ -39,3 +41,10 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     # Does not allow overwrite.
     with pytest.raises(OSError, match='already exists'):
         mm.vue_save_as_fits()
+
+    mm.n_moment = 1
+    mm.vue_calculate_moment()
+
+    assert dc[2].label == 'Moment 1: test[FLUX]'
+
+    assert len(dc.links) == 10

--- a/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
@@ -20,10 +20,10 @@ def test_linking_after_spectral_smooth(spectrum1d_cube):
 
     assert len(dc) == 2
     assert dc[1].label == 'Smoothed test stddev 3.2'
-    assert len(dc.external_links) == 1
+    assert len(dc.external_links) == 3
 
-    assert dc.external_links[0].cids1[0] is dc[0].world_component_ids[0]
-    assert dc.external_links[0].cids2[0] is dc[1].world_component_ids[0]
+    assert dc.external_links[2].cids1[0] is dc[0].world_component_ids[0]
+    assert dc.external_links[2].cids2[0] is dc[1].world_component_ids[0]
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address the problem with over-plotting contours in cubeviz. It uses `pixel_component_ids` to do this, so data is linked by pixel rather than by WCS.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #318 

Close #1159

GIF shows contours of cubes on top of each other.
![Mar-09-2022 09-35-03](https://user-images.githubusercontent.com/7179333/157463649-c081c09b-a2ec-4d4d-96a6-1c1d14abc951.gif)

GIF shows contours of moment map plotted over a cube.
![Mar-09-2022 09-36-13](https://user-images.githubusercontent.com/7179333/157463673-891a6e0a-186c-43e0-a89d-1d5d7c432fea.gif)

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
