### PR TITLE
add results to viewer: smarter defaults when overwriting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,10 @@ Bug Fixes
 
 - Fixes subset mode to reset to "Replace" when choosing to "Create New" subset. [#1532]
 
+- Fixes behavior of adding results from a plugin that overwrite an existing entry.  The loaded
+  and visibility states are now always adopted from the existing entry that would be overwritten.
+  [#1538]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/components/plugin_add_results.vue
+++ b/jdaviz/components/plugin_add_results.vue
@@ -22,7 +22,15 @@
     ></plugin-viewer-select>
 
     <v-row v-else>
-      <v-switch
+      <v-switch v-if="label_overwrite"
+        class="hide-input"
+        :label="'Show in '+add_to_viewer_items[1].label"
+        :disabled="true"
+        :hint="'Visibility of the modified entry will be adopted from the current \''+label+'\' data entry.'"
+        persistent-hint
+      >
+      </v-switch>
+      <v-switch v-else
         v-model="add_to_viewer_selected == this.add_to_viewer_items[1].label"
         @change="(e) => {$emit('update:add_to_viewer_selected', this.$props.add_to_viewer_items[Number(e)].label)}"
         :label="'Show in '+add_to_viewer_items[1].label"
@@ -43,6 +51,13 @@
     </v-row>
   </div>
 </template>
+
+<style scoped>
+  .hide-input .v-input--selection-controls__input {
+    opacity: 0;
+  }
+</style>
+
 <script>
 module.exports = {
   props: ['label', 'label_default', 'label_auto', 'label_invalid_msg', 'label_overwrite', 'label_label', 'label_hint',

--- a/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
@@ -26,6 +26,15 @@ def test_linking_after_spectral_smooth(spectrum1d_cube):
     assert gs.results_label_overwrite is True
     gs.add_to_viewer_selected = 'spectrum-viewer'
     gs.vue_apply()
+    # but since we're overwriting, add_to_viewer_selected is ignored (and hidden in the UI)
+    # so will still be hidden
+    assert len(gs.dataset_items) == 1
+    # by removing the data entry, the overwrite will no longer apply
+    app.remove_data_from_viewer('spectrum-viewer', 'spectral-smooth stddev-3.2')
+    app.data_collection.remove(app.data_collection['spectral-smooth stddev-3.2'])
+
+    gs.add_to_viewer_selected = 'spectrum-viewer'
+    gs.vue_apply()
     # since we now plotted the results, the dataset should be fixed,
     # but the dataset dropdown contains multiple choices, so the dataset
     # itself is prepended to the default label, and there is no longer


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request addresses an issues discovered in the review of #1514 with wider implications.  When adding results from a plugin to a viewer that will overwrite an existing data entry, selecting to not show in the viewer raised a traceback error.  This traceback alone could be fixed and could result in "unloading" the data entry from the viewer, but this then will result in issues if that data entry was the reference data (which usually isn't allowed, but #1514 provides an exception where the original reference data was created by a plugin and allowed to be overwritten).

**Previous behavior**:

https://user-images.githubusercontent.com/877591/182617186-9a769e00-f03a-42bd-887d-ddf5546088f7.mov

**Proposed new behavior**:

https://user-images.githubusercontent.com/877591/182617352-e1b1bb07-771c-4b2d-ba55-b590102da9a3.mov


and after iterating with @Jenneh, the label now shows as:

<img width="241" alt="image" src="https://user-images.githubusercontent.com/877591/182894528-da6d57aa-274c-47a3-b83d-960fe18db701.png">


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->



### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
