### PR TITLE
uncertainty rounding component: smarter default if uncertainty isn't passed at all

### DIFF
--- a/jdaviz/components/number_uncertainty.vue
+++ b/jdaviz/components/number_uncertainty.vue
@@ -20,10 +20,10 @@ module.exports = {
   methods: {
     updateTruncatedValues() {
       var nDigs = this.defaultDigs;
-      if (parseFloat(this.uncertainty) == 0) {
+      if (this.uncertainty === undefined || parseFloat(this.uncertainty) == 0 || this.uncertainty == '') {
         // then treat as no uncertainty
         this.uncertTrunc = null;
-      } else if (this.uncertainty !== '') {
+      } else {
         // then uncertainty was provided, so we'll round the uncertainty to 2 significant digits
         this.uncertTrunc = +parseFloat(this.uncertainty).toPrecision(2);
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request adds support in the `<j-number-uncertainty>` (implemented in #1244) to support not passing uncertainties (and still rounding the number).  This should not have any affect on existing internal uses in line analysis (so I don't think it warrants a changelog entry?), but will make the component usable in #1292.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
