### PR TITLE
Cubeviz image viewer coordinates display

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ New Features
 Cubeviz
 ^^^^^^^
 
+- Cubeviz image viewer now has coordinates info panel like Imviz. [#1315]
+
 Imviz
 ^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,9 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Parser now respects user-provided ``data_label`` when ``Spectrum1D``
+  object is loaded. Previously, it only had effect on FITS data. [#1315]
+
 Imviz
 ^^^^^
 

--- a/docs/cubeviz/displaycubes.rst
+++ b/docs/cubeviz/displaycubes.rst
@@ -195,3 +195,13 @@ The spectrum of colors used to visualize data can be changed using this drop dow
 
     :ref:`Plot Settings (Specviz) <plot-settings>`
         Plot settings for the spectrum 1D viewer.
+
+.. _cubeviz_cursor_info:
+
+Cursor Information
+==================
+
+By moving your cursor along the image viewer, you will be able to see information on the
+cursor's location in pixel space (X and Y), the RA and Dec at that point, and the value
+of the data there. This information is located in the top bar of the UI, on the
+middle-right side.

--- a/docs/imviz/displayimages.rst
+++ b/docs/imviz/displayimages.rst
@@ -54,6 +54,8 @@ and bias. Moving along the X-axis will change the bias and moving along the Y-ax
 contrast. If you would like to reset to the default contrast and bias settings, you can
 double-click on the display while the mode is active.
 
+.. _imviz_cursor_info:
+
 Cursor Information
 ==================
 

--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -8,12 +8,14 @@ settings:
     toolbar: true
     tray: true
     tab_headers: false
+  dense_toolbar: false
   context:
     notebook:
       max_height: 600px
 toolbar:
   - g-data-tools
   - g-subset-tools
+  - g-coords-info
 tray:
   - g-plot-options
   - g-subset-plugin

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -8,12 +8,10 @@ from jdaviz.configs.cubeviz.plugins.moment_maps.moment_maps import MomentMap
 
 @pytest.mark.filterwarnings('ignore:No observer defined on WCS')
 def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
-    app = cubeviz_helper.app
-    dc = app.data_collection
-    app.add_data(spectrum1d_cube, 'test[FLUX]')
-    app.add_data_to_viewer('flux-viewer', 'test[FLUX]')
+    dc = cubeviz_helper.app.data_collection
+    cubeviz_helper.load_data(spectrum1d_cube, data_label='test')
 
-    mm = MomentMap(app=app)
+    mm = MomentMap(app=cubeviz_helper.app)
     mm.dataset_selected = 'test[FLUX]'
 
     mm.n_moment = 0  # Collapsed sum, will get back 2D spatial image
@@ -30,10 +28,19 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     assert mm.results_label_overwrite is True
 
     result = dc[1].get_object(cls=CCDData)
-    assert result.shape == (2, 4)  # Cube shape is (2, 2, 4)
+    assert result.shape == (4, 2)  # Cube shape is (2, 2, 4)
 
     # FIXME: Need spatial WCS, see https://github.com/spacetelescope/jdaviz/issues/1025
     assert dc[1].coords is None
+
+    # Make sure coordinate display still works
+    flux_viewer = cubeviz_helper.app.get_viewer('flux-viewer')
+    flux_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+    assert flux_viewer.state.slices == (0, 0, 1)
+    assert flux_viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
+    assert flux_viewer.label_mouseover.value == '+8.00000e+00 Jy'  # Slice 0 has 8 pixels, this is Slice 1  # noqa
+    assert flux_viewer.label_mouseover.world_ra_deg == '204.9997755346'
+    assert flux_viewer.label_mouseover.world_dec_deg == '27.0000999998'
 
     assert mm.filename == 'moment0_test_FLUX.fits'  # Auto-populated on calculate.
     mm.filename = str(tmpdir.join(mm.filename))  # But we want it in tmpdir for testing.
@@ -52,3 +59,9 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     assert dc[2].label == 'moment 1'
 
     assert len(dc.links) == 10
+
+    # Coordinate display should be unaffected.
+    assert flux_viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
+    assert flux_viewer.label_mouseover.value == '+8.00000e+00 Jy'  # Slice 0 has 8 pixels, this is Slice 1  # noqa
+    assert flux_viewer.label_mouseover.world_ra_deg == '204.9997755346'
+    assert flux_viewer.label_mouseover.world_dec_deg == '27.0000999998'

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -75,9 +75,9 @@ def parse_data(app, file_obj, data_type=None, data_label=None):
     #  into something glue can understand.
     elif isinstance(file_obj, Spectrum1D):
         if file_obj.flux.ndim == 3:
-            _parse_spectrum1d_3d(app, file_obj)
+            _parse_spectrum1d_3d(app, file_obj, data_label=data_label)
         else:
-            _parse_spectrum1d(app, file_obj)
+            _parse_spectrum1d(app, file_obj, data_label=data_label)
     else:
         raise NotImplementedError(f'Unsupported data format: {file_obj}')
 
@@ -202,8 +202,11 @@ def _parse_esa_s3d(app, hdulist, data_label, ext='DATA', viewer_name='flux-viewe
         app.add_data_to_viewer('spectrum-viewer', data_label)
 
 
-def _parse_spectrum1d_3d(app, file_obj):
-    # Load spectrum1d as a cube
+def _parse_spectrum1d_3d(app, file_obj, data_label=None):
+    """Load spectrum1d as a cube."""
+
+    if data_label is None:
+        data_label = "Unknown spectrum object"
 
     for attr in ["flux", "mask", "uncertainty"]:
         val = getattr(file_obj, attr)
@@ -224,20 +227,21 @@ def _parse_spectrum1d_3d(app, file_obj):
 
         s1d = Spectrum1D(flux=flux, wcs=file_obj.wcs)
 
-        data_label = f"Unknown spectrum object[{attr.upper()}]"
-        app.add_data(s1d, data_label)
+        cur_data_label = f"{data_label}[{attr.upper()}]"
+        app.add_data(s1d, cur_data_label)
 
         if attr == 'flux':
-            app.add_data_to_viewer('flux-viewer', data_label)
-            app.add_data_to_viewer('spectrum-viewer', data_label)
+            app.add_data_to_viewer('flux-viewer', cur_data_label)
+            app.add_data_to_viewer('spectrum-viewer', cur_data_label)
         elif attr == 'mask':
-            app.add_data_to_viewer('mask-viewer', data_label)
+            app.add_data_to_viewer('mask-viewer', cur_data_label)
         else:  # 'uncertainty'
-            app.add_data_to_viewer('uncert-viewer', data_label)
+            app.add_data_to_viewer('uncert-viewer', cur_data_label)
 
 
-def _parse_spectrum1d(app, file_obj):
-    data_label = "Unknown spectrum object"
+def _parse_spectrum1d(app, file_obj, data_label=None):
+    if data_label is None:
+        data_label = "Unknown spectrum object"
 
     # TODO: glue-astronomy translators only look at the flux property of
     #  specutils Spectrum1D objects. Fix to support uncertainties and masks.

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -56,6 +56,29 @@ def test_fits_image_hdu_parse_from_file(tmpdir, image_hdu_obj, cubeviz_helper):
     assert len(cubeviz_helper.app.data_collection) == 3
     assert cubeviz_helper.app.data_collection[0].label.endswith('[FLUX]')
 
+    # This tests the same data as test_fits_image_hdu_parse above.
+
+    flux_viewer = cubeviz_helper.app.get_viewer('flux-viewer')
+    flux_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+    assert flux_viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
+    assert flux_viewer.label_mouseover.value == '+1.00000e+00 1e-17 erg / (Angstrom cm2 pix s)'
+    assert flux_viewer.label_mouseover.world_ra_deg == '205.4433848390'
+    assert flux_viewer.label_mouseover.world_dec_deg == '26.9996149270'
+
+    unc_viewer = cubeviz_helper.app.get_viewer('uncert-viewer')
+    unc_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': -1, 'y': 0}})
+    assert unc_viewer.label_mouseover.pixel == 'x=-1.0 y=00.0'
+    assert unc_viewer.label_mouseover.value == ''  # Out of bounds
+    assert unc_viewer.label_mouseover.world_ra_deg == '205.4441642302'
+    assert unc_viewer.label_mouseover.world_dec_deg == '26.9996148973'
+
+    mask_viewer = cubeviz_helper.app.get_viewer('mask-viewer')
+    mask_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 9, 'y': 0}})
+    assert mask_viewer.label_mouseover.pixel == 'x=09.0 y=00.0'
+    assert mask_viewer.label_mouseover.value == '+0.00000e+00 ct'  # No unit define, ct as fallback
+    assert mask_viewer.label_mouseover.world_ra_deg == '205.4441642302'
+    assert mask_viewer.label_mouseover.world_dec_deg == '26.9996148973'
+
 
 @pytest.mark.filterwarnings('ignore')
 def test_spectrum3d_parse(image_hdu_obj, cubeviz_helper):
