### PR TITLE
display/clear progress snackbars regardless of verbosity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ New Features
 - The app and individual plugins can be opened in a new window by clicking a button in the top 
   right-hand corner. [#977, #1423]
 
-- Snackbar queue priority and history access. [#1352]
+- Snackbar queue priority and history access. [#1352, #1437]
 
 - Subset Tools plugin now shows information for composite subsets. [#1378]
 

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -42,7 +42,11 @@ class SnackbarQueue:
             else:
                 state.snackbar_history.append(new_history)
 
-        if not popup:
+        if not (popup or msg.loading):
+            if self.loading:
+                # then we still need to clear the existing loading message
+                self.loading = False
+                self.close_current_message(state)
             return
 
         if msg.loading:


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes a bug introduced in #1352 and now shows and clears progress snackbars (example: fitting model to cube) regardless of the verbosity settings.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
