### PR TITLE
Imviz: Set to 95 percentile on load for default viewer

### DIFF
--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -186,6 +186,8 @@ class Imviz(ConfigHelper):
                     if cur_label not in prev_data_labels:
                         self.app.add_data_to_viewer(f"{self.app.config}-0", cur_label)
 
+        self.default_viewer.cuts = '95%'
+
     def link_data(self, **kwargs):
         """(Re)link loaded data in Imviz with the desired link type.
         All existing links will be replaced.

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -283,7 +283,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer.cuts = '95%'\n",
+    "viewer.cuts = '99.5%'\n",
     "viewer.cuts"
    ]
   },


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to hack-fix Imviz to force 95th percentile on load until a proper fix (#710) can be figured out. This hack-fix only applies to default viewer. All manually created extra viewers will still have software default of minmax.

Maybe good enough for most use case?

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
