### PR TITLE
Fixing clearing identified spectral line when removed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,8 @@ Mosviz
 Specviz
 ^^^^^^^
 
+- Fixed clearing an identified spectral line when its removed. [#1322]
+
 Specviz2d
 ^^^^^^^^^
 

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -13,7 +13,7 @@ from matplotlib.colors import cnames
 from astropy import units as u
 
 
-from jdaviz.core.events import SpectralMarksChangedMessage
+from jdaviz.core.events import SpectralMarksChangedMessage, LineIdentifyMessage
 from jdaviz.core.registries import viewer_registry
 from jdaviz.core.marks import SpectralLine, LineUncertainties, ScatterMask
 from jdaviz.core.linelists import load_preset_linelist, get_available_linelists
@@ -205,6 +205,11 @@ class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
 
         msg = SpectralMarksChangedMessage(marks, sender=self)
         self.session.hub.broadcast(msg)
+
+        if not np.any([mark.identify for mark in marks]):
+            # then clear the identified entry
+            msg = LineIdentifyMessage(name_rest='', sender=self)
+            self.session.hub.broadcast(msg)
 
     def erase_spectral_lines(self, name=None, name_rest=None, show_none=True):
         """


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This PR clears the internal string storing the identified line if the currently identified line is removed.  Should ~resolve~ take care of https://github.com/spacetelescope/jdaviz/pull/1318#discussion_r872588309 in #1318.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
