### PR TITLE
BUG: Metadata viewer to ignore invalid FITS header

### DIFF
--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -139,8 +139,11 @@ def standardize_metadata(metadata):
     dictionary.
     """
     if isinstance(metadata, fits.Header):
-        out_meta = dict(metadata)
-        out_meta[COMMENTCARD_KEY] = metadata.comments
+        try:
+            out_meta = dict(metadata)
+            out_meta[COMMENTCARD_KEY] = metadata.comments
+        except Exception:  # Invalid FITS header  # pragma: no cover
+            out_meta = {}
     elif isinstance(metadata, dict):
         out_meta = metadata.copy()
         # specutils nests it but we do not want nesting


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to avoid Metadata Viewer from crashing when user loads a file with invalid FITS header. Also see https://github.com/spacetelescope/dat_pyinthesky/issues/177 . This is split from #1333 . As noted in the other PR, I have a very hard time creating invalid FITS header by hand and I do not want to download a whole cube to test this one thing, so I did not add any test.

This fixes an unreleased feature (#1325), so it does not need a change log.

Would be nice to merge this fast so I can build #1333 on top of this.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
