### PR TITLE
Fix contour from moment map on cube

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,8 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Fixed linking of data to allow contour over-plotting for moment map. [#1159]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -25,6 +25,8 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     assert mm.moment_available
     assert dc[1].label == 'Moment 0: test[FLUX]'
 
+    assert len(dc.links) == 8
+
     result = dc[1].get_object(cls=CCDData)
     assert result.shape == (2, 4)  # Cube shape is (2, 2, 4)
 
@@ -39,3 +41,10 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     # Does not allow overwrite.
     with pytest.raises(OSError, match='already exists'):
         mm.vue_save_as_fits()
+
+    mm.n_moment = 1
+    mm.vue_calculate_moment()
+
+    assert dc[2].label == 'Moment 1: test[FLUX]'
+
+    assert len(dc.links) == 10


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to propose an alternative but just for fixing moment map part of #1154. @javerbukh , I don't mean to trample on your turf but I don't know how to better explain what I had in mind when I was reviewing your PR without opening one myself. Hope you don't mind. 😬 

I still think the cube-on-cube action should be fixed at the parser level (maybe as part of #1040 or after it) instead of app level, but since I cannot reproduce the success at https://github.com/spacetelescope/jdaviz/pull/1154#issuecomment-1064701347 , I am not sure how to investigate that part further.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #318 

Close #1154 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
