### PR TITLE
Astrowidgets: Option to apply some settings to all layers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Cubeviz
 Imviz
 ^^^^^
 
+- You can now set ``viewer.apply_to_all_layers = True`` to apply stretch, cuts, or colormap
+  changes to all layers in the given viewer at once. [#1594]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -350,3 +350,8 @@ class ImvizImageView(BqplotImageView, AstrowidgetsImageViewerMixin, JdavizViewer
             raise ValueError(f'{data_label} not found in data collection external links')
 
         return link_type
+
+    def iter_image_layer_indices(self):
+        for i, lyr in enumerate(self.layers):
+            if layer_is_image_data(lyr.layer):
+                yield i

--- a/notebooks/concepts/imviz_load_fits_hdu.ipynb
+++ b/notebooks/concepts/imviz_load_fits_hdu.ipynb
@@ -104,6 +104,43 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "87b586bd",
+   "metadata": {},
+   "source": [
+    "## Set stretch, cuts, and colormap for all layers at once"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2219cbbb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz.default_viewer.apply_to_all_layers = True\n",
+    "imviz.default_viewer.stretch = 'arcsinh'\n",
+    "imviz.default_viewer.cuts = (0.1, 1)\n",
+    "imviz.default_viewer.set_colormap('Viridis')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac7812b7",
+   "metadata": {},
+   "source": [
+    "Now, blink to see these are applied to all layers."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46685d3e",
+   "metadata": {},
+   "source": [
+    "## Close the FITS file handler when we are done"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "cf112d5f-e10a-420e-9144-d8883d8dc2cf",
@@ -130,7 +167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to add option into the Astrowidgets mixin to allow applying stretch, cuts, or colormap settings to all the viewer image layers at once.

Pro: This is a requested feature by @hcferguson .

Con: This deviates from the Astrowidgets API because I have to introduce a glue-specific property. Maybe @eteq has opinion on this front. @kecnry might have opinions too in case this deviates from his grand plan to unified APIs.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1477 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-2670)
