### PR TITLE
BUG: Fix contrast/bias mouse-drag handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,9 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Contrast/bias mouse-drag is now a little more responsive and
+  calculates contrast in the same way as Glue in Qt mode. [#1394]
+
 - Fixed a bug where image loaded via the "IMPORT DATA" button is not
   linked to the data collection, resulting in Imviz unusable until
   the data are re-linked manually. [#1365]

--- a/jdaviz/configs/imviz/plugins/tools.py
+++ b/jdaviz/configs/imviz/plugins/tools.py
@@ -153,7 +153,7 @@ class ContrastBias(CheckableTool):
         # Note that we throttle this to 200ms here as changing the contrast
         # and bias it expensive since it forces the whole image to be redrawn
         if event == 'dragmove':
-            if (time.time() - self._time_last) <= 0.2:
+            if (time.time() - self._time_last) <= 0.1:
                 return
 
             event_x = data['pixel']['x']
@@ -173,11 +173,12 @@ class ContrastBias(CheckableTool):
             i_top = get_top_layer_index(self.viewer)
             state = self.viewer.layers[i_top].state
 
+            # Also see glue/viewers/matplotlib/qt/toolbar_mode.py
             # bias range 0..1
             # contrast range 0..4
             with delay_callback(state, 'bias', 'contrast'):
                 state.bias = x
-                state.contrast = y * 4
+                state.contrast = (1 - y) * 4
 
             self._time_last = time.time()
 

--- a/jdaviz/configs/imviz/tests/test_viewer_tools.py
+++ b/jdaviz/configs/imviz/tests/test_viewer_tools.py
@@ -1,0 +1,56 @@
+import time
+
+from numpy.testing import assert_allclose
+
+from jdaviz.configs.imviz.helper import get_top_layer_index
+from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_NoWCS
+
+
+class TestContrastBiasTool(BaseImviz_WCS_NoWCS):
+
+    def teardown_method(self, method):
+        self.cb_tool.deactivate()
+
+    def test_contrast_bias_mousedrag(self):
+        # setup_class is already called by parent class, so we do this here.
+        self.cb_tool = self.viewer.toolbar_nested.tools['jdaviz:contrastbias']
+        self.cb_tool.activate()
+
+        state = self.viewer.layers[get_top_layer_index(self.viewer)].state
+        lag_time = 0.1
+
+        # Should start with default values.
+        assert_allclose(state.bias, 0.5)
+        assert_allclose(state.contrast, 1)
+
+        # Simulate some mouse-drag events.
+
+        self.cb_tool.on_mouse_or_key_event({'event': 'dragmove', 'pixel': {'x': 0, 'y': 0}})
+        assert_allclose(state.bias, 0)
+        assert_allclose(state.contrast, 4)
+        # Event during throttle has no effect.
+        self.cb_tool.on_mouse_or_key_event({'event': 'dragmove', 'pixel': {'x': 50, 'y': 50}})
+        assert_allclose(state.bias, 0)
+        assert_allclose(state.contrast, 4)
+
+        time.sleep(lag_time)
+        self.cb_tool.on_mouse_or_key_event({'event': 'dragmove', 'pixel': {'x': 50, 'y': 50}})
+        assert_allclose(state.bias, 0.5050505050505051)
+        assert_allclose(state.contrast, 1.9797979797979797)
+
+        time.sleep(lag_time)
+        self.cb_tool.on_mouse_or_key_event({'event': 'dragmove', 'pixel': {'x': 99, 'y': 99}})
+        assert_allclose(state.bias, 1)
+        assert_allclose(state.contrast, 0)
+
+        # Out-of-bounds event is ignored.
+        time.sleep(lag_time)
+        self.cb_tool.on_mouse_or_key_event({'event': 'dragmove', 'pixel': {'x': -1, 'y': 50}})
+        assert_allclose(state.bias, 1)
+        assert_allclose(state.contrast, 0)
+
+        # Simulate double-click reset event.
+
+        self.cb_tool.on_mouse_or_key_event({'event': 'dblclick'})
+        assert_allclose(state.bias, 0.5)
+        assert_allclose(state.contrast, 1)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is an attempt to fix contrast/bias mouse-drag handling. Also added a test for it.

Also see https://github.com/glue-viz/glue/blob/e1331eccc07dc2e0d2c2320ec7e8793a366af002/glue/viewers/matplotlib/qt/toolbar_mode.py#L102

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1359

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
