### PR TITLE
Spatial-Spectral highlighting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,6 +79,8 @@ Cubeviz
 
 - Increased spectral slider performance considerably. [#1550]
 
+- Fixed the spectral subset highlighting of spatial subsets in the profile viewer. [#1528]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -80,9 +80,7 @@ class Cubeviz(ConfigHelper, LineListMixin):
         if not isinstance(wavelength, (int, float)):
             raise TypeError("wavelength must be a float or int")
         # Retrieve the x slices from the spectrum viewer's marks
-        x_all = [m for m in self.app.get_viewer('spectrum-viewer').figure.marks
-                 if m.__class__.__name__ in ['Lines', 'LinesGL']
-                 ][0].x
+        x_all = self.app.get_viewer('spectrum-viewer').native_marks[0].x
         index = np.argmin(abs(x_all - wavelength))
         return self.select_slice(int(index))
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_data_selection.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_data_selection.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.mark.filterwarnings('ignore:No observer defined on WCS')
-def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
+def test_data_selection(cubeviz_helper, spectrum1d_cube, tmpdir):
     app = cubeviz_helper.app
     # NOTE: these are the same underlying data.  This works fine for the current scope
     # of the tests (to make sure checking/unchecking operations change the data exposed

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -226,6 +226,11 @@ class CubevizProfileView(SpecvizProfileView):
                                       m.spectral_subset_mark in spectral_marks))]
 
     def _expected_subset_layer_default(self, layer_state):
+        """
+        This gets called whenever the layer of an expected new subset is added, we want to set the
+        default for the linewidth depending on whether it is spatial or spectral, and handle
+        creating any necessary marks for spatial-spectral subset intersections.
+        """
         super()._expected_subset_layer_default(layer_state)
 
         this_mark = self._get_marks_for_layers([layer_state])[0]

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -210,7 +210,7 @@ class CubevizProfileView(SpecvizProfileView):
         layers_list = list(self.state.layers)
         # here we'll assume that all custom marks are subclasses of Lines/GL but don't directly
         # use Lines/LinesGL (so an isinstance check won't be sufficient here)
-        layer_marks = [m for m in self.figure.marks if m.__class__.__name__ in ['Lines', 'LinesGL']]
+        layer_marks = self.native_marks
         # and now we'll assume that the marks are in the same order as the layers, this should
         # be the case as long as the order isn't manually resorted
         return [layer_marks[layers_list.index(layer)] for layer in layers]

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -1,9 +1,10 @@
 import numpy as np
 from glue.core import BaseData
+from glue.core.subset import RoiSubsetState, RangeSubsetState
 from glue_jupyter.bqplot.image import BqplotImageView
 
 from jdaviz.core.registries import viewer_registry
-from jdaviz.core.marks import SliceIndicatorMarks
+from jdaviz.core.marks import SliceIndicatorMarks, ShadowSpatialSpectral
 from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
 from jdaviz.configs.cubeviz.helper import layer_is_cube_image_data
 from jdaviz.configs.imviz.helper import data_has_valid_wcs
@@ -196,6 +197,58 @@ class CubevizProfileView(SpecvizProfileView):
         # NOTE: super will initialize nested toolbar with
         # default_tool_priority=['jdaviz:selectslice']
         super().__init__(*args, **kwargs)
