### PR TITLE
POC: display-units via bqplot artist class

### DIFF
--- a/jdaviz/__init__.py
+++ b/jdaviz/__init__.py
@@ -18,8 +18,17 @@ from jdaviz.configs.cubeviz import Cubeviz, CubeViz  # noqa
 from jdaviz.configs.imviz import Imviz  # noqa
 from jdaviz.utils import enable_hot_reloading  # noqa
 
+import bqplot_image_gl
 import bqplot
-from jdaviz.core.marks import BaseUnitLine
-bqplot.Lines = BaseUnitLine
+from jdaviz.core.marks import LinesWithUnitsMixin
 
-del layer_artist, bqplot, BaseUnitLine
+class BqplotLinesWithUnits(bqplot.Lines, LinesWithUnitsMixin):
+    pass
+
+class ImageGLLinesWithUnits(bqplot_image_gl.LinesGL, LinesWithUnitsMixin):
+    pass
+
+bqplot_image_gl.LinesGL = ImageGLLinesWithUnits
+bqplot.Lines = BqplotLinesWithUnits
+
+del bqplot, bqplot_image_gl, LinesWithUnitsMixin, BqplotLinesWithUnits, ImageGLLinesWithUnits

--- a/jdaviz/__init__.py
+++ b/jdaviz/__init__.py
@@ -6,6 +6,9 @@
 from ._astropy_init import *   # noqa
 # ----------------------------------------------------------------------------
 
+from glue_jupyter.bqplot.profile import layer_artist
+layer_artist.USE_GL = False
+
 # top-level API as exposed to users
 from jdaviz.app import *  # noqa
 from jdaviz.configs.specviz import Specviz, SpecViz  # noqa
@@ -14,3 +17,9 @@ from jdaviz.configs.mosviz import Mosviz, MosViz  # noqa
 from jdaviz.configs.cubeviz import Cubeviz, CubeViz  # noqa
 from jdaviz.configs.imviz import Imviz  # noqa
 from jdaviz.utils import enable_hot_reloading  # noqa
+
+import bqplot
+from jdaviz.core.marks import BaseUnitLine
+bqplot.Lines = BaseUnitLine
+
+del layer_artist, bqplot, BaseUnitLine

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -479,6 +479,7 @@ class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
             if hasattr(mark, 'set_display_units'):
                 if mark._native_xunit is None:
                     mark.set_native_units(xunit=self.xunit, yunit=self.yunit)
+                    mark._x_equivalencies = u.spectral()
                 mark.set_display_units(xunit=xunit, yunit=yunit)
 
         if xunit is not None:
@@ -488,8 +489,8 @@ class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
 
         # update limits
         with delay_callback(self.state, 'x_min', 'x_max', 'y_min', 'y_max'):
-            self.state.x_min = (prev_xmin * prev_xunit).to_value(self.xunit)
-            self.state.x_max = (prev_xmax * prev_xunit).to_value(self.xunit)
+            self.state.x_min = (prev_xmin * prev_xunit).to_value(self.xunit, equivalencies=u.spectral())
+            self.state.x_max = (prev_xmax * prev_xunit).to_value(self.xunit, equivalencies=u.spectral())
             self.state.y_min = (prev_ymin * prev_yunit).to_value(self.yunit)
             self.state.y_max = (prev_ymax * prev_yunit).to_value(self.yunit)
 

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -15,6 +15,8 @@ class LinesWithUnitsMixin():
     _yunit = None
     _native_x = None
     _native_y = None
+    _x_equivalencies = []
+    _y_equivalencies = []
 
     def __setattr__(self, attr, value):
         if not self._changing_units:
@@ -50,10 +52,12 @@ class LinesWithUnitsMixin():
             raise ValueError("native units have not (yet) been set, cannot set display units")
         self._changing_units = True
         if xunit is not None:
-            self.x = (self._native_x * self._native_xunit).to_value(xunit)
+            self.x = (self._native_x * self._native_xunit).to_value(xunit,
+                                                                    equivalencies=self._x_equivalencies)
             self._xunit = u.Unit(xunit)
         if yunit is not None:
-            self.y = (self._native_y * self._native_yunit).to_value(yunit)
+            self.y = (self._native_y * self._native_yunit).to_value(yunit,
+                                                                    equivalencies=self._y_equivalencies)
             self._yunit = u.Unit(yunit)
         self._changing_units = False
 

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -6,19 +6,15 @@ from specutils import Spectrum1D
 from jdaviz.core.events import SliceToolStateMessage, LineIdentifyMessage
 
 
-class BaseUnitLine(Lines, HubListener):
+class LinesWithUnitsMixin():
     _changing_units = False
