### PR TITLE
BUG: Cubeviz coordinate display should follow top visible layer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,9 @@ Cubeviz
 
 - Fixed linking of plugin data to the reference data that was used to create it [#1412]
 
+- Fixed coordinates display not showing the top layer information when multiple
+  layers are loaded into the image viewer. [#1445]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -60,6 +60,8 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
         except ValueError:
             raise ValueError("Moment must be a positive integer")
         # Need transpose to align JWST mirror shape. Not sure why.
+        # TODO: WCS can be grabbed from cube.wcs[:, :, 0] but CCDData will not take it.
+        #       But if we use NDData, glue-astronomy translator fails.
         self.moment = CCDData(analysis.moment(slab, order=n_moment).T)
 
         fname_label = self.dataset_selected.replace("[", "_").replace("]", "")

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -10,6 +10,11 @@ from jdaviz.configs.cubeviz.plugins.moment_maps.moment_maps import MomentMap
 def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     dc = cubeviz_helper.app.data_collection
     cubeviz_helper.load_data(spectrum1d_cube, data_label='test')
+    flux_viewer = cubeviz_helper.app.get_viewer('flux-viewer')
+
+    # Since we are not really displaying, need this to trigger GUI stuff.
+    flux_viewer.shape = (100, 100)
+    flux_viewer.state._set_axes_aspect_ratio(1)
 
     mm = MomentMap(app=cubeviz_helper.app)
     mm.dataset_selected = 'test[FLUX]'
@@ -33,20 +38,29 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     assert mm.results_label == 'moment 0'
     assert mm.results_label_overwrite is True
 
-    result = dc[1].get_object(cls=CCDData)
-    assert result.shape == (4, 2)  # Cube shape is (2, 2, 4)
-
-    # FIXME: Need spatial WCS, see https://github.com/spacetelescope/jdaviz/issues/1025
-    assert dc[1].coords is None
-
-    # Make sure coordinate display still works
-    flux_viewer = cubeviz_helper.app.get_viewer('flux-viewer')
+    # Make sure coordinate display works
     flux_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
     assert flux_viewer.state.slices == (0, 0, 1)
     assert flux_viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
     assert flux_viewer.label_mouseover.value == '+8.00000e+00 Jy'  # Slice 0 has 8 pixels, this is Slice 1  # noqa
     assert flux_viewer.label_mouseover.world_ra_deg == '204.9997755346'
     assert flux_viewer.label_mouseover.world_dec_deg == '27.0000999998'
+
+    # Make sure adding it to viewer does not crash.
+    cubeviz_helper.app.add_data_to_viewer('flux-viewer', 'moment 0')
+
+    result = dc[1].get_object(cls=CCDData)
+    assert result.shape == (4, 2)  # Cube shape is (2, 2, 4)
+
+    # FIXME: Need spatial WCS, see https://github.com/spacetelescope/jdaviz/issues/1025
+    assert dc[1].coords is None
+
+    # Make sure coordinate display now show moment map info (no WCS)
+    flux_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+    assert flux_viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
+    assert flux_viewer.label_mouseover.value == '+8.00000e+00 Jy'  # Slice 0 has 8 pixels, this is Slice 1  # noqa
+    assert flux_viewer.label_mouseover.world_ra_deg == ''
+    assert flux_viewer.label_mouseover.world_dec_deg == ''
 
     assert mm.filename == 'moment0_test_FLUX.fits'  # Auto-populated on calculate.
     mm.filename = str(tmpdir.join(mm.filename))  # But we want it in tmpdir for testing.
@@ -82,5 +96,5 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     # Coordinate display should be unaffected.
     assert flux_viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
     assert flux_viewer.label_mouseover.value == '+8.00000e+00 Jy'  # Slice 0 has 8 pixels, this is Slice 1  # noqa
-    assert flux_viewer.label_mouseover.world_ra_deg == '204.9997755346'
-    assert flux_viewer.label_mouseover.world_dec_deg == '27.0000999998'
+    assert flux_viewer.label_mouseover.world_ra_deg == ''
+    assert flux_viewer.label_mouseover.world_dec_deg == ''

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -65,7 +65,8 @@ class CubevizImageView(BqplotImageView, JdavizViewerMixin):
 
             # Extract first dataset from visible layers and use this for coordinates - the choice
             # of dataset shouldn't matter if the datasets are linked correctly
-            image = visible_layers[0].layer
+            active_layer = visible_layers[-1]
+            image = active_layer.layer
 
             # Extract data coordinates - these are pixels in the reference image
             x = data['domain']['x']
@@ -94,8 +95,8 @@ class CubevizImageView(BqplotImageView, JdavizViewerMixin):
             # Extract data values at this position.
             # Check if shape is [x, y, z] or [x, y] and show value accordingly.
             if (-0.5 < x < image.shape[0] - 0.5 and -0.5 < y < image.shape[1] - 0.5
-                    and hasattr(visible_layers[0], 'attribute')):
-                attribute = visible_layers[0].attribute
+                    and hasattr(active_layer, 'attribute')):
+                attribute = active_layer.attribute
                 if len(image.shape) == 3:
                     value = image.get_data(attribute)[int(round(x)), int(round(y)),
                                                       self.state.slices[-1]]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Coordinate display for Cubeviz was added in #1315 . But without this patch, when multiple dataset are loaded into an image viewer, it shows the info from the bottommost layer, not topmost. This is the most apparent when you load a moment map (it currently has no WCS) on top of the flux cube in the flux viewer. You see the moment map displayed but the coordinate display would still show WCS from the flux cube. With this patch, coordinate display will now show correctly.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This was discovered during my investigation of another bug in #1328 . 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-2560)
