### PR TITLE
Use subsets for spectrum-at-spaxel tool

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ Cubeviz
 ^^^^^^^
 
 - New tool for visualizing spectrum at a pixel's coordinate location
-  in the image viewer [#1317]
+  in the image viewer [#1317, #1377]
 
 Imviz
 ^^^^^

--- a/docs/cubeviz/displaycubes.rst
+++ b/docs/cubeviz/displaycubes.rst
@@ -123,7 +123,7 @@ This tool allows the user to create a one spaxel subset in an image viewer. This
 visualized in the spectrum viewer by showing the spectrum at that spaxel. Users can hold down the
 alt key (Alt key on Windows, Option key on Mac) while clicking on a spaxel to create a new subset at
 that point. Users can then compare spectra at different spaxels using the spectrum viewer. Users can
-also utilize the different subset modes that are explained in the :ref:`<spatial-regions>` section.
+also utilize the different subset modes that are explained in the :ref:`Spatial Regions <spatial-regions>` section.
 
 .. _display-settings:
 

--- a/docs/cubeviz/displaycubes.rst
+++ b/docs/cubeviz/displaycubes.rst
@@ -119,13 +119,11 @@ axis as in Specviz.
 Spectrum At Spaxel
 ==================
 
-This tool allows a user to select one pixel in the image viewer and visualize the spectrum
-at that point in the spectrum viewer. The selected pixel will be highlighted in the image viewer
-and the spectrum will have the same color. If there are multiple data selected in the image viewer
-a spectrum will be created for each data. Once the tool is deselected, the highlighted pixel will
-revert back to normal but the created spectrum/spectra will remain in the spectrum viewer.
-The zoom level of the spectrum viewer will then revert to what it was when the tool was first
-activated.
+This tool allows the user to create a one spaxel subset in an image viewer. This subset will then be
+visualized in the spectrum viewer by showing the spectrum at that spaxel. Users can hold down the
+alt key (Alt key on Windows, Option key on Mac) while clicking on a spaxel to create a new subset at
+that point. Users can then compare spectra at different spaxels using the spectrum viewer. Users can
+also utilize the different subset modes that are explained in the :ref:`<spatial-regions>` section.
 
 .. _display-settings:
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
@@ -1,10 +1,11 @@
 import pytest
 from astropy.nddata import CCDData
 
+from regions import RectanglePixelRegion
+
 
 @pytest.mark.filterwarnings('ignore:No observer defined on WCS')
 def test_spectrum_at_spaxel(cubeviz_helper, spectrum1d_cube):
-    app = cubeviz_helper.app
     cubeviz_helper.load_data(spectrum1d_cube, data_label='test')
 
     flux_viewer = cubeviz_helper.app.get_viewer("flux-viewer")
@@ -18,16 +19,56 @@ def test_spectrum_at_spaxel(cubeviz_helper, spectrum1d_cube):
     assert len(spectrum_viewer.data()) == 1
 
     # Click on spaxel location
-    flux_viewer.toolbar.active_tool.on_mouse_event({'event': 'click', 'domain': {'x': x, 'y': y}})
+    flux_viewer.toolbar.active_tool.on_mouse_event({'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
     assert len(flux_viewer.figure.marks) == 3
     assert len(spectrum_viewer.data()) == 2
-    assert app.data_collection[-1].label == "test[FLUX]_at_spaxel"
-    assert app.data_collection[-1].meta["reference_data"] == "test[FLUX]"
-    assert app.data_collection[-1].meta["created_from_spaxel"] == f"({x}, {y})"
+
+    # Check that a new subset was created
+    subsets = cubeviz_helper.app.get_subsets_from_viewer('flux-viewer')
+    reg = subsets.get('Subset 1')
+    assert len(subsets) == 1
+    assert isinstance(reg, RectanglePixelRegion)
 
     # Deselect tool
     flux_viewer.toolbar.active_tool = None
+    assert len(flux_viewer.figure.marks) == 3
+
+
+def test_spectrum_at_spaxel_altkey_true(cubeviz_helper, spectrum1d_cube):
+    cubeviz_helper.load_data(spectrum1d_cube, data_label='test')
+
+    flux_viewer = cubeviz_helper.app.get_viewer("flux-viewer")
+    spectrum_viewer = cubeviz_helper.app.get_viewer("spectrum-viewer")
+
+    # Set the active tool to spectrumperspaxel
+    flux_viewer.toolbar.active_tool = flux_viewer.toolbar.tools['jdaviz:spectrumperspaxel']
+    x = 1
+    y = 1
     assert len(flux_viewer.figure.marks) == 2
+    assert len(spectrum_viewer.data()) == 1
+
+    # Click on spaxel location
+    flux_viewer.toolbar.active_tool.on_mouse_event({'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
+    assert len(flux_viewer.figure.marks) == 3
+    assert len(spectrum_viewer.data()) == 2
+
+    # Check that subset was created
+    subsets = cubeviz_helper.app.get_subsets_from_viewer('flux-viewer')
+    reg = subsets.get('Subset 1')
+    assert len(subsets) == 1
+    assert isinstance(reg, RectanglePixelRegion)
+
+    # Using altKey should create a new subset
+    x = 2
+    y = 2
+    flux_viewer.toolbar.active_tool.on_mouse_event({'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': True})
+    assert len(flux_viewer.figure.marks) == 4
+    assert len(spectrum_viewer.data()) == 3
+
+    subsets = cubeviz_helper.app.get_subsets_from_viewer('flux-viewer')
+    reg2 = subsets.get('Subset 2')
+    assert len(subsets) == 2
+    assert isinstance(reg2, RectanglePixelRegion)
 
 
 def test_spectrum_at_spaxel_with_2d(cubeviz_helper):
@@ -49,10 +90,10 @@ def test_spectrum_at_spaxel_with_2d(cubeviz_helper):
     assert len(spectrum_viewer.data()) == 0
 
     # Click on spaxel location
-    flux_viewer.toolbar.active_tool.on_mouse_event({'event': 'click', 'domain': {'x': x, 'y': y}})
-    assert len(flux_viewer.figure.marks) == 2
+    flux_viewer.toolbar.active_tool.on_mouse_event({'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
+    assert len(flux_viewer.figure.marks) == 3
     assert len(spectrum_viewer.data()) == 0
 
     # Deselect tool
     flux_viewer.toolbar.active_tool = None
-    assert len(flux_viewer.figure.marks) == 2
+    assert len(flux_viewer.figure.marks) == 3

--- a/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
@@ -19,7 +19,8 @@ def test_spectrum_at_spaxel(cubeviz_helper, spectrum1d_cube):
     assert len(spectrum_viewer.data()) == 1
 
     # Click on spaxel location
-    flux_viewer.toolbar.active_tool.on_mouse_event({'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
+    flux_viewer.toolbar.active_tool.on_mouse_event(
+        {'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
     assert len(flux_viewer.figure.marks) == 3
     assert len(spectrum_viewer.data()) == 2
 
@@ -48,7 +49,8 @@ def test_spectrum_at_spaxel_altkey_true(cubeviz_helper, spectrum1d_cube):
     assert len(spectrum_viewer.data()) == 1
 
     # Click on spaxel location
-    flux_viewer.toolbar.active_tool.on_mouse_event({'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
+    flux_viewer.toolbar.active_tool.on_mouse_event(
+        {'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
     assert len(flux_viewer.figure.marks) == 3
     assert len(spectrum_viewer.data()) == 2
 
@@ -61,7 +63,8 @@ def test_spectrum_at_spaxel_altkey_true(cubeviz_helper, spectrum1d_cube):
     # Using altKey should create a new subset
     x = 2
     y = 2
-    flux_viewer.toolbar.active_tool.on_mouse_event({'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': True})
+    flux_viewer.toolbar.active_tool.on_mouse_event(
+        {'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': True})
     assert len(flux_viewer.figure.marks) == 4
     assert len(spectrum_viewer.data()) == 3
 
@@ -90,7 +93,8 @@ def test_spectrum_at_spaxel_with_2d(cubeviz_helper):
     assert len(spectrum_viewer.data()) == 0
 
     # Click on spaxel location
-    flux_viewer.toolbar.active_tool.on_mouse_event({'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
+    flux_viewer.toolbar.active_tool.on_mouse_event(
+        {'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
     assert len(flux_viewer.figure.marks) == 3
     assert len(spectrum_viewer.data()) == 0
 

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -5,6 +5,8 @@ from glue.config import viewer_tool
 from glue.viewers.common.tool import CheckableTool
 from glue.core.link_helpers import LinkSame
 from specutils import Spectrum1D
+from glue.core.roi import RectangularROI, XRangeROI, CircularROI
+from glue.core.edit_subset_mode import OrMode, NewMode, ReplaceMode
 
 from jdaviz.core.events import SliceSelectWavelengthMessage, SliceToolStateMessage
 from jdaviz.core.marks import SelectedSpaxel
@@ -58,142 +60,43 @@ class SpectrumPerSpaxel(CheckableTool):
     tool_tip = 'Click on the viewer and see the spectrum at that spaxel in the spectrum viewer'
 
     def __init__(self, viewer, **kwargs):
-        self.old_y_min = 0
-        self.old_y_max = 0
-        self.spectrum_viewer = None
+        self.previous_subset_mode = None
 
-        # Keep track of data created during this session and remove
-        # them from the spectrum viewer after the tool is deactivated
-        self.created_data_labels = []
-
-        # #b515d1 is magenta
-        self.colors = ['#b515d1']
         super().__init__(viewer, **kwargs)
 
     def activate(self):
         self.viewer.add_event_callback(self.on_mouse_event,
                                        events=['click'])
-        self.spectrum_viewer = self.viewer.jdaviz_app.get_viewer("spectrum-viewer")
 
     def deactivate(self):
         self.viewer.remove_event_callback(self.on_mouse_event)
-        self.remove_highlight_on_spaxel()
-        for label in self.created_data_labels:
-            self.viewer.jdaviz_app.remove_data_from_viewer("spectrum-viewer", label)
-        self.created_data_labels = []
 
     def on_mouse_event(self, data):
         event = data['event']
 
-        if event == 'click':
-            event_x = data['domain']['x']
-            event_y = data['domain']['y']
+        if event == 'click' and data['altKey'] is True:
+            self.alt_subset_at_spaxel(data)
+        elif event == 'click':
+            self.subset_at_spaxel(data)
 
-            x = round(event_x)
-            y = round(event_y)
+    def alt_subset_at_spaxel(self, data):
+        # Add a new subset if the alt key is held down
+        previous_subset_mode = self.viewer.session.edit_subset_mode.mode
 
-            if len(self.created_data_labels) == 0:
-                self.highlight_spaxel(x, y)
-            else:
-                self.update_highlight_spaxel(x, y)
+        self.viewer.session.edit_subset_mode.mode = NewMode
+        self.subset_at_spaxel(data)
+        self.viewer.session.edit_subset_mode.mode = previous_subset_mode
 
-            # Check if there are any cubes in the viewer
-            cube_in_viewer = False
-            dc = self.viewer.session.data_collection
-
-            # Spectrum is created for each active layer in the viewer
-            for data in self.viewer.data():
-                if len(data.shape) != 3:
-                    continue
-                cube_in_viewer = True
-
-                cube = data.get_object(cls=Spectrum1D, statistic=None)
-                if x >= cube.shape[0] or y >= cube.shape[1] or x < 0 or y < 0:
-                    continue
-
-                spec = Spectrum1D(flux=cube.flux[x][y], spectral_axis=cube.spectral_axis,
-                                  meta=cube.meta)
-                # Add meta data for reference data and spaxel
-                spec.meta.update({"reference_data": data.label,
-                                  "created_from_spaxel": f"({x}, {y})",
-                                  "Plugin": "Spectrum per spaxel"})
-                label = f"{data.label}_at_spaxel"
-
-                # Remove data from viewer, re-add data to app, and then add data
-                # back to spectrum viewer
-                self.viewer.jdaviz_app.remove_data_from_viewer("spectrum-viewer", label)
-                self.viewer.jdaviz_app.add_data(spec, data_label=label, notify_done=False)
-                self.viewer.jdaviz_app.add_data_to_viewer("spectrum-viewer",
-                                                          label,
-                                                          clear_other_data=False)
-                self.created_data_labels.append(label)
-
-                # Set color of spectrum to not conflict with subset colors
-                for layer in self.spectrum_viewer.state.layers:
-                    if layer.layer.label == label:
-                        layer.color = self.colors[0]
-
-                # Link newly created spectrum to reference data
-                ref_cube = self.spectrum_viewer.state.reference_data
-                new_spec = dc[label]
-                self.link_data(ref_cube, new_spec)
-
-            # Flux viewer is empty or contains only 2D images
-            if not cube_in_viewer:
-                self.remove_highlight_on_spaxel()
-                msg = SnackbarMessage("No cube in viewer, cannot create spectrum from spaxel",
-                                      sender=self, color="warning")
-                self.viewer.session.hub.broadcast(msg)
-                return
-
-    def link_data(self, data1, data2):
-        # If spectrum is also reference data
-        if data1.label == data2.label:
-            return
-
-        world1 = data1.world_component_ids
-        world2 = data2.world_component_ids
-        # Reference data is cube
-        if len(world1) == 3 and len(world2) == 1:
-            links = [LinkSame(world1[2], world2[0])]
-        # Reference data is 1D spectrum
-        elif len(world1) == 1 and len(world2) == 1:
-            links = [LinkSame(world1[0], world2[0])]
-        else:
-            return
-
-        self.viewer.session.data_collection.add_link(links)
-
-    def highlight_spaxel(self, x, y):
-        # Creates an X that shows the spaxel at coordinate (x, y)
-        x_coords, y_coords = self._calc_coords(x, y)
-
-        # Create LinearScale that is the same size as the image viewer
-        scales = {'x': self.viewer.figure.interaction.x_scale,
-                  'y': self.viewer.figure.interaction.y_scale}
-        highlight = SelectedSpaxel(x=x_coords, y=y_coords, scales=scales,
-                                   fill='none', colors=self.colors, stroke_width=2,
-                                   close_path=True)
-        self.viewer.figure.marks = self.viewer.figure.marks + [highlight]
-
-    def update_highlight_spaxel(self, x, y):
-        x_coords, y_coords = self._calc_coords(x, y)
-
-        for spaxel in self.viewer.figure.marks:
-            if isinstance(spaxel, SelectedSpaxel):
-                spaxel.x = x_coords
-                spaxel.y = y_coords
-
-    def remove_highlight_on_spaxel(self):
-        self.viewer.figure.marks = [x for x in self.viewer.figure.marks
-                                    if not isinstance(x, SelectedSpaxel)]
+    def subset_at_spaxel(self, data):
+        x = data['domain']['x']
+        y = data['domain']['y']
+        xmin, xmax, ymin, ymax = self._calc_coords(x, y)
+        self.viewer.apply_roi(RectangularROI(xmin, xmax, ymin, ymax))
 
     def _calc_coords(self, x, y):
         xmin = x - 0.5
         xmax = x + 0.5
         ymin = y - 0.5
         ymax = y + 0.5
-        x_coords = [[xmin, xmax], [xmin, xmax]]
-        y_coords = [[ymin, ymax], [ymax, ymin]]
 
-        return x_coords, y_coords
+        return xmin, xmax, ymin, ymax

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -3,14 +3,10 @@ import os
 
 from glue.config import viewer_tool
 from glue.viewers.common.tool import CheckableTool
-from glue.core.link_helpers import LinkSame
-from specutils import Spectrum1D
-from glue.core.roi import RectangularROI, XRangeROI, CircularROI
-from glue.core.edit_subset_mode import OrMode, NewMode, ReplaceMode
+from glue.core.roi import RectangularROI
+from glue.core.edit_subset_mode import NewMode
 
 from jdaviz.core.events import SliceSelectWavelengthMessage, SliceToolStateMessage
-from jdaviz.core.marks import SelectedSpaxel
-from jdaviz.core.events import SnackbarMessage
 
 __all__ = []
 

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -56,8 +56,6 @@ class SpectrumPerSpaxel(CheckableTool):
     tool_tip = 'Click on the viewer and see the spectrum at that spaxel in the spectrum viewer'
 
     def __init__(self, viewer, **kwargs):
-        self.previous_subset_mode = None
-
         super().__init__(viewer, **kwargs)
 
     def activate(self):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request changes the spectrum-at-spaxel tool to use subsets instead of new Spectrum1D objects.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1375
Fixes #1374

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