-
-    def __init__(self, x, y, **kwargs):
-        self._viewer = None
-        self._native_xunit = None
-        self._native_yunit = None
-        self._xunit = None
-        self._yunit = None
-        self._native_x = x
-        self._native_y = y
-
-        super().__init__(x=x, y=y, **kwargs)
+    _viewer = None
+    _native_xunit = None
+    _native_yunit = None
+    _xunit = None
+    _yunit = None
+    _native_x = None
+    _native_y = None
 
     def __setattr__(self, attr, value):
         if not self._changing_units:

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -357,3 +357,7 @@ class LineUncertainties(Lines):
 class ScatterMask(Scatter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+
+### Need to have glue get our subclass in place of bqplot.Lines
+Lines = BaseUnitLine

--- a/jdaviz/core/tools.py
+++ b/jdaviz/core/tools.py
@@ -4,6 +4,7 @@ from echo import delay_callback
 
 from glue.config import viewer_tool
 from glue.core import HubListener
+from glue.core.roi import RangeROI
 from glue.viewers.common.tool import Tool
 from glue_jupyter.bqplot.common.tools import (CheckableTool, HomeTool, BqplotPanZoomMode,
                                               BqplotPanZoomXMode, BqplotPanZoomYMode,
@@ -30,6 +31,28 @@ BqplotCircleMode.icon = os.path.join(ICON_DIR, 'select_circle.svg')
 BqplotEllipseMode.icon = os.path.join(ICON_DIR, 'select_ellipse.svg')
 BqplotXRangeMode.icon = os.path.join(ICON_DIR, 'select_x.svg')
 BqplotYRangeMode.icon = os.path.join(ICON_DIR, 'select_y.svg')
+
+
+@viewer_tool
+class BqplotXRangeModeUnitAware(BqplotXRangeMode):
+    icon = os.path.join(ICON_DIR, 'select_x.svg')
+    tool_id = 'jdaviz:xrange'
+    action_text = 'X range ROI'
+    tool_tip = 'Select a range of x values'
+
+    def update_selection(self, *args):
+        with self.viewer._output_widget:
+            if self.interact.selected is not None:
+                x = self.interact.selected
+                if x is not None and len(x):
+                    x = (x * self.viewer.xunit).to_value(self.viewer._native_xunit, equivalencies=self.viewer._x_equivalencies)
+                    roi = RangeROI(min=min(x), max=max(x), orientation='x')
+                    self.viewer.apply_roi(roi)
+                    mark = self.viewer.figure.marks[-1]
+                    mark._x_equivalencies = self.viewer._x_equivalencies
+                    mark._y_equivalencies = self.viewer._y_equivalencies
+                    mark.set_native_units(self.viewer._native_xunit, self.viewer._native_yunit)
+                    mark.set_display_units(self.viewer.xunit, self.viewer.yunit)
 
 
 class _BaseSelectZoom(BqplotSelectionTool):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is a proof of concept for how we (or perhaps upstream in glue-jupyter) could handle on-the-fly display unit conversion via the plotting artists themselves, with the unit choice at the **viewer-level**.

Current API (specviz only):

```
sv = specviz.app.get_viewer('spectrum-viewer')
sv.set_display_units(xunit='um')
```

where `xunit` and/or `yunit` can be passed as kwargs arguments as either a string or unit object (no current logic to test the validity of the unit, so make sure its valid)

Remaining todo items:
- [x] unit aware axes limits
- [x] override glue's class within jdaviz (not in notebook)
- [x] set_native_units within jdaviz (not in notebook)
- [x] viewer-level setting of units, which loops over all line artists and also sets the axes labels (viewer.set_plot_axes)
- [x] test/scope support for subsets
- [x] scope implementing as mixin so works for GL/MPL
- [x] support for spectral equivalencies (and scope how that might work in general - not all axes should support equivalencies)
- [x] subsets: `glue.core.subset.roi_to_subset_state` creates the subset after dragging, but is comparing plot coordinates to the underlying data coordinates in different units, so resulting in no overlap.  This will either need to be changed to be aware of the unit change or the passed roi will need to be converted back to native units before getting to `roi_to_subset_state`.
- [ ] `viewer.state._reset_x_limits()`/`viewer.state._reset_y_limits()` relies on the underlying data collection, which is left untouched in this approach.  We could override the `_reset_x_limits` and `_reset_y_limits` methods themselves, but would need to recreate a lot of that glue logic but by looping through the lines artists instead of the data-collection (and thinking about the fact that spectral lines are allowed to be out-of-limits and look at the hidden properties, etc).
- [ ] spectral lines, slice, etc, will need to be refactored to be able to set display units for x (rather than observing changes to underlying data objects to handle unit changes).  (This will likely need to be done even with the upstream approach, although might differ slightly).

Further to do items if moving forward in this direction:
- [ ] generalize for GL/MPL via mixin (and remove hardcoded `USE_GL=False`)
- [ ] only override lines artist in jdaviz's glue-jupyter (or move implementation upstream) rather than hacky override done in init
- [ ] generalize for all viewers and subset selection tools
- [ ] expose UI element to choose from valid unit choices based on input data
- [ ] when requesting display units, run checks to make sure valid and raise useful errors
- [ ] decide how to handle layers with mixed units in the same viewer
- [ ] unit plugin to set default for each physical type.  Probably means that the unit dropdowns need to be "default-aware" similar to the plugin labels


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
