### PR TITLE
Cubeviz spectral subset tweaks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,9 @@ Cubeviz
 
 - Cubeviz parser now sets the wavelength axis to what is in the CUNIT3 header [#1480]
 
+- Includes spectral subset layers in the layer dropdowns in plot options and fixes behavior when
+  toggling visibility of these layers. [#1501]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/components/plugin_layer_select.vue
+++ b/jdaviz/components/plugin_layer_select.vue
@@ -66,9 +66,11 @@ module.exports = {
 };
 </script>
 
-<style>
-.v-select__selections {
+<style scoped>
+  .v-select__selections {
     flex-wrap: nowrap !important;
+    display: block !important;
+    margin-bottom: -32px;
   }
   .single-line {
       white-space: nowrap;

--- a/jdaviz/components/plugin_viewer_select.vue
+++ b/jdaviz/components/plugin_viewer_select.vue
@@ -66,10 +66,12 @@ module.exports = {
 };
 </script>
 
-<style>
-.v-select__selections {
-  flex-wrap: nowrap !important;
-}
+<style scoped>
+  .v-select__selections {
+    flex-wrap: nowrap !important;
+    display: block !important;
+    margin-bottom: -32px;
+  }
   .single-line {
       white-space: nowrap;
       overflow: hidden;

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -49,16 +49,14 @@
       :hint="multiselect ? 'Select viewers to set options simultaneously' : 'Select the viewer to set options.'"
     />
 
-    <div>
-      <plugin-layer-select
-        :items="layer_items"
-        :selected.sync="layer_selected"
-        :multiselect="multiselect"
-        :show_if_single_entry="true"
-        :label="multiselect ? 'Layers': 'Layer'"
-        :hint="multiselect ? 'Select layers to set options simultaneously' : 'Select the data or subset to set options.'"
-      />
-    </div>
+    <plugin-layer-select
+      :items="layer_items"
+      :selected.sync="layer_selected"
+      :multiselect="multiselect"
+      :show_if_single_entry="true"
+      :label="multiselect ? 'Layers': 'Layer'"
+      :hint="multiselect ? 'Select layers to set options simultaneously' : 'Select the data or subset to set options.'"
+    />
 
     <j-plugin-section-header v-if="layer_selected.length">Layer Visibility</j-plugin-section-header>
     <glue-state-sync-wrapper :sync="layer_visible_sync" :multiselect="multiselect" @unmix-state="unmix_state('layer_visible')">

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from glue.core.subset import RoiSubsetState, RangeSubsetState
+from glue.core.subset import RoiSubsetState
 from glue_jupyter.bqplot.profile import BqplotProfileView
 from glue_jupyter.bqplot.image import BqplotImageView
 from glue_jupyter.table import TableViewer

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from glue.core.subset import RoiSubsetState
+from glue.core.subset import RoiSubsetState, RangeSubsetState
 from glue_jupyter.bqplot.profile import BqplotProfileView
 from glue_jupyter.bqplot.image import BqplotImageView
 from glue_jupyter.table import TableViewer
@@ -35,9 +35,15 @@ class JdavizViewerMixin:
             if layer.layer.label == label:
                 return layer
 
-    def _expected_subset_layer_default(self, layer):
+    def _expected_subset_layer_default(self, layer_state):
+        if self.__class__.__name__ == 'CubevizImageView':
+            # Do not override default for subsets as for some reason
+            # this isn't getting called when they're first added, but rather when
+            # the next state change is made (for example: manually changing the visibility)
+            return
+
         # default visibility based on the visibility of the "parent" data layer
-        layer.visible = self._get_layer(layer.layer.data.label).visible
+        layer_state.visible = self._get_layer(layer_state.layer.data.label).visible
 
     def _update_layer_icons(self):
         # update visible_layers (TODO: move this somewhere that can update on color change, etc)
@@ -123,11 +129,13 @@ class JdavizViewerMixin:
             # MosvizTableViewer uses this as a mixin, but we do not need any of this layer
             # logic there
             return
+
         # NOTE: the subscription to this method is handled in ConfigHelper
         # we don't have access to the actual subset yet to tell if its spectral or spatial, so
         # we'll store the name of this new subset and change the default linewidth when the
         # layers are added
-        self._expected_subset_layers.append(msg.subset.label)
+        if msg.subset.label not in self._expected_subset_layers and msg.subset.label:
+            self._expected_subset_layers.append(msg.subset.label)
 
     def _initialize_toolbar_nested(self, default_tool_priority=[]):
         # would be nice to call this from __init__,

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -10,7 +10,6 @@ from glue.core.message import (DataCollectionAddMessage,
                                SubsetDeleteMessage,
                                SubsetUpdateMessage)
 from glue.core.subset import RoiSubsetState
-from glue_jupyter.bqplot.image import BqplotImageView
 from glue_jupyter.widgets.linked_dropdown import get_choices as _get_glue_choices
 from specutils import Spectrum1D
 from traitlets import Any, Bool, HasTraits, List, Unicode, observe

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -471,9 +471,6 @@ class LayerSelect(BaseSelectPluginComponent):
             self._clear_cache()
             self._on_layers_changed()
 
-    def _valid_layer(self, viewer, layer):
-        return True
-
     @observe('filters')
     def _on_layers_changed(self, msg=None):
         # NOTE: _on_layers_changed is passed without a msg object during init
@@ -484,7 +481,7 @@ class LayerSelect(BaseSelectPluginComponent):
         viewers = [self._get_viewer(viewer) for viewer in viewer_names]
 
         manual_items = [{'label': label} for label in self.manual_options]
-        layers = [layer for viewer in viewers for layer in viewer.layers if self._valid_layer(viewer, layer)]  # noqa
+        layers = [layer for viewer in viewers for layer in viewer.layers]
         # remove duplicates - NOTE: by doing this, any color-mismatch between layers with the
         # same name in different viewers will be randomly assigned within plot_options
         # based on which was found _first.
@@ -509,7 +506,7 @@ class LayerSelect(BaseSelectPluginComponent):
         viewers = [self._get_viewer(viewer_name) for viewer_name in viewer_names]
 
         layers = [[layer for layer in viewer.layers
-                   if layer.layer.label in selected and self._valid_layer(viewer, layer)]
+                   if layer.layer.label in selected]
                   for viewer in viewers]
 
         if not self.multiselect and len(layers) == 1:

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -473,10 +473,6 @@ class LayerSelect(BaseSelectPluginComponent):
             self._on_layers_changed()
 
     def _valid_layer(self, viewer, layer):
-        if isinstance(viewer, BqplotImageView) and self.plugin.config == 'cubeviz':
-            # exclude spectral subsets in image viewers (but not in 2d spectrum viewers)
-            if hasattr(layer.state.layer, 'subset_state') and not isinstance(layer.state.layer.subset_state, RoiSubsetState):  # noqa
-                return False
         return True
 
     @observe('filters')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request includes spectral subset layers in the layer dropdowns for image viewers in cubeviz's plot options plugin.  In order to do so, it includes a workaround to prevent the layer visibility default logic (which was otherwise firing after the _next_ state change rather than the original creation of the layer itself, which resulted in buggy behavior when trying to manually change the visibility of these layers).  This also improves some styling of the multiselect dropdowns for layers/viewers in the plot options plugin.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
