### PR TITLE
mosviz gaussian smooth: only include data from spectrum-viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -108,6 +108,9 @@ Imviz
 Mosviz
 ^^^^^^
 
+- Data dropdown in the gaussian smooth plugin is limited to data entries from the 
+  spectrum-viewer (excluding images and 2d spectra). [#1452]
+
 Specviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -36,6 +36,10 @@ class GaussianSmooth(TemplateMixin, DatasetSelectMixin, AddResultsMixin):
             self.dataset._viewers = ['flux-viewer', 'spectrum-viewer']
             # clear the cache in case the spectrum-viewer selection was already cached
             self.dataset._clear_cache()
+        elif self.config == "mosviz":
+            # only allow smoothing 1d spectra
+            self.dataset._viewers = ['spectrum-viewer']
+            self.dataset._clear_cache()
 
         # set the filter on the viewer options
         self._update_viewer_filters()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request limits the data dropdown in the gaussian smooth plugin in mosviz to only include data entries in the (1d) spectrum-viewer.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1451

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
