### PR TITLE
re-usable component for viewer dropdown

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -77,6 +77,10 @@ ipyvue.register_component_from_file(None, 'plugin-subset-select',
                                     os.path.join(os.path.dirname(__file__),
                                                  'components/plugin_subset_select.vue'))
 
+ipyvue.register_component_from_file(None, 'plugin-viewer-select',
+                                    os.path.join(os.path.dirname(__file__),
+                                                 'components/plugin_viewer_select.vue'))
+
 # Register pure vue component. This allows us to do recursive component instantiation only in the
 # vue component file
 ipyvue.register_component_from_file('g-viewer-tab', "container.vue", __file__)

--- a/jdaviz/components/plugin_viewer_select.vue
+++ b/jdaviz/components/plugin_viewer_select.vue
@@ -1,0 +1,46 @@
+<template>
+  <div>
+  <v-row v-if="items.length > 1">
+    <v-select
+      :items="items"
+      v-model="selected"
+      @change="$emit('update:selected', $event)"
+      :label="label ? label : 'Viewer'"
+      :hint="hint ? hint : 'Select viewer.'"
+      :rules="rules ? rules : []"
+      item-text="ref_or_id"
+      item-value="ref_or_id"
+      persistent-hint
+    >
+    <template slot="selection" slot-scope="data">
+      <div class="single-line">
+        <span>
+          {{ data.item.ref_or_id }}
+        </span>
+      </div>
+    </template>
+    <template slot="item" slot-scope="data">
+      <div class="single-line">
+        <span>
+          {{ data.item.ref_or_id }}
+        </span>
+      </div>
+    </template>
+    </v-select>
+  </v-row>
+  </div>
+</template>
+
+<script>
+module.exports = {
+  props: ['items', 'selected', 'label', 'hint', 'rules']
+};
+</script>
+
+<style>
+  .single-line {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+  }
+</style>

--- a/jdaviz/configs/default/plugins/export_plot/export_plot.py
+++ b/jdaviz/configs/default/plugins/export_plot/export_plot.py
@@ -1,41 +1,22 @@
-from traitlets import List, Unicode
-
-from jdaviz.core.events import (ViewerAddedMessage, ViewerRemovedMessage)
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import TemplateMixin
+from jdaviz.core.template_mixin import TemplateMixin, ViewerSelectMixin
 
 __all__ = ['ExportViewer']
 
 
 @tray_registry('g-export-plot', label="Export Plot")
-class ExportViewer(TemplateMixin):
+class ExportViewer(TemplateMixin, ViewerSelectMixin):
     template_file = __file__, "export_plot.vue"
-    viewer_items = List([]).tag(sync=True)
-    selected_viewer = Unicode("").tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        self.hub.subscribe(self, ViewerAddedMessage,
-                           handler=lambda _: self._on_viewers_changed())
-        self.hub.subscribe(self, ViewerRemovedMessage,
-                           handler=lambda _: self._on_viewers_changed())
-
-        # initialize viewer_items from original viewers
-        self._on_viewers_changed()
-
-    def _on_viewers_changed(self):
-        self.viewer_items = self.app.get_viewer_ids()
-        if self.selected_viewer not in self.viewer_items:
-            # default to first entry, will trigger _on_viewer_select to set layer defaults
-            self.selected_viewer = self.viewer_items[0] if len(self.viewer_items) else ""
 
     def vue_save_figure(self, filetype):
         """
         Callback for save figure events in the front end viewer toolbars. Uses
         the bqplot.Figure save methods.
         """
-        viewer = self.app.get_viewer_by_id(self.selected_viewer)
+        viewer = self.viewer.selected_obj
         if filetype == "png":
             viewer.figure.save_png()
         elif filetype == "svg":

--- a/jdaviz/configs/default/plugins/export_plot/export_plot.vue
+++ b/jdaviz/configs/default/plugins/export_plot/export_plot.vue
@@ -4,17 +4,14 @@
       <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#export-plot'">Export viewer plot as an image.</j-docs-link>
     </v-row>
 
