### PR TITLE
plugin method to open in tray

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ New Features
 - New ``jdaviz.core.region_translators.regions2roi()`` function to convert certain
   ``regions`` shapes into ``glue`` ROIs. [#1463]
 
+- New plugin-level ``open_in_tray`` method to programmatically show the plugin. [#1559]
+
 Cubeviz
 ^^^^^^^
 
@@ -41,8 +43,6 @@ Specviz2d
 
 API Changes
 -----------
-
-- New plugin-level ``show_in_tray`` method. [#1559]
 
 Cubeviz
 ^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,8 @@ Specviz2d
 API Changes
 -----------
 
+- New plugin-level ``show_in_tray`` method. [#1559]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.py
@@ -8,13 +8,13 @@ from specutils.spectra.spectrum1d import Spectrum1D
 
 from jdaviz.core.events import AddDataMessage, SliceToolStateMessage, SliceSelectSliceMessage
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import TemplateMixin
+from jdaviz.core.template_mixin import PluginTemplateMixin
 
 __all__ = ['Slice']
 
 
 @tray_registry('cubeviz-slice', label="Slice")
-class Slice(TemplateMixin):
+class Slice(PluginTemplateMixin):
     template_file = __file__, "slice.vue"
     slider = Any(0).tag(sync=True)
     wavelength = Any(-1).tag(sync=True)

--- a/jdaviz/configs/default/plugins/export_plot/export_plot.py
+++ b/jdaviz/configs/default/plugins/export_plot/export_plot.py
@@ -1,11 +1,11 @@
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import TemplateMixin, ViewerSelectMixin
+from jdaviz.core.template_mixin import PluginTemplateMixin, ViewerSelectMixin
 
 __all__ = ['ExportViewer']
 
 
 @tray_registry('g-export-plot', label="Export Plot")
-class ExportViewer(TemplateMixin, ViewerSelectMixin):
+class ExportViewer(PluginTemplateMixin, ViewerSelectMixin):
     template_file = __file__, "export_plot.vue"
 
     def __init__(self, *args, **kwargs):

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -9,7 +9,7 @@ from traitlets import List, Unicode, Bool, observe
 from jdaviz.core.custom_traitlets import FloatHandleEmpty
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import TemplateMixin, DatasetSelectMixin, AddResultsMixin
+from jdaviz.core.template_mixin import PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin
 
 __all__ = ['GaussianSmooth']
 
@@ -19,7 +19,7 @@ u.add_enabled_units([spaxel])
 
 
 @tray_registry('g-gaussian-smooth', label="Gaussian Smooth")
-class GaussianSmooth(TemplateMixin, DatasetSelectMixin, AddResultsMixin):
+class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
     template_file = __file__, "gaussian_smooth.vue"
     stddev = FloatHandleEmpty(1).tag(sync=True)
     selected_data_is_1d = Bool(True).tag(sync=True)

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -1,14 +1,14 @@
 from traitlets import Bool, List, observe
 
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import TemplateMixin, DatasetSelectMixin
+from jdaviz.core.template_mixin import PluginTemplateMixin, DatasetSelectMixin
 from jdaviz.utils import PRIHDR_KEY, COMMENTCARD_KEY
 
 __all__ = ['MetadataViewer']
 
 
 @tray_registry('g-metadata-viewer', label="Metadata Viewer")
-class MetadataViewer(TemplateMixin, DatasetSelectMixin):
+class MetadataViewer(PluginTemplateMixin, DatasetSelectMixin):
     template_file = __file__, "metadata_viewer.vue"
     has_metadata = Bool(False).tag(sync=True)
     has_primary = Bool(False).tag(sync=True)

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -8,7 +8,7 @@ from glue_jupyter.bqplot.image.state import BqplotImageLayerState
 from glue_jupyter.common.toolbar_vuetify import read_icon
 
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import (TemplateMixin, ViewerSelect, LayerSelect,
+from jdaviz.core.template_mixin import (PluginTemplateMixin, ViewerSelect, LayerSelect,
                                         PlotOptionsSyncState)
 from jdaviz.core.tools import ICON_DIR
 
@@ -16,7 +16,7 @@ __all__ = ['PlotOptions']
 
 
 @tray_registry('g-plot-options', label="Plot Options")
-class PlotOptions(TemplateMixin):
+class PlotOptions(PluginTemplateMixin):
     template_file = __file__, "plot_options.vue"
 
     # multiselect is shared between viewer and layer

--- a/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
+++ b/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
@@ -8,7 +8,7 @@ from traitlets import List, Unicode, Bool, observe
 
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import TemplateMixin, SubsetSelect
+from jdaviz.core.template_mixin import PluginTemplateMixin, SubsetSelect
 
 __all__ = ['SubsetPlugin']
 
@@ -22,7 +22,7 @@ SUBSET_MODES = {
 
 
 @tray_registry('g-subset-plugin', label="Subset Tools")
-class SubsetPlugin(TemplateMixin):
+class SubsetPlugin(PluginTemplateMixin):
     template_file = __file__, "subset_plugin.vue"
     select = List([]).tag(sync=True)
     subset_items = List([]).tag(sync=True)

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -22,14 +22,14 @@ from jdaviz.core.custom_traitlets import FloatHandleEmpty
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.region_translators import regions2aperture
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import TemplateMixin, DatasetSelectMixin, SubsetSelect
+from jdaviz.core.template_mixin import PluginTemplateMixin, DatasetSelectMixin, SubsetSelect
 from jdaviz.utils import bqplot_clear_figure, PRIHDR_KEY
 
 __all__ = ['SimpleAperturePhotometry']
 
 
 @tray_registry('imviz-aper-phot-simple', label="Imviz Simple Aperture Photometry")
-class SimpleAperturePhotometry(TemplateMixin, DatasetSelectMixin):
+class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin):
     template_file = __file__, "aper_phot_simple.vue"
     subset_items = List([]).tag(sync=True)
     subset_selected = Unicode("").tag(sync=True)

--- a/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
@@ -1,5 +1,5 @@
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import TemplateMixin
+from jdaviz.core.template_mixin import PluginTemplateMixin
 from jdaviz.core.events import SnackbarMessage
 
 from traitlets import Bool
@@ -43,7 +43,7 @@ def jwst_header_to_skyregion(header):
 
 
 @tray_registry('g-slit-overlay', label="Slit Overlay")
-class SlitOverlay(TemplateMixin):
+class SlitOverlay(PluginTemplateMixin):
     template_file = __file__, "slit_overlay.vue"
     visible = Bool(True).tag(sync=True)
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -3,7 +3,6 @@ from astropy.table import QTable
 import numpy as np
 from glue.core.roi import XRangeROI
 from glue.core.edit_subset_mode import NewMode
-from ipywidgets.widgets import widget_serialization
 
 from jdaviz.configs.specviz.plugins.line_analysis.line_analysis import _coerce_unit
 from jdaviz.core.events import LineIdentifyMessage
@@ -14,10 +13,8 @@ def test_plugin(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
-    specviz_helper.app.state.drawer = True
-    tray_names = [ti['name'] for ti in specviz_helper.app.state.tray_items]
-    plugin_index = tray_names.index('specviz-line-analysis')
-    specviz_helper.app.state.tray_items_open = [plugin_index]
+    plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
+    plugin.open_in_tray()
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -33,8 +30,6 @@ def test_plugin(specviz_helper, spectrum1d):
     sv.apply_roi(XRangeROI(6500, 7400))
     specviz_helper.app.state.drawer = True
 
-    ipy_model_id = specviz_helper.app.state.tray_items[plugin_index]['widget']
-    plugin = widget_serialization['from_json'](ipy_model_id, None)
     assert 'Subset 1' in plugin.spectral_subset.labels
     plugin.selected_subset = 'Subset 1'
     plugin.selected_continuum = 'Surrounding'
@@ -121,10 +116,8 @@ def test_continuum_surrounding_spectral_subset(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
-    specviz_helper.app.state.drawer = True
-    tray_names = [ti['name'] for ti in specviz_helper.app.state.tray_items]
-    plugin_index = tray_names.index('specviz-line-analysis')
-    specviz_helper.app.state.tray_items_open = [plugin_index]
+    plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
+    plugin.open_in_tray()
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -150,10 +143,8 @@ def test_continuum_spectral_same_value(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
-    specviz_helper.app.state.drawer = True
-    tray_names = [ti['name'] for ti in specviz_helper.app.state.tray_items]
-    plugin_index = tray_names.index('specviz-line-analysis')
-    specviz_helper.app.state.tray_items_open = [plugin_index]
+    plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
+    plugin.open_in_tray()
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -179,10 +170,8 @@ def test_continuum_surrounding_invalid_width(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
-    specviz_helper.app.state.drawer = True
-    tray_names = [ti['name'] for ti in specviz_helper.app.state.tray_items]
-    plugin_index = tray_names.index('specviz-line-analysis')
-    specviz_helper.app.state.tray_items_open = [plugin_index]
+    plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
+    plugin.open_in_tray()
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -206,10 +195,8 @@ def test_continuum_subset_spectral_entire(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
-    specviz_helper.app.state.drawer = True
-    tray_names = [ti['name'] for ti in specviz_helper.app.state.tray_items]
-    plugin_index = tray_names.index('specviz-line-analysis')
-    specviz_helper.app.state.tray_items_open = [plugin_index]
+    plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
+    plugin.open_in_tray()
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -235,10 +222,8 @@ def test_continuum_subset_spectral_subset2(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
-    specviz_helper.app.state.drawer = True
-    tray_names = [ti['name'] for ti in specviz_helper.app.state.tray_items]
-    plugin_index = tray_names.index('specviz-line-analysis')
-    specviz_helper.app.state.tray_items_open = [plugin_index]
+    plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
+    plugin.open_in_tray()
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -270,10 +255,8 @@ def test_continuum_surrounding_no_right(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
-    specviz_helper.app.state.drawer = True
-    tray_names = [ti['name'] for ti in specviz_helper.app.state.tray_items]
-    plugin_index = tray_names.index('specviz-line-analysis')
-    specviz_helper.app.state.tray_items_open = [plugin_index]
+    plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
+    plugin.open_in_tray()
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -300,10 +283,8 @@ def test_continuum_surrounding_no_left(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
-    specviz_helper.app.state.drawer = True
-    tray_names = [ti['name'] for ti in specviz_helper.app.state.tray_items]
-    plugin_index = tray_names.index('specviz-line-analysis')
-    specviz_helper.app.state.tray_items_open = [plugin_index]
+    plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
+    plugin.open_in_tray()
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -330,10 +311,8 @@ def test_subset_changed(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
     specviz_helper.load_spectrum(spectrum1d, data_label=label)
 
-    specviz_helper.app.state.drawer = True
-    tray_names = [ti['name'] for ti in specviz_helper.app.state.tray_items]
-    plugin_index = tray_names.index('specviz-line-analysis')
-    specviz_helper.app.state.tray_items_open = [plugin_index]
+    plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
+    plugin.open_in_tray()
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -19,10 +19,7 @@ def test_plugin(specviz2d_helper):
     sp2dv = specviz2d_helper.app.get_viewer('spectrum-2d-viewer')
     assert len(sp2dv.figure.marks) == 2
 
-    specviz2d_helper.app.state.drawer = True
-    tray_names = [ti['name'] for ti in specviz2d_helper.app.state.tray_items]
-    plugin_index = tray_names.index('spectral-extraction')
-    specviz2d_helper.app.state.tray_items_open = [plugin_index]
+    pext.open_in_tray()
     assert len(sp2dv.figure.marks) == 11
     assert pext.marks['trace'].visible is True
     assert len(pext.marks['trace'].x) > 0

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -102,6 +102,9 @@ class PluginTemplateMixin(TemplateMixin):
         self.plugin_opened = app_state.drawer and self._registry_name in tray_names_open
 
     def open_in_tray(self):
+        """
+        Open the plugin in the sidebar/tray (and open the sidebar if it is not already).
+        """
         app_state = self.app.state
         app_state.drawer = True
         index = [ti['name'] for ti in app_state.tray_items].index(self._registry_name)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -86,7 +86,7 @@ class TemplateMixin(VuetifyTemplate, HubListener):
 
 class PluginTemplateMixin(TemplateMixin):
     """
-    This base class can be inherited by all sidebar plugins to expose common functionality.
+    This base class can be inherited by all sidebar/tray plugins to expose common functionality.
     """
     disabled_msg = Unicode("").tag(sync=True)
     plugin_opened = Bool(False).tag(sync=True)
@@ -100,6 +100,13 @@ class PluginTemplateMixin(TemplateMixin):
         app_state = self.app.state
         tray_names_open = [app_state.tray_items[i]['name'] for i in app_state.tray_items_open]
         self.plugin_opened = app_state.drawer and self._registry_name in tray_names_open
+
+    def open_in_tray(self):
+        app_state = self.app.state
+        app_state.drawer = True
+        index = [ti['name'] for ti in app_state.tray_items].index(self._registry_name)
+        if index not in app_state.tray_items_open:
+            app_state.tray_items_open = app_state.tray_items_open + [index]
 
 
 class BasePluginComponent(HubListener):

--- a/jdaviz/core/tools.py
+++ b/jdaviz/core/tools.py
@@ -212,13 +212,8 @@ class _BaseSidebarShortcut(Tool):
     viewer_attr = 'viewer'
 
     def activate(self):
-        jdaviz_state = self.viewer.jdaviz_app.state
-        jdaviz_state.drawer = True
-        tray_item_names = [tray_item['name'] for tray_item in jdaviz_state.tray_items]
-        index = tray_item_names.index(self.plugin_name)
-        if index not in jdaviz_state.tray_items_open:
-            jdaviz_state.tray_items_open = jdaviz_state.tray_items_open + [index]
         plugin = self.viewer.jdaviz_app.get_tray_item_from_name(self.plugin_name)
+        plugin.open_in_tray()
         viewer_id = self.viewer.reference_id
         viewer_select = getattr(plugin, self.viewer_attr)
         if viewer_select.multiselect:


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request adds a convenience method on the plugin object to open the sidebar and open the plugin entry (if not already opened).  This essentially moves existing object in the tool (to open plot options or export) to the plugins, to be more easily accessible from the API.

For example:

```
plugin = viz.app.get_tray_item_from_name('g-metadata-viewer')
plugin.open_in_tray()
```

I'm mainly proposing this because I'm sick of having code in notebooks to manually find the index and set the state to reproduce workflows.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
