### PR TITLE
Nested helpers don't overwrite helper reference 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,8 +49,8 @@ Cubeviz
 
 - Fixed validation message of moment number in moment map plugin. [#1536]
 
-- Fixed ``app._jdaviz_helper`` returning Specviz helper instead of Cubeviz helper when Specviz
-  helper is called. ``app._jdaviz_helper`` always returns Cubeviz helper [#1546]
+- Fixed ``viewer.jdaviz_helper`` returning Specviz helper instead of Cubeviz helper after Specviz
+  helper is called via ``Cubeviz.specviz``. Now ``viewer.jdaviz_helper`` always returns the Cubeviz helper. [#1546]
 
 Imviz
 ^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,13 +44,13 @@ Bug Fixes
   and visibility states are now always adopted from the existing entry that would be overwritten.
   [#1538]
 
-- The top-level config will now always be returned via ``app._jdaviz_helper`` and any associated
-  callthroughs [#1546]
-
 Cubeviz
 ^^^^^^^
 
 - Fixed validation message of moment number in moment map plugin. [#1536]
+
+- Fixed ``app._jdaviz_helper`` returning Specviz helper instead of Cubeviz helper when Specviz
+  helper is called. ``app._jdaviz_helper`` always returns Cubeviz helper [#1546]
 
 Imviz
 ^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,9 @@ Bug Fixes
   and visibility states are now always adopted from the existing entry that would be overwritten.
   [#1538]
 
+- The top-level config will now always be returned via ``app._jdaviz_helper`` and any associated
+  callthroughs [#1546]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
@@ -1,6 +1,3 @@
-from jdaviz import Cubeviz
-
-
 def test_nested_helper(cubeviz_helper):
     '''Ensures the Cubeviz helper is always returned, even after the Specviz helper is called'''
     # Force Specviz helper to instantiate

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
@@ -1,0 +1,13 @@
+from jdaviz import Cubeviz
+
+
+def test_nested_helper(cubeviz_helper):
+    '''Ensures the Cubeviz helper is always returned, even after the Specviz helper is called'''
+    # Force Specviz helper to instantiate
+    cubeviz_helper.specviz
+
+    assert cubeviz_helper.app._jdaviz_helper == cubeviz_helper
+
+    # The viewers also have a callthrough to the app's _jdaviz_helper attribute
+    spec_viewer = cubeviz_helper.app.get_viewer('spectrum-viewer')
+    assert spec_viewer.jdaviz_helper == cubeviz_helper

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -53,7 +53,9 @@ class ConfigHelper(HubListener):
 
         # give a reference from the app back to this config helper.  These can be accessed from a
         # viewer via viewer.jdaviz_app and viewer.jdaviz_helper
-        self.app._jdaviz_helper = self
+        # if the helper has already been set, this is probably a nested viz tool. Don't overwrite
+        if not hasattr(self.app, '_jdaviz_helper'):
+            self.app._jdaviz_helper = self
 
         self.app.hub.subscribe(self, SubsetCreateMessage,
                                handler=lambda msg: self._propagate_callback_to_viewers('_on_subset_create', msg)) # noqa


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This is a quick patch PR for #1544, where the helper will check to see if the `jdaviz_helper` attribute is already set. If it is, it will NOT overwrite the existing helper reference there, assuming it is a nested helper within a larger helper.

I could theoretically see a user wanting to get the nested helper in some scenarios, but I think getting the "highest" helper is going to be more intuitive for most users. If we get some complaints down the line, we can adjust the strategy here.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1544 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
