### PR TITLE
feat: use Solara FileBrowser to import files and directories.

### DIFF
--- a/jdaviz/configs/default/plugins/data_tools/data_tools.py
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.py
@@ -1,10 +1,13 @@
+from pathlib import Path
+from typing import Callable, Optional
 from jdaviz.core.template_mixin import TemplateMixin
 from jdaviz.core.events import LoadDataMessage
 from traitlets import Unicode, Bool
 import os
 from jdaviz.configs.default.plugins.data_tools.file_chooser import FileChooser
 from jdaviz.core.registries import tool_registry
-
+import solara as sol
+import react_ipywidgets as react
 __all__ = ['DataTools']
 
 
@@ -12,43 +15,53 @@ __all__ = ['DataTools']
 class DataTools(TemplateMixin):
     template_file = __file__, "data_tools.vue"
     dialog = Bool(False).tag(sync=True)
-    valid_path = Bool(True).tag(sync=True)
     error_message = Unicode().tag(sync=True)
+    directory = Unicode(None, allow_none=True).tag(sync=True)
+    file = Unicode(None, allow_none=True).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         start_path = os.environ.get('JDAVIZ_START_DIR', os.path.curdir)
+        start_path = str(Path(start_path).resolve())
 
-        self._file_upload = FileChooser(start_path)
+        def on_directory_change(directory : Path):
+            self.directory = str(directory)
+
+        def on_file_open(file : Path):
+            self._load(file)
+
+        def on_path_select(path : Optional[Path]):
+            if path is None:
+                self.directory = None
+                self.file = None
+            else:
+                if path.is_dir():
+                    self.directory = str(path)
+                else:
+                    self.file = str(path)
+
+        element = sol.FileBrowser(start_path,
+                                  on_directory_change=on_directory_change,
+                                  on_file_open=on_file_open,
+                                  on_path_select=on_path_select,
+                                  can_select=True,
+                                  )
+        self._file_upload, rc = react.render(element)
 
         self.components = {'g-file-import': self._file_upload}
 
-        self._file_upload.observe(self._on_file_path_changed, names='file_path')
-
-    def _on_file_path_changed(self, event):
-        if (self._file_upload.file_path is not None
-                and not os.path.exists(self._file_upload.file_path)
-                or not os.path.isfile(self._file_upload.file_path)):
-            self.error_message = "No file exists at given path"
-            self.valid_path = False
+    def _load(self, path : Path):
+        try:
+            load_data_message = LoadDataMessage(str(path), sender=self)
+            self.hub.broadcast(load_data_message)
+        except Exception:
+            self.error_message = "An error occurred when loading the file"
         else:
-            self.error_message = ""
-            self.valid_path = True
+            self.dialog = False
 
-    def vue_load_data(self, *args, **kwargs):
-        if self._file_upload.file_path is None:
-            self.error_message = "No file selected"
-        elif os.path.exists(self._file_upload.file_path):
-            try:
-                load_data_message = LoadDataMessage(self._file_upload.file_path, sender=self)
-                self.hub.broadcast(load_data_message)
-            except Exception as err:
-                self.error_message = f"An error occurred when loading the file: {repr(err)}"
-            else:
-                self.dialog = False
+    def vue_load_file(self, *args, **kwargs):
+        self._load(Path(self.file))
 
-            if self.config == 'imviz':
-                # Do this like what Imviz does at the end of loading sequence from helper.
-                from jdaviz.configs.imviz.helper import link_image_data
-                link_image_data(self._app, link_type='pixels', error_on_fail=False)
+    def vue_load_directory(self, *args, **kwargs):
+        self._load(Path(self.directory))

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.vue
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.vue
@@ -8,18 +8,14 @@
       </template>
 
       <v-card>
-
         <v-card-title class="headline" color="primary" primary-title>Import Data</v-card-title>
 
         <v-card-text>
-          Select a file with data you want to load into this instance of Jdaviz
-          and click "IMPORT". Imported data can be shown in any compatible
-          viewer. Note that single clicks navigate into directories.
           <v-container>
             <v-row>
               <v-col>
                 <g-file-import id="file-uploader"></g-file-import>
-                <span style="color: red;">{{ error_message }}</span>
+                <span style="color: red">{{ error_message }}</span>
               </v-col>
             </v-row>
           </v-container>
@@ -28,9 +24,40 @@
         <v-card-actions>
           <div class="flex-grow-1"></div>
           <v-btn color="primary" text @click="dialog = false">Cancel</v-btn>
-          <v-btn color="primary" text @click="load_data" :disabled="!valid_path">Import</v-btn>
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on }">
+              <!-- wrap in a span to enable tooltip when button disabled -->
+              <span v-on="on">
+                <v-btn
+                  color="primary"
+                  text
+                  @click="load_directory"
+                  :disabled="!Boolean(directory)"
+                  >Import directory</v-btn
+                >
+              </span>
+            </template>
+            <div>
+              <span v-if="Boolean(directory)">Import {{ directory }}</span>
+              <span v-else>Select or enter a directory before importing</span>
+            </div>
+          </v-tooltip>
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on }">
+              <span v-on="on">
+                <v-btn
+                  color="primary"
+                  text
+                  @click="load_file"
+                  :disabled="!Boolean(file)"
+                  >Import file</v-btn
+                >
+              </span>
+            </template>
+            <span v-if="Boolean(file)">Import {{ file }}</span>
+            <span v-else>Select a file before importing, or double click a file.</span>
+          </v-tooltip>
         </v-card-actions>
-
       </v-card>
     </v-dialog>
   </v-toolbar-items>

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ install_requires =
     regions>=0.6
     scikit-image
     sidecar>=0.5.1
+    solara>=0.3.0
 
 [options.extras_require]
 test =


### PR DESCRIPTION
### Description

This file browser is more in line with the rest of the look and feel
(not based on ipywidgets-controls, but on ipyvuetify).

Also, maintenance of this will be done by Maarten&Mario.


Also, looking at the comments at #573 this is implemented using:

   * Single click to select a directory or file
   * Import button for directory or file
   * Double click to quickly import a file.

Tooltips are added to make clear what each button does, or why
it is disabled.

This requires solara >= 0.3



