### PR TITLE
Update docs packaging and build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,5 +20,7 @@ python:
       extra_requirements:
         - docs
 
-# Don't build any extra formats
-formats: []
+# Build PDF and zipped HTML
+formats:
+    - pdf
+    - htmlzip

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,12 +4,10 @@ include setup.cfg
 include LICENSE.rst
 include pyproject.toml
 
-recursive-include docs *
 recursive-include licenses *
 recursive-include share *
 
 prune build
-prune docs/_build
-prune docs/api
+prune docs
 
 global-exclude *.pyc *.o


### PR DESCRIPTION
This updates our configuration to no longer packaged the docs (due to the large GIF file sizes) in the release tar files, and instead generates PDF and zipped HTML version of the docs that can be downloaded by the users for offline use.