### PR TITLE
imviz tabs: hide popout button

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -121,7 +121,8 @@ Imviz
   an existing Subset has been modified until it is reselected from
   the dropdown menu. [#1447]
 
-- Disables the buggy "popout in new window" buttons on the viewer tabs. [#1461]
+- Disables the "popout in new window" buttons on the image viewer tabs
+  in favor of other ways of popping out Jdaviz from notebook. [#1461]
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -121,6 +121,8 @@ Imviz
   an existing Subset has been modified until it is reselected from
   the dropdown menu. [#1447]
 
+- Disables the buggy "popout in new window" buttons on the viewer tabs. [#1461]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -291,6 +291,10 @@ div.output_wrapper {
   padding-left: 0;
 }
 
+.lm_popout {
+  display: none;
+}
+
 .v-toolbar__items .v-btn {
   /* allow v-toolbar-items styling to pass through tooltip wrapping span */
   /* css is copied from .v-toolbar__items>.v-btn */


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request hides the "popout in new window" button for the golden layout tabs in imviz.  The current implementation is buggy as it loads the whole notebook in a new window.  In the future, we could make use of #977 instead and re-enable the button.

<img width="1200" alt="image" src="https://user-images.githubusercontent.com/877591/177617668-37a77099-14e1-4762-8524-c8f9b32709c0.png">



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
