### PR TITLE
BUG: Surviving Data in viewer must be visible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,9 @@ Imviz
 - Fixed data shown out of order when ``load_data`` is called after
   ``app``. [#1178]
 
+- Fixed the subsequent dataset not showing after blinking if the dataset
+  being shown is removed from viewer. [#1164]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1177,8 +1177,11 @@ class Application(VuetifyTemplate, HubListener):
 
             # Make everything visible again in Imviz.
             if self.config == 'imviz':
+                from jdaviz.configs.imviz.helper import layer_is_image_data
+
                 for lyr in viewer.state.layers:
-                    lyr.visible = True
+                    if layer_is_image_data(lyr.layer):
+                        lyr.visible = True
                 viewer.on_limits_change()  # Trigger compass redraw
 
     def _on_data_added(self, msg):

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1175,6 +1175,12 @@ class Application(VuetifyTemplate, HubListener):
                     and active_data._preferred_translation is not None):
                 self._set_plot_axes_labels(viewer_id)
 
+            # Make everything visible again in Imviz.
+            if self.config == 'imviz':
+                for lyr in viewer.state.layers:
+                    lyr.visible = True
+                viewer.on_limits_change()  # Trigger compass redraw
+
     def _on_data_added(self, msg):
         """
         Callback for when data is added to the internal ``DataCollection``.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to fix a bug where data set to not visible after blinking remains invisible even if it is the only Data left in the viewer.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1107 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
