### PR TITLE
Simple Aperture Photometry: Gaussian1D fitting for radial profile

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Added the ability to fit Gaussian1D model to radial profile in
+  Simple Aperture Photometry plugin. [#1409]
+
 Mosviz
 ^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,8 @@ Imviz
 ^^^^^
 
 - Added the ability to fit Gaussian1D model to radial profile in
-  Simple Aperture Photometry plugin. [#1409]
+  Simple Aperture Photometry plugin. Radial profile now centers
+  on source centroid, not Subset center. [#1409]
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ Imviz
 ^^^^^
 
 - Added the ability to fit Gaussian1D model to radial profile in
-  Simple Aperture Photometry plugin. Radial profile now centers
+  Simple Aperture Photometry plugin. Radial profile and curve of growth now center
   on source centroid, not Subset center. [#1409]
 
 Mosviz

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -184,6 +184,13 @@ results are displayed under the :guilabel:`CALCULATE` button.
 
     Radial profile (raw).
 
+If you opted to fit a `~astropy.modeling.functional_models.Gaussian1D`
+to the radial profile, the last fitted model parameters will be displayed
+under the radial profile plot. The model itself can be obtained by as follows.
+See :ref:`astropy:astropy-modeling` on how to manipulate the model::
+
+    my_gaussian1d = imviz.app.fitted_models['phot_radial_profile']
+
 You can also retrieve the photometry results as `~astropy.table.QTable` as follows,
 assuming ``imviz`` is the instance of your Imviz application::
 
@@ -259,12 +266,6 @@ The columns are as follow:
 
 Once you have the results in a table, you can further manipulated them as
 documented in :ref:`astropy:astropy-table`.
-
-If you opted to fit a `~astropy.modeling.functional_models.Gaussian1D`
-to the radial profile, the last fitted model can be obtained by as follows.
-See :ref:`astropy:astropy-modeling` on how to manipulate the model::
-
-    my_gaussian1d = imviz.app.fitted_models['phot_radial_profile']
 
 .. _imviz-export-plot:
 

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -171,8 +171,8 @@ an interactively selected region. A typical workflow is as follows:
     However, if NaN exists in data, it will be treated as 0.
 
 When calculation is complete, a plot would show the radial profile
-of the background subtracted data and the photometry results are displayed under the
-:guilabel:`CALCULATE` button.
+of the background subtracted data and the photometry and model fitting (if requested)
+results are displayed under the :guilabel:`CALCULATE` button.
 
 .. figure:: img/imviz_radial_profile.png
     :alt: Imviz radial profile plot.

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -160,7 +160,9 @@ an interactively selected region. A typical workflow is as follows:
     Caution: having too many data points may cause performance issues with this feature. 
     The exact limitations depend on your hardware.
 
-10. Once all inputs are populated correctly, click on the :guilabel:`CALCULATE`
+10. Toggle :guilabel:`Fit Gaussian` on to fit a `~astropy.modeling.functional_models.Gaussian1D`
+    model to the radial profile data. This is disabled for curve-of-growth.
+11. Once all inputs are populated correctly, click on the :guilabel:`CALCULATE`
     button to perform simple aperture photometry.
 
 .. note::
@@ -182,7 +184,7 @@ of the background subtracted data and the photometry results are displayed under
 
     Radial profile (raw).
 
-You can also retrieve the results as `~astropy.table.QTable` as follows,
+You can also retrieve the photometry results as `~astropy.table.QTable` as follows,
 assuming ``imviz`` is the instance of your Imviz application::
 
     results = imviz.get_aperture_photometry_results()
@@ -257,6 +259,12 @@ The columns are as follow:
 
 Once you have the results in a table, you can further manipulated them as
 documented in :ref:`astropy:astropy-table`.
+
+If you opted to fit a `~astropy.modeling.functional_models.Gaussian1D`
+to the radial profile, the last fitted model can be obtained by as follows.
+See :ref:`astropy:astropy-modeling` on how to manipulate the model::
+
+    my_gaussian1d = imviz.app.fitted_models['phot_radial_profile']
 
 .. _imviz-export-plot:
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -47,6 +47,7 @@ class SimpleAperturePhotometry(TemplateMixin, DatasetSelectMixin):
     plot_available = Bool(False).tag(sync=True)
     radial_plot = Any('').tag(sync=True, **widget_serialization)
     fit_radial_profile = Bool(False).tag(sync=True)
+    fit_results = List().tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -349,7 +350,7 @@ class SimpleAperturePhotometry(TemplateMixin, DatasetSelectMixin):
                                               label=comp.units or 'Value')]
 
                 if self.current_plot_type == "Radial Profile":
-                    self._fig.title = 'Radial profile from Subset center'
+                    self._fig.title = 'Radial profile from source centroid'
                     x_data, y_data = _radial_profile(
                         phot_aperstats.data_cutout, phot_aperstats.bbox, phot_aperstats.centroid,
                         raw=False)
@@ -357,7 +358,7 @@ class SimpleAperturePhotometry(TemplateMixin, DatasetSelectMixin):
                                                scales={'x': line_x_sc, 'y': line_y_sc},
                                                marker_size=32, colors='gray')
                 else:  # Radial Profile (Raw)
-                    self._fig.title = 'Raw radial profile from Subset center'
+                    self._fig.title = 'Raw radial profile from source centroid'
                     x_data, y_data = _radial_profile(
                         phot_aperstats.data_cutout, phot_aperstats.bbox, phot_aperstats.centroid,
                         raw=True)
@@ -419,16 +420,18 @@ class SimpleAperturePhotometry(TemplateMixin, DatasetSelectMixin):
                                 f'{x:.4e} ({phot_table["aperture_sum_counts_err"][0]:.4e})'})
                 else:
                     tmp.append({'function': key, 'result': str(x)})