-    <v-row v-if="viewer_items.length > 1">
-      <v-select
-        :items="viewer_items"
-        v-model="selected_viewer"
-        label="Viewer"
-        hint="Select the viewer to export."
-        persistent-hint
-      ></v-select>
-    </v-row>
+    <plugin-viewer-select
+      :items="viewer_items"
+      :selected.sync="viewer_selected"
+      label="Viewer"
+      hint="Select the viewer to export."
+    />
 
-    <div v-if="selected_viewer">
+    <div v-if="viewer_selected">
       <v-list>
        <v-list-item>
         <v-btn

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -4,20 +4,17 @@
       <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#plot-options'">Viewer and data/layer options.</j-docs-link>
     </v-row>
 
-    <v-row v-if="viewer_items.length > 1">
-      <v-select
-        :items="viewer_items"
-        v-model="selected_viewer"
-        label="Viewer"
-        hint="Select the viewer to set options."
-        persistent-hint
-      ></v-select>
-    </v-row>
+    <plugin-viewer-select
+      :items="viewer_items"
+      :selected.sync="viewer_selected"
+      label="Viewer"
+      hint="Select the viewer to set options."
+    />
 
-    <div v-if="selected_viewer">
+    <div v-if="viewer_selected">
       <j-plugin-section-header>Viewer Options</j-plugin-section-header>
       <v-row class="row-no-outside-padding">
-        <jupyter-widget v-if="selected_viewer" :widget="viewer_widget"></jupyter-widget>
+        <jupyter-widget v-if="viewer_selected" :widget="viewer_widget"></jupyter-widget>
       </v-row>
 
       <v-row v-if="['specviz', 'mosviz', 'specviz2d', 'cubeviz'].indexOf(config)!==-1">
@@ -31,7 +28,7 @@
       
       <j-plugin-section-header>Layer Options</j-plugin-section-header>      
       <v-row class="row-no-outside-padding">
-        <jupyter-widget v-if="selected_viewer" :widget="layer_widget"></jupyter-widget>
+        <jupyter-widget v-if="viewer_selected" :widget="layer_widget"></jupyter-widget>
       </v-row>
     </div>
 

--- a/jdaviz/configs/imviz/plugins/compass/compass.py
+++ b/jdaviz/configs/imviz/plugins/compass/compass.py
@@ -1,48 +1,38 @@
-from traitlets import Unicode, List, observe
+from traitlets import Unicode, observe
 
-from jdaviz.core.events import (ViewerAddedMessage, ViewerRemovedMessage,
-                                AddDataMessage, RemoveDataMessage)
+from jdaviz.core.events import AddDataMessage, RemoveDataMessage
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import PluginTemplateMixin
+from jdaviz.core.template_mixin import PluginTemplateMixin, ViewerSelectMixin
 
 __all__ = ['Compass']
 
 
 @tray_registry('imviz-compass', label="Imviz Compass")
-class Compass(PluginTemplateMixin):
+class Compass(PluginTemplateMixin, ViewerSelectMixin):
     template_file = __file__, "compass.vue"
-    viewer_items = List([]).tag(sync=True)
-    selected_viewer = Unicode("").tag(sync=True)
     data_label = Unicode("").tag(sync=True)
     img_data = Unicode("").tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewers_changed)
-        self.hub.subscribe(self, ViewerRemovedMessage, handler=self._on_viewers_changed)
         self.hub.subscribe(self, AddDataMessage, handler=self._on_viewer_data_changed)
         self.hub.subscribe(self, RemoveDataMessage, handler=self._on_viewer_data_changed)
 
-        self._on_viewers_changed()  # Populate it on start-up
-
-    def _on_viewers_changed(self, msg=None):
-        self.viewer_items = self.app.get_viewer_ids()
-
-        # Selected viewer was removed but Imviz always has a default viewer to fall back on.
-        if self.selected_viewer not in self.viewer_items:
-            self.selected_viewer = f'{self.app.config}-0'
-
     def _on_viewer_data_changed(self, msg=None):
