### PR TITLE
Add UI option to show uncertainties in specviz viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Mosviz
 Specviz
 ^^^^^^^
 
+- Exposed toggle in Plot Options plugin for viewing uncertainties. [#1189]
+
 API Changes
 -----------
 

--- a/docs/cubeviz/plugins.rst
+++ b/docs/cubeviz/plugins.rst
@@ -23,6 +23,9 @@ Plot Options
 
 This plugin gives access to per-viewer and per-layer plotting options.
 
+For more information on Specviz specific options, please see
+:ref:`Specviz: Plot options <specviz-plot-options>`.
+
 .. _slice:
 
 Slice

--- a/docs/specviz/plugins.rst
+++ b/docs/specviz/plugins.rst
@@ -44,6 +44,11 @@ Plot Options
 
 This plugin gives access to per-viewer and per-layer plotting options.
 
+Included in this plugin is a toggle called :guilabel:`Plot Uncertainty`,
+which will show uncertainty values as a shaded area above and below the
+spectrum. With this option toggled on, all spectra added to Specviz will
+have it's uncertainty values displayed as well.
+
 .. _gaussian-smooth:
 
 Gaussian Smooth

--- a/docs/specviz/plugins.rst
+++ b/docs/specviz/plugins.rst
@@ -47,7 +47,7 @@ This plugin gives access to per-viewer and per-layer plotting options.
 Included in this plugin is a toggle called :guilabel:`Plot Uncertainty`,
 which will show uncertainty values as a shaded area above and below the
 spectrum. With this option toggled on, all spectra added to Specviz will
-have it's uncertainty values displayed as well.
+have their uncertainty values displayed as well.
 
 .. _gaussian-smooth:
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -1,7 +1,8 @@
-from traitlets import Any, List, Unicode, observe
+from traitlets import Any, List, Unicode, observe, Bool
 from ipywidgets.widgets import widget_serialization
 
-from jdaviz.core.events import (ViewerAddedMessage, ViewerRemovedMessage)
+from jdaviz.core.events import (ViewerAddedMessage, ViewerRemovedMessage,
+                                AddDataMessage, RemoveDataMessage)
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import TemplateMixin
 
@@ -17,6 +18,9 @@ class PlotOptions(TemplateMixin):
     viewer_widget = Any().tag(sync=True, **widget_serialization)
     layer_widget = Any().tag(sync=True, **widget_serialization)
 
+    # Toggle for showing uncertainty in viewer
+    show_uncertainty = Bool(False).tag(sync=True)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -24,6 +28,10 @@ class PlotOptions(TemplateMixin):
                            handler=lambda _: self._on_viewers_changed())
         self.hub.subscribe(self, ViewerRemovedMessage,
                            handler=lambda _: self._on_viewers_changed())
+        self.hub.subscribe(self, AddDataMessage,
+                           handler=lambda _: self._on_data_changed())
+        self.hub.subscribe(self, RemoveDataMessage,
+                           handler=lambda _: self._on_data_changed())
 
         # initialize viewer_items from original viewers
         self._on_viewers_changed()
@@ -38,8 +46,19 @@ class PlotOptions(TemplateMixin):
         # message from elsewhere requesting to change the selected viewer
         self.selected_viewer = msg.viewer
 
+    def _on_data_changed(self):
+        self.show_uncertainty = False
+
     @observe("selected_viewer")
     def _selected_viewer_changed(self, event={}):
         viewer = self.app.get_viewer_by_id(event.get('new', self.selected_viewer))
         self.viewer_widget = viewer.viewer_options
         self.layer_widget = viewer.layer_options
+
+    @observe("show_uncertainty")
+    def _toggle_uncertainty(self, event):
+        spec_viewer = self.app.get_viewer("spectrum-viewer")
+        if self.show_uncertainty:
+            spec_viewer.show_uncertainties()
+        else:
+            spec_viewer.clean()

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -47,7 +47,8 @@ class PlotOptions(TemplateMixin):
         self.selected_viewer = msg.viewer
 
     def _on_data_changed(self):
-        self.show_uncertainty = False
+        # Make sure new data has it's uncertainty plotted
+        self._toggle_uncertainty(None)
 
     @observe("selected_viewer")
     def _selected_viewer_changed(self, event={}):
@@ -61,4 +62,4 @@ class PlotOptions(TemplateMixin):
         if self.show_uncertainty:
             spec_viewer.show_uncertainties()
         else:
