### PR TITLE
BUG: Fix load data after imviz.app does not show last loaded data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,9 @@ Imviz
 
 - Fixed Compass plugin performance for large image. [#1152]
 
+- Fixed data shown out of order when ``load_data`` is called after
+  ``app``. [#1178]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -306,6 +306,9 @@ class Application(VuetifyTemplate, HubListener):
         any components are compatible with already loaded data. If so, link
         them so that they can be displayed on the same profile1D plot.
         """
+        if self.config == 'imviz':  # Imviz does its own thing
+            return
+
         new_len = len(self.data_collection)
 
         # Allow for batch linking of data in the parser rather than on

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -21,7 +21,7 @@ INFO_MSG = ("The file contains more viewable extensions. Add the '[*]' suffix"
 
 
 @data_parser_registry("imviz-data-parser")
-def parse_data(app, file_obj, ext=None, data_label=None, show_in_viewer=True):
+def parse_data(app, file_obj, ext=None, data_label=None):
     """Parse a data file into Imviz.
 
     Parameters
@@ -38,9 +38,6 @@ def parse_data(app, file_obj, ext=None, data_label=None, show_in_viewer=True):
     data_label : str, optional
         The label to be applied to the Glue data component.
 
-    show_in_viewer : bool, optional
-        Show data in viewer.
-
     """
     if isinstance(file_obj, str):
         if data_label is None:
@@ -54,14 +51,14 @@ def parse_data(app, file_obj, ext=None, data_label=None, show_in_viewer=True):
             else:  # Assume RGB
                 pf = rgb2gray(im)
             pf = pf[::-1, :]  # Flip it
-            _parse_image(app, pf, data_label, show_in_viewer, ext=ext)
+            _parse_image(app, pf, data_label, ext=ext)
         else:  # Assume FITS
             with fits.open(file_obj) as pf:
-                _parse_image(app, pf, data_label, show_in_viewer, ext=ext)
+                _parse_image(app, pf, data_label, ext=ext)
     else:
         if data_label is None:
             data_label = f'imviz_data|{str(base64.b85encode(uuid.uuid4().bytes), "utf-8")}'
-        _parse_image(app, file_obj, data_label, show_in_viewer, ext=ext)
+        _parse_image(app, file_obj, data_label, ext=ext)
 
 
 def get_image_data_iterator(app, file_obj, data_label, ext=None):
@@ -123,7 +120,7 @@ def get_image_data_iterator(app, file_obj, data_label, ext=None):
     return data_iter
 
 
-def _parse_image(app, file_obj, data_label, show_in_viewer, ext=None):
+def _parse_image(app, file_obj, data_label, ext=None):
     if data_label is None:
         raise NotImplementedError('data_label should be set by now')
 
@@ -136,8 +133,6 @@ def _parse_image(app, file_obj, data_label, show_in_viewer, ext=None):
             data_label = data_label + "_2"  # 0th-order solution as proposed in issue #600
 
         app.add_data(data, data_label)
-        if show_in_viewer:
-            app.add_data_to_viewer(f"{app.config}-0", data_label)
 
     # Do not run link_image_data here. We do it at the end in Imviz.load_data()
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to fix #1126

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
