### PR TITLE
spectral-extraction: API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,7 +44,7 @@ Specviz
 Specviz2d
 ^^^^^^^^^
 
-- Spectral extraction plugin. [#1514, #1555, #1560, #1562]
+- Spectral extraction plugin. [#1514, #1554, #1555, #1560, #1562]
 
 - CLI support for launching Specviz2d for a single 2D spectrum file input.
   Use notebook version if you want to open separate 2D and 1D spectra in Specviz2d. [#1576]

--- a/docs/specviz2d/plugins.rst
+++ b/docs/specviz2d/plugins.rst
@@ -69,7 +69,7 @@ To export and access the specreduce Trace object defined in the plugin, call :me
 
   trace = sp_ext.export_trace()
 
-To import the parameters from a Trace object (either a new Trace object, or an exported one modified in the notebook) into the plugin, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.import_trace`::
+To import the parameters from a specreduce Trace object, whether it's new or was exported and modified in the notebook, call:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.import_trace`::
 
   sp_ext.import_trace(trace)
 
@@ -94,9 +94,9 @@ To export and access the specreduce Background object defined in the plugin, cal
 
   bg = sp_ext.export_bg()
 
-To access the background image or background-subtracted image as a specutils Spectrum1D object, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_bg_img` or :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_bg_img`, respectively.
+To access the background image or background-subtracted image as a :class:`~specutils.Spectrum1D` object, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_bg_img` or :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_bg_img`, respectively.
 
-To import the parameters from a Background object (either a new Background object, or an exported one modified in the notebook) into the plugin, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.import_bg`::
+To import the parameters from a specreduce Background object into the plugin, whether it's new or was exported and modified in the notebook, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.import_bg`::
 
   sp_ext.import_bg(bg)
 
@@ -120,13 +120,13 @@ To visualize or export the resulting 2D spectrum, provide a data label and click
 resulting spectrum object can be :ref:`accessed from the API <specviz2d-export-data-1d>` in the same
 way as any other data product in the spectrum viewer.
 
-To export and access the specreduce Extract object defined in the plugin, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_extract`::
+To export and access the specreduce extraction object defined in the plugin, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_extract`::
 
   ext = sp_ext.export_extract()
 
-To access the extracted spectrum as a specutils Spectrum1D object, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_extract_spectrum`.
+To access the extracted spectrum as a :class:`~specutils.Spectrum1D` object, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_extract_spectrum`.
 
-To import the parameters from an Extract object (either a new Extract object, or an exported one modified in the notebook) into the plugin, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.import_extract`::
+To import the parameters from a specreduce extraction object (either a new object, or an exported one modified in the notebook) into the plugin, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.import_extract`::
 
   sp_ext.import_extract(ext)
 

--- a/docs/specviz2d/plugins.rst
+++ b/docs/specviz2d/plugins.rst
@@ -46,6 +46,11 @@ Spectral Extraction
 The Spectral Extraction plugin exposes `specreduce <https://specreduce.readthedocs.io>`_
 methods for tracing, background subtraction, and spectral extraction from 2D spectra.
 
+To interact with the plugin via the API in a notebook, access the plugin object via::
+
+  sp_ext = viz.app.get_tray_item_from_name('spectral-extraction')
+
+
 Trace
 -----
 
@@ -59,6 +64,14 @@ of the plugin, the live visualization will change to show the trace as a solid l
 To create a new trace in the plugin, choose the desired "Trace Type" and edit any input arguments.
 A preview of the trace will update in real time in the 2D spectrum viewer.
 
+
+To export and access the specreduce Trace object defined in the plugin, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_trace`::
+
+  trace = sp_ext.export_trace()
+
+To import the parameters from a Trace object (either a new Trace object, or an exported one modified in the notebook) into the plugin, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.import_trace`::
+
+  sp_ext.import_trace(trace)
 
 Background
 ----------
@@ -76,6 +89,16 @@ and choose a label for the new data entry.  The exported images will now appear 
 menu in the 2D spectrum viewer, and can be :ref:`exported into the notebook via the API <specviz2d-export-data-2d>`.  
 To refine the trace based on the background-subtracted image, return
 to the Trace step and select the exported background-subtracted image as input. 
+
+To export and access the specreduce Background object defined in the plugin, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_bg`::
+
+  bg = sp_ext.export_bg()
+
+To access the background image or background-subtracted image as a specutils Spectrum1D object, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_bg_img` or :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_bg_img`, respectively.
+
+To import the parameters from a Background object (either a new Background object, or an exported one modified in the notebook) into the plugin, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.import_bg`::
+
+  sp_ext.import_bg(bg)
 
 Extract
 -------
@@ -96,6 +119,16 @@ as input.
 To visualize or export the resulting 2D spectrum, provide a data label and click "Extract".  The 
 resulting spectrum object can be :ref:`accessed from the API <specviz2d-export-data-1d>` in the same
 way as any other data product in the spectrum viewer.
+
+To export and access the specreduce Extract object defined in the plugin, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_extract`::
+
+  ext = sp_ext.export_extract()
+
+To access the extracted spectrum as a specutils Spectrum1D object, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_extract_spectrum`.
+
+To import the parameters from an Extract object (either a new Extract object, or an exported one modified in the notebook) into the plugin, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.import_extract`::
+
+  sp_ext.import_extract(ext)
 
 
 .. _specviz2d-gaussian-smooth:

--- a/jdaviz/configs/specviz2d/helper.py
+++ b/jdaviz/configs/specviz2d/helper.py
@@ -161,7 +161,7 @@ class Specviz2d(ConfigHelper, LineListMixin):
                 # new defaults.  We'll just call it again manually.
                 spext._trace_dataset_selected()
                 try:
-                    spext.export_extract(add_data=True)
+                    spext.export_extract_spectrum(add_data=True)
                 except Exception:
                     msg = SnackbarMessage(
                         "Automatic spectrum extraction failed.  See the spectral extraction"

--- a/jdaviz/configs/specviz2d/helper.py
+++ b/jdaviz/configs/specviz2d/helper.py
@@ -161,7 +161,7 @@ class Specviz2d(ConfigHelper, LineListMixin):
                 # new defaults.  We'll just call it again manually.
                 spext._trace_dataset_selected()
                 try:
-                    spext.create_extract(add_data=True)
+                    spext.export_extract(add_data=True)
                 except Exception:
                     msg = SnackbarMessage(
                         "Automatic spectrum extraction failed.  See the spectral extraction"

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -454,7 +454,7 @@ class SpectralExtraction(PluginTemplateMixin):
         return trace
 
     def vue_create_trace(self, *args):
-        _ = self.export_trace(add_data=True)
+        self.export_trace(add_data=True)
 
     def _get_bg_trace(self):
         if self.bg_type_selected == 'Manual':
@@ -555,7 +555,7 @@ class SpectralExtraction(PluginTemplateMixin):
 
         return bg_spec
 
-    def vue_create_bg(self, *args):
+    def vue_create_bg_img(self, *args):
         try:
             self.export_bg_img(add_data=True)
         except Exception as e:
@@ -585,7 +585,7 @@ class SpectralExtraction(PluginTemplateMixin):
         return bg_sub_spec
 
     def vue_create_bg_sub(self, *args):
-        _ = self.export_bg_sub(add_data=True)
+        self.export_bg_sub(add_data=True)
 
     def _get_ext_trace(self):
         return self.export_trace(add_data=False)
@@ -651,4 +651,4 @@ class SpectralExtraction(PluginTemplateMixin):
         return spectrum
 
     def vue_extract_spectrum(self, *args):
-        _ = self.export_extract_spectrum(add_data=True)
+        self.export_extract_spectrum(add_data=True)

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -392,14 +392,14 @@ class SpectralExtraction(PluginTemplateMixin):
     def _set_create_kwargs(self, **kwargs):
         invalid_kwargs = [k for k in kwargs.keys() if not hasattr(self, k)]
         if len(invalid_kwargs):
-            raise ValueError(f"{invalid_kwargs} are not valid attributes to pass as a kwargs")
+            raise ValueError(f"{invalid_kwargs} are not valid attributes to pass as kwargs")
 
         for k, v in kwargs.items():
             setattr(self, k, v)
 
     def import_trace(self, trace):
         """
-        Import the input parameters from an existing specreduce trace object into the plugin.
+        Import the input parameters from an existing specreduce Trace object into the plugin.
 
         Parameters
         ----------
@@ -422,7 +422,8 @@ class SpectralExtraction(PluginTemplateMixin):
 
     def export_trace(self, add_data=False, **kwargs):
         """
-        Create a trace object from the input parameters defined in the plugin.
+        Create a specreduce Trace object from the input parameters
+        defined in the plugin.
 
         Parameters
         ----------
@@ -467,7 +468,7 @@ class SpectralExtraction(PluginTemplateMixin):
 
     def import_bg(self, bg):
         """
-        Import the input parameters from an existing specreduce background object into the plugin.
+        Import the input parameters from an existing specreduce Background object into the plugin.
 
         Parameters
         ----------
@@ -503,7 +504,7 @@ class SpectralExtraction(PluginTemplateMixin):
 
     def export_bg(self, **kwargs):
         """
-        Create a specreduce background object from the input parameters defined in the plugin.
+        Create a specreduce Background object from the input parameters defined in the plugin.
 
         Parameters
         ----------
@@ -614,7 +615,7 @@ class SpectralExtraction(PluginTemplateMixin):
 
     def export_extract(self, **kwargs):
         """
-        Create a specreduce.extract object from the input parameters defined in the plugin.
+        Create a specreduce extraction object from the input parameters defined in the plugin.
         """
         self._set_create_kwargs(**kwargs)
         if len(kwargs) and self.active_step != 'ext':
@@ -635,7 +636,6 @@ class SpectralExtraction(PluginTemplateMixin):
             Whether to add the resulting spectrum to the application, according to the options
             defined in the plugin.
         """
-        # TODO: update to call self.export_extract(**kwargs)
         extract = self.export_extract(**kwargs)
         spectrum = extract.spectrum
         # Specreduce returns a spectral axis in pixels, so we'll replace with input spectral_axis

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -406,7 +406,7 @@ class SpectralExtraction(PluginTemplateMixin):
         trace : specreduce.tracing.Trace
             Trace object to import
         """
-        if not isinstance(trace, tracing.Trace):
+        if not isinstance(trace, tracing.Trace):  # pragma: no cover
             raise TypeError("trace must be a specreduce.tracing.Trace object")
 
         if isinstance(trace, tracing.FlatTrace):
@@ -417,7 +417,7 @@ class SpectralExtraction(PluginTemplateMixin):
             self.trace_pixel = trace.guess
             self.trace_window = trace.window
             self.trace_bins = trace.bins
-        else:
+        else:  # pragma: no cover
             raise NotImplementedError(f"trace of type {trace.__class__.__name__} not supported")
 
     def export_trace(self, add_data=False, **kwargs):
@@ -475,7 +475,7 @@ class SpectralExtraction(PluginTemplateMixin):
         bg : specreduce.background.Background
             Background object to import
         """
-        if not isinstance(bg, background.Background):
+        if not isinstance(bg, background.Background):  # pragma: no cover
             raise TypeError("bg must be a specreduce.background.Background object")
 
         # TODO: should we detect/set the referenced dataset?
@@ -487,7 +487,7 @@ class SpectralExtraction(PluginTemplateMixin):
             if np.all(seps1 == seps1[0]) and np.all(seps2 == seps1[0]):
                 self.bg_type_selected = 'TwoSided'
                 self.bg_separation = int(seps1[0])
-            else:
+            else:  # pragma: no cover
                 raise NotImplementedError("backgrounds with custom traces not supported (could not detect common separation)")  # noqa
         elif len(bg.traces) == 1:
             # either one_sided or trace, let's see if its constant offset from the trace
@@ -495,9 +495,9 @@ class SpectralExtraction(PluginTemplateMixin):
             if np.all(seps == seps[0]):
                 self.bg_type_selected = 'OneSided'
                 self.bg_separation = int(seps[0])
-            else:
+            else:  # pragma: no cover
                 raise NotImplementedError("backgrounds with custom traces not supported (could not detect common separation)")  # noqa
-        else:
+        else:  # pragma: no cover
             raise NotImplementedError("backgrounds with more than 2 traces not supported")
 
         self.bg_width = bg.width
@@ -531,7 +531,7 @@ class SpectralExtraction(PluginTemplateMixin):
                                                  trace,
                                                  self.bg_separation,
                                                  width=self.bg_width)
-        else:
+        else:  # pragma: no cover
             raise NotImplementedError(f"bg_type={self.bg_type_selected} not implemented")
 
         return bg
@@ -606,7 +606,7 @@ class SpectralExtraction(PluginTemplateMixin):
         ext : specreduce.extract.BoxcarExtract
             Extract object to import
         """
-        if not isinstance(ext, extract.BoxcarExtract):
+        if not isinstance(ext, extract.BoxcarExtract):  # pragma: no cover
             # TODO: add support for Optimal/Horne
             raise TypeError("ext must be a specreduce.extract.BoxcarExtract object")
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -303,7 +303,7 @@ class SpectralExtraction(PluginTemplateMixin):
             return
 
         try:
-            trace = self.export_trace(add_data=False)
+            trace = self.export_trace()
         except Exception:
             # NOTE: ignore error, but will be raised when clicking ANY of the export buttons
             self.marks['trace'].clear()
@@ -420,16 +420,10 @@ class SpectralExtraction(PluginTemplateMixin):
         else:  # pragma: no cover
             raise NotImplementedError(f"trace of type {trace.__class__.__name__} not supported")
 
-    def export_trace(self, add_data=False, **kwargs):
+    def export_trace(self, **kwargs):
         """
         Create a specreduce Trace object from the input parameters
         defined in the plugin.
-
-        Parameters
-        ----------
-        add_data : bool
-            Whether to add the resulting trace to the application, according to the options
-            defined in the plugin.
         """
         self._set_create_kwargs(**kwargs)
         if len(kwargs) and self.active_step != 'trace':
@@ -449,20 +443,14 @@ class SpectralExtraction(PluginTemplateMixin):
         else:
             raise NotImplementedError(f"trace_type={self.trace_type_selected} not implemented")
 
-        if add_data:
-            raise NotImplementedError("exporting trace to data entry not yet supported")
-
         return trace
-
-    def vue_create_trace(self, *args):
-        self.export_trace(add_data=True)
 
     def _get_bg_trace(self):
         if self.bg_type_selected == 'Manual':
             trace = tracing.FlatTrace(self.trace_dataset.selected_obj.data,
                                       self.bg_trace_pixel)
         else:
-            trace = self.export_trace(add_data=False)
+            trace = self.export_trace()
 
         return trace
 
@@ -589,7 +577,7 @@ class SpectralExtraction(PluginTemplateMixin):
         self.export_bg_sub(add_data=True)
 
     def _get_ext_trace(self):
-        return self.export_trace(add_data=False)
+        return self.export_trace()
 
     def _get_ext_input_spectrum(self):
         if self.ext_dataset_selected == 'From Plugin':

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -474,7 +474,7 @@ class SpectralExtraction(PluginTemplateMixin):
             seps2 = trace.trace - bg.traces[1].trace
             if np.all(seps1 == seps1[0]) and np.all(seps2 == seps1[0]):
                 self.bg_type_selected = 'TwoSided'
-                self.bg_separation = int(seps1[0])
+                self.bg_separation = abs(int(seps1[0]))
             else:  # pragma: no cover
                 raise NotImplementedError("backgrounds with custom traces not supported (could not detect common separation)")  # noqa
         elif len(bg.traces) == 1:

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -182,7 +182,7 @@
                 :add_to_viewer_selected.sync="bg_add_to_viewer_selected"
                 action_label="Export"
                 action_tooltip="Create Background Image"
-                @click:action="create_bg"
+                @click:action="create_bg_img"
               ></plugin-add-results>
             </v-expansion-panel-content>
           </v-expansion-panel>
@@ -252,7 +252,7 @@
         action_label="Extract"
         action_tooltip="Extract 1D Spectrum"
         :action_disabled="ext_specreduce_err.length"
-        @click:action="extract"
+        @click:action="extract_spectrum"
       ></plugin-add-results>
     </div>
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -27,12 +27,12 @@ def test_plugin(specviz2d_helper):
     # create FlatTrace
     pext.trace_type_selected = 'Flat'
     pext.trace_pixel = 28
-    trace = pext.create_trace()
+    trace = pext.export_trace()
     assert isinstance(trace, tracing.FlatTrace)
 
     # create KosmosTrace
     pext.trace_type_selected = 'Auto'
-    trace = pext.create_trace()
+    trace = pext.export_trace()
     assert isinstance(trace, tracing.KosmosTrace)
 
     # interact with background section, check marks
@@ -53,9 +53,9 @@ def test_plugin(specviz2d_helper):
     assert len(pext.marks['bg2_center'].x) == 0
 
     # create background image
-    bg = pext.create_bg()
+    bg = pext.export_bg()
     assert isinstance(bg, Spectrum1D)
-    bg_sub = pext.create_bg_sub()
+    bg_sub = pext.export_bg_sub()
     assert isinstance(bg_sub, Spectrum1D)
 
     # interact with extraction section, check marks
@@ -67,7 +67,7 @@ def test_plugin(specviz2d_helper):
         assert len(pext.marks[mark].x) > 0
 
     # create subtracted spectrum
-    sp_ext = pext.create_extract()
+    sp_ext = pext.export_extract()
     assert isinstance(sp_ext, Spectrum1D)
 
     # test exception handling

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -38,6 +38,8 @@ def test_plugin(specviz2d_helper):
     trace = pext.export_trace()
     assert isinstance(trace, tracing.KosmosTrace)
     assert trace.guess == 27
+    trace = pext.export_trace(trace_pixel=26)
+    assert trace.guess == 26
     trace.guess = 28
     pext.import_trace(trace)
     assert pext.trace_pixel == 28
@@ -50,21 +52,29 @@ def test_plugin(specviz2d_helper):
     for mark in ['bg1_center', 'bg2_center']:
         assert pext.marks[mark].visible is True
         assert len(pext.marks[mark].x) > 0
+    bg = pext.export_bg()
+    pext.import_bg(bg)
+    assert pext.bg_type_selected == 'TwoSided'
+
     pext.bg_type_selected = 'Manual'
     assert len(pext.marks['bg1_center'].x) == 0
     assert len(pext.marks['bg2_center'].x) == 0
     assert len(pext.marks['bg1_lower'].x) > 0
+
     pext.bg_type_selected = 'OneSided'
     # only bg1 is populated for OneSided
     assert len(pext.marks['bg1_center'].x) > 0
     assert len(pext.marks['bg2_center'].x) == 0
 
     # create background image
+    pext.bg_separation = 4
     bg = pext.export_bg()
     assert isinstance(bg, background.Background)
     assert len(bg.traces) == 1
-    assert bg.traces[0].trace[0] == 28 + 5
+    assert bg.traces[0].trace[0] == 28 + 4
     assert bg.width == 3
+    bg = pext.export_bg(bg_width=5)
+    assert bg.width == 5
     bg.width = 4
     pext.import_bg(bg)
     assert pext.bg_width == 4

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     voila>=0.3.5
     pyyaml>=5.4.1
     specutils>=1.7.0
-    specreduce==1.1.0
+    specreduce>=1.1.0,<1.2.0
     photutils>=1.4
     glue-astronomy>=0.5
     asteval>=0.9.23


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This PR extends on #1514 with a more flexible user-API for 2D to 1D spectral extraction.

[Updated spectral extraction docs](https://jdaviz--1554.org.readthedocs.build/en/1554/specviz2d/plugins.html#spectral-extraction)

- [x] requires https://github.com/astropy/specreduce/pull/117 (approved, merged, released, and pinned here), and is expected to fail CI until then.

Proposed public methods on the spectral-extraction plugin, accessed with `specviz2d.app.get_tray_item_from_name('spectral-extraction')`:
* `import_trace(trace)` - takes a specreduce trace object and loads the _input parameters_ into the plugin.  Supports `FlatTrace` and `KosmosTrace`.
* `export_trace(add_data=False, **kwargs)` - creates and returns a trace from the input parameters in the plugin.  If `add_data=True`, this adds a new data entry (once supported by glue-astronomy).
* `import_bg(bg)` - takes a specreduce background object and loads the _input parameters_ into the plugin.  Supports one-sided and two-sided backgrounds only, recognized relative to the currently set trace.
* `export_bg(**kwargs)` - creates and returns a specreduce background object from the input parameters in the plugin.
* `export_bg_img(add_data=False, **kwargs)` - returns the background 2d spectrum, optionally adding it as a data entry in the app/viewer.
* `export_bg_sub(add_data=False, **kwargs)` - returns the background-subtracted 2d spectrum, optionally adding it as a data entry in the app/viewer.
* `import_extract(ext)` - takes a specreduce extraction object and loads the _input parameters_ into the plugin.  Supports `BoxcarExtract` (should be extended to `OptimalExtract` once supported by the plugin).
* `export_extract(**kwargs)` - creates and returns a specreduce extract object from the input parameters in the plugin.
* `export_extract_spectrum(add_data=False, **kwargs)` - returns the extracted spectrum, optionally adding it as a data entry in the app/viewer.

For all `export_` methods: `**kwargs` allows setting traitlets directly from the method, and raises an error if any unsupported kwargs are passed.

For all methods: calling the method or changing a traitlet counts as an interaction with the applicable "step" and updates the visualization in real time (see screen recording below).

Note: I think we should give some thought about the import/export prefixes (these could alternatively be load/update and get, for example).  We could also consider abstracting these away with getters/setters for `trace`, `background`, and `extract` attributes, but then would lose the ability to pass `**kwargs` and so would require setting traitlets manually or through the specreduce API as well as the ability to request `add_data=True` which is particularly useful for the background and background-subtraction methods.


https://user-images.githubusercontent.com/877591/183725054-06d13233-17ef-494d-9bdb-6f754d126903.mov




<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