-        if self.selected_viewer:
-            viewer = self.app.get_viewer_by_id(self.selected_viewer)
+        if self.viewer_selected:
+            viewer = self.viewer.selected_obj
             viewer.on_limits_change()  # Force redraw
 
-    @observe("selected_viewer", "plugin_opened")
+    @observe("viewer_selected", "plugin_opened")
     def _compass_with_new_viewer(self, *args, **kwargs):
+        if not hasattr(self, 'viewer'):
+            # mixin object not yet initialized
+            return
+
         # There can be only one!
         for vid, viewer in self.app._viewer_store.items():
-            if vid == self.selected_viewer and self.plugin_opened:
+            if vid == self.viewer.selected_id and self.plugin_opened:
                 viewer.compass = self
                 viewer.on_limits_change()  # Force redraw
             else:

--- a/jdaviz/configs/imviz/plugins/compass/compass.vue
+++ b/jdaviz/configs/imviz/plugins/compass/compass.vue
@@ -6,15 +6,12 @@
       </j-docs-link>
     </v-row>
 
-    <v-row>
-      <v-select
-        :items="viewer_items"
-        v-model="selected_viewer"
-        label="Viewer"
-        hint="Select a viewer to show."
-        persistent-hint
-      ></v-select>
-    </v-row>
+    <plugin-viewer-select
+      :items="viewer_items"
+      :selected.sync="viewer_selected"
+      label="Viewer"
+      hint="Select a viewer to show."
+    />
 
     <v-row v-if="data_label">
       <v-chip

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -9,7 +9,7 @@ from glue.core.subset import RoiSubsetState
 from traitlets import Bool, List, Unicode
 
 from jdaviz import __version__