+
+    def _get_spatial_subset_layers(self):
+        return [ls for ls in self.state.layers
+                if isinstance(getattr(ls.layer, 'subset_state', None), RoiSubsetState)]
+
+    def _get_spectral_subset_layers(self):
+        return [ls for ls in self.state.layers
+                if isinstance(getattr(ls.layer, 'subset_state', None), RangeSubsetState)]
+
+    def _get_marks_for_layers(self, layers):
+        layers_list = list(self.state.layers)
+        # here we'll assume that all custom marks are subclasses of Lines/GL but don't directly
+        # use Lines/LinesGL (so an isinstance check won't be sufficient here)
+        layer_marks = [m for m in self.figure.marks if m.__class__.__name__ in ['Lines', 'LinesGL']]
+        # and now we'll assume that the marks are in the same order as the layers, this should
+        # be the case as long as the order isn't manually resorted
+        return [layer_marks[layers_list.index(layer)] for layer in layers]
+
+    def _on_subset_delete(self, msg):
+        # delete any ShadowSpatialSpectral mark for which either of the spectral or spatial marks
+        # no longer exists
+        spectral_marks = self._get_marks_for_layers(self._get_spectral_subset_layers())
+        spatial_marks = self._get_marks_for_layers(self._get_spatial_subset_layers())
+        self.figure.marks = [m for m in self.figure.marks
+                             if not (isinstance(m, ShadowSpatialSpectral) and
+                                     (m.spatial_spectrum_mark in spatial_marks or
+                                      m.spectral_subset_mark in spectral_marks))]
+
+    def _expected_subset_layer_default(self, layer_state):
+        super()._expected_subset_layer_default(layer_state)
+
+        this_mark = self._get_marks_for_layers([layer_state])[0]
+        new_marks = []
+
+        if isinstance(layer_state.layer.subset_state, RoiSubsetState):
+            layer_state.linewidth = 1
+
+            # need to add marks for every intersection between THIS spatial subset and ALL spectral
+            spectral_marks = self._get_marks_for_layers(self._get_spectral_subset_layers())
+            for spectral_mark in spectral_marks:
+                new_marks += [ShadowSpatialSpectral(this_mark, spectral_mark)]
+
+        else:
+            layer_state.linewidth = 3
+
+            # need to add marks for every intersection between THIS spectral subset and ALL spatial
+            spatial_marks = self._get_marks_for_layers(self._get_spatial_subset_layers())
+            for spatial_mark in spatial_marks:
+                new_marks += [ShadowSpatialSpectral(spatial_mark, this_mark)]
+
+        # NOTE: += or append won't pick up on change
+        self.figure.marks = self.figure.marks + new_marks
 
     @property
     def slice_indicator(self):

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -25,6 +25,20 @@ class JdavizViewerMixin:
         # NOTE: anything here most likely won't be called by viewers because of inheritance order
         super().__init__(*args, **kwargs)
 
+    @property
+    def native_marks(self):
+        """
+        Return all marks that are Lines/LinesGL objects (and not subclasses)
+        """
+        return [m for m in self.figure.marks if m.__class__.__name__ in ['Lines', 'LinesGL']]
+
+    @property
+    def custom_marks(self):
+        """
+        Return all marks that are not Lines/LinesGL objects (but can be subclasses)
+        """
+        return [m for m in self.figure.marks if m.__class__.__name__ not in ['Lines', 'LinesGL']]
+
     def _subscribe_to_layers_update(self):
         # subscribe to new layers
         self._expected_subset_layers = []

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -2,7 +2,7 @@ import numpy as np
 import warnings
 
 from glue.core import BaseData
-from glue.core.subset import Subset, RoiSubsetState
+from glue.core.subset import Subset
 from glue.config import data_translator
 from glue_jupyter.bqplot.profile import BqplotProfileView
 from glue.core.exceptions import IncompatibleAttribute
@@ -64,12 +64,10 @@ class SpecvizProfileView(BqplotProfileView, JdavizViewerMixin):
         # Change collapse function to sum
         self.state.function = 'sum'
 
-    def _expected_subset_layer_default(self, layer):
-        super()._expected_subset_layer_default(layer)
-        if isinstance(layer.layer.subset_state, RoiSubsetState):
-            layer.linewidth = 1
-        else:
-            layer.linewidth = 3
+    def _expected_subset_layer_default(self, layer_state):
+        super()._expected_subset_layer_default(layer_state)
+
+        layer_state.linewidth = 3
 
     def data(self, cls=None):
         # Grab the user's chosen statistic for collapsing data

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -12,7 +12,7 @@ import warnings
 import numpy as np
 import astropy.units as u
 from glue.core import HubListener
-from glue.core.message import SubsetCreateMessage
+from glue.core.message import SubsetCreateMessage, SubsetDeleteMessage
 
 from jdaviz.app import Application
 
@@ -59,6 +59,8 @@ class ConfigHelper(HubListener):
 
         self.app.hub.subscribe(self, SubsetCreateMessage,
                                handler=lambda msg: self._propagate_callback_to_viewers('_on_subset_create', msg)) # noqa
