### PR TITLE
Add Spatial Collapsed Spectrum selection to Line Analysis

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Cubeviz
 
 - Image viewers now have linked pan/zoom and linked box zoom. [#1596]
 
+- Added ability to select spatial subset collasped spectrum for Line Analysis [#1583]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -67,7 +67,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
     template_file = __file__, "line_analysis.vue"
 
     spatial_subset_items = List().tag(sync=True)
-    collapsed_spectrum_selected = Unicode().tag(sync=True)
+    spatial_subset_selected = Unicode().tag(sync=True)
 
     continuum_subset_items = List().tag(sync=True)
     continuum_subset_selected = Unicode().tag(sync=True)
@@ -103,7 +103,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         if self.app.state.settings.get("configuration") == "cubeviz":
             self.spatial_subset = SubsetSelect(self,
                                                'spatial_subset_items',
-                                               'collapsed_spectrum_selected',
+                                               'spatial_subset_selected',
                                                default_text='Entire Cube Spectrum',
                                                allowed_type='spatial')
         else:
@@ -152,7 +152,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
             The glue message passed to this callback method.
         """
         if (msg.subset.label in [self.spectral_subset_selected,
-                                 self.collapsed_spectrum_selected,
+                                 self.spatial_subset_selected,
                                  self.continuum_subset_selected]
                 and self.plugin_opened):
             self._calculate_statistics()
@@ -224,7 +224,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
             # in which case we'll default to the identified line
             self.selected_line = self.identified_line
 
-    @observe("collapsed_spectrum_selected", "spectral_subset_selected", "dataset_selected",
+    @observe("spatial_subset_selected", "spectral_subset_selected", "dataset_selected",
              "continuum_subset_selected", "width")
     def _calculate_statistics(self, *args, **kwargs):
         """
@@ -237,13 +237,13 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         # show spinner with overlay
         self.results_computing = True
 
-        if self.config == 'cubeviz' and self.collapsed_spectrum_selected != 'Entire Cube Spectrum':
+        if self.config == 'cubeviz' and self.spatial_subset_selected != 'Entire Cube Spectrum':
             # then we're acting on the auto-collapsed data in the spectrum-viewer
             # of a spatial subset.  In the future, we may want to expose on-the-fly
             # collapse options... but right now these will follow the settings of the
             # spectrum-viewer itself
             full_spectrum = self.app.get_data_from_viewer('spectrum-viewer',
-                                                          self.collapsed_spectrum_selected)
+                                                          self.spatial_subset_selected)
         else:
             full_spectrum = self.dataset.selected_obj
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -104,7 +104,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
             self.spatial_subset = SubsetSelect(self,
                                                'spatial_subset_items',
                                                'spatial_subset_selected',
-                                               default_text='Entire Cube Spectrum',
+                                               default_text='Entire Cube',
                                                allowed_type='spatial')
         else:
             self.spatial_subset = None

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -237,7 +237,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         # show spinner with overlay
         self.results_computing = True
 
-        if self.config == 'cubeviz' and self.collapsed_spectrum_selected != 'Entire Cube':
+        if self.config == 'cubeviz' and self.collapsed_spectrum_selected != 'Entire Cube Spectrum':
             # then we're acting on the auto-collapsed data in the spectrum-viewer
             # of a spatial subset.  In the future, we may want to expose on-the-fly
             # collapse options... but right now these will follow the settings of the

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -25,8 +25,8 @@
       :items="spatial_subset_items"
       :selected.sync="spatial_subset_selected"
       :show_if_single_entry="true"
-      label="Collapsed Spectrum"
-      hint="Select collapsed spectrum to analyze."
+      label="Spatial region"
+      hint="Select which region's collapsed spectrum to analyze."
     />
 
     <plugin-subset-select 

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -20,6 +20,15 @@
       hint="Select the data set to be analysed."
     />
 
+    <plugin-subset-select
+      v-if="config=='cubeviz'"
+      :items="spatial_subset_items"
+      :selected.sync="collapsed_spectrum_selected"
+      :show_if_single_entry="true"
+      label="Collapsed Spectrum"
+      hint="Select collapsed spectrum to analyze."
+    />
+
     <plugin-subset-select 
       :items="spectral_subset_items"
       :selected.sync="spectral_subset_selected"

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -23,7 +23,7 @@
     <plugin-subset-select
       v-if="config=='cubeviz'"
       :items="spatial_subset_items"
-      :selected.sync="collapsed_spectrum_selected"
+      :selected.sync="spatial_subset_selected"
       :show_if_single_entry="true"
       label="Collapsed Spectrum"
       hint="Select collapsed spectrum to analyze."

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -52,6 +52,7 @@ def test_spatial_subset(cubeviz_helper, spectrum1d_cube):
 
     # add a region and rerun stats for that region
     cubeviz_helper.app.get_viewer('flux-viewer').apply_roi(RectangularROI(1, 3.5, -0.2, 3.3))
+    cubeviz_helper.app.get_viewer('flux-viewer').session.edit_subset_mode._mode = NewMode
     cubeviz_helper.app.get_viewer('spectrum-viewer').apply_roi(XRangeROI(6500, 7400))
 
     cubeviz_helper.app.state.drawer = True

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -47,8 +47,17 @@ def test_spatial_subset(cubeviz_helper, spectrum1d_cube):
     Not checking the value attempts to circumvent the issue we ran into here:
     https://github.com/spacetelescope/jdaviz/pull/1564#discussion_r949427663
     """
+
+    flux = np.arange(250).reshape((5, 5, 10)) * u.Jy
+    wcs_dict = {"CTYPE1": "RA---TAN", "CTYPE2": "DEC--TAN", "CTYPE3": "WAVE-LOG",
+                "CRVAL1": 205, "CRVAL2": 27, "CRVAL3": 4.622e-7,
+                "CDELT1": -0.0001, "CDELT2": 0.0001, "CDELT3": 8e-11,
+                "CRPIX1": 0, "CRPIX2": 0, "CRPIX3": 0}
+    w = WCS(wcs_dict)
+    large_cube = Spectrum1D(flux=flux, wcs=w)
+
     label = "Test Cube"
-    cubeviz_helper.load_data(spectrum1d_cube, data_label=label)
+    cubeviz_helper.load_data(large_cube, data_label=label)
 
     # add a region and rerun stats for that region
     cubeviz_helper.app.get_viewer('flux-viewer').apply_roi(RectangularROI(-0.5, 0.5, 0.5, 2.5))

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -84,8 +84,8 @@ def test_spatial_subset(cubeviz_helper):
     for result in plugin.results:
         # Check that there exists a value
         assert not np.isnan(float(result['result']))
-        # Check the unit is not nan or dimensionless
-        assert u.Unit(result['unit']) != u.Unit('nan')
+        # Check the unit is not dimensionless
+        assert u.Unit(result['unit']) != u.dimensionless_unscaled
 
 
 def test_line_identify(specviz_helper, spectrum1d):

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -51,9 +51,12 @@ def test_spatial_subset(cubeviz_helper, spectrum1d_cube):
     cubeviz_helper.load_data(spectrum1d_cube, data_label=label)
 
     # add a region and rerun stats for that region
-    cubeviz_helper.app.get_viewer('flux-viewer').apply_roi(RectangularROI(1, 3.5, -0.2, 3.3))
+    cubeviz_helper.app.get_viewer('flux-viewer').apply_roi(RectangularROI(-0.5, 0.5, 0.5, 2.5))
     cubeviz_helper.app.get_viewer('flux-viewer').session.edit_subset_mode._mode = NewMode
-    cubeviz_helper.app.get_viewer('spectrum-viewer').apply_roi(XRangeROI(6500, 7400))
+    # The cube only has one slice, so we have to grab the entire viewer's range to create a region
+    cubeviz_helper.app.get_viewer('spectrum-viewer').apply_roi(
+        XRangeROI(cubeviz_helper.app.get_viewer('spectrum-viewer').state.x_min,
+                  cubeviz_helper.app.get_viewer('spectrum-viewer').state.x_max))
 
     cubeviz_helper.app.state.drawer = True
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -1,8 +1,10 @@
 import astropy.units as u
 from astropy.table import QTable
+from astropy.wcs import WCS
 import numpy as np
 from glue.core.roi import XRangeROI, RectangularROI
 from glue.core.edit_subset_mode import NewMode
+from specutils import Spectrum1D
 
 from jdaviz.configs.specviz.plugins.line_analysis.line_analysis import _coerce_unit
 from jdaviz.core.events import LineIdentifyMessage

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -83,7 +83,7 @@ def test_spatial_subset(cubeviz_helper):
 
     for result in plugin.results:
         # Check that there exists a value
-        assert not np.isnan(result['value'])
+        assert not np.isnan(result['result'])
         # Check the unit is not nan or dimensionless
         assert u.Unit(result['unit']) != u.Unit('nan')
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -41,7 +41,7 @@ def test_plugin(specviz_helper, spectrum1d):
             assert len(result_dict.get('uncertainty')) > 0
 
 
-def test_spatial_subset(cubeviz_helper, spectrum1d_cube):
+def test_spatial_subset(cubeviz_helper):
     """
     Tests that the spatial selection returns any valid result, DOES NOT VALIDATE THE VALUE
     Not checking the value attempts to circumvent the issue we ran into here:

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -1,9 +1,10 @@
 import astropy.units as u
 from astropy.table import QTable
 from astropy.wcs import WCS
-import numpy as np
 from glue.core.roi import XRangeROI, RectangularROI
 from glue.core.edit_subset_mode import NewMode
+import numpy as np
+import pytest
 from specutils import Spectrum1D
 
 from jdaviz.configs.specviz.plugins.line_analysis.line_analysis import _coerce_unit
@@ -43,6 +44,7 @@ def test_plugin(specviz_helper, spectrum1d):
             assert len(result_dict.get('uncertainty')) > 0
 
 
+@pytest.mark.filterwarnings('ignore:No observer defined on WCS')
 def test_spatial_subset(cubeviz_helper):
     """
     Tests that the spatial selection returns any valid result, DOES NOT VALIDATE THE VALUE

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -63,7 +63,7 @@ def test_spatial_subset(cubeviz_helper, image_cube_hdu_obj):
     plugin = cubeviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
     plugin.open_in_tray()
 
-    plugin.collapsed_spectrum_selected = 'Subset 1'
+    plugin.spatial_subset_selected = 'Subset 1'
     plugin.spectral_subset_selected = 'Subset 2'
     plugin.continuum_subset_selected = 'Surrounding'
     plugin.width = 1

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -83,7 +83,7 @@ def test_spatial_subset(cubeviz_helper):
 
     for result in plugin.results:
         # Check that there exists a value
-        assert not np.isnan(result['result'])
+        assert not np.isnan(float(result['result']))
         # Check the unit is not nan or dimensionless
         assert u.Unit(result['unit']) != u.Unit('nan')
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Previously, it was not possible to perform line analysis on the spectrum generated by Cubeviz' autocollapse for spatial subsets. This PR adds that feature. 

BIG THANKS to @pllim for fixing the mysterious test failure!

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