-from jdaviz.core.events import (ViewerAddedMessage, ViewerRemovedMessage)
+from jdaviz.core.events import ViewerAddedMessage, ViewerRemovedMessage
 
 __all__ = ['TemplateMixin', 'PluginTemplateMixin',
            'BasePluginComponent',
@@ -458,12 +458,11 @@ class ViewerSelect(BasePluginComponent):
     * ``selected_id`` (string corresponding to the id of ``selected_item``)
     * ``selected_obj`` (viewer item corresponding to ``selected``)
 
-
     To use in a plugin:
 
     * create traitlets with default values
     * register with all the automatic logic in the plugin's init by passing the string names
-      of the respective traitlets.
+      of the respective traitlets
     * use component in plugin template (see below)
     * refer to properties above based on the interally stored reference to the
       instantiated object of this component
@@ -479,14 +478,10 @@ class ViewerSelect(BasePluginComponent):
 
     """
     def __init__(self, plugin, items, selected):
-        super().__init__(plugin,
-                         items=items,
-                         selected=selected)
+        super().__init__(plugin, items=items, selected=selected)
 
-        self.hub.subscribe(self, ViewerAddedMessage,
-                           handler=lambda _: self._on_viewers_changed())
-        self.hub.subscribe(self, ViewerRemovedMessage,
-                           handler=lambda _: self._on_viewers_changed())
+        self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewers_changed)
+        self.hub.subscribe(self, ViewerRemovedMessage, handler=self._on_viewers_changed)
         self.add_observe(selected, self._selected_changed)
 
         # initialize viewer_items from original viewers
@@ -538,7 +533,8 @@ class ViewerSelect(BasePluginComponent):
             # default to first entry, will trigger any observer on selected
             self.selected = self.ref_or_ids[0] if len(self.items) else ""
 
-    def _on_viewers_changed(self):
+    def _on_viewers_changed(self, msg=None):
+        # NOTE: _on_viewers_changed is passed without a msg object during init
         # list of dictionaries with id, ref, ref_or_id
         def _dict_from_viewer(viewer_item):
             d = {'id': viewer_item['id']}
@@ -597,6 +593,4 @@ class ViewerSelectMixin(VuetifyTemplate, HubListener):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.viewer = ViewerSelect(self,
-                                   'viewer_items',
-                                   'viewer_selected')
+        self.viewer = ViewerSelect(self, 'viewer_items', 'viewer_selected')

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -9,10 +9,12 @@ from glue.core.subset import RoiSubsetState
 from traitlets import Bool, List, Unicode
 
 from jdaviz import __version__
+from jdaviz.core.events import (ViewerAddedMessage, ViewerRemovedMessage)
 
 __all__ = ['TemplateMixin', 'PluginTemplateMixin',
            'BasePluginComponent',
-           'SubsetSelect', 'SpatialSubsetSelectMixin', 'SpectralSubsetSelectMixin']
+           'SubsetSelect', 'SpatialSubsetSelectMixin', 'SpectralSubsetSelectMixin',
+           'ViewerSelect', 'ViewerSelectMixin']
 
 
 class TemplateMixin(VuetifyTemplate, HubListener):
@@ -436,3 +438,165 @@ class SpatialSubsetSelectMixin(VuetifyTemplate, HubListener):
                                            'spatial_subset_selected_has_subregions',
                                            default_text='No Subset',
                                            allowed_type='spatial')
+
+
+class ViewerSelect(BasePluginComponent):
+    """
+    Traitlets (in the object, custom traitlets in the plugin):
+
+    * ``items`` (list of dicts with keys: id, reference, ref_or_id)
+    * ``selected`` (string)
+
+    Properties (in the object only):
+
+    * ``ids`` (list of ids corresponding to ``items``)
+    * ``references`` (list of references corresponding to ``items``)
+    * ``ref_or_ids`` (list of references falling back on ids corresponding to ``items``.  These
+        are the values seen in the dropdown, although setting either id or reference to the traitlet
+        will still process correctly)
+    * ``selected_item`` (dict of the currently selected entry in ``items``)
+    * ``selected_id`` (string corresponding to the id of ``selected_item``)
+    * ``selected_obj`` (viewer item corresponding to ``selected``)
+
+
+    To use in a plugin:
+
+    * create traitlets with default values
+    * register with all the automatic logic in the plugin's init by passing the string names
+      of the respective traitlets.
+    * use component in plugin template (see below)
+    * refer to properties above based on the interally stored reference to the
+      instantiated object of this component
+
+    Example template (label and hint are optional)::
+
+      <plugin-viewer-select
+        :items="viewer_items"
+        :selected.sync="viewer_selected"
+        label="Viewer"
+        hint="Select viewer."
+      />
+
+    """
+    def __init__(self, plugin, items, selected):
+        super().__init__(plugin,
+                         items=items,
+                         selected=selected)
+
+        self.hub.subscribe(self, ViewerAddedMessage,
+                           handler=lambda _: self._on_viewers_changed())
+        self.hub.subscribe(self, ViewerRemovedMessage,
+                           handler=lambda _: self._on_viewers_changed())
+        self.add_observe(selected, self._selected_changed)
+
+        # initialize viewer_items from original viewers
+        self._on_viewers_changed()
+
+    @property
+    def ids(self):
+        return [item['id'] for item in self.items]
+
+    @property
+    def references(self):
+        return [item['reference'] for item in self.items]
+
+    @property
+    def ref_or_ids(self):
+        return [item['ref_or_id'] for item in self.items]
+
+    @property
+    def selected_item(self):
+        for item in self.items:
+            if item['ref_or_id'] == self.selected:
+                return item
+        # try again but this time allow match to id alone.  Note that _selected_changed
+        # will handle resetting the trait to the reference since it exists, but this
+        # will allow access to the underlying item/object for any observes in the meantime.
+        for item in self.items:
+            if item['id'] == self.selected:
+                return item
+
+    @property
+    def selected_id(self):
+        return self.selected_item['id']
+
+    @property
+    def selected_obj(self):
+        return self.app.get_viewer_by_id(self.selected_id)
+
+    def _selected_changed(self, event):
+        if event['new'] not in self.ref_or_ids:
+            if self.selected in self.ids:
+                # provided id in place of ref
+                self.selected = self.ref_or_ids[self.ids.index(self.selected)]
+            else:
+                self._handle_default()
+                raise ValueError(f"{event['new']} not one of {self.ref_or_ids}")
+
+    def _handle_default(self):
+        if self.selected not in self.ref_or_ids:
+            # default to first entry, will trigger any observer on selected
+            self.selected = self.ref_or_ids[0] if len(self.items) else ""
+
+    def _on_viewers_changed(self):
+        # list of dictionaries with id, ref, ref_or_id
+        def _dict_from_viewer(viewer_item):
+            d = {'id': viewer_item['id']}
+            if viewer_item.get('reference') is not None:
+                d['reference'] = viewer_item['reference']
+                d['ref_or_id'] = viewer_item['reference']
+            else:
+                d['reference'] = None
+                d['ref_or_id'] = viewer_item['id']
+            return d
+
+        self.items = [_dict_from_viewer(self.app._viewer_item_by_id(vid))
+                      for vid in self.app._viewer_store]
+        self._handle_default()
+
+
+class ViewerSelectMixin(VuetifyTemplate, HubListener):
+    """
+    Applies the ViewerSelect component as a mixin in the base plugin.  This
+    automatically adds traitlets as well as new properties to the plugin with minimal
+    extra code.  For multiple instances or custom traitlet names/defaults, use the
+    SpectralSubsetSelect component instead.
+
+    Traitlets (available from the plugin):
+
+    * ``viewer_items``
+    * ``viewer_selected``
+
+    Properties (available from the plugin):
+
+    * ``viewer.ids``
+    * ``viewer.references``
+    * ``viewer.ref_or_ids``
+    * ``viewer.selected_item``
+    * ``viewer.selected_id``
+    * ``viewer.selected_obj``
+
+    To use in a plugin:
+
+    * add ``ViewerSelectMixin`` as a mixin to the class
+    * use the traitlets and properties above as needed (note the prefix for properties)
+
+    Example template (label and hint are optional)::
+
+        <v-row>
+          <plugin-viewer-select
+            :items="viewer_items"
+            :selected.sync="viewer_selected"
+            label="Viewer"
+            hint="Select viewer."
+          />
+        </v-row>
+    """
+    viewer_items = List().tag(sync=True)
+    viewer_selected = Unicode().tag(sync=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.viewer = ViewerSelect(self,
+                                   'viewer_items',
+                                   'viewer_selected')

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -547,7 +547,8 @@ class ViewerSelect(BasePluginComponent):
             return d
 
         self.items = [_dict_from_viewer(self.app._viewer_item_by_id(vid))
-                      for vid in self.app._viewer_store]
+                      for vid, viewer in self.app._viewer_store.items()
+                      if viewer.__class__.__name__ != 'MosvizTableViewer']
         self._handle_default()
 
 

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -1,3 +1,5 @@
+import pytest
+
 from glue.core.roi import XRangeROI
 
 
@@ -35,15 +37,24 @@ def test_spectralsubsetselect(specviz_helper, spectrum1d):
     assert p.spectral_subset.selected_obj is not None
 
 
-def test_viewer_select(specviz_helper, spectrum1d):
-    specviz_helper.load_spectrum(spectrum1d)
-    sv = specviz_helper.app.get_viewer('spectrum-viewer')
+@pytest.mark.filterwarnings('ignore:No observer defined on WCS')
+def test_viewer_select(cubeviz_helper, spectrum1d_cube):
+    app = cubeviz_helper.app
+    app.add_data(spectrum1d_cube, 'test')
+    app.add_data_to_viewer("spectrum-viewer", "test")
+    app.add_data_to_viewer("flux-viewer", "test")
+    fv = app.get_viewer("flux-viewer")
+    sv = app.get_viewer("spectrum-viewer")
 
     # export plot uses the mixin
-    p = specviz_helper.app.get_tray_item_from_name('g-export-plot')
-    assert len(p.viewer.ids) == 1
-    assert len(p.viewer.references) == 1
-    assert len(p.viewer.ref_or_ids) == 1
+    p = app.get_tray_item_from_name('g-export-plot')
+    assert len(p.viewer.ids) == 4
+    assert len(p.viewer.references) == 4
+    assert len(p.viewer.ref_or_ids) == 4
+    assert p.viewer.selected_obj == fv
+
+    # set by reference
+    p.viewer_selected = 'spectrum-viewer'
     assert p.viewer.selected_obj == sv
 
     # try setting based on id instead of reference

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -33,3 +33,19 @@ def test_spectralsubsetselect(specviz_helper, spectrum1d):
     assert p.spectral_subset.selected_obj is None
     p.spectral_subset_selected = 'Subset 1'
     assert p.spectral_subset.selected_obj is not None
+
+
+def test_viewer_select(specviz_helper, spectrum1d):
+    specviz_helper.load_spectrum(spectrum1d)
+    sv = specviz_helper.app.get_viewer('spectrum-viewer')
+
+    # export plot uses the mixin
+    p = specviz_helper.app.get_tray_item_from_name('g-export-plot')
+    assert len(p.viewer.ids) == 1
+    assert len(p.viewer.references) == 1
+    assert len(p.viewer.ref_or_ids) == 1
+    assert p.viewer.selected_obj == sv
+
+    # try setting based on id instead of reference
+    p.viewer_selected = p.viewer.ids[0]
+    assert p.viewer_selected == p.viewer.ref_or_ids[0]

--- a/jdaviz/core/tools.py
+++ b/jdaviz/core/tools.py
@@ -146,7 +146,7 @@ class SelectLine(CheckableTool, HubListener):
 
 class _BaseSidebarShortcut(Tool):
     plugin_label = None  # define in subclass
-    viewer_select_traitlet = 'selected_viewer'
+    viewer_select_traitlet = 'viewer_selected'
 
     def activate(self):
         jdaviz_state = self.viewer.jdaviz_app.state
@@ -162,7 +162,7 @@ class _BaseSidebarShortcut(Tool):
 @viewer_tool
 class SidebarShortcutPlotOptions(_BaseSidebarShortcut):
     plugin_name = 'g-plot-options'
-    viewer_select_traitlet = 'selected_viewer'
+    viewer_select_traitlet = 'viewer_selected'
 
     icon = os.path.join(ICON_DIR, 'tune.svg')
     tool_id = 'jdaviz:sidebar_plot'
@@ -173,7 +173,7 @@ class SidebarShortcutPlotOptions(_BaseSidebarShortcut):
 @viewer_tool
 class SidebarShortcutExportPlot(_BaseSidebarShortcut):
     plugin_name = 'g-export-plot'
-    viewer_select_traitlet = 'selected_viewer'
+    viewer_select_traitlet = 'viewer_selected'
 
     icon = os.path.join(ICON_DIR, 'image.svg')
     tool_id = 'jdaviz:sidebar_export'
@@ -184,7 +184,7 @@ class SidebarShortcutExportPlot(_BaseSidebarShortcut):
 @viewer_tool
 class SidebarShortcutCompass(_BaseSidebarShortcut):
     plugin_name = 'imviz-compass'
-    viewer_select_traitlet = 'selected_viewer'
+    viewer_select_traitlet = 'viewer_selected'
 
     icon = os.path.join(ICON_DIR, 'compass.svg')
     tool_id = 'jdaviz:sidebar_compass'


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request continues the pattern in #1156 to pull up duplicated logic from plugins and into a re-usable component for viewer select dropdowns.  In doing so, it also gives flexibility for reference vs ID (so that cubeviz will show the more user-friendly "uncert-viewer" names instead of "cubeviz-2" but imviz will still work with IDs since references are never created).  All other functionality should be unchanged - this is mostly just a code refactoring.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
