### PR TITLE
contrast-bias tool: debounce instead of reject based on time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,9 @@ Imviz
 - Fixed a bug where Line Profile might crash when the second image
   is rotated w.r.t. the reference image and they are linked by WCS. [#1392]
 
+- Contrast/bias mouse-drag is now more responsive and
+  calculates contrast in the same way as Glue in Qt mode. [#1403]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/tools.py
+++ b/jdaviz/configs/imviz/plugins/tools.py
@@ -158,7 +158,7 @@ class ContrastBias(CheckableTool):
         # bias range 0..1
         # contrast range 0..4
         bias = event_x / (self._max_x - 1)
-        contrast = 4 * event_y / (self._max_y - 1)
+        contrast = 4 * (1 - (event_y / (self._max_y - 1)))
 
         with delay_callback(self._layer_state, 'bias', 'contrast'):
             self._layer_state.bias = bias

--- a/jdaviz/configs/imviz/plugins/tools.py
+++ b/jdaviz/configs/imviz/plugins/tools.py
@@ -1,4 +1,3 @@
-import time
 import os
 
 from echo import delay_callback
@@ -6,6 +5,7 @@ from echo import delay_callback
 from glue.config import viewer_tool
 from glue.viewers.common.tool import CheckableTool
 from glue_jupyter.bqplot.common.tools import BqplotPanZoomMode
+from glue_jupyter.utils import debounced
 
 from jdaviz.core.tools import BoxZoom
 
@@ -134,59 +134,56 @@ class ContrastBias(CheckableTool):
     tool_tip = 'Click and drag to adjust contrast and bias, double-click to reset'
 
     def __init__(self, viewer, **kwargs):
-        self._time_last = 0
         super().__init__(viewer, **kwargs)
 
     def activate(self):
         self.viewer.add_event_callback(self.on_mouse_or_key_event,
                                        events=['dragstart', 'dragmove',
-                                               'dragend', 'dblclick'])
+                                               'dblclick'])
 
     def deactivate(self):
         self.viewer.remove_event_callback(self.on_mouse_or_key_event)
+
+    @debounced(delay_seconds=0.03, method=True)
+    def _dragevent(self, data):
+        event_x = data['pixel']['x']
+        event_y = data['pixel']['y']
+
+        if ((event_x < 0) or (event_x >= self._max_x) or
+                (event_y < 0) or (event_y >= self._max_y)):
+            return
+
+        # Normalize w.r.t. viewer display from 0 to 1
+        # Also see glue/viewers/matplotlib/qt/toolbar_mode.py
+        # bias range 0..1
+        # contrast range 0..4
+        bias = event_x / (self._max_x - 1)
+        contrast = 4 * event_y / (self._max_y - 1)
+
+        with delay_callback(self._layer_state, 'bias', 'contrast'):
+            self._layer_state.bias = bias
+            self._layer_state.contrast = contrast
 
     def on_mouse_or_key_event(self, data):
         from jdaviz.configs.imviz.helper import get_top_layer_index
 
         event = data['event']
 
-        # Note that we throttle this to 200ms here as changing the contrast
-        # and bias it expensive since it forces the whole image to be redrawn
-        if event == 'dragmove':
-            if (time.time() - self._time_last) <= 0.2:
-                return
-
-            event_x = data['pixel']['x']
-            event_y = data['pixel']['y']
-            max_x = self.viewer.shape[1]
-            max_y = self.viewer.shape[0]
-
-            if ((event_x < 0) or (event_x >= max_x) or
-                    (event_y < 0) or (event_y >= max_y)):
-                return
-
-            # Normalize w.r.t. viewer display from 0 to 1
-            x = event_x / (max_x - 1)
-            y = event_y / (max_y - 1)
-
+        if event == 'dragstart':
             # When blinked, first layer might not be top layer
+            # TODO: could optimize this further by listening for changes to the layers
+            # and viewer size rather than having to set this on the dragstart event
             i_top = get_top_layer_index(self.viewer)
             state = self.viewer.layers[i_top].state
-
-            # bias range 0..1
-            # contrast range 0..4
-            with delay_callback(state, 'bias', 'contrast'):
-                state.bias = x
-                state.contrast = y * 4
-
-            self._time_last = time.time()
-
+            self._layer_state = state
+            self._max_x = self.viewer.shape[1]
+            self._max_y = self.viewer.shape[0]
+        elif event == 'dragmove':
+            self._dragevent(data)
         elif event == 'dblclick':
-            # When blinked, first layer might not be top layer
+            # Restore defaults that are applied on load
             i_top = get_top_layer_index(self.viewer)
             state = self.viewer.layers[i_top].state
-
-            # Restore defaults that are applied on load
             with delay_callback(state, 'bias', 'contrast'):
                 state.bias = 0.5
                 state.contrast = 1

--- a/jdaviz/configs/imviz/tests/test_viewer_tools.py
+++ b/jdaviz/configs/imviz/tests/test_viewer_tools.py
@@ -1,0 +1,48 @@
+from numpy.testing import assert_allclose
+
+from jdaviz.configs.imviz.helper import get_top_layer_index
+from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_NoWCS
+
+
+class TestContrastBiasTool(BaseImviz_WCS_NoWCS):
+
+    def teardown_method(self, method):
+        self.cb_tool.deactivate()
+
+    def test_contrast_bias_mousedrag(self):
+        # setup_class is already called by parent class, so we do this here.
+        self.cb_tool = self.viewer.toolbar_nested.tools['jdaviz:contrastbias']
+        self.cb_tool.activate()
+
+        state = self.viewer.layers[get_top_layer_index(self.viewer)].state
+
+        # Should start with default values.
+        assert_allclose(state.bias, 0.5)
+        assert_allclose(state.contrast, 1)
+
+        # Simulate some mouse-drag events.
+
+        self.cb_tool.on_mouse_or_key_event({'event': 'dragstart'})
+
+        self.cb_tool.on_mouse_or_key_event({'event': 'dragmove', 'pixel': {'x': 0, 'y': 0}})
+        assert_allclose(state.bias, 0)
+        assert_allclose(state.contrast, 4)
+
+        self.cb_tool.on_mouse_or_key_event({'event': 'dragmove', 'pixel': {'x': 50, 'y': 50}})
+        assert_allclose(state.bias, 0.5050505050505051)
+        assert_allclose(state.contrast, 1.9797979797979797)
+
+        self.cb_tool.on_mouse_or_key_event({'event': 'dragmove', 'pixel': {'x': 99, 'y': 99}})
+        assert_allclose(state.bias, 1)
+        assert_allclose(state.contrast, 0)
+
+        # Out-of-bounds event is ignored.
+        self.cb_tool.on_mouse_or_key_event({'event': 'dragmove', 'pixel': {'x': -1, 'y': 50}})
+        assert_allclose(state.bias, 1)
+        assert_allclose(state.contrast, 0)
+
+        # Simulate double-click reset event.
+
+        self.cb_tool.on_mouse_or_key_event({'event': 'dblclick'})
+        assert_allclose(state.bias, 0.5)
+        assert_allclose(state.contrast, 1)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is an alternate to #1394 (although still needs to pull in the tests and perhaps contrast inversion from that PR) to optimize the drag behavior by replacing the rejection of events based on timestamp with debouncing in python (and caching the state and viewer size on dragstart).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1359

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
