### PR TITLE
Don't show error snackbar on deselecting all data in Imviz

### DIFF
--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -64,6 +64,9 @@ class SimpleAperturePhotometry(TemplateMixin, DatasetSelectMixin):
 
     @observe('dataset_selected')
     def _dataset_selected_changed(self, event={}):
+        if self._selected_data is None:
+            self.reset_results()
+            return
         try:
             self._selected_data = self.dataset.selected_dc_item
             self.counts_factor = 0


### PR DESCRIPTION
On main, deselecting all data from a viewer causes an error snackbar message to be raised from the aperture photometry plugin. This prevents that from happening.