### PR TITLE
bump required version of ipypopout to 0.0.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     regions>=0.6
     scikit-image
     sidecar>=0.5.1
-    ipypopout>=0.0.10
+    ipypopout>=0.0.11
 
 [options.extras_require]
 test =


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request bumps the version requirement of ipypopout to 0.0.11 to gracefully fallback on not showing the popout button (instead of raising an error) when the jupyter kernel is not detected.

Full diff of changes in ipypopout: https://github.com/mariobuikhuizen/ipypopout/commit/5e7570de0e99c66a93b5305398b49311d35117a8 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1533

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
