### PR TITLE
linewidth indicator in legend labels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 New Features
 ------------
 
+- Layer icons now show indication of linewidth. [#1593]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -68,6 +68,7 @@ custom_components = {'j-tooltip': 'components/tooltip.vue',
                      'j-docs-link': 'components/docs_link.vue',
                      'j-viewer-data-select': 'components/viewer_data_select.vue',
                      'j-viewer-data-select-item': 'components/viewer_data_select_item.vue',
+                     'j-layer-viewer-icon': 'components/layer_viewer_icon.vue',
                      'j-tray-plugin': 'components/tray_plugin.vue',
                      'j-play-pause-widget': 'components/play_pause_widget.vue',
                      'j-plugin-section-header': 'components/plugin_section_header.vue',
@@ -146,8 +147,8 @@ class ApplicationState(State):
         'checktoradial': read_icon(os.path.join(ICON_DIR, 'checktoradial.svg'), 'svg+xml')
     }, docstring="Custom application icons")
 
-    viewer_icons = DictCallbackProperty({}, docstring="Indexed icons for viewers across the app")
-    layer_icons = DictCallbackProperty({}, docstring="Indexed icons for layers across the app")
+    viewer_icons = DictCallbackProperty({}, docstring="Indexed icons (numbers) for viewers across the app")  # noqa
+    layer_icons = DictCallbackProperty({}, docstring="Indexed icons (letters) for layers across the app")  # noqa
 
     data_items = ListCallbackProperty(
         docstring="List of data items parsed from the Glue data collection.")
