### PR TITLE
CLI: change layout from an option to a positional argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ Specviz
 API Changes
 -----------
 
+- CLI now takes the layout as a required second positional argument
+  (`jdaviz cubeviz path/to/file`). [#1252]
+
 Cubeviz
 ^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ API Changes
 -----------
 
 - CLI now takes the layout as a required second positional argument
-  (`jdaviz cubeviz path/to/file`). [#1252]
+  (``jdaviz cubeviz path/to/file``). [#1252]
 
 Cubeviz
 ^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Specviz
 API Changes
 -----------
 
-- CLI now takes the layout as a required second positional argument
+- CLI now takes the layout as a required first positional argument after jdaviz
   (``jdaviz cubeviz path/to/file``). [#1252]
 
 Cubeviz

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ As a Web Application
 from a terminal, type::
 
     jdaviz --help
-    jdaviz /path/to/data/spectral_file --layout=specviz
+    jdaviz specviz /path/to/data/spectral_file
 
 For more information on the command line interface, see the
 `Jdaviz Quickstart <https://jdaviz.readthedocs.io/en/latest/quickstart.html>`_.

--- a/docs/mosviz/import_data.rst
+++ b/docs/mosviz/import_data.rst
@@ -31,7 +31,7 @@ If an instrument is not specified, Mosviz will default to NIRSpec parsing.
 Specifying an instrument from the command line is not supported yet, and will default to
 NIRSpec parsing as if an instrument wasn't provided::
 
-    jdaviz /path/to/my/data --layout=mosviz
+    jdaviz mosviz /path/to/my/data
 
 Manual Loading
 --------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -13,11 +13,11 @@ As a Web Application
 from a terminal, type::
 
     jdaviz --help
-    jdaviz /path/to/data/spectral_file --layout=specviz
+    jdaviz specviz /path/to/data/spectral_file
 
 For example, to load a `SDSS MaNGA IFU data cube <https://data.sdss.org/sas/dr14/manga/spectro/redux/v2_1_2/8485/stack/manga-8485-1901-LOGCUBE.fits.gz>`_ into ``Cubeviz``, you would run the following from a terminal::
 
-    jdaviz /my/manga/cube/manga-8485-1901-LOGCUBE.fits.gz --layout=cubeviz
+    jdaviz cubeviz /my/manga/cube/manga-8485-1901-LOGCUBE.fits.gz
 
 In a Jupyter Notebook
 ---------------------

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -16,14 +16,11 @@ CONFIGS_DIR = os.path.join(os.path.dirname(__file__), 'configs')
 
 @click.version_option(__version__)
 @click.command()
+@click.argument('layout',
+                nargs=1,
+                type=click.Choice(['cubeviz', 'specviz', 'mosviz', 'imviz'],
+                                  case_sensitive=False))
 @click.argument('filename', nargs=1)
-@click.option('--layout',
-              default='default',
-              nargs=1,
-              show_default=True,
-              type=click.Choice(['default', 'cubeviz', 'specviz', 'mosviz', 'imviz'],
-                                case_sensitive=False),
-              help="Configuration to use on application startup")
 @click.option('--browser',
               default='default',
               nargs=1,


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request changes the `--layout` option in the CLI to a positional (required) argument.  So `jdaviz FILENAME --layout=cubeviz` is now `jdaviz cubeviz FILENAME`.  This also removes `'default'` as an option for layout until it is properly supported.  In doing all of this, the CLI outputs change for the following:

**BEFORE**
`jdaviz`:

```
Usage: jdaviz [OPTIONS] FILENAME
Try 'jdaviz --help' for help.

Error: Missing argument 'FILENAME'.
```

`jdaviz --help`:

```
Usage: jdaviz [OPTIONS] FILENAME

  Start a Jdaviz application instance with data loaded from FILENAME.

Options:
  --layout [default|cubeviz|specviz|mosviz|imviz]
                                  Configuration to use on application startup
                                  [default: default]
  --browser TEXT                  Browser to use for application  [default:
                                  default]
  --theme [light|dark]            Theme to use for application  [default:
                                  light]
  --verbosity [debug|info|warning|error]
                                  Verbosity of the application  [default:
                                  info]
  --hotreload / --no-hotreload    Whether to enable hot-reloading of the UI
                                  (for development)
  --version                       Show the version and exit.
  --help                          Show this message and exit.
```


**AFTER**
`jdaviz`:
```
Usage: jdaviz [OPTIONS] {cubeviz|specviz|mosviz|imviz} FILENAME
Try 'jdaviz --help' for help.

Error: Missing argument '{cubeviz|specviz|mosviz|imviz}'. Choose from:
	cubeviz,
	specviz,
	mosviz,
	imviz
```

`jdaviz cubeviz`:

```
Usage: jdaviz [OPTIONS] {cubeviz|specviz|mosviz|imviz} FILENAME
Try 'jdaviz --help' for help.

Error: Missing argument 'FILENAME'.
```

`jdaviz --help`:

```
Usage: jdaviz [OPTIONS] {cubeviz|specviz|mosviz|imviz} FILENAME

  Start a Jdaviz application instance with data loaded from FILENAME.

Options:
  --browser TEXT                  Browser to use for application  [default:
                                  default]
  --theme [light|dark]            Theme to use for application  [default:
                                  light]
  --verbosity [debug|info|warning|error]
                                  Verbosity of the application  [default:
                                  info]
  --hotreload / --no-hotreload    Whether to enable hot-reloading of the UI
                                  (for development)
  --version                       Show the version and exit.
  --help                          Show this message and exit.
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
