### PR TITLE
Move export plot plugin to last in the listing

### DIFF
--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -15,7 +15,6 @@ toolbar:
   - g-data-tools
   - g-subset-tools
 tray:
-  - g-export-plot
   - g-plot-options
   - cubeviz-slice
   - g-gaussian-smooth
@@ -25,6 +24,7 @@ tray:
   - g-line-list
   - specviz-line-analysis
   - cubeviz-moment-maps
+  - g-export-plot
 viewer_area:
   - container: col
     children:

--- a/jdaviz/configs/default/default.yaml
+++ b/jdaviz/configs/default/default.yaml
@@ -12,5 +12,5 @@ toolbar:
   - g-viewer-creator
   - g-subset-tools
 tray:
-  - g-export-plot
   - g-gaussian-smooth
+  - g-export-plot

--- a/jdaviz/configs/imviz/imviz.yaml
+++ b/jdaviz/configs/imviz/imviz.yaml
@@ -19,11 +19,11 @@ toolbar:
   - g-coords-info
 tray:
   - g-metadata-viewer
-  - g-export-plot
   - g-plot-options
   - imviz-links-control
   - imviz-compass
   - imviz-aper-phot-simple
+  - g-export-plot
 viewer_area:
   - container: col
     children:

--- a/jdaviz/configs/mosviz/mosviz.yaml
+++ b/jdaviz/configs/mosviz/mosviz.yaml
@@ -14,13 +14,13 @@ toolbar:
   - g-row-lock
 tray:
   - g-metadata-viewer
-  - g-export-plot
   - g-plot-options
   - g-gaussian-smooth
   - g-slit-overlay
   - g-model-fitting
   - g-line-list
   - specviz-line-analysis
+  - g-export-plot
 viewer_area:
   - container: col
     children:

--- a/jdaviz/configs/specviz/specviz.yaml
+++ b/jdaviz/configs/specviz/specviz.yaml
@@ -15,13 +15,13 @@ toolbar:
   - g-subset-tools
 tray:
   - g-metadata-viewer
-  - g-export-plot
   - g-plot-options
   - g-gaussian-smooth
   - g-model-fitting
   - g-unit-conversion
   - g-line-list
   - specviz-line-analysis
+  - g-export-plot
 viewer_area:
   - container: col
     children:

--- a/jdaviz/configs/specviz2d/specviz2d.yaml
+++ b/jdaviz/configs/specviz2d/specviz2d.yaml
@@ -12,13 +12,13 @@ toolbar:
   - g-data-tools
   - g-subset-tools
 tray:
-  - g-export-plot
   - g-plot-options
   - g-gaussian-smooth
   - g-model-fitting
   - g-unit-conversion
   - g-line-list
   - specviz-line-analysis
+  - g-export-plot
 viewer_area:
   - container: col
     children:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

It just bothers me that it is not listed last because usually you export at the end of the workflow. 😆 

With this patch (example below from Imviz):

![Screenshot 2022-03-11 095357](https://user-images.githubusercontent.com/2090236/157891349-8294bb12-91d3-4ba1-b583-3b1230f53dfa.png)

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
