### PR TITLE
reset subset mode to "replace" when changing selection to "Create New"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ Specviz
 Bug Fixes
 ---------
 
+- Fixes subset mode to reset to "Replace" when choosing to "Create New" subset. [#1532]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -1,3 +1,4 @@
+from glue.core.message import EditSubsetMessage
 from glue.core.edit_subset_mode import (AndMode, AndNotMode, OrMode,
                                         ReplaceMode, XorMode)
 from glue_jupyter.widgets.subset_mode_vuetify import SelectionModeMenu
@@ -32,11 +33,12 @@ class SubsetTools(TemplateMixin):
             'g-subset-mode': SelectionModeMenu(session=self.session)
         }
 
-        # self.hub.subscribe(self, EditSubsetMessage,
-        #                    handler=self.vue_subset_mode_changed)
+        self.hub.subscribe(self, EditSubsetMessage,
+                           handler=self._subset_edit_event)
 
-    # def vue_subset_mode_changed(self, index):
-    #     mode = list(SUBSET_MODES.values())[index]
-
-    #     if self.session.edit_subset_mode.mode != mode:
-    #         self.session.edit_subset_mode.mode = mode
+    def _subset_edit_event(self, msg):
+        # NOTE: here we'll assume that only a single subset is selected (glue supports
+        # multiple subsets being selected, but jdaviz doesn't)
+        if not (len(msg.subset)):
+            # then changed to "Create New", we want to revert the mode to ReplaceMode
+            self.session.edit_subset_mode.mode = ReplaceMode


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes unexpected behavior when switching to create a new subset with the subset mode on something other than replace (especially when not clicking away to finalize the previous subset selection).

Previous behavior:

https://user-images.githubusercontent.com/877591/181807105-5acf6917-4d02-49e6-bc19-0f62db7340d8.mov


New behavior (still temporarily shows the highlighting when not finalizing selection before changing subsets, but the final result is as expected):


https://user-images.githubusercontent.com/877591/181807133-819a43d5-6f6e-4b71-a33a-7d0ee8dc33db.mov



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
