### PR TITLE
Plugin: spectral extraction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,11 @@ Mosviz
 Specviz
 ^^^^^^^
 
+Specviz2d
+^^^^^^^^^
+
+- Spectral extraction plugin (currently only trace support). [#1514]
+
 API Changes
 -----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ Specviz
 Specviz2d
 ^^^^^^^^^
 
-- Spectral extraction plugin (currently only trace support). [#1514]
+- Spectral extraction plugin. [#1514]
 
 API Changes
 -----------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -174,6 +174,7 @@ Using Jdaviz
   imviz/index.rst
   specviz/index.rst
   cubeviz/index.rst
+  specviz2d/index.rst
   mosviz/index.rst
   save_state.rst
   display.rst

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -138,6 +138,9 @@ Plugins
 .. automodapi:: jdaviz.configs.specviz.plugins.unit_conversion.unit_conversion
    :no-inheritance-diagram:
 
+.. automodapi:: jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction
+   :no-inheritance-diagram:
+
 .. _jdaviz-api-nuts-bolts:
 
 Nuts and Bolts

--- a/docs/specviz2d/index.rst
+++ b/docs/specviz2d/index.rst
@@ -1,0 +1,19 @@
+.. image:: ../logos/specviz2d.svg
+   :width: 400
+
+.. _specviz2d:
+
+#########
+Specviz2D
+#########
+
+Specviz2d is a tool for visualization and quick-look analysis of 2D astronomical spectra.
+
+.. We do not want a real section here so navbar shows toc directly.
+
+**Using Specviz**
+
+.. toctree::
+  :maxdepth: 2
+
+  plugins

--- a/docs/specviz2d/plugins.rst
+++ b/docs/specviz2d/plugins.rst
@@ -53,22 +53,65 @@ The first section of the plugin allows for creating and visualizing
 `specreduce Trace <https://specreduce.readthedocs.io/en/latest/#module-specreduce.tracing>`_
 objects.
 
+To create a new trace in the plugin, choose the desired "Trace Type" and edit any input arguments.
+A preview of the trace will update in real time in the 2D spectrum viewer.
+
+To export the trace as a data object into the 2D spectrum viewer (to access via the API or to 
+adjust plotting options), open the "Export Trace" panel, choose a label for the new data entry,
+and click "Create".  Note that this step is not required to create an extraction with simple
+workflows.
+
 Trace objects created outside of jdaviz can be loaded into the app via::
 
     viz.app.add_data(my_trace)
 
 and then added to the viewer through the data menu.
 
-
-To create a new trace in the plugin, choose the desired "Trace Type", any input arguments,
-optionally override the name of the resulting data entry, and click "Create".  This will run
-the respective specreduce function and load the resulting Trace object into the app
-(and 2d spectrum viewer).  This trace will then be available to be used as input for the
-background subtraction and spectral extraction steps of the plugin.
-
 Once trace objects are loaded into the app, they can be offset (in the cross-dispersion direction)
-by selecting the trace label, entering an offset, and overwriting the existing data entry with the
-modified trace.
+by selecting the trace label, entering an offset, and overwriting the existing data entry (or
+creating a new one) with the modified trace.
+
+Background
+----------
+
+The background step of the plugin allows for creating background and background-subtracted
+images via `specreduce.background <https://specreduce.readthedocs.io/en/latest/#module-specreduce.background>`_.
+
+Once interacting with any of the inputs in the background step, the live visualization will change
+from showing just the trace to showing the center (dotted) and edges (solid) of the background 
+region(s).  Choosing "From Plugin" for the trace will use the trace defined in the Trace section,
+without needing to export the trace to a data entry.  Choosing "Manual" allows for creating a simple
+flat trace for the background (perhaps different than the trace used for extraction).  If a trace
+was loaded into the app (either through the API or by exporting it), those traces can also be selected
+as input from the dropdown.
+
+To visualize the resulting background or background-subtracted image, click on the respective panel,
+and choose a label for the new data entry.  The exported images will now appear in the data dropdown
+menu in the 2D spectrum viewer.  To refine the trace based on the background-subtracted image, return
+to the Trace step and select the exported background-subtracted image as input. 
+
+Extract
+-------
+
+The extraction step of the plugin extracts a 1D spectrum from an input 2D spectrum via
+`specreduce.extract <https://specreduce.readthedocs.io/en/latest/#module-specreduce.extract>`_.
+
+Once interacting with any of the inputs in the extract step, the live visualization will change
+to show the center (dotted) and edges (solid) of the extraction region.
+
+The input 2D spectrum default to "From Plugin" which will use the settings defined in the Background
+step to create a background-subtracted image without needing to export it into the app itself.
+To use a different 2D spectrum loaded in the app (or exported from the Background step), choose
+that from the dropdown instead.
+
+As in the Background step, the central trace of the extraction region can either be adopted from the
+settings in the Trace step (with "From Plugin"), an independent flat trace ("Manual"), or by selecting
+the label of a Trace loaded into the app.
+
+To visualize or export the resulting 2D spectrum, provide a data label and click "Extract".  The 
+resulting spectrum object can be accessed from the API as any other data product in the spectrum 
+viewer.
+
 
 .. _specviz2d-gaussian-smooth:
 

--- a/docs/specviz2d/plugins.rst
+++ b/docs/specviz2d/plugins.rst
@@ -53,6 +53,9 @@ The first section of the plugin allows for creating and visualizing
 `specreduce Trace <https://specreduce.readthedocs.io/en/latest/#module-specreduce.tracing>`_
 objects.
 
+Once interacting with any of the inputs in the extract step, the live visualization will change
+to show the trace as a solid line.
+
 To create a new trace in the plugin, choose the desired "Trace Type" and edit any input arguments.
 A preview of the trace will update in real time in the 2D spectrum viewer.
 
@@ -78,12 +81,9 @@ The background step of the plugin allows for creating background and background-
 images via `specreduce.background <https://specreduce.readthedocs.io/en/latest/#module-specreduce.background>`_.
 
 Once interacting with any of the inputs in the background step, the live visualization will change
-from showing just the trace to showing the center (dotted) and edges (solid) of the background 
-region(s).  Choosing "From Plugin" for the trace will use the trace defined in the Trace section,
-without needing to export the trace to a data entry.  Choosing "Manual" allows for creating a simple
-flat trace for the background (perhaps different than the trace used for extraction).  If a trace
-was loaded into the app (either through the API or by exporting it), those traces can also be selected
-as input from the dropdown.
+to showing the center (dotted) and edges (solid) of the background 
+region(s).  Choose between creating the background around the trace defined in the Trace section,
+or around a "Manual" flat trace.
 
 To visualize the resulting background or background-subtracted image, click on the respective panel,
 and choose a label for the new data entry.  The exported images will now appear in the data dropdown
@@ -102,11 +102,8 @@ to show the center (dotted) and edges (solid) of the extraction region.
 The input 2D spectrum default to "From Plugin" which will use the settings defined in the Background
 step to create a background-subtracted image without needing to export it into the app itself.
 To use a different 2D spectrum loaded in the app (or exported from the Background step), choose
-that from the dropdown instead.
-
-As in the Background step, the central trace of the extraction region can either be adopted from the
-settings in the Trace step (with "From Plugin"), an independent flat trace ("Manual"), or by selecting
-the label of a Trace loaded into the app.
+that from the dropdown instead.  To skip background subtraction, choose the original 2D spectrum
+as input.
 
 To visualize or export the resulting 2D spectrum, provide a data label and click "Extract".  The 
 resulting spectrum object can be accessed from the API as any other data product in the spectrum 

--- a/docs/specviz2d/plugins.rst
+++ b/docs/specviz2d/plugins.rst
@@ -1,0 +1,131 @@
+.. _specviz2d-plugins:
+
+*********************
+Data Analysis Plugins
+*********************
+
+The Specviz2D data analysis plugins are meant to aid quick-look analysis
+of 2D spectroscopic data. All plugins are accessed via the :guilabel:`plugin`
+icon in the upper right corner of the Specviz application. 
+
+.. _specviz2d-metadata-viewer:
+
+Metadata Viewer
+===============
+
+.. seealso::
+
+    :ref:`Metadata Viewer <imviz_metadata-viewer>`
+        Imviz documentation on using the metadata viewer.
+
+.. _specviz2d-plot-options:
+
+Plot Options
+============
+
+.. seealso::
+
+    :ref:`Spectral Plot Options <specviz-plot-settings>`
+        Documentation on further details regarding the plot setting controls.
+
+.. _specviz2d-subset-plugin:
+
+Subset Tools
+============
+
+.. seealso::
+
+    :ref:`Subset Tools <imviz-subset-plugin>`
+        Imviz documentation describing the concept of subsets in Jdaviz.
+
+.. _specviz2d-spectral-extraction:
+
+Spectral Extraction
+===================
+
+The Spectral Extraction plugin exposes `specreduce <https://specreduce.readthedocs.io>`_
+methods for tracing, background subtraction, and spectral extraction from 2D spectra.
+
+Trace
+-----
+
+The first section of the plugin allows for creating and visualizing 
+`specreduce Trace <https://specreduce.readthedocs.io/en/latest/#module-specreduce.tracing>`_
+objects.
+
+Trace objects created outside of jdaviz can be loaded into the app via::
+
+    viz.app.add_data(my_trace)
+
+and then added to the viewer through the data menu.
+
+
+To create a new trace in the plugin, choose the desired "Trace Type", any input arguments,
+optionally override the name of the resulting data entry, and click "Create".  This will run
+the respective specreduce function and load the resulting Trace object into the app
+(and 2d spectrum viewer).  This trace will then be available to be used as input for the
+background subtraction and spectral extraction steps of the plugin.
+
+Once trace objects are loaded into the app, they can be offset (in the cross-dispersion direction)
+by selecting the trace label, entering an offset, and overwriting the existing data entry with the
+modified trace.
+
+.. _specviz2d-gaussian-smooth:
+
+Gaussian Smooth
+===============
+
+.. seealso::
+
+    :ref:`Gaussian Smooth <gaussian-smooth>`
+        Specviz documentation on Gaussian Smooth.
+
+.. _specviz2d-model-fitting:
+
+Model Fitting
+=============
+
+.. seealso::
+
+    :ref:`Model Fitting <specviz-model-fitting>`
+        Specviz documentation on Model Fitting.
+
+
+.. _specviz2d-unit-conversion:
+
+Unit Conversion
+===============
+
+.. seealso::
+
+    :ref:`Unit Conversion <unit-conversion>`
+        Specviz documentation on Unit Conversion.
+
+
+.. _specviz2d-line-lists:
+
+Line Lists
+==========
+
+.. seealso::
+
+    :ref:`Line Lists <line-lists>`
+        Specviz documentation on Line Lists.
+        
+
+.. _specviz2d-line-analysis:
+
+Line Analysis
+=============
+
+.. seealso::
+
+    :ref:`Line Analysis <line-analysis>`
+        Specviz documentation on Line Analysis.
+
+.. _specviz2d-export-plot:
+
+Export Plot
+===========
+
+This plugin allows exporting the plot in a given viewer to various image formats.

--- a/docs/specviz2d/plugins.rst
+++ b/docs/specviz2d/plugins.rst
@@ -53,8 +53,8 @@ The first section of the plugin allows for creating and visualizing
 `specreduce Trace <https://specreduce.readthedocs.io/en/latest/#module-specreduce.tracing>`_
 objects.
 
-Once interacting with any of the inputs in the extract step, the live visualization will change
-to show the trace as a solid line.
+Once you interact with any of the inputs in the extract step or hover over that area
+of the plugin, the live visualization will change to show the trace as a solid line.
 
 To create a new trace in the plugin, choose the desired "Trace Type" and edit any input arguments.
 A preview of the trace will update in real time in the 2D spectrum viewer.
@@ -80,10 +80,10 @@ Background
 The background step of the plugin allows for creating background and background-subtracted
 images via `specreduce.background <https://specreduce.readthedocs.io/en/latest/#module-specreduce.background>`_.
 
-Once interacting with any of the inputs in the background step, the live visualization will change
-to showing the center (dotted) and edges (solid) of the background 
-region(s).  Choose between creating the background around the trace defined in the Trace section,
-or around a "Manual" flat trace.
+Once you interact with any of the inputs in the background step or hover over that area
+of the plugin, the live visualization will change to show the center (dotted line) and edges
+(solid lines) of the background region(s).  Choose between creating the background
+around the trace defined in the Trace section, or around a "Manual" flat trace.
 
 To visualize the resulting background or background-subtracted image, click on the respective panel,
 and choose a label for the new data entry.  The exported images will now appear in the data dropdown
@@ -96,18 +96,19 @@ Extract
 The extraction step of the plugin extracts a 1D spectrum from an input 2D spectrum via
 `specreduce.extract <https://specreduce.readthedocs.io/en/latest/#module-specreduce.extract>`_.
 
-Once interacting with any of the inputs in the extract step, the live visualization will change
-to show the center (dotted) and edges (solid) of the extraction region.
+Once you interact with any of the inputs in the extract step or hover over that area
+of the plugin, the live visualization will change to show the center (dotted line) and
+edges (solid lines) of the extraction region.```
 
-The input 2D spectrum default to "From Plugin" which will use the settings defined in the Background
+The input 2D spectrum defaults to "From Plugin", which will use the settings defined in the Background
 step to create a background-subtracted image without needing to export it into the app itself.
 To use a different 2D spectrum loaded in the app (or exported from the Background step), choose
 that from the dropdown instead.  To skip background subtraction, choose the original 2D spectrum
 as input.
 
 To visualize or export the resulting 2D spectrum, provide a data label and click "Extract".  The 
-resulting spectrum object can be accessed from the API as any other data product in the spectrum 
-viewer.
+resulting spectrum object can be accessed from the API in the same way as any other
+data product in the spectrum viewer.
 
 
 .. _specviz2d-gaussian-smooth:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -403,11 +403,17 @@ class Application(VuetifyTemplate, HubListener):
         ref_data = dc[reference_data] if reference_data else dc[0]
         linked_data = dc[data_to_be_linked] if data_to_be_linked else dc[-1]
 
-        if 'Trace' in linked_data.meta:
-            links = [LinkSame(linked_data.components[2], ref_data.components[0]),
-                     LinkSame(linked_data.components[0], ref_data.components[1])]
-            dc.add_link(links)
-            return
+        if linked_data.meta.get('Plugin', None) == 'SpectralExtraction':
+            if 'Trace' in linked_data.meta:
+                links = [LinkSame(linked_data.components[2], ref_data.components[0]),
+                         LinkSame(linked_data.components[0], ref_data.components[1])]
+                dc.add_link(links)
+                return
+            else:
+                links = [LinkSame(linked_data.components[0], ref_data.components[0]),
+                         LinkSame(linked_data.components[1], ref_data.components[1])]
+                dc.add_link(links)
+                return
 
         # The glue-astronomy SpectralCoordinates currently seems incompatible with glue
         # WCSLink. This gets around it until there's an upstream fix.

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1378,6 +1378,8 @@ class Application(VuetifyTemplate, HubListener):
             component_ids = [str(c) for c in data.component_ids()]
         if data.label == 'MOS Table':
             typ = 'table'
+        elif 'Trace' in data.meta:
+            typ = 'trace'
         elif ndims == 1:
             typ = '1d spectrum'
         elif ndims == 2 and wcsaxes is not None:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -403,6 +403,12 @@ class Application(VuetifyTemplate, HubListener):
         ref_data = dc[reference_data] if reference_data else dc[0]
         linked_data = dc[data_to_be_linked] if data_to_be_linked else dc[-1]
 
+        if 'Trace' in linked_data.meta:
+            links = [LinkSame(linked_data.components[2], ref_data.components[0]),
+                     LinkSame(linked_data.components[0], ref_data.components[1])]
+            dc.add_link(links)
+            return
+
         # The glue-astronomy SpectralCoordinates currently seems incompatible with glue
         # WCSLink. This gets around it until there's an upstream fix.
         if isinstance(linked_data.coords, SpectralCoordinates):

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -629,7 +629,9 @@ class Application(VuetifyTemplate, HubListener):
                     if cls is not None:
                         # If data is one-dimensional, assume that it can be
                         #  collapsed via the defined statistic
-                        if cls == Spectrum1D:
+                        if 'Trace' in layer_data.meta:
+                            layer_data = layer_data.get_object()
+                        elif cls == Spectrum1D:
                             layer_data = layer_data.get_object(cls=cls,
                                                                statistic=statistic)
                         else:

--- a/jdaviz/components/plugin_dataset_select.vue
+++ b/jdaviz/components/plugin_dataset_select.vue
@@ -15,7 +15,7 @@
     <template slot="selection" slot-scope="data">
       <div class="single-line">
         <span>
-          <v-icon style='margin-right: 2px'>{{ data.item.icon }}</v-icon>
+          <v-icon v-if="data.item.icon" style='margin-right: 2px'>{{ data.item.icon }}</v-icon>
           {{ data.item.label }}
         </span>
       </div>
@@ -23,7 +23,7 @@
     <template slot="item" slot-scope="data">
       <div class="single-line">
         <span>
-          <v-icon style='margin-right: 2px'>{{ data.item.icon }}</v-icon>
+          <v-icon v-if="data.item.icon" style='margin-right: 2px'>{{ data.item.icon }}</v-icon>
           {{ data.item.label }}
         </span>
       </div>

--- a/jdaviz/components/plugin_layer_select.vue
+++ b/jdaviz/components/plugin_layer_select.vue
@@ -18,12 +18,12 @@
       <div class="single-line" style="width: 100%">
         <v-chip v-if="multiselect" style="width: calc(100% - 20px)">
           <span>
-            <v-icon style='margin-left: -10px; margin-right: 2px'>{{ data.item.icon }}</v-icon>
+            <v-icon v-if="data.item.icon" style='margin-left: -10px; margin-right: 2px'>{{ data.item.icon }}</v-icon>
             {{ data.item.label }}
           </span>
         </v-chip>
         <span v-else>
-          <v-icon style='margin-right: 2px'>{{ data.item.icon }}</v-icon>
+          <v-icon v-if="data.item.icon" style='margin-right: 2px'>{{ data.item.icon }}</v-icon>
           {{ data.item.label }}
         </span>
       </div>

--- a/jdaviz/components/plugin_viewer_select.vue
+++ b/jdaviz/components/plugin_viewer_select.vue
@@ -18,12 +18,12 @@
       <div class="single-line" style="width: 100%">
         <v-chip v-if="multiselect" style="width: calc(100% - 20px)">
           <span>
-            <v-icon style='margin-left: -10px; margin-right: 2px'>{{ data.item.icon }}</v-icon>
+            <v-icon v-if="data.item.icon" style='margin-left: -10px; margin-right: 2px'>{{ data.item.icon }}</v-icon>
             {{ data.item.label }}
           </span>
         </v-chip>
         <span v-else>
-          <v-icon style='margin-right: 2px'>{{ data.item.icon }}</v-icon>
+          <v-icon v-if="data.item.icon" style='margin-right: 2px'>{{ data.item.icon }}</v-icon>
           {{ data.item.label }}
         </span>
       </div>

--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -104,6 +104,10 @@ module.exports = {
       if (['image-viewer', 'spectrum-2d-viewer'].indexOf(this.$props.viewer.reference) !== -1) {
         multi_select = false
       }
+    } else if (this.$props.viewer.config === 'specviz2d') {
+      if (this.$props.viewer.reference === 'spectrum-2d-viewer') {
+        multi_select = false
+      }
     }
     return {
       // default to passed values, whenever value or uncertainty are changed

--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -129,10 +129,6 @@ module.exports = {
       }
       return inViewer
     },
-    dataItemFromPlugin(item, plugin_name) {
-      const plugin = item.meta['Plugin'] || null
-      return plugin === plugin_name
-    },
     itemIsVisible(item, returnExtraItems) {
       if (this.$props.viewer.config === 'mosviz') {
         if (this.$props.viewer.reference === 'spectrum-viewer' && item.type !== '1d spectrum') {
@@ -165,9 +161,9 @@ module.exports = {
         }
       } else if (this.$props.viewer.config === 'specviz2d') {
         if (this.$props.viewer.reference === 'spectrum-viewer') {
-          return item.ndims === 1 && !this.dataItemFromPlugin(item, 'SpectralExtraction') && this.dataItemInViewer(item, returnExtraItems)
+          return item.ndims === 1 && item.type!=='trace' && this.dataItemInViewer(item, returnExtraItems)
         } else if (this.$props.viewer.reference === 'spectrum-2d-viewer') {
-          return (item.ndims === 2 || this.dataItemFromPlugin(item, 'SpectralExtraction')) && this.dataItemInViewer(item, returnExtraItems)
+          return (item.ndims === 2 || item.type==='trace') && this.dataItemInViewer(item, returnExtraItems)
         }
       }
       // for any situation not covered above, default to showing the entry

--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -129,6 +129,10 @@ module.exports = {
       }
       return inViewer
     },
+    dataItemFromPlugin(item, plugin_name) {
+      const plugin = item.meta['Plugin'] || null
+      return plugin === plugin_name
+    },
     itemIsVisible(item, returnExtraItems) {
       if (this.$props.viewer.config === 'mosviz') {
         if (this.$props.viewer.reference === 'spectrum-viewer' && item.type !== '1d spectrum') {
@@ -161,9 +165,9 @@ module.exports = {
         }
       } else if (this.$props.viewer.config === 'specviz2d') {
         if (this.$props.viewer.reference === 'spectrum-viewer') {
-          return item.ndims === 1 && this.dataItemInViewer(item, returnExtraItems)
+          return item.ndims === 1 && !this.dataItemFromPlugin(item, 'SpectralExtraction') && this.dataItemInViewer(item, returnExtraItems)
         } else if (this.$props.viewer.reference === 'spectrum-2d-viewer') {
-          return item.ndims === 2 && this.dataItemInViewer(item, returnExtraItems)
+          return (item.ndims === 2 || this.dataItemFromPlugin(item, 'SpectralExtraction')) && this.dataItemInViewer(item, returnExtraItems)
         }
       }
       // for any situation not covered above, default to showing the entry

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -22,7 +22,7 @@
       </j-tooltip>
     </div>
 
-    <j-tooltip :tooltipcontent="'data label: '+item.name" span_style="font-size: 12pt; padding-top: 6px; padding-left: 6px; width: calc(100% - 140px); white-space: nowrap; cursor: default;">
+    <j-tooltip :tooltipcontent="'data label: '+item.name" span_style="font-size: 12pt; padding-top: 6px; padding-left: 6px; width: calc(100% - 80px); white-space: nowrap; cursor: default;">
       <v-icon class='invert-if-dark' style='color: #000000DE; margin-left: 4px; margin-right: -2px'>{{icon}}</v-icon>
       <div class="text-ellipsis-middle" style="font-weight: 500">
         <span>

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -6,7 +6,7 @@
           icon
           :color="visibleState==='visible' ? 'accent' : 'default'"
           @click="selectClicked">
-            <v-icon v-if="multi_select">{{visibleState!=='hidden' ? "mdi-checkbox-marked" : "mdi-checkbox-blank-outline"}}</v-icon>
+            <v-icon v-if="multi_select || item.type==='trace'">{{visibleState!=='hidden' ? "mdi-checkbox-marked" : "mdi-checkbox-blank-outline"}}</v-icon>
             <v-icon v-else>{{visibleState!=='hidden' ? "mdi-radiobox-marked" : "mdi-radiobox-blank"}}</v-icon>
         </v-btn>
       </j-tooltip>
@@ -80,11 +80,12 @@ module.exports = {
       // checkboxes control VISIBILITY of layers not loaded state
       // if we just loaded the data, its probably already visible, but we'll still make sure all
       // appropriate layers are visible and properly handle replace for non-multiselect
+      // NOTE: replace=True will exclude removing trace items
       this.$emit('data-item-visibility', {
         id: this.$props.viewer.id,
         item_id: this.$props.item.id,
-        visible: prevVisibleState != 'visible' || !this.multi_select,
-        replace: !this.multi_select
+        visible: prevVisibleState != 'visible' || (!this.multi_select && this.$props.item.type !== 'trace'),
+        replace: !this.multi_select && this.$props.item.type !== 'trace'
       })
 
     }

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -115,6 +115,12 @@ module.exports = {
     },
     isUnloadable() {
       if (this.$props.item.meta.Plugin !== undefined) {
+        // (almost) always allow unloading plugin exports
+        if (this.$props.viewer.config === 'specviz2d' && this.$props.item.name === 'Spectrum 1D') {
+          // the "Spectrum 1D" object is auto-generated from a plugin, but since its the default
+          // reference data, we don't want to allow unloading it
+          return false
+        }
         return true
       }
       if (this.$props.viewer.config === 'cubeviz') {
@@ -129,6 +135,12 @@ module.exports = {
           return this.$props.item.name.indexOf('[MASK]') === -1
         } else if (this.$props.viewer.reference === 'spectrum-viewer') {
           return this.$props.item.name.indexOf('[FLUX]') === -1          
+        }
+      } else if (this.$props.viewer.config === 'specviz2d') {
+        if (this.$props.viewer.reference === 'spectrum-2d-viewer') {
+          return this.$props.item.name !== 'Spectrum 2D'
+        } else if (this.$props.viewer.reference === 'spectrum-viewer') {
+          return this.$props.item.name !== 'Spectrum 1D'
         }
       }
       return true

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -152,6 +152,14 @@ class LineListTool(PluginTemplateMixin):
         if viewer_data is None:
             return
 
+        if viewer_data.spectral_axis.unit == u.pix:
+            # disable the plugin until we can address this properly (either using the wavelength
+            # solution to support pixels in line-lists, or properly displaying the extracted
+            # 1d spectrum in wavelength-space)
+            self.disabled_msg = 'Line Lists unavailable when x-axis is in pixels'
+        else:
+            self.disabled_msg = ''
+
         self._units["x"] = str(viewer_data.spectral_axis.unit)
         self._units["y"] = str(viewer_data.flux.unit)
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -4,6 +4,7 @@ from traitlets import Any, Dict, Float, Bool, Int, List, Unicode, observe
 
 from glue.viewers.profile.state import ProfileViewerState, ProfileLayerState
 from glue.viewers.image.state import ImageSubsetLayerState
+from glue_jupyter.bqplot.image.state import BqplotImageLayerState
 from glue_jupyter.common.toolbar_vuetify import read_icon
 
 from jdaviz.core.registries import tray_registry
@@ -26,7 +27,7 @@ class PlotOptions(TemplateMixin):
     layer_items = List().tag(sync=True)
     layer_selected = Any().tag(sync=True)  # Any needed for multiselect
 
-    # spectrum viewer/layer options:
+    # profile/line viewer/layer options:
     layer_visible_value = Bool().tag(sync=True)
     layer_visible_sync = Dict().tag(sync=True)
 
@@ -114,19 +115,25 @@ class PlotOptions(TemplateMixin):
         self.viewer = ViewerSelect(self, 'viewer_items', 'viewer_selected', 'multiselect')
         self.layer = LayerSelect(self, 'layer_items', 'layer_selected', 'viewer_selected', 'multiselect')  # noqa
 
-        def not_profile(state):
-            return not isinstance(state, (ProfileViewerState, ProfileLayerState))
-
         def is_profile(state):
             return isinstance(state, (ProfileViewerState, ProfileLayerState))
+
+        def not_profile(state):
+            return not is_profile(state)
+
+        def is_image(state):
+            return isinstance(state, BqplotImageLayerState)
+
+        def not_image(state):
+            return not is_image(state)
 
         def is_spatial_subset(state):
             return isinstance(state, ImageSubsetLayerState)
 
         def is_not_subset(state):
-            return not isinstance(state, ImageSubsetLayerState)
+            return not is_spatial_subset(state)
 
-        # Spectrum viewer/layer options:
+        # Profile/line viewer/layer options:
         self.layer_visible = PlotOptionsSyncState(self, self.viewer, self.layer, 'visible',
                                                   'layer_visible_value', 'layer_visible_sync',
                                                   state_filter=is_not_subset)
@@ -134,7 +141,7 @@ class PlotOptions(TemplateMixin):
                                                       'collapse_func_value', 'collapse_func_sync')
         self.line_color = PlotOptionsSyncState(self, self.viewer, self.layer, 'color',
                                                'line_color_value', 'line_color_sync',
-                                               state_filter=is_profile)
+                                               state_filter=not_image)
         self.line_width = PlotOptionsSyncState(self, self.viewer, self.layer, 'linewidth',
                                                'line_width_value', 'line_width_sync')
         self.line_opacity = PlotOptionsSyncState(self, self.viewer, self.layer, 'alpha',
@@ -146,33 +153,33 @@ class PlotOptions(TemplateMixin):
         # Image viewer/layer options:
         self.stretch = PlotOptionsSyncState(self, self.viewer, self.layer, 'stretch',
                                             'stretch_value', 'stretch_sync',
-                                            state_filter=not_profile)
+                                            state_filter=is_image)
         self.stretch_perc = PlotOptionsSyncState(self, self.viewer, self.layer, 'percentile',
                                                  'stretch_perc_value', 'stretch_perc_sync',
-                                                 state_filter=not_profile)
+                                                 state_filter=is_image)
         self.stretch_min = PlotOptionsSyncState(self, self.viewer, self.layer, 'v_min',
                                                 'stretch_min_value', 'stretch_min_sync',
-                                                state_filter=not_profile)
+                                                state_filter=is_image)
         self.stretch_max = PlotOptionsSyncState(self, self.viewer, self.layer, 'v_max',
                                                 'stretch_max_value', 'stretch_max_sync',
-                                                state_filter=not_profile)
+                                                state_filter=is_image)
 
         self.subset_visible = PlotOptionsSyncState(self, self.viewer, self.layer, 'visible',
                                                    'subset_visible_value', 'subset_visible_sync',
                                                    state_filter=is_spatial_subset)
         self.bitmap_visible = PlotOptionsSyncState(self, self.viewer, self.layer, 'bitmap_visible',
                                                    'bitmap_visible_value', 'bitmap_visible_sync',
-                                                   state_filter=not_profile)
+                                                   state_filter=is_image)
         self.color_mode = PlotOptionsSyncState(self, self.viewer, self.layer, 'color_mode',
                                                'color_mode_value', 'color_mode_sync')
         self.bitmap_color = PlotOptionsSyncState(self, self.viewer, self.layer, 'color',
                                                  'bitmap_color_value', 'bitmap_color_sync',
-                                                 state_filter=not_profile)
+                                                 state_filter=is_image)
         self.bitmap_cmap = PlotOptionsSyncState(self, self.viewer, self.layer, 'cmap',
                                                 'bitmap_cmap_value', 'bitmap_cmap_sync')
         self.bitmap_opacity = PlotOptionsSyncState(self, self.viewer, self.layer, 'alpha',
                                                    'bitmap_opacity_value', 'bitmap_opacity_sync',
-                                                   state_filter=not_profile)
+                                                   state_filter=is_image)
         self.bitmap_contrast = PlotOptionsSyncState(self, self.viewer, self.layer, 'contrast',
                                                     'bitmap_contrast_value', 'bitmap_contrast_sync')
         self.bitmap_bias = PlotOptionsSyncState(self, self.viewer, self.layer, 'bias',

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -78,8 +78,8 @@
     </glue-state-sync-wrapper>
 
 
-    <!-- PROFILE -->
-    <j-plugin-section-header v-if="line_width_sync.in_subscribed_states || collapse_func_sync.in_subscribed_states">Profile Line</j-plugin-section-header>
+    <!-- PROFILE/LINE -->
+    <j-plugin-section-header v-if="line_width_sync.in_subscribed_states || collapse_func_sync.in_subscribed_states">Line</j-plugin-section-header>
     <glue-state-sync-wrapper v-if="config === 'cubeviz'" :sync="collapse_func_sync" :multiselect="multiselect" @unmix-state="unmix_state('function')">
       <v-select
         :items="collapse_func_sync.choices"

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -3,7 +3,6 @@ import numpy as np
 from glue.core.subset import RoiSubsetState
 from glue_jupyter.bqplot.profile import BqplotProfileView
 from glue_jupyter.bqplot.image import BqplotImageView
-from glue_jupyter.bqplot.scatter.layer_artist import BqplotScatterLayerState
 from glue_jupyter.table import TableViewer
 
 from jdaviz.components.toolbar_nested import NestedJupyterToolbar
@@ -49,10 +48,6 @@ class JdavizViewerMixin:
     def _update_layer_icons(self):
         # update visible_layers (TODO: move this somewhere that can update on color change, etc)
         def _get_layer_color(layer):
-            if isinstance(layer, BqplotScatterLayerState):
-                # then this could be a scatter layer in an image viewer,
-                # so we'll ignore the color_mode
-                return layer.color
             if getattr(self.state, 'color_mode', None) == 'Colormaps':
                 for subset in self.jdaviz_app.data_collection.subset_groups:
                     if subset.label == layer.layer.label:
@@ -67,9 +62,6 @@ class JdavizViewerMixin:
                 suffix = f" (collapsed: {self.state.function})"
             else:
                 suffix = ""
-
-            if 'Trace' in layer.layer.data.meta:
-                return "mdi-chart-line-stacked", ""
 
             # then the underlying data is cube-like and we're in the profile viewer, so we
             # want to include the collapse function *unless* the layer is a spectral subset

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -3,6 +3,7 @@ import numpy as np
 from glue.core.subset import RoiSubsetState
 from glue_jupyter.bqplot.profile import BqplotProfileView
 from glue_jupyter.bqplot.image import BqplotImageView
+from glue_jupyter.bqplot.scatter.layer_artist import BqplotScatterLayerState
 from glue_jupyter.table import TableViewer
 
 from jdaviz.components.toolbar_nested import NestedJupyterToolbar
@@ -48,6 +49,10 @@ class JdavizViewerMixin:
     def _update_layer_icons(self):
         # update visible_layers (TODO: move this somewhere that can update on color change, etc)
         def _get_layer_color(layer):
+            if isinstance(layer, BqplotScatterLayerState):
+                # then this could be a scatter layer in an image viewer,
+                # so we'll ignore the color_mode
+                return layer.color
             if getattr(self.state, 'color_mode', None) == 'Colormaps':
                 for subset in self.jdaviz_app.data_collection.subset_groups:
                     if subset.label == layer.layer.label:
@@ -62,6 +67,9 @@ class JdavizViewerMixin:
                 suffix = f" (collapsed: {self.state.function})"
             else:
                 suffix = ""
+
+            if 'Trace' in layer.layer.data.meta:
+                return "mdi-chart-line-stacked", ""
 
             # then the underlying data is cube-like and we're in the profile viewer, so we
             # want to include the collapse function *unless* the layer is a spectral subset

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -2,6 +2,7 @@
   <j-tray-plugin
     description="Return statistics for a single spectral line."
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#line-analysis'"
+    :disabled_msg="disabled_msg"
     :popout_button="popout_button">
 
     <j-plugin-section-header>Line</j-plugin-section-header>

--- a/jdaviz/configs/specviz2d/helper.py
+++ b/jdaviz/configs/specviz2d/helper.py
@@ -3,6 +3,7 @@ import numpy as np
 from jdaviz.core.helpers import ConfigHelper
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.configs.default.plugins.line_lists.line_list_mixin import LineListMixin
+from jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction import SpectralExtraction  # noqa
 
 __all__ = ['Specviz2d']
 
@@ -140,15 +141,20 @@ class Specviz2d(ConfigHelper, LineListMixin):
 
             # Collapse the 2D spectrum to 1D if no 1D spectrum provided
             if spectrum_1d is None:
-                self.app.load_data(spectrum_2d,
-                                   parser_reference="spec2d-1d-parser",
-                                   data_label=spectrum_1d_label,
-                                   show_in_viewer=show_in_viewer)
+                # create a non-interactive (so that it does not create duplicate marks with the
+                # plugin-instance created later) instance of the SpectralExtraction plugin,
+                # and use the defaults to generate the initial 1D extracted spectrum
+                spext = SpectralExtraction(app=self.app, interactive=False)
+                # for some reason, the trailets are resetting to their default values even
+                # though _trace_dataset_selected was called internally to set them to reasonable
+                # new defaults.  We'll just call it again manually.
+                spext._trace_dataset_selected()
+                _ = spext.create_extract(add_data=True)
 
                 # Warn that this shouldn't be used for science
-                msg = ("The collapsed 1D spectrum is for quicklook"
-                       " purposes only. Use the spectral extraction plugin"
-                       " for custom extraction.")
+                msg = ("The extracted 1D spectrum was generated automatically."
+                       " See the spectral extraction plugin for details or to"
+                       " perform a custom extraction.")
                 msg = SnackbarMessage(msg, color='warning', sender=self,
                                       timeout=10000)
                 self.app.hub.broadcast(msg)

--- a/jdaviz/configs/specviz2d/helper.py
+++ b/jdaviz/configs/specviz2d/helper.py
@@ -147,8 +147,8 @@ class Specviz2d(ConfigHelper, LineListMixin):
 
                 # Warn that this shouldn't be used for science
                 msg = ("The collapsed 1D spectrum is for quicklook"
-                       " purposes only. A robust extraction should be used for"
-                       " scientific use cases.")
+                       " purposes only. Use the spectral extraction plugin"
+                       " for custom extraction.")
                 msg = SnackbarMessage(msg, color='warning', sender=self,
                                       timeout=10000)
                 self.app.hub.broadcast(msg)

--- a/jdaviz/configs/specviz2d/plugins/__init__.py
+++ b/jdaviz/configs/specviz2d/plugins/__init__.py
@@ -1,1 +1,2 @@
 from .parsers import *  # noqa
+from .spectral_extraction.spectral_extraction import * # noqa

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -269,7 +269,7 @@ class SpectralExtraction(PluginTemplateMixin):
 
         return self._marks
 
-    @observe('trace_dataset_selected',
+    @observe('trace_dataset_selected', 'trace_type_selected',
              'trace_pixel', 'trace_bins', 'trace_window', 'active_step')
     def _interaction_in_trace_step(self, event={}):
         if not self.plugin_opened or not self._do_marks:

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -241,7 +241,7 @@ class SpectralExtraction(PluginTemplateMixin):
             # we don't have data yet for scales, defer initializing
             return {}
 
-        # then haven't been initialized yet, so initialize with empty
+        # the marks haven't been initialized yet, so initialize with empty
         # marks that will be populated once the first analysis is done.
         self._marks = {'trace': PluginLine(viewer2d, visible=self.plugin_opened),
                        'ext_lower': PluginLine(viewer2d, visible=self.plugin_opened),

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -371,7 +371,7 @@ class SpectralExtraction(PluginTemplateMixin):
         self.active_step = 'ext'
         self._update_plugin_marks()
 
-    def create_trace(self, add_data=True):
+    def create_trace(self, add_data=False):
         """
         Create a trace object from the input parameters defined in the plugin.
 
@@ -437,7 +437,7 @@ class SpectralExtraction(PluginTemplateMixin):
 
         return bg
 
-    def create_bg(self, add_data=True):
+    def create_bg(self, add_data=False):
         """
         Create a background 2D spectrum from the input parameters defined in the plugin.
 
@@ -460,7 +460,7 @@ class SpectralExtraction(PluginTemplateMixin):
     def vue_create_bg(self, *args):
         _ = self.create_bg(add_data=True)
 
-    def create_bg_sub(self, add_data=True):
+    def create_bg_sub(self, add_data=False):
         """
         Create a background-subtracted 2D spectrum from the input parameters defined in the plugin.
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -507,8 +507,12 @@ class SpectralExtraction(PluginTemplateMixin):
 
         boxcar = extract.BoxcarExtract()
         spectrum = boxcar(inp_sp2d.data, trace, width=self.ext_width)
-        # specreduce returns a spectral axis in pixels, so we'll replace with the input
-        spectrum = Spectrum1D(spectral_axis=inp_sp2d.spectral_axis, flux=spectrum.flux)
+        # Specreduce returns a spectral axis in pixels, so we'll replace with input spectral_axis
+        # NOTE: this is currently disabled until proper handling of axes-limit linking between
+        # the 2D spectrum image (plotted in pixels) and a 1D spectrum (plotted in freq or
+        # wavelength) is implemented.
+
+        # spectrum = Spectrum1D(spectral_axis=inp_sp2d.spectral_axis, flux=spectrum.flux)
 
         if add_data:
             self.ext_add_results.add_results_from_plugin(spectrum, replace=False)

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -1,0 +1,223 @@
+import numpy as np
+
+from traitlets import Bool, List, Unicode, observe
+
+
+from jdaviz.core.registries import tray_registry
+from jdaviz.core.template_mixin import (PluginTemplateMixin,
+                                        DatasetSelect,
+                                        AddResults)
+from jdaviz.core.custom_traitlets import IntHandleEmpty
+
+from specreduce import tracing
+
+__all__ = ['SpectralExtraction']
+
+
+@tray_registry('spectral-extraction', label="Spectral Extraction")
+class SpectralExtraction(PluginTemplateMixin):
+    dialog = Bool(False).tag(sync=True)
+    template_file = __file__, "spectral_extraction.vue"
+
+    # TRACE
+    trace_dataset_items = List().tag(sync=True)
+    trace_dataset_selected = Unicode().tag(sync=True)
+
+    trace_type_items = List(['FlatTrace', 'AutoTrace']).tag(sync=True)
+    trace_type_selected = Unicode('FlatTrace').tag(sync=True)
+
+    trace_pixel = IntHandleEmpty(0).tag(sync=True)
+
+    trace_peak_method_items = List(['Gaussian', 'Centroid', 'Max']).tag(sync=True)
+    trace_peak_method_selected = Unicode('Gaussian').tag(sync=True)
+
+    trace_bins = IntHandleEmpty(20).tag(sync=True)
+    trace_window = IntHandleEmpty(0).tag(sync=True)
+
+    trace_results_label = Unicode().tag(sync=True)
+    trace_results_label_default = Unicode().tag(sync=True)
+    trace_results_label_auto = Bool(True).tag(sync=True)
+    trace_results_label_invalid_msg = Unicode('').tag(sync=True)
+    trace_results_label_overwrite = Bool().tag(sync=True)
+    trace_add_to_viewer_items = List().tag(sync=True)
+    trace_add_to_viewer_selected = Unicode().tag(sync=True)
+
+    # BACKGROUND
+    bg_dataset_items = List().tag(sync=True)
+    bg_dataset_selected = Unicode().tag(sync=True)
+
+    bg_type_items = List(['TwoSided', 'OneSided', 'Trace']).tag(sync=True)
+    bg_type_selected = Unicode('TwoSided').tag(sync=True)
+
+    bg_trace_items = List().tag(sync=True)
+    bg_trace_selected = Unicode().tag(sync=True)
+
+    bg_trace_pixel = IntHandleEmpty(0).tag(sync=True)
+
+    bg_separation = IntHandleEmpty(0).tag(sync=True)
+    bg_width = IntHandleEmpty(0).tag(sync=True)
+
+    bg_results_label = Unicode().tag(sync=True)
+    bg_results_label_default = Unicode().tag(sync=True)
+    bg_results_label_auto = Bool(True).tag(sync=True)
+    bg_results_label_invalid_msg = Unicode('').tag(sync=True)
+    bg_results_label_overwrite = Bool().tag(sync=True)
+    bg_add_to_viewer_items = List().tag(sync=True)
+    bg_add_to_viewer_selected = Unicode().tag(sync=True)
+
+    bg_sub_results_label = Unicode().tag(sync=True)
+    bg_sub_results_label_default = Unicode().tag(sync=True)
+    bg_sub_results_label_auto = Bool(True).tag(sync=True)
+    bg_sub_results_label_invalid_msg = Unicode('').tag(sync=True)
+    bg_sub_results_label_overwrite = Bool().tag(sync=True)
+    bg_sub_add_to_viewer_items = List().tag(sync=True)
+    bg_sub_add_to_viewer_selected = Unicode().tag(sync=True)
+
+    # EXTRACT
+    ext_dataset_items = List().tag(sync=True)
+    ext_dataset_selected = Unicode().tag(sync=True)
+
+    ext_trace_items = List().tag(sync=True)
+    ext_trace_selected = Unicode().tag(sync=True)
+
+    ext_trace_pixel = IntHandleEmpty(0).tag(sync=True)
+
+    ext_results_label = Unicode().tag(sync=True)
+    ext_results_label_default = Unicode().tag(sync=True)
+    ext_results_label_auto = Bool(True).tag(sync=True)
+    ext_results_label_invalid_msg = Unicode('').tag(sync=True)
+    ext_results_label_overwrite = Bool().tag(sync=True)
+    ext_add_to_viewer_items = List().tag(sync=True)
+    ext_add_to_viewer_selected = Unicode().tag(sync=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # TRACE
+        self.trace_dataset = DatasetSelect(self,
+                                           'trace_dataset_items',
+                                           'trace_dataset_selected',
+                                           filters=['layer_in_spectrum_2d_viewer', 'not_trace'])
+
+        self.trace_add_results = AddResults(self, 'trace_results_label',
+                                            'trace_results_label_default',
+                                            'trace_results_label_auto',
+                                            'trace_results_label_invalid_msg',
+                                            'trace_results_label_overwrite',
+                                            'trace_add_to_viewer_items',
+                                            'trace_add_to_viewer_selected')
+        self.trace_add_results.viewer.filters = ['is_spectrum_2d_viewer']
+        self.trace_results_label_default = 'trace'
+
+        # BACKGROUND
+        self.bg_dataset = DatasetSelect(self,
+                                        'bg_dataset_items',
+                                        'bg_dataset_selected',
+                                        filters=['layer_in_spectrum_2d_viewer', 'not_trace'])
+
+        self.bg_trace = DatasetSelect(self,
+                                      'bg_trace_items',
+                                      'bg_trace_selected',
+                                      default_text='Manual',
+                                      filters=['is_trace'])
+
+        self.bg_add_results = AddResults(self, 'bg_results_label',
+                                         'bg_results_label_default',
+                                         'bg_results_label_auto',
+                                         'bg_results_label_invalid_msg',
+                                         'bg_results_label_overwrite',
+                                         'bg_add_to_viewer_items',
+                                         'bg_add_to_viewer_selected')
+        self.bg_add_results.viewer.filters = ['is_spectrum_2d_viewer']
+        self.bg_results_label_default = 'background'
+
+        self.bg_sub_add_results = AddResults(self, 'bg_sub_results_label',
+                                             'bg_sub_results_label_default',
+                                             'bg_sub_results_label_auto',
+                                             'bg_sub_results_label_invalid_msg',
+                                             'bg_sub_results_label_overwrite',
+                                             'bg_sub_add_to_viewer_items',
+                                             'bg_sub_add_to_viewer_selected')
+        self.bg_sub_add_results.viewer.filters = ['is_spectrum_2d_viewer']
+        self.bg_sub_results_label_default = 'background-subtracted'
+
+        # EXTRACT
+        self.ext_dataset = DatasetSelect(self,
+                                         'ext_dataset_items',
+                                         'ext_dataset_selected',
+                                         filters=['layer_in_spectrum_2d_viewer', 'not_trace'])
+
+        self.ext_trace = DatasetSelect(self,
+                                       'ext_trace_items',
+                                       'ext_trace_selected',
+                                       default_text='Manual',
+                                       filters=['is_trace'])
+
+        self.ext_add_results = AddResults(self, 'ext_results_label',
+                                          'ext_results_label_default',
+                                          'ext_results_label_auto',
+                                          'ext_results_label_invalid_msg',
+                                          'ext_results_label_overwrite',
+                                          'ext_add_to_viewer_items',
+                                          'ext_add_to_viewer_selected')
+        self.ext_add_results.viewer.filters = ['is_spectrum_viewer']
+        self.ext_results_label_default = 'extracted spectrum'
+
+    @observe('plugin_opened')
+    def _on_plugin_opened_changed(self, *args):
+        # toggle continuum lines in spectrum viewer based on whether this plugin
+        # is currently open in the tray
+        for pos, mark in self.marks.items():
+            mark.visible = self.plugin_opened
+#        if self.plugin_opened:
+#            self._calculate_statistics()
+
+    @property
+    def marks(self):
+        return {}
+
+    @observe('trace_dataset_selected')
+    def _trace_dataset_selected(self, msg):
+        width = self.trace_dataset.selected_obj.shape[0]
+        half_pixel = int(np.floor(width / 2))
+        if self.trace_pixel == 0:
+            self.trace_pixel = half_pixel
+        if self.trace_window == 0:
+            self.trace_window = int(np.ceil(width / 10))
+        if self.bg_trace_pixel == 0:
+            self.bg_trace_pixel = half_pixel
+        if self.bg_separation == 0:
+            self.bg_separation = int(np.ceil(width / 10))
+        if self.bg_width == 0:
+            self.bg_width = int(np.ceil(width / 10))
+        if self.ext_trace_pixel == 0:
+            self.ext_trace_pixel = half_pixel
+
+    def create_trace(self, add_data=True):
+        if self.trace_type_selected == 'FlatTrace':
+            trace = tracing.FlatTrace(self.trace_dataset.selected_obj.data,
+                                      self.trace_pixel)
+        elif self.trace_type_selected == 'AutoTrace':
+            trace = tracing.KosmosTrace(self.trace_dataset.selected_obj.data,
+                                        guess=self.trace_pixel,
+                                        bins=self.trace_bins,
+                                        window=self.trace_window,
+                                        peak_method=self.trace_peak_method_selected.lower())
+        else:
+            raise NotImplementedError(f"trace_type={self.trace_type_selected} not implemented")
+
+        if add_data:
+            self.trace_add_results.add_results_from_plugin(trace, replace=False)
+        return trace
+
+    def vue_create_trace(self, *args):
+        _ = self.create_trace(add_data=True)
+
+    def vue_create_bg(self, *args):
+        raise NotImplementedError()
+
+    def vue_create_bg_sub(self, *args):
+        raise NotImplementedError()
+
+    def vue_extract(self, *args):
+        raise NotImplementedError()

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -41,9 +41,6 @@ class SpectralExtraction(PluginTemplateMixin):
 
     trace_pixel = IntHandleEmpty(0).tag(sync=True)
 
-    trace_peak_method_items = List(['Gaussian', 'Centroid', 'Max']).tag(sync=True)
-    trace_peak_method_selected = Unicode('Gaussian').tag(sync=True)
-
     trace_bins = IntHandleEmpty(20).tag(sync=True)
     trace_window = IntHandleEmpty(0).tag(sync=True)
 
@@ -280,8 +277,7 @@ class SpectralExtraction(PluginTemplateMixin):
         return self._marks
 
     @observe('trace_trace_selected', 'trace_offset', 'trace_dataset_selected',
-             'trace_pixel', 'trace_peak_method_selected',
-             'trace_bins', 'trace_window', 'active_step')
+             'trace_pixel', 'trace_bins', 'trace_window', 'active_step')
     def _interaction_in_trace_step(self, event={}):
         if not self.plugin_opened or not self._do_marks:
             return
@@ -398,8 +394,7 @@ class SpectralExtraction(PluginTemplateMixin):
             trace = tracing.KosmosTrace(self.trace_dataset.selected_obj.data,
                                         guess=self.trace_pixel,
                                         bins=self.trace_bins,
-                                        window=self.trace_window,
-                                        peak_method=self.trace_peak_method_selected.lower())
+                                        window=self.trace_window)
 
         else:
             raise NotImplementedError(f"trace_type={self.trace_type_selected} not implemented")

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -190,6 +190,28 @@ class SpectralExtraction(PluginTemplateMixin):
         if self.ext_width == 0:
             self.ext_width = default_width
 
+    def update_marks(self, step=None):
+        """
+        Manually update the live-preview marks for a given step in spectral extraction.  This API
+        mimics opening the plugin and interacting with one of the steps.
+
+        Parameters
+        ----------
+        step : str
+            Step in the extraction process to visualize.  Must be one of: 'trace', 'bg', 'ext'.
+        """
+        if step is not None:
+            if step not in ['trace', 'bg', 'ext']:
+                raise ValueError("step must be one of: trace, bg, ext")
+            self.active_step = step
+        self.plugin_opened = True
+
+    def clear_marks(self):
+        """
+        Manually clear the live-preview marks.
+        """
+        self.plugin_opened = False
+
     @observe('plugin_opened', 'setting_interactive_extract')
     def _update_plugin_marks(self, *args):
         if not self._do_marks:

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -174,19 +174,6 @@ class SpectralExtraction(PluginTemplateMixin):
         self.ext_add_results.viewer.filters = ['is_spectrum_viewer']
         self.ext_results_label_default = 'extracted spectrum'
 
-    @observe('plugin_opened')
-    def _on_plugin_opened_changed(self, *args):
-        # toggle continuum lines in spectrum viewer based on whether this plugin
-        # is currently open in the tray
-        for pos, mark in self.marks.items():
-            mark.visible = self.plugin_opened
-#        if self.plugin_opened:
-#            self._calculate_statistics()
-
-    @property
-    def marks(self):
-        return {}
-
     @observe('trace_dataset_selected')
     def _trace_dataset_selected(self, msg):
         width = self.trace_dataset.selected_obj.shape[0]

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -28,11 +28,6 @@ class SpectralExtraction(PluginTemplateMixin):
     setting_interactive_extract = Bool(True).tag(sync=True)
 
     # TRACE
-    trace_trace_items = List().tag(sync=True)
-    trace_trace_selected = Unicode().tag(sync=True)
-
-    trace_offset = IntHandleEmpty(0).tag(sync=True)
-
     trace_dataset_items = List().tag(sync=True)
     trace_dataset_selected = Unicode().tag(sync=True)
 
@@ -43,14 +38,6 @@ class SpectralExtraction(PluginTemplateMixin):
 
     trace_bins = IntHandleEmpty(20).tag(sync=True)
     trace_window = IntHandleEmpty(0).tag(sync=True)
-
-    trace_results_label = Unicode().tag(sync=True)
-    trace_results_label_default = Unicode().tag(sync=True)
-    trace_results_label_auto = Bool(True).tag(sync=True)
-    trace_results_label_invalid_msg = Unicode('').tag(sync=True)
-    trace_results_label_overwrite = Bool().tag(sync=True)
-    trace_add_to_viewer_items = List().tag(sync=True)
-    trace_add_to_viewer_selected = Unicode().tag(sync=True)
 
     # BACKGROUND
     bg_dataset_items = List().tag(sync=True)
@@ -100,26 +87,10 @@ class SpectralExtraction(PluginTemplateMixin):
         self._do_marks = kwargs.get('interactive', True)
 
         # TRACE
-        self.trace_trace = DatasetSelect(self,
-                                         'trace_trace_items',
-                                         'trace_trace_selected',
-                                         default_text='New Trace',
-                                         filters=['is_trace'])
-
         self.trace_dataset = DatasetSelect(self,
                                            'trace_dataset_items',
                                            'trace_dataset_selected',
                                            filters=['layer_in_spectrum_2d_viewer', 'not_trace'])
-
-        self.trace_add_results = AddResults(self, 'trace_results_label',
-                                            'trace_results_label_default',
-                                            'trace_results_label_auto',
-                                            'trace_results_label_invalid_msg',
-                                            'trace_results_label_overwrite',
-                                            'trace_add_to_viewer_items',
-                                            'trace_add_to_viewer_selected')
-        self.trace_add_results.viewer.filters = ['is_spectrum_2d_viewer']
-        self.trace_results_label_default = 'trace'
 
         # BACKGROUND
         self.bg_dataset = DatasetSelect(self,
@@ -298,7 +269,7 @@ class SpectralExtraction(PluginTemplateMixin):
 
         return self._marks
 
-    @observe('trace_trace_selected', 'trace_offset', 'trace_dataset_selected',
+    @observe('trace_dataset_selected',
              'trace_pixel', 'trace_bins', 'trace_window', 'active_step')
     def _interaction_in_trace_step(self, event={}):
         if not self.plugin_opened or not self._do_marks:
@@ -403,12 +374,7 @@ class SpectralExtraction(PluginTemplateMixin):
             Whether to add the resulting trace to the application, according to the options
             defined in the plugin.
         """
-        if self.trace_trace_selected != 'New Trace':
-            # then we're offsetting an existing trace
-            trace = tracing.ArrayTrace(self.trace_dataset.selected_obj.data,
-                                       self.trace_trace.selected_obj.trace+self.trace_offset)
-
-        elif self.trace_type_selected == 'Flat':
+        if self.trace_type_selected == 'Flat':
             trace = tracing.FlatTrace(self.trace_dataset.selected_obj.data,
                                       self.trace_pixel)
 
@@ -422,7 +388,7 @@ class SpectralExtraction(PluginTemplateMixin):
             raise NotImplementedError(f"trace_type={self.trace_type_selected} not implemented")
 
         if add_data:
-            self.trace_add_results.add_results_from_plugin(trace, replace=False)
+            raise NotImplementedError("exporting trace to data entry not yet supported")
 
         return trace
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -130,7 +130,8 @@ class SpectralExtraction(PluginTemplateMixin):
         self.bg_trace = DatasetSelect(self,
                                       'bg_trace_items',
                                       'bg_trace_selected',
-                                      default_text='Manual',
+                                      default_text='From Plugin',
+                                      manual_options=['Manual'],
                                       filters=['is_trace'])
 
         self.bg_add_results = AddResults(self, 'bg_results_label',
@@ -157,12 +158,14 @@ class SpectralExtraction(PluginTemplateMixin):
         self.ext_dataset = DatasetSelect(self,
                                          'ext_dataset_items',
                                          'ext_dataset_selected',
+                                         default_text='From Plugin',
                                          filters=['layer_in_spectrum_2d_viewer', 'not_trace'])
 
         self.ext_trace = DatasetSelect(self,
                                        'ext_trace_items',
                                        'ext_trace_selected',
-                                       default_text='Manual',
+                                       default_text='From Plugin',
+                                       manual_options=['Manual'],
                                        filters=['is_trace'])
 
         self.ext_add_results = AddResults(self, 'ext_results_label',

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -412,7 +412,7 @@ class SpectralExtraction(PluginTemplateMixin):
                                                  self.bg_separation,
                                                  width=self.bg_width)
         elif self.bg_type_selected == 'TwoSided':
-            bg = background.Background.one_sided(self.bg_dataset.selected_obj.data,
+            bg = background.Background.two_sided(self.bg_dataset.selected_obj.data,
                                                  trace,
                                                  self.bg_separation,
                                                  width=self.bg_width)

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -323,8 +323,8 @@ class SpectralExtraction(PluginTemplateMixin):
     def create_trace(self, add_data=True):
         if self.trace_trace_selected != 'New Trace':
             # then we're offsetting an existing trace
-            trace = self.trace_trace.selected_obj
-            trace.shift(self.trace_offset)
+            trace = tracing.ArrayTrace(self.trace_dataset.selected_obj.data,
+                                       self.trace_trace.selected_obj.trace+self.trace_offset)
 
         elif self.trace_type_selected == 'FlatTrace':
             trace = tracing.FlatTrace(self.trace_dataset.selected_obj.data,

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -8,8 +8,7 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         DatasetSelect,
                                         AddResults)
 from jdaviz.core.custom_traitlets import IntHandleEmpty
-from jdaviz.core.marks import (PluginLine,
-                               ShadowLine)
+from jdaviz.core.marks import PluginLine
 
 from specutils import Spectrum1D
 from specreduce import tracing
@@ -255,17 +254,14 @@ class SpectralExtraction(PluginTemplateMixin):
                                                 line_style='dotted'),
                        'bg2_lower': PluginLine(viewer2d, visible=self.plugin_opened),
                        'bg2_upper': PluginLine(viewer2d, visible=self.plugin_opened)}
-        shadows = [ShadowLine(mark, shadow_width=2) for mark in self._marks.values()]
         # NOTE: += won't trigger the figure to notice new marks
-        viewer2d.figure.marks = viewer2d.figure.marks + shadows + list(self._marks.values())
+        viewer2d.figure.marks = viewer2d.figure.marks + list(self._marks.values())
 
         mark1d = PluginLine(viewer1d, visible=self.plugin_opened)
-        shadow1d = ShadowLine(mark1d, shadow_width=2)
-
         self._marks['extract'] = mark1d
 
         # NOTE: += won't trigger the figure to notice new marks
-        viewer1d.figure.marks = viewer1d.figure.marks + [shadow1d, mark1d]
+        viewer1d.figure.marks = viewer1d.figure.marks + [mark1d]
 
         return self._marks
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -86,6 +86,7 @@ class SpectralExtraction(PluginTemplateMixin):
     ext_trace_selected = Unicode().tag(sync=True)
 
     ext_trace_pixel = IntHandleEmpty(0).tag(sync=True)
+    ext_width = IntHandleEmpty(0).tag(sync=True)
 
     ext_results_label = Unicode().tag(sync=True)
     ext_results_label_default = Unicode().tag(sync=True)
@@ -190,6 +191,8 @@ class SpectralExtraction(PluginTemplateMixin):
             self.bg_width = int(np.ceil(width / 10))
         if self.ext_trace_pixel == 0:
             self.ext_trace_pixel = half_pixel
+        if self.ext_width == 0:
+            self.ext_width = int(np.ceil(width / 10))
 
     def create_trace(self, add_data=True):
         if self.trace_trace_selected != 'New Trace':

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -292,10 +292,13 @@ class SpectralExtraction(PluginTemplateMixin):
 
     @observe('trace_trace_selected', 'trace_offset', 'trace_dataset_selected',
              'trace_type_selected', 'trace_pixel', 'trace_peak_method_selected',
-             'trace_bins', 'trace_window')
-    def _interaction_in_trace_step(self, *args):
+             'trace_bins', 'trace_window', 'active_step')
+    def _interaction_in_trace_step(self, event={}):
         if not self.plugin_opened or not self._do_marks:
             return
+        if event.get('name', '') == 'active_step' and event.get('new') != 'trace':
+            return
+
         try:
             trace = self.create_trace(add_data=False)
         except Exception:
@@ -311,10 +314,13 @@ class SpectralExtraction(PluginTemplateMixin):
         self._update_plugin_marks()
 
     @observe('bg_dataset_selected', 'bg_type_selected', 'bg_trace_selected', 'bg_trace_pixel',
-             'bg_separation', 'bg_width')
-    def _interaction_in_bg_step(self, *args):
+             'bg_separation', 'bg_width', 'active_step')
+    def _interaction_in_bg_step(self, event={}):
         if not self.plugin_opened or not self._do_marks:
             return
+        if event.get('name', '') == 'active_step' and event.get('new') != 'bg':
+            return
+
         try:
             trace = self._get_bg_trace()
         except Exception:
@@ -357,9 +363,12 @@ class SpectralExtraction(PluginTemplateMixin):
         self.active_step = 'bg'
         self._update_plugin_marks()
 
-    @observe('ext_dataset_selected', 'ext_trace_selected', 'ext_trace_pixel', 'ext_width')
-    def _interaction_in_ext_step(self, *args):
+    @observe('ext_dataset_selected', 'ext_trace_selected', 'ext_trace_pixel', 'ext_width',
+             'active_step')
+    def _interaction_in_ext_step(self, event={}):
         if not self.plugin_opened or not self._do_marks:
+            return
+        if event.get('name', '') == 'active_step' and event.get('new') != 'ext':
             return
 
         try:

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -239,6 +239,18 @@
       </v-text-field>
     </v-row>
 
+    <v-row>
+      <v-text-field
+        label="Width"
+        type="number"
+        v-model.number="ext_width"
+        :rules="[() => ext_width!=='' || 'This field is required']"
+        hint="Width of extraction window, in pixels."
+        persistent-hint
+      >
+      </v-text-field>
+    </v-row>
+
     <plugin-add-results
       :label.sync="ext_results_label"
       :label_default="ext_results_label_default"

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -31,28 +31,7 @@
         <j-docs-link>Create a trace for the spectrum.</j-docs-link>
       </v-row>
 
-      <plugin-dataset-select
-        :items="trace_trace_items"
-        :selected.sync="trace_trace_selected"
-        :show_if_single_entry="false"
-        label="Trace"
-        hint="Existing trace to offset or create a new trace"
-      />
-
-      <div v-if="trace_trace_selected !== 'New Trace'">
-        <v-row>
-          <v-text-field
-            label="Offset"
-            type="number"
-            v-model.number="trace_offset"
-            :rules="[() => trace_offset!=='' || 'This field is required']"
-            hint="Offset to apply to existing trace, in pixels."
-            persistent-hint
-          >
-          </v-text-field>
-        </v-row>
-      </div>
-      <div v-else>
+      <div>
         <plugin-dataset-select
           :items="trace_dataset_items"
           :selected.sync="trace_dataset_selected"
@@ -107,31 +86,6 @@
           </v-text-field>
         </v-row>
       </div>
-
-      <v-row>
-        <v-expansion-panels popout>
-          <v-expansion-panel>
-            <v-expansion-panel-header v-slot="{ open }">
-              <span style="padding: 6px">Export Trace</span>
-            </v-expansion-panel-header>
-            <v-expansion-panel-content>
-              <plugin-add-results
-                :label.sync="trace_results_label"
-                :label_default="trace_results_label_default"
-                :label_auto.sync="trace_results_label_auto"
-                :label_invalid_msg="trace_results_label_invalid_msg"
-                :label_overwrite="trace_results_label_overwrite"
-                label_hint="Label for the trace"
-                :add_to_viewer_items="trace_add_to_viewer_items"
-                :add_to_viewer_selected.sync="trace_add_to_viewer_selected"
-                action_label="Create"
-                action_tooltip="Create Trace"
-                @click:action="create_trace"
-              ></plugin-add-results>
-            </v-expansion-panel-content>
-          </v-expansion-panel>
-        </v-expansion-panels>
-      </v-row>
     </div>
 
     <div @mouseover="() => active_step='bg'">
@@ -285,6 +239,6 @@
       ></plugin-add-results>
     </div>
 
-    </div>  
+    </div>
   </j-tray-plugin>
 </template>

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -164,7 +164,7 @@
                 label_hint="Label for the background image"
                 :add_to_viewer_items="bg_add_to_viewer_items"
                 :add_to_viewer_selected.sync="bg_add_to_viewer_selected"
-                action_label="Background"
+                action_label="Export"
                 action_tooltip="Create Background Image"
                 @click:action="create_bg"
               ></plugin-add-results>
@@ -188,7 +188,7 @@
                 label_hint="Label for the background-subtracted image"
                 :add_to_viewer_items="bg_sub_add_to_viewer_items"
                 :add_to_viewer_selected.sync="bg_sub_add_to_viewer_selected"
-                action_label="Subtract"
+                action_label="Export"
                 action_tooltip="Create Background Subtracted Image"
                 @click:action="create_bg_sub"
               ></plugin-add-results>

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -1,0 +1,236 @@
+<template>
+  <j-tray-plugin
+    description="2D to 1D spectral extraction."
+    :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#spectral-extraction'"
+    :popout_button="popout_button">
+
+    <j-plugin-section-header>Trace</j-plugin-section-header>
+    <v-row>
+      <j-docs-link>Create a trace for the spectrum.</j-docs-link>
+    </v-row>
+
+    <plugin-dataset-select
+      :items="trace_dataset_items"
+      :selected.sync="trace_dataset_selected"
+      :show_if_single_entry="false"
+      label="2D Spectrum"
+      hint="Select the data used to create the trace."
+    />
+
+    <v-row>
+      <v-select
+        :items="trace_type_items"
+        v-model="trace_type_selected"
+        label="Trace Type"
+        hint="Method to use for creating trace"
+        persistent-hint
+      ></v-select>
+    </v-row>
+
+    <v-row>
+      <v-text-field
+        label="Pixel"
+        type="number"
+        v-model.number="trace_pixel"
+        :rules="[() => trace_pixel!=='' || 'This field is required']"
+        hint="Pixel number/column to start the trace."
+        persistent-hint
+      >
+      </v-text-field>
+    </v-row>
+
+    <v-row v-if="trace_type_selected==='AutoTrace'">
+      <v-text-field
+        label="Bins"
+        type="number"
+        v-model.number="trace_bins"
+        :rules="[() => trace_bins!=='' || 'This field is required']"
+        hint="Number of bins in the dispersion direction."
+        persistent-hint
+      >
+      </v-text-field>
+    </v-row>
+
+    <v-row v-if="trace_type_selected==='AutoTrace'">
+      <v-text-field
+        label="Window Width"
+        type="number"
+        v-model.number="trace_window"
+        :rules="[() => trace_window!=='' || 'This field is required']"
+        hint="Width of window to consider for peak finding."
+        persistent-hint
+      >
+      </v-text-field>
+    </v-row>
+
+    <v-row v-if="trace_type_selected==='AutoTrace'">
+      <v-select
+        :items="trace_peak_method_items"
+        v-model="trace_peak_method_selected"
+        label="Peak Method"
+        hint="Method to use for identifying the peak in each bin"
+        persistent-hint
+      ></v-select>
+    </v-row>
+
+    <plugin-add-results
+      :label.sync="trace_results_label"
+      :label_default="trace_results_label_default"
+      :label_auto.sync="trace_results_label_auto"
+      :label_invalid_msg="trace_results_label_invalid_msg"
+      :label_overwrite="trace_results_label_overwrite"
+      label_hint="Label for the trace"
+      :add_to_viewer_items="trace_add_to_viewer_items"
+      :add_to_viewer_selected.sync="trace_add_to_viewer_selected"
+      action_label="Create"
+      action_tooltip="Create Trace"
+      @click:action="create_trace"
+    ></plugin-add-results>
+
+    <j-plugin-section-header>Background</j-plugin-section-header>
+    <v-row>
+      <j-docs-link>Create a background and/or background-subtracted image.</j-docs-link>
+    </v-row>
+
+    <plugin-dataset-select
+      :items="bg_dataset_items"
+      :selected.sync="bg_dataset_selected"
+      :show_if_single_entry="false"
+      label="2D Spectrum"
+      hint="Select the data used to determine the background."
+    />
+
+    <v-row>
+      <v-select
+        :items="bg_type_items"
+        v-model="bg_type_selected"
+        label="Background Type"
+        hint="Method to use for creating background"
+        persistent-hint
+      ></v-select>
+    </v-row>
+
+    <plugin-dataset-select
+      :items="bg_trace_items"
+      :selected.sync="bg_trace_selected"
+      :show_if_single_entry="true"
+      label="Trace"
+      hint="Trace to use for determining the background region."
+    />
+
+    <v-row v-if="bg_trace_selected === 'Manual'">
+      <v-text-field
+        label="Pixel"
+        type="number"
+        v-model.number="bg_trace_pixel"
+        :rules="[() => bg_trace_pixel!=='' || 'This field is required']"
+        hint="Pixel number/column to use for the trace."
+        persistent-hint
+      >
+      </v-text-field>
+    </v-row>
+
+    <v-row v-if="['OneSided', 'TwoSided'].indexOf(bg_type_selected) !== -1">
+      <v-text-field
+        label="Separation"
+        type="number"
+        v-model.number="bg_separation"
+        :rules="[() => bg_separation!=='' || 'This field is required']"
+        hint="Separation between trace and background window(s), in pixels."
+        persistent-hint
+      >
+      </v-text-field>
+    </v-row>
+
+    <v-row>
+      <v-text-field
+        label="Width"
+        type="number"
+        v-model.number="bg_width"
+        :rules="[() => bg_width!=='' || 'This field is required']"
+        hint="Width of background window, in pixels."
+        persistent-hint
+      >
+      </v-text-field>
+    </v-row>
+
+    <plugin-add-results
+      :label.sync="bg_results_label"
+      :label_default="bg_results_label_default"
+      :label_auto.sync="bg_results_label_auto"
+      :label_invalid_msg="bg_results_label_invalid_msg"
+      :label_overwrite="bg_results_label_overwrite"
+      label_hint="Label for the background image"
+      :add_to_viewer_items="bg_add_to_viewer_items"
+      :add_to_viewer_selected.sync="bg_add_to_viewer_selected"
+      action_label="Background"
+      action_tooltip="Create Background Image"
+      @click:action="create_bg"
+    ></plugin-add-results>
+
+    <plugin-add-results
+      :label.sync="bg_sub_results_label"
+      :label_default="bg_sub_results_label_default"
+      :label_auto.sync="bg_sub_results_label_auto"
+      :label_invalid_msg="bg_sub_results_label_invalid_msg"
+      :label_overwrite="bg_sub_results_label_overwrite"
+      label_hint="Label for the background-subtracted image"
+      :add_to_viewer_items="bg_sub_add_to_viewer_items"
+      :add_to_viewer_selected.sync="bg_sub_add_to_viewer_selected"
+      action_label="Subtract"
+      action_tooltip="Create Background Subtracted Image"
+      @click:action="create_bg_sub"
+    ></plugin-add-results>
+
+
+    <j-plugin-section-header>Extraction</j-plugin-section-header>
+    <v-row>
+      <j-docs-link>Extract a 1D spectrum from a 2D spectrum.</j-docs-link>
+    </v-row>
+
+    <plugin-dataset-select
+      :items="ext_dataset_items"
+      :selected.sync="ext_dataset_selected"
+      :show_if_single_entry="false"
+      label="2D Spectrum"
+      hint="Select the data used to extract the spectrum."
+    />
+
+    <plugin-dataset-select
+      :items="ext_trace_items"
+      :selected.sync="ext_trace_selected"
+      :show_if_single_entry="true"
+      label="Trace"
+      hint="Trace to use for extracting the spectrum."
+    />
+
+    <v-row v-if="ext_trace_selected === 'Manual'">
+      <v-text-field
+        label="Pixel"
+        type="number"
+        v-model.number="ext_trace_pixel"
+        :rules="[() => ext_trace_pixel!=='' || 'This field is required']"
+        hint="Pixel number/column to use for the trace."
+        persistent-hint
+      >
+      </v-text-field>
+    </v-row>
+
+    <plugin-add-results
+      :label.sync="ext_results_label"
+      :label_default="ext_results_label_default"
+      :label_auto.sync="ext_results_label_auto"
+      :label_invalid_msg="ext_results_label_invalid_msg"
+      :label_overwrite="ext_results_label_overwrite"
+      label_hint="Label for the extracted 1D spectrum"
+      :add_to_viewer_items="ext_add_to_viewer_items"
+      :add_to_viewer_selected.sync="ext_add_to_viewer_selected"
+      action_label="Extract"
+      action_tooltip="Extract 1D Spectrum"
+      @click:action="extract"
+    ></plugin-add-results>
+
+
+    </div>  
+  </j-tray-plugin>
+</template>

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -96,19 +96,30 @@
       </v-row>
     </div>
 
-    <plugin-add-results
-      :label.sync="trace_results_label"
-      :label_default="trace_results_label_default"
-      :label_auto.sync="trace_results_label_auto"
-      :label_invalid_msg="trace_results_label_invalid_msg"
-      :label_overwrite="trace_results_label_overwrite"
-      label_hint="Label for the trace"
-      :add_to_viewer_items="trace_add_to_viewer_items"
-      :add_to_viewer_selected.sync="trace_add_to_viewer_selected"
-      action_label="Create"
-      action_tooltip="Create Trace"
-      @click:action="create_trace"
-    ></plugin-add-results>
+    <v-row>
+      <v-expansion-panels popout>
+        <v-expansion-panel>
+          <v-expansion-panel-header v-slot="{ open }">
+            <span style="padding: 6px">Export Results</span>
+          </v-expansion-panel-header>
+          <v-expansion-panel-content>
+            <plugin-add-results
+              :label.sync="trace_results_label"
+              :label_default="trace_results_label_default"
+              :label_auto.sync="trace_results_label_auto"
+              :label_invalid_msg="trace_results_label_invalid_msg"
+              :label_overwrite="trace_results_label_overwrite"
+              label_hint="Label for the trace"
+              :add_to_viewer_items="trace_add_to_viewer_items"
+              :add_to_viewer_selected.sync="trace_add_to_viewer_selected"
+              action_label="Create"
+              action_tooltip="Create Trace"
+              @click:action="create_trace"
+            ></plugin-add-results>
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </v-row>
 
     <j-plugin-section-header>Background</j-plugin-section-header>
     <v-row>
@@ -138,7 +149,7 @@
       :selected.sync="bg_trace_selected"
       :show_if_single_entry="true"
       label="Trace"
-      hint="Trace to use for determining the background region."
+      hint="Trace to use for determining the background region.  'From Plugin' uses trace defined in Trace section above."
     />
 
     <v-row v-if="bg_trace_selected === 'Manual'">
@@ -177,33 +188,46 @@
       </v-text-field>
     </v-row>
 
-    <plugin-add-results
-      :label.sync="bg_results_label"
-      :label_default="bg_results_label_default"
-      :label_auto.sync="bg_results_label_auto"
-      :label_invalid_msg="bg_results_label_invalid_msg"
-      :label_overwrite="bg_results_label_overwrite"
-      label_hint="Label for the background image"
-      :add_to_viewer_items="bg_add_to_viewer_items"
-      :add_to_viewer_selected.sync="bg_add_to_viewer_selected"
-      action_label="Background"
-      action_tooltip="Create Background Image"
-      @click:action="create_bg"
-    ></plugin-add-results>
+    <v-row>
+      <v-expansion-panels popout>
+        <v-expansion-panel>
+          <v-expansion-panel-header v-slot="{ open }">
+            <span style="padding: 6px">Export Results</span>
+          </v-expansion-panel-header>
+          <v-expansion-panel-content>
+            <plugin-add-results
+              :label.sync="bg_results_label"
+              :label_default="bg_results_label_default"
+              :label_auto.sync="bg_results_label_auto"
+              :label_invalid_msg="bg_results_label_invalid_msg"
+              :label_overwrite="bg_results_label_overwrite"
+              label_hint="Label for the background image"
+              :add_to_viewer_items="bg_add_to_viewer_items"
+              :add_to_viewer_selected.sync="bg_add_to_viewer_selected"
+              action_label="Background"
+              action_tooltip="Create Background Image"
+              @click:action="create_bg"
+            ></plugin-add-results>
 
-    <plugin-add-results
-      :label.sync="bg_sub_results_label"
-      :label_default="bg_sub_results_label_default"
-      :label_auto.sync="bg_sub_results_label_auto"
-      :label_invalid_msg="bg_sub_results_label_invalid_msg"
-      :label_overwrite="bg_sub_results_label_overwrite"
-      label_hint="Label for the background-subtracted image"
-      :add_to_viewer_items="bg_sub_add_to_viewer_items"
-      :add_to_viewer_selected.sync="bg_sub_add_to_viewer_selected"
-      action_label="Subtract"
-      action_tooltip="Create Background Subtracted Image"
-      @click:action="create_bg_sub"
-    ></plugin-add-results>
+            <plugin-add-results
+              :label.sync="bg_sub_results_label"
+              :label_default="bg_sub_results_label_default"
+              :label_auto.sync="bg_sub_results_label_auto"
+              :label_invalid_msg="bg_sub_results_label_invalid_msg"
+              :label_overwrite="bg_sub_results_label_overwrite"
+              label_hint="Label for the background-subtracted image"
+              :add_to_viewer_items="bg_sub_add_to_viewer_items"
+              :add_to_viewer_selected.sync="bg_sub_add_to_viewer_selected"
+              action_label="Subtract"
+              action_tooltip="Create Background Subtracted Image"
+              @click:action="create_bg_sub"
+            ></plugin-add-results>
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </v-row>
+
+
 
 
     <j-plugin-section-header>Extraction</j-plugin-section-header>
@@ -216,7 +240,7 @@
       :selected.sync="ext_dataset_selected"
       :show_if_single_entry="false"
       label="2D Spectrum"
-      hint="Select the data used to extract the spectrum."
+      hint="Select the data used to extract the spectrum.  'From Plugin' uses background-subtraced image defined in Background section above."
     />
 
     <plugin-dataset-select
@@ -224,7 +248,7 @@
       :selected.sync="ext_trace_selected"
       :show_if_single_entry="true"
       label="Trace"
-      hint="Trace to use for extracting the spectrum."
+      hint="Trace to use for extracting the spectrum.  'From Plugin' uses trace defined in Trace section above."
     />
 
     <v-row v-if="ext_trace_selected === 'Manual'">

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -10,68 +10,91 @@
     </v-row>
 
     <plugin-dataset-select
-      :items="trace_dataset_items"
-      :selected.sync="trace_dataset_selected"
+      :items="trace_trace_items"
+      :selected.sync="trace_trace_selected"
       :show_if_single_entry="false"
-      label="2D Spectrum"
-      hint="Select the data used to create the trace."
+      label="Trace"
+      hint="Existing trace to offset or create a new trace"
     />
 
-    <v-row>
-      <v-select
-        :items="trace_type_items"
-        v-model="trace_type_selected"
-        label="Trace Type"
-        hint="Method to use for creating trace"
-        persistent-hint
-      ></v-select>
-    </v-row>
+    <div v-if="trace_trace_selected !== 'New Trace'">
+      <v-row>
+        <v-text-field
+          label="Offset"
+          type="number"
+          v-model.number="trace_offset"
+          :rules="[() => trace_offset!=='' || 'This field is required']"
+          hint="Offset to apply to existing trace, in pixels."
+          persistent-hint
+        >
+        </v-text-field>
+      </v-row>
+    </div>
+    <div v-else>
+      <plugin-dataset-select
+        :items="trace_dataset_items"
+        :selected.sync="trace_dataset_selected"
+        :show_if_single_entry="false"
+        label="2D Spectrum"
+        hint="Select the data used to create the trace."
+      />
 
-    <v-row>
-      <v-text-field
-        label="Pixel"
-        type="number"
-        v-model.number="trace_pixel"
-        :rules="[() => trace_pixel!=='' || 'This field is required']"
-        hint="Pixel number/column to start the trace."
-        persistent-hint
-      >
-      </v-text-field>
-    </v-row>
+      <v-row>
+        <v-select
+          :items="trace_type_items"
+          v-model="trace_type_selected"
+          label="Trace Type"
+          hint="Method to use for creating trace"
+          persistent-hint
+        ></v-select>
+      </v-row>
 
-    <v-row v-if="trace_type_selected==='AutoTrace'">
-      <v-text-field
-        label="Bins"
-        type="number"
-        v-model.number="trace_bins"
-        :rules="[() => trace_bins!=='' || 'This field is required']"
-        hint="Number of bins in the dispersion direction."
-        persistent-hint
-      >
-      </v-text-field>
-    </v-row>
+      <v-row>
+        <v-text-field
+          label="Pixel"
+          type="number"
+          v-model.number="trace_pixel"
+          :rules="[() => trace_pixel!=='' || 'This field is required']"
+          hint="Pixel number/column to start the trace."
+          persistent-hint
+        >
+        </v-text-field>
+      </v-row>
 
-    <v-row v-if="trace_type_selected==='AutoTrace'">
-      <v-text-field
-        label="Window Width"
-        type="number"
-        v-model.number="trace_window"
-        :rules="[() => trace_window!=='' || 'This field is required']"
-        hint="Width of window to consider for peak finding."
-        persistent-hint
-      >
-      </v-text-field>
-    </v-row>
+      <v-row v-if="trace_type_selected==='AutoTrace'">
+        <v-text-field
+          label="Bins"
+          type="number"
+          v-model.number="trace_bins"
+          :rules="[() => trace_bins!=='' || 'This field is required']"
+          hint="Number of bins in the dispersion direction."
+          persistent-hint
+        >
+        </v-text-field>
+      </v-row>
 
-    <v-row v-if="trace_type_selected==='AutoTrace'">
-      <v-select
-        :items="trace_peak_method_items"
-        v-model="trace_peak_method_selected"
-        label="Peak Method"
-        hint="Method to use for identifying the peak in each bin"
-        persistent-hint
-      ></v-select>
-    </v-row>
+      <v-row v-if="trace_type_selected==='AutoTrace'">
+        <v-text-field
+          label="Window Width"
+          type="number"
+          v-model.number="trace_window"
+          :rules="[() => trace_window!=='' || 'This field is required']"
+          hint="Width of window to consider for peak finding."
+          persistent-hint
+        >
+        </v-text-field>
+      </v-row>
+
+      <v-row v-if="trace_type_selected==='AutoTrace'">
+        <v-select
+          :items="trace_peak_method_items"
+          v-model="trace_peak_method_selected"
+          label="Peak Method"
+          hint="Method to use for identifying the peak in each bin"
+          persistent-hint
+        ></v-select>
+      </v-row>
+    </div>
 
     <plugin-add-results
       :label.sync="trace_results_label"

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -4,6 +4,27 @@
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#spectral-extraction'"
     :popout_button="popout_button">
 
+    <v-row>
+      <v-expansion-panels popout>
+        <v-expansion-panel>
+          <v-expansion-panel-header v-slot="{ open }">
+            <span style="padding: 6px">Settings</span>
+          </v-expansion-panel-header>
+          <v-expansion-panel-content>
+            <v-row>
+              <v-switch
+                v-model="setting_interactive_extract"
+                label="Show live-extraction"
+                hint="Whether to compute/show extraction when making changes to input parameters.  Disable if live-preview becomes laggy."
+                persistent-hint
+              ></v-switch>
+            </v-row>
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </v-row>
+
+
     <div @mouseover="() => active_step='trace'">
       <j-plugin-section-header>Trace</j-plugin-section-header>
       <v-row>
@@ -62,7 +83,7 @@
           </v-text-field>
         </v-row>
 
-        <v-row v-if="trace_type_selected==='AutoTrace'">
+        <v-row v-if="trace_type_selected==='Auto'">
           <v-text-field
             label="Bins"
             type="number"
@@ -74,7 +95,7 @@
           </v-text-field>
         </v-row>
 
-        <v-row v-if="trace_type_selected==='AutoTrace'">
+        <v-row v-if="trace_type_selected==='Auto'">
           <v-text-field
             label="Window Width"
             type="number"
@@ -86,7 +107,7 @@
           </v-text-field>
         </v-row>
 
-        <v-row v-if="trace_type_selected==='AutoTrace'">
+        <v-row v-if="trace_type_selected==='Auto'">
           <v-select
             :items="trace_peak_method_items"
             v-model="trace_peak_method_selected"
@@ -147,15 +168,7 @@
         ></v-select>
       </v-row>
 
-      <plugin-dataset-select
-        :items="bg_trace_items"
-        :selected.sync="bg_trace_selected"
-        :show_if_single_entry="true"
-        label="Trace"
-        hint="Trace to use for determining the background region.  'From Plugin' uses trace defined in Trace section above."
-      />
-
-      <v-row v-if="bg_trace_selected === 'Manual'">
+      <v-row v-if="bg_type_selected === 'Manual'">
         <v-text-field
           label="Pixel"
           type="number"
@@ -254,26 +267,6 @@
         label="2D Spectrum"
         hint="Select the data used to extract the spectrum.  'From Plugin' uses background-subtraced image defined in Background section above."
       />
-
-      <plugin-dataset-select
-        :items="ext_trace_items"
-        :selected.sync="ext_trace_selected"
-        :show_if_single_entry="true"
-        label="Trace"
-        hint="Trace to use for extracting the spectrum.  'From Plugin' uses trace defined in Trace section above."
-      />
-
-      <v-row v-if="ext_trace_selected === 'Manual'">
-        <v-text-field
-          label="Pixel"
-          type="number"
-          v-model.number="ext_trace_pixel"
-          :rules="[() => ext_trace_pixel!=='' || 'This field is required']"
-          hint="Pixel number/column to use for the trace."
-          persistent-hint
-        >
-        </v-text-field>
-      </v-row>
 
       <v-row>
         <v-text-field

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -4,300 +4,303 @@
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#spectral-extraction'"
     :popout_button="popout_button">
 
-    <j-plugin-section-header>Trace</j-plugin-section-header>
-    <v-row>
-      <j-docs-link>Create a trace for the spectrum.</j-docs-link>
-    </v-row>
-
-    <plugin-dataset-select
-      :items="trace_trace_items"
-      :selected.sync="trace_trace_selected"
-      :show_if_single_entry="false"
-      label="Trace"
-      hint="Existing trace to offset or create a new trace"
-    />
-
-    <div v-if="trace_trace_selected !== 'New Trace'">
+    <div @mouseover="() => active_step='trace'">
+      <j-plugin-section-header>Trace</j-plugin-section-header>
       <v-row>
-        <v-text-field
-          label="Offset"
-          type="number"
-          v-model.number="trace_offset"
-          :rules="[() => trace_offset!=='' || 'This field is required']"
-          hint="Offset to apply to existing trace, in pixels."
-          persistent-hint
-        >
-        </v-text-field>
+        <j-docs-link>Create a trace for the spectrum.</j-docs-link>
+      </v-row>
+
+      <plugin-dataset-select
+        :items="trace_trace_items"
+        :selected.sync="trace_trace_selected"
+        :show_if_single_entry="false"
+        label="Trace"
+        hint="Existing trace to offset or create a new trace"
+      />
+
+      <div v-if="trace_trace_selected !== 'New Trace'">
+        <v-row>
+          <v-text-field
+            label="Offset"
+            type="number"
+            v-model.number="trace_offset"
+            :rules="[() => trace_offset!=='' || 'This field is required']"
+            hint="Offset to apply to existing trace, in pixels."
+            persistent-hint
+          >
+          </v-text-field>
+        </v-row>
+      </div>
+      <div v-else>
+        <plugin-dataset-select
+          :items="trace_dataset_items"
+          :selected.sync="trace_dataset_selected"
+          :show_if_single_entry="false"
+          label="2D Spectrum"
+          hint="Select the data used to create the trace."
+        />
+
+        <v-row>
+          <v-select
+            :items="trace_type_items"
+            v-model="trace_type_selected"
+            label="Trace Type"
+            hint="Method to use for creating trace"
+            persistent-hint
+          ></v-select>
+        </v-row>
+
+        <v-row>
+          <v-text-field
+            label="Pixel"
+            type="number"
+            v-model.number="trace_pixel"
+            :rules="[() => trace_pixel!=='' || 'This field is required']"
+            hint="Pixel number/column to start the trace."
+            persistent-hint
+          >
+          </v-text-field>
+        </v-row>
+
+        <v-row v-if="trace_type_selected==='AutoTrace'">
+          <v-text-field
+            label="Bins"
+            type="number"
+            v-model.number="trace_bins"
+            :rules="[() => trace_bins!=='' || 'This field is required']"
+            hint="Number of bins in the dispersion direction."
+            persistent-hint
+          >
+          </v-text-field>
+        </v-row>
+
+        <v-row v-if="trace_type_selected==='AutoTrace'">
+          <v-text-field
+            label="Window Width"
+            type="number"
+            v-model.number="trace_window"
+            :rules="[() => trace_window!=='' || 'This field is required']"
+            hint="Width of window to consider for peak finding."
+            persistent-hint
+          >
+          </v-text-field>
+        </v-row>
+
+        <v-row v-if="trace_type_selected==='AutoTrace'">
+          <v-select
+            :items="trace_peak_method_items"
+            v-model="trace_peak_method_selected"
+            label="Peak Method"
+            hint="Method to use for identifying the peak in each bin"
+            persistent-hint
+          ></v-select>
+        </v-row>
+      </div>
+
+      <v-row>
+        <v-expansion-panels popout>
+          <v-expansion-panel>
+            <v-expansion-panel-header v-slot="{ open }">
+              <span style="padding: 6px">Export Trace</span>
+            </v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <plugin-add-results
+                :label.sync="trace_results_label"
+                :label_default="trace_results_label_default"
+                :label_auto.sync="trace_results_label_auto"
+                :label_invalid_msg="trace_results_label_invalid_msg"
+                :label_overwrite="trace_results_label_overwrite"
+                label_hint="Label for the trace"
+                :add_to_viewer_items="trace_add_to_viewer_items"
+                :add_to_viewer_selected.sync="trace_add_to_viewer_selected"
+                action_label="Create"
+                action_tooltip="Create Trace"
+                @click:action="create_trace"
+              ></plugin-add-results>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
       </v-row>
     </div>
-    <div v-else>
+
+    <div @mouseover="() => active_step='bg'">
+      <j-plugin-section-header>Background</j-plugin-section-header>
+      <v-row>
+        <j-docs-link>Create a background and/or background-subtracted image.</j-docs-link>
+      </v-row>
+
       <plugin-dataset-select
-        :items="trace_dataset_items"
-        :selected.sync="trace_dataset_selected"
+        :items="bg_dataset_items"
+        :selected.sync="bg_dataset_selected"
         :show_if_single_entry="false"
         label="2D Spectrum"
-        hint="Select the data used to create the trace."
+        hint="Select the data used to determine the background."
       />
 
       <v-row>
         <v-select
-          :items="trace_type_items"
-          v-model="trace_type_selected"
-          label="Trace Type"
-          hint="Method to use for creating trace"
+          :items="bg_type_items"
+          v-model="bg_type_selected"
+          label="Background Type"
+          hint="Method to use for creating background"
           persistent-hint
         ></v-select>
+      </v-row>
+
+      <plugin-dataset-select
+        :items="bg_trace_items"
+        :selected.sync="bg_trace_selected"
+        :show_if_single_entry="true"
+        label="Trace"
+        hint="Trace to use for determining the background region.  'From Plugin' uses trace defined in Trace section above."
+      />
+
+      <v-row v-if="bg_trace_selected === 'Manual'">
+        <v-text-field
+          label="Pixel"
+          type="number"
+          v-model.number="bg_trace_pixel"
+          :rules="[() => bg_trace_pixel!=='' || 'This field is required']"
+          hint="Pixel number/column to use for the trace."
+          persistent-hint
+        >
+        </v-text-field>
+      </v-row>
+
+      <v-row v-if="['OneSided', 'TwoSided'].indexOf(bg_type_selected) !== -1">
+        <v-text-field
+          label="Separation"
+          type="number"
+          v-model.number="bg_separation"
+          :rules="[() => bg_separation!=='' || 'This field is required']"
+          hint="Separation between trace and background window(s), in pixels."
+          persistent-hint
+        >
+        </v-text-field>
       </v-row>
 
       <v-row>
         <v-text-field
-          label="Pixel"
+          label="Width"
           type="number"
-          v-model.number="trace_pixel"
-          :rules="[() => trace_pixel!=='' || 'This field is required']"
-          hint="Pixel number/column to start the trace."
+          v-model.number="bg_width"
+          :rules="[() => bg_width!=='' || 'This field is required']"
+          hint="Width of background window, in pixels."
           persistent-hint
         >
         </v-text-field>
       </v-row>
 
-      <v-row v-if="trace_type_selected==='AutoTrace'">
-        <v-text-field
-          label="Bins"
-          type="number"
-          v-model.number="trace_bins"
-          :rules="[() => trace_bins!=='' || 'This field is required']"
-          hint="Number of bins in the dispersion direction."
-          persistent-hint
-        >
-        </v-text-field>
+      <v-row>
+        <v-expansion-panels popout>
+          <v-expansion-panel>
+            <v-expansion-panel-header v-slot="{ open }">
+              <span style="padding: 6px">Export Background</span>
+            </v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <plugin-add-results
+                :label.sync="bg_results_label"
+                :label_default="bg_results_label_default"
+                :label_auto.sync="bg_results_label_auto"
+                :label_invalid_msg="bg_results_label_invalid_msg"
+                :label_overwrite="bg_results_label_overwrite"
+                label_hint="Label for the background image"
+                :add_to_viewer_items="bg_add_to_viewer_items"
+                :add_to_viewer_selected.sync="bg_add_to_viewer_selected"
+                action_label="Background"
+                action_tooltip="Create Background Image"
+                @click:action="create_bg"
+              ></plugin-add-results>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
       </v-row>
-
-      <v-row v-if="trace_type_selected==='AutoTrace'">
-        <v-text-field
-          label="Window Width"
-          type="number"
-          v-model.number="trace_window"
-          :rules="[() => trace_window!=='' || 'This field is required']"
-          hint="Width of window to consider for peak finding."
-          persistent-hint
-        >
-        </v-text-field>
-      </v-row>
-
-      <v-row v-if="trace_type_selected==='AutoTrace'">
-        <v-select
-          :items="trace_peak_method_items"
-          v-model="trace_peak_method_selected"
-          label="Peak Method"
-          hint="Method to use for identifying the peak in each bin"
-          persistent-hint
-        ></v-select>
+      <v-row>
+        <v-expansion-panels popout>
+          <v-expansion-panel>
+            <v-expansion-panel-header v-slot="{ open }">
+              <span style="padding: 6px">Export Subtracted</span>
+            </v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <plugin-add-results
+                :label.sync="bg_sub_results_label"
+                :label_default="bg_sub_results_label_default"
+                :label_auto.sync="bg_sub_results_label_auto"
+                :label_invalid_msg="bg_sub_results_label_invalid_msg"
+                :label_overwrite="bg_sub_results_label_overwrite"
+                label_hint="Label for the background-subtracted image"
+                :add_to_viewer_items="bg_sub_add_to_viewer_items"
+                :add_to_viewer_selected.sync="bg_sub_add_to_viewer_selected"
+                action_label="Subtract"
+                action_tooltip="Create Background Subtracted Image"
+                @click:action="create_bg_sub"
+              ></plugin-add-results>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
       </v-row>
     </div>
 
-    <v-row>
-      <v-expansion-panels popout>
-        <v-expansion-panel>
-          <v-expansion-panel-header v-slot="{ open }">
-            <span style="padding: 6px">Export Trace</span>
-          </v-expansion-panel-header>
-          <v-expansion-panel-content>
-            <plugin-add-results
-              :label.sync="trace_results_label"
-              :label_default="trace_results_label_default"
-              :label_auto.sync="trace_results_label_auto"
-              :label_invalid_msg="trace_results_label_invalid_msg"
-              :label_overwrite="trace_results_label_overwrite"
-              label_hint="Label for the trace"
-              :add_to_viewer_items="trace_add_to_viewer_items"
-              :add_to_viewer_selected.sync="trace_add_to_viewer_selected"
-              action_label="Create"
-              action_tooltip="Create Trace"
-              @click:action="create_trace"
-            ></plugin-add-results>
-          </v-expansion-panel-content>
-        </v-expansion-panel>
-      </v-expansion-panels>
-    </v-row>
+    <div @mouseover="() => active_step='ext'">
+      <j-plugin-section-header>Extraction</j-plugin-section-header>
+      <v-row>
+        <j-docs-link>Extract a 1D spectrum from a 2D spectrum.</j-docs-link>
+      </v-row>
 
-    <j-plugin-section-header>Background</j-plugin-section-header>
-    <v-row>
-      <j-docs-link>Create a background and/or background-subtracted image.</j-docs-link>
-    </v-row>
+      <plugin-dataset-select
+        :items="ext_dataset_items"
+        :selected.sync="ext_dataset_selected"
+        :show_if_single_entry="false"
+        label="2D Spectrum"
+        hint="Select the data used to extract the spectrum.  'From Plugin' uses background-subtraced image defined in Background section above."
+      />
 
-    <plugin-dataset-select
-      :items="bg_dataset_items"
-      :selected.sync="bg_dataset_selected"
-      :show_if_single_entry="false"
-      label="2D Spectrum"
-      hint="Select the data used to determine the background."
-    />
+      <plugin-dataset-select
+        :items="ext_trace_items"
+        :selected.sync="ext_trace_selected"
+        :show_if_single_entry="true"
+        label="Trace"
+        hint="Trace to use for extracting the spectrum.  'From Plugin' uses trace defined in Trace section above."
+      />
 
-    <v-row>
-      <v-select
-        :items="bg_type_items"
-        v-model="bg_type_selected"
-        label="Background Type"
-        hint="Method to use for creating background"
-        persistent-hint
-      ></v-select>
-    </v-row>
+      <v-row v-if="ext_trace_selected === 'Manual'">
+        <v-text-field
+          label="Pixel"
+          type="number"
+          v-model.number="ext_trace_pixel"
+          :rules="[() => ext_trace_pixel!=='' || 'This field is required']"
+          hint="Pixel number/column to use for the trace."
+          persistent-hint
+        >
+        </v-text-field>
+      </v-row>
 
-    <plugin-dataset-select
-      :items="bg_trace_items"
-      :selected.sync="bg_trace_selected"
-      :show_if_single_entry="true"
-      label="Trace"
-      hint="Trace to use for determining the background region.  'From Plugin' uses trace defined in Trace section above."
-    />
+      <v-row>
+        <v-text-field
+          label="Width"
+          type="number"
+          v-model.number="ext_width"
+          :rules="[() => ext_width!=='' || 'This field is required']"
+          hint="Width of extraction window, in pixels."
+          persistent-hint
+        >
+        </v-text-field>
+      </v-row>
 
-    <v-row v-if="bg_trace_selected === 'Manual'">
-      <v-text-field
-        label="Pixel"
-        type="number"
-        v-model.number="bg_trace_pixel"
-        :rules="[() => bg_trace_pixel!=='' || 'This field is required']"
-        hint="Pixel number/column to use for the trace."
-        persistent-hint
-      >
-      </v-text-field>
-    </v-row>
-
-    <v-row v-if="['OneSided', 'TwoSided'].indexOf(bg_type_selected) !== -1">
-      <v-text-field
-        label="Separation"
-        type="number"
-        v-model.number="bg_separation"
-        :rules="[() => bg_separation!=='' || 'This field is required']"
-        hint="Separation between trace and background window(s), in pixels."
-        persistent-hint
-      >
-      </v-text-field>
-    </v-row>
-
-    <v-row>
-      <v-text-field
-        label="Width"
-        type="number"
-        v-model.number="bg_width"
-        :rules="[() => bg_width!=='' || 'This field is required']"
-        hint="Width of background window, in pixels."
-        persistent-hint
-      >
-      </v-text-field>
-    </v-row>
-
-    <v-row>
-      <v-expansion-panels popout>
-        <v-expansion-panel>
-          <v-expansion-panel-header v-slot="{ open }">
-            <span style="padding: 6px">Export Background</span>
-          </v-expansion-panel-header>
-          <v-expansion-panel-content>
-            <plugin-add-results
-              :label.sync="bg_results_label"
-              :label_default="bg_results_label_default"
-              :label_auto.sync="bg_results_label_auto"
-              :label_invalid_msg="bg_results_label_invalid_msg"
-              :label_overwrite="bg_results_label_overwrite"
-              label_hint="Label for the background image"
-              :add_to_viewer_items="bg_add_to_viewer_items"
-              :add_to_viewer_selected.sync="bg_add_to_viewer_selected"
-              action_label="Background"
-              action_tooltip="Create Background Image"
-              @click:action="create_bg"
-            ></plugin-add-results>
-          </v-expansion-panel-content>
-        </v-expansion-panel>
-      </v-expansion-panels>
-    </v-row>
-    <v-row>
-      <v-expansion-panels popout>
-        <v-expansion-panel>
-          <v-expansion-panel-header v-slot="{ open }">
-            <span style="padding: 6px">Export Subtracted</span>
-          </v-expansion-panel-header>
-          <v-expansion-panel-content>
-            <plugin-add-results
-              :label.sync="bg_sub_results_label"
-              :label_default="bg_sub_results_label_default"
-              :label_auto.sync="bg_sub_results_label_auto"
-              :label_invalid_msg="bg_sub_results_label_invalid_msg"
-              :label_overwrite="bg_sub_results_label_overwrite"
-              label_hint="Label for the background-subtracted image"
-              :add_to_viewer_items="bg_sub_add_to_viewer_items"
-              :add_to_viewer_selected.sync="bg_sub_add_to_viewer_selected"
-              action_label="Subtract"
-              action_tooltip="Create Background Subtracted Image"
-              @click:action="create_bg_sub"
-            ></plugin-add-results>
-          </v-expansion-panel-content>
-        </v-expansion-panel>
-      </v-expansion-panels>
-    </v-row>
-
-
-
-    <j-plugin-section-header>Extraction</j-plugin-section-header>
-    <v-row>
-      <j-docs-link>Extract a 1D spectrum from a 2D spectrum.</j-docs-link>
-    </v-row>
-
-    <plugin-dataset-select
-      :items="ext_dataset_items"
-      :selected.sync="ext_dataset_selected"
-      :show_if_single_entry="false"
-      label="2D Spectrum"
-      hint="Select the data used to extract the spectrum.  'From Plugin' uses background-subtraced image defined in Background section above."
-    />
-
-    <plugin-dataset-select
-      :items="ext_trace_items"
-      :selected.sync="ext_trace_selected"
-      :show_if_single_entry="true"
-      label="Trace"
-      hint="Trace to use for extracting the spectrum.  'From Plugin' uses trace defined in Trace section above."
-    />
-
-    <v-row v-if="ext_trace_selected === 'Manual'">
-      <v-text-field
-        label="Pixel"
-        type="number"
-        v-model.number="ext_trace_pixel"
-        :rules="[() => ext_trace_pixel!=='' || 'This field is required']"
-        hint="Pixel number/column to use for the trace."
-        persistent-hint
-      >
-      </v-text-field>
-    </v-row>
-
-    <v-row>
-      <v-text-field
-        label="Width"
-        type="number"
-        v-model.number="ext_width"
-        :rules="[() => ext_width!=='' || 'This field is required']"
-        hint="Width of extraction window, in pixels."
-        persistent-hint
-      >
-      </v-text-field>
-    </v-row>
-
-    <plugin-add-results
-      :label.sync="ext_results_label"
-      :label_default="ext_results_label_default"
-      :label_auto.sync="ext_results_label_auto"
-      :label_invalid_msg="ext_results_label_invalid_msg"
-      :label_overwrite="ext_results_label_overwrite"
-      label_hint="Label for the extracted 1D spectrum"
-      :add_to_viewer_items="ext_add_to_viewer_items"
-      :add_to_viewer_selected.sync="ext_add_to_viewer_selected"
-      action_label="Extract"
-      action_tooltip="Extract 1D Spectrum"
-      @click:action="extract"
-    ></plugin-add-results>
-
+      <plugin-add-results
+        :label.sync="ext_results_label"
+        :label_default="ext_results_label_default"
+        :label_auto.sync="ext_results_label_auto"
+        :label_invalid_msg="ext_results_label_invalid_msg"
+        :label_overwrite="ext_results_label_overwrite"
+        label_hint="Label for the extracted 1D spectrum"
+        :add_to_viewer_items="ext_add_to_viewer_items"
+        :add_to_viewer_selected.sync="ext_add_to_viewer_selected"
+        action_label="Extract"
+        action_tooltip="Extract 1D Spectrum"
+        @click:action="extract"
+      ></plugin-add-results>
+    </div>
 
     </div>  
   </j-tray-plugin>

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -100,7 +100,7 @@
       <v-expansion-panels popout>
         <v-expansion-panel>
           <v-expansion-panel-header v-slot="{ open }">
-            <span style="padding: 6px">Export Results</span>
+            <span style="padding: 6px">Export Trace</span>
           </v-expansion-panel-header>
           <v-expansion-panel-content>
             <plugin-add-results
@@ -192,7 +192,7 @@
       <v-expansion-panels popout>
         <v-expansion-panel>
           <v-expansion-panel-header v-slot="{ open }">
-            <span style="padding: 6px">Export Results</span>
+            <span style="padding: 6px">Export Background</span>
           </v-expansion-panel-header>
           <v-expansion-panel-content>
             <plugin-add-results
@@ -208,7 +208,17 @@
               action_tooltip="Create Background Image"
               @click:action="create_bg"
             ></plugin-add-results>
-
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </v-row>
+    <v-row>
+      <v-expansion-panels popout>
+        <v-expansion-panel>
+          <v-expansion-panel-header v-slot="{ open }">
+            <span style="padding: 6px">Export Subtracted</span>
+          </v-expansion-panel-header>
+          <v-expansion-panel-content>
             <plugin-add-results
               :label.sync="bg_sub_results_label"
               :label_default="bg_sub_results_label_default"
@@ -226,7 +236,6 @@
         </v-expansion-panel>
       </v-expansion-panels>
     </v-row>
-
 
 
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -106,16 +106,6 @@
           >
           </v-text-field>
         </v-row>
-
-        <v-row v-if="trace_type_selected==='Auto'">
-          <v-select
-            :items="trace_peak_method_items"
-            v-model="trace_peak_method_selected"
-            label="Peak Method"
-            hint="Method to use for identifying the peak in each bin"
-            persistent-hint
-          ></v-select>
-        </v-row>
       </div>
 
       <v-row>

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -1,4 +1,28 @@
+import pytest
+from asdf.asdf import AsdfWarning
+from astropy.utils.data import download_file
 
-def test_plugin(specviz2d_helper, spectrum2d):
-    label = "Test 1D Spectrum"
-    specviz2d_helper.load_spectrum(spectrum2d, data_label=label)
+from specreduce import tracing
+
+
+@pytest.mark.remote_data
+def test_plugin(specviz2d_helper):
+    fn = download_file('https://stsci.box.com/shared/static/exnkul627fcuhy5akf2gswytud5tazmw.fits', cache=True)  # noqa
+
+    with pytest.warns(AsdfWarning, match='jwextension'):
+        specviz2d_helper.load_data(spectrum_2d=fn)
+
+    pext = specviz2d_helper.app.get_tray_item_from_name('spectral-extraction')
+
+    trace = pext.create_trace()
+    assert isinstance(trace, tracing.FlatTrace)
+
+    pext.trace_trace_selected = 'trace'
+    pext.trace_offset = 2
+    trace = pext.create_trace()
+    assert isinstance(trace, tracing.FlatTrace)
+
+    pext.trace_trace_selected = 'New Trace'
+    pext.trace_type_selected = 'AutoTrace'
+    trace = pext.create_trace()
+    assert isinstance(trace, tracing.KosmosTrace)

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -1,0 +1,4 @@
+
+def test_plugin(specviz2d_helper, spectrum2d):
+    label = "Test 1D Spectrum"
+    specviz2d_helper.load_spectrum(spectrum2d, data_label=label)

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -28,6 +28,7 @@ def test_plugin(specviz2d_helper):
     assert len(pext.marks['trace'].x) > 0
 
     # create FlatTrace
+    pext.trace_type_selected = 'Flat'
     pext.trace_pixel = 28
     trace = pext.create_trace()
     assert isinstance(trace, tracing.FlatTrace)
@@ -40,7 +41,7 @@ def test_plugin(specviz2d_helper):
 
     # create KosmosTrace
     pext.trace_trace_selected = 'New Trace'
-    pext.trace_type_selected = 'AutoTrace'
+    pext.trace_type_selected = 'Auto'
     trace = pext.create_trace()
     assert isinstance(trace, tracing.KosmosTrace)
 
@@ -48,13 +49,14 @@ def test_plugin(specviz2d_helper):
     assert len(sp2dv.figure.marks) == 23
 
     # interact with background section, check marks
-    pext.bg_separation = 3
-    pext.bg_width = 1
+    pext.trace_type_selected = 'Flat'
+    pext.bg_separation = 5
+    pext.bg_width = 3
     pext.bg_type_selected = 'TwoSided'
     for mark in ['bg1_center', 'bg2_center']:
         assert pext.marks[mark].visible is True
         assert len(pext.marks[mark].x) > 0
-    pext.bg_type_selected = 'Trace'
+    pext.bg_type_selected = 'Manual'
     assert len(pext.marks['bg1_center'].x) == 0
     assert len(pext.marks['bg2_center'].x) == 0
     assert len(pext.marks['bg1_lower'].x) > 0
@@ -64,9 +66,6 @@ def test_plugin(specviz2d_helper):
     assert len(pext.marks['bg2_center'].x) == 0
 
     # create background image
-    pext.bg_trace_selected = 'Manual'
-    pext.bg_trace_pixel = 20
-    pext.bg_separation = -8
     bg = pext.create_bg()
     assert isinstance(bg, Spectrum1D)
     bg_sub = pext.create_bg_sub()

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -33,20 +33,10 @@ def test_plugin(specviz2d_helper):
     trace = pext.create_trace()
     assert isinstance(trace, tracing.FlatTrace)
 
-    # offset existing trace
-    pext.trace_trace_selected = 'trace'
-    pext.trace_offset = 2
-    trace = pext.create_trace()
-    assert isinstance(trace, tracing.ArrayTrace)
-
     # create KosmosTrace
-    pext.trace_trace_selected = 'New Trace'
     pext.trace_type_selected = 'Auto'
     trace = pext.create_trace()
     assert isinstance(trace, tracing.KosmosTrace)
-
-    # 3 new trace objects should have been loaded and plotted in the spectrum-2d-viewer
-    assert len(sp2dv.figure.marks) == 23
 
     # interact with background section, check marks
     pext.trace_type_selected = 'Flat'

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -23,7 +23,7 @@ def test_plugin(specviz2d_helper):
     tray_names = [ti['name'] for ti in specviz2d_helper.app.state.tray_items]
     plugin_index = tray_names.index('spectral-extraction')
     specviz2d_helper.app.state.tray_items_open = [plugin_index]
-    assert len(sp2dv.figure.marks) == 20
+    assert len(sp2dv.figure.marks) == 11
     assert pext.marks['trace'].visible is True
     assert len(pext.marks['trace'].x) > 0
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -3,6 +3,7 @@ from asdf.asdf import AsdfWarning
 from astropy.utils.data import download_file
 
 from specreduce import tracing
+from specutils import Spectrum1D
 
 
 @pytest.mark.remote_data
@@ -14,15 +15,71 @@ def test_plugin(specviz2d_helper):
 
     pext = specviz2d_helper.app.get_tray_item_from_name('spectral-extraction')
 
+    # test trace marks - won't be created until after opening the plugin
+    sp2dv = specviz2d_helper.app.get_viewer('spectrum-2d-viewer')
+    assert len(sp2dv.figure.marks) == 2
+
+    specviz2d_helper.app.state.drawer = True
+    tray_names = [ti['name'] for ti in specviz2d_helper.app.state.tray_items]
+    plugin_index = tray_names.index('spectral-extraction')
+    specviz2d_helper.app.state.tray_items_open = [plugin_index]
+    assert len(sp2dv.figure.marks) == 20
+    assert pext.marks['trace'].visible is True
+    assert len(pext.marks['trace'].x) > 0
+
+    # create FlatTrace
+    pext.trace_pixel = 28
     trace = pext.create_trace()
     assert isinstance(trace, tracing.FlatTrace)
 
+    # offset existing trace
     pext.trace_trace_selected = 'trace'
     pext.trace_offset = 2
     trace = pext.create_trace()
-    assert isinstance(trace, tracing.FlatTrace)
+    assert isinstance(trace, tracing.ArrayTrace)
 
+    # create KosmosTrace
     pext.trace_trace_selected = 'New Trace'
     pext.trace_type_selected = 'AutoTrace'
     trace = pext.create_trace()
     assert isinstance(trace, tracing.KosmosTrace)
+
+    # 3 new trace objects should have been loaded and plotted in the spectrum-2d-viewer
+    assert len(sp2dv.figure.marks) == 23
+
+    # interact with background section, check marks
+    pext.bg_separation = 3
+    pext.bg_width = 1
+    pext.bg_type_selected = 'TwoSided'
+    for mark in ['bg1_center', 'bg2_center']:
+        assert pext.marks[mark].visible is True
+        assert len(pext.marks[mark].x) > 0
+    pext.bg_type_selected = 'Trace'
+    assert len(pext.marks['bg1_center'].x) == 0
+    assert len(pext.marks['bg2_center'].x) == 0
+    assert len(pext.marks['bg1_lower'].x) > 0
+    pext.bg_type_selected = 'OneSided'
+    # only bg1 is populated for OneSided
+    assert len(pext.marks['bg1_center'].x) > 0
+    assert len(pext.marks['bg2_center'].x) == 0
+
+    # create background image
+    pext.bg_trace_selected = 'Manual'
+    pext.bg_trace_pixel = 20
+    pext.bg_separation = -8
+    bg = pext.create_bg()
+    assert isinstance(bg, Spectrum1D)
+    bg_sub = pext.create_bg_sub()
+    assert isinstance(bg_sub, Spectrum1D)
+
+    # interact with extraction section, check marks
+    pext.ext_width = 1
+    for mark in ['bg1_center', 'bg2_center']:
+        assert pext.marks[mark].visible is False
+    for mark in ['ext_lower', 'ext_upper']:
+        assert pext.marks[mark].visible is True
+        assert len(pext.marks[mark].x) > 0
+
+    # create subtracted spectrum
+    sp_ext = pext.create_extract()
+    assert isinstance(sp_ext, Spectrum1D)

--- a/jdaviz/configs/specviz2d/specviz2d.yaml
+++ b/jdaviz/configs/specviz2d/specviz2d.yaml
@@ -15,6 +15,7 @@ tray:
   - g-metadata-viewer
   - g-plot-options
   - g-subset-plugin
+  - spectral-extraction
   - g-gaussian-smooth
   - g-model-fitting
   - g-unit-conversion

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -22,7 +22,6 @@ def test_2d_parser(specviz2d_helper):
     dc_1 = specviz2d_helper.app.data_collection[1]
     assert dc_1.label == 'Spectrum 1D'
     assert 'header' not in dc_1.meta
-    assert dc_1.meta['NAXIS'] == 2
 
 
 def test_1d_parser(specviz2d_helper, spectrum1d):

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -10,6 +10,7 @@ from jdaviz.core.events import (SliceToolStateMessage, LineIdentifyMessage,
 
 __all__ = ['OffscreenLinesMarks', 'BaseSpectrumVerticalLine', 'SpectralLine',
            'SliceIndicatorMarks', 'ShadowMixin', 'ShadowLine', 'ShadowLabelFixedY',
+           'PluginLine', 'TraceLine',
            'LineAnalysisContinuum', 'LineAnalysisContinuumCenter',
            'LineAnalysisContinuumLeft', 'LineAnalysisContinuumRight',
            'LineUncertainties', 'ScatterMask', 'SelectedSpaxel']
@@ -430,18 +431,22 @@ class ShadowLabelFixedY(Label, ShadowMixin):
             self._update_align()
 
 
-class LineAnalysisContinuum(Lines, HubListener):
+class PluginLine(Lines, HubListener):
     def __init__(self, viewer, x=[], y=[], **kwargs):
-        # we do not need to worry about the x-units changing since the stats
-        # need to be re-computed on unit conversion anyways (which will
-        # trigger updates to x and y from the line analysis plugin)
-
         # color is same blue as import button
         super().__init__(x=x, y=y, colors=["#007BA1"], scales=viewer.scales, **kwargs)
 
     def update_xy(self, x, y):
         self.x = x
         self.y = y
+
+
+class TraceLine(PluginLine):
+    pass
+
+
+class LineAnalysisContinuum(PluginLine):
+    pass
 
 
 class LineAnalysisContinuumCenter(LineAnalysisContinuum):

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -10,7 +10,7 @@ from jdaviz.core.events import (SliceToolStateMessage, LineIdentifyMessage,
 
 __all__ = ['OffscreenLinesMarks', 'BaseSpectrumVerticalLine', 'SpectralLine',
            'SliceIndicatorMarks', 'ShadowMixin', 'ShadowLine', 'ShadowLabelFixedY',
-           'PluginLine', 'TraceLine',
+           'PluginLine',
            'LineAnalysisContinuum', 'LineAnalysisContinuumCenter',
            'LineAnalysisContinuumLeft', 'LineAnalysisContinuumRight',
            'LineUncertainties', 'ScatterMask', 'SelectedSpaxel']
@@ -442,10 +442,6 @@ class PluginLine(Lines, HubListener):
 
     def clear(self):
         self.update_xy([], [])
-
-
-class TraceLine(PluginLine):
-    pass
 
 
 class LineAnalysisContinuum(PluginLine):

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -440,6 +440,9 @@ class PluginLine(Lines, HubListener):
         self.x = x
         self.y = y
 
+    def clear(self):
+        self.update_xy([], [])
+
 
 class TraceLine(PluginLine):
     pass

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from astropy import units as u
 from bqplot import LinearScale
 from bqplot.marks import Lines, Label, Scatter
@@ -437,8 +439,8 @@ class PluginLine(Lines, HubListener):
         super().__init__(x=x, y=y, colors=["#007BA1"], scales=viewer.scales, **kwargs)
 
     def update_xy(self, x, y):
-        self.x = x
-        self.y = y
+        self.x = np.asarray(x)
+        self.y = np.asarray(y)
 
     def clear(self):
         self.update_xy([], [])

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1291,7 +1291,8 @@ class AddResults(BasePluginComponent):
     """
     def __init__(self, plugin, label, label_default, label_auto,
                  label_invalid_msg, label_overwrite,
-                 add_to_viewer_items, add_to_viewer_selected):
+                 add_to_viewer_items, add_to_viewer_selected,
+                 label_whitelist_overwrite=[]):
         super().__init__(plugin, label=label,
                          label_default=label_default, label_auto=label_auto,
                          label_invalid_msg=label_invalid_msg, label_overwrite=label_overwrite,
@@ -1303,6 +1304,9 @@ class AddResults(BasePluginComponent):
                            handler=lambda _: self._on_label_changed())
         self.hub.subscribe(self, DataCollectionDeleteMessage,
                            handler=lambda _: self._on_label_changed())
+
+        # allows overwriting specific data entries not from the same plugin
+        self.label_whitelist_overwrite = label_whitelist_overwrite
 
         self.viewer = ViewerSelect(plugin, add_to_viewer_items, add_to_viewer_selected,
                                    manual_options=['None'],
@@ -1327,7 +1331,8 @@ class AddResults(BasePluginComponent):
 
         for data in self.app.data_collection:
             if self.label == data.label:
-                if data.meta.get('Plugin', None) == self._plugin.__class__.__name__:
+                if data.meta.get('Plugin', None) == self._plugin.__class__.__name__ or\
+                        data.label in self.label_whitelist_overwrite:
                     self.label_invalid_msg = ''
                     self.label_overwrite = True
                     return

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -925,6 +925,9 @@ class ViewerSelect(BaseSelectPluginComponent):
         def is_spectrum_viewer(viewer):
             return 'ProfileView' in viewer.__class__.__name__
 
+        def is_spectrum_2d_viewer(viewer):
+            return 'Profile2DView' in viewer.__class__.__name__
+
         def is_image_viewer(viewer):
             return 'ImageView' in viewer.__class__.__name__
 
@@ -1010,8 +1013,27 @@ class DatasetSelect(BaseSelectPluginComponent):
     """
     def __init__(self, plugin, items, selected,
                  filters=['not_from_plugin_model_fitting', 'layer_in_viewers'],
+                 default_text=None, manual_options=[],
                  default_mode='first'):
+        """
+        Parameters
+        ----------
+        plugin
+            the parent plugin object
+        items : str
+            the name of the items traitlet defined in ``plugin``
+        selected : str
+            the name of the selected traitlet defined in ``plugin``
+        default_text : str or None
+            the text to show for no selection.  If not provided or None, no entry will be provided
+            in the dropdown for no selection.
+        manual_options: list
+            list of options to provide that are not automatically populated by subsets.  If
+            ``default`` text is provided but not in ``manual_options`` it will still be included as
+            the first item in the list.
+        """
         super().__init__(plugin, items=items, selected=selected, filters=filters,
+                         default_text=default_text, manual_options=manual_options,
                          default_mode=default_mode)
         self._cached_properties += ["selected_dc_item"]
         # Add/Remove Data are triggered when checked/unchecked from viewers
@@ -1083,9 +1105,21 @@ class DatasetSelect(BaseSelectPluginComponent):
 
         def layer_in_spectrum_viewer(data):
             if not len(self.app.get_viewer_reference_names()):
-                # then this is a bar Application object, so ignore this filter
+                # then this is a bare Application object, so ignore this filter
                 return True
             return data.label in [l.layer.label for l in self.spectrum_viewer.layers] # noqa E741
+
+        def layer_in_spectrum_2d_viewer(data):
+            if not len(self.app.get_viewer_reference_names()):
+                # then this is a bare Application object, so ignore this filter
+                return True
+            return data.label in [l.layer.label for l in self.app.get_viewer('spectrum-2d-viewer').layers]  # noqa
+
+        def is_trace(data):
+            return hasattr(data, 'meta') and 'Trace' in data.meta
+
+        def not_trace(data):
+            return not is_trace(data)
 
         def is_image(data):
             return len(data.shape) == 3
@@ -1102,8 +1136,9 @@ class DatasetSelect(BaseSelectPluginComponent):
 
             return d
 
-        self.items = [_dc_to_dict(data) for data in self.app.data_collection
-                      if self._is_valid_item(data)]
+        manual_items = [{'label': label} for label in self.manual_options]
+        self.items = manual_items + [_dc_to_dict(data) for data in self.app.data_collection
+                                     if self._is_valid_item(data)]
         self._apply_default_selection()
         # future improvement: only clear cache if the selected data entry was changed?
         self._clear_cache(*self._cached_properties)
@@ -1304,18 +1339,16 @@ class AddResults(BasePluginComponent):
         self.label_invalid_msg = ''
         self.label_overwrite = False
 
-    def add_results_from_plugin(self, data_item):
+    def add_results_from_plugin(self, data_item, replace=None):
         """
         Add ``data_item`` to the app's data_collection according to the default or user-provided
         label and adds to any requested viewers.
         """
         if self.label_invalid_msg:
             raise ValueError(self.label_invalid_msg)
-        data_item.meta['Plugin'] = self._plugin.__class__.__name__
-        if self.app.config == 'mosviz':
-            data_item.meta['mosviz_row'] = self.app.state.settings['mosviz_row']
 
-        replace = self.viewer.selected_reference != 'spectrum-viewer'
+        if replace is None:
+            replace = self.viewer.selected_reference != 'spectrum-viewer'
 
         if self.label_overwrite and len(self.add_to_viewer_items) <= 2:
             # the switch for add_to_viewer is hidden, and so the loaded state of the overwritten
@@ -1335,6 +1368,11 @@ class AddResults(BasePluginComponent):
                 self.app.remove_data_from_viewer(self.viewer.selected_reference, self.label)
             self.app.data_collection.remove(self.app.data_collection[self.label])
 
+        if not hasattr(data_item, 'meta'):
+            data_item.meta = {}
+        data_item.meta['Plugin'] = self._plugin.__class__.__name__
+        if self.app.config == 'mosviz':
+            data_item.meta['mosviz_row'] = self.app.state.settings['mosviz_row']
         self.app.add_data(data_item, self.label)
 
         if add_to_viewer_selected != 'None':

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     voila>=0.3.5
     pyyaml>=5.4.1
     specutils>=1.7.0
+    specreduce>=1.0.0
     photutils>=1.4
     glue-astronomy>=0.4
     asteval>=0.9.23


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements a new plugin in specviz2d for spectral extraction via specreduce.  ~~It currently only implements the functionality for Trace creation, offsetting, loading from the API, and visualizing in the 2d spectrum viewer.  The UI elements for the other "steps" (background, extraction) are implemented (in order to plan for the necessary interaction between the steps), but are currently non-functional.~~ (woops! - that was a nice plan, but planning for how things would interact with each other eventually became just an API call away from actually implementing and devs decided it would be easier to review/merge in a complete form anyways)

**IMPORTANT**: this PR fixes the units on the x-axis to be shown in pixels instead of erroneously in meters, but by doing so _disables_ the line list and line analysis plugins when in pixels (whenever not manually loading a 1D spectrum in other units).  Future work will either need to properly handle plotting in wavelength or update the logic in these plugins to handle converting on-the-fly using the wavelength solution, if available.

[view specviz2d barebones docs](https://jdaviz--1514.org.readthedocs.build/en/1514/specviz2d/index.html) and the [spectral-extraction docs](https://jdaviz--1514.org.readthedocs.build/en/1514/specviz2d/plugins.html#spectral-extraction) (full specviz2d docs are out-of-scope, but created the plugins page so links from jdaviz work).

~**NOTE** this PR currently requires the following non-merged branches from other dependencies (and will likely fail CI tests until they are merged and pinned here)~:
* ~[glue-astronomy#72](https://github.com/glue-viz/glue-astronomy/pull/72)~ (functionality stripped from this PR)
* ~[specreduce#115](https://github.com/astropy/specreduce/pull/115)~ (functionality stripped from this PR)

Once the upstream PRs above are released, we can re-introduce the functionality in this plugin as a follow-up PR.

Sorry dev-reviewers for another large diff 😬 !  But many of the new lines are just boilerplate new plugin and boilerplate docs for specviz2d, so hopefully it won't be too difficult to parse 🤞 

~Note: this screen recording was still in pixel space.  This has since been updated to show in wavelength, when possible, but the linking from the example notebook is so non-linear that it's almost unusable.  We should probably consider switching it out with data that works better and then open follow-up efforts to improve support for more general input data.~

https://user-images.githubusercontent.com/877591/180841351-730211b6-8eea-4574-b0c8-4a306414cdb3.mov

 

In addition to the UI, once [glue-astronomy#72](https://github.com/glue-viz/glue-astronomy/pull/72) is released, we can implement support for importing traces created in the notebook via `app.add_data` (this functionality has been stripped from the PR so that we're not blocked waiting for that PR to be approved, merged, and released):

```  
from specreduce import tracing
trace = tracing.FlatTrace(spectrum1d.data, 29)

specviz2d.app.add_data(trace, data_label='trace_imported')
specviz2d.app.add_data_to_viewer('spectrum-2d-viewer', 'trace_imported')
```

You can also use the plugin API to interact with specreduce directly with something like:

```
ext_plugin = specviz2d.app.get_tray_item_from_name('spectral-extraction')
ext_plugin.trace_pixel = 29
trace = ext_plugin.create_trace()
```

Note that if the live-preview of the extracted spectrum disappears, that is because an error is being raised by specreduce.  When using auto (Kosmos) trace or a manual background, specreduce is often throwing a (probably incorrect) error detecting an overlap in background regions.  These cases also result in increased lag as they take a while to compute through specreduce.  These cases should be fixed in specreduce and are out-of-scope here.


**TODO**:
- [x] layer icon colors for traces (don't currently update when changing colors since they're following image viewer rules)
- [x] separate icon for traces in layer icons similar to spectral and spatial subsets
- [x] fix live-preview of Trace offsetting
- [x] try/except for trace previewing (clear if trace fails)
- [ ] better rules and error handling (example: KosmosTrace requires bins >= 4)
- [x] better workaround/fix for all `range(len(trace.trace))` instances.
- [x] UI/UX review from @Jenneh 
- [x] trace entries in data-menu to always show check, change spectrum-2d to default to single select for actual images
- [x] use plugin infrastructure for original spectrum 1d and set defaults in plugin accordingly (see https://github.com/spacetelescope/jdaviz/pull/1514#discussion_r926936508)
- [x] plugin documentation
- [x] test coverage
- [x] PR for glue-astronomy, merged, pinned, or remove support until it is
- [x] PR for specreduce merged and pinned, or remove support for peak_method until it is
- [x] remove or finish background/extract support (see list below for what is left to be done for those)

If not removing background/extraction steps into a separate follow-up PR:
- [x] test coverage for background/extraction steps
- [x] docs for background/extraction steps
- [x] fix plotting of background/subtracted image

Potential Future Work:
* ~advanced mode toggle (when in simple, hide intermediate export expansion panels as well as all inputs that default to "From Plugin")~ (ended up partially simplifying the options without losing too much flexibility, a separate toggle at this point is probably overkill)
* improved trace plot options support (currently shows with markers, but no line, but with line-like choices)
* default color of trace to be non-gray?
* can we edit existing entry in place instead of adding new data entry (then would be able to keep plot options)?  This would likely need to be done in the `AddResults` component itself.

Things brought up in other issues/tickets that are not (yet) directly addressed:
* Parameters can be specified manually in GUI and exported in notebook for reproducibility (like get_model_parameters).
* Ability to set same parameters for all the spectra in the Mosviz table.
* `spectrum_result= spec2d.extract_spectrum(2dspectrum_background_subtracted_already, trace_object, extractor_object)`

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Post-merge TODO

- Add GitHub issue templates for Specviz2d.
- Update change log template in release instructions to include Specviz2d.

Closes #809

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
