### PR TITLE
Fix aperture photometry result for WCS linked dithered non-reference data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,9 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Fixed inaccurate aperture photometry results when aperture photometry is done on
+  a non-reference image if images are linked by WCS. [#1524]
+
 Mosviz
 ^^^^^^
 

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -128,11 +128,7 @@ an interactively selected region. A typical workflow is as follows:
 4. Select the desired region using the :guilabel:`Subset` dropdown menu.
 5. If you want to subtract background before performing photometry,
    you have the following 3 options. Otherwise if your image is already
-   background subtracted, choose "Manual" and leave the background set at 0.
-   If you change the linking (see :ref:`imviz-link-control`) after you have
-   a background calculated from Annulus or Subset, you need to re-select
-   the aperture or background subset, respectively, to have it properly
-   recalculated:
+   background subtracted, choose "Manual" and leave the background set at 0:
 
   * Manual: Enter the background value in the :guilabel:`Background value` field.
     This value must be in the same unit as display data, if applicable.

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -114,12 +114,6 @@ This plugin only considers pixel locations, not sky coordinates.
 Simple Aperture Photometry
 ==========================
 
-.. warning::
-
-    Results for dithered data linked by WCS might be inaccurate unless the selected
-    data is the reference data. See https://github.com/glue-viz/glue-astronomy/issues/52
-    for more details.
-
 This plugin performs simple aperture photometry
 and plots a radial profile for one object within
 an interactively selected region. A typical workflow is as follows:

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -75,6 +75,10 @@ performant at the cost of accuracy but should be accurate to within a pixel
 for most cases. If approximation fails, WCS linking still automatically
 falls back to full transformation.
 
+For the best experience, it is recommended that you decide what kind of
+link you want and set it at the beginning of your Imviz session,
+rather than later.
+
 For more details on linking, see :ref:`dev_glue_linking`.
 
 From the API
@@ -124,7 +128,11 @@ an interactively selected region. A typical workflow is as follows:
 4. Select the desired region using the :guilabel:`Subset` dropdown menu.
 5. If you want to subtract background before performing photometry,
    you have the following 3 options. Otherwise if your image is already
-   background subtracted, choose "Manual" and leave the background set at 0:
+   background subtracted, choose "Manual" and leave the background set at 0.
+   If you change the linking (see :ref:`imviz-link-control`) after you have
+   a background calculated from Annulus or Subset, you need to re-select
+   the aperture or background subset, respectively, to have it properly
+   recalculated:
 
   * Manual: Enter the background value in the :guilabel:`Background value` field.
     This value must be in the same unit as display data, if applicable.

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -500,10 +500,6 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
     if update_plugin and 'imviz-links-control' in [item['name'] for item in app.state.tray_items]:
         link_plugin = app.get_tray_item_from_name('imviz-links-control')
         link_plugin.linking_in_progress = True
-        app.hub.broadcast(LinkUpdatedMessage(link_type,
-                                             wcs_fallback_scheme == 'pixels',
-                                             wcs_use_affine,
-                                             sender=app))
     else:
         link_plugin = None
 
@@ -573,5 +569,10 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
             'Images successfully relinked', color='success', timeout=8000, sender=app))
 
     if link_plugin is not None:
+        # Only broadcast after success.
+        app.hub.broadcast(LinkUpdatedMessage(link_type,
+                                             wcs_fallback_scheme == 'pixels',
+                                             wcs_use_affine,
+                                             sender=app))
         # reset the progress spinner
         link_plugin.linking_in_progress = False

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -151,7 +151,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin):
                         # Assume it is always pixel region, not sky region. Even with multiple
                         # viewers, they all seem to share the same reference image even when it is
                         # not loaded in all the viewers, so use default viewer.
-                        viewer = self.session.jdaviz_app._jdaviz_helper.default_viewer
+                        viewer = self.app._jdaviz_helper.default_viewer
+
                         x, y, _ = viewer._get_real_xy(
                             self.app.data_collection[self.dataset_selected],
                             reg.center.x, reg.center.y)

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -177,8 +177,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin):
         if self.dataset_selected == '' or self.subset_selected == '':
             return
 
