### PR TITLE
BUG: Simple Aperture Photometry plugin to update when Subset updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -105,6 +105,10 @@ Imviz
 - Fixed a bug where some custom colormap added to Imviz is inaccessible
   via ``viewer.set_colormap()`` API. [#1440]
 
+- Fixed a bug where Simple Aperture Photometry plugin does not know
+  an existing Subset has been modified until it is reselected from
+  the dropdown menu. [#1447]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
+from glue.core.edit_subset_mode import ReplaceMode
 from numpy.testing import assert_allclose, assert_array_equal
 from photutils.aperture import (ApertureStats, CircularAperture, EllipticalAperture,
                                 RectangularAperture, EllipticalAnnulus)
@@ -248,6 +249,13 @@ def test_annulus_background(imviz_helper):
     # Manually change width
     phot_plugin.bg_annulus_width = 5
     assert_allclose(phot_plugin.background_value, 4.894003242594493)
+
+    # Move the last created Subset (ellipse) and make sure background updates
+    imviz_helper.app.session.edit_subset_mode.mode = ReplaceMode
+    imviz_helper._apply_interactive_region('bqplot:ellipse', (0, 30), (51, 55))
+    assert_allclose(phot_plugin.bg_annulus_inner_r, 40)
+    assert_allclose(phot_plugin.bg_annulus_width, 5)
+    assert_allclose(phot_plugin.background_value, 4.894003)
 
     # Bad annulus should not crash plugin
     phot_plugin.bg_annulus_inner_r = -1


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to ensure Simple Aperture Photometry plugin is aware of Subset that is updated *after* it is created, if relevant to calculations. Most things will not recalculate until user presses "Calculate" but the background is calculated "live" before the button is pressed. There are 3 dropdowns. The dataset dropdown already triggers all recalculations, so I don't think it is affected but this bug.

This patch fixes the following cases:

1. When aperture is selected, editing the aperture Subset will cause: (a) background to update immediately in "Annulus" mode, and (b) the rest to update when pressing "Calculate".
2. When background is from Subset, editing the background Subset till cause the background to update immediately.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1443 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