+
             # Also display fit results
+            fit_tmp = []
             if fit_model is not None and isinstance(fit_model, Gaussian1D):
-                model_name = fit_model.__class__.__name__
                 for param in ('fwhm', 'mean', 'amplitude'):
                     p_val = getattr(fit_model, param)
                     if isinstance(p_val, Parameter):
                         p_val = p_val.value
-                    tmp.append({'function': f'{model_name}_{param}',
-                                'result': f'{p_val:.4e}'})
+                    fit_tmp.append({'function': param, 'result': f'{p_val:.4e}'})
+
             self.results = tmp
+            self.fit_results = fit_tmp
             self.result_available = True
             self.radial_plot = self._fig
             self.bqplot_figs_resize = [self._fig]

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -446,8 +446,9 @@ def _radial_profile(radial_cutout, reg_bb, aperture, raw=False):
     radial_img = radial_cutout.compressed()  # data unit
 
     if raw:
-        x_arr = radial_r
-        y_arr = radial_img
+        i_arr = np.argsort(radial_r)
+        x_arr = radial_r[i_arr]
+        y_arr = radial_img[i_arr]
     else:
         # This algorithm is from the imexam package,
         # see licenses/IMEXAM_LICENSE.txt for more details

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -351,14 +351,16 @@ class SimpleAperturePhotometry(TemplateMixin, DatasetSelectMixin):
                 if self.current_plot_type == "Radial Profile":
                     self._fig.title = 'Radial profile from Subset center'
                     x_data, y_data = _radial_profile(
-                        phot_aperstats.data_cutout, phot_aperstats.bbox, aperture, raw=False)
+                        phot_aperstats.data_cutout, phot_aperstats.bbox, phot_aperstats.centroid,
+                        raw=False)
                     bqplot_line = bqplot.Lines(x=x_data, y=y_data, marker='circle',
                                                scales={'x': line_x_sc, 'y': line_y_sc},
                                                marker_size=32, colors='gray')
                 else:  # Radial Profile (Raw)
                     self._fig.title = 'Raw radial profile from Subset center'
                     x_data, y_data = _radial_profile(
-                        phot_aperstats.data_cutout, phot_aperstats.bbox, aperture, raw=True)
+                        phot_aperstats.data_cutout, phot_aperstats.bbox, phot_aperstats.centroid,
+                        raw=True)
                     bqplot_line = bqplot.Scatter(x=x_data, y=y_data, marker='circle',
                                                  scales={'x': line_x_sc, 'y': line_y_sc},
                                                  default_size=1, colors='gray')
@@ -436,7 +438,7 @@ class SimpleAperturePhotometry(TemplateMixin, DatasetSelectMixin):
 # NOTE: These are hidden because the APIs are for internal use only
 # but we need them as a separate functions for unit testing.
 
