### PR TITLE
Add mentions of glue to jdaviz docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,12 +10,12 @@ Jdaviz
    ``jdaviz`` is one tool that is part of STScI's larger
    `Data Analysis Tools Ecosystem <https://jwst-docs.stsci.edu/jwst-post-pipeline-data-analysis>`_.
 
-``jdaviz`` is a package of astronomical data analysis visualization
-tools based on the Jupyter platform.  These GUI-based tools link data
-visualization and interactive analysis.  They are designed to work
-within a Jupyter notebook cell, as a standalone desktop application,
-or as embedded windows within a website -- all with nearly-identical
-user interfaces.
+``jdaviz`` is a package of astronomical data analysis visualization tools based
+on the `Jupyter <https://jupyter.org/>`_ platform and the `glue
+<http://glueviz.org/>`_ data visualization framework. These GUI-based tools link
+data visualization and interactive analysis.  They are designed to work within a
+Jupyter notebook cell, as a standalone desktop application, or as embedded
+windows within a website -- all with nearly-identical user interfaces.
 
 ``jdaviz`` applications currently include tools for interactive
 visualization of spectroscopic and imaging data.
@@ -28,6 +28,10 @@ cube.
 spectra, typically the output of a multi-object spectrograph (e.g.,
 JWST NIRSpec), and includes viewers for 1D and 2D spectra as well as
 contextual information like on-sky views of the spectrograph slit.
+
+For users who are interested in using glue in contexts beyond those provided by
+``jdaviz``, please visit http://glueviz.org for download links and more
+information.
 
 .. _jdaviz_instrument_table:
 


### PR DESCRIPTION
### Description

At the moment, there is no clear mention in the jdaviz that jdaviz is based on glue/glue-jupyter - since it is essential to jdaviz in the same way as Jupyter, I thought it would make sense to mention it somewhere in the intro, and to also allow users who want to explore glue with more flexibility to know where to find more information.

I'm open to the wording of course, but this is just an initial suggestion.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
