### PR TITLE
fix setting plot options state when setting cmap through API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,9 @@ Specviz
 Bug Fixes
 ---------
 
-* Fix scrolling of "x" button in data menus. [#1491]
+- Fix scrolling of "x" button in data menus. [#1491]
+
+- Fix plot options colormap when setting colormap manually through API. [#1507]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1584,8 +1584,8 @@ class PlotOptionsSyncState(BasePluginComponent):
             return
 
         self._processing_change_from_glue = True
-        if "Colormap" in value.__class__.__name__:  # TODO: better logic
-            value = str(value)
+        if "Colormap" in value.__class__.__name__:
+            value = value.name
         elif isinstance(self.value, (int, float)) and self._glue_name != 'percentile':
             # glue might pass us ints for float or vice versa, but our traitlets care
             # so let's cast to the type expected by the traitlet to avoid having to


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes setting the plot options state for colormap when set through the API (either by manually setting the glue-state or through the astrowidgets API).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1506

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
