### PR TITLE
Cubeviz cube fitting: Fix fitted cube all zeroes, allow MP bypass

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,9 @@ Cubeviz
 - Parser now respects user-provided ``data_label`` when ``Spectrum1D``
   object is loaded. Previously, it only had effect on FITS data. [#1315]
 
+- Fixed a bug where fitting a model to the entire cube returns all
+  zeroes on failure. [#1333]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -264,7 +264,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
             self._window = None
         else:
             spectral_min, spectral_max = self.spectral_subset.selected_min_max(self._spectrum1d)
-            self._window = (spectral_min.value, spectral_max.value)
+            self._window = u.Quantity([spectral_min, spectral_max])
 
     @observe('comp_selected', 'poly_order')
     def _update_comp_label_default(self, event={}):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address reported bug where a failed cube fit would silently return a cube with all zeroes because multiprocessing swallowed all the exceptions. This PR intents to:

* fix the bug that caused the exception in the first place
* allow bypassing multiprocessing when `n_cpu` is set to 1 (this feature is for developers only)

Fix #1245

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-2425)
