### PR TITLE
Fix ESA axes

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -184,8 +184,8 @@ def _parse_esa_s3d(app, hdulist, data_label, ext='DATA', viewer_name='flux-viewe
 
     wcs_dict = {
         'CTYPE1': 'WAVE    ', 'CUNIT1': 'um', 'CDELT1': hdr['CDELT3'] * 1E6,
-        'CRPIX1': hdr['CRPIX3'] - 1,
-        'CRVAL1': hdr['CRVAL3'] * 1E6, 'NAXIS1': hdr['NAXIS3'] - 2,
+        'CRPIX1': hdr['CRPIX3'],
+        'CRVAL1': hdr['CRVAL3'] * 1E6, 'NAXIS1': hdr['NAXIS3'],
         'CTYPE2': 'DEC--TAN', 'CUNIT2': 'deg', 'CDELT2': hdr['CDELT1'], 'CRPIX2': hdr['CRPIX1'],
         'CRVAL2': hdr['CRVAL1'], 'NAXIS2': hdr['NAXIS1'],
         'CTYPE3': 'RA---TAN', 'CUNIT3': 'deg', 'CDELT3': hdr['CDELT2'], 'CRPIX3': hdr['CRPIX2'],

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -181,15 +181,18 @@ def _parse_esa_s3d(app, hdulist, data_label, ext='DATA', viewer_name='flux-viewe
         flux = hdulist[ext].data << unit
 
     hdr = hdulist[1].header
+
     wcs_dict = {
-        'CTYPE1': 'RA---TAN', 'CUNIT1': 'deg', 'CDELT1': hdr['CDELT2'], 'CRPIX1': hdr['CRPIX2'],
-        'CRVAL1': hdr['CRVAL2'], 'NAXIS1': hdr['NAXIS2'],
+        'CTYPE1': 'WAVE    ', 'CUNIT1': 'um', 'CDELT1': hdr['CDELT3'] * 1E6, 'CRPIX1': hdr['CRPIX3'] - 1,
+        'CRVAL1': hdr['CRVAL3'] * 1E6, 'NAXIS1': hdr['NAXIS3'] - 2,
         'CTYPE2': 'DEC--TAN', 'CUNIT2': 'deg', 'CDELT2': hdr['CDELT1'], 'CRPIX2': hdr['CRPIX1'],
         'CRVAL2': hdr['CRVAL1'], 'NAXIS2': hdr['NAXIS1'],
-        'CTYPE3': 'WAVE-LOG', 'CUNIT3': 'um', 'CDELT3': hdr['CDELT3'] * 1E6,
-        'CRPIX3': hdr['CRPIX3'] - 1, 'CRVAL3': hdr['CRVAL3'] * 1E6, 'NAXIS3': hdr['NAXIS3'] - 2}
+        'CTYPE3': 'RA---TAN', 'CUNIT3': 'deg', 'CDELT3': hdr['CDELT2'], 'CRPIX3': hdr['CRPIX2'],
+        'CRVAL3': hdr['CRVAL2'], 'NAXIS3': hdr['NAXIS2']}
 
     wcs = WCS(wcs_dict)
+    flux = np.moveaxis(flux, 0, -1)
+    flux = np.swapaxes(flux, 0, 1)
     data = Spectrum1D(flux, wcs=wcs)
 
     app.add_data(data, data_label)

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -183,7 +183,8 @@ def _parse_esa_s3d(app, hdulist, data_label, ext='DATA', viewer_name='flux-viewe
     hdr = hdulist[1].header
 
     wcs_dict = {
-        'CTYPE1': 'WAVE    ', 'CUNIT1': 'um', 'CDELT1': hdr['CDELT3'] * 1E6, 'CRPIX1': hdr['CRPIX3'] - 1,
+        'CTYPE1': 'WAVE    ', 'CUNIT1': 'um', 'CDELT1': hdr['CDELT3'] * 1E6,
+        'CRPIX1': hdr['CRPIX3'] - 1,
         'CRVAL1': hdr['CRVAL3'] * 1E6, 'NAXIS1': hdr['NAXIS3'] - 2,
         'CTYPE2': 'DEC--TAN', 'CUNIT2': 'deg', 'CDELT2': hdr['CDELT1'], 'CRPIX2': hdr['CRPIX1'],
         'CRVAL2': hdr['CRVAL1'], 'NAXIS2': hdr['NAXIS1'],


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address the axes not appearing correctly in the original ESA parser implementation. The wavelength axes also did not appear correctly because it used `WAVE-LOG` instead of a barebones wavelength value for `CTYPE1`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive. I think no change log needed since no users (except for @PatrickOgle) can tell that anything is even different!

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
