### PR TITLE
Correct the linking for 1D model results in Cubeviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,7 +50,7 @@ Mosviz
 Specviz
 ^^^^^^^
 
-- Fixed a bug where spectra with different spectral axes were not properly linked. [#1526]
+- Fixed a bug where spectra with different spectral axes were not properly linked. [#1526, #1531]
 
 Other Changes and Additions
 ---------------------------

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -406,7 +406,7 @@ class Application(VuetifyTemplate, HubListener):
         # The glue-astronomy SpectralCoordinates currently seems incompatible with glue
         # WCSLink. This gets around it until there's an upstream fix.
         if isinstance(linked_data.coords, SpectralCoordinates):
-            wc_old = ref_data.world_component_ids[0]
+            wc_old = ref_data.world_component_ids[-1]
             wc_new = linked_data.world_component_ids[0]
             self.data_collection.add_link(LinkSame(wc_old, wc_new))
             return


### PR DESCRIPTION
This should have been grabbing the last world coordinate, not the first, in case the reference data is multi-dimensional.

Closes #1530 