### PR TITLE
image viewers: default to panzoom tools

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,8 +76,8 @@ Other Changes and Additions
 
 - Jdaviz now requires Python 3.8 or later. [#1145]
 
-- Viewer toolbars are now nested and consolidated, with viewer and layer options
-  moved to the sidebar. [#1140]
+- Viewer toolbars are now nested and consolidated, with default tools and viewer and layer options
+  moved to the sidebar. [#1140, #1203]
 
 - Redshifts imported with a custom line list are now ignored.  Redshift must be set app-wide via 
   viz.set_redshift or the line list plugin. [#1134]

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -34,7 +34,8 @@ class CubevizImageView(BqplotImageView, JdavizViewerMixin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._initialize_toolbar_nested()
+        # default to any zoom/pan tool, whichever is currently primary
+        self._initialize_toolbar_nested(default_tool_priority=self.tools_nested[1])
 
     def set_plot_axes(self):
         self.figure.axes[1].tick_format = None

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -42,7 +42,8 @@ class ImvizImageView(BqplotImageView, AstrowidgetsImageViewerMixin, JdavizViewer
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.init_astrowidgets_api()
-        self._initialize_toolbar_nested()
+        # default to either panzoom tool (whichever is currently primary)
+        self._initialize_toolbar_nested(default_tool_priority=self.tools_nested[2])
 
         self.label_mouseover = None
         self.compass = None

--- a/jdaviz/configs/mosviz/plugins/viewers.py
+++ b/jdaviz/configs/mosviz/plugins/viewers.py
@@ -86,7 +86,8 @@ class MosvizImageView(BqplotImageView, JdavizViewerMixin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._initialize_toolbar_nested()
+        # default to either panzoom tool (whichever is currently primary)
+        self._initialize_toolbar_nested(default_tool_priority=self.tools_nested[2])
 
     def data(self, cls=None):
         return [layer_state.layer  # .get_object(cls=cls or self.default_class)


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request makes pan/zoom tools the default tool for all image viewers, which effectively disables support (without then manually disabling the default pan/zoom tool) for manually editing a subset after it has been "finalized" and therefore _avoids_ #1200.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
