### PR TITLE
Viewer/layer labels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 New Features
 ------------
 
+- Viewer/layer labels with icons that are synced app-wide. [#1465]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -376,7 +376,9 @@ class Application(VuetifyTemplate, HubListener):
         else:
             raise NotImplementedError(f"cannot recognize new layer from {msg}")
 
-        self.state.layer_icons.setdefault(layer_name, f"mdi-alpha-{chr(97 + len(self.state.layer_icons))}-box-outline")  # noqa
+        if layer_name not in self.state.layer_icons:
+            self.state.layer_icons = {**self.state.layer_icons,
+                                      layer_name: f"mdi-alpha-{chr(97 + len(self.state.layer_icons))}-box-outline"}  # noqa
 
     def _link_new_data(self, reference_data=None, data_to_be_linked=None):
         """

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1393,7 +1393,7 @@ class Application(VuetifyTemplate, HubListener):
         last_num = int(last_vid.split('-')[-1])
         return last_num + 1
 
-    def _create_viewer_item(self, viewer, vid=None, name=None, reference=None):
+    def _create_viewer_item(self, viewer, vid=None, name=None, reference=None, index=0):
         """
         Convenience method for generating viewer item dictionaries.
 
@@ -1409,6 +1409,8 @@ class Application(VuetifyTemplate, HubListener):
         reference : str, optional
             The reference associated with this viewer as defined in the yaml
             configuration file.
+        index : int, optional
+            Index of the viewer (used for icons in the UI to identify the viewers)
 
         Returns
         -------
@@ -1432,6 +1434,7 @@ class Application(VuetifyTemplate, HubListener):
         return {
             'id': vid,
             'name': name or vid,
+            'index': index,
             'widget': "IPY_MODEL_" + viewer.figure_widget.model_id,
             'toolbar_nested': "IPY_MODEL_" + viewer.toolbar_nested.model_id if viewer.toolbar_nested else '',  # noqa
             'tools': "IPY_MODEL_" + viewer.toolbar_selection_tools.model_id,
@@ -1479,7 +1482,7 @@ class Application(VuetifyTemplate, HubListener):
         # Create the viewer item dictionary
         if name is None:
             name = viewer.__class__.__name__
-        new_viewer_item = self._create_viewer_item(viewer=viewer, vid=vid, name=name)
+        new_viewer_item = self._create_viewer_item(viewer=viewer, vid=vid, name=name, index=len(self._viewer_store)+1)
 
         new_stack_item = self._create_stack_item(
             container='gl-stack',
@@ -1558,7 +1561,8 @@ class Application(VuetifyTemplate, HubListener):
                     viewer_item = self._create_viewer_item(
                         name=view.get('name'),
                         viewer=viewer,
-                        reference=view.get('reference'))
+                        reference=view.get('reference'),
+                        index=len(self._viewer_store)+1)
 
                     self._viewer_store[viewer_item['id']] = viewer
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -183,7 +183,6 @@ class Application(VuetifyTemplate, HubListener):
     config = Unicode("").tag(sync=True)
     vdocs = Unicode("").tag(sync=True)
     popout_button = Any().tag(sync=True, **widget_serialization)
-    viewer_labels = Bool(True).tag(sync=True)
 
     def __init__(self, configuration=None, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1469,7 +1469,8 @@ class Application(VuetifyTemplate, HubListener):
             'tools_open': False,
             'layer_options': "IPY_MODEL_" + viewer.layer_options.model_id,
             'viewer_options': "IPY_MODEL_" + viewer.viewer_options.model_id,
-            'selected_data_items': {},
+            'selected_data_items': {},  # data-label: visibility state (visible, hidden, mixed)
+            'visible_layers': {},  # label: {color, label_suffix} (read-only access)
             'config': self.config,  # give viewer access to app config/layout
             'data_open': False,
             'collapse': True,

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -342,8 +342,9 @@ a:active {
   filter: invert(1) saturate(1) brightness(100);
 }
 
-.invert-if-dark.theme--dark {
+.invert, .invert-if-dark.theme--dark {
     filter: invert(1) saturate(1) brightness(100);
+    color: white;
 }
 
 .jdaviz-nested-toolbar .v-btn {

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -84,6 +84,8 @@
                   :data_items="state.data_items"
                   :app_settings="state.settings"
                   :icons="state.icons"
+                  :viewer_icons="state.viewer_icons"
+                  :layer_icons="state.layer_icons"
                   @resize="relayout"
                   :closefn="destroy_viewer_item"
                   @data-item-selected="data_item_selected($event)"

--- a/jdaviz/components/plugin_dataset_select.vue
+++ b/jdaviz/components/plugin_dataset_select.vue
@@ -37,6 +37,9 @@ module.exports = {
 </script>
 
 <style>
+  .v-select__selections {
+    flex-wrap: nowrap !important;
+  }
   .single-line {
       white-space: nowrap;
       overflow: hidden;

--- a/jdaviz/components/plugin_dataset_select.vue
+++ b/jdaviz/components/plugin_dataset_select.vue
@@ -15,6 +15,7 @@
     <template slot="selection" slot-scope="data">
       <div class="single-line">
         <span>
+          <v-icon style='margin-right: 2px'>{{ data.item.icon }}</v-icon>
           {{ data.item.label }}
         </span>
       </div>
@@ -22,6 +23,7 @@
     <template slot="item" slot-scope="data">
       <div class="single-line">
         <span>
+          <v-icon style='margin-right: 2px'>{{ data.item.icon }}</v-icon>
           {{ data.item.label }}
         </span>
       </div>

--- a/jdaviz/components/plugin_layer_select.vue
+++ b/jdaviz/components/plugin_layer_select.vue
@@ -23,6 +23,7 @@
           </span>
         </v-chip>
         <span v-else>
+          <v-icon style='margin-right: 2px'>{{ data.item.icon }}</v-icon>
           {{ data.item.label }}
         </span>
       </div>
@@ -49,6 +50,7 @@
     <template slot="item" slot-scope="data">
       <div class="single-line">
         <span>
+          <v-icon style='margin-left: -2px; margin-right: 2px'>{{ data.item.icon }}</v-icon>
           {{ data.item.label }}
         </span>
       </div>

--- a/jdaviz/components/plugin_layer_select.vue
+++ b/jdaviz/components/plugin_layer_select.vue
@@ -67,6 +67,9 @@ module.exports = {
 </script>
 
 <style>
+.v-select__selections {
+    flex-wrap: nowrap !important;
+  }
   .single-line {
       white-space: nowrap;
       overflow: hidden;

--- a/jdaviz/components/plugin_subset_select.vue
+++ b/jdaviz/components/plugin_subset_select.vue
@@ -49,6 +49,9 @@ module.exports = {
 </script>
 
 <style>
+.v-select__selections {
+  flex-wrap: nowrap !important;
+}
   .single-line {
       white-space: nowrap;
       overflow: hidden;

--- a/jdaviz/components/plugin_viewer_select.vue
+++ b/jdaviz/components/plugin_viewer_select.vue
@@ -67,6 +67,9 @@ module.exports = {
 </script>
 
 <style>
+.v-select__selections {
+  flex-wrap: nowrap !important;
+}
   .single-line {
       white-space: nowrap;
       overflow: hidden;

--- a/jdaviz/components/plugin_viewer_select.vue
+++ b/jdaviz/components/plugin_viewer_select.vue
@@ -19,10 +19,11 @@
         <v-chip v-if="multiselect" style="width: calc(100% - 20px)">
           <span>
             <v-icon style='margin-left: -10px; margin-right: 2px'>{{ data.item.icon }}</v-icon>
-            {{ data.item.label.split("-viewer")[0] }}
+            {{ data.item.label }}
           </span>
         </v-chip>
         <span v-else>
+          <v-icon style='margin-right: 2px'>{{ data.item.icon }}</v-icon>
           {{ data.item.label }}
         </span>
       </div>
@@ -49,6 +50,7 @@
     <template slot="item" slot-scope="data">
       <div class="single-line">
         <span>
+          <v-icon style='margin-left: -2px; margin-right: 2px'>{{ data.item.icon }}</v-icon>
           {{ data.item.label }}
         </span>
       </div>

--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -17,7 +17,7 @@
         </v-btn>
       </template>
   
-      <v-list style="max-height: 500px; width: 430px; padding-top: 0px" class="overflow-y-auto">
+      <v-list style="max-height: 500px; width: 460px; padding-top: 0px" class="overflow-y-auto">
         <v-row key="title" style="padding-left: 25px; margin-right: 0px; background-color: #E3F2FD">
             <span style="overflow-wrap: anywhere; font-size: 12pt; padding-top: 6px; padding-left: 6px; font-weight: bold; color: black">
               {{viewerTitleCase}}
@@ -47,6 +47,7 @@
         <v-row v-for="item in filteredDataItems" :key="item.id" style="padding-left: 25px; margin-right: 0px; margin-top: 4px; margin-bottom: 4px">
           <j-viewer-data-select-item
             :item="item"
+            :icon="layer_icons[item.name]"
             :viewer="viewer"
             :multi_select="multi_select"
             @data-item-selected="$emit('data-item-selected', $event)"
@@ -75,6 +76,7 @@
           <v-row v-if="showExtraItems" v-for="item in extraDataItems"  :key="item.id" style="padding-left: 25px; margin-right: 0px; margin-top: 4px; margin-bottom: 4px">
             <j-viewer-data-select-item
               :item="item"
+              :icon="layer_icons[item.name]"
               :viewer="viewer"
               :multi_select="multi_select"
               @data-item-selected="$emit('data-item-selected', $event)"
@@ -91,7 +93,7 @@
 <script>
 
 module.exports = {
-  props: ['data_items', 'viewer', 'app_settings', 'viewer_data_visibility', 'icons'],
+  props: ['data_items', 'viewer', 'layer_icons', 'app_settings', 'viewer_data_visibility', 'icons'],
   data: function () {
     var multi_select = true
     if (this.$props.viewer.config === 'cubeviz') {

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -22,8 +22,9 @@
       </j-tooltip>
     </div>
 
-    <j-tooltip :tooltipcontent="'data label: '+item.name" span_style="font-size: 12pt; padding-top: 6px; padding-left: 6px; width: calc(100% - 80px); cursor: default;">
-      <div class="text-ellipsis-middle">
+    <j-tooltip :tooltipcontent="'data label: '+item.name" span_style="font-size: 12pt; padding-top: 6px; padding-left: 6px; width: calc(100% - 140px); white-space: nowrap; cursor: default;">
+      <v-icon class='invert-if-dark' style='color: #000000DE; margin-left: 4px; margin-right: -2px'>{{icon}}</v-icon>
+      <div class="text-ellipsis-middle" style="font-weight: 500">
         <span>
           {{itemNamePrefix}}
         </span>
@@ -61,7 +62,7 @@
 <script>
 
 module.exports = {
-  props: ['item', 'multi_select', 'viewer'],
+  props: ['item', 'icon', 'multi_select', 'viewer'],
   methods: {
     selectClicked() {
       prevVisibleState = this.visibleState

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -68,6 +68,7 @@ class CubevizImageView(BqplotImageView, JdavizViewerMixin):
             # of dataset shouldn't matter if the datasets are linked correctly
             active_layer = visible_layers[-1]
             image = active_layer.layer
+            self.label_mouseover.icon = self.jdaviz_app.state.layer_icons.get(active_layer.layer.label)  # noqa
 
             # Extract data coordinates - these are pixels in the reference image
             x = data['domain']['x']

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -1,6 +1,5 @@
 import os
 
-from echo import add_callback
 from traitlets import Any, Dict, Float, Bool, Int, List, Unicode, observe
 
 from glue.viewers.profile.state import ProfileViewerState, ProfileLayerState
@@ -201,7 +200,7 @@ class PlotOptions(TemplateMixin):
         # display_units
 
         self.setting_show_viewer_labels = self.app.state.settings['viewer_labels']
-        add_callback(self.app.state, 'settings', self._on_app_settings_changed)
+        self.app.state.add_callback('settings', self._on_app_settings_changed)
 
     @observe('setting_show_viewer_labels')
     def _on_show_viewer_labels_changed(self, event):

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -1,6 +1,7 @@
 import os
 
-from traitlets import Any, Dict, Float, Bool, Int, List, Unicode
+from echo import add_callback
+from traitlets import Any, Dict, Float, Bool, Int, List, Unicode, observe
 
 from glue.viewers.profile.state import ProfileViewerState, ProfileLayerState
 from glue.viewers.image.state import ImageSubsetLayerState
@@ -107,6 +108,8 @@ class PlotOptions(TemplateMixin):
     icon_radialtocheck = Unicode(read_icon(os.path.join(ICON_DIR, 'radialtocheck.svg'), 'svg+xml')).tag(sync=True)  # noqa
     icon_checktoradial = Unicode(read_icon(os.path.join(ICON_DIR, 'checktoradial.svg'), 'svg+xml')).tag(sync=True)  # noqa
 
+    setting_show_viewer_labels = Bool(True).tag(sync=True)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.viewer = ViewerSelect(self, 'viewer_items', 'viewer_selected', 'multiselect')
@@ -196,6 +199,16 @@ class PlotOptions(TemplateMixin):
                                               state_filter=not_profile)
         # zoom limits
         # display_units
+
+        self.setting_show_viewer_labels = self.app.state.settings['viewer_labels']
+        add_callback(self.app.state, 'settings', self._on_app_settings_changed)
+
+    @observe('setting_show_viewer_labels')
+    def _on_show_viewer_labels_changed(self, event):
+        self.app.state.settings['viewer_labels'] = event['new']
+
+    def _on_app_settings_changed(self, value):
+        self.setting_show_viewer_labels = value['viewer_labels']
 
     def vue_unmix_state(self, name):
         sync_state = getattr(self, name)

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -5,6 +5,26 @@
     :popout_button="popout_button">
 
     <v-row>
+      <v-expansion-panels popout>
+        <v-expansion-panel>
+          <v-expansion-panel-header v-slot="{ open }">
+            <span style="padding: 6px">Settings</span>
+          </v-expansion-panel-header>
+          <v-expansion-panel-content>
+            <v-row>
+              <v-switch
+                v-model="setting_show_viewer_labels"
+                label="Show labels in viewers"
+                hint="Whether to show viewer/layer labels on each viewer"
+                persistent-hint
+              ></v-switch>
+            </v-row>
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </v-row>
+
+    <v-row>
       <div style="width: calc(100% - 32px)">
       </div>
       <div style="width: 32px">

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -39,31 +39,7 @@ class JdavizViewerMixin:
         # default visibility based on the visibility of the "parent" data layer
         layer.visible = self._get_layer(layer.layer.data.label).visible
 
-    def _on_layers_update(self, layers=None):
-        if self.__class__.__name__ == 'MosvizTableViewer':
-            # MosvizTableViewer uses this as a mixin, but we do not need any of this layer
-            # logic there
-            return
-
-        viewer_item = self.jdaviz_app._viewer_item_by_id(self.reference_id)
-        selected_data_items = viewer_item['selected_data_items']
-
-        # update selected_data_items
-        for data_id, visibility in selected_data_items.items():
-            label = next((x['name'] for x in self.jdaviz_app.state.data_items
-                          if x['id'] == data_id), None)
-
-            visibilities = []
-            for layer in self.state.layers:
-                if layer.layer.data.label == label:
-                    visibilities.append(layer.visible)
-            if np.all(visibilities):
-                selected_data_items[data_id] = 'visible'
-            elif np.any(visibilities):
-                selected_data_items[data_id] = 'mixed'
-            else:
-                selected_data_items[data_id] = 'hidden'
-
+    def _update_layer_icons(self):
         # update visible_layers (TODO: move this somewhere that can update on color change, etc)
         def _get_layer_color(layer):
             if getattr(self.state, 'color_mode', None) == 'Colormaps':
@@ -100,7 +76,36 @@ class JdavizViewerMixin:
                 visible_layers[layer.layer.label] = {'color': _get_layer_color(layer),
                                                      'prefix_icon': prefix_icon,
                                                      'suffix_label': suffix}
+
+        viewer_item = self.jdaviz_app._viewer_item_by_id(self.reference_id)
         viewer_item['visible_layers'] = visible_layers
+
+    def _on_layers_update(self, layers=None):
+        if self.__class__.__name__ == 'MosvizTableViewer':
+            # MosvizTableViewer uses this as a mixin, but we do not need any of this layer
+            # logic there
+            return
+
+        viewer_item = self.jdaviz_app._viewer_item_by_id(self.reference_id)
+        selected_data_items = viewer_item['selected_data_items']
+
+        # update selected_data_items
+        for data_id, visibility in selected_data_items.items():
+            label = next((x['name'] for x in self.jdaviz_app.state.data_items
+                          if x['id'] == data_id), None)
+
+            visibilities = []
+            for layer in self.state.layers:
+                if layer.layer.data.label == label:
+                    visibilities.append(layer.visible)
+            if np.all(visibilities):
+                selected_data_items[data_id] = 'visible'
+            elif np.any(visibilities):
+                selected_data_items[data_id] = 'mixed'
+            else:
+                selected_data_items[data_id] = 'hidden'
+
+        self._update_layer_icons()
 
         if not len(self._expected_subset_layers):
             return

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -44,8 +44,10 @@ class JdavizViewerMixin:
             # logic there
             return
 
-        selected_data_items = self.jdaviz_app._viewer_item_by_id(self.reference_id)['selected_data_items']  # noqa
+        viewer_item = self.jdaviz_app._viewer_item_by_id(self.reference_id)
+        selected_data_items = viewer_item['selected_data_items']
 
+        # update selected_data_items
         for data_id, visibility in selected_data_items.items():
             label = next((x['name'] for x in self.jdaviz_app.state.data_items
                           if x['id'] == data_id), None)
@@ -60,6 +62,25 @@ class JdavizViewerMixin:
                 selected_data_items[data_id] = 'mixed'
             else:
                 selected_data_items[data_id] = 'hidden'
+
+        # update visible_layers (TODO: move this somewhere that can update on color change, etc)
+        def _get_layer_color(layer):
+            return layer.color
+
+        def _get_layer_suffix(layer):
+            #if self.__class__.__name__ == 'CubevizProfileView' and len(layer.layer.data.shape) == 3:
+            #    # then the underlying data is cube-like and we're in the profile viewer, so we
+            #    # want to include the collapse function *unless* the layer is a spectral subset
+            #    if isinstance(subset.subset_state, RoiSubsetState):
+            #        return f" (collapsed: {self.state.function})"
+            return ''
+
+        visible_layers = {}
+        for layer in self.state.layers:
+            if layer.visible:
+                visible_layers[layer.layer.label] = {'color': _get_layer_color(layer),
+                                                     'label_suffix': _get_layer_suffix(layer)}
+        viewer_item['visible_layers'] = visible_layers
 
         if not len(self._expected_subset_layers):
             return

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -94,7 +94,7 @@ class JdavizViewerMixin:
             return '', ''
 
         visible_layers = {}
-        for layer in self.state.layers:
+        for layer in self.state.layers[::-1]:
             if layer.visible:
                 prefix_icon, suffix = _get_layer_info(layer)
                 visible_layers[layer.layer.label] = {'color': _get_layer_color(layer),

--- a/jdaviz/configs/imviz/plugins/compass/compass.py
+++ b/jdaviz/configs/imviz/plugins/compass/compass.py
@@ -10,6 +10,7 @@ __all__ = ['Compass']
 @tray_registry('imviz-compass', label="Imviz Compass")
 class Compass(PluginTemplateMixin, ViewerSelectMixin):
     template_file = __file__, "compass.vue"
+    icon = Unicode("").tag(sync=True)
     data_label = Unicode("").tag(sync=True)
     img_data = Unicode("").tag(sync=True)
 
@@ -40,6 +41,7 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
 
     def clear_compass(self):
         """Clear the content of the plugin."""
+        self.icon = ''
         self.data_label = ''
         self.img_data = ''
 
@@ -48,5 +50,6 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
         Input is rendered buffer from Matplotlib.
 
         """
+        self.icon = self.app.state.layer_icons.get(data_label)
         self.data_label = data_label
         self.img_data = img_data

--- a/jdaviz/configs/imviz/plugins/compass/compass.vue
+++ b/jdaviz/configs/imviz/plugins/compass/compass.vue
@@ -14,7 +14,10 @@
     <v-row v-if="data_label">
       <v-chip
         label=true
-      >{{ data_label }}</v-chip>
+      >
+        <v-icon>{{ icon }}</v-icon>
+        {{ data_label }}
+      </v-chip>
     </v-row>
 
     <img class='invert-in-dark' v-if="img_data" :src="`data:image/png;base64,${img_data}`" style="width: 100%; max-width: 400px" />

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -9,6 +9,7 @@ __all__ = ['CoordsInfo']
 @tool_registry('g-coords-info')
 class CoordsInfo(TemplateMixin):
     template_file = __file__, "coords_info.vue"
+    icon = Unicode("").tag(sync=True)
     pixel = Unicode("").tag(sync=True)
     value = Unicode("").tag(sync=True)
     world_label_prefix = Unicode("\u00A0").tag(sync=True)

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.vue
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.vue
@@ -1,23 +1,28 @@
 <template>
-  <div v-if="pixel" style="white-space: nowrap; line-height: 14pt; margin: 0; position: absolute; top: 50%; transform: translateY(-50%); -ms-transform: translateY(-50%);">
-    <table>
-      <tr>
-        <td colspan="4">
-          <b v-if="pixel">Pixel </b>{{ pixel }}&nbsp;&nbsp;<b v-if="value">Value </b>{{ value }}
-        </td>
-      </tr>
-      <tr>
-        <td width="42"><b>{{ world_label_prefix }}</b></td>
-        <td width="115">{{ world_ra }}</td>
-        <td width="120">{{ world_dec }}</td>
-        <td>{{ world_label_icrs }}</td>
-      </tr>
-      <tr>
-        <td width="42"></td>
-        <td width="115">{{ world_ra_deg }}</td>
-        <td width="120">{{ world_dec_deg }}</td>
-        <td>{{ world_label_deg }}</td>
-      </tr>
-    </table>
-  </div>
+  <div v-if="pixel">
+    <span style="position: absolute; top: 50%; transform: translateY(-50%); -ms-transform: translateY(-50%);">
+      <v-icon>{{icon}}</v-icon>
+    </span>
+    <div style="display: inline-block; white-space: nowrap; line-height: 14pt; margin: 0; position: absolute; margin-left: 26px; top: 50%; transform: translateY(-50%); -ms-transform: translateY(-50%);">
+      <table>
+        <tr>
+          <td colspan="4">
+            <b v-if="pixel">Pixel </b>{{ pixel }}&nbsp;&nbsp;<b v-if="value">Value </b>{{ value }}
+          </td>
+        </tr>
+        <tr>
+          <td width="42"><b>{{ world_label_prefix }}</b></td>
+          <td width="115">{{ world_ra }}</td>
+          <td width="120">{{ world_dec }}</td>
+          <td>{{ world_label_icrs }}</td>
+        </tr>
+        <tr>
+          <td width="42"></td>
+          <td width="115">{{ world_ra_deg }}</td>
+          <td width="120">{{ world_dec_deg }}</td>
+          <td>{{ world_label_deg }}</td>
+        </tr>
+      </table>
+    </div>
+</div>
 </template>

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -102,6 +102,7 @@ class ImvizImageView(BqplotImageView, AstrowidgetsImageViewerMixin, JdavizViewer
             # Extract first dataset from visible layers and use this for coordinates - the choice
             # of dataset shouldn't matter if the datasets are linked correctly
             image = active_layer.layer
+            self.label_mouseover.icon = self.jdaviz_app.state.layer_icons.get(active_layer.layer.label)  # noqa
 
             # Extract data coordinates - these are pixels in the reference image
             x = data['domain']['x']

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -31,6 +31,7 @@
               :data_items="data_items" 
               :viewer="viewer"
               :app_settings="app_settings"
+              :layer_icons="layer_icons"
               :icons="icons"
               @data-item-selected="$emit('data-item-selected', $event)"
               @data-item-visibility="$emit('data-item-visibility', $event)"
@@ -67,11 +68,13 @@
             </div>
 
             <div v-for="(icon, layer_name) in layer_icons" :class="viewer.config==='imviz' ? 'viewer-label viewer-label-imviz invert-if-dark' : 'viewer-label invert-if-dark'">
-              <div v-if="layer_in_viewer(viewer, data_items, layer_name)">
+              <div v-if="Object.keys(viewer.visible_layers).indexOf(layer_name) !== -1">
                 <j-tooltip span_style="white-space: nowrap">
                   <v-icon :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'" style="float: right">{{icon}}</v-icon>
                 </j-tooltip>
-                <span :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'" style="margin-left: 24px; margin-right: 32px; line-height: 24px">{{layer_name}}</span>
+                <span :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'" style="margin-left: 24px; margin-right: 32px; line-height: 24px">
+                  {{layer_name}}{{viewer.visible_layers[layer_name].label_suffix}}
+                </span>
               </div>
             </div>
           </div>
@@ -130,19 +133,6 @@ module.exports = {
        * between a user closing a tab or a re-render. However, when the user closes a tab, the
        * source of the event is a vue component. We can use that distinction as a close signal. */
       source.$root && this.closefn(viewerId);
-    },
-    layer_in_viewer(viewer, data_items, layer_name) {
-      for (data_item of data_items) {
-        if (data_item['name'] == layer_name) {
-          // determine if this layer is LOADED (not necessarily visible) in the selected viewer
-          // NOTE: this logic doesn't work for subsets, and doesn't handle mixed-state well
-          // it should probably be replaced by accessing the direct visibility of the layer itself
-          // or by exposing more fine-grained information in viewer.selected_data_items
-          return (Object.keys(viewer.selected_data_items).indexOf(data_item['id']) !== -1 && viewer.selected_data_items[data_item['id']] === 'visible')
-        }
-      }
-      // then layer_name is likely of a subset, so we'll only include for spectrum-viewers
-      return viewer.reference === 'spectrum-viewer';
     }
   },
   computed: {

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -67,18 +67,16 @@
               <span :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'" style="margin-left: 24px; margin-right: 32px; line-height: 24px">{{viewer.reference || viewer.id}}</span>
             </div>
 
-            <div v-for="(icon, layer_name) in layer_icons" :class="viewer.config==='imviz' ? 'viewer-label viewer-label-imviz invert-if-dark' : 'viewer-label invert-if-dark'">
-              <div v-if="Object.keys(viewer.visible_layers).indexOf(layer_name) !== -1">
-                <j-tooltip span_style="white-space: nowrap">
-                  <v-icon :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'" style="float: right" :color="viewer.visible_layers[layer_name].color">{{icon}}</v-icon>
-                </j-tooltip>
-                <span :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'" style="margin-left: 24px; margin-right: 32px; line-height: 24px">
-                  <v-icon v-if="viewer.visible_layers[layer_name].prefix_icon" dense>
-                    {{viewer.visible_layers[layer_name].prefix_icon}}
-                  </v-icon>
-                  {{layer_name}}{{viewer.visible_layers[layer_name].suffix_label}}
-                </span>
-              </div>
+            <div v-for="(layer_info, layer_name) in viewer.visible_layers" :class="viewer.config==='imviz' ? 'viewer-label viewer-label-imviz invert-if-dark' : 'viewer-label invert-if-dark'">
+              <j-tooltip span_style="white-space: nowrap">
+                <v-icon :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'" style="float: right" :color="layer_info.color">{{layer_icons[layer_name]}}</v-icon>
+              </j-tooltip>
+              <span :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'" style="margin-left: 24px; margin-right: 32px; line-height: 24px">
+                <v-icon v-if="layer_info.prefix_icon" dense>
+                  {{layer_info.prefix_icon}}
+                </v-icon>
+                {{layer_name}}{{layer_info.suffix_label}}
+              </span>
             </div>
           </div>
 

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -60,7 +60,7 @@
 
         <v-card tile flat style="flex: 1; margin-top: -2px; overflow-y: hidden;">
           <div v-if="app_settings.viewer_labels" class='viewer-label-container'>
-            <div class="viewer-label invert-if-dark">
+            <div v-if="Object.keys(viewer_icons).length > 1" class="viewer-label invert-if-dark">
               <j-tooltip span_style="white-space: nowrap">
                 <v-icon class="invert-if-dark" style="float: right">{{viewer_icons[[viewer.id]]}}</v-icon>
               </j-tooltip>

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -135,7 +135,10 @@ module.exports = {
       for (data_item of data_items) {
         if (data_item['name'] == layer_name) {
           // determine if this layer is LOADED (not necessarily visible) in the selected viewer
-          return (Object.keys(viewer.selected_data_items).indexOf(data_item['id']) !== -1 && viewer.selected_data_items[data_item['id']] !== 'hidden')
+          // NOTE: this logic doesn't work for subsets, and doesn't handle mixed-state well
+          // it should probably be replaced by accessing the direct visibility of the layer itself
+          // or by exposing more fine-grained information in viewer.selected_data_items
+          return (Object.keys(viewer.selected_data_items).indexOf(data_item['id']) !== -1 && viewer.selected_data_items[data_item['id']] === 'visible')
         }
       }
       // then layer_name is likely of a subset, so we'll only include for spectrum-viewers

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -70,10 +70,13 @@
             <div v-for="(icon, layer_name) in layer_icons" :class="viewer.config==='imviz' ? 'viewer-label viewer-label-imviz invert-if-dark' : 'viewer-label invert-if-dark'">
               <div v-if="Object.keys(viewer.visible_layers).indexOf(layer_name) !== -1">
                 <j-tooltip span_style="white-space: nowrap">
-                  <v-icon :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'" style="float: right">{{icon}}</v-icon>
+                  <v-icon :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'" style="float: right" :color="viewer.visible_layers[layer_name].color">{{icon}}</v-icon>
                 </j-tooltip>
                 <span :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'" style="margin-left: 24px; margin-right: 32px; line-height: 24px">
-                  {{layer_name}}{{viewer.visible_layers[layer_name].label_suffix}}
+                  <v-icon v-if="viewer.visible_layers[layer_name].prefix_icon" dense>
+                    {{viewer.visible_layers[layer_name].prefix_icon}}
+                  </v-icon>
+                  {{layer_name}}{{viewer.visible_layers[layer_name].suffix_label}}
                 </span>
               </div>
             </div>

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -56,11 +56,11 @@
         </div>
 
         <v-card tile flat style="flex: 1; margin-top: -2px; overflow-y: auto">
-          <div class="viewer-label invert-if-dark">
+          <div :class="viewer.config==='imviz' ? 'viewer-label viewer-label-imviz invert-if-dark' : 'viewer-label invert-if-dark'">
             <j-tooltip :tooltipcontent="viewer.reference+' (click to select)'" span_style="white-space: nowrap">
-              <v-icon class="invert-if-dark">mdi-numeric-{{viewer.index}}-circle-outline</v-icon>
+              <v-icon :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'">mdi-numeric-{{viewer.index}}-circle-outline</v-icon>
             </j-tooltip>
-            <span class="invert-if-dark" style="padding: 10px">{{viewer.reference || viewer.id}}</span>
+            <span :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'" style="padding: 10px">{{viewer.reference || viewer.id}}</span>
           </div>
           <jupyter-widget :widget="viewer.widget" style="width: 100%; height: 100%"></jupyter-widget>
         </v-card>
@@ -75,14 +75,19 @@
   border-bottom-right-radius: 4px; 
   z-index: 1;
   width: 24px;
-  overflow-x: hidden;
+  overflow: hidden;
   white-space: nowrap;
   cursor: pointer;
 }
-
+.viewer-label-imviz {
+  background-color: #393939c2;
+}
 .viewer-label:hover {
   background-color: #e5e5e5;
   width: auto;
+}
+.viewer-label-imviz:hover {
+  background-color: #777777c2;
 }
 </style>
 

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -60,18 +60,18 @@
 
         <v-card tile flat style="flex: 1; margin-top: -2px; overflow-y: hidden;">
           <div v-if="app_settings.viewer_labels" class='viewer-label-container'>
-            <div :class="viewer.config==='imviz' ? 'viewer-label viewer-label-imviz invert-if-dark' : 'viewer-label invert-if-dark'">
+            <div class="viewer-label invert-if-dark">
               <j-tooltip span_style="white-space: nowrap">
-                <v-icon :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'" style="float: right">{{viewer_icons[[viewer.id]]}}</v-icon>
+                <v-icon class="invert-if-dark" style="float: right">{{viewer_icons[[viewer.id]]}}</v-icon>
               </j-tooltip>
-              <span :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'" style="margin-left: 24px; margin-right: 32px; line-height: 24px">{{viewer.reference || viewer.id}}</span>
+              <span class="invert-if-dark" style="margin-left: 24px; margin-right: 32px; line-height: 24px">{{viewer.reference || viewer.id}}</span>
             </div>
 
-            <div v-for="(layer_info, layer_name) in viewer.visible_layers" :class="viewer.config==='imviz' ? 'viewer-label viewer-label-imviz invert-if-dark' : 'viewer-label invert-if-dark'">
+            <div v-for="(layer_info, layer_name) in viewer.visible_layers" class="viewer-label invert-if-dark">
               <j-tooltip span_style="white-space: nowrap">
-                <v-icon :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'" style="float: right" :color="layer_info.color">{{layer_icons[layer_name]}}</v-icon>
+                <v-icon class="invert-if-dark" style="float: right" :color="layer_info.color">{{layer_icons[layer_name]}}</v-icon>
               </j-tooltip>
-              <span :class="viewer.config==='imviz' ? 'invert' : 'invert-if-dark'" style="margin-left: 24px; margin-right: 32px; line-height: 24px">
+              <span class="invert-if-dark" style="margin-left: 24px; margin-right: 32px; line-height: 24px">
                 <v-icon v-if="layer_info.prefix_icon" dense>
                   {{layer_info.prefix_icon}}
                 </v-icon>
@@ -96,23 +96,20 @@
 .viewer-label {
   display: block;
   float: right;
-  background-color: white;
+  background-color: #c3c3c3c3;
   width: 24px;
   overflow: hidden;
   white-space: nowrap;
   /*cursor: pointer;*/
 }
-.viewer-label-imviz {
-  background-color: #393939c2;
+.viewer-label:last-child {
+  border-bottom-left-radius: 4px;
 }
 .viewer-label:hover {
   background-color: #e5e5e5;
   width: auto;
   border-bottom-left-radius: 4px; 
   border-top-left-radius: 4px;
-}
-.viewer-label-imviz:hover {
-  background-color: #777777c2;
 }
 </style>
 

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -55,12 +55,36 @@
 
         </div>
 
-        <v-card tile flat style="flex: 1; margin-top: -2px; overflow-y: auto;">
+        <v-card tile flat style="flex: 1; margin-top: -2px; overflow-y: auto">
+          <div class="viewer-label invert-if-dark">
+            <j-tooltip :tooltipcontent="viewer.reference+' (click to select)'" span_style="white-space: nowrap">
+              <v-icon class="invert-if-dark">mdi-numeric-{{viewer.index}}-circle-outline</v-icon>
+            </j-tooltip>
+            <span class="invert-if-dark" style="padding: 10px">{{viewer.reference || viewer.id}}</span>
+          </div>
           <jupyter-widget :widget="viewer.widget" style="width: 100%; height: 100%"></jupyter-widget>
         </v-card>
     </gl-component>
   </component>
 </template>
+
+<style>
+.viewer-label {
+  position: absolute;
+  background-color: transparent;
+  border-bottom-right-radius: 4px; 
+  z-index: 1;
+  width: 24px;
+  overflow-x: hidden;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.viewer-label:hover {
+  background-color: #e5e5e5;
+  width: auto;
+}
+</style>
 
 <script>
 module.exports = {

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -168,20 +168,21 @@ class BasePluginComponent(HubListener):
 
     @property
     def viewer_dicts(self):
-        def _dict_from_viewer(viewer, viewer_item, index=None):
-            d = {'viewer': viewer, 'id': viewer_item['id']}
+        def _dict_from_viewer(viewer, viewer_item):
+            d = {'viewer': viewer,
+                 'id': viewer_item['id'],
+                 'icon': self.app.state.viewer_icons.get(viewer_item['id'])}
             if viewer_item.get('reference') is not None:
                 d['reference'] = viewer_item['reference']
                 d['label'] = viewer_item['reference']
             else:
                 d['reference'] = None
                 d['label'] = viewer_item['id']
-            if index is not None:
-                d['icon'] = f"mdi-numeric-{index+1}-circle-outline"
+
             return d
 
-        return [_dict_from_viewer(viewer, self.app._viewer_item_by_id(vid), index)
-                for index, (vid, viewer) in enumerate(self.app._viewer_store.items())
+        return [_dict_from_viewer(viewer, self.app._viewer_item_by_id(vid))
+                for vid, viewer in self.app._viewer_store.items()
                 if viewer.__class__.__name__ != 'MosvizTableViewer']
 
     @cached_property
@@ -453,10 +454,10 @@ class LayerSelect(BaseSelectPluginComponent):
         except TypeError:
             return self.app.get_viewer_by_id(viewer)
 
-    def _layer_to_dict(self, layer, index=None):
-        d = {"label": layer.layer.label, "color": layer.state.color}
-        if index is not None:
-            d['icon'] = f"mdi-alpha-{chr(97 + index)}-box-outline"
+    def _layer_to_dict(self, layer):
+        d = {"label": layer.layer.label,
+             "color": layer.state.color,
+             "icon": self.app.state.layer_icons.get(layer.layer.label)}
         return d
 
     def _on_viewer_changed(self, msg=None):
@@ -495,7 +496,7 @@ class LayerSelect(BaseSelectPluginComponent):
         _, inds = np.unique(layer_labels, return_index=True)
         layers = [layers[i] for i in inds]
 
-        self.items = manual_items + [self._layer_to_dict(layer, index) for index, layer in enumerate(layers)]  # noqa
+        self.items = manual_items + [self._layer_to_dict(layer) for layer in layers]
         self._apply_default_selection()
 
     @cached_property

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from functools import cached_property
 from ipyvuetify import VuetifyTemplate
+from echo import add_callback
 from glue.config import colormaps
 from glue.core import HubListener
 from glue.core.message import (DataCollectionAddMessage,
@@ -443,6 +444,7 @@ class LayerSelect(BaseSelectPluginComponent):
         self.hub.subscribe(self, SubsetDeleteMessage,
                            handler=lambda _: self._on_layers_changed())
 
+        self.app.state.add_callback('layer_icons', lambda _: self._on_layers_changed())
         self.add_observe(viewer, self._on_viewer_changed)
         self._on_layers_changed()
 
@@ -1026,6 +1028,7 @@ class DatasetSelect(BaseSelectPluginComponent):
         self.hub.subscribe(self, RemoveDataMessage, handler=self._on_data_changed)
         self.hub.subscribe(self, DataCollectionDeleteMessage, handler=self._on_data_changed)
 
+        self.app.state.add_callback('layer_icons', lambda _: self._on_data_changed())
         # initialize items from original viewers
         self._on_data_changed()
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from functools import cached_property
 from ipyvuetify import VuetifyTemplate
-from echo import add_callback
 from glue.config import colormaps
 from glue.core import HubListener
 from glue.core.message import (DataCollectionAddMessage,

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1102,7 +1102,13 @@ class DatasetSelect(BaseSelectPluginComponent):
     def _on_data_changed(self, msg=None):
         # NOTE: _on_data_changed is passed without a msg object during init
         # future improvement: don't recreate the entire list when msg is passed
-        self.items = [{"label": data.label} for data in self.app.data_collection
+        def _dc_to_dict(data):
+            d = {'label': data.label,
+                 'icon': self.app.state.layer_icons.get(data.label)}
+
+            return d
+
+        self.items = [_dc_to_dict(data) for data in self.app.data_collection
                       if self._is_valid_item(data)]
         self._apply_default_selection()
         # future improvement: only clear cache if the selected data entry was changed?

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1438,6 +1438,8 @@ class PlotOptionsSyncState(BasePluginComponent):
         for selected_layer_label in layer_labels:
             layer_states.append([])
             for viewer in viewers:
+                if viewer is None:
+                    continue
                 for layer in viewer.layers:
                     if layer.layer.label == selected_layer_label:
                         layer_states[-1].append(layer.state)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements per-viewer labels showing the viewer reference name as well as the currently loaded/visible layers, with icons that are synced across all viewer/layer dropdown menus in the plugins.

In short, every viewer is given a numbered icon, and every layer is given a lettered icon, which is available to use app-wide (in the UI only) to quickly associate items in dropdowns with the applicable entries in the viewers.  These numbers/letters are shown in the upper-right of the viewers to be as out-of-the-way as possible, but hovering over them expands to show the label of the viewer/layer.

Few use-cases (note: since these recordings, the viewer numbered icons have been hidden when there is only a single viewer):

https://user-images.githubusercontent.com/877591/178118145-be666200-f109-45fe-a919-e72cb0bd7662.mov


https://user-images.githubusercontent.com/877591/178118249-a8c06ac3-6a2f-425e-bb7a-547e8e8ece58.mov


https://user-images.githubusercontent.com/877591/178118399-a268f314-475a-4c63-aaaf-22c8a29f116f.mov


https://user-images.githubusercontent.com/877591/178118700-1040ee31-5a80-46bc-96f9-c132a7f2e6e1.mov




**included in this PR**: 
- [x] fix subset visibility check in spectrum-viewer (hiding data layers currently excludes the icon from displaying, but subset layers need separate logic) and directly check visibility of data layers rather than relying on the menu mixed/visible/hidden state.
- [x] fix bug where mask_viewer icon is not populated on load (likely just the traitlet not pushing the update to the UI or an order at which events are fired)
- [x] fix bug where new layer icon doesn't show in subset dropdown in plot options (for example: adding moment map to flux viewer and then edit plot options to contour only)
- [x] show relevant layer icon in mouseover display, compass, etc? (could replace the need to display in top-down order)
- [x] include layer icons in dataset dropdowns? (would not be able to color, since layers might be different colors in different viewers)
- [x] show relevant layer icon in data menu to associate with letters
- [x] test whether coordinate display updating on blink (but not mousemove) is broken by this PR or in main (and either fix or file separate ticket) - see #1470
- [x] what to do when running out of letters and/or vertical space?
- [x] hide viewer icon when only a single viewer?
- [x] color layer icons (might be different per-viewer) to effectively act as a legend?  This might clash with any active/top indication and force us to use background color or "dot" markers for those instead of just turning the icon the active orange color.
- [x] cubeviz spectrum-viewer: indication of collapse method in expanded label.
- [x] icon to left of expanded label with spectral/spatial icon
- [x] display layer icons in top-down order
- [x] fix color reverting to gray when setting color_mode back to Colormaps
- [x] styling tweaks (iterate with @Jenneh)

**Possible follow-up efforts**
* ability to click layer icons to set active layer for coordinate display?  If this defaults to the top layer, then we need to distinguish if we're indicating both the top layer and "active" layer.  Alternatively clicking could disable the layer (but then it would disappear from the list, which might be awkward UX).
* ability to drag and drop to re-order z-order of layers
* also color icons in layer dropdowns (but can't necessarily in data dropdowns since layers can be different colors in different viewers)
* try to avoid the temporary extra entry during blinking (delay updating the state until blinking is complete)?
* subset select components in plugins are in a somewhat random order - they should appear in alphabetical order
* button to hide/dodge icons?  Or perhaps option to only show the viewer number and then show layer letters when hovering over that?
* use on-the-fly icon creation (via css) so we can control the font and handle numbers past 9 and letters past z
* settings switch for including/excluding subsets from the shown layers?
* re-order existing icons when deleting viewer/subset (to remove gaps)?

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Closes #1426

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
