### PR TITLE
Remove redundant linking code

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -131,7 +131,7 @@ class MomentMap(PluginTemplateMixin, SpectralSubsetSelectMixin):
         # Link to the first dataset with compatible coordinates
         for i in range(new_len - 1):
             pc_old = self.app.data_collection[i].pixel_component_ids
-            # New data is a moment map
+            # If data_collection[i] is also from the moment map
             if ("Plugin" in self.app.data_collection[i].meta and
                     self.app.data_collection[i].meta["Plugin"] == "Moment Map"):
                 links = [LinkSame(pc_old[0], pc_new[0]),

--- a/jdaviz/configs/default/plugins/collapse/tests/test_collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/tests/test_collapse.py
@@ -22,5 +22,5 @@ def test_linking_after_collapse(cubeviz_helper, spectral_cube_wcs):
     assert dc[1].label == 'Collapsed 1 Unknown spectrum object[FLUX]'
     assert len(dc.external_links) == 2
 
-    assert dc.external_links[1].cids1[0] is dc[0].pixel_component_ids[1]
-    assert dc.external_links[1].cids2[0] is dc[1].pixel_component_ids[1]
+    assert dc.external_links[1].cids1[0] is dc[1].pixel_component_ids[0]
+    assert dc.external_links[1].cids2[0] is dc[0].pixel_component_ids[1]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address a problem where collapsed data throws errors when added to an image viewer in cubeviz. This removes the linking code from the collapse plugin since the same code is used in app.py.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1167 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
