### PR TITLE
BUG: Fix Imviz linking data from file chooser

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,10 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Fixed a bug where image loaded via the "IMPORT DATA" button is not
+  linked to the data collection, resulting in Imviz unusable until
+  the data are re-linked manually. [#1365]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.py
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.py
@@ -43,7 +43,12 @@ class DataTools(TemplateMixin):
             try:
                 load_data_message = LoadDataMessage(self._file_upload.file_path, sender=self)
                 self.hub.broadcast(load_data_message)
-            except Exception:
-                self.error_message = "An error occurred when loading the file"
+            except Exception as err:
+                self.error_message = f"An error occurred when loading the file: {repr(err)}"
             else:
                 self.dialog = False
+
+            if self.config == 'imviz':
+                # Do this like what Imviz does at the end of loading sequence from helper.
+                from jdaviz.configs.imviz.helper import link_image_data
+                link_image_data(self._app, link_type='pixels', error_on_fail=False)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to fix a bug where Imviz behaves weirdly because image loaded via file chooser (`IMPORT DATA`) is not linked to anything. File chooser itself is GUI driven and not tested, so I did not add any test for this.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1364

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
