### PR TITLE
spectral-extraction: support import/export trace via glue-astronomy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ Specviz2d
 
 - Support for Horne/Optimal extraction. [#1572]
 
+- Support for importing/exporting Trace objects as data entries. [#1556]
+
 API Changes
 -----------
 

--- a/docs/specviz2d/plugins.rst
+++ b/docs/specviz2d/plugins.rst
@@ -69,9 +69,9 @@ adjust plotting options), open the "Export Trace" panel, choose a label for the 
 and click "Create".  Note that this step is not required to create an extraction with simple
 workflows.
 
-Trace objects created outside of jdaviz can be loaded into the app via::
+Trace objects created outside of jdaviz can be loaded into the app via :meth:`~jdaviz.configs.specviz2d.helper.Specviz2d.load_trace`:
 
-    viz.app.add_data(my_trace)
+  viz.load_trace(my_trace, data_label="my trace")
 
 and then added to the viewer through the data menu.
 

--- a/docs/specviz2d/plugins.rst
+++ b/docs/specviz2d/plugins.rst
@@ -83,7 +83,7 @@ To export and access the specreduce Trace object defined in the plugin, call :me
 
   trace = sp_ext.export_trace()
 
-To import the parameters from a specreduce Trace object, whether it's new or was exported and modified in the notebook, call:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.import_trace`::
+To import the parameters from a specreduce Trace object, whether it's new or was exported and modified in the notebook, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.import_trace`::
 
   sp_ext.import_trace(trace)
 

--- a/docs/specviz2d/plugins.rst
+++ b/docs/specviz2d/plugins.rst
@@ -64,6 +64,20 @@ of the plugin, the live visualization will change to show the trace as a solid l
 To create a new trace in the plugin, choose the desired "Trace Type" and edit any input arguments.
 A preview of the trace will update in real time in the 2D spectrum viewer.
 
+To export the trace as a data object into the 2D spectrum viewer (to access via the API or to 
+adjust plotting options), open the "Export Trace" panel, choose a label for the new data entry,
+and click "Create".  Note that this step is not required to create an extraction with simple
+workflows.
+
+Trace objects created outside of jdaviz can be loaded into the app via::
+
+    viz.app.add_data(my_trace)
+
+and then added to the viewer through the data menu.
+
+Once trace objects are loaded into the app, they can be offset (in the cross-dispersion direction)
+by selecting the trace label, entering an offset, and overwriting the existing data entry (or
+creating a new one) with the modified trace.
 
 To export and access the specreduce Trace object defined in the plugin, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_trace`::
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -404,17 +404,16 @@ class Application(VuetifyTemplate, HubListener):
         ref_data = dc[reference_data] if reference_data else dc[0]
         linked_data = dc[data_to_be_linked] if data_to_be_linked else dc[-1]
 
-        if linked_data.meta.get('Plugin', None) == 'SpectralExtraction':
-            if 'Trace' in linked_data.meta:
-                links = [LinkSame(linked_data.components[1], ref_data.components[0]),
-                         LinkSame(linked_data.components[0], ref_data.components[1])]
-                dc.add_link(links)
-                return
-            else:
-                links = [LinkSame(linked_data.components[0], ref_data.components[0]),
-                         LinkSame(linked_data.components[1], ref_data.components[1])]
-                dc.add_link(links)
-                return
+        if 'Trace' in linked_data.meta:
+            links = [LinkSame(linked_data.components[1], ref_data.components[0]),
+                     LinkSame(linked_data.components[0], ref_data.components[1])]
+            dc.add_link(links)
+            return
+        elif linked_data.meta.get('Plugin', None) == 'SpectralExtraction':
+            links = [LinkSame(linked_data.components[0], ref_data.components[0]),
+                     LinkSame(linked_data.components[1], ref_data.components[1])]
+            dc.add_link(links)
+            return
 
         # The glue-astronomy SpectralCoordinates currently seems incompatible with glue
         # WCSLink. This gets around it until there's an upstream fix.

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -406,7 +406,7 @@ class Application(VuetifyTemplate, HubListener):
 
         if linked_data.meta.get('Plugin', None) == 'SpectralExtraction':
             if 'Trace' in linked_data.meta:
-                links = [LinkSame(linked_data.components[2], ref_data.components[0]),
+                links = [LinkSame(linked_data.components[1], ref_data.components[0]),
                          LinkSame(linked_data.components[0], ref_data.components[1])]
                 dc.add_link(links)
                 return

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -136,6 +136,10 @@ class PlotOptions(PluginTemplateMixin):
         def is_not_subset(state):
             return not is_spatial_subset(state)
 
+        def line_visible(state):
+            # exclude for scatter layers where the marker is shown instead of the line
+            return getattr(state, 'line_visible', True)
+
         # Profile/line viewer/layer options:
         self.layer_visible = PlotOptionsSyncState(self, self.viewer, self.layer, 'visible',
                                                   'layer_visible_value', 'layer_visible_sync',
@@ -146,7 +150,8 @@ class PlotOptions(PluginTemplateMixin):
                                                'line_color_value', 'line_color_sync',
                                                state_filter=not_image)
         self.line_width = PlotOptionsSyncState(self, self.viewer, self.layer, 'linewidth',
-                                               'line_width_value', 'line_width_sync')
+                                               'line_width_value', 'line_width_sync',
+                                               state_filter=line_visible)
         self.line_opacity = PlotOptionsSyncState(self, self.viewer, self.layer, 'alpha',
                                                  'line_opacity_value', 'line_opacity_sync',
                                                  state_filter=is_profile)

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -3,6 +3,7 @@ import numpy as np
 from glue.core.subset import RoiSubsetState
 from glue_jupyter.bqplot.profile import BqplotProfileView
 from glue_jupyter.bqplot.image import BqplotImageView
+from glue_jupyter.bqplot.scatter.layer_artist import BqplotScatterLayerState
 from glue_jupyter.table import TableViewer
 
 from jdaviz.components.toolbar_nested import NestedJupyterToolbar
@@ -74,6 +75,10 @@ class JdavizViewerMixin:
     def _update_layer_icons(self):
         # update visible_layers (TODO: move this somewhere that can update on color change, etc)
         def _get_layer_color(layer):
+            if isinstance(layer, BqplotScatterLayerState):
+                # then this could be a scatter layer in an image viewer,
+                # so we'll ignore the color_mode
+                return layer.color
             if getattr(self.state, 'color_mode', None) == 'Colormaps':
                 for subset in self.jdaviz_app.data_collection.subset_groups:
                     if subset.label == layer.layer.label:
@@ -92,6 +97,9 @@ class JdavizViewerMixin:
                 suffix = f" (collapsed: {self.state.function})"
             else:
                 suffix = ""
+
+            if 'Trace' in layer.layer.data.meta:
+                return "mdi-chart-line-stacked", ""
 
             # then the underlying data is cube-like and we're in the profile viewer, so we
             # want to include the collapse function *unless* the layer is a spectral subset

--- a/jdaviz/configs/specviz2d/helper.py
+++ b/jdaviz/configs/specviz2d/helper.py
@@ -180,3 +180,20 @@ class Specviz2d(ConfigHelper, LineListMixin):
             self.app.load_data(spectrum_1d, data_label=spectrum_1d_label,
                                parser_reference="specviz-spectrum1d-parser",
                                show_in_viewer=show_in_viewer)
+
+    def load_trace(self, trace, data_label, show_in_viewer=True):
+        """
+        Load a trace object and load into the spectrum-2d-viewer
+
+        Parameters
+        ----------
+        trace : Trace
+            A specreduce trace object
+        data_label : str
+            String representing the label
+        show_in_viewer : bool
+            Whether to load into the spectrum-2d-viewer.
+        """
+        self.app.add_data(trace, data_label=data_label)
+        if show_in_viewer:
+            self.app.add_data_to_viewer('spectrum-2d-viewer', data_label)

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -500,6 +500,8 @@ class SpectralExtraction(PluginTemplateMixin):
             self.trace_pixel = trace.guess
             self.trace_window = trace.window
             self.trace_bins = trace.bins
+        elif isinstance(trace, tracing.ArrayTrace):  # pragma: no cover
+            raise NotImplementedError(f"cannot import ArrayTrace into plugin.  Use viz.load_trace instead")  # noqa
         else:  # pragma: no cover
             raise NotImplementedError(f"trace of type {trace.__class__.__name__} not supported")
 
@@ -520,8 +522,15 @@ class SpectralExtraction(PluginTemplateMixin):
 
         if self.trace_trace_selected != 'New Trace':
             # then we're offsetting an existing trace
-            trace = tracing.ArrayTrace(self.trace_dataset.selected_obj.data,
-                                       self.trace_trace.selected_obj.trace+self.trace_offset)
+            # for FlatTrace, we can keep and expose a new FlatTrace (which has the advantage of
+            # being able to load back into the plugin)
+            orig_trace = self.trace_trace.selected_obj
+            if isinstance(orig_trace, tracing.FlatTrace):
+                trace = tracing.FlatTrace(self.trace_dataset.selected_obj.data,
+                                          orig_trace.trace_pos+self.trace_offset)
+            else:
+                trace = tracing.ArrayTrace(self.trace_dataset.selected_obj.data,
+                                           self.trace_trace.selected_obj.trace+self.trace_offset)
 
         elif self.trace_type_selected == 'Flat':
             trace = tracing.FlatTrace(self.trace_dataset.selected_obj.data,

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -176,6 +176,14 @@
         ></v-select>
       </v-row>
 
+      <plugin-dataset-select
+        :items="bg_trace_items"
+        :selected.sync="bg_trace_selected"
+        :show_if_single_entry="false"
+        label="Background Trace"
+        hint="Trace to use as reference for background window(s).  'From Plugin' uses trace defined in Trace section above."
+      />
+
       <v-row v-if="bg_type_selected === 'Manual'">
         <v-text-field
           label="Pixel"
@@ -276,6 +284,14 @@
         :show_if_single_entry="false"
         label="2D Spectrum"
         hint="Select the data used to extract the spectrum.  'From Plugin' uses background-subtraced image defined in Background section above."
+      />
+
+      <plugin-dataset-select
+        :items="ext_trace_items"
+        :selected.sync="ext_trace_selected"
+        :show_if_single_entry="false"
+        label="Extraction Trace"
+        hint="Trace to use as center of extraction window.  'From Plugin' uses trace defined in Trace section above."
       />
 
       <v-row>

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -33,7 +33,28 @@
         </j-docs-link>
       </v-row>
 
-      <div>
+      <plugin-dataset-select
+        :items="trace_trace_items"
+        :selected.sync="trace_trace_selected"
+        :show_if_single_entry="false"
+        label="Trace"
+        hint="Existing trace to offset or create a new trace"
+      />
+
+      <div v-if="trace_trace_selected !== 'New Trace'">
+        <v-row>
+          <v-text-field
+            label="Offset"
+            type="number"
+            v-model.number="trace_offset"
+            :rules="[() => trace_offset!=='' || 'This field is required']"
+            hint="Offset to apply to existing trace, in pixels."
+            persistent-hint
+          >
+          </v-text-field>
+        </v-row>
+      </div>
+      <div v-else>
         <plugin-dataset-select
           :items="trace_dataset_items"
           :selected.sync="trace_dataset_selected"
@@ -98,6 +119,31 @@
           ></v-select>
         </v-row>
       </div>
+
+      <v-row>
+        <v-expansion-panels popout>
+          <v-expansion-panel>
+            <v-expansion-panel-header v-slot="{ open }">
+              <span style="padding: 6px">Export Trace</span>
+            </v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <plugin-add-results
+                :label.sync="trace_results_label"
+                :label_default="trace_results_label_default"
+                :label_auto.sync="trace_results_label_auto"
+                :label_invalid_msg="trace_results_label_invalid_msg"
+                :label_overwrite="trace_results_label_overwrite"
+                label_hint="Label for the trace"
+                :add_to_viewer_items="trace_add_to_viewer_items"
+                :add_to_viewer_selected.sync="trace_add_to_viewer_selected"
+                action_label="Create"
+                action_tooltip="Create Trace"
+                @click:action="create_trace"
+              ></plugin-add-results>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </v-row>
     </div>
 
     <div @mouseover="() => active_step='bg'">

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -37,12 +37,12 @@ def test_plugin(specviz2d_helper):
     pext.trace_trace_selected = 'trace'
     pext.trace_offset = 2
     trace = pext.export_trace(add_data=True)  # overwrite
-    assert isinstance(trace, tracing.ArrayTrace)
+    assert isinstance(trace, tracing.FlatTrace)
 
     # create KosmosTrace
     pext.trace_trace_selected = 'New Trace'
     pext.trace_type_selected = 'Auto'
-    trace = pext.export_trace(add_data=False)
+    trace = pext.export_trace(add_data=True)
     assert isinstance(trace, tracing.KosmosTrace)
     assert trace.guess == 27
     trace = pext.export_trace(trace_pixel=26, add_data=False)
@@ -51,10 +51,17 @@ def test_plugin(specviz2d_helper):
     pext.import_trace(trace)
     assert pext.trace_pixel == 28
 
+    # offset existing trace
+    pext.trace_trace_selected = 'trace'
+    pext.trace_offset = 2
+    trace = pext.export_trace(add_data=True)  # overwrite
+    assert isinstance(trace, tracing.ArrayTrace)
+
     # 3 new trace objects should have been loaded and plotted in the spectrum-2d-viewer
     assert len(sp2dv.figure.marks) == 14
 
     # interact with background section, check marks
+    pext.trace_trace_selected = 'New Trace'
     pext.trace_type_selected = 'Flat'
     pext.bg_separation = 5
     pext.bg_width = 3

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -26,23 +26,33 @@ def test_plugin(specviz2d_helper):
     # create FlatTrace
     pext.trace_type_selected = 'Flat'
     pext.trace_pixel = 28
-    trace = pext.export_trace()
+    trace = pext.export_trace(add_data=True)
     assert isinstance(trace, tracing.FlatTrace)
     assert trace.trace_pos == 28
     trace.trace_pos = 27
     pext.import_trace(trace)
     assert pext.trace_pixel == 27
 
+    # offset existing trace
+    pext.trace_trace_selected = 'trace'
+    pext.trace_offset = 2
+    trace = pext.export_trace(add_data=True)  # overwrite
+    assert isinstance(trace, tracing.ArrayTrace)
+
     # create KosmosTrace
+    pext.trace_trace_selected = 'New Trace'
     pext.trace_type_selected = 'Auto'
-    trace = pext.export_trace()
+    trace = pext.export_trace(add_data=False)
     assert isinstance(trace, tracing.KosmosTrace)
     assert trace.guess == 27
-    trace = pext.export_trace(trace_pixel=26)
+    trace = pext.export_trace(trace_pixel=26, add_data=False)
     assert trace.guess == 26
     trace.guess = 28
     pext.import_trace(trace)
     assert pext.trace_pixel == 28
+
+    # 3 new trace objects should have been loaded and plotted in the spectrum-2d-viewer
+    assert len(sp2dv.figure.marks) == 14
 
     # interact with background section, check marks
     pext.trace_type_selected = 'Flat'

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1267,6 +1267,7 @@ class DatasetSelect(SelectPluginComponent):
         # Add/Remove Data are triggered when checked/unchecked from viewers
         self.hub.subscribe(self, AddDataMessage, handler=self._on_data_changed)
         self.hub.subscribe(self, RemoveDataMessage, handler=self._on_data_changed)
+        self.hub.subscribe(self, DataCollectionAddMessage, handler=self._on_data_changed)
         self.hub.subscribe(self, DataCollectionDeleteMessage, handler=self._on_data_changed)
 
         self.app.state.add_callback('layer_icons', lambda _: self._on_data_changed())
@@ -1276,6 +1277,8 @@ class DatasetSelect(SelectPluginComponent):
     @property
     def default_data_cls(self):
         if self.app.config == 'imviz':
+            return None
+        if 'is_trace' in self.filters:
             return None
         return Spectrum1D
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request extends on #1514 to add support for displaying traces as glue data objects (and therefore importing trace objects via `app.add_data`).  

This also supports flexible workflows where the background and extraction step reference different traces (including the case of offsetting an auto/kosmos trace within the app, or loading a custom trace from the API):


https://user-images.githubusercontent.com/877591/189728882-90cb90be-257c-4a9a-8813-dd56ef36454c.mov



[updated spectral extraction docs](https://jdaviz--1556.org.readthedocs.build/en/1556/specviz2d/plugins.html#spectral-extraction)

- [x] requires https://github.com/glue-viz/glue-astronomy/pull/72 being merged, released, and pinned here.
- [x] blocked by #1554 being merged, this rebased on top of that, and then re-implement support for extract_trace API

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