-def _radial_profile(radial_cutout, reg_bb, aperture, raw=False):
+def _radial_profile(radial_cutout, reg_bb, centroid, raw=False):
     """Calculate radial profile.
 
     Parameters
@@ -447,8 +449,8 @@ def _radial_profile(radial_cutout, reg_bb, aperture, raw=False):
     reg_bb : obj
         Bounding box from ``ApertureStats``.
 
-    aperture : obj
-        ``photutils`` aperture object.
+    centroid : tuple of int
+        ``ApertureStats`` centroid or desired center in ``(x, y)``.
 
     raw : bool
         If `True`, returns raw data points for scatter plot.
@@ -456,8 +458,8 @@ def _radial_profile(radial_cutout, reg_bb, aperture, raw=False):
 
     """
     reg_ogrid = np.ogrid[reg_bb.iymin:reg_bb.iymax, reg_bb.ixmin:reg_bb.ixmax]
-    radial_dx = reg_ogrid[1] - aperture.positions[0]
-    radial_dy = reg_ogrid[0] - aperture.positions[1]
+    radial_dx = reg_ogrid[1] - centroid[0]
+    radial_dy = reg_ogrid[0] - centroid[1]
     radial_r = np.hypot(radial_dx, radial_dy)[~radial_cutout.mask].ravel()  # pix
     radial_img = radial_cutout.compressed()  # data unit
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -110,7 +110,8 @@
           ></v-select>
         </v-row>
 
-        <v-row v-if="current_plot_type != 'Curve of Growth'">
+        <v-row v-if="current_plot_type.indexOf('Radial Profile') != -1">
+
           <v-switch
             label="Fit Gaussian"
             hint="Fit Gaussian1D to radial profile"

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -133,8 +133,25 @@
       <jupyter-widget :widget="radial_plot" style="width: 100%; height: 480px" />
     </v-row>
 
+    <div v-if="plot_available && fit_radial_profile">
+      <j-plugin-section-header>Gaussian Fit Results</j-plugin-section-header>
+      <v-row no-gutters>
+        <v-col cols=6><U>Result</U></v-col>
+        <v-col cols=6><U>Value</U></v-col>
+      </v-row>
+      <v-row
+        v-for="item in fit_results"
+        :key="item.function"
+        no-gutters>
+        <v-col cols=6>
+          {{  item.function  }}
+        </v-col>
+        <v-col cols=6>{{ item.result }}</v-col>
+      </v-row>
+    </div>
+
     <div v-if="result_available">
-      <j-plugin-section-header>Results</j-plugin-section-header>
+      <j-plugin-section-header>Photometry Results</j-plugin-section-header>
       <v-row no-gutters>
         <v-col cols=6><U>Result</U></v-col>
         <v-col cols=6><U>Value</U></v-col>

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -110,6 +110,15 @@
           ></v-select>
         </v-row>
 
+        <v-row v-if="current_plot_type != 'Curve of Growth'">
+          <v-switch
+            label="Fit Gaussian"
+            hint="Fit Gaussian1D to radial profile"
+            v-model="fit_radial_profile"
+            persistent-hint>
+          </v-switch>
+        </v-row>
+
         <v-row justify="end">
           <v-btn color="primary" text @click="do_aper_phot">Calculate</v-btn>
         </v-row>

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -18,6 +18,10 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
 
         phot_plugin = self.imviz.app.get_tray_item_from_name('imviz-aper-phot-simple')
 
+        # Model fitting is already tested in astropy.
+        # Here, we enable it just to make sure it does not crash.
+        phot_plugin.fit_radial_profile = True
+
         # Make sure invalid Data/Subset selection does not crash plugin.
         with pytest.raises(ValueError):
             phot_plugin.dataset_selected = 'no_such_data'

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -259,13 +259,14 @@ def test_annulus_background(imviz_helper):
 class TestRadialProfile():
     def setup_class(self):
         data = np.ones((51, 51)) * u.nJy
-        self.aperture = EllipticalAperture((25, 25), 20, 15)
-        phot_aperstats = ApertureStats(data, self.aperture)
+        aperture = EllipticalAperture((25, 25), 20, 15)
+        phot_aperstats = ApertureStats(data, aperture)
         self.data_cutout = phot_aperstats.data_cutout
         self.bbox = phot_aperstats.bbox
+        self.centroid = phot_aperstats.centroid
 
     def test_profile_raw(self):
-        x_arr, y_arr = _radial_profile(self.data_cutout, self.bbox, self.aperture, raw=True)
+        x_arr, y_arr = _radial_profile(self.data_cutout, self.bbox, self.centroid, raw=True)
         # Too many data points to compare each one for X.
         assert x_arr.shape == y_arr.shape == (923, )
         assert_allclose(x_arr.min(), 0)
@@ -273,7 +274,7 @@ class TestRadialProfile():
         assert_allclose(y_arr, 1)
 
     def test_profile_imexam(self):
