### PR TITLE
default width of subset for spectral vs spatial

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,9 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Fixed the default thickness of a subset layer in the spectral viewer to remain 1 for
+  spatial subsets and 3 for spectral subsets. [#1380]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -224,12 +224,11 @@ def test_subset_default_thickness(specviz_helper, spectrum1d):
     specviz_helper.load_spectrum(spectrum1d)
 
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
-    tool = sv.toolbar.tools['bqplot:xrange']
-    tool.activate()
-    tool.interact.brushing = True
-    tool.interact.selected = [2.5, 3.5]
-    tool.interact.brushing = False
-
+    sv.toolbar.active_tool = sv.toolbar.tools['bqplot:xrange']
+    from glue.core.roi import XRangeROI
+    sv.apply_roi(XRangeROI(2.5, 3.5))
+    # _on_layers_update is not triggered within CI
+    sv._on_layers_update()
     assert sv.state.layers[-1].linewidth == 3
 
 

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -14,7 +14,6 @@ from glue.core import HubListener
 from glue.core.message import SubsetCreateMessage
 
 from jdaviz.app import Application
-from jdaviz.core.events import AddDataMessage
 
 from IPython.display import display
 
@@ -57,8 +56,6 @@ class ConfigHelper(HubListener):
 
         self.app.hub.subscribe(self, SubsetCreateMessage,
                                handler=lambda msg: self._propagate_callback_to_viewers('_on_subset_create', msg)) # noqa
-        self.app.hub.subscribe(self, AddDataMessage,
-                               handler=lambda msg: self._propagate_callback_to_viewers('_on_add_data', msg)) # noqa
 
     def _propagate_callback_to_viewers(self, method, msg):
         # viewers don't have access to the app/hub to subscribe to messages, so we'll


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request changes the default subset layer thickness (introduced in #994) to be dependent on whether it is a spatial subset (collapsed in the spectrum-viewer) or a spectral subset.

Before:
<img width="991" alt="Screen Shot 2022-06-08 at 12 20 31 PM" src="https://user-images.githubusercontent.com/877591/172667429-abf62add-562d-4aeb-a286-f6a7b87ec3a6.png">

After:
<img width="991" alt="Screen Shot 2022-06-08 at 12 20 03 PM" src="https://user-images.githubusercontent.com/877591/172667417-9a73e11b-5f31-4d86-8e0e-975765c74d2f.png">




<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
