### PR TITLE
Load DS9 regions into Subsets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ New Features
 
 - Subset Tools plugin now allows basic editing and also shows rotation for certain shapes. [#1427]
 
+- New ``jdaviz.core.region_translators.regions2roi()`` function to convert certain
+  ``regions`` shapes into ``glue`` ROIs. [#1463]
+
 Cubeviz
 ^^^^^^^
 
@@ -44,6 +47,12 @@ Cubeviz
 
 Imviz
 ^^^^^
+
+- ``Imviz.load_static_regions_from_file()`` and ``Imviz.load_static_regions()`` are
+  deprecated in favor of ``Imviz.load_regions_from_file()`` and ``Imviz.load_regions()``,
+  respectively. This is because some region shapes can be made interactive now even though
+  they are loaded from API. The new methods have slightly different API signatures, please
+  read the API documentation carefully before use. [#1463]
 
 Mosviz
 ^^^^^^

--- a/docs/imviz/export_data.rst
+++ b/docs/imviz/export_data.rst
@@ -9,7 +9,7 @@ Exporting Data from Imviz
 Spatial Regions
 ===============
 
-You can extract spatial regions::
+You can extract supported spatial regions as follows::
 
     regions = imviz.get_interactive_regions()
     regions

--- a/docs/imviz/import_data.rst
+++ b/docs/imviz/import_data.rst
@@ -131,7 +131,7 @@ Importing regions via the API
 
 If you have a region file supported by :ref:`regions:regions_io`, you
 can load the regions into Imviz as follows. Any unsupported region will
-be skipped with warning and a list of ``(region, reason)`` that failed to load
+be skipped with a warning and a list of ``(region, reason)`` that failed to load
 will be returned, if any::
 
     bad_regions = imviz.load_regions_from_file("/path/to/data/myregions.reg")

--- a/docs/imviz/import_data.rst
+++ b/docs/imviz/import_data.rst
@@ -130,11 +130,13 @@ Importing regions via the API
 =============================
 
 If you have a region file supported by :ref:`regions:regions_io`, you
-can load the regions into Imviz as follows. Any unsupported region will
-be skipped with a warning and a list of ``(region, reason)`` that failed to load
-will be returned, if any::
+can load the regions into Imviz as follows::
 
     bad_regions = imviz.load_regions_from_file("/path/to/data/myregions.reg")
+
+Unsupported regions will be skipped and trigger a warning. Those that
+failed to load, if any, will be returned as a list of tuples of the
+form ``(region, reason)``.
 
 For more details on the API, please see
 :meth:`~jdaviz.configs.imviz.helper.Imviz.load_regions_from_file`

--- a/docs/imviz/import_data.rst
+++ b/docs/imviz/import_data.rst
@@ -131,12 +131,12 @@ Importing regions via the API
 
 If you have a region file supported by :ref:`regions:regions_io`, you
 can load the regions into Imviz as follows. Any unsupported region will
-be skipped with warning and a dictionary of regions that failed to load
+be skipped with warning and a list of ``(region, reason)`` that failed to load
 will be returned, if any::
 
-    bad_regions = imviz.load_static_regions_from_file("/path/to/data/myregions.reg")
+    bad_regions = imviz.load_regions_from_file("/path/to/data/myregions.reg")
 
 For more details on the API, please see
-:meth:`~jdaviz.configs.imviz.helper.Imviz.load_static_regions_from_file`
-and :meth:`~jdaviz.configs.imviz.helper.Imviz.load_static_regions` methods
+:meth:`~jdaviz.configs.imviz.helper.Imviz.load_regions_from_file`
+and :meth:`~jdaviz.configs.imviz.helper.Imviz.load_regions` methods
 in Imviz.

--- a/docs/imviz/import_data.rst
+++ b/docs/imviz/import_data.rst
@@ -132,11 +132,13 @@ Importing regions via the API
 If you have a region file supported by :ref:`regions:regions_io`, you
 can load the regions into Imviz as follows::
 
-    bad_regions = imviz.load_regions_from_file("/path/to/data/myregions.reg")
+    imviz.load_regions_from_file("/path/to/data/myregions.reg")
 
 Unsupported regions will be skipped and trigger a warning. Those that
 failed to load, if any, will be returned as a list of tuples of the
-form ``(region, reason)``.
+form ``(region, reason)`` if requested, as follows::
+
+    bad_regions = imviz.load_regions_from_file("/path/to/data/myregions.reg", return_bad_regions=True)
 
 For more details on the API, please see
 :meth:`~jdaviz.configs.imviz.helper.Imviz.load_regions_from_file`

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -330,7 +330,7 @@ class Imviz(ConfigHelper):
                 # TODO: Do we want user to specify viewer? Does it matter?
                 self.app.session.edit_subset_mode._mode = NewMode
                 self.default_viewer.apply_roi(state)
-                self.default_viewer.session.edit_subset_mode.edit_subset = None  # No overwrite next iteration # noqa
+                self.app.session.edit_subset_mode.edit_subset = None  # No overwrite next iteration # noqa
 
             # Last resort: Masked Subset that is static
             else:
@@ -593,6 +593,7 @@ class Imviz(ConfigHelper):
         tool.interact.brushing = True
         tool.interact.selected = [from_pix, to_pix]
         tool.interact.brushing = False
+        self.app.session.edit_subset_mode.edit_subset = None  # No overwrite next iteration
 
     # TODO: Make this public API?
     def _delete_region(self, subset_label):

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -833,7 +833,7 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
 
 def _next_subset_num(label_prefix, subset_groups):
     """Assumes ``prefix i`` format.
-    Does not go back an fill in lower but available numbers. This is consistent with Glue.
+    Does not go back and fill in lower but available numbers. This is consistent with Glue.
     """
     labels = [sg.label.split(' ')[1] for sg in subset_groups
               if sg.label.startswith(label_prefix)]

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -232,7 +232,9 @@ class Imviz(ConfigHelper):
 
     def load_regions(self, regions, max_num_regions=None, refdata_label=None, **kwargs):
         """Load given region(s) into the viewer.
-        Region(s) is relative to the reference image defined by ``refdata_label``.
+        WCS-to-pixel translation and mask creation, if needed, is relative
+        to the image defined by ``refdata_label``. Meanwhile, the rest of
+        the Subset operations are based on reference image as defined by Glue.
 
         .. note:: Loading too many regions will affect Imviz performance.
 
@@ -261,10 +263,11 @@ class Imviz(ConfigHelper):
             Default is to load everything.
 
         refdata_label : str or `None`
-            Label of reference data to use. Data must already be loaded into
-            Imviz. If `None`, defaults to the reference data in the default viewer.
-            Choice of reference data is important when sky region or
-            WCS linking is involved.
+            Label of data to use for sky-to-pixel conversion for a region, or
+            mask creation. Data must already be loaded into Imviz.
+            If `None`, defaults to the reference data in the default viewer.
+            Choice of this data is particularly important when sky or masked
+            region is involved.
 
         kwargs : dict
             Extra keywords to be passed into the region's ``to_mask`` method.
@@ -382,7 +385,7 @@ class Imviz(ConfigHelper):
 
         return bad_regions
 
-    @deprecated('2.8', alternative='load_regions_from_file')
+    @deprecated('2.9', alternative='load_regions_from_file')
     def load_static_regions_from_file(self, region_file, region_format='ds9', prefix='region',
                                       max_num_regions=20, **kwargs):
         """Load regions defined in the given file.
@@ -422,7 +425,7 @@ class Imviz(ConfigHelper):
             bad_regions = self.load_static_regions(my_regions, **kwargs)
         return bad_regions
 
-    @deprecated('2.8', alternative='load_regions')
+    @deprecated('2.9', alternative='load_regions')
     def load_static_regions(self, regions, **kwargs):
         """Load given region(s) into the viewer.
         Region(s) is relative to the reference image.

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -283,9 +283,9 @@ class Imviz(ConfigHelper):
         -------
         bad_regions : list of (obj, str) or `None`
             If requested (see ``return_bad_regions`` option), return a
-            list of ``(region, reason)`` tuple for region objects that failed to load.
+            list of ``(region, reason)`` tuples for region objects that failed to load.
             If all the regions loaded successfully, this list will be empty.
-            If not requested, this will always be `None` regardless.
+            If not requested, return `None`.
 
         """
         from photutils.aperture import (CircularAperture, SkyCircularAperture,

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -223,14 +223,15 @@ class Imviz(ConfigHelper):
 
         Returns
         -------
-        bad_regions : list of (obj, str)
+        bad_regions : list of (obj, str) or `None`
             See :meth:`load_regions`.
 
         """
         raw_regs = Regions.read(region_file, format=region_format)
         return self.load_regions(raw_regs, max_num_regions=max_num_regions, **kwargs)
 
-    def load_regions(self, regions, max_num_regions=None, refdata_label=None, **kwargs):
+    def load_regions(self, regions, max_num_regions=None, refdata_label=None,
+                     return_bad_regions=False, **kwargs):
         """Load given region(s) into the viewer.
         WCS-to-pixel translation and mask creation, if needed, is relative
         to the image defined by ``refdata_label``. Meanwhile, the rest of
@@ -269,6 +270,10 @@ class Imviz(ConfigHelper):
             Choice of this data is particularly important when sky or masked
             region is involved.
 
+        return_bad_regions : bool
+            If `True`, return the regions that failed to load (see ``bad_regions``);
+            This is useful for debugging. If `False`, do not return anything (`None`).
+
         kwargs : dict
             Extra keywords to be passed into the region's ``to_mask`` method.
             **This is ignored if the region can be made interactive or
@@ -276,9 +281,11 @@ class Imviz(ConfigHelper):
 
         Returns
         -------
-        bad_regions : list of (obj, str)
-            List of ``(region, reason)`` tuple for region objects that failed to load.
-            If all the regions loaded successfully, this will be empty.
+        bad_regions : list of (obj, str) or `None`
+            If requested (see ``return_bad_regions`` option), return a
+            list of ``(region, reason)`` tuple for region objects that failed to load.
+            If all the regions loaded successfully, this list will be empty.
+            If not requested, this will always be `None` regardless.
 
         """
         from photutils.aperture import (CircularAperture, SkyCircularAperture,
@@ -383,7 +390,8 @@ class Imviz(ConfigHelper):
             f"Loaded {n_loaded}/{n_reg_in} regions, max_num_regions={max_num_regions}, "
             f"bad={n_reg_bad}", color=snack_color, timeout=8000, sender=self.app))
 
-        return bad_regions
+        if return_bad_regions:
+            return bad_regions
 
     @deprecated('2.9', alternative='load_regions_from_file')
     def load_static_regions_from_file(self, region_file, region_format='ds9', prefix='region',

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -4,7 +4,7 @@ from astropy.wcs import WCS
 from glue.core.link_helpers import LinkSame
 from glue.plugins.wcs_autolinking.wcs_autolinking import OffsetLink, WCSLink
 from numpy.testing import assert_allclose
-from regions import PixCoord, CirclePixelRegion
+from regions import PixCoord, CirclePixelRegion, PolygonPixelRegion
 
 from jdaviz.configs.imviz.helper import get_reference_image_data
 from jdaviz.configs.imviz.tests.utils import (
@@ -102,7 +102,9 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
 
         # Add subsets, both interactive and static.
         self.imviz._apply_interactive_region('bqplot:circle', (1.5, 2.5), (3.6, 4.6))
-        self.imviz.load_regions([CirclePixelRegion(center=PixCoord(x=6, y=2), radius=5)])
+        self.imviz.load_regions([CirclePixelRegion(center=PixCoord(x=6, y=2), radius=5),
+                                 PolygonPixelRegion(vertices=PixCoord(x=[1, 2, 2], y=[1, 1, 2])),
+                                 PolygonPixelRegion(vertices=PixCoord(x=[2, 3, 3], y=[2, 2, 3]))])
 
         # Add markers.
         tbl = Table({'x': (0, 0), 'y': (0, 1)})
@@ -119,7 +121,10 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
                         (0, 100))
 
         # Ensure subsets are still there.
+        all_labels = [layer.layer.label for layer in self.viewer.state.layers]
         assert sorted(self.imviz.get_interactive_regions()) == ['Subset 1', 'Subset 2']
+        assert 'MaskedSubset 1' in all_labels
+        assert 'MaskedSubset 2' in all_labels
 
         # Ensure markers are deleted.
         # Zoom and pan will reset in this case, so we do not check those.

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -102,8 +102,7 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
 
         # Add subsets, both interactive and static.
         self.imviz._apply_interactive_region('bqplot:circle', (1.5, 2.5), (3.6, 4.6))
-        self.imviz.load_static_regions({
-            'my_reg': CirclePixelRegion(center=PixCoord(x=6, y=2), radius=5)})
+        self.imviz.load_regions([CirclePixelRegion(center=PixCoord(x=6, y=2), radius=5)])
 
         # Add markers.
         tbl = Table({'x': (0, 0), 'y': (0, 1)})
@@ -120,8 +119,7 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
                         (0, 100))
 
         # Ensure subsets are still there.
-        assert 'Subset 1' in self.imviz.get_interactive_regions()
-        assert 'my_reg' in [layer.layer.label for layer in self.viewer.state.layers]
+        assert sorted(self.imviz.get_interactive_regions()) == ['Subset 1', 'Subset 2']
 
         # Ensure markers are deleted.
         # Zoom and pan will reset in this case, so we do not check those.

--- a/jdaviz/configs/imviz/tests/test_regions.py
+++ b/jdaviz/configs/imviz/tests/test_regions.py
@@ -5,7 +5,8 @@ from astropy.coordinates import SkyCoord, Angle
 from astropy.utils.data import get_pkg_data_filename
 from photutils import CircularAperture, SkyCircularAperture
 from regions import (PixCoord, CircleSkyRegion, RectanglePixelRegion, CirclePixelRegion,
-                     EllipsePixelRegion, PointPixelRegion, PointSkyRegion, Regions)
+                     EllipsePixelRegion, PointPixelRegion, PointSkyRegion, PolygonPixelRegion,
+                     CircleAnnulusSkyRegion, Regions)
 
 from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_NoWCS
 
@@ -21,6 +22,123 @@ class BaseRegionHandler:
                 n += 1
                 assert layer.visible
         assert n == count
+
+
+class TestLoadRegions(BaseImviz_WCS_NoWCS, BaseRegionHandler):
+    def teardown_method(self, method):
+        """Clear all the subsets for the next test method."""
+        self.imviz._delete_all_regions()
+
+    def test_regions_invalid(self):
+        # Wrong object
+        bad_regions = self.imviz.load_regions([self.imviz])
+        assert len(bad_regions) == 1 and bad_regions[0][1] == 'Mask creation failed'
+
+        # Sky region on image without WCS
+        sky = SkyCoord(337.51894337, -20.83208305, unit='deg')
+        reg = CircleSkyRegion(center=sky, radius=0.0004 * u.deg)
+        bad_regions = self.imviz.load_regions([reg], refdata_label='no_wcs[SCI,1]')
+        assert len(bad_regions) == 1 and bad_regions[0][1] == 'Sky region provided but data has no WCS'  # noqa
+
+        reg = SkyCircularAperture(sky, 0.5 * u.arcsec)
+        bad_regions = self.imviz.load_regions([reg], refdata_label='no_wcs[SCI,1]')
+        assert len(bad_regions) == 1 and bad_regions[0][1] == 'Sky region provided but data has no WCS'  # noqa
+
+        reg = CircleAnnulusSkyRegion(center=sky, inner_radius=0.0004 * u.deg,
+                                     outer_radius=0.0005 * u.deg)
+        bad_regions = self.imviz.load_regions([reg], refdata_label='no_wcs[SCI,1]')
+        assert len(bad_regions) == 1 and bad_regions[0][1] == 'Sky region provided but data has no WCS'  # noqa
+
+        # Unsupported functionality from outside load_regions
+        reg = PointSkyRegion(center=sky)
+        bad_regions = self.imviz.load_regions(reg)
+        assert len(bad_regions) == 1 and bad_regions[0][1] == 'Failed to load: NotImplementedError()'  # noqa
+
+        # Out-of-bounds masked subset (pix)
+        reg = PolygonPixelRegion(vertices=PixCoord(x=[11, 12, 12], y=[11, 11, 12]))
+        bad_regions = self.imviz.load_regions(reg)
+        assert len(bad_regions) == 1 and bad_regions[0][1] == 'Mask creation failed'
+
+        # Make sure nothing is actually loaded
+        self.verify_region_loaded('MaskedSubset 1', count=0)
+        assert self.imviz.get_interactive_regions() == {}
+
+    def test_regions_fully_out_of_bounds(self):
+        """Unlike load_static_regions, glue ROI will not error when out of bounds."""
+        my_reg = CirclePixelRegion(center=PixCoord(x=100, y=100), radius=5)
+        bad_regions = self.imviz.load_regions([my_reg])
+        assert len(bad_regions) == 0
+        self.verify_region_loaded('Subset 1')
+        assert len(self.imviz.get_interactive_regions()) == 1
+
+    def test_regions_mask(self):
+        mask = np.zeros((10, 10), dtype=np.bool_)
+        mask[0, 0] = True
+        bad_regions = self.imviz.load_regions([mask])
+        assert len(bad_regions) == 0
+        self.verify_region_loaded('MaskedSubset 1')
+        assert self.imviz.get_interactive_regions() == {}
+
+        # Also test deletion by label here.
+        self.imviz._delete_region('MaskedSubset 1')
+        self.verify_region_loaded('MaskedSubset 1', count=0)
+
+        # Deletion of non-existent label is silent no-op.
+        self.imviz._delete_region('foo')
+
+    def test_regions_pixel(self):
+        # A little out-of-bounds should still overlay the overlapped part.
+        my_reg = CirclePixelRegion(center=PixCoord(x=6, y=2), radius=5)
+        bad_regions = self.imviz.load_regions([my_reg])
+        assert len(bad_regions) == 0
+        self.verify_region_loaded('Subset 1')
+        assert len(self.imviz.get_interactive_regions()) == 1
+
+    def test_regions_sky_has_wcs(self):
+        # Mimic interactive region (before)
+        self.imviz._apply_interactive_region('bqplot:circle', (1.5, 2.5), (3.6, 4.6))
+
+        sky = SkyCoord(ra=337.5202808, dec=-20.833333059999998, unit='deg')
+        # This will become indistinguishable from normal Subset.
+        my_reg_sky_1 = CircleSkyRegion(sky, Angle(0.5, u.arcsec))
+        # Masked subset.
+        my_reg_sky_2 = CircleAnnulusSkyRegion(center=sky, inner_radius=0.0004 * u.deg,
+                                              outer_radius=0.0005 * u.deg)
+        # Add them both.
+        bad_regions = self.imviz.load_regions([my_reg_sky_1, my_reg_sky_2])
+        assert len(bad_regions) == 0
+
+        # Mimic interactive regions (after)
+        self.imviz._apply_interactive_region('bqplot:ellipse', (-2, 0), (5, 4.5))
+        self.imviz._apply_interactive_region('bqplot:rectangle', (0, 0), (10, 10))
+
+        # Check interactive regions. We do not check if the translation is correct,
+        # that check hopefully is already done in glue-astronomy.
+        # Apparently, static region ate up one number...
+        subsets = self.imviz.get_interactive_regions()
+        assert list(subsets.keys()) == ['Subset 1', 'Subset 2', 'Subset 4', 'Subset 5'], subsets
+        assert isinstance(subsets['Subset 1'], CirclePixelRegion)
+        assert isinstance(subsets['Subset 2'], CirclePixelRegion)
+        assert isinstance(subsets['Subset 4'], EllipsePixelRegion)
+        assert isinstance(subsets['Subset 5'], RectanglePixelRegion)
+
+        # Check static region
+        self.verify_region_loaded('MaskedSubset 1')
+
+    def test_photutils_pixel(self):
+        my_aper = CircularAperture((5, 5), r=2)
+        bad_regions = self.imviz.load_regions([my_aper])
+        assert len(bad_regions) == 0
+        self.verify_region_loaded('Subset 1')
+        assert len(self.imviz.get_interactive_regions()) == 1
+
+    def test_photutils_sky_has_wcs(self):
+        sky = SkyCoord(ra=337.5202808, dec=-20.833333059999998, unit='deg')
+        my_aper_sky = SkyCircularAperture(sky, 0.5 * u.arcsec)
+        bad_regions = self.imviz.load_regions([my_aper_sky])
+        assert len(bad_regions) == 0
+        self.verify_region_loaded('Subset 1')
+        assert len(self.imviz.get_interactive_regions()) == 1
 
 
 @pytest.mark.filterwarnings(r'ignore:.*is deprecated and may be removed in a future version')
@@ -56,9 +174,6 @@ class TestLoadStaticRegions(BaseImviz_WCS_NoWCS, BaseRegionHandler):
         # Also test deletion by label here.
         self.imviz._delete_region('my_mask')
         self.verify_region_loaded('my_mask', count=0)
-
-        # Deletion of non-existent label is silent no-op.
-        self.imviz._delete_region('foo')
 
     def test_regions_pixel(self):
         # A little out-of-bounds should still overlay the overlapped part.
@@ -123,6 +238,56 @@ class TestLoadStaticRegions(BaseImviz_WCS_NoWCS, BaseRegionHandler):
         assert len(bad_regions) == 0
         self.verify_region_loaded('my_aper_sky_1')
         assert self.imviz.get_interactive_regions() == {}
+
+
+class TestLoadRegionsFromFile(BaseRegionHandler):
+
+    def setup_class(self):
+        self.region_file = get_pkg_data_filename(
+            'data/ds9.fits.reg', package='regions.io.ds9.tests')
+        self.arr = np.ones((1024, 1024))
+        self.raw_regions = Regions.read(self.region_file, format='ds9')
+
+    def test_ds9_load_all(self, imviz_helper):
+        self.viewer = imviz_helper.default_viewer
+        imviz_helper.load_data(self.arr, data_label='my_image')
+        bad_regions = imviz_helper.load_regions_from_file(self.region_file)
+        assert len(bad_regions) == 1
+
+        # Will load 8/9 and 6 of that become ROIs.
+        subsets = imviz_helper.get_interactive_regions()
+        assert list(subsets.keys()) == ['Subset 1', 'Subset 2', 'Subset 3',
+                                        'Subset 4', 'Subset 5', 'Subset 6'], subsets
+
+        for i in (1, 2):  # The other 2 are MaskedSubset
+            self.verify_region_loaded(f'MaskedSubset {i}', count=1)
+
+    def test_ds9_load_two_good(self, imviz_helper):
+        self.viewer = imviz_helper.default_viewer
+        imviz_helper.load_data(self.arr, data_label='my_image')
+        bad_regions = imviz_helper.load_regions_from_file(self.region_file, max_num_regions=2)
+        assert len(bad_regions) == 0
+        subsets = imviz_helper.get_interactive_regions()
+        assert list(subsets.keys()) == ['Subset 1', 'Subset 2'], subsets
+        self.verify_region_loaded('MaskedSubset 1', count=0)
+
+    def test_ds9_load_one_bad(self, imviz_helper):
+        self.viewer = imviz_helper.default_viewer
+        imviz_helper.load_data(self.arr, data_label='my_image')
+        bad_regions = imviz_helper.load_regions(self.raw_regions[6])
+        assert len(bad_regions) == 1
+        assert imviz_helper.get_interactive_regions() == {}
+        self.verify_region_loaded('MaskedSubset 1', count=0)
+
+    def test_ds9_load_one_good_one_bad(self, imviz_helper):
+        self.viewer = imviz_helper.default_viewer
+        imviz_helper.load_data(self.arr, data_label='my_image')
+        bad_regions = imviz_helper.load_regions([self.raw_regions[3], self.raw_regions[6]])
+        assert len(bad_regions) == 1
+
+        subsets = imviz_helper.get_interactive_regions()
+        assert list(subsets.keys()) == ['Subset 1'], subsets
+        self.verify_region_loaded('MaskedSubset 1', count=0)
 
 
 @pytest.mark.filterwarnings(r'ignore:.*is deprecated and may be removed in a future version')

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -390,10 +390,8 @@
     "my_mask = np.zeros(data.shape, dtype=np.bool_)\n",
     "my_mask[idx] = True\n",
     "\n",
-    "my_regions = {'my_aper': my_aper, 'my_aper_sky': my_aper_sky,\n",
-    "              'my_reg': my_reg, 'my_reg_sky': my_reg_sky,\n",
-    "              'my_mask': my_mask}\n",
-    "imviz.load_static_regions(my_regions)"
+    "my_regions = [my_aper, my_aper_sky, my_reg, my_reg_sky, my_mask]\n",
+    "imviz.load_regions(my_regions)"
    ]
   },
   {
@@ -744,7 +742,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/concepts/imviz_simple_aper_phot.ipynb
+++ b/notebooks/concepts/imviz_simple_aper_phot.ipynb
@@ -20,6 +20,7 @@
     "import warnings\n",
     "\n",
     "from astropy.utils.data import download_file\n",
+    "from regions import CirclePixelRegion, RectanglePixelRegion, PixCoord\n",
     "\n",
     "from jdaviz import Imviz"
    ]
@@ -51,12 +52,10 @@
    "source": [
     "jwf277w = download_file('https://stsci.box.com/shared/static/iao1zxtigyrhq7k3wtu5nchrxzlhj9kv.fits', cache=True)\n",
     "jwf444w = download_file('https://stsci.box.com/shared/static/rey83o5wq6g7qd7xym6r1jq9wlsxaqnt.fits', cache=True)\n",
-    "my_cen = (1002, 1154)\n",
-    "my_radius = 20\n",
-    "my_zoom = 4\n",
     "\n",
-    "my_bg_cen = (925, 1152)\n",
-    "my_bg_hw = 10\n",
+    "my_aper = CirclePixelRegion(center=PixCoord(x=1002, y=1154), radius=20)\n",
+    "my_bg = RectanglePixelRegion(center=PixCoord(x=925, y=1152), width=20, height=20)\n",
+    "my_zoom = 4\n",
     "\n",
     "imviz.load_data(jwf277w, data_label='JWST_F277W')\n",
     "imviz.load_data(jwf444w, data_label='JWST_F444W')"
@@ -72,17 +71,15 @@
   },
   {
    "cell_type": "raw",
-   "id": "e6bf9745",
+   "id": "d90b822e",
    "metadata": {},
    "source": [
     "acs_47tuc_1 = download_file('https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HST/product/jbqf03gjq_flc.fits', cache=True)\n",
     "acs_47tuc_2 = download_file('https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HST/product/jbqf03h1q_flc.fits', cache=True)\n",
-    "my_cen = (1090, 1157)\n",
-    "my_radius = 10\n",
-    "my_zoom = 6\n",
     "\n",
-    "my_bg_cen = (1029, 1138)\n",
-    "my_bg_hw = 10\n",
+    "my_aper = CirclePixelRegion(center=PixCoord(x=1090, y=1157), radius=10)\n",
+    "my_bg = RectanglePixelRegion(center=PixCoord(x=1029, y=1138), width=20, height=20)\n",
+    "my_zoom = 6\n",
     "\n",
     "with warnings.catch_warnings():\n",
     "    warnings.simplefilter('ignore')  # Hide FITS warnings\n",
@@ -103,7 +100,7 @@
   },
   {
    "cell_type": "raw",
-   "id": "b487556a",
+   "id": "54dc3ef7",
    "metadata": {},
    "source": [
     "import numpy as np\n",
@@ -112,12 +109,10 @@
     "gm = Gaussian2D(100, 25, 25, 5, 5)\n",
     "y, x = np.mgrid[0:51, 0:51]\n",
     "arr = gm(x, y)\n",
-    "my_cen = (25, 25)\n",
-    "my_radius = 10\n",
-    "my_zoom = 'fit'\n",
     "\n",
-    "my_bg_cen = (45, 30)\n",
-    "my_bg_hw = 3\n",
+    "my_aper = CirclePixelRegion(center=PixCoord(x=25, y=25), radius=10)\n",
+    "my_bg = RectanglePixelRegion(center=PixCoord(x=45, y=30), width=6, height=6)\n",
+    "my_zoom = 'fit'\n",
     "\n",
     "imviz.load_data(arr, data_label='my_gaussian')"
    ]
@@ -156,17 +151,11 @@
    "outputs": [],
    "source": [
     "viewer = imviz.default_viewer\n",
-    "viewer.cuts = '95%'\n",
-    "viewer.center_on(my_cen)\n",
+    "viewer.center_on(my_aper.center.xy)\n",
     "viewer.zoom_level = my_zoom\n",
     "\n",
     "# Click on image to finalize selection.\n",
-    "imviz._apply_interactive_region(\n",
-    "    'bqplot:circle', (my_cen[0] - my_radius, my_cen[1] - my_radius),\n",
-    "                     (my_cen[0] + my_radius, my_cen[1] + my_radius))\n",
-    "imviz._apply_interactive_region(\n",
-    "    'bqplot:rectangle', (my_bg_cen[0] - my_bg_hw, my_bg_cen[1] - my_bg_hw),\n",
-    "                        (my_bg_cen[0] + my_bg_hw, my_bg_cen[1] + my_bg_hw))"
+    "imviz.load_regions([my_aper, my_bg])"
    ]
   },
   {


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to allow loading DS9 regions into native Glue subset ROIs instead of the "static regions" that do not work with most plugins.

This is a breaking change for the following APIs:

https://github.com/spacetelescope/jdaviz/blob/cbcd65c6a85f83cd23777a97d224912ad5e20182/jdaviz/configs/imviz/helper.py#L198

https://github.com/spacetelescope/jdaviz/blob/cbcd65c6a85f83cd23777a97d224912ad5e20182/jdaviz/configs/imviz/helper.py#L236

https://github.com/spacetelescope/jdaviz/blob/cbcd65c6a85f83cd23777a97d224912ad5e20182/jdaviz/configs/imviz/helper.py#L343

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Pre-requisite for:

* #1432

Close #1141 

### TODO

- [x] Add tests for new API.
- [x] Update notebooks (official and concepts).
- [x] Update docs.

### Post-merge

- Open follow-up issue to remove the deprecated methods in a future release.
- Open follow-up issue to move region translation code upstream to `glue-astronomy`.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-2640)
