### PR TITLE
Prefer EXP_TYPE keyword to identify cubes

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -53,9 +53,14 @@ def parse_data(app, file_obj, data_type=None, data_label=None):
         with fits.open(file_obj) as hdulist:
             prihdr = hdulist[0].header
             telescop = prihdr.get('TELESCOP', '').lower()
+            exptype = prihdr.get('EXP_TYPE', '').lower()
+            # NOTE: Alerted to deprecation of FILETYPE keyword from pipeline on 2022-07-08
+            # Kept for posterity in for data processed prior to this date. Use EXP_TYPE instead
             filetype = prihdr.get('FILETYPE', '').lower()
             system = prihdr.get('SYSTEM', '').lower()
-            if telescop == 'jwst' and filetype == '3d ifu cube':
+            if telescop == 'jwst' and ('ifu' in exptype or
+                                       'mrs' in exptype or
+                                       filetype == '3d ifu cube'):
                 for ext, viewer_name in (('SCI', 'flux-viewer'),
                                          ('ERR', 'uncert-viewer'),
                                          ('DQ', 'mask-viewer')):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

We were alerted to the deprecation of the FILETYPE header keyword from the pipeline products, which broke some Nirspec IFU Cubes from loading. This PR falls back to the exposure type (EXP_TYPE) keyword to identify MIRI and Nirspec IFU cubes in order to perform the necessary parsing for Cubeviz. A quick grep suggests we do not use FILETYPE anywhere else.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