+        self.app.hub.subscribe(self, SubsetDeleteMessage,
+                               handler=lambda msg: self._propagate_callback_to_viewers('_on_subset_delete', msg)) # noqa
 
     def _propagate_callback_to_viewers(self, method, msg):
         # viewers don't have access to the app/hub to subscribe to messages, so we'll

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -3,6 +3,7 @@ import numpy as np
 from astropy import units as u
 from bqplot import LinearScale
 from bqplot.marks import Lines, Label, Scatter
+from copy import deepcopy
 from glue.core import HubListener
 from specutils import Spectrum1D
 
@@ -372,13 +373,48 @@ class ShadowLine(Lines, HubListener, ShadowMixin):
                               ['scales', 'x', 'y', 'visible', 'line_style', 'marker'],
                               ['stroke_width', 'marker_size'])
 
+
+class ShadowSpatialSpectral(Lines, HubListener, ShadowMixin):
+    """
+    Shadow the mark of a spatial subset collapsed spectrum, with the mask from a spectral subset,
+    and the styling from the spatial subset.
+    """
+    def __init__(self, spatial_spectrum_mark, spectral_subset_mark):
+        # spatial_spectrum_mark: Lines mark corresponding to the spatially-collapsed spectrum
+        # from a spatial subset
+        # spectral_subset_mark: Lines mark on the FULL cube corresponding to the glue-highlight
+        # of the spectral subset
+        super().__init__(scales=spatial_spectrum_mark.scales, marker=None)
+
+        self._spatial_mark_id = self._get_id(spatial_spectrum_mark)
+        self._setup_shadowing(spatial_spectrum_mark,
+                              ['scales', 'y', 'visible', 'line_style'],
+                              ['x'])
+
+        self._spectral_mark_id = self._get_id(spectral_subset_mark)
+        self._setup_shadowing(spectral_subset_mark,
+                              ['stroke_width', 'x', 'y', 'visible', 'opacities', 'colors'])
+
+    @property
+    def spatial_spectrum_mark(self):
+        return self._shadowing[self._spatial_mark_id]
+
+    @property
+    def spectral_subset_mark(self):
+        return self._shadowing[self._spectral_mark_id]
+
     def _on_shadowing_changed(self, change):
-        super()._on_shadowing_changed(change)
-        if change['name'] in ['stroke_width', 'marker_size']:
-            # apply the same, but increased by the shadow width
-            setattr(self, change['name'],
-                    change['new'] + self._shadow_width if change['new'] else 0)
-        return
+        if hasattr(self, '_spectral_mark_id'):
+            if change['name'] == 'y':
+                # force a copy or else we'll overwrite the mask to the spatial mark!
+                change['new'] = deepcopy(self.spatial_spectrum_mark.y)
+                change['new'][np.isnan(self.spectral_subset_mark.y)] = np.nan
+
+            elif change['name'] == 'visible':
+                # only show if BOTH shadowing marks are set to visible
+                change['new'] = self.spectral_subset_mark.visible and self.spatial_spectrum_mark.visible  # noqa
+
+        return super()._on_shadowing_changed(change)
 
 
 class ShadowLabelFixedY(Label, ShadowMixin):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements spectral subset highlighting of automatically-collapsed spectra of spatial subsets in the profile viewer of cubeviz.  It does so by a new custom bqplot mark which "shadows" the position of the mark corresponding to the spatial-spectrum, but the nan-mask and styling of the mark corresponding to the spectral-subset on the full spectrum.  Everytime a new subset _layer_ is added, a mark is created for each combination of the corresponding subset mark and all marks of the _other_ (spatial vs spectral) type.  Everytime a subset is removed, the marks are pruned to remove any where one of the referenced marks no longer exists.  Pure hacky dark magic at its ugliest/finest.... and because of that this should be tested thoroughly.

https://user-images.githubusercontent.com/877591/181636479-1696d670-0ddc-4264-ae73-912d4a3cf26b.mov


https://user-images.githubusercontent.com/877591/181636770-84e13c0a-f467-483f-a49c-cd5ff920279f.mov


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1179

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
