### PR TITLE
Moment map bugfixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,8 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Fixed bugs when loading results from the moment map plugin into a image viewer. [#1402]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -66,8 +66,8 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
         fname_label = self.dataset_selected.replace("[", "_").replace("]", "")
         self.filename = f"moment{n_moment}_{fname_label}.fits"
 
-        self.add_results.add_results_from_plugin(self.moment)
         self._link_moment_data()
+        self.add_results.add_results_from_plugin(self.moment)
 
         self.moment_available = True
 

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.py
@@ -75,9 +75,6 @@ class Slice(TemplateMixin):
             if len(msg.data.shape) == 3:
                 self.max_value = msg.data.shape[-1] - 1
                 self._watch_viewer(msg.viewer, True)
-            else:
-                # then the viewer is showing a static 2d image instead of cube data
-                self._watch_viewer(msg.viewer, False)
 
         elif isinstance(msg.viewer, BqplotProfileView):
             self._watch_viewer(msg.viewer, True)

--- a/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
@@ -49,7 +49,7 @@ def test_slice(cubeviz_helper, spectrum1d_cube):
     mm.add_to_viewer_selected = 'flux-viewer'
     mm.vue_calculate_moment()
 
-    assert len(sl._watched_viewers) == 0
+    assert len(sl._watched_viewers) == 1
     assert len(sl._indicator_viewers) == 1
 
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes to bugs when plotting moment map plugin results in a cubeviz viewer.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
