### PR TITLE
re-usable dataset select component

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,8 @@ Other Changes and Additions
 - Change default collapse function to sum.
   This affects collapsed spectrum in Cubeviz and its Collapse plugin default. [#1229]
 
+- Data dropdowns in plugins are now filtered to only applicable entries. [#1221]
+
 2.4 (2022-03-29)
 ================
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -73,6 +73,10 @@ ipyvue.register_component_from_file(None, 'j-plugin-section-header',
                                     os.path.join(os.path.dirname(__file__),
                                                  'components/plugin_section_header.vue'))
 
+ipyvue.register_component_from_file(None, 'plugin-dataset-select',
+                                    os.path.join(os.path.dirname(__file__),
+                                                 'components/plugin_dataset_select.vue'))
+
 ipyvue.register_component_from_file(None, 'plugin-subset-select',
                                     os.path.join(os.path.dirname(__file__),
                                                  'components/plugin_subset_select.vue'))

--- a/jdaviz/components/plugin_dataset_select.vue
+++ b/jdaviz/components/plugin_dataset_select.vue
@@ -5,8 +5,8 @@
       :items="items"
       v-model="selected"
       @change="$emit('update:selected', $event)"
-      :label="label ? label : 'Viewer'"
-      :hint="hint ? hint : 'Select viewer.'"
+      :label="label ? label : 'Data'"
+      :hint="hint ? hint : 'Select data.'"
       :rules="rules ? rules : []"
       item-text="label"
       item-value="label"
@@ -30,7 +30,6 @@
   </v-row>
  </div>
 </template>
-
 <script>
 module.exports = {
   props: ['items', 'selected', 'label', 'hint', 'rules', 'show_if_single_entry']

--- a/jdaviz/components/plugin_subset_select.vue
+++ b/jdaviz/components/plugin_subset_select.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-  <v-row>
+  <v-row v-if="items.length > 1 || show_if_single_entry">
     <v-select
       :items="items"
       v-model="selected"
@@ -44,7 +44,7 @@
 
 <script>
 module.exports = {
-  props: ['items', 'selected', 'label', 'has_subregions', 'has_subregions_warning', 'hint', 'rules']
+  props: ['items', 'selected', 'label', 'has_subregions', 'has_subregions_warning', 'hint', 'rules', 'show_if_single_entry']
 };
 </script>
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -58,9 +58,9 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
         # Need transpose to align JWST mirror shape. Not sure why.
         self.moment = CCDData(analysis.moment(slab, order=n_moment).T)
 
-        label = "Moment {}: {}".format(n_moment, self.dataset_selected)
+        label = f"Moment {n_moment}: {self.dataset_selected}"
         fname_label = self.dataset_selected.replace("[", "_").replace("]", "")
-        self.filename = "moment{}_{}.fits".format(n_moment, fname_label)
+        self.filename = f"moment{n_moment}_{fname_label}.fits"
 
         # Add information to meta data that this originated from
         # the moment map plugin. Then, link the moment map data

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
@@ -4,15 +4,13 @@
       <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#moment-maps'">Create a 2D image from a data cube</j-docs-link>
     </v-row>
 
-    <v-row>
-      <v-select
-        :items="dc_items"
-        v-model="selected_data"
-        label="Data"
-        hint="Select the data set."
-        persistent-hint
-      ></v-select>
-    </v-row>
+    <plugin-dataset-select
+      :items="dataset_items"
+      :selected.sync="dataset_selected"
+      :show_if_single_entry="false"
+      label="Data"
+      hint="Select the data set."
+    />
 
     <plugin-subset-select 
       :items="spectral_subset_items"
@@ -36,8 +34,9 @@
     <v-row>
       <v-text-field
         ref="n_moment"
+        type="number"
         label="Moment"
-        v-model="n_moment"
+        v-model.number="n_moment"
         hint="The desired moment."
         persistent-hint
         :rules="[() => !!n_moment || 'This field is required']"

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
@@ -16,6 +16,7 @@
       :items="spectral_subset_items"
       :selected.sync="spectral_subset_selected"
       :has_subregions="spectral_subset_selected_has_subregions"
+      :show_if_single_entry="true"
       has_subregions_warning="The selected selected subset has subregions, the entire range will be used, ignoring any gaps."
       label="Spectral region"
       hint="Spectral region to compute the moment map."

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -11,12 +11,10 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     app = cubeviz_helper.app
     dc = app.data_collection
     app.add_data(spectrum1d_cube, 'test[FLUX]')
+    app.add_data_to_viewer('flux-viewer', 'test[FLUX]')
 
     mm = MomentMap(app=app)
-    mm._subset_selected = 'None'
-    mm._on_data_updated(None)
-
-    mm._on_data_selected({'new': 'test[FLUX]'})
+    mm.dataset_selected = 'test[FLUX]'
 
     mm.n_moment = 0  # Collapsed sum, will get back 2D spatial image
     mm.vue_calculate_moment()

--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -1,26 +1,23 @@
 import warnings
 
-from astropy import units as u
-from glue.core.message import (DataCollectionAddMessage,
-                               DataCollectionDeleteMessage)
 from glue.core import Data
 from glue.core.link_helpers import LinkSame
 from specutils import Spectrum1D
 from specutils.manipulation import spectral_slab
-from traitlets import List, Unicode, observe
+from traitlets import List, Unicode
 
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import PluginTemplateMixin, SpectralSubsetSelectMixin
+from jdaviz.core.template_mixin import (PluginTemplateMixin,
+                                        DatasetSelectMixin,
+                                        SpectralSubsetSelectMixin)
 
 __all__ = ['Collapse']
 
 
 @tray_registry('g-collapse', label="Collapse")
-class Collapse(PluginTemplateMixin, SpectralSubsetSelectMixin):
+class Collapse(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMixin):
     template_file = __file__, "collapse.vue"
-    data_items = List([]).tag(sync=True)
-    selected_data_item = Unicode().tag(sync=True)
     funcs = List(['Mean', 'Median', 'Min', 'Max', 'Sum']).tag(sync=True)
     selected_func = Unicode('Sum').tag(sync=True)
 
@@ -31,48 +28,22 @@ class Collapse(PluginTemplateMixin, SpectralSubsetSelectMixin):
     viewers = List(['None', 'Left', 'Center', 'Right']).tag(sync=True)
     selected_viewer = Unicode('None').tag(sync=True)
 
-    spectral_unit = Unicode().tag(sync=True)
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.hub.subscribe(self, DataCollectionAddMessage,
-                           handler=self._on_data_updated)
-        self.hub.subscribe(self, DataCollectionDeleteMessage,
-                           handler=self._on_data_updated)
-
-        self._selected_data = None
-        self._selected_cube = None
         self._label_counter = 0
 
-    def _on_data_updated(self, msg):
-        self.data_items = [x.label for x in self.data_collection]
-        # Default to selecting the first loaded cube
-        if self._selected_data is None:
-            for i in range(len(self.data_items)):
-                try:
-                    self.selected_data_item = self.data_items[i]
-                except (ValueError, TypeError):
-                    continue
-
-    @observe('selected_data_item')
-    def _on_data_item_selected(self, event):
-        data_label = event['new']
-        if data_label not in self.data_collection.labels:
-            return
-        self._selected_data = self.data_collection[self.data_collection.labels.index(data_label)]
-        self._selected_cube = self._selected_data.get_object(cls=Spectrum1D, statistic=None)
-        self.spectral_unit = self._selected_cube.spectral_axis.unit.to_string()
+        self.dataset.add_filter('is_image')
 
     def vue_collapse(self, *args, **kwargs):
         # Collapsing over the spectral axis. Cut out the desired spectral
         # region. Defaults to the entire spectrum.
-        spec_min = float(self.spectral_subset.selected_min(self._selected_cube)) * u.Unit(self.spectral_unit) # noqa
-        spec_max = float(self.spectral_subset.selected_max(self._selected_cube)) * u.Unit(self.spectral_unit) # noqa
+        cube = self.dataset.get_object(cls=Spectrum1D, statistic=None)
+        spec_min, spec_max = self.spectral_subset.selected_min_max(cube)
 
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', message='No observer defined on WCS')
-            spec = spectral_slab(self._selected_cube, spec_min, spec_max)
+            spec = spectral_slab(cube, spec_min, spec_max)
             # Spatial-spatial image only.
             collapsed_spec = spec.collapse(self.selected_func.lower(), axis=-1).T  # Quantity
 
@@ -81,7 +52,7 @@ class Collapse(PluginTemplateMixin, SpectralSubsetSelectMixin):
         data.get_component('flux').units = str(collapsed_spec.unit)
 
         self._label_counter += 1
-        label = f"Collapsed {self._label_counter} {self._selected_data.label}"
+        label = f"Collapsed {self._label_counter} {self.dataset_selected}"
 
         data.meta["Plugin"] = "Collapse"
         self.app.add_data(data, label)
@@ -89,7 +60,7 @@ class Collapse(PluginTemplateMixin, SpectralSubsetSelectMixin):
         self._link_collapse_data()
 
         snackbar_message = SnackbarMessage(
-            f"Data set '{self._selected_data.label}' collapsed successfully.",
+            f"Data set '{self.dataset_selected}' collapsed successfully.",
             color="success",
             sender=self)
         self.hub.broadcast(snackbar_message)

--- a/jdaviz/configs/default/plugins/collapse/collapse.vue
+++ b/jdaviz/configs/default/plugins/collapse/collapse.vue
@@ -4,15 +4,13 @@
       <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#collapse'">Collapse a spectral cube along one axis.</j-docs-link>
     </v-row>
 
-    <v-row>
-      <v-select
-        :items="data_items"
-        v-model="selected_data_item"
-        label="Data"
-        hint="Select the data set to use in collapse."
-        persistent-hint
-      ></v-select>
-    </v-row>
+    <plugin-dataset-select
+      :items="dataset_items"
+      :selected.sync="dataset_selected"
+      :show_if_single_entry="false"
+      label="Data"
+      hint="Select the data set to collapse."
+    />
 
     <v-row>
       <v-select
@@ -24,27 +22,24 @@
       ></v-select>
     </v-row>
 
-    <div>
-      <plugin-subset-select 
-        :items="spectral_subset_items"
-        :selected.sync="spectral_subset_selected"
-        :has_subregions="spectral_subset_selected_has_subregions"
-        has_subregions_warning="The selected selected subset has subregions, the entire range will be used, ignoring any gaps."
-        label="Spectral region"
-        hint="Select spectral region to apply the collapse."
-      />
+    <plugin-subset-select 
+      :items="spectral_subset_items"
+      :selected.sync="spectral_subset_selected"
+      :has_subregions="spectral_subset_selected_has_subregions"
+      has_subregions_warning="The selected selected subset has subregions, the entire range will be used, ignoring any gaps."
+      label="Spectral region"
+      hint="Select spectral region to apply the collapse."
+    />
 
-      <v-row>
-        <v-select
-          :items="viewers"
-          v-model="selected_viewer"
-          label='Plot in Viewer'
-          hint='Collapsed cube will replace plot in the specified viewer.  Will also be available in the data dropdown in all image viewers.'
-          persistent-hint
-        ></v-select>
-      </v-row>
-
-    </div>
+    <v-row>
+      <v-select
+        :items="viewers"
+        v-model="selected_viewer"
+        label='Plot in Viewer'
+        hint='Collapsed cube will replace plot in the specified viewer.  Will also be available in the data dropdown in all image viewers.'
+        persistent-hint
+      ></v-select>
+    </v-row>
 
     <v-row justify="end">
       <j-tooltip tipid='plugin-collapse-apply'>

--- a/jdaviz/configs/default/plugins/collapse/collapse.vue
+++ b/jdaviz/configs/default/plugins/collapse/collapse.vue
@@ -26,6 +26,7 @@
       :items="spectral_subset_items"
       :selected.sync="spectral_subset_selected"
       :has_subregions="spectral_subset_selected_has_subregions"
+      :show_if_single_entry="true"
       has_subregions_warning="The selected selected subset has subregions, the entire range will be used, ignoring any gaps."
       label="Spectral region"
       hint="Select spectral region to apply the collapse."

--- a/jdaviz/configs/default/plugins/collapse/tests/test_collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/tests/test_collapse.py
@@ -14,6 +14,7 @@ def test_linking_after_collapse(cubeviz_helper, spectral_cube_wcs):
     coll = Collapse(app=cubeviz_helper.app)
 
     coll.selected_data_item = 'Unknown spectrum object[FLUX]'
+    coll.dataset_selected = 'Unknown spectrum object[FLUX]'
 
     coll.add_replace_results = False
     coll.vue_collapse()

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -43,7 +43,7 @@ class GaussianSmooth(TemplateMixin, DatasetSelectMixin):
         if self.config == "cubeviz":
             self.show_modes = True
             # retrieve the data from the cube, not the collapsed 1d spectrum
-            self.dataset._viewer_refs = ['flux-viewer', 'spectrum-viewer']
+            self.dataset._viewers = ['flux-viewer', 'spectrum-viewer']
             # clear the cache in case the spectrum-viewer selection was already cached
             self.dataset._clear_cache()
 

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.vue
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.vue
@@ -4,15 +4,15 @@
         <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#gaussian-smooth'">Smooth your data in xy or wavelength with a Gaussian kernel</j-docs-link>
       </v-row>
 
-      <v-row>
-        <v-select
-          :items="dc_items"
-          v-model="selected_data"
-          label="Data"
-          hint="Select the data set to be smoothed."
-          persistent-hint
-        ></v-select>
-      </v-row>
+      <!-- for mosviz, the entries change on row change, so we want to always show the dropdown
+           to make sure that is clear -->
+      <plugin-dataset-select
+        :items="dataset_items"
+        :selected.sync="dataset_selected"
+        :show_if_single_entry="config=='mosviz'"
+        label="Data"
+        hint="Select the data to be smoothed."
+      />
 
       <v-row v-if="show_modes">
         <v-select
@@ -27,8 +27,9 @@
       <v-row>
         <v-text-field
           ref="stddev"
+          type="number"
           label="Standard deviation"
-          v-model="stddev"
+          v-model.number="stddev"
           type="number"
           hint="The stddev of the kernel, in pixels."
           persistent-hint
@@ -36,7 +37,7 @@
         ></v-text-field>
       </v-row>
 
-      <v-row v-if="selected_data && stddev > 0">
+      <v-row v-if="dataset_selected && stddev > 0">
         <v-select v-if="selected_mode == 'Spatial'"
           :items="viewers"
           v-model="selected_viewer"
@@ -53,14 +54,14 @@
 
       <v-row justify="end">
         <j-tooltip v-if="selected_mode=='Spectral'" tipid='plugin-gaussian-apply'>
-          <v-btn :disabled="stddev <= 0 || selected_data == ''"
+          <v-btn :disabled="stddev <= 0 || dataset_selected == ''"
             color="accent" text 
             @click="spectral_smooth"
           >Apply</v-btn>
         </j-tooltip>
         <j-tooltip v-else tipid='plugin-gaussian-apply'>
           <v-btn 
-            :disabled="stddev <= 0 || selected_data == ''"
+            :disabled="stddev <= 0 || dataset_selected == ''"
             color="accent" text
             @click="spatial_convolution"
           >Apply</v-btn>

--- a/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
@@ -10,11 +10,14 @@ def test_linking_after_spectral_smooth(spectrum1d_cube):
     app = Application(configuration="cubeviz")
     dc = app.data_collection
     app.add_data(spectrum1d_cube, 'test')
+    app.add_data_to_viewer('flux-viewer', 'test')
+
+    assert len(dc) == 1
+    assert len(dc.external_links) == 0
 
     gs = GaussianSmooth(app=app)
-
-    gs._on_data_selected({'new': 'test'})
-    gs.stddev = '3.2'
+    gs.dataset_selected = 'test'
+    gs.stddev = 3.2
     gs.add_replace_results = False
     gs.vue_spectral_smooth()
 
@@ -32,10 +35,11 @@ def test_spatial_convolution(spectrum1d_cube):
     app = Application(configuration="cubeviz")
     dc = app.data_collection
     app.add_data(spectrum1d_cube, 'test')
+    app.add_data_to_viewer('flux-viewer', 'test')
 
     gs = GaussianSmooth(app=app)
-    gs._on_data_selected({'new': 'test'})
-    gs.stddev = '3'
+    gs.dataset_selected = 'test'
+    gs.stddev = 3
     gs.vue_spatial_convolution()
 
     assert len(dc) == 2

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -377,7 +377,7 @@ class LineListTool(PluginTemplateMixin):
         # by taking abs, this will work for wavelength or frequency units.
         half_range = abs(x_max - x_min) / x_mid
         ndec = -np.log10(half_range)
-        if ndec > 0:
+        if ndec > 0 and not np.isinf(ndec):
             # round to at least 2 digits, or the first significant digit
             ndec = np.max([2, int(np.ceil(ndec))])
         else:
@@ -406,7 +406,7 @@ class LineListTool(PluginTemplateMixin):
         # When using the slider, we'll "round" redshift to the digits in the
         # slider step to avoid extra digits due to rounding errors
         ndec = -np.log10(event['new'])
-        if ndec > 0:
+        if ndec > 0 and not np.isinf(ndec):
             # round to at least 2 digits, or one past the first significant digit
             # note: the UI will not show trailing zeros, we just want to avoid
             # and 1 at floating point precision if not significant

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -20,7 +20,7 @@ class MetadataViewer(TemplateMixin, DatasetSelectMixin):
 
     @observe("dataset_selected")
     def _show_metadata(self, event):
-        data = self.dataset.selected_obj
+        data = self.dataset.selected_dc_item
         if data is None:
             self.has_metadata = False
             self.metadata = []

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -16,12 +16,12 @@ class MetadataViewer(TemplateMixin, DatasetSelectMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # override the default filters on dataset entries to require metadata in entries
-        self.dataset.add_filter('has_metadata', 'not_from_plugin')
+        self.dataset.add_filter('not_from_plugin')
 
     @observe("dataset_selected")
     def _show_metadata(self, event):
         data = self.dataset.selected_dc_item
-        if data is None:
+        if data is None or not hasattr(data, 'meta') or not isinstance(data.meta, dict) or len(data.meta) < 1: # noqa
             self.has_metadata = False
             self.metadata = []
             return

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -20,12 +20,12 @@ class MetadataViewer(TemplateMixin, DatasetSelectMixin):
 
     @observe("dataset_selected")
     def _show_metadata(self, event):
-        if not self.dataset.selected:
+        data = self.dataset.selected_obj
+        if data is None:
             self.has_metadata = False
             self.metadata = []
             return
 
-        data = self.dataset.selected_obj
         if 'header' in data.meta and isinstance(data.meta['header'], (dict, Header)):
             if isinstance(data.meta['header'], Header):  # Specviz
                 meta = dict(data.meta['header'])

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.vue
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.vue
@@ -4,15 +4,15 @@
       <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#metadata-viewer'">View metadata.</j-docs-link>
     </v-row>
 
-    <v-row>
-      <v-select
-        :items="dc_items"
-        v-model="selected_data"
-        label="Data"
-        hint="Select the data to see metadata."
-        persistent-hint
-      ></v-select>
-    </v-row>
+    <!-- for specviz, we'll allow this to hide for a single entry, but since filters are being
+         applied on other configs, we'll always show -->
+    <plugin-dataset-select
+      :items="dataset_items"
+      :selected.sync="dataset_selected"
+      :show_if_single_entry="config!='specviz'"
+      label="Data"
+      hint="Select the data to see metadata."
+    />
 
     <div v-if="has_metadata">
       <j-plugin-section-header>Metadata</j-plugin-section-header>

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.vue
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.vue
@@ -14,8 +14,8 @@
       hint="Select the data to see metadata."
     />
 
+    <j-plugin-section-header>Metadata</j-plugin-section-header>
     <div v-if="has_metadata">
-      <j-plugin-section-header>Metadata</j-plugin-section-header>
       <v-row no-gutters>
         <v-col cols=6><U>Key</U></v-col>
         <v-col cols=6><U>Value</U></v-col>
@@ -28,6 +28,11 @@
         <v-col cols=6>{{ item[1] }}</v-col>
       </v-row>
     </div>
+    <v-row v-else>
+      <span class="v-messages v-messages__message text--secondary">
+          Selected data does not contain any metadata.
+      </span>
+    </v-row>
 
   </j-tray-plugin>
 </template>

--- a/jdaviz/configs/default/plugins/metadata_viewer/tests/test_metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/tests/test_metadata_viewer.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from astropy.nddata import NDData
 
 from jdaviz.configs.default.plugins.metadata_viewer.metadata_viewer import MetadataViewer
@@ -15,30 +16,32 @@ def test_view_dict(imviz_helper):
     imviz_helper.load_data(ndd_1, data_label='has_simple_meta')
     imviz_helper.load_data(ndd_2, data_label='has_nested_meta')
     imviz_helper.load_data(arr, data_label='no_meta')
-    assert mv.dc_items == ['has_simple_meta[DATA]', 'has_nested_meta[DATA]', 'no_meta']
+    assert mv.dataset.labels == ['has_simple_meta[DATA]', 'has_nested_meta[DATA]']
 
-    mv.selected_data = 'has_simple_meta[DATA]'
+    mv.dataset_selected = 'has_simple_meta[DATA]'
     assert mv.has_metadata
     assert mv.metadata == [
         ('BAR', '10.0'), ('BOZO', 'None'), ('EXTNAME', 'SCI'),
         ('EXTVER', '1'), ('FOO', '')], mv.metadata
 
-    mv.selected_data = 'has_nested_meta[DATA]'
+    mv.dataset_selected = 'has_nested_meta[DATA]'
     assert mv.has_metadata
     assert mv.metadata == [
         ('EXTNAME', 'ASDF'), ('REF.bar', '10.0'),
         ('REF.foo.1', ''), ('REF.foo.2.0', '1'), ('REF.foo.2.1', '2')], mv.metadata
 
-    mv.selected_data = 'no_meta'
-    assert not mv.has_metadata
-    assert mv.metadata == []
+    with pytest.raises(ValueError):
+        mv.dataset_selected = 'no_meta'
+    assert mv.dataset_selected == mv.dataset.labels[0]
 
 
 def test_view_invalid(imviz_helper):
     mv = MetadataViewer(app=imviz_helper.app)
-    assert mv.dc_items == []
+    assert mv.dataset.labels == []
 
     # Should not even happen but if it does, do not crash.
-    mv.selected_data = 'foo'
+    with pytest.raises(ValueError):
+        mv.dataset_selected = 'foo'
+    assert mv.dataset_selected == ''
     assert not mv.has_metadata
     assert mv.metadata == []

--- a/jdaviz/configs/default/plugins/metadata_viewer/tests/test_metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/tests/test_metadata_viewer.py
@@ -16,7 +16,7 @@ def test_view_dict(imviz_helper):
     imviz_helper.load_data(ndd_1, data_label='has_simple_meta')
     imviz_helper.load_data(ndd_2, data_label='has_nested_meta')
     imviz_helper.load_data(arr, data_label='no_meta')
-    assert mv.dataset.labels == ['has_simple_meta[DATA]', 'has_nested_meta[DATA]']
+    assert mv.dataset.labels == ['has_simple_meta[DATA]', 'has_nested_meta[DATA]', 'no_meta']
 
     mv.dataset_selected = 'has_simple_meta[DATA]'
     assert mv.has_metadata
@@ -30,9 +30,8 @@ def test_view_dict(imviz_helper):
         ('EXTNAME', 'ASDF'), ('REF.bar', '10.0'),
         ('REF.foo.1', ''), ('REF.foo.2.0', '1'), ('REF.foo.2.1', '2')], mv.metadata
 
-    with pytest.raises(ValueError):
-        mv.dataset_selected = 'no_meta'
-    assert mv.dataset_selected == mv.dataset.labels[0]
+    mv.dataset_selected = 'no_meta'
+    assert not mv.has_metadata
 
 
 def test_view_invalid(imviz_helper):

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -204,6 +204,10 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
             IPyWidget callback event object. In this case, represents the data
             label of the data collection object selected by the user.
         """
+        if not hasattr(self, 'dataset'):
+            # during initial init, this can trigger before the component is initialized
+            return
+
         selected_spec = self.dataset.selected_obj
         if selected_spec is None:
             return

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -89,7 +89,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
             self.spatial_subset = None
 
         # when accessing the selected data, access the spectrum-viewer version
-        self.dataset._viewer_refs = ['spectrum-viewer']
+        self.dataset._viewers = ['spectrum-viewer']
         # require entries to be in spectrum-viewer (not other cubeviz images, etc)
         self.dataset.add_filter('layer_in_spectrum_viewer')
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -425,8 +425,8 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         if self._warn_if_no_equation():
             return
 
-        if self.selected_data in self.app.data_collection.labels:
-            data = self.app.data_collection[self.selected_data]
+        if self.dataset_selected in self.app.data_collection.labels:
+            data = self.app.data_collection[self.dataset_selected]
         else:  # User selected some subset from spectrum viewer, just use original cube
             data = self.app.data_collection[0]
 
@@ -434,7 +434,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         # that the user has selected a pre-existing 1d data object.
         if data.ndim != 3:
             snackbar_message = SnackbarMessage(
-                f"Selected data {self.selected_data} is not cube-like",
+                f"Selected data {self.dataset_selected} is not cube-like",
                 color='error',
                 sender=self)
             self.hub.broadcast(snackbar_message)

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -14,6 +14,15 @@
       hint="Select the data set to be fitted."
     />
 
+    <plugin-subset-select
+      v-if="cube_fit"
+      :items="spatial_subset_items"
+      :selected.sync="spatial_subset_selected"
+      :show_if_single_entry="false"
+      label="Spatial region"
+      hint="Select spatial region to fit."
+    />
+
     <plugin-subset-select 
       :items="spectral_subset_items"
       :selected.sync="spectral_subset_selected"

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -18,7 +18,7 @@
       v-if="cube_fit"
       :items="spatial_subset_items"
       :selected.sync="spatial_subset_selected"
-      :show_if_single_entry="false"
+      :show_if_single_entry="true"
       label="Spatial region"
       hint="Select spatial region to fit."
     />
@@ -26,7 +26,7 @@
     <plugin-subset-select 
       :items="spectral_subset_items"
       :selected.sync="spectral_subset_selected"
-      :show_if_single_entry="false"
+      :show_if_single_entry="true"
       label="Spectral region"
       hint="Select spectral region to fit."
     />

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -4,25 +4,23 @@
       <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#model-fitting'">Fit an analytic model to data or a subset.</j-docs-link>
     </v-row>
 
-    <v-form v-model="form_valid_data_selection">
-      <v-row>
-        <v-select
-          :items="dc_items"
-          v-model="selected_data"
-          label="Data"
-          hint="Select the data set to be fitted."
-          :rules="[() => !!selected_data || 'This field is required']"
-          persistent-hint
-        ></v-select>
-      </v-row>
+    <!-- for mosviz, the entries change on row change, so we want to always show the dropdown
+         to make sure that is clear -->
+    <plugin-dataset-select
+      :items="dataset_items"
+      :selected.sync="dataset_selected"
+      :show_if_single_entry="config=='mosviz'"
+      label="Data"
+      hint="Select the data set to be fitted."
+    />
 
-      <plugin-subset-select 
-        :items="spectral_subset_items"
-        :selected.sync="spectral_subset_selected"
-        label="Spectral region"
-        hint="Select spectral region to fit."
-      />
-    </v-form>
+    <plugin-subset-select 
+      :items="spectral_subset_items"
+      :selected.sync="spectral_subset_selected"
+      :show_if_single_entry="false"
+      label="Spectral region"
+      hint="Select spectral region to fit."
+    />
 
     <j-plugin-section-header>Model Components</j-plugin-section-header>
     <v-form v-model="form_valid_model_component">
@@ -66,7 +64,7 @@
           <v-btn 
             color="primary" 
             text 
-            :disabled="!form_valid_model_component || !form_valid_data_selection"
+            :disabled="!form_valid_model_component"
             @click="add_model"
             >Add Component
           </v-btn>
@@ -195,6 +193,9 @@
 
     <div v-if="cube_fit">
       <j-plugin-section-header>Cube Fit</j-plugin-section-header>
+      <!-- TODO: use plugin-viewer-select once custom viewer names are supported.  For now we'll
+           use a custom component so that they can be referred to by position (left, center, right)
+           instead of the viewer names -->
       <v-row>
         <v-select
           :items="viewers"

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -61,8 +61,7 @@ def test_model_ids(spectral_cube_wcs):
     dc.append(Data(x=np.ones((3, 4, 5)), label='test', coords=spectral_cube_wcs))
 
     plugin = ModelFitting(app=app)
-
-    plugin.data_selected = 'test'
+    plugin.dataset_selected = 'test'
     plugin.component_models = [{'id': 'valid_string_already_exists'}]
     plugin.temp_model = 'Linear1D'
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -6,20 +6,19 @@
       </j-docs-link>
     </v-row>
 
-    <v-row>
-      <v-select
-        :items="dc_items"
-        v-model="data_selected"
-        label="Data"
-        hint="Select data for photometry."
-        persistent-hint
-      ></v-select>
-    </v-row>
+    <plugin-dataset-select
+      :items="dataset_items"
+      :selected.sync="dataset_selected"
+      :show_if_single_entry="false"
+      label="Data"
+      hint="Select the data for photometry."
+    />
 
-    <div v-if='data_selected'>
+    <div v-if='dataset_selected'>
       <plugin-subset-select
         :items="subset_items"
         :selected.sync="subset_selected"
+        :show_if_single_entry="true"
         label="Aperture"
         hint="Select aperture region for photometry."
       />
@@ -29,6 +28,7 @@
           :items="bg_subset_items"
           :selected.sync="bg_subset_selected"
           :rules="[() => bg_subset_selected!==subset_selected || 'Must not match aperture.']"
+          :show_if_single_entry="true"
           label="Background"
           hint="Select subset region for background calculation."
         />

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -261,7 +261,6 @@ class TestParseImage:
 
         # Test simple aperture photometry plugin.
         phot_plugin = imviz_helper.app.get_tray_item_from_name('imviz-aper-phot-simple')
-        phot_plugin._on_viewer_data_changed()
         phot_plugin.data_selected = 'contents[DATA]'
         phot_plugin.subset_selected = 'Subset 1'
         assert_allclose(phot_plugin.background_value, 0)
@@ -393,7 +392,6 @@ class TestParseImage:
                                                (1465, 2541),
                                                (1512, 2611))  # Galaxy
         phot_plugin = imviz_helper.app.get_tray_item_from_name('imviz-aper-phot-simple')
-        phot_plugin._on_viewer_data_changed()
         phot_plugin.data_selected = 'contents[SCI,1]'
         phot_plugin.subset_selected = 'Subset 1'
         phot_plugin.background_value = 0.0014  # Manual entry: Median on whole array

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -65,7 +65,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
                                       allowed_type='spectral')
 
         # when accessing the selected data, access the spectrum-viewer version
-        self.dataset._viewer_refs = ['spectrum-viewer']
+        self.dataset._viewers = ['spectrum-viewer']
         # require entries to be in spectrum-viewer (not other cubeviz images, etc)
         self.dataset.add_filter('layer_in_spectrum_viewer')
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -92,7 +92,8 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin):
         msg : `glue.core.Message`
             The glue message passed to this callback method.
         """
-        if msg.subset.label in [self.spectral_subset_selected, self.continuum_selected]:
+        if (msg.subset.label in [self.spectral_subset_selected, self.continuum_selected]
+                and self.plugin_opened):
             self._calculate_statistics()
 
     @observe('plugin_opened')
@@ -169,12 +170,8 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin):
         # show spinner with overlay
         self.results_computing = True
 
-        if self.dataset_selected == "" or self.width == "":
-            self.update_results(None)
-            return
-
         full_spectrum = self.dataset.selected_obj
-        if full_spectrum is None:
+        if full_spectrum is None or self.width == "" or not self.plugin_opened:
             # this can happen DURING a unit conversion change
             self.update_results(None)
             return
@@ -295,7 +292,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin):
                 # TODO: update specutils to be consistent with region vs regions and default to
                 # regions=None so this elif can be removed
                 temp_result = FUNCTIONS[function](spec_subtracted, region=None)
-                self.results_centroid = temp_result.to_value(u.AA)
+                self.results_centroid = temp_result.to_value(u.AA, equivalencies=u.spectral())
             else:
                 temp_result = FUNCTIONS[function](spec_subtracted)
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -32,20 +32,20 @@
     <v-row>
       <j-docs-link>
         {{spectral_subset_selected=='Entire Spectrum' ? "Since using the entire spectrum, the end points will be used to fit a linear continuum." : "Choose a region to fit a linear line as the underlying continuum."}}  
-        {{continuum_selected=='Surrounding' && spectral_subset_selected!='Entire Spectrum' ? "Choose a width in number of data points to consider on each side of the line region defined above." : null}}
+        {{continuum_subset_selected=='Surrounding' && spectral_subset_selected!='Entire Spectrum' ? "Choose a width in number of data points to consider on each side of the line region defined above." : null}}
         When this plugin is opened, a visual indicator will show on the spectrum plot showing the continuum fitted as a thick line, and interpolated into the line region as a thin line.
       </j-docs-link>
     </v-row>
 
     <plugin-subset-select 
       :items="continuum_subset_items"
-      :selected.sync="continuum_selected"
-      :rules="[() => continuum_selected!==spectral_subset_selected || 'Must not match line selection.']"
+      :selected.sync="continuum_subset_selected"
+      :rules="[() => continuum_subset_selected!==spectral_subset_selected || 'Must not match line selection.']"
       label="Continuum"
       hint="Select spectral region that defines the continuum."
     />
 
-    <v-row v-if="continuum_selected=='Surrounding' && spectral_subset_selected!='Entire Spectrum'">
+    <v-row v-if="continuum_subset_selected=='Surrounding' && spectral_subset_selected!='Entire Spectrum'">
       <!-- DEV NOTE: if changing the validation rules below, also update the logic to clear the results
            in line_analysis.py  -->
       <v-text-field

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -11,15 +11,15 @@
       <j-docs-link>Choose a region that defines the spectral line.</j-docs-link>
     </v-row>
 
-    <v-row v-if="dc_items.length > 1">
-      <v-select
-        :items="dc_items"
-        v-model="selected_spectrum"
-        label="Data"
-        hint="Select the data set to be analysed."
-        persistent-hint
-      ></v-select>
-    </v-row>
+    <!-- for mosviz, the entries change on row change, so we want to always show the dropdown
+         to make sure that is clear -->
+    <plugin-dataset-select
+      :items="dataset_items"
+      :selected.sync="dataset_selected"
+      :show_if_single_entry="config=='mosviz'"
+      label="Data"
+      hint="Select the data set to be analysed."
+    />
 
     <plugin-subset-select 
       :items="spectral_subset_items"

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -24,6 +24,7 @@
     <plugin-subset-select 
       :items="spectral_subset_items"
       :selected.sync="spectral_subset_selected"
+      :show_if_single_entry="true"
       label="Spectral region"
       hint="Select spectral region that defines the line."
     />
@@ -40,6 +41,7 @@
     <plugin-subset-select 
       :items="continuum_subset_items"
       :selected.sync="continuum_subset_selected"
+      :show_if_single_entry="true"
       :rules="[() => continuum_subset_selected!==spectral_subset_selected || 'Must not match line selection.']"
       label="Continuum"
       hint="Select spectral region that defines the continuum."

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -42,7 +42,7 @@ class UnitConversion(PluginTemplateMixin, DatasetSelectMixin):
         # when accessing the selected data, access the spectrum-viewer version
         # TODO: we'll probably want to update unit-conversion to be able to act on cubes directly
         # in the future
-        self.dataset._viewer_refs = ['spectrum-viewer']
+        self.dataset._viewers = ['spectrum-viewer']
         # require entries to be in spectrum-viewer (not other cubeviz images, etc)
         self.dataset.add_filter('layer_in_spectrum_viewer')
 

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -1,12 +1,11 @@
 from astropy import units as u
 from astropy.nddata import VarianceUncertainty, StdDevUncertainty, InverseVariance
 from glue.core.message import SubsetCreateMessage, SubsetDeleteMessage
-from specutils import Spectrum1D
-from traitlets import List, Unicode, Any
+from traitlets import List, Unicode, Any, observe
 
-from jdaviz.core.events import SnackbarMessage, RemoveDataMessage, AddDataMessage, RedshiftMessage
+from jdaviz.core.events import SnackbarMessage, RedshiftMessage
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import PluginTemplateMixin
+from jdaviz.core.template_mixin import PluginTemplateMixin, DatasetSelectMixin
 from jdaviz.core.validunits import (create_spectral_equivalencies_list,
                                     create_flux_equivalencies_list)
 from jdaviz.configs.specviz.helper import _apply_redshift_to_spectra
@@ -19,12 +18,9 @@ unit_exponents = {StdDevUncertainty: 1,
 
 
 @tray_registry('g-unit-conversion', label="Unit Conversion")
-class UnitConversion(PluginTemplateMixin):
+class UnitConversion(PluginTemplateMixin, DatasetSelectMixin):
 
     template_file = __file__, "unit_conversion.vue"
-
-    dc_items = List([]).tag(sync=True)
-    selected_data = Unicode().tag(sync=True)
 
     current_flux_unit = Unicode().tag(sync=True)
     current_spectral_axis_unit = Unicode().tag(sync=True)
@@ -37,61 +33,18 @@ class UnitConversion(PluginTemplateMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._viewer_data = None
-
-        self.spectrum = None
-
-        self.hub.subscribe(self, AddDataMessage, handler=self._on_viewer_data_changed)
-        self.hub.subscribe(self, RemoveDataMessage, handler=self._on_viewer_data_changed)
         self.hub.subscribe(self, SubsetCreateMessage, handler=self._on_viewer_subset_changed)
         self.hub.subscribe(self, SubsetDeleteMessage, handler=self._on_viewer_subset_changed)
 
         self._redshift = None
         self.app.hub.subscribe(self, RedshiftMessage, handler=self._redshift_listener)
 
-    def _on_viewer_data_changed(self, msg=None):
-        """
-        Callback method for when data is added or removed from a viewer, or
-        when a subset is created, deleted, or updated. This method receives
-        a glue message containing viewer information in the case of the former
-        set of events, and updates the available data list displayed to the
-        user.
-
-        Notes
-        -----
-        We do not attempt to parse any data at this point, at it can cause
-        visible lag in the application.
-
-        Parameters
-        ----------
-        msg : `glue.core.Message`
-            The glue message passed to this callback method.
-        """
-        self._viewer_id = self.app._viewer_item_by_reference(
-            'spectrum-viewer').get('id')
-
-        # Subsets are global and are not linked to specific viewer instances,
-        # so it's not required that we match any specific ids for that case.
-        # However, if the msg is not none, check to make sure that it's the
-        # viewer we care about.
-        if msg is not None and msg.viewer_id != self._viewer_id:
-            return
-
-        self._viewer_data = self.app.get_data_from_viewer('spectrum-viewer',
-                                                          include_subsets=False)
-
-        self.dc_items = [data.label
-                         for data in self.app.data_collection
-                         if data is not None]
-
-        if self.app.get_viewer("spectrum-viewer").state.reference_data is not None:
-
-            data_label = self.app.get_viewer("spectrum-viewer").state.reference_data.label
-            spectrum = self._viewer_data[data_label]
-
-            self.set_spectrum(spectrum, data_label)
-
-        self.update_ui()
+        # when accessing the selected data, access the spectrum-viewer version
+        # TODO: we'll probably want to update unit-conversion to be able to act on cubes directly
+        # in the future
+        self.dataset._viewer_refs = ['spectrum-viewer']
+        # require entries to be in spectrum-viewer (not other cubeviz images, etc)
+        self.dataset.add_filter('layer_in_spectrum_viewer')
 
     def _on_viewer_subset_changed(self, *args):
         if len(self.app.data_collection.subset_groups) == 0:
@@ -104,43 +57,22 @@ class UnitConversion(PluginTemplateMixin):
         if msg.param == "redshift":
             self._redshift = msg.value
 
-    def set_spectrum(self, spectrum, label):
-        """
-        Set spectrum for unit conversion.
-
-        Parameters
-        ----------
-        spectrum : `~specutils.Spectrum1D`
-            Spectrum for unit conversion.
-        label : str
-            Label used to represent spectrum.
-        """
-        self.spectrum = spectrum
-        self.selected_data = label
-
-    def vue_data_selected(self, event):
-
-        self.set_spectrum(self.app.data_collection[event].get_object(cls=Spectrum1D), event)
-
-        self.update_ui()
-
-    def update_ui(self):
+    @observe('dataset_selected')
+    def update_ui(self, event=None):
         """
         Set up UI to have all values of currently visible spectra.
         """
-        if len(self._viewer_data) < 1:
-            self.selected_data = ""
-            self.current_flux_unit = ""
-            self.current_spectral_axis_unit = ""
+        spectrum = self.dataset.selected_obj
+        if spectrum is None:
             return
 
         # Set UI label to show current flux and spectral axis units.
-        self.current_flux_unit = self.spectrum.flux.unit.to_string()
-        self.current_spectral_axis_unit = self.spectrum.spectral_axis.unit.to_string()
+        self.current_flux_unit = spectrum.flux.unit.to_string()
+        self.current_spectral_axis_unit = spectrum.spectral_axis.unit.to_string()
 
         # Populate drop down with all valid options for unit conversion.
-        self.spectral_axis_unit_equivalencies = create_spectral_equivalencies_list(self.spectrum)
-        self.flux_unit_equivalencies = create_flux_equivalencies_list(self.spectrum)
+        self.spectral_axis_unit_equivalencies = create_spectral_equivalencies_list(spectrum)
+        self.flux_unit_equivalencies = create_flux_equivalencies_list(spectrum)
 
     def vue_unit_conversion(self, *args, **kwargs):
         """
@@ -149,9 +81,9 @@ class UnitConversion(PluginTemplateMixin):
         """
         if self._redshift is not None:
             # apply the global redshift to the new spectrum
-            spectrum = _apply_redshift_to_spectra(self.spectrum, self._redshift)
+            spectrum = _apply_redshift_to_spectra(self.dataset.selected_obj, self._redshift)
         else:
-            spectrum = self.spectrum
+            spectrum = self.dataset.selected_obj
 
         converted_spec = self.process_unit_conversion(spectrum,
                                                       self.new_flux_unit,
@@ -162,9 +94,9 @@ class UnitConversion(PluginTemplateMixin):
         new_label = ""
 
         # Finds the '_units_copy_' spectrum and does unit conversions in that copy.
-        if "_units_copy_" in self.selected_data:
+        if "_units_copy_" in self.dataset_selected:
 
-            selected_data_label = self.selected_data
+            selected_data_label = self.dataset_selected
             selected_data_label_split = selected_data_label.split("_units_copy_")
 
             new_label = selected_data_label_split[0] + label
@@ -199,7 +131,7 @@ class UnitConversion(PluginTemplateMixin):
                 self.app.add_data_to_viewer("spectrum-viewer", new_label, clear_other_data=True)
 
         else:
-            new_label = self.selected_data + label
+            new_label = self.dataset_selected + label
 
             if new_label in self.data_collection:
                 # Spectrum with these converted units already exists.

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -4,15 +4,15 @@
       <j-docs-link :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#unit-conversion'">Convert the spectral flux density and spectral axis units.</j-docs-link>
     </v-row>
 
-    <v-row>
-      <v-text-field
-        v-model="selected_data"
-        label="Data"
-        hint="Data to be converted."
-        disabled="True"
-        persistent-hint
-      ></v-text-field>
-    </v-row>
+    <!-- for mosviz, the entries change on row change, so we want to always show the dropdown
+         to make sure that is clear -->
+    <plugin-dataset-select
+      :items="dataset_items"
+      :selected.sync="dataset_selected"
+      :show_if_single_entry="config=='mosviz'"
+      label="Data"
+      hint="Select the data to be converted."
+    />
 
     <v-row>
       <v-text-field
@@ -63,7 +63,7 @@
 
     <v-row justify="end">
       <j-tooltip tipid='plugin-unit-conversion-apply'>
-        <v-btn :disabled="selected_data == ''"
+        <v-btn :disabled="dataset_selected == ''"
         color="accent" text @click="unit_conversion">Apply</v-btn>
       </j-tooltip>
     </v-row>

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -10,6 +10,7 @@ from astropy.utils.data import download_file
 
 from jdaviz.app import Application
 from jdaviz.configs.specviz.plugins.unit_conversion import unit_conversion as uc
+from jdaviz.core.marks import LineUncertainties
 from jdaviz import Specviz
 
 
@@ -257,12 +258,12 @@ def test_plot_uncertainties(specviz_helper, spectrum1d):
 
     specviz_viewer = specviz_helper.app.get_viewer("spectrum-viewer")
 
-    assert len(specviz_viewer.figure.marks) == 1
+    assert len([m for m in specviz_viewer.figure.marks if isinstance(m, LineUncertainties)]) == 0
 
     specviz_viewer.show_uncertainties()
 
-    assert len(specviz_viewer.figure.marks) == 2
+    assert len([m for m in specviz_viewer.figure.marks if isinstance(m, LineUncertainties)]) == 1
 
     specviz_viewer.clean()
 
-    assert len(specviz_viewer.figure.marks) == 1
+    assert len([m for m in specviz_viewer.figure.marks if isinstance(m, LineUncertainties)]) == 0

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -708,6 +708,12 @@ class DatasetSelect(BaseSelectPluginComponent):
         self._on_data_changed()
 
     @property
+    def default_data_cls(self):
+        if self.app.config == 'imviz':
+            return None
+        return Spectrum1D
+
+    @property
     def filters(self):
         return self._filters
 
@@ -742,11 +748,11 @@ class DatasetSelect(BaseSelectPluginComponent):
             if match is not None:
                 if hasattr(match, 'get_object'):
                     # cube viewers return the data collection instance from get_data_from_viewer
-                    return match.get_object(cls=Spectrum1D)
+                    return match.get_object(cls=self.default_data_cls)
                 return match
         # handle the case of empty Application with no viewer, we'll just pull directly
         # from the data collection
-        return self.get_object(cls=Spectrum1D)
+        return self.get_object(cls=self.default_data_cls)
 
     def _is_valid_item(self, data):
         def not_from_plugin(data):

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -227,7 +227,7 @@ class SubsetSelect(BaseSelectPluginComponent):
     """
     Traitlets (in the object, custom traitlets in the plugin):
 
-    * ``items`` (list of dicts with keys: label, color)
+    * ``items`` (list of dicts with keys: label, color, type)
     * ``selected`` (string)
     * ``selected_has_subregions`` (bool, OPTIONAL)
 
@@ -503,7 +503,7 @@ class ViewerSelect(BaseSelectPluginComponent):
     """
     Traitlets (in the object, custom traitlets in the plugin):
 
-    * ``items`` (list of dicts with keys: id, reference, ref_or_id)
+    * ``items`` (list of dicts with keys: id, reference, label)
     * ``selected`` (string)
 
     Properties (in the object only):
@@ -652,7 +652,7 @@ class DatasetSelect(BaseSelectPluginComponent):
     """
     Traitlets (in the object, custom traitlets in the plugin):
 
-    * ``items`` (list of dicts with keys: )
+    * ``items`` (list of dicts with keys: label)
     * ``selected`` (string)
 
     Properties (in the object only):

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -257,6 +257,7 @@ class SubsetSelect(BaseSelectPluginComponent):
       <plugin-subset-select
         :items="spectral_subset_items"
         :selected.sync="spectral_subset_selected"
+        :show_if_single_entry="true"
         label="Subset"
         hint="Select subset."
       />
@@ -432,6 +433,7 @@ class SpectralSubsetSelectMixin(VuetifyTemplate, HubListener):
       <plugin-subset-select
         :items="spectral_subset_items"
         :selected.sync="spectral_subset_selected"
+        :show_if_single_entry="true"
         label="Spectral region"
         hint="Select spectral region."
       />

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -21,7 +21,7 @@ def test_spectralsubsetselect(specviz_helper, spectrum1d):
     assert p.spectral_subset.selected_obj is not None
     expected_min = spectrum1d.spectral_axis[spectrum1d.spectral_axis.value >= 6500][0]
     expected_max = spectrum1d.spectral_axis[spectrum1d.spectral_axis.value <= 7400][-1]
-    assert p.spectral_subset.selected_min_max(spectrum1d)[0] == (expected_min, expected_max)
+    assert p.spectral_subset.selected_min_max(spectrum1d) == (expected_min, expected_max)
 
     assert p.spectral_subset.app == p.app
     assert p.spectral_subset.spectrum_viewer == sv

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -19,10 +19,9 @@ def test_spectralsubsetselect(specviz_helper, spectrum1d):
     p.spectral_subset_selected = 'Subset 1'
     assert p.spectral_subset_selected_has_subregions is False
     assert p.spectral_subset.selected_obj is not None
-    expected_min = spectrum1d.spectral_axis[spectrum1d.spectral_axis.value >= 6500][0].value
-    expected_max = spectrum1d.spectral_axis[spectrum1d.spectral_axis.value <= 7400][-1].value
-    assert p.spectral_subset.selected_min(spectrum1d) == expected_min
-    assert p.spectral_subset.selected_max(spectrum1d) == expected_max
+    expected_min = spectrum1d.spectral_axis[spectrum1d.spectral_axis.value >= 6500][0]
+    expected_max = spectrum1d.spectral_axis[spectrum1d.spectral_axis.value <= 7400][-1]
+    assert p.spectral_subset.selected_min_max(spectrum1d)[0] == (expected_min, expected_max)
 
     assert p.spectral_subset.app == p.app
     assert p.spectral_subset.spectrum_viewer == sv
@@ -50,7 +49,7 @@ def test_viewer_select(cubeviz_helper, spectrum1d_cube):
     p = app.get_tray_item_from_name('g-export-plot')
     assert len(p.viewer.ids) == 4
     assert len(p.viewer.references) == 4
-    assert len(p.viewer.ref_or_ids) == 4
+    assert len(p.viewer.labels) == 4
     assert p.viewer.selected_obj == fv
 
     # set by reference
@@ -59,4 +58,4 @@ def test_viewer_select(cubeviz_helper, spectrum1d_cube):
 
     # try setting based on id instead of reference
     p.viewer_selected = p.viewer.ids[0]
-    assert p.viewer_selected == p.viewer.ref_or_ids[0]
+    assert p.viewer_selected == p.viewer.labels[0]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements a re-usable dataset select component with:
* entry-filtering (some cases only want 1d spectra, only spectra in the current mosviz row, excluding output from model fitting plugin, etc).
* automatic hiding when only one entry (by default - this can be disabled)
* default selection to first entry
* convenience functionality to access the selected Spectrum1D or data-collection objects from within the plugin.

This also creates a new `BaseSelectPluginComponent` which holds shared logic between the `DatasetSelect`, `ViewerSelect` (#1195), and `SubsetSelect` (#1156, #1175).

Finally, this splits the spatial subsets into their own dropdown in model fitting.  For cubeviz this will effectively _replace_ the data dropdown since the data dropdown is hidden as it is only populated with a single choice (unless more data is manually added).

Below are some before (left) & after (right) screenshots:

<div>
<img width="400" alt="mosviz metadata before" src="https://user-images.githubusercontent.com/877591/161330126-16ac4378-37e7-4015-85c8-62a95d67f3f4.png">
<img width="400" alt="mosviz metadata after" src="https://user-images.githubusercontent.com/877591/161330077-0561a052-6d91-4c82-a2e1-f17127b58232.png">
</div>

<div>
<img width="400" alt="cubeviz fitting before" src="https://user-images.githubusercontent.com/877591/161330524-118c6527-595a-4872-8262-3c9665b9bf6b.png">

<img width="400" alt="cubeviz fitting after" src="https://user-images.githubusercontent.com/877591/161330565-410ce08b-b065-456c-84f2-944b38a2d6e8.png">
</div>

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1220

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
