### PR TITLE
BUG: aperture sum counted npix twice

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,12 @@ Imviz
 - Radial profile plot in Simple Aperture Photometry plugin
   no longer shows masked aperture data. [#1224]
 
+- Aperture sum in Simple Aperture Photometry plugin no longer reports
+  the wrong value in MJy when input data is in MJy/sr. Previously,
+  it applied number of pixels twice in the calculations, so sum in MJy
+  with 10-pixel aperture would be off by a factor of 10. This bug did not
+  affect data in any other units. [#1332]
+
 - Markers API now handles GWCS with ICRS Lon/Lat defined instead of
   Right Ascension and Declination. [#1314]
 

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -206,8 +206,8 @@ The columns are as follow:
 * :attr:`~photutils.aperture.ApertureStats.sum_aper_area`: The pixel area
   covered by the region. Partial coverage is reported as fraction.
 * ``pixarea_tot``: If per steradian is in input data unit and pixel area is
-  provided, this contains the total pixel area covered by the aperture in
-  steradian. Otherwise, it is `None`.
+  provided, this contains the conversion factor for the *sum* to take out
+  the steradian unit. Otherwise, it is `None`.
 * ``aperture_sum_counts``: This is the aperture sum converted to counts,
   if :guilabel:`Counts conversion factor` was set. Otherwise, it is `None`.
   This calculation is done without taking account of ``pixarea_tot``, even

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -263,11 +263,11 @@ class SimpleAperturePhotometry(TemplateMixin, DatasetSelectMixin):
             phot_table['xcentroid'].unit = u.pix  # photutils only assumes, we make it real
             phot_table['ycentroid'].unit = u.pix
             rawsum = phot_table['sum'][0]
-            npix = phot_table['sum_aper_area'][0]
 
             if include_pixarea_fac:
                 pixarea = pixarea * (u.arcsec * u.arcsec / (u.pix * u.pix))
-                pixarea_fac = npix * pixarea.to(u.sr / (u.pix * u.pix))
+                # NOTE: Sum already has npix value encoded, so we simply apply the npix unit here.
+                pixarea_fac = (u.pix * u.pix) * pixarea.to(u.sr / (u.pix * u.pix))
                 phot_table['sum'] = [rawsum * pixarea_fac]
             else:
                 pixarea_fac = None

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -280,9 +280,9 @@ class TestParseImage:
         assert_allclose(sky.dec.deg, -69.494592)
         data_unit = u.MJy / u.sr
         assert_quantity_allclose(tbl[0]['background'], 0.1741226315498352 * data_unit)
-        assert_quantity_allclose(tbl[0]['sum'], 4.989882e-09 * u.MJy)
+        assert_quantity_allclose(tbl[0]['sum'], 4.486487e-11 * u.MJy, rtol=1e-6)
         assert_quantity_allclose(tbl[0]['sum_aper_area'], 111.220234 * (u.pix * u.pix))
-        assert_quantity_allclose(tbl[0]['pixarea_tot'], 1.038438e-11 * u.sr, atol=1e-15 * u.sr)
+        assert_quantity_allclose(tbl[0]['pixarea_tot'], 9.33677e-14 * u.sr, rtol=1e-6)
         assert_quantity_allclose(tbl[0]['aperture_sum_counts'], 132061.576643 * u.count, rtol=1e-6)
         assert_quantity_allclose(tbl[0]['aperture_sum_counts_err'], 363.402775 * u.count)
         assert_quantity_allclose(tbl[0]['counts_fac'], 0.0036385915646798953 * (data_unit / u.ct))


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to fix a bug where aperture sum counted npix twice when converting from MJy/sr to MJy. Thanks to @orifox for finding this bug and @larrybradley for the fix suggestion!

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-2411)