-        # Force background auto-calculation to update when linking has changed.
-        self._bg_subset_selected_changed()
+        # Force background auto-calculation (including annulus) to update when linking has changed.
+        self._subset_selected_changed()
 
     @observe('subset_selected')
     def _subset_selected_changed(self, event={}):

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -21,7 +21,7 @@ from regions import (CircleAnnulusPixelRegion, CirclePixelRegion, EllipsePixelRe
 from traitlets import Any, Bool, List, Unicode, observe
 
 from jdaviz.core.custom_traitlets import FloatHandleEmpty
-from jdaviz.core.events import SnackbarMessage
+from jdaviz.core.events import SnackbarMessage, LinkUpdatedMessage
 from jdaviz.core.region_translators import regions2aperture
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import PluginTemplateMixin, DatasetSelectMixin, SubsetSelect
@@ -76,6 +76,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin):
         self._fitted_model_name = 'phot_radial_profile'
 
         self.session.hub.subscribe(self, SubsetUpdateMessage, handler=self._on_subset_update)
+        self.session.hub.subscribe(self, LinkUpdatedMessage, handler=self._on_link_update)
 
     def reset_results(self):
         self.result_available = False
@@ -171,6 +172,13 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin):
             self._subset_selected_changed()
         elif sbst.label == self.bg_subset_selected and sbst.data.label == self.dataset_selected:
             self._bg_subset_selected_changed()
+
+    def _on_link_update(self, msg):
+        if self.dataset_selected == '' or self.subset_selected == '':
+            return
+
+        # Force background auto-calculation to update when linking has changed.
+        self._bg_subset_selected_changed()
 
     @observe('subset_selected')
     def _subset_selected_changed(self, event={}):

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -99,15 +99,14 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         assert_array_equal(tbl['subset_label'], ['Subset 1', 'Subset 1'])
         assert tbl['timestamp'].scale == 'utc'
 
-        # BUG: https://github.com/glue-viz/glue-astronomy/issues/52
-        # Sky should have been the same and the pix different, but not until bug is fixed.
-        # The aperture sum might be different too if mask is off limit in second image.
-        assert_quantity_allclose(tbl['xcentroid'], 4.5 * u.pix)
+        # Sky is the same but xcentroid different due to dithering.
+        # The aperture sum is different too because mask is a little off limit in second image.
+        assert_quantity_allclose(tbl['xcentroid'], [4.5, 5.5] * u.pix)
         assert_quantity_allclose(tbl['ycentroid'], 4.5 * u.pix)
         sky = tbl['sky_centroid']
-        assert_allclose(sky.ra.deg, [337.518943, 337.519241])
-        assert_allclose(sky.dec.deg, [-20.832083, -20.832083])
-        assert_allclose(tbl['sum'], 63.61725123519332)
+        assert_allclose(sky.ra.deg, 337.518943)
+        assert_allclose(sky.dec.deg, -20.832083)
+        assert_allclose(tbl['sum'], 62.22684693104279)
 
         # Make sure it also works on an ellipse subset.
         self.imviz._apply_interactive_region('bqplot:ellipse', (0, 0), (9, 4))

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -73,7 +73,7 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
             'data_label', 'subset_label', 'timestamp']
         assert_array_equal(tbl['id'], [1, 2])
         assert_allclose(tbl['background'], 0)
-        assert_quantity_allclose(tbl['sum_aper_area'], 63.617251 * (u.pix * u.pix))
+        assert_quantity_allclose(tbl['sum_aper_area'], [63.617251, 62.22684693104279] * (u.pix * u.pix))  # noqa
         assert_array_equal(tbl['pixarea_tot'], None)
         assert_array_equal(tbl['aperture_sum_counts'], None)
         assert_array_equal(tbl['aperture_sum_counts_err'], None)
@@ -106,7 +106,7 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         sky = tbl['sky_centroid']
         assert_allclose(sky.ra.deg, 337.518943)
         assert_allclose(sky.dec.deg, -20.832083)
-        assert_allclose(tbl['sum'], 62.22684693104279)
+        assert_allclose(tbl['sum'], [63.617251, 62.22684693104279])
 
         # Make sure it also works on an ellipse subset.
         self.imviz._apply_interactive_region('bqplot:ellipse', (0, 0), (9, 4))


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address a critical but subtle bug where aperture photometry gives inaccurate result when photometry is performed on a non-reference data that is dithered from reference data and they are linked by WCS.

This works around https://github.com/glue-viz/glue-astronomy/issues/52

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1508

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
