### PR TITLE
Move set collapse function to init method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,7 +52,7 @@ Other Changes and Additions
 ---------------------------
 
 - Change default collapse function to sum.
-  This affects collapsed spectrum in Cubeviz and its Collapse plugin default. [#1229]
+  This affects collapsed spectrum in Cubeviz and its Collapse plugin default. [#1229, #1237]
 
 2.4 (2022-03-29)
 ================

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -57,6 +57,9 @@ class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
         self.display_uncertainties = False
         self.display_mask = False
 
+        # Change collapse function to sum
+        self.state.function = 'sum'
+
     def _on_subset_create(self, msg):
         for layer in self.state.layers:
             if layer.layer.label == msg.subset.label:
@@ -478,10 +481,3 @@ class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
 
         # Set Y-axis to scientific notation
         self.figure.axes[1].tick_format = '0.1e'
-
-        # Change collapse function to sum and
-        # reset axes limits to match new spectrum view
-        self.state.function = 'sum'
-        # TODO: remove when glue-viz/glue PR #2277 is merged
-        #  and the released version is pinned
-        self.state.reset_limits()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address the problem that the Specviz viewer would reset it limits every time data was added. That line of code has been removed and the original code to set the collapse function to sum is in the init method

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Follow-up of #1229 .

Close #1236

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
