### PR TITLE
Homogenize doc page titles/subheadings between the configs

### DIFF
--- a/docs/cubeviz/import_data.rst
+++ b/docs/cubeviz/import_data.rst
@@ -1,8 +1,8 @@
 .. _cubeviz-import-data:
 
-***********
-Import Data
-***********
+***************************
+Importing Data into Cubeviz
+***************************
 
 There are two primary ways in which you can load your data into the Cubeviz
 application. Cubeviz supports loading FITS files that can be parsed as 

--- a/docs/imviz/import_data.rst
+++ b/docs/imviz/import_data.rst
@@ -1,8 +1,8 @@
 .. _imviz-import-data:
 
-***********
-Import Data
-***********
+*************************
+Importing Data into Imviz
+*************************
 
 Imviz can load data in the form of a filename (FITS, JPEG, or PNG),
 an `~astropy.nddata.NDData` object, or a NumPy array if the data is 2D.

--- a/docs/mosviz/import_data.rst
+++ b/docs/mosviz/import_data.rst
@@ -1,8 +1,8 @@
 .. _mosviz-import-api:
 
-***********
-Import Data
-***********
+**************************
+Importing Data into Mosviz
+**************************
 
 Mosviz provides two different ways to load data: Auto-recognition directory loading
 or manual loading:

--- a/docs/specviz/import_data.rst
+++ b/docs/specviz/import_data.rst
@@ -1,6 +1,6 @@
-*************************
-Loading Data into Specviz
-*************************
+***************************
+Importing Data into Specviz
+***************************
 
 By design, Specviz only supports data that can be parsed as :class:`~specutils.Spectrum1D` objects, as that allows the Python-level interface and parsing tools to be defined in ``specutils`` instead of being duplicated in Jdaviz.  :class:`~specutils.Spectrum1D` objects are very flexible in their capabilities, however, and hence should address most astronomical spectrum use cases.
 
@@ -38,7 +38,7 @@ users can select which spectra that have be loaded to be visualized in the viewe
 
 .. _specviz-import-api:
 
-Loading data via the API
+Importing data via the API
 ------------------------
 Alternatively, if users are working in a coding environment like a Jupyter notebook, they have access to the :class:`~jdaviz.configs.specviz.helper.Specviz` helper class API. Using this API, users can load data into the application through code.
 Below is an example of importing the :class:`~jdaviz.configs.specviz.helper.Specviz` helper class, creating a :class:`~specutils.Spectrum1D` object from a data file via the `specutils.Spectrum1D.read` method::
@@ -70,7 +70,7 @@ This method works well for data files that ``specutils`` understands.  However, 
 For more information about using the Specutils package, please see the
 `Specutils documentation <https://specutils.readthedocs.io>`_.
 
-Loading multiple spectra via the API
+Importing multiple spectra via the API
 ------------------------------------
 In addition to loading single spectra as above, in some cases it may be useful
 to load multiple related spectra at once into the Jdaviz application. The most common

--- a/docs/specviz/import_data.rst
+++ b/docs/specviz/import_data.rst
@@ -39,7 +39,7 @@ users can select which spectra that have be loaded to be visualized in the viewe
 .. _specviz-import-api:
 
 Importing data via the API
-------------------------
+--------------------------
 Alternatively, if users are working in a coding environment like a Jupyter notebook, they have access to the :class:`~jdaviz.configs.specviz.helper.Specviz` helper class API. Using this API, users can load data into the application through code.
 Below is an example of importing the :class:`~jdaviz.configs.specviz.helper.Specviz` helper class, creating a :class:`~specutils.Spectrum1D` object from a data file via the `specutils.Spectrum1D.read` method::
 
@@ -71,7 +71,7 @@ For more information about using the Specutils package, please see the
 `Specutils documentation <https://specutils.readthedocs.io>`_.
 
 Importing multiple spectra via the API
-------------------------------------
+--------------------------------------
 In addition to loading single spectra as above, in some cases it may be useful
 to load multiple related spectra at once into the Jdaviz application. The most common
 such case is when you have spectra of the same object covering multiple wavelength

--- a/docs/specviz/plugins.rst
+++ b/docs/specviz/plugins.rst
@@ -4,24 +4,20 @@
 Data Analysis Plugins
 *********************
 
-To enable quick analysis of astronomical spectra, Specviz ships with a number of
+To enable quick analysis of astronomical spectra, Specviz includes a number of
 plugins that let you do various standard spectral analysis tasks.  Note that
 these plugins all depend on ``specutils`` to do the actual analysis work - when
 doing these operations in the Notebook you are often better off using
 the ``specutils`` or ``astropy`` APIs directly instead of using the plugins. But
-for quick-look or interaction heavy workflows, the plugins provide a UI-based
+for quick-look or interaction-heavy workflows, the plugins provide a UI-based
 alternative.
 
 Data analysis plugins are found in the plugin tray, accessed via the
 :guilabel:`plugin` icon in the upper right corner of the Specviz application window.
 Each plugin may be used to perform data analysis tasks on
-selected datasets.
-
-Input/Output
-============
-
-Data to be operated on are selected in each plugin via a
-:guilabel:`Data` pulldown menu.
+selected datasets. Data to be operated on are selected in each plugin via a
+:guilabel:`Data` pulldown menu; plugins may also have a 
+:guilabel:`Subset` dropdown where relevant if any subsets have been defined.
 
 .. _specviz-metadata-viewer:
 


### PR DESCRIPTION
These are the only inconsistencies I could find between the doc page titles in the different configs. I'm trying to be good and resist making more changes here 😆 .