-            spec_viewer.clean()
+            spec_viewer._clean_error()

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -62,6 +62,10 @@ class PlotOptions(TemplateMixin):
             viewer = "cubeviz-3"
         elif self.app.state.settings.get("configuration") == "specviz":
             viewer = "specviz-0"
+        elif self.app.state.settings.get("configuration") == "specviz2d":
+            viewer = "specviz2d-1"
+        elif self.app.state.settings.get("configuration") == "mosviz":
+            viewer = "mosviz-2"
         else:
             return
         spec_viewer = self.app.get_viewer_by_id(viewer)

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -58,7 +58,14 @@ class PlotOptions(TemplateMixin):
 
     @observe("show_uncertainty")
     def _toggle_uncertainty(self, event):
-        spec_viewer = self.app.get_viewer("spectrum-viewer")
+        if self.app.state.settings.get("configuration") == "cubeviz":
+            viewer = "cubeviz-3"
+        elif self.app.state.settings.get("configuration") == "specviz":
+            viewer = "specviz-0"
+        else:
+            return
+        spec_viewer = self.app.get_viewer_by_id(viewer)
+
         if self.show_uncertainty:
             spec_viewer.show_uncertainties()
         else:

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -19,6 +19,15 @@
       <v-row class="row-no-outside-padding">
         <jupyter-widget v-if="selected_viewer" :widget="viewer_widget"></jupyter-widget>
       </v-row>
+
+      <v-row>
+        <v-switch
+            v-model="show_uncertainty"
+            label="Plot Uncertainty"
+            hint="Show uncertainty values in the y-axis above and below the spectrum."
+            persistent-hint>
+        </v-switch>
+      </v-row>
       
       <j-plugin-section-header>Layer Options</j-plugin-section-header>      
       <v-row class="row-no-outside-padding">

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -20,7 +20,7 @@
         <jupyter-widget v-if="selected_viewer" :widget="viewer_widget"></jupyter-widget>
       </v-row>
 
-      <v-row v-if="['specviz', 'mosviz'].indexOf(config)!==-1">
+      <v-row v-if="['specviz', 'mosviz', 'specviz2d', 'cubeviz'].indexOf(config)!==-1">
         <v-switch
             v-model="show_uncertainty"
             label="Plot Uncertainty"

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -20,7 +20,7 @@
         <jupyter-widget v-if="selected_viewer" :widget="viewer_widget"></jupyter-widget>
       </v-row>
 
-      <v-row>
+      <v-row v-if="['specviz', 'mosviz'].indexOf(config)!==-1">
         <v-switch
             v-model="show_uncertainty"
             label="Plot Uncertainty"

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -391,11 +391,18 @@ class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
         if not self.display_mask:
             return
 
+        # Remove existing mask marks
+        self._clean_mask()
+
         # Loop through all active data in the viewer
         for index, layer_state in enumerate(self.state.layers):
             comps = [str(component) for component in layer_state.layer.components]
 
-            # Ignore data that does not have an 'mask' component
+            # Skip subsets
+            if hasattr(layer_state.layer, "subset_state"):
+                continue
+
+            # Ignore data that does not have a mask component
             if "mask" in comps:
                 mask = np.array(layer_state.layer['mask'].data)
 
@@ -420,17 +427,25 @@ class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
                                              )
                 # Add mask marks to viewer
                 self.figure.marks = list(self.figure.marks) + [mask_line_mark]
-            
+
     def _plot_uncertainties(self):
         if not self.display_uncertainties:
             return
 
+        # Remove existing error bars
+        self._clean_error()
+
         # Loop through all active data in the viewer
         for index, layer_state in enumerate(self.state.layers):
+
+            # Skip subsets
+            if hasattr(layer_state.layer, "subset_state"):
+                continue
+
             comps = [str(component) for component in layer_state.layer.components]
 
-            # Ignore data that does not have an 'uncertainty' component
-            if "uncertainty" in comps:
+            # Ignore data that does not have an uncertainty component
+            if "uncertainty" in comps:  # noqa
                 error = np.array(layer_state.layer['uncertainty'].data)
 
                 data_x = layer_state.layer.data.get_object().spectral_axis
@@ -459,6 +474,7 @@ class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
                                                     fill='between',
                                                     close_path=False
                                                     )
+
                 # Add error lines to viewer
                 self.figure.marks = list(self.figure.marks) + [error_line_mark]
 

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -355,32 +355,6 @@ class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
         # trace representing the spectrum itself.
         result = super().add_data(data, color, alpha, **layer_state)
 
