### PR TITLE
DOC: Add Jupyter Lab IndexError as known issue upstream

### DIFF
--- a/docs/known_bugs.rst
+++ b/docs/known_bugs.rst
@@ -71,7 +71,7 @@ Lab fails to start with IndexError
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In some environments, you occasionally might not able to start Jdaviz in 
-Jupyter Lab due to this error ::
+Jupyter Lab due to this error::
 
     IndexError: pop from an empty deque
 

--- a/docs/known_bugs.rst
+++ b/docs/known_bugs.rst
@@ -70,8 +70,8 @@ Application-wide
 Lab fails to start with IndexError
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In some environment, you might not able to start Jdaviz in Jupyter Lab
-and see this error occasionally::
+In some environments, you occasionally might not able to start Jdaviz in 
+Jupyter Lab due to this error ::
 
     IndexError: pop from an empty deque
 

--- a/docs/known_bugs.rst
+++ b/docs/known_bugs.rst
@@ -9,6 +9,7 @@ so please also consult `existing Jdaviz GitHub issues <https://github.com/spacet
 as well if you are unable to find your issue here:
 
 * :ref:`known_issues_installation`
+* :ref:`known_issues_app`
 * :ref:`known_issues_cubeviz`
 * :ref:`known_issues_imviz`
 * :ref:`known_issues_specviz`
@@ -61,6 +62,23 @@ in bottleneck trying to build numpy from source and crash, stalling the
 installation altogether. When this happens, exit the installation, install
 bottleneck with conda, and try to install jdaviz again.
 
+.. _known_issues_app:
+
+Application-wide
+----------------
+
+Lab fails to start with IndexError
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In some environment, you might not able to start Jdaviz in Jupyter Lab
+and see this error occasionally::
+
+    IndexError: pop from an empty deque
+
+This is an upstream issue at https://github.com/jupyterlab/jupyterlab/issues/11934
+that is not related to Jdaviz. The workaround is to find another environment
+where you do not see this error or use Jupyter Notebook instead.
+
 .. _known_issues_cubeviz:
 
 Cubeviz
@@ -73,7 +91,6 @@ When trying to do a second collapse with the same spectral region, but with
 resized bounds: change to Region=None, resize the region, then reselect Region 1,
 the region bounds are correct. However, applying Collapse again, it errors out and
 the image viewer that contained the initial collapse goes blank.
-
 
 Cube viewer contrast changes when collapsing Jupyter scroll window
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION


<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to document a known upstream issue that @javerbukh reported at https://github.com/spacetelescope/jdaviz/pull/1373#issuecomment-1150001663 . Also see jupyterlab/jupyterlab#11934 .

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
