### PR TITLE
Linelist spectral range unit compatibility

### DIFF
--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -26,6 +26,9 @@ from jdaviz.core.validunits import create_spectral_equivalencies_list
 
 __all__ = ['LineListTool']
 
+# Set the base unit of this plugin to the SI base unit for length: meters
+BASE_WAVE_UNIT = u.m
+
 
 @tray_registry('g-line-list', label="Line Lists")
 class LineListTool(PluginTemplateMixin):
@@ -303,6 +306,11 @@ class LineListTool(PluginTemplateMixin):
                     line_list['lines'][i]['obs'] = self._rs_line_obs_change[2]
                 else:
                     line_list['lines'][i]['obs'] = self._rest_to_obs(float(line['rest']))
+
+                # Keep a copy of the observed wavelength in the base unit for this plugin
+                line_list['lines'][i]['obs_meter'] = (line_list['lines'][i]['obs'] * u.Unit(
+                                                        line_list['lines'][i]['unit'])
+                                                      ).to(BASE_WAVE_UNIT).value
 
             new_list_contents[list_name] = line_list
 

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.vue
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.vue
@@ -360,7 +360,7 @@
         }
 
         if (filter_range) {
-          in_range = (lineItem.obs > this.spectrum_viewer_min) && (lineItem.obs < this.spectrum_viewer_max)
+          in_range = (lineItem.obs_base > this.spectrum_viewer_min_base) && (lineItem.obs < this.spectrum_viewer_max_base)
         }
         else{
           in_range = true


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This is to address #1337. Not done yet, but figured I'd publish as far as I could get. @kecnry and I architected a plan to introduce a BASE_UNIT (which I chose meters as the SI unit of length) and keep separate tally of a new `line['obs_base']` that is converted to this base unit. The main complication I have is where to set it. @kecnry suggested `_update_line_list_obs`, but my debugger only fires there when the redshift slider is modified (and indeed the only reference I can see to that method is from the redshift slider side. It technically observes `plugin_opened`, but I didn't actually catch it firing...

Another complication: The redshift slider bounds rely on the raw values of the spectral viewer, so I created a NEW traitlet, rather than modifying the existing one. The RS slider will need to use that one.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1337 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