-        data_trace_pointer = 0
-
-        # Index of spectrum trace plotted by the super class. It is the
-        # **latest** item in figure.marks that is a Line instance
-        for ind, mark in reversed(list(enumerate(self.figure.marks))):
-            # we'll use __class__.__name__ since other entries (spectral lines,
-            # etc) defined in jdaviz.core.marks inherit from Lines
-            if mark.__class__.__name__ == 'Lines':
-                data_trace_pointer = ind
-                break
-        else:  # pragma: no cover
-            raise ValueError("could not find mark for added data")
-
-        # Color and opacity are taken from the already plotted trace,
-        # in case they are not set explicitly by the caller.
-        self._color = self.figure.marks[data_trace_pointer].colors[0]
-        if color:
-            self._color = color
-
-        self._alpha = self.figure.marks[data_trace_pointer].opacities[0]
-        if alpha:
-            self._alpha = alpha
-
-        # An opacity defined specifically for the shaded areas.
-        self._alpha_shade = self._alpha / 3
-
         self._plot_uncertainties()
 
         self._plot_mask()
@@ -415,15 +389,16 @@ class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
 
                 # A subclass of the bqplot Scatter object, ScatterMask places
                 # 'X' marks where there is masked data in the viewer.
+                color = layer_state.color
+                alpha_shade = layer_state.alpha / 3
                 mask_line_mark = ScatterMask(scales=self.scales,
                                              marker='cross',
                                              x=data_x,
                                              y=y,
                                              stroke_width=0.5,
-                                             # colors=['red'],
-                                             colors=[self._color],
+                                             colors=[color],
                                              default_size=25,
-                                             default_opacities=[self._alpha]
+                                             default_opacities=[alpha_shade]
                                              )
                 # Add mask marks to viewer
                 self.figure.marks = list(self.figure.marks) + [mask_line_mark]
@@ -461,16 +436,18 @@ class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
                 # A subclass of the bqplot Lines object, LineUncertainties keeps
                 # track of uncertainties plotted in the viewer. LineUncertainties
                 # appear with two lines and shaded area in between.
+                color = layer_state.color
+                alpha_shade = layer_state.alpha / 3
                 error_line_mark = LineUncertainties(viewer=self,
                                                     x=[x],
                                                     y=[y],
                                                     scales=self.scales,
                                                     stroke_width=1,
-                                                    colors=[self._color, self._color],
-                                                    fill_colors=[self._color, self._color],
+                                                    colors=[color, color],
+                                                    fill_colors=[color, color],
                                                     opacities=[0.0, 0.0],
-                                                    fill_opacities=[self._alpha_shade,
-                                                                    self._alpha_shade],
+                                                    fill_opacities=[alpha_shade,
+                                                                    alpha_shade],
                                                     fill='between',
                                                     close_path=False
                                                     )

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -243,3 +243,19 @@ def test_load_spectrum_list_directory(tmpdir, specviz_helper):
     for element in specviz_helper.app.data_collection:
         assert element.data.main_components[0] in ['flux']
         assert element.data.main_components[1] in ['uncertainty']
+
+
+def test_plot_uncertainties(specviz_helper, spectrum1d):
+    specviz_helper.load_spectrum(spectrum1d)
+
+    specviz_viewer = specviz_helper.app.get_viewer("spectrum-viewer")
+
+    assert len(specviz_viewer.figure.marks) == 1
+
+    specviz_viewer.show_uncertainties()
+
+    assert len(specviz_viewer.figure.marks) == 2
+
+    specviz_viewer.clean()
+
+    assert len(specviz_viewer.figure.marks) == 1

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -1,5 +1,5 @@
 from astropy import units as u
-from bqplot.marks import Lines
+from bqplot.marks import Lines, Scatter
 from glue.core import HubListener
 from specutils import Spectrum1D
 
@@ -280,3 +280,13 @@ class LineAnalysisContinuumLeft(LineAnalysisContinuum):
 
 class LineAnalysisContinuumRight(LineAnalysisContinuumLeft):
     pass
+
+
+class LineUncertainties(Lines):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class ScatterMask(Scatter):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to allow the user to show the uncertainty of a spectrum in the specviz viewer using a UI toggle. It also fixes the code for showing uncertainties and masks, allowing them to work for multiple data selected in the specviz viewer.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1146 fixes #285

<img width="1323" alt="Screen Shot 2022-03-22 at 12 38 23 PM" src="https://user-images.githubusercontent.com/7179333/159530104-256f8302-4318-4d49-89f6-1ad392712077.png">

### TODO

- [ ] Make test coverage job pass.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
