### PR TITLE
Add reversed colormaps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ New Features
 - Labels in data menus are truncated to fit in a single line but ensure visibility of extensions.
   [#1390]
 
+- Several reversed version of colormaps now available for image viewers. [#1407]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -13,10 +13,11 @@ from ipygoldenlayout import GoldenLayout
 from ipysplitpanes import SplitPanes
 from traitlets import Dict, Bool, Unicode
 from specutils import Spectrum1D, SpectralRegion
+import matplotlib.cm as cm
 import numpy as np
 
 from glue.core.exceptions import IncompatibleAttribute
-from glue.config import data_translator
+from glue.config import colormaps, data_translator
 from glue.config import settings as glue_settings
 from glue.core import BaseData, HubListener, Data, DataCollection
 from glue.core.link_helpers import LinkSame
@@ -241,6 +242,18 @@ class Application(VuetifyTemplate, HubListener):
 
         # Add a fitted_models dictionary that the helpers (or user) can access
         self.fitted_models = {}
+
+        # Add inverse colormaps to Glue global state. Also see ColormapRegistry in
+        # https://github.com/glue-viz/glue/blob/main/glue/config.py
+        new_cms = (['Reversed: Gray', cm.gray_r],
+                   ['Reversed: Viridis', cm.viridis_r],
+                   ['Reversed: Plasma', cm.plasma_r],
+                   ['Reversed: Inferno', cm.inferno_r],
+                   ['Reversed: Magma', cm.magma_r],
+                   ['Reversed: Hot', cm.hot_r])
+        for cur_cm in new_cms:
+            if cur_cm not in colormaps.members:
+                colormaps.add(*cur_cm)
 
     @property
     def hub(self):

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -157,7 +157,8 @@ class TestCmapStretchCuts(BaseImviz_WCS_NoWCS):
     def test_colormap_options(self):
         assert self.viewer.colormap_options == [
             'BuGn', 'PRGn', 'PuBu', 'PuOr', 'RdBu', 'RdPu', 'RdYlBu', 'YlGnBu', 'YlOrRd',
-            'gray', 'hot', 'inferno', 'magma', 'plasma', 'viridis']
+            'gray', 'gray_r', 'hot', 'hot_r', 'inferno', 'inferno_r', 'magma', 'magma_r',
+            'plasma', 'plasma_r', 'viridis', 'viridis_r']
 
     def test_invalid_colormap(self):
         with pytest.raises(ValueError, match='Invalid colormap'):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to add reversed version for several colormaps.

![Screenshot 2022-06-20 143748](https://user-images.githubusercontent.com/2090236/174663087-472d6ccf-192c-4466-a7f5-46061a295bf1.png)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-2471)
