### PR TITLE
This makes CLI info calls faster but at what cost?

### DIFF
--- a/jdaviz/__init__.py
+++ b/jdaviz/__init__.py
@@ -7,10 +7,10 @@ from ._astropy_init import *   # noqa
 # ----------------------------------------------------------------------------
 
 # top-level API as exposed to users
-from jdaviz.app import *  # noqa
-from jdaviz.configs.specviz import Specviz, SpecViz  # noqa
-from jdaviz.configs.specviz2d import Specviz2d  # noqa
-from jdaviz.configs.mosviz import Mosviz, MosViz  # noqa
-from jdaviz.configs.cubeviz import Cubeviz, CubeViz  # noqa
-from jdaviz.configs.imviz import Imviz  # noqa
+#from jdaviz.app import *  # noqa
+#from jdaviz.configs.specviz import Specviz, SpecViz  # noqa
+#from jdaviz.configs.specviz2d import Specviz2d  # noqa
+#from jdaviz.configs.mosviz import Mosviz, MosViz  # noqa
+#from jdaviz.configs.cubeviz import Cubeviz, CubeViz  # noqa
+#from jdaviz.configs.imviz import Imviz  # noqa
 from jdaviz.utils import enable_hot_reloading  # noqa

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -6,8 +6,6 @@ import sys
 import tempfile
 
 import click
-from voila.app import Voila
-from voila.configuration import VoilaConfiguration
 
 from jdaviz import __version__
 from jdaviz.app import _verbosity_levels
@@ -72,6 +70,9 @@ def main(filename, layout='default', browser='default', theme='light',
         Whether to enable hot-reloading of the UI (for development)
     """
     import logging  # Local import to avoid possibly messing with JWST pipeline logger.
+
+    from voila.app import Voila
+    from voila.configuration import VoilaConfiguration
 
     # Tornado Webserver py3.8 compatibility hotfix for windows
     if sys.platform == 'win32':


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to see how to make `jdaviz --help` and `jdaviz --version` faster. It is very related to #881 . Turns out just special casing `--help` or `--version` is not enough, because of the entrypoint call that would import `jdaviz` anyway:

https://github.com/spacetelescope/jdaviz/blob/e1748199d984ad184030a15973c9ec7621e7aa5e/setup.cfg#L72

The only way I can make it not so slow is not try to import everything into top-level in `__init__.py`, but that of course would disable things like `from jdaviz import Imviz`. With this patch, `jdaviz --help` takes like 1 second instead of 30 seconds. If I get rid of `click` and use `argparse` with this, it is almost instantaneous. But maybe this is not worth to fix...

Fix #1362

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
