### PR TITLE
Hide Cubeviz import button after importing data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ New Features
 Cubeviz
 ^^^^^^^
 
+- The "Import Data" button is hidden after a data cube is loaded into the app [#1495]
+
 Imviz
 ^^^^^
 
@@ -79,7 +81,7 @@ Other Changes and Additions
 
 New Features
 ------------
-- The app and individual plugins can be opened in a new window by clicking a button in the top 
+- The app and individual plugins can be opened in a new window by clicking a button in the top
   right-hand corner. [#977, #1423]
 
 - Snackbar queue priority and history access. [#1352, #1437]
@@ -126,7 +128,7 @@ API Changes
   have been renamed to "Colormap" and "Monochromatic," respectively, for all image
   viewers. [#1406]
 
-- Viz tool display changed to ``viz.show()`` from ``viz.app``. Sidecar no longer returned by 
+- Viz tool display changed to ``viz.show()`` from ``viz.app``. Sidecar no longer returned by
   show methods. [#965]
 
 Imviz
@@ -188,7 +190,7 @@ Imviz
 Mosviz
 ^^^^^^
 
-- Data dropdown in the gaussian smooth plugin is limited to data entries from the 
+- Data dropdown in the gaussian smooth plugin is limited to data entries from the
   spectrum-viewer (excluding images and 2d spectra). [#1452]
 
 2.6 (2022-05-25)
@@ -328,7 +330,7 @@ Other Changes and Additions
 - Help button in toolbar to open docs in a new tab. [#1240]
 - Snackbar queue handles loading interrupt more cleanly. [#1249]
 - Reported quantities are rounded/truncated to avoid showing unnecessary precision. [#1244]
-- Line analysis quantities are coerced so length units cancel and constants are removed from units. 
+- Line analysis quantities are coerced so length units cancel and constants are removed from units.
   [#1261]
 
 2.4 (2022-03-29)
@@ -371,7 +373,7 @@ Bug Fixes
 ---------
 
 - Fixed support for table scrolling by enabling scrollbar. [#1116]
-- Fixed loading additional spectra into a spectrum viewer after creating a 
+- Fixed loading additional spectra into a spectrum viewer after creating a
   spectral subset. [#1205]
 
 Cubeviz
@@ -404,7 +406,7 @@ Other Changes and Additions
 - Viewer toolbars are now nested and consolidated, with viewer and layer options
   moved to the sidebar. [#1140]
 
-- Redshifts imported with a custom line list are now ignored.  Redshift must be set app-wide via 
+- Redshifts imported with a custom line list are now ignored.  Redshift must be set app-wide via
   viz.set_redshift or the line list plugin. [#1134]
 
 - Subset selection dropdowns in plugins now show synced color indicators. [#1156, #1175]
@@ -532,7 +534,7 @@ Specviz
 Other Changes and Additions
 ---------------------------
 
-- Redshift slider and options are moved from the toolbar to the Line List 
+- Redshift slider and options are moved from the toolbar to the Line List
   plugin in the plugin tray. [#1031]
 
 - Spectral lines and redshift are refactored to improve performance. [#1036]
@@ -586,7 +588,7 @@ Imviz
 Mosviz
 ^^^^^^
 
-- New toggle button to lock/unlock viewer settings (x-limits in 1d and 2d spectrum viewers and 
+- New toggle button to lock/unlock viewer settings (x-limits in 1d and 2d spectrum viewers and
   stretch and percentile for 2d spectrum and image viewers). [#918]
 
 - Ability to add custom columns and change visibility of columns in the table. [#961]

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -20,14 +20,14 @@
                     'padding-left': '15%',
                     'padding-top': '20px'}"
             @click="state.logger_overlay = false">
-        <v-row 
-            dense 
+        <v-row
+            dense
             @click="(e) => {e.stopImmediatePropagation()}"
             v-for="history in state.snackbar_history.slice().reverse()"
             style="width: 80%">
-          <v-alert 
-            dense 
-            :type="history.color" 
+          <v-alert
+            dense
+            :type="history.color"
             style="width: 100%; margin: 6px 0px 0px; text-align: left">
               [{{history.time}}]: {{history.text}}
           </v-alert>
@@ -38,7 +38,8 @@
       <v-toolbar-items v-for="item in state.tool_items">
         <v-divider v-if="['g-data-tools', 'g-subset-tools'].indexOf(item.name) === -1" vertical style="margin: 0px 10px"></v-divider>
         <v-divider v-else-if="item.name === 'g-subset-tools'" vertical style="margin: 0px 10px; border-width: 0"></v-divider>
-        <j-tooltip :tipid="item.name">
+        <j-tooltip v-if="config == 'cubeviz' && item.name == 'g-data-tools' && state.data_items.length !== 0"></j-tooltip>
+        <j-tooltip v-else :tipid="item.name">
           <jupyter-widget :widget="item.widget" :key="item.name"></jupyter-widget>
         </j-tooltip>
       </v-toolbar-items>
@@ -375,7 +376,7 @@ a:active {
 
 .color-to-accent {
   /* https://codepen.io/sosuke/pen/Pjoqqp for #C75109 */
-  filter: brightness(0) saturate(100%) invert(31%) sepia(84%) saturate(1402%) hue-rotate(1deg) brightness(95%) contrast(94%);  
+  filter: brightness(0) saturate(100%) invert(31%) sepia(84%) saturate(1402%) hue-rotate(1deg) brightness(95%) contrast(94%);
 }
 
 .v-overlay__content {

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -38,7 +38,7 @@ class Cubeviz(ConfigHelper, LineListMixin):
             else:
                 viewer.state.x_att_pixel = ref_data.id["Pixel Axis 2 [x]"]
 
-    def load_data(self, data):
+    def load_data(self, data, **kwargs):
         """
         Load and parse a data cube with Cubeviz.
         (Note that only one cube may be loaded per Cubeviz instance.)
@@ -52,7 +52,7 @@ class Cubeviz(ConfigHelper, LineListMixin):
         if len(self.app.state.data_items) != 0:
             raise RuntimeError('only one cube may be loaded per Cubeviz instance')
 
-        super().load_data(data, parser_reference="cubeviz-data-parser")
+        super().load_data(data, parser_reference="cubeviz-data-parser", **kwargs)
 
     def select_slice(self, slice):
         """

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -38,6 +38,22 @@ class Cubeviz(ConfigHelper, LineListMixin):
             else:
                 viewer.state.x_att_pixel = ref_data.id["Pixel Axis 2 [x]"]
 
+    def load_data(self, data):
+        """
+        Load and parse a data cube with Cubeviz.
+        (Note that only one cube may be loaded per Cubeviz instance.)
+
+        Parameters
+        ----------
+        data : str or `~astropy.io.fits.HDUList`
+            A string file path or astropy FITS object pointing to the
+            data cube.
+        """
+        if len(self.app.state.data_items) != 0:
+            raise RuntimeError('only one cube may be loaded per Cubeviz instance')
+
+        super().load_data(data, parser_reference="cubeviz-data-parser")
+
     def select_slice(self, slice):
         """
         Select a slice by index.

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -28,7 +28,7 @@ def parse_data(app, file_obj, data_type=None, data_label=None):
     ----------
     app : `~jdaviz.app.Application`
         The application-level object used to reference the viewers.
-    file_path : str
+    file_obj : str
         The path to a cube-like data file.
     data_type : str, {'flux', 'mask', 'uncert'}
         The data type used to explicitly differentiate parsed data.

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -132,3 +132,11 @@ def test_spectrum1d_parse(spectrum1d, cubeviz_helper):
 def test_numpy_cube(cubeviz_helper):
     with pytest.raises(NotImplementedError, match='Unsupported data format'):
         cubeviz_helper.load_data(np.ones(27).reshape((3, 3, 3)))
+
+
+def test_multiple_load(image_hdu_obj, cubeviz_helper):
+    cubeviz_helper.load_data(image_hdu_obj)
+
+    # first load should be succesful; subsequent attempts should fail
+    with pytest.raises(RuntimeError, match=r".?only one (data)?cube.?"):
+        cubeviz_helper.load_data(image_hdu_obj)

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.vue
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.vue
@@ -14,7 +14,8 @@
         <v-card-text>
           Select a file with data you want to load into this instance of Jdaviz
           and click "IMPORT". Imported data can be shown in any compatible
-          viewer. Note that single clicks navigate into directories.
+          viewer{{ config == 'cubeviz' ? ', though only one data cube may be loaded per instance' : ''}}.
+          Note that single clicks navigate into directories.
           <v-container>
             <v-row>
               <v-col>

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -377,7 +377,7 @@ class Mosviz(ConfigHelper, LineListMixin):
                   spectra_1d_label=None, spectra_2d_label=None,
                   images_label=None, *args, **kwargs):
         """
-        Load and parse a set of MOS spectra and images
+        Load and parse a set of MOS spectra and images.
 
         Parameters
         ----------


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

Here is an attempt that would close #1345. Do we like keeping the buffer on the left of the subset creation button or should it be flush with the left app border after the import button disappears?

https://user-images.githubusercontent.com/12895749/179110595-e8ad1339-5533-48ce-9e23-b414d5611bfe.mov

I also added a `load_data()` method to the `Cubeviz` class in order to raise an error if someone attempts to programmatically add a cube when one is already present in the app. I didn't allow for keyword arguments like some of the other configs' versions do: specifying a `data_type` (flux, mask, uncert) doesn't make sense if we only allow data to be loaded once, and using `data_label` to apply labels with glue seems like it should be internal.

Thanks to @kecnry for helping me get started.

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [X] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
