### PR TITLE
generalize subset select component to handle spatial and spectral

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,7 +90,7 @@ Other Changes and Additions
 - Redshifts imported with a custom line list are now ignored.  Redshift must be set app-wide via 
   viz.set_redshift or the line list plugin. [#1134]
 
-- Subset selection dropdowns in plugins now show synced color indicators. [#1156]
+- Subset selection dropdowns in plugins now show synced color indicators. [#1156, #1175]
 
 2.3 (2022-03-01)
 ================

--- a/jdaviz/components/plugin_subset_select.vue
+++ b/jdaviz/components/plugin_subset_select.vue
@@ -5,8 +5,8 @@
       :items="items"
       v-model="selected"
       @change="$emit('update:selected', $event)"
-      :label="label ? label : 'Spectral Region'"
-      :hint="hint ? hint : 'Select spectral region.'"
+      :label="label ? label : 'Subset'"
+      :hint="hint ? hint : 'Select subset.'"
       :rules="rules ? rules : []"
       item-text="label"
       item-value="label"
@@ -15,7 +15,7 @@
       <template slot="selection" slot-scope="data">
         <div class="single-line">
           <v-icon v-if="data.item.color" left :color="data.item.color">
-            mdi-chart-bell-curve
+            {{ data.item.type=='spectral' ? 'mdi-chart-bell-curve' : 'mdi-chart-scatter-plot' }}
           </v-icon>
           <span>
             {{ data.item.label }}
@@ -25,7 +25,7 @@
       <template slot="item" slot-scope="data">
         <div class="single-line">
           <v-icon v-if="data.item.color" left :color="data.item.color">
-            mdi-chart-bell-curve
+            {{ data.item.type=='spectral' ? 'mdi-chart-bell-curve' : 'mdi-chart-scatter-plot' }}
           </v-icon>
           <span>
             {{ data.item.label }}

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
@@ -19,6 +19,7 @@
       :selected.sync="spectral_subset_selected"
       :has_subregions="spectral_subset_selected_has_subregions"
       has_subregions_warning="The selected selected subset has subregions, the entire range will be used, ignoring any gaps."
+      label="Spectral region"
       hint="Spectral region to compute the moment map."
     />
 

--- a/jdaviz/configs/default/plugins/collapse/collapse.vue
+++ b/jdaviz/configs/default/plugins/collapse/collapse.vue
@@ -30,6 +30,7 @@
         :selected.sync="spectral_subset_selected"
         :has_subregions="spectral_subset_selected_has_subregions"
         has_subregions_warning="The selected selected subset has subregions, the entire range will be used, ignoring any gaps."
+        label="Spectral region"
         hint="Select spectral region to apply the collapse."
       />
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -68,6 +68,7 @@ class ModelFitting(PluginTemplateMixin, SpectralSubsetSelectMixin):
     available_models = List(list(MODELS.keys())).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
+        self._spectrum1d = None
         super().__init__(*args, **kwargs)
 
         self._units = {}
@@ -273,6 +274,10 @@ class ModelFitting(PluginTemplateMixin, SpectralSubsetSelectMixin):
     @observe("spectral_subset_selected")
     def _on_spectral_subset_selected(self, event):
         # If "Entire Spectrum" selected, reset based on bounds of selected data
+        if self._spectrum1d is None:
+            # TODO: this should be removed as soon as the data dropdown component is
+            # created and defaults at init
+            return
         if self.spectral_subset_selected == "Entire Spectrum":
             self._window = None
             self.spectral_min = self._spectrum1d.spectral_axis[0].value

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -19,6 +19,7 @@
       <plugin-subset-select 
         :items="spectral_subset_items"
         :selected.sync="spectral_subset_selected"
+        label="Spectral region"
         hint="Select spectral region to fit."
       />
     </v-form>

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -124,6 +124,9 @@ class SimpleAperturePhotometry(TemplateMixin):
         # Auto-populate background, if applicable
         self._bg_subset_selected_changed()
 
+        # update self._selected_subset with the new self._selected_data
+        self._subset_selected_changed()
+
     def _get_region_from_subset(self, subset):
         for subset_grp in self.app.data_collection.subset_groups:
             if subset_grp.label == subset:

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -14,7 +14,7 @@ from jdaviz.configs.imviz.helper import layer_is_image_data
 from jdaviz.core.events import AddDataMessage, RemoveDataMessage, SnackbarMessage
 from jdaviz.core.region_translators import regions2aperture
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import TemplateMixin
+from jdaviz.core.template_mixin import TemplateMixin, SubsetSelect
 
 __all__ = ['SimpleAperturePhotometry']
 
@@ -42,6 +42,18 @@ class SimpleAperturePhotometry(TemplateMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        self.subset = SubsetSelect(self,
+                                   'subset_items',
+                                   'subset_selected',
+                                   default_text=None,
+                                   allowed_type='spatial')
+
+        self.bg_subset = SubsetSelect(self,
+                                      'bg_subset_items',
+                                      'bg_subset_selected',
+                                      default_text='Manual',
+                                      allowed_type='spatial')
+
         self.hub.subscribe(self, AddDataMessage, handler=self._on_viewer_data_changed)
         self.hub.subscribe(self, RemoveDataMessage, handler=self._on_viewer_data_changed)
         self.hub.subscribe(self, SubsetCreateMessage, handler=self._on_viewer_data_changed)
@@ -64,10 +76,6 @@ class SimpleAperturePhotometry(TemplateMixin):
         # To support multiple viewers, we allow the entire data collection.
         self.dc_items = [lyr.label for lyr in self.app.data_collection
                          if layer_is_image_data(lyr)]
-
-        self.subset_items = [lyr.label for lyr in self.app.data_collection.subset_groups
-                             if lyr.label.startswith('Subset')]
-        self.bg_subset_items = ['Manual'] + self.subset_items
 
     @observe('data_selected')
     def _data_selected_changed(self, event={}):

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -141,7 +141,7 @@ class SimpleAperturePhotometry(TemplateMixin):
     @observe('subset_selected')
     def _subset_selected_changed(self, event={}):
         subset_selected = event.get('new', self.subset_selected)
-        if self._selected_data is None:
+        if self._selected_data is None or subset_selected == '':
             self.reset_results()
             return
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -17,26 +17,21 @@
     </v-row>
 
     <div v-if='data_selected'>
-      <v-row>
-        <v-select
-          :items="subset_items"
-          v-model="subset_selected"
-          label="Subset"
-          hint="Select subset region for photometry."
-          persistent-hint
-        ></v-select>
-      </v-row>
+      <plugin-subset-select
+        :items="subset_items"
+        :selected.sync="subset_selected"
+        label="Aperture"
+        hint="Select aperture region for photometry."
+      />
 
       <div v-if="subset_selected">
-        <v-row>
-          <v-select
-            :items="bg_subset_items"
-            v-model="bg_subset_selected"
-            label="Subset (background)"
-            hint="Select subset region for background calculation."
-            persistent-hint
-          ></v-select>
-        </v-row>
+        <plugin-subset-select
+          :items="bg_subset_items"
+          :selected.sync="bg_subset_selected"
+          :rules="[() => bg_subset_selected!==subset_selected || 'Must not match aperture.']"
+          label="Background"
+          hint="Select subset region for background calculation."
+        />
 
         <v-row>
           <v-text-field

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -23,7 +23,8 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         with pytest.raises(ValueError):
             # will raise an error and revert to first entry
             phot_plugin.subset_selected = 'no_such_subset'
-        assert phot_plugin.subset_selected == phot_plugin.subset.labels[0]
+        assert phot_plugin.subset_selected == ''
+        phot_plugin.subset_selected = phot_plugin.subset.labels[0]
         assert_allclose(phot_plugin.background_value, 0)
         phot_plugin.vue_do_aper_phot()
         assert not phot_plugin.result_available
@@ -34,9 +35,7 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         assert phot_plugin.current_plot_type == 'Radial Profile'  # Software default
 
         phot_plugin.data_selected = 'has_wcs_1[SCI,1]'
-        with pytest.raises(ValueError):
-            phot_plugin.subset_selected = 'no_such_subset'
-        assert phot_plugin.subset_selected == phot_plugin.subset.labels[0]
+        phot_plugin.subset_selected = phot_plugin.subset.labels[0]
         with pytest.raises(ValueError):
             phot_plugin.bg_subset_selected = 'no_such_subset'
         assert phot_plugin.bg_subset_selected == 'Manual'

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
@@ -19,9 +20,10 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         # Make sure invalid Data/Subset selection does not crash plugin.
         phot_plugin.data_selected = 'no_such_data'
         assert phot_plugin._selected_data is None
-        phot_plugin.subset_selected = 'no_such_subset'
-        assert phot_plugin._selected_subset is None
-        phot_plugin.bg_subset_selected = 'no_such_subset'
+        with pytest.raises(ValueError):
+            # will raise an error and revert to first entry
+            phot_plugin.subset_selected = 'no_such_subset'
+        assert phot_plugin.subset_selected == phot_plugin.subset.labels[0]
         assert_allclose(phot_plugin.background_value, 0)
         phot_plugin.vue_do_aper_phot()
         assert not phot_plugin.result_available
@@ -32,9 +34,12 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         assert phot_plugin.current_plot_type == 'Radial Profile'  # Software default
 
         phot_plugin.data_selected = 'has_wcs_1[SCI,1]'
-        phot_plugin.subset_selected = 'no_such_subset'
-        assert phot_plugin._selected_subset is None
-        phot_plugin.bg_subset_selected = 'no_such_subset'
+        with pytest.raises(ValueError):
+            phot_plugin.subset_selected = 'no_such_subset'
+        assert phot_plugin.subset_selected == phot_plugin.subset.labels[0]
+        with pytest.raises(ValueError):
+            phot_plugin.bg_subset_selected = 'no_such_subset'
+        assert phot_plugin.bg_subset_selected == 'Manual'
         assert_allclose(phot_plugin.background_value, 0)
 
         # Perform photometry on both images using same Subset.
@@ -42,8 +47,10 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         phot_plugin.vue_do_aper_phot()
         phot_plugin.data_selected = 'has_wcs_2[SCI,1]'
         phot_plugin.current_plot_type = 'Radial Profile (Raw)'
+        assert phot_plugin._selected_data is not None
+        assert phot_plugin._selected_subset is not None
         phot_plugin.vue_do_aper_phot()
-        assert phot_plugin.bg_subset_items == ['Manual', 'Subset 1']
+        assert phot_plugin.bg_subset.labels == ['Manual', 'Subset 1']
         assert_allclose(phot_plugin.background_value, 0)
         assert_allclose(phot_plugin.counts_factor, 0)
         assert_allclose(phot_plugin.pixel_area, 0)

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -20,7 +20,7 @@ from jdaviz.core.marks import (LineAnalysisContinuum,
                                LineAnalysisContinuumRight,
                                Shadow)
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import PluginTemplateMixin, SpectralSubsetSelect
+from jdaviz.core.template_mixin import PluginTemplateMixin, SubsetSelect
 from jdaviz.core.tools import ICON_DIR
 
 __all__ = ['LineAnalysis']
@@ -39,11 +39,11 @@ class LineAnalysis(PluginTemplateMixin):
     dc_items = List([]).tag(sync=True)
     selected_spectrum = Unicode("").tag(sync=True)
 
-    spectral_subset_items = List([{"label": "Entire Spectrum", "color": False}]).tag(sync=True)
-    spectral_subset_selected = Unicode("Entire Spectrum").tag(sync=True)
+    spectral_subset_items = List().tag(sync=True)
+    spectral_subset_selected = Unicode().tag(sync=True)
 
-    continuum_subset_items = List([{"label": "Surrounding", "color": False}]).tag(sync=True)
-    continuum_selected = Unicode("Surrounding").tag(sync=True)
+    continuum_subset_items = List().tag(sync=True)
+    continuum_selected = Unicode().tag(sync=True)
 
     width = FloatHandleEmpty(3).tag(sync=True)
     results_computing = Bool(False).tag(sync=True)
@@ -66,12 +66,16 @@ class LineAnalysis(PluginTemplateMixin):
         self._units = {}
         self.update_results(None)
 
-        self.spectral_subset = SpectralSubsetSelect(self,
-                                                    'spectral_subset_items',
-                                                    'spectral_subset_selected')
-        self.continuum = SpectralSubsetSelect(self,
-                                              'continuum_subset_items',
-                                              'continuum_selected')
+        self.spectral_subset = SubsetSelect(self,
+                                            'spectral_subset_items',
+                                            'spectral_subset_selected',
+                                            default_text="Entire Spectrum",
+                                            allowed_type='spectral')
+        self.continuum = SubsetSelect(self,
+                                      'continuum_subset_items',
+                                      'continuum_selected',
+                                      default_text='Surrounding',
+                                      allowed_type='spectral')
 
         self.hub.subscribe(self, AddDataMessage,
                            handler=self._on_viewer_data_changed)

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -24,6 +24,7 @@
     <plugin-subset-select 
       :items="spectral_subset_items"
       :selected.sync="spectral_subset_selected"
+      label="Spectral region"
       hint="Select spectral region that defines the line."
     />
 
@@ -40,7 +41,8 @@
       :items="continuum_subset_items"
       :selected.sync="continuum_selected"
       :rules="[() => continuum_selected!==spectral_subset_selected || 'Must not match line selection.']"
-      hint="Select spectral region that defines the line."
+      label="Continuum"
+      hint="Select spectral region that defines the continuum."
     />
 
     <v-row v-if="continuum_selected=='Surrounding' && spectral_subset_selected!='Entire Spectrum'">

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -234,8 +234,8 @@ class SubsetSelect(BasePluginComponent):
         # NOTE: calling .remove will not trigger traitlet update
         self.items = [s for s in self.items
                       if s['label'] != subset.label]
-        if self.selected not in self.labels:
-            self.selected = "Entire Spectrum"
+        if self.selected not in self.labels and len(self.labels):
+            self.selected = self.labels[0]
 
     def _update_subset(self, subset, attribute=None):
         if self._allowed_type is not None and self._subset_type(subset) != self._allowed_type:
@@ -287,6 +287,7 @@ class SubsetSelect(BasePluginComponent):
         for item in self.items:
             if item['label'] == self.selected:
                 return item
+        return {}
 
     @cached_property
     def selected_obj(self):
@@ -300,18 +301,18 @@ class SubsetSelect(BasePluginComponent):
                 return match
 
     def selected_min(self, spectrum1d):
-        if self.selected_item['type'] != 'spectral':
-            raise TypeError("currently selected subset is not spectral")
         if self.selected == self._default_text:
             return np.nanmin(spectrum1d.spectral_axis.value)
+        if self.selected_item.get('type') != 'spectral':
+            raise TypeError("currently selected subset is not spectral")
         else:
             return self.selected_obj.lower.value
 
     def selected_max(self, spectrum1d):
-        if self.selected_item['type'] != 'spectral':
-            raise TypeError("currently selected subset is not spectral")
         if self.selected == self._default_text:
             return np.nanmax(spectrum1d.spectral_axis.value)
+        if self.selected_item.get('type') != 'spectral':
+            raise TypeError("currently selected subset is not spectral")
         else:
             return self.selected_obj.upper.value
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -236,8 +236,11 @@ class SubsetSelect(BasePluginComponent):
             return
 
         if msg.subset.label not in self.labels:
-            # NOTE: += will not trigger traitlet update
-            self.items = self.items + [self._subset_to_dict(msg.subset)]  # noqa
+            # NOTE: this logic will need to be revisited if generic renaming of subsets is added
+            # see https://github.com/spacetelescope/jdaviz/pull/1175#discussion_r829372470
+            if msg.subset.label.startswith('Subset'):
+                # NOTE: += will not trigger traitlet update
+                self.items = self.items + [self._subset_to_dict(msg.subset)]  # noqa
         else:
             if msg.attribute in ('style'):
                 # TODO: may need to add label and then rebuild the entire list if/when

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -327,7 +327,7 @@ class SubsetSelect(BasePluginComponent):
         if self.selected == self._default_text:
             return np.nanmin(spectrum1d.spectral_axis.value)
         if self.selected_item.get('type') != 'spectral':
-            raise TypeError("currently selected subset is not spectral")
+            raise TypeError("This action is only supported on spectral-type subsets")
         else:
             return self.selected_obj.lower.value
 
@@ -335,7 +335,7 @@ class SubsetSelect(BasePluginComponent):
         if self.selected == self._default_text:
             return np.nanmax(spectrum1d.spectral_axis.value)
         if self.selected_item.get('type') != 'spectral':
-            raise TypeError("currently selected subset is not spectral")
+            raise TypeError("This action is only supported on spectral-type subsets")
         else:
             return self.selected_obj.upper.value
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -308,9 +308,9 @@ class SubsetSelect(BasePluginComponent):
         if self.selected == self._default_text:
             return None
         subset_type = self.selected_item['type']
-        # NOTE: this might cause some issues with multiple viewers in imviz which
-        # don't have reference names, but get_subsets_from_viewer requires reference
-        # and not IDs
+        # NOTE: we use reference names here instead of IDs since get_subsets_from_viewer requires
+        # that.  For imviz, this will mean we won't be able to loop through each of the viewers,
+        # but the original viewer should have access to all the subsets.
         for viewer_ref in self.viewer_refs:
             match = self.app.get_subsets_from_viewer(viewer_ref,
                                                      subset_type=subset_type).get(self.selected)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -170,7 +170,7 @@ class SubsetSelect(BasePluginComponent):
         """
         Parameters
         ----------
-        plugin :
+        plugin
             the parent plugin object
         items : str
             the name of the items traitlet defined in ``plugin``
@@ -181,10 +181,10 @@ class SubsetSelect(BasePluginComponent):
         viewer_refs : list
             the reference names of the viewer to extract the subregion.  If not provided or None,
             will loop through all references.
-        default_text: str or None
+        default_text : str or None
             the text to show for no selection.  If not provided or None, no entry will be provided
             in the dropdown for no selection.
-        allowed_type: str or None
+        allowed_type : str or None
             whether to filter to 'spatial' or 'spectral' types of subsets.  If not provided or None,
             will include both entries.
         """

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -202,8 +202,10 @@ class SubsetSelect(BasePluginComponent):
         if selected_has_subregions is not None:
             self.selected_has_subregions = False
 
-        self.hub.subscribe(self, SubsetUpdateMessage, handler=lambda msg: self._update_subset(msg.subset, msg.attribute))
-        self.hub.subscribe(self, SubsetDeleteMessage, handler=lambda msg: self._delete_subset(msg.subset))
+        self.hub.subscribe(self, SubsetUpdateMessage,
+                           handler=lambda msg: self._update_subset(msg.subset, msg.attribute))
+        self.hub.subscribe(self, SubsetDeleteMessage,
+                           handler=lambda msg: self._delete_subset(msg.subset))
         self.add_observe(selected, self._selected_changed)
 
         # intialize any subsets that have already been created

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -234,6 +234,13 @@ class SubsetSelect(BasePluginComponent):
         else:
             return 'spectral'
 
+    def _apply_default_selection(self):
+        # default to the default_text, if available, otherwise empty
+        if self._default_text:
+            self.selected = self._default_text
+        else:
+            self.selected = ''
+
     def _subset_to_dict(self, subset):
         # find layer artist in default spectrum-viewer
         for viewer in self.viewers:
@@ -248,8 +255,8 @@ class SubsetSelect(BasePluginComponent):
         # NOTE: calling .remove will not trigger traitlet update
         self.items = [s for s in self.items
                       if s['label'] != subset.label]
-        if self.selected not in self.labels and len(self.labels):
-            self.selected = self.labels[0]
+        if self.selected not in self.labels:
+            self._apply_default_selection()
 
     def _update_subset(self, subset, attribute=None):
         if self._allowed_type is not None and self._subset_type(subset) != self._allowed_type:
@@ -278,9 +285,8 @@ class SubsetSelect(BasePluginComponent):
             self._update_has_subregions()
 
     def _selected_changed(self, event):
-        if event['new'] not in self.labels:
-            if len(self.labels):
-                self.selected = self.labels[0]
+        if event['new'] not in self.labels + ['']:
+            self._apply_default_selection()
             raise ValueError(f"{event['new']} not one of {self.labels}")
         self._clear_cache("selected_obj", "selected_item")
         self._update_has_subregions()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request extends upon #1156 to support both spatial and spectral subsets (including in the same dropdown, although we don't have any uses for that, yet).  Most of this is just a generalization of logic, with a new Mixin for `SpatialSubsetSelectMixin`.

For the aperture photometry plugin, the dropdowns now look like:

<img width="1012" alt="Screen Shot 2022-03-17 at 1 47 59 PM" src="https://user-images.githubusercontent.com/877591/158864533-1a6d760e-084b-40e3-874a-04e215844df0.png">

Although not actually in use, a mixed dropdown would look like:

<img width="303" alt="Screen Shot 2022-03-17 at 1 45 40 PM" src="https://user-images.githubusercontent.com/877591/158864602-581d421b-c2ec-4e7a-af4b-f3e1d4b5defe.png">

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
