### PR TITLE
Add workaround for Spectrum1D GWCS links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,8 @@ Mosviz
 Specviz
 ^^^^^^^
 
+- Fixed a bug where spectra with different spectral axes were not properly linked. [#1526]
+
 Other Changes and Additions
 ---------------------------
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -416,7 +416,6 @@ class Application(VuetifyTemplate, HubListener):
                 raise AttributeError
             dc.add_link(WCSLink(ref_data, linked_data))
         except (AttributeError, IncompatibleWCS):
-            raise
             pc_ref = [str(id).split(" ")[-1][1] for id in ref_data.pixel_component_ids]
             pc_linked = [str(id).split(" ")[-1][1] for id in linked_data.pixel_component_ids]
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -29,6 +29,7 @@ from glue.core.message import (DataCollectionAddMessage,
                                SubsetDeleteMessage)
 from glue.core.state_objects import State
 from glue.core.subset import Subset, RangeSubsetState, RoiSubsetState
+from glue_astronomy.spectral_coordinates import SpectralCoordinates
 from glue_jupyter.app import JupyterApplication
 from glue_jupyter.common.toolbar_vuetify import read_icon
 from glue_jupyter.state_traitlets_helpers import GlueState
@@ -402,11 +403,20 @@ class Application(VuetifyTemplate, HubListener):
         ref_data = dc[reference_data] if reference_data else dc[0]
         linked_data = dc[data_to_be_linked] if data_to_be_linked else dc[-1]
 
+        # The glue-astronomy SpectralCoordinates currently seems incompatible with glue
+        # WCSLink. This gets around it until there's an upstream fix.
+        if isinstance(linked_data.coords, SpectralCoordinates):
+            wc_old = ref_data.world_component_ids[0]
+            wc_new = linked_data.world_component_ids[0]
+            self.data_collection.add_link(LinkSame(wc_old, wc_new))
+            return
+
         try:
             if linked_data.meta.get("Plugin", None) == 'GaussianSmooth':
                 raise AttributeError
             dc.add_link(WCSLink(ref_data, linked_data))
         except (AttributeError, IncompatibleWCS):
+            raise
             pc_ref = [str(id).split(" ")[-1][1] for id in ref_data.pixel_component_ids]
             pc_linked = [str(id).split(" ")[-1][1] for id in linked_data.pixel_component_ids]
 
@@ -1330,7 +1340,9 @@ class Application(VuetifyTemplate, HubListener):
             The Glue data collection add message containing information about
             the new data.
         """
-        self._link_new_data()
+        # We don't need to link the first data to itself
+        if len(self.data_collection) > 1:
+            self._link_new_data()
         data_item = self._create_data_item(msg.data)
         self.state.data_items.append(data_item)
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -32,7 +32,7 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     assert len(mv_data) == 1
     assert mv_data[0].label == 'moment 0'
 
-    assert len(dc.links) == 14
+    assert len(dc.links) == 8
 
     # label should remain unchanged but raise overwrite warnings
     assert mm.results_label == 'moment 0'
@@ -78,20 +78,20 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
 
     assert dc[2].label == 'moment 1'
 
-    assert len(dc.links) == 16
-    assert len(dc.external_links) == 5
+    assert len(dc.links) == 10
+    assert len(dc.external_links) == 4
     # Link 3D z to 2D x and 3D y to 2D y
 
     # Link 3:
     # Pixel Axis 0 [z] from cube.pixel_component_ids[0]
     # Pixel Axis 1 [x] from plugin.pixel_component_ids[1]
-    assert dc.external_links[3].cids1[0] == dc[0].pixel_component_ids[0]
-    assert dc.external_links[3].cids2[0] == dc[-1].pixel_component_ids[1]
+    assert dc.external_links[2].cids1[0] == dc[0].pixel_component_ids[0]
+    assert dc.external_links[2].cids2[0] == dc[-1].pixel_component_ids[1]
     # Link 4:
     # Pixel Axis 1 [y] from cube.pixel_component_ids[1]
     # Pixel Axis 0 [y] from plugin.pixel_component_ids[0]
-    assert dc.external_links[4].cids1[0] == dc[0].pixel_component_ids[1]
-    assert dc.external_links[4].cids2[0] == dc[-1].pixel_component_ids[0]
+    assert dc.external_links[3].cids1[0] == dc[0].pixel_component_ids[1]
+    assert dc.external_links[3].cids2[0] == dc[-1].pixel_component_ids[0]
 
     # Coordinate display should be unaffected.
     assert flux_viewer.label_mouseover.pixel == 'x=00.0 y=00.0'

--- a/jdaviz/configs/default/plugins/collapse/tests/test_collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/tests/test_collapse.py
@@ -22,17 +22,17 @@ def test_linking_after_collapse(cubeviz_helper, spectral_cube_wcs):
 
     assert len(dc) == 2
     assert dc[1].label == 'collapsed'
-    assert len(dc.external_links) == 3
+    assert len(dc.external_links) == 2
 
     # Link 3D z to 2D x and 3D y to 2D y
 
     # Link 1:
     # Pixel Axis 0 [z] from cube.pixel_component_ids[0]
     # Pixel Axis 1 [x] from plugin.pixel_component_ids[1]
-    assert dc.external_links[1].cids1[0] == dc[0].pixel_component_ids[0]
-    assert dc.external_links[1].cids2[0] == dc[-1].pixel_component_ids[1]
+    assert dc.external_links[0].cids1[0] == dc[0].pixel_component_ids[0]
+    assert dc.external_links[0].cids2[0] == dc[-1].pixel_component_ids[1]
     # Link 2:
     # Pixel Axis 1 [y] from cube.pixel_component_ids[1]
     # Pixel Axis 0 [y] from plugin.pixel_component_ids[0]
-    assert dc.external_links[2].cids1[0] == dc[0].pixel_component_ids[1]
-    assert dc.external_links[2].cids2[0] == dc[-1].pixel_component_ids[0]
+    assert dc.external_links[1].cids1[0] == dc[0].pixel_component_ids[1]
+    assert dc.external_links[1].cids2[0] == dc[-1].pixel_component_ids[0]

--- a/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
@@ -13,7 +13,6 @@ def test_linking_after_spectral_smooth(spectrum1d_cube):
     app.add_data_to_viewer('flux-viewer', 'test')
 
     assert len(dc) == 1
-    assert len(dc.external_links) == 3
 
     gs = GaussianSmooth(app=app)
     gs.dataset_selected = 'test'
@@ -38,27 +37,27 @@ def test_linking_after_spectral_smooth(spectrum1d_cube):
 
     assert len(dc) == 2
     assert dc[1].label == 'spectral-smooth stddev-3.2'
-    assert len(dc.external_links) == 6
+    assert len(dc.external_links) == 3
 
     # Link cube 3D x, y, z to plugin 3D x, y, z
 
     # Link 2:
     # Pixel Axis 0 [z] from cube.pixel_component_ids[0]
     # Pixel Axis 0 [z] from plugin.pixel_component_ids[0]
-    assert dc.external_links[3].cids1[0] == dc[0].pixel_component_ids[0]
-    assert dc.external_links[3].cids2[0] == dc[-1].pixel_component_ids[0]
+    assert dc.external_links[0].cids1[0] == dc[0].pixel_component_ids[0]
+    assert dc.external_links[0].cids2[0] == dc[-1].pixel_component_ids[0]
 
     # Link 3:
     # Pixel Axis 1 [y] from cube.pixel_component_ids[1]
     # Pixel Axis 1 [y] from plugin.pixel_component_ids[1]
-    assert dc.external_links[4].cids1[0] == dc[0].pixel_component_ids[1]
-    assert dc.external_links[4].cids2[0] == dc[-1].pixel_component_ids[1]
+    assert dc.external_links[1].cids1[0] == dc[0].pixel_component_ids[1]
+    assert dc.external_links[1].cids2[0] == dc[-1].pixel_component_ids[1]
 
     # Link 4:
     # Pixel Axis 2 [x] from cube.pixel_component_ids[2]
     # Pixel Axis 2 [x] from plugin.pixel_component_ids[2]
-    assert dc.external_links[5].cids1[0] == dc[0].pixel_component_ids[2]
-    assert dc.external_links[5].cids2[0] == dc[-1].pixel_component_ids[2]
+    assert dc.external_links[2].cids1[0] == dc[0].pixel_component_ids[2]
+    assert dc.external_links[2].cids2[0] == dc[-1].pixel_component_ids[2]
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")


### PR DESCRIPTION
Fixes #1525, although this should be considered a temporary workaround until (hopefully) upstream fixes happen. The root cause of the issue is that Glue's `WCSLink` looks for a `has_celestial` attribute on the `data.coords` object. In the case of a `Spectrum1D` that's initialized with a spectral_axis array rather than a WCS (and thus creates a lookup table GWCS), glue_astronomy creates a special `SpectralCoordinates` object for the `data.coords` that was missing the `has_celestial` attribute. This caused an `AttributeError` every time and thus the linking to fall back on pixel links. 

Unfortunately, after I locally added `has_celestial=False` to the `SpectralCoordinates`, the `WCSLink` seemed to still fail. So here we fall back on the old explicit manual linking for this case while more debugging happens upstream.


Note that I also took the opportunity here to stop linking the first data to itself, since (I'm pretty sure) it's unnecessary.