### PR TITLE
TST: Fix dev job failure

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -99,6 +99,7 @@ filterwarnings =
     ignore::DeprecationWarning:voila
     ignore:Starting with ImageIO v3 the behavior of this function will switch to that of iio\.v3\.imread:DeprecationWarning
     ignore:::specutils.spectra.spectrum1d
+    ignore:_SixMetaPathImporter\.find_spec\(\) not found:ImportWarning
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to see which dev version of package is responsible for this failure in dev job:

```
2022-05-25T20:54:31.4804054Z collected 0 items
2022-05-25T20:54:31.4804592Z INTERNALERROR> Traceback (most recent call last):
2022-05-25T20:54:31.4805277Z INTERNALERROR>   File "<frozen importlib._bootstrap>", line 939, in _find_spec
2022-05-25T20:54:31.4806603Z INTERNALERROR> AttributeError: '_SixMetaPathImporter' object has no attribute 'find_spec'
2022-05-25T20:54:31.4807265Z INTERNALERROR> 
2022-05-25T20:54:31.4807897Z INTERNALERROR> During handling of the above exception, another exception occurred:
2022-05-25T20:54:31.4808519Z INTERNALERROR> 
2022-05-25T20:54:31.4809044Z INTERNALERROR> Traceback (most recent call last):
2022-05-25T20:54:31.4810303Z INTERNALERROR>   File "/home/runner/work/jdaviz/jdaviz/.tox/py310-test-devdeps/lib/python3.10/site-packages/_pytest/main.py", line 268, in wrap_session
2022-05-25T20:54:31.4811218Z INTERNALERROR>     session.exitstatus = doit(config, session) or 0
2022-05-25T20:54:31.4812477Z INTERNALERROR>   File "/home/runner/work/jdaviz/jdaviz/.tox/py310-test-devdeps/lib/python3.10/site-packages/_pytest/main.py", line 321, in _main
2022-05-25T20:54:31.4813389Z INTERNALERROR>     config.hook.pytest_collection(session=session)
2022-05-25T20:54:31.4814667Z INTERNALERROR>   File "/home/runner/work/jdaviz/jdaviz/.tox/py310-test-devdeps/lib/python3.10/site-packages/pluggy/_hooks.py", line 265, in __call__
2022-05-25T20:54:31.4815656Z INTERNALERROR>     return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
2022-05-25T20:54:31.4816996Z INTERNALERROR>   File "/home/runner/work/jdaviz/jdaviz/.tox/py310-test-devdeps/lib/python3.10/site-packages/pluggy/_manager.py", line 80, in _hookexec
2022-05-25T20:54:31.4817966Z INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
2022-05-25T20:54:31.4819279Z INTERNALERROR>   File "/home/runner/work/jdaviz/jdaviz/.tox/py310-test-devdeps/lib/python3.10/site-packages/pluggy/_callers.py", line 60, in _multicall
2022-05-25T20:54:31.4820114Z INTERNALERROR>     return outcome.get_result()
2022-05-25T20:54:31.4821321Z INTERNALERROR>   File "/home/runner/work/jdaviz/jdaviz/.tox/py310-test-devdeps/lib/python3.10/site-packages/pluggy/_result.py", line 60, in get_result
2022-05-25T20:54:31.4822203Z INTERNALERROR>     raise ex[1].with_traceback(ex[2])
2022-05-25T20:54:31.4824033Z INTERNALERROR>   File "/home/runner/work/jdaviz/jdaviz/.tox/py310-test-devdeps/lib/python3.10/site-packages/pluggy/_callers.py", line 39, in _multicall
2022-05-25T20:54:31.4824909Z INTERNALERROR>     res = hook_impl.function(*args)
2022-05-25T20:54:31.4826179Z INTERNALERROR>   File "/home/runner/work/jdaviz/jdaviz/.tox/py310-test-devdeps/lib/python3.10/site-packages/_pytest/main.py", line 332, in pytest_collection
2022-05-25T20:54:31.4827056Z INTERNALERROR>     session.perform_collect()
2022-05-25T20:54:31.4828270Z INTERNALERROR>   File "/home/runner/work/jdaviz/jdaviz/.tox/py310-test-devdeps/lib/python3.10/site-packages/_pytest/main.py", line 635, in perform_collect
2022-05-25T20:54:31.4829194Z INTERNALERROR>     fspath, parts = resolve_collection_argument(
2022-05-25T20:54:31.4830543Z INTERNALERROR>   File "/home/runner/work/jdaviz/jdaviz/.tox/py310-test-devdeps/lib/python3.10/site-packages/_pytest/main.py", line 878, in resolve_collection_argument
2022-05-25T20:54:31.4831459Z INTERNALERROR>     strpath = search_pypath(strpath)
2022-05-25T20:54:31.4832688Z INTERNALERROR>   File "/home/runner/work/jdaviz/jdaviz/.tox/py310-test-devdeps/lib/python3.10/site-packages/_pytest/main.py", line 834, in search_pypath
2022-05-25T20:54:31.4833598Z INTERNALERROR>     spec = importlib.util.find_spec(module_name)
2022-05-25T20:54:31.4834455Z INTERNALERROR>   File "/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/importlib/util.py", line 103, in find_spec
2022-05-25T20:54:31.4835260Z INTERNALERROR>     return _find_spec(fullname, parent_path)
2022-05-25T20:54:31.4835972Z INTERNALERROR>   File "<frozen importlib._bootstrap>", line 941, in _find_spec
2022-05-25T20:54:31.4836744Z INTERNALERROR>   File "<frozen importlib._bootstrap>", line 914, in _find_spec_legacy
2022-05-25T20:54:31.4837649Z INTERNALERROR> ImportWarning: _SixMetaPathImporter.find_spec() not found; falling back to find_module()
```

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-2461)