-        x_arr, y_arr = _radial_profile(self.data_cutout, self.bbox, self.aperture, raw=False)
+        x_arr, y_arr = _radial_profile(self.data_cutout, self.bbox, self.centroid, raw=False)
         assert_allclose(x_arr, range(20))
         assert_allclose(y_arr, 1)
 

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -168,7 +168,7 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         # Curve of growth
         phot_plugin.current_plot_type = 'Curve of Growth'
         phot_plugin.vue_do_aper_phot()
-        assert phot_plugin._fig.title == 'Curve of growth from Subset center'
+        assert phot_plugin._fig.title == 'Curve of growth from source centroid'
 
 
 class TestSimpleAperPhot_NoWCS(BaseImviz_WCS_NoWCS):
@@ -298,11 +298,12 @@ def test_curve_of_growth(with_unit):
                  RectangularAperture(cen, 20, 15))
 
     for aperture in apertures:
-        final_sum = ApertureStats(data, aperture).sum
+        astat = ApertureStats(data, aperture)
+        final_sum = astat.sum
         if pixarea_fac is not None:
             final_sum = final_sum * pixarea_fac
         x_arr, sum_arr, x_label, y_label = _curve_of_growth(
-            data, aperture, final_sum, background=bg, pixarea_fac=pixarea_fac)
+            data, astat.centroid, aperture, final_sum, background=bg, pixarea_fac=pixarea_fac)
         assert_allclose(x_arr, [2, 4, 6, 8, 10, 12, 14, 16, 18, 20])
         assert y_label == expected_ylabel
 
@@ -321,5 +322,5 @@ def test_curve_of_growth(with_unit):
             assert_allclose(sum_arr, [3, 12, 27, 48, 75, 108, 147, 192, 243, 300])
 
     with pytest.raises(TypeError, match='Unsupported aperture'):
-        _curve_of_growth(data, EllipticalAnnulus(cen, 3, 8, 5), 100,
+        _curve_of_growth(data, cen, EllipticalAnnulus(cen, 3, 8, 5), 100,
                          pixarea_fac=pixarea_fac)

--- a/notebooks/concepts/imviz_simple_aper_phot.ipynb
+++ b/notebooks/concepts/imviz_simple_aper_phot.ipynb
@@ -195,7 +195,7 @@
    "id": "b45fcdfe",
    "metadata": {},
    "source": [
-    "If you fitted Gaussian to radial profile, you can get it back out like this."
+    "If you fitted Gaussian to radial profile, you can get it back out like this. If it does not exist, you will get `None`."
    ]
   },
   {
@@ -205,14 +205,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_gaussian = imviz.app.fitted_models['phot_radial_profile']\n",
+    "my_gaussian = imviz.app.fitted_models.get('phot_radial_profile', None)\n",
     "my_gaussian"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e546682",
+   "id": "b7c59fef",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/concepts/imviz_simple_aper_phot.ipynb
+++ b/notebooks/concepts/imviz_simple_aper_phot.ipynb
@@ -191,9 +191,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b45fcdfe",
+   "metadata": {},
+   "source": [
+    "If you fitted Gaussian to radial profile, you can get it back out like this."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "00435609",
+   "id": "bcb594f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_gaussian = imviz.app.fitted_models['phot_radial_profile']\n",
+    "my_gaussian"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e546682",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to enable Gaussian1D fitting for radial profile in the Simple Aperture Photometry plugin.

(Screenshots a bit outdated, but you get the idea.)

![Screenshot 2022-06-22 145608](https://user-images.githubusercontent.com/2090236/175126268-60c56d02-24dc-4f09-aa65-9009f6a2a375.png)

<table>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/2090236/175126269-dd9d3387-d44b-4d8d-bca6-474faf4ed690.png"/>
</td>
<td>
<img src="https://user-images.githubusercontent.com/2090236/175126270-37e84690-1151-462e-aa0f-75363661669f.png"/>
</td>
</tr>
</table>

![Screenshot 2022-06-29 154805](https://user-images.githubusercontent.com/2090236/176529358-a3830efa-6afb-43e0-a8fc-eff62b16adb2.png)

### TODO

- [x] See why multiple fits are shown.
- [x] Display fitted FWHM in GUI?
- [x] Want re-centering of raw radial profile data?
- [x] Fix `mean` at zero before fitting Gaussian1D. See https://github.com/spacetelescope/imexam/issues/165 and https://github.com/spacetelescope/imexam/pull/241
- [x] Have Curve of Growth recenter too like Radial Profile.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-2132)
