### PR TITLE
fix: workaround for extra click when using ctrl-click in safari

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ Specviz
 Bug Fixes
 ---------
 
+- Fixed clicking in Safari on MacOS when using CTRL-click as right-click. [#1262]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/components/toolbar_nested.py
+++ b/jdaviz/components/toolbar_nested.py
@@ -19,6 +19,7 @@ class NestedJupyterToolbar(BasicJupyterToolbar):
 
     # whether to show a popup menu
     show_suboptions = traitlets.Bool(False).tag(sync=True)
+    close_on_click = traitlets.Bool(False).tag(sync=True)
     # which submenu to show when show_suboptions is True
     suboptions_ind = traitlets.Int(0).tag(sync=True)
     # absolute positions to display the menu

--- a/jdaviz/components/toolbar_nested.vue
+++ b/jdaviz/components/toolbar_nested.vue
@@ -4,8 +4,8 @@
         <v-tooltip v-for="[id, {tooltip, img, menu_ind, has_suboptions, primary}] of Object.entries(tools_data)" v-if="primary" bottom>
             <template v-slot:activator="{ on }">
                 <v-btn v-on="on" icon :value="id" @contextmenu="(e) => show_submenu(e, has_suboptions, menu_ind)">
-                    <img :src="img" width="20"/>
-                    <v-icon small v-if="has_suboptions" class="suboptions-carrot">mdi-menu-down</v-icon>
+                    <img :src="img" width="20" @click.ctrl.stop=""/>
+                    <v-icon small v-if="has_suboptions" class="suboptions-carrot" @click.ctrl.stop="">mdi-menu-down</v-icon>
                 </v-btn>
             </template>
             <span>{{ tooltip }}{{has_suboptions ? " [right-click for alt. tools]" : ""}}</span>
@@ -18,6 +18,7 @@
       absolute
       offset-y
       dense
+      :close-on-click="close_on_click"
     >
       <v-list>
         <v-tooltip
@@ -40,6 +41,19 @@
 
 <script>
   export default {
+    watch: {
+      show_suboptions(value) {
+        /* workaround for safari on MacOS, which triggers an extra click when using ctrl-click as right-click. The
+         * `close-on-click` can't be prevented with `@click.ctrl.stop` */
+        if (value) {
+          setTimeout(() => {
+            this.close_on_click = true;
+          }, 100)
+        } else {
+          this.close_on_click = false;
+        }
+      }
+    },
     methods: {
       show_submenu (e, has_suboptions, menu_ind) {
         // needed to prevent browser context-menu


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
This pull request is to address the extra click produced in Safari on MacOs when using ctrl-click as right-click.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1256

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