@@ -378,7 +379,7 @@ class Application(VuetifyTemplate, HubListener):
 
         if layer_name not in self.state.layer_icons:
             self.state.layer_icons = {**self.state.layer_icons,
-                                      layer_name: f"mdi-alpha-{chr(97 + len(self.state.layer_icons))}-box-outline"}  # noqa
+                                      layer_name: chr(97 + len(self.state.layer_icons))}
 
     def _link_new_data(self, reference_data=None, data_to_be_linked=None):
         """
@@ -1497,7 +1498,7 @@ class Application(VuetifyTemplate, HubListener):
         # own attribute instead.
         viewer._reference_id = vid  # For reverse look-up
 
-        self.state.viewer_icons.setdefault(vid, f"mdi-numeric-{len(self.state.viewer_icons)+1}-circle-outline")  # noqa
+        self.state.viewer_icons.setdefault(vid, len(self.state.viewer_icons)+1)
 
         return {
             'id': vid,

--- a/jdaviz/components/glue_state_sync_wrapper.vue
+++ b/jdaviz/components/glue_state_sync_wrapper.vue
@@ -8,7 +8,7 @@
           </div>
         </v-col>
         <v-col v-if="multiselect" cols="4" style="text-align: center; padding: 0">
-          <v-icon v-for="icon in sync.icons">{{icon}}</v-icon>
+          <j-layer-viewer-icon v-for="icon in sync.icons" :icon="icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
         </v-col>
       </v-row>
     </div>

--- a/jdaviz/components/layer_viewer_icon.vue
+++ b/jdaviz/components/layer_viewer_icon.vue
@@ -1,0 +1,33 @@
+<template>
+  <span :class="prevent_invert_if_dark ? '' : 'invert-if-dark'" :style="span_style+'; color: '+color+'; '+borderStyle">
+        {{String(icon).toUpperCase()}}
+  </span>
+</template>
+
+<script>
+module.exports = {
+  props: ['span_style', 'color', 'icon', 'linewidth', 'linestyle', 'prevent_invert_if_dark'],
+  computed: {
+    borderStyle() {
+      if (this.$props.linewidth > 0) { 
+        return 'border-bottom: '+this.$props.linewidth+'px '+this.$props.linestyle+' '+this.$props.color
+      }
+      return ''
+    },
+  }
+};
+</script>
+
+<style scoped>
+span {
+  width: 20px;
+  height: 20px;
+  line-height: 10px;
+  margin-top: 4px;
+  margin-right: 2px;
+  padding-top: 3px;
+  text-align: center;
+  font-size: 12pt;
+  font-weight: bold; 
+}
+</style>

--- a/jdaviz/components/layer_viewer_icon.vue
+++ b/jdaviz/components/layer_viewer_icon.vue
@@ -1,5 +1,5 @@
 <template>
-  <span :class="prevent_invert_if_dark ? '' : 'invert-if-dark'" :style="span_style+'; color: '+color+'; '+borderStyle">
+  <span v-if="icon !== undefined" :class="prevent_invert_if_dark ? '' : 'invert-if-dark'" :style="span_style+'; color: '+color+'; '+borderStyle">
         {{String(icon).toUpperCase()}}
   </span>
 </template>

--- a/jdaviz/components/plugin_dataset_select.vue
+++ b/jdaviz/components/plugin_dataset_select.vue
@@ -15,7 +15,7 @@
     <template slot="selection" slot-scope="data">
       <div class="single-line">
         <span>
-          <v-icon v-if="data.item.icon" style='margin-right: 2px'>{{ data.item.icon }}</v-icon>
+          <j-layer-viewer-icon v-if="data.item.icon" span_style="margin-right: 4px" :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
           {{ data.item.label }}
         </span>
       </div>
@@ -23,7 +23,7 @@
     <template slot="item" slot-scope="data">
       <div class="single-line">
         <span>
-          <v-icon v-if="data.item.icon" style='margin-right: 2px'>{{ data.item.icon }}</v-icon>
+          <j-layer-viewer-icon v-if="data.item.icon" span_style="margin-right: 4px" :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
           {{ data.item.label }}
         </span>
       </div>

--- a/jdaviz/components/plugin_layer_select.vue
+++ b/jdaviz/components/plugin_layer_select.vue
@@ -18,12 +18,12 @@
       <div class="single-line" style="width: 100%">
         <v-chip v-if="multiselect" style="width: calc(100% - 20px)">
           <span>
-            <v-icon v-if="data.item.icon" style='margin-left: -10px; margin-right: 2px'>{{ data.item.icon }}</v-icon>
+            <j-layer-viewer-icon :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
             {{ data.item.label }}
           </span>
         </v-chip>
         <span v-else>
-          <v-icon v-if="data.item.icon" style='margin-right: 2px'>{{ data.item.icon }}</v-icon>
+          <j-layer-viewer-icon span_style="margin-right: 4px" :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
           {{ data.item.label }}
         </span>
       </div>
@@ -50,7 +50,7 @@
     <template slot="item" slot-scope="data">
       <div class="single-line">
         <span>
-          <v-icon style='margin-left: -2px; margin-right: 2px'>{{ data.item.icon }}</v-icon>
+          <j-layer-viewer-icon span_style="margin-right: 4px" :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
           {{ data.item.label }}
         </span>
       </div>

--- a/jdaviz/components/plugin_viewer_select.vue
+++ b/jdaviz/components/plugin_viewer_select.vue
@@ -18,12 +18,12 @@
       <div class="single-line" style="width: 100%">
         <v-chip v-if="multiselect" style="width: calc(100% - 20px)">
           <span>
-            <v-icon v-if="data.item.icon" style='margin-left: -10px; margin-right: 2px'>{{ data.item.icon }}</v-icon>
+            <j-layer-viewer-icon :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
             {{ data.item.label }}
           </span>
         </v-chip>
         <span v-else>
-          <v-icon v-if="data.item.icon" style='margin-right: 2px'>{{ data.item.icon }}</v-icon>
+          <j-layer-viewer-icon span_style="margin-right: 4px" :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
           {{ data.item.label }}
         </span>
       </div>
@@ -50,7 +50,7 @@
     <template slot="item" slot-scope="data">
       <div class="single-line">
         <span>
-          <v-icon style='margin-left: -2px; margin-right: 2px'>{{ data.item.icon }}</v-icon>
+          <j-layer-viewer-icon span_style='margin-right: 4px' :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
           {{ data.item.label }}
         </span>
       </div>

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -23,7 +23,7 @@
     </div>
 
     <j-tooltip :tooltipcontent="'data label: '+item.name" span_style="font-size: 12pt; padding-top: 6px; padding-left: 6px; width: calc(100% - 80px); white-space: nowrap; cursor: default;">
-      <v-icon class='invert-if-dark' style='color: #000000DE; margin-left: 4px; margin-right: -2px'>{{icon}}</v-icon>
+      <j-layer-viewer-icon span_style="margin-left: 4px; margin-right: 2px" :icon="icon" color="#000000DE"></j-layer-viewer-icon>      
       <div class="text-ellipsis-middle" style="font-weight: 500">
         <span>
           {{itemNamePrefix}}

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -71,6 +71,10 @@ class JdavizViewerMixin:
                 return ''
             return layer.color
 
+        def _get_layer_linewidth(layer):
+            linewidth = getattr(layer, 'linewidth', 0)
+            return min(linewidth, 6)
+
         def _get_layer_info(layer):
             if self.__class__.__name__ == 'CubevizProfileView' and len(layer.layer.data.shape) == 3:
                 suffix = f" (collapsed: {self.state.function})"
@@ -94,6 +98,7 @@ class JdavizViewerMixin:
             if layer.visible:
                 prefix_icon, suffix = _get_layer_info(layer)
                 visible_layers[layer.layer.label] = {'color': _get_layer_color(layer),
+                                                     'linewidth': _get_layer_linewidth(layer),
                                                      'prefix_icon': prefix_icon,
                                                      'suffix_label': suffix}
 

--- a/jdaviz/configs/imviz/plugins/compass/compass.vue
+++ b/jdaviz/configs/imviz/plugins/compass/compass.vue
@@ -15,7 +15,7 @@
       <v-chip
         label=true
       >
-        <v-icon>{{ icon }}</v-icon>
+        <j-layer-viewer-icon :icon="icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
         {{ data_label }}
       </v-chip>
     </v-row>

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.vue
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="pixel">
     <span style="position: absolute; top: 50%; transform: translateY(-50%); -ms-transform: translateY(-50%);">
-      <v-icon>{{icon}}</v-icon>
+      <j-layer-viewer-icon :icon="icon" color="white" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
     </span>
     <div style="display: inline-block; white-space: nowrap; line-height: 14pt; margin: 0; position: absolute; margin-left: 26px; top: 50%; transform: translateY(-50%); -ms-transform: translateY(-50%);">
       <table>

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -62,14 +62,14 @@
           <div v-if="app_settings.viewer_labels" class='viewer-label-container'>
             <div v-if="Object.keys(viewer_icons).length > 1" class="viewer-label invert-if-dark">
               <j-tooltip span_style="white-space: nowrap">
-                <v-icon class="invert-if-dark" style="float: right">{{viewer_icons[[viewer.id]]}}</v-icon>
+                <j-layer-viewer-icon span_style="float: right;" :icon="viewer_icons[viewer.id]"></j-layer-viewer-icon>
               </j-tooltip>
               <span class="invert-if-dark" style="margin-left: 24px; margin-right: 32px; line-height: 24px">{{viewer.reference || viewer.id}}</span>
             </div>
 
             <div v-for="(layer_info, layer_name) in viewer.visible_layers" class="viewer-label invert-if-dark">
               <j-tooltip span_style="white-space: nowrap">
-                <v-icon class="invert-if-dark" style="float: right" :color="layer_info.color">{{layer_icons[layer_name]}}</v-icon>
+                <j-layer-viewer-icon span_style="float: right;" :icon="layer_icons[layer_name]" :linewidth="layer_info.linewidth" :linestyle="'solid'" :color="layer_info.color"></j-layer-viewer-icon>
               </j-tooltip>
               <span class="invert-if-dark" style="margin-left: 24px; margin-right: 32px; line-height: 24px">
                 <v-icon v-if="layer_info.prefix_icon" dense>

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -103,7 +103,7 @@
   /*cursor: pointer;*/
 }
 .viewer-label:last-child {
-  border-bottom-left-radius: 4px;
+  padding-bottom: 2px;
 }
 .viewer-label:hover {
   background-color: #e5e5e5;


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request adds an indication of the linewidth to the layer labels/legends. 
* replaces the previous stock icon in a box with custom letter with underline depending on linewidth (up to a max of 6px)
* replaces the previous stock icon for viewers with matching number styling
* image layers have no underline or box
* uses same icon in dropdowns/menus/mouseover (but without color/linewidth styling since often can correspond to multiple layers across different viewers)


NOTE: "UN" flash in the legend has been fixed and the bottom entry has a little extra padding and the rounded-corner removed so the line indicator is more visible.

https://user-images.githubusercontent.com/877591/186232908-8de8dcd7-8831-4424-bc90-80415664dc24.mov


And I even remembered to make sure dark mode still works!

<img width="1309" alt="image" src="https://user-images.githubusercontent.com/877591/186244762-998d2883-0884-43f0-9491-2404f8da266e.png">


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
