### PR TITLE
snackbar queue: better handling of loading interrupts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,7 @@ Other Changes and Additions
   axis order and work with updated glue-astronomy translators. [#1174]
 
 - Help button in toolbar to open docs in a new tab. [#1240]
+- Snackbar queue handles loading interrupt more cleanly. [#1249]
 
 2.4 (2022-03-29)
 ================

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -442,11 +442,9 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         # Get the primary data component
         spec = data.get_object(Spectrum1D, statistic=None)
 
-        # TODO: in vuetify >2.3, timeout should be set to -1 to keep open
-        #  indefinitely
         snackbar_message = SnackbarMessage(
             "Fitting model to cube...",
-            loading=True, timeout=0, sender=self)
+            loading=True, sender=self)
         self.hub.broadcast(snackbar_message)
 
         # Retrieve copy of the models with proper "fixed" dictionaries

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -15,28 +15,52 @@ class SnackbarQueue:
     '''
     def __init__(self):
         self.queue = deque()
+        # track whether we're showing a loading message which won't clear by timeout,
+        # but instead requires another message with msg.loading = False to clear
+        self.loading = False
+        # track whether this is the first message - we'll increase the timeout for that
+        # to give time for the app to load.
         self.first = True
 
     def put(self, state, msg):
-        if len(self.queue) == 0:
+        if msg.loading:
+            # immediately show the loading message indefinitely until cleared by a new message
+            # with loading=False (or overwritten by a new indefinite message with loading=True)
+            self.loading = True
             self._write_message(state, msg)
-
-        if not msg.loading:
-            self.queue.appendleft(msg)
+        elif self.loading:
+            # clear the loading state, immediately show this message, then re-enter the queue
+            self.loading = False
+            self._write_message(state, msg)
+        else:
+            self.queue.append(msg)
+            if len(self.queue) == 1:
+                self._write_message(state, msg)
 
     def close_current_message(self, state):
 
-        # turn off snackbar and remove corresponding
-        # message from  queue.
+        # turn off snackbar iteself
         state.snackbar['show'] = False
+
+        if self.loading:
+            # then we've been interrupted, so keep this item in the queue to show after
+            # loading is complete
+            return
+
         if len(self.queue) > 0:
-            _ = self.queue.pop()
+            # determine if the closed entry came from the queue (not an interrupt)
+            # in which case we should remove it from the queue.  We clear here instead
+            # of when creating the snackbar so that items that are interrupted
+            # (ie by a loading message) will reappear again at the top of the queue
+            # so they are not missed
+            msg = self.queue[0]
+            if msg.text == state.snackbar['text']:
+                _ = self.queue.popleft()
 
         # in case there are messages in the queue still,
         # display the next.
         if len(self.queue) > 0:
-            msg = self.queue.pop()
-            self.queue.append(msg)
+            msg = self.queue[0]
             self._write_message(state, msg)
 
     def _write_message(self, state, msg):
@@ -49,6 +73,8 @@ class SnackbarQueue:
         state.snackbar['show'] = True
 
         if msg.loading:
+            # do not create timeout - the message will be indefinite until
+            # cleared by another message
             return
 
         # timeout of the first message needs to be increased by a
@@ -63,6 +89,8 @@ class SnackbarQueue:
             timeout += 5000
             self.first = False
 
+        # create the timeout function which will close this message and
+        # show the next message if one has been added to the queue since
         def sleep_function(timeout):
             timeout_ = float(timeout) / 1000
             time.sleep(timeout_)

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -39,13 +39,13 @@ class SnackbarQueue:
 
     def close_current_message(self, state):
 
-        # turn off snackbar iteself
-        state.snackbar['show'] = False
-
         if self.loading:
             # then we've been interrupted, so keep this item in the queue to show after
             # loading is complete
             return
+
+        # turn off snackbar iteself
+        state.snackbar['show'] = False
 
         if len(self.queue) > 0:
             # determine if the closed entry came from the queue (not an interrupt)
@@ -68,6 +68,8 @@ class SnackbarQueue:
         state.snackbar['show'] = False
         state.snackbar['text'] = msg.text
         state.snackbar['color'] = msg.color
+        # TODO: in vuetify >2.3, timeout should be set to -1 to keep open
+        #  indefinitely
         state.snackbar['timeout'] = 0  # timeout controlled by thread
         state.snackbar['loading'] = msg.loading
         state.snackbar['show'] = True
@@ -85,6 +87,9 @@ class SnackbarQueue:
         # the implementation of VSnackbarQueue in ipyvuetify, it's
         # better to keep the solution contained all in one place here.
         timeout = msg.timeout
+        if timeout < 500:
+            # half-second minimum timeout
+            timeout = 500
         if self.first:
             timeout += 5000
             self.first = False


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address loading snackbar messages from being ignored if a current snackbar is being displayed.  The new behavior is that a message with `loading=True` will immediately interrupt the current queue and will show indefinitely until another message is pushed to the queue, at which point THAT message will show first and then the queue will continue with the message that was first interrupted.

This should be thoroughly tested in the app with real use-cases, but can also be tested manually with something like:

```
from jdaviz.core.events import SnackbarMessage
from time import sleep

for i in range(5):
    msg = SnackbarMessage(f"message {i}", color='info', sender=None)
    specviz.app.hub.broadcast(msg)

sleep(6)

# interrupt with loading message (should interrupt during "message 1")
msg = SnackbarMessage(f"LOADING INTERRUPT (3s)", loading=True, sender=None)
specviz.app.hub.broadcast(msg)

sleep(3)

# clear loading, show this message, then continue wherever the loop was interrupted, in order
msg = SnackbarMessage(f"LOADING COMPLETE", color='success', sender=None)
specviz.app.hub.broadcast(msg)
```

which gives the following behavior:

https://user-images.githubusercontent.com/877591/163448803-e7406972-2d69-47f1-a14e-345f00f2c7f0.mov


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1246

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
