### PR TITLE
fix support for ipywidgets 8 and remove max pin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,8 @@ Bug Fixes
   and visibility states are now always adopted from the existing entry that would be overwritten.
   [#1538]
 
+- Fix support for ipywidgets 8 (while maintaining support for ipywidgets 7). [#1592]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1162,6 +1162,9 @@ class Application(VuetifyTemplate, HubListener):
         """
         Forces any rendered ``Bqplot`` instances to resize themselves.
         """
+        def get_widget(ipymodel):
+            return getattr(self, '_active_widgets', self.widgets).get(ipymodel)
+
         def resize(stack_items):
             for stack in stack_items:
                 for viewer_item in stack.get('viewers'):
@@ -1179,7 +1182,7 @@ class Application(VuetifyTemplate, HubListener):
         # resize tray items
         for tray_item in self.state.tray_items:
             # access the actual plugin object (there is no store for plugins)
-            tray_obj = self.widgets.get(tray_item['widget'].split('IPY_MODEL_')[1])
+            tray_obj = get_widget(tray_item['widget'].split('IPY_MODEL_')[1])
             for bqplot_fig in tray_obj.bqplot_figs_resize:
                 bqplot_fig.layout.height = '99.9%'
                 bqplot_fig.layout.height = '100%'

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1162,9 +1162,6 @@ class Application(VuetifyTemplate, HubListener):
         """
         Forces any rendered ``Bqplot`` instances to resize themselves.
         """
-        def get_widget(ipymodel):
-            return getattr(self, '_active_widgets', self.widgets).get(ipymodel)
-
         def resize(stack_items):
             for stack in stack_items:
                 for viewer_item in stack.get('viewers'):
@@ -1182,7 +1179,7 @@ class Application(VuetifyTemplate, HubListener):
         # resize tray items
         for tray_item in self.state.tray_items:
             # access the actual plugin object (there is no store for plugins)
-            tray_obj = get_widget(tray_item['widget'].split('IPY_MODEL_')[1])
+            tray_obj = widget_serialization['from_json'](tray_item['widget'], None)
             for bqplot_fig in tray_obj.bqplot_figs_resize:
                 bqplot_fig.layout.height = '99.9%'
                 bqplot_fig.layout.height = '100%'

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ install_requires =
     ipyvuetify>=1.7.0
     ipysplitpanes>=0.1.0
     ipygoldenlayout>=0.3.0
-    ipywidgets<8.0
     voila>=0.3.5
     pyyaml>=5.4.1
     specutils>=1.7.0


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request attempts to support ipywidgets 8 change in `.widgets` becoming a private `._active_widgets` while still supporting the old syntax.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

xref https://github.com/jupyter-widgets/ipywidgets/pull/3122

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
