### PR TITLE
spectral-extraction: support for optimal extraction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,11 @@ Mosviz
 Specviz
 ^^^^^^^
 
+Specviz2D
+^^^^^^^^^
+
+- Support for Horne/Optimal extraction. [#1572]
+
 API Changes
 -----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ Mosviz
 Specviz
 ^^^^^^^
 
-Specviz2D
+Specviz2d
 ^^^^^^^^^
 
 - Support for Horne/Optimal extraction. [#1572]

--- a/docs/specviz2d/plugins.rst
+++ b/docs/specviz2d/plugins.rst
@@ -131,6 +131,9 @@ To import the parameters from a specreduce extraction object (either a new objec
   sp_ext.import_extract(ext)
 
 
+Note: Horne extraction uses uncertainties on the input 2D spectrum.  If the spectrum uncertainties are not explicitly assigned a type, they are assumed to be standard deviation uncertainties.
+
+
 .. _specviz2d-gaussian-smooth:
 
 Gaussian Smooth

--- a/docs/specviz2d/plugins.rst
+++ b/docs/specviz2d/plugins.rst
@@ -131,7 +131,11 @@ To import the parameters from a specreduce extraction object (either a new objec
   sp_ext.import_extract(ext)
 
 
-Note: Horne extraction uses uncertainties on the input 2D spectrum.  If the spectrum uncertainties are not explicitly assigned a type, they are assumed to be standard deviation uncertainties.
+.. note::
+
+    Horne extraction uses uncertainties on the input 2D spectrum. If the
+    spectrum uncertainties are not explicitly assigned a type, they are assumed
+    to be standard deviation uncertainties.
 
 
 .. _specviz2d-gaussian-smooth:

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -11,7 +11,7 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
 from jdaviz.core.custom_traitlets import IntHandleEmpty
 from jdaviz.core.marks import PluginLine
 
-from astropy.nddata import NDData, StdDevUncertainty, VarianceUncertainty
+from astropy.nddata import NDData, StdDevUncertainty, VarianceUncertainty, UnknownUncertainty
 from specutils import Spectrum1D
 from specreduce import tracing
 from specreduce import background
@@ -402,7 +402,7 @@ class SpectralExtraction(PluginTemplateMixin):
         # when specutils handles the warning/exception
         if self.ext_type_selected == 'Horne':
             inp_sp2d = self._get_ext_input_spectrum()
-            self.ext_uncert_warn = inp_sp2d.uncertainty is not None and not hasattr(inp_sp2d.uncertainty, 'uncertainty_type')  # noqa
+            self.ext_uncert_warn = isinstance(inp_sp2d.uncertainty, UnknownUncertainty)
         else:
             self.ext_uncert_warn = False
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -80,6 +80,7 @@ class SpectralExtraction(PluginTemplateMixin):
 
     ext_width = IntHandleEmpty(0).tag(sync=True)
 
+    ext_uncert_warn = Bool(False).tag(sync=True)
     ext_specreduce_err = Unicode().tag(sync=True)
 
     ext_results_label = Unicode().tag(sync=True)
@@ -396,6 +397,14 @@ class SpectralExtraction(PluginTemplateMixin):
 
         self.active_step = 'ext'
         self._update_plugin_marks()
+
+        # TODO: remove this, the traitlet, and the row in spectral_extraction.vue
+        # when specutils handles the warning/exception
+        if self.ext_type_selected == 'Horne':
+            inp_sp2d = self._get_ext_input_spectrum()
+            self.ext_uncert_warn = inp_sp2d.uncertainty is not None and not hasattr(inp_sp2d.uncertainty, 'uncertainty_type')  # noqa
+        else:
+            self.ext_uncert_warn = False
 
     def _set_create_kwargs(self, **kwargs):
         invalid_kwargs = [k for k in kwargs.keys() if not hasattr(self, k)]

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -11,7 +11,9 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
 from jdaviz.core.custom_traitlets import IntHandleEmpty
 from jdaviz.core.marks import PluginLine
 
+from astropy.nddata import VarianceUncertainty
 from specutils import Spectrum1D
+from specutils.analysis.uncertainty import _convert_uncertainty
 from specreduce import tracing
 from specreduce import background
 from specreduce import extract
@@ -623,10 +625,10 @@ class SpectralExtraction(PluginTemplateMixin):
         if self.ext_type_selected == 'Boxcar':
             ext = extract.BoxcarExtract(inp_sp2d.data, trace, width=self.ext_width)
         elif self.ext_type_selected == 'Optimal':
-            # TODO: convert uncertainty depending on type?
-            variance = inp_sp2d.uncertainty
-            if variance is None:
+            if inp_sp2d.uncertainty is None:
                 variance = np.ones_like(inp_sp2d.data)
+            else:
+                variance = _convert_uncertainty(inp_sp2d.uncertainty, VarianceUncertainty)
             ext = extract.OptimalExtract(inp_sp2d.data, trace, variance=variance)
         else:
             raise NotImplementedError(f"extraction type '{self.ext_type_selected}' not supported")  # noqa

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -75,7 +75,7 @@ class SpectralExtraction(PluginTemplateMixin):
     ext_dataset_items = List().tag(sync=True)
     ext_dataset_selected = Unicode().tag(sync=True)
 
-    ext_type_items = List(['Boxcar', 'Optimal']).tag(sync=True)
+    ext_type_items = List(['Boxcar', 'Horne']).tag(sync=True)
     ext_type_selected = Unicode('Boxcar').tag(sync=True)
 
     ext_width = IntHandleEmpty(0).tag(sync=True)
@@ -623,12 +623,12 @@ class SpectralExtraction(PluginTemplateMixin):
 
         if self.ext_type_selected == 'Boxcar':
             ext = extract.BoxcarExtract(inp_sp2d.data, trace, width=self.ext_width)
-        elif self.ext_type_selected == 'Optimal':
+        elif self.ext_type_selected == 'Horne':
             uncert = inp_sp2d.uncertainty if inp_sp2d.uncertainty is not None else VarianceUncertainty(np.ones_like(inp_sp2d.data))  # noqa
             if not hasattr(uncert, 'uncertainty_type'):
                 uncert = StdDevUncertainty(uncert)
             image = NDData(inp_sp2d.data, uncertainty=uncert)
-            ext = extract.OptimalExtract(image, trace)
+            ext = extract.HorneExtract(image, trace)
         else:
             raise NotImplementedError(f"extraction type '{self.ext_type_selected}' not supported")  # noqa
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -11,9 +11,8 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
 from jdaviz.core.custom_traitlets import IntHandleEmpty
 from jdaviz.core.marks import PluginLine
 
-from astropy.nddata import VarianceUncertainty
+from astropy.nddata import NDData, StdDevUncertainty, VarianceUncertainty
 from specutils import Spectrum1D
-from specutils.analysis.uncertainty import _convert_uncertainty
 from specreduce import tracing
 from specreduce import background
 from specreduce import extract
@@ -625,11 +624,11 @@ class SpectralExtraction(PluginTemplateMixin):
         if self.ext_type_selected == 'Boxcar':
             ext = extract.BoxcarExtract(inp_sp2d.data, trace, width=self.ext_width)
         elif self.ext_type_selected == 'Optimal':
-            if inp_sp2d.uncertainty is None:
-                variance = np.ones_like(inp_sp2d.data)
-            else:
-                variance = _convert_uncertainty(inp_sp2d.uncertainty, VarianceUncertainty)
-            ext = extract.OptimalExtract(inp_sp2d.data, trace, variance=variance)
+            uncert = inp_sp2d.uncertainty if inp_sp2d.uncertainty is not None else VarianceUncertainty(np.ones_like(inp_sp2d.data))  # noqa
+            if not hasattr(uncert, 'uncertainty_type'):
+                uncert = StdDevUncertainty(uncert)
+            image = NDData(inp_sp2d.data, uncertainty=uncert)
+            ext = extract.OptimalExtract(image, trace)
         else:
             raise NotImplementedError(f"extraction type '{self.ext_type_selected}' not supported")  # noqa
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -242,6 +242,12 @@
         ></v-select>
       </v-row>
 
+      <v-row v-if="ext_uncert_warn">
+        <span class="v-messages v-messages__message text--secondary">
+          <b style="color: red !important">WARNING:</b> uncertainties do not have assigned type, assuming standard deviation.
+        </span>
+      </v-row>
+
       <v-row v-if="ext_type_selected === 'Boxcar'">
         <v-text-field
           label="Width"

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -265,7 +265,7 @@
         :add_to_viewer_selected.sync="ext_add_to_viewer_selected"
         action_label="Extract"
         action_tooltip="Extract 1D Spectrum"
-        :action_disabled="ext_specreduce_err.length"
+        :action_disabled="ext_specreduce_err.length > 0"
         @click:action="extract_spectrum"
       ></plugin-add-results>
     </div>

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -28,7 +28,9 @@
     <div @mouseover="() => active_step='trace'">
       <j-plugin-section-header>Trace</j-plugin-section-header>
       <v-row>
-        <j-docs-link>Create a trace for the spectrum.</j-docs-link>
+        <j-docs-link>
+          Create a trace for the spectrum.  See the <j-external-link link='https://specreduce.readthedocs.io/en/latest/#module-specreduce.tracing' linktext='specreduce docs'></j-external-link> for more details on the available trace types.
+        </j-docs-link>
       </v-row>
 
       <div>
@@ -217,7 +219,9 @@
     <div @mouseover="() => active_step='ext'">
       <j-plugin-section-header>Extraction</j-plugin-section-header>
       <v-row>
-        <j-docs-link>Extract a 1D spectrum from a 2D spectrum.</j-docs-link>
+        <j-docs-link>
+          Extract a 1D spectrum from a 2D spectrum.  See the <j-external-link link='https://specreduce.readthedocs.io/en/latest/#module-specreduce.extract' linktext='specreduce docs'></j-external-link> for more details on the available extraction methods.
+        </j-docs-link>
       </v-row>
 
       <plugin-dataset-select
@@ -233,7 +237,7 @@
           :items="ext_type_items"
           v-model="ext_type_selected"
           label="Extraction Type"
-          hint="Method to use for extracting the spectrum"
+          hint="Method to use for extracting the spectrum."
           persistent-hint
         ></v-select>
       </v-row>

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -229,6 +229,16 @@
       />
 
       <v-row>
+        <v-select
+          :items="ext_type_items"
+          v-model="ext_type_selected"
+          label="Extraction Type"
+          hint="Method to use for extracting the spectrum"
+          persistent-hint
+        ></v-select>
+      </v-row>
+
+      <v-row v-if="ext_type_selected === 'Boxcar'">
         <v-text-field
           label="Width"
           type="number"

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -244,7 +244,7 @@
 
       <v-row v-if="ext_uncert_warn">
         <span class="v-messages v-messages__message text--secondary">
-          <b style="color: red !important">WARNING:</b> uncertainties do not have assigned type, assuming standard deviation.
+          <b style="color: red !important">WARNING:</b> uncertainties on input 2D spectrum have unclear units; assuming standard deviation.
         </span>
       </v-row>
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -105,6 +105,10 @@ def test_plugin(specviz2d_helper):
     sp_ext = pext.export_extract_spectrum()
     assert isinstance(sp_ext, Spectrum1D)
 
+    # test API calls
+    for step in ['trace', 'bg', 'ext']:
+        pext.update_marks(step)
+
     # test exception handling
     pext.trace_type = 'Auto'
     pext.bg_type_selected = 'TwoSided'
@@ -114,10 +118,6 @@ def test_plugin(specviz2d_helper):
     pext.bg_results_label = 'should not be created'
     pext.vue_create_bg_img()
     assert 'should not be created' not in [d.label for d in specviz2d_helper.app.data_collection]
-
-    # test API calls
-    for step in ['trace', 'bg', 'ext']:
-        pext.update_marks(step)
 
     with pytest.raises(ValueError):
         pext.export_extract(invalid_kwarg=5)

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -101,7 +101,7 @@ def test_plugin(specviz2d_helper):
     sp_ext = pext.export_extract_spectrum()
     assert isinstance(sp_ext, Spectrum1D)
 
-    pext.ext_type_selected = 'Optimal'
+    pext.ext_type_selected = 'Horne'
     sp_ext = pext.export_extract_spectrum()
     assert isinstance(sp_ext, Spectrum1D)
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -101,6 +101,10 @@ def test_plugin(specviz2d_helper):
     sp_ext = pext.export_extract_spectrum()
     assert isinstance(sp_ext, Spectrum1D)
 
+    pext.ext_type_selected = 'Optimal'
+    sp_ext = pext.export_extract_spectrum()
+    assert isinstance(sp_ext, Spectrum1D)
+
     # test exception handling
     pext.trace_type = 'Auto'
     pext.bg_type_selected = 'TwoSided'


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request adds support for optimal extraction (in addition to the existing boxcar extraction) to the spectral extraction plugin in specviz2d.

- [x]  requires https://github.com/astropy/specreduce/pull/118 to be merged/released first (otherwise will return a spectrum of all zeros).


**TODO**:
- [x] merge, release, pin specreduce bugfix
- [x] determine whether to map spectrum1d uncertainties to variances

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
