### PR TITLE
BUG: Fix Line Profile not handling dithered data in Imviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,12 +28,6 @@ Cubeviz
 Imviz
 ^^^^^
 
-- Line profile plot in Line Profile plugin no longer affects
-  radial profile plot in Simple Aperture Photometry plugin. [#1224]
-
-- Radial profile plot in Simple Aperture Photometry plugin
-  no longer shows masked aperture data. [#1224]
-
 Mosviz
 ^^^^^^
 
@@ -48,6 +42,15 @@ Cubeviz
 
 Imviz
 ^^^^^
+
+- Line profile plot in Line Profile plugin no longer affects
+  radial profile plot in Simple Aperture Photometry plugin. [#1224]
+
+- Line profile plot no longer report wrong coordinates on
+  dithered data that is not the reference data. [#1293]
+
+- Radial profile plot in Simple Aperture Photometry plugin
+  no longer shows masked aperture data. [#1224]
 
 Mosviz
 ^^^^^^

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -71,8 +71,7 @@ values of X and Y, and then press the :guilabel:`PLOT` button.
 The top visible image, the same one displayed under :ref:`imviz-compass`,
 will be used for these plots.
 
-This plugin only considers pixel locations, regardless of linking type set in
-:ref:`imviz-link-control`.
+This plugin only considers pixel locations, not sky coordinates.
 
 .. _aper-phot-simple:
 


### PR DESCRIPTION


<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to report correct X and Y when "l" is pressed over dithered data that is not the reference data. You can try this out by linking the Imviz example notebook by WCS and then press "l" and then blink and then press "l" again.

I also moved entries from #1224 to the correct section. They were bug fixes, not API changes.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1285 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