@@ -67,12 +90,34 @@ def test_spectrum3d_parse(image_hdu_obj, cubeviz_helper):
     assert len(cubeviz_helper.app.data_collection) == 1
     assert cubeviz_helper.app.data_collection[0].label.endswith('[FLUX]')
 
+    # Same as flux viewer data in test_fits_image_hdu_parse_from_file
+    flux_viewer = cubeviz_helper.app.get_viewer('flux-viewer')
+    flux_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+    assert flux_viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
+    assert flux_viewer.label_mouseover.value == '+1.00000e+00 1e-17 erg / (Angstrom cm2 pix s)'
+    assert flux_viewer.label_mouseover.world_ra_deg == '205.4433848390'
+    assert flux_viewer.label_mouseover.world_dec_deg == '26.9996149270'
+
+    # These viewers have no data.
+
+    unc_viewer = cubeviz_helper.app.get_viewer('uncert-viewer')
+    unc_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': -1, 'y': 0}})
+    assert unc_viewer.label_mouseover is None
+
+    mask_viewer = cubeviz_helper.app.get_viewer('mask-viewer')
+    mask_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 9, 'y': 0}})
+    assert mask_viewer.label_mouseover is None
+
 
 def test_spectrum1d_parse(spectrum1d, cubeviz_helper):
     cubeviz_helper.load_data(spectrum1d)
 
     assert len(cubeviz_helper.app.data_collection) == 1
     assert cubeviz_helper.app.data_collection[0].label.endswith('[FLUX]')
+
+    # Coordinate display is only for spatial image, which is missing here.
+    flux_viewer = cubeviz_helper.app.get_viewer('flux-viewer')
+    assert flux_viewer.label_mouseover is None
 
 
 def test_numpy_cube(cubeviz_helper):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to add Imviz-like coordinates display for Cubeviz image viewers.

This is all UI so I am not sure how to add tests. There is currently no unit test for this equivalent capability in Imviz. Reviewers should interactively load a few different datasets that we are supposed to support and see what happens...

Here is a screenshot with data from Cubeviz example notebook (the mouse was at the center of flux viewer for this one):

![Screenshot 2022-05-12 132328](https://user-images.githubusercontent.com/2090236/168134151-7ed48fe3-fa10-4b44-b92a-63ee159dfe8d.png)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1090 

Imviz's display was originally done by @astrofrog (e.g., #557).

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)? (N/A)
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
