### PR TITLE
spectral-extraction: clarification improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ Specviz
 Specviz2d
 ^^^^^^^^^
 
-- Spectral extraction plugin. [#1514]
+- Spectral extraction plugin. [#1514, #1562]
 
 API Changes
 -----------

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -3,6 +3,7 @@ import numpy as np
 from traitlets import Bool, List, Unicode, observe
 
 
+from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         DatasetSelect,
@@ -71,6 +72,8 @@ class SpectralExtraction(PluginTemplateMixin):
     ext_dataset_selected = Unicode().tag(sync=True)
 
     ext_width = IntHandleEmpty(0).tag(sync=True)
+
+    ext_specreduce_err = Unicode().tag(sync=True)
 
     ext_results_label = Unicode().tag(sync=True)
     ext_results_label_default = Unicode().tag(sync=True)
@@ -201,12 +204,14 @@ class SpectralExtraction(PluginTemplateMixin):
         if self.setting_interactive_extract:
             try:
                 sp1d = self.create_extract(add_data=False)
-            except Exception:
+            except Exception as e:
                 # NOTE: ignore error, but will be raised when clicking ANY of the export buttons
                 # NOTE: KosmosTrace or manual background are often giving a
                 # "background regions overlapped" error from specreduce
+                self.ext_specreduce_err = str(e)
                 self.marks['extract'].clear()
             else:
+                self.ext_specreduce_err = ''
                 self.marks['extract'].update_xy(sp1d.spectral_axis.value,
                                                 sp1d.flux.value)
         else:
@@ -442,7 +447,12 @@ class SpectralExtraction(PluginTemplateMixin):
         return bg_spec
 
     def vue_create_bg(self, *args):
-        _ = self.create_bg(add_data=True)
+        try:
+            _ = self.create_bg(add_data=True)
+        except Exception as e:
+            msg = (f"Specreduce background failed with the following error: {str(e)}")
+            msg = SnackbarMessage(msg, color='error', sender=self)
+            self.app.hub.broadcast(msg)
 
     def create_bg_sub(self, add_data=False):
         """

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -208,7 +208,7 @@ class SpectralExtraction(PluginTemplateMixin):
                 # NOTE: ignore error, but will be raised when clicking ANY of the export buttons
                 # NOTE: KosmosTrace or manual background are often giving a
                 # "background regions overlapped" error from specreduce
-                self.ext_specreduce_err = str(e)
+                self.ext_specreduce_err = repr(e)
                 self.marks['extract'].clear()
             else:
                 self.ext_specreduce_err = ''
@@ -448,11 +448,12 @@ class SpectralExtraction(PluginTemplateMixin):
 
     def vue_create_bg(self, *args):
         try:
-            _ = self.create_bg(add_data=True)
+            self.create_bg(add_data=True)
         except Exception as e:
-            msg = (f"Specreduce background failed with the following error: {str(e)}")
-            msg = SnackbarMessage(msg, color='error', sender=self)
-            self.app.hub.broadcast(msg)
+            self.app.hub.broadcast(
+                SnackbarMessage(f"Specreduce background failed with the following error: {repr(e)}",
+                                color='error', sender=self)
+            )
 
     def create_bg_sub(self, add_data=False):
         """

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -94,6 +94,12 @@
         <j-docs-link>Create a background and/or background-subtracted image.</j-docs-link>
       </v-row>
 
+      <v-row v-if="ext_dataset_selected !== 'From Plugin'">
+        <span class="v-messages v-messages__message text--secondary">
+          <b>NOTE:</b> extracted spectrum is using "{{ext_dataset_selected}}" as input data, so will not update in real-time.  Switch to "From Plugin" to use the background subtraction defined here.
+        </span>
+      </v-row>
+
       <plugin-dataset-select
         :items="bg_dataset_items"
         :selected.sync="bg_dataset_selected"

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -96,7 +96,7 @@
 
       <v-row v-if="ext_dataset_selected !== 'From Plugin'">
         <span class="v-messages v-messages__message text--secondary">
-          <b>NOTE:</b> extracted spectrum is using "{{ext_dataset_selected}}" as input data, so will not update in real-time.  Switch to "From Plugin" to use the background subtraction defined here.
+          <b style="color: red !important">NOTE:</b> extracted spectrum is using "{{ext_dataset_selected}}" as input data, so will not update in real-time.  Switch to "From Plugin" to use the background subtraction defined here.
         </span>
       </v-row>
 
@@ -241,9 +241,16 @@
         :add_to_viewer_selected.sync="ext_add_to_viewer_selected"
         action_label="Extract"
         action_tooltip="Extract 1D Spectrum"
+        :action_disabled="ext_specreduce_err.length"
         @click:action="extract"
       ></plugin-add-results>
     </div>
+
+    <v-row v-if="ext_specreduce_err">
+      <span class="v-messages v-messages__message text--secondary">
+        <b style="color: red !important">ERROR from specreduce:</b> {{ext_specreduce_err}}
+      </span>
+    </v-row>
 
     </div>
   </j-tray-plugin>

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -56,7 +56,7 @@
             type="number"
             v-model.number="trace_pixel"
             :rules="[() => trace_pixel!=='' || 'This field is required']"
-            hint="Pixel number/column to start the trace."
+            :hint="trace_type_selected === 'Flat' ? 'Pixel number/column for the trace.' : 'Pixel number/column guess'"
             persistent-hint
           >
           </v-text-field>
@@ -130,7 +130,7 @@
           type="number"
           v-model.number="bg_separation"
           :rules="[() => bg_separation!=='' || 'This field is required']"
-          hint="Separation between trace and background window(s), in pixels."
+          hint="Separation between trace and center of the background window(s), in pixels."
           persistent-hint
         >
         </v-text-field>

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -124,7 +124,7 @@
           type="number"
           v-model.number="bg_trace_pixel"
           :rules="[() => bg_trace_pixel!=='' || 'This field is required']"
-          hint="Pixel number/column to use for the trace."
+          hint="Pixel number/column to use for the center of the manual background window."
           persistent-hint
         >
         </v-text-field>

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -72,3 +72,13 @@ def test_plugin(specviz2d_helper):
     # create subtracted spectrum
     sp_ext = pext.create_extract()
     assert isinstance(sp_ext, Spectrum1D)
+
+    # test exception handling
+    pext.trace_type = 'Auto'
+    pext.bg_type_selected = 'TwoSided'
+    pext.bg_separation = 1
+    pext.bg_width = 5
+    assert len(pext.ext_specreduce_err) > 0
+    pext.bg_results_label = 'should not be created'
+    pext.vue_create_bg()
+    assert 'should not be created' not in [d.label for d in specviz2d_helper.app.data_collection]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request: 
* clarifies some of the input parameter descriptions in the UI,
* adds a note in the plugin when the extraction input data is selected to something other than "From Plugin" to explain that the spectrum preview will no longer update in real time,
* exposes specreduce errors in the plugin (for live-preview of the extraction) and in a snackbar (when exporting the background or background-subtracted image fails).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
