### PR TITLE
Expose parameter uncertainties

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ New Features
 
 - Layer icons now show indication of linewidth. [#1593]
 
+- Model Fitting plugin now displays parameter uncertainties after fitting. [#1597]
+
 Cubeviz
 ^^^^^^^
 

--- a/docs/specviz/plugins.rst
+++ b/docs/specviz/plugins.rst
@@ -90,6 +90,11 @@ defaults to the sum of all created components, but can be modified to
 exclude some of components without needing to delete them entirely
 or to change to subtraction, for example.
 
+After fitting, the expandable menu for each component model will update to
+show the fitted value of each parameter rather than the initial value, and
+will additionally show the standard deviation uncertainty of the fitted
+parameter value if the parameter was not set to be fixed to the initial value.
+
 .. seealso::
 
     :ref:`Export Models <specviz-export-model>`

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -142,8 +142,8 @@
                     >
                     </v-text-field>
                   </v-col>
-                  <v-col v-if="param.std">
-                    +/- {{roundUncertainty(param.std)}}
+                  <v-col v-if="param.std" style="padding-bottom: 22px">
+                    &#177; {{roundUncertainty(param.std)}}
                   </v-col>
                   <v-col style="font-size: 10pt" class="py-my-0">
                     {{ param.unit.replace("Angstrom", "&#8491;") }}

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -118,10 +118,10 @@
                 <v-row
                   justify="left"
                   align="center"
-                  class="py-my-0">
+                  class="py-0 my-0">
                 <v-col cols=12 class="py-my-0">
                   <j-tooltip tipid='plugin-model-fitting-param-fixed'>
-                    <v-checkbox v-model="param.fixed" :disabled="!componentInEquation(item.id)">
+                    <v-checkbox v-model="param.fixed" :disabled="!componentInEquation(item.id)" dense>
                       <template v-slot:label>
                         <span class="font-weight-bold" style="overflow-wrap: anywhere; font-size: 10pt">
                           {{param.name}}
@@ -134,17 +134,18 @@
                 <v-row
                   justify="left"
                   align="center"
-                  class="py-my-0">
-                  <v-col cols=4 class="py-my-0">
+                  class="py-0 my-0">
+                  <v-col class="py-my-0">
                     <v-text-field
+                      dense
                       v-model="param.value"
                     >
                     </v-text-field>
                   </v-col>
-                  <v-col cols=4 v-if="param.std">
-                    +/- {{param.std}}
+                  <v-col v-if="param.std">
+                    +/- {{roundUncertainty(param.std)}}
                   </v-col>
-                  <v-col cols=8 style="font-size: 10pt" class="py-my-0">
+                  <v-col style="font-size: 10pt" class="py-my-0">
                     {{ param.unit.replace("Angstrom", "&#8491;") }}
                   </v-col>
                 </v-row>
@@ -210,6 +211,9 @@
     methods: {
       componentInEquation(componentId) {
         return this.model_equation.split(/[+*\/-]/).indexOf(componentId) !== -1
+      },
+      roundUncertainty(uncertainty) {
+        return uncertainty.toPrecision(2)
       }
     }
   }

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -123,7 +123,7 @@
                   <j-tooltip tipid='plugin-model-fitting-param-fixed'>
                     <v-checkbox v-model="param.fixed" :disabled="!componentInEquation(item.id)" dense>
                       <template v-slot:label>
-                        <span class="font-weight-bold" style="overflow-wrap: anywhere; font-size: 10pt">
+                        <span class="font-weight-bold" style="overflow-wrap: anywhere; font-size: 12pt">
                           {{param.name}}
                         </span>
                       </template>
@@ -149,6 +149,7 @@
                     {{ param.unit.replace("Angstrom", "&#8491;") }}
                   </v-col>
                 </v-row>
+                <v-divider></v-divider>
               </v-div>
             </v-expansion-panel-content>
           </v-expansion-panel>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -111,46 +111,44 @@
               >
                 <span><b>{{ item.id }}</b> model component not in equation</span>
               </v-row>
-              <v-row
-                justify="left"
-                align="center"
-                class="row-no-outside-padding"
-              >
-                <v-col cols=4>
-                  <p class="font-weight-bold">Param</p>
-                </v-col>
-                <v-col cols=8> <!-- covers value and unit in rows -->
-                  <p class="font-weight-bold">Value</p>
-                </v-col>
-              </v-row>
-              <v-row
-                justify="left"
-                align="center"
-                class="row-no-outside-padding"
+              <v-div
                 v-for="param in item.parameters"
                 :style="componentInEquation(item.id) ? '': 'opacity: 0.3'"
               >
-                <v-col cols=4>
+                <v-row
+                  justify="left"
+                  align="center"
+                  class="py-my-0">
+                <v-col cols=12 class="py-my-0">
                   <j-tooltip tipid='plugin-model-fitting-param-fixed'>
                     <v-checkbox v-model="param.fixed" :disabled="!componentInEquation(item.id)">
                       <template v-slot:label>
-                        <span class="text--primary" style="overflow-wrap: anywhere; font-size: 10pt">
+                        <span class="font-weight-bold" style="overflow-wrap: anywhere; font-size: 10pt">
                           {{param.name}}
                         </span>
                       </template>
                     </v-checkbox>
                   </j-tooltip>
                 </v-col>
-                <v-col cols=4>
-                  <v-text-field
-                    v-model="param.value"
-                  >
-                  </v-text-field>
-                </v-col>
-                <v-col cols=4 style="font-size: 10pt">
-                  {{ param.unit.replace("Angstrom", "&#8491;") }}
-                </v-col>
-              </v-row>
+                </v-row>
+                <v-row
+                  justify="left"
+                  align="center"
+                  class="py-my-0">
+                  <v-col cols=4 class="py-my-0">
+                    <v-text-field
+                      v-model="param.value"
+                    >
+                    </v-text-field>
+                  </v-col>
+                  <v-col cols=4 v-if="param.std">
+                    +/- {{param.std}}
+                  </v-col>
+                  <v-col cols=8 style="font-size: 10pt" class="py-my-0">
+                    {{ param.unit.replace("Angstrom", "&#8491;") }}
+                  </v-col>
+                </v-row>
+              </v-div>
             </v-expansion-panel-content>
           </v-expansion-panel>
         </v-expansion-panels>

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -3,6 +3,7 @@ Tests the features of the Model Fitting Plugin (Selecting model parameters, addi
 This does NOT test the actual fitting self (see test_fitting.py for that)
 """
 
+import numpy as np
 import pytest
 
 from jdaviz.configs.default.plugins.model_fitting.initializers import MODELS
@@ -73,6 +74,12 @@ def test_register_model(specviz_helper, spectrum1d):
     modelfit_plugin.results_label = test_label
     modelfit_plugin.vue_model_fitting()
     assert test_label in specviz_helper.app.data_collection
+
+    # Test that the parameter uncertainties were updated
+    expected_uncertainties = {'slope': 0.00038, 'intercept': 2.67}
+    result_model = modelfit_plugin.component_models[0]
+    for param in result_model["parameters"]:
+        assert np.allclose(param["std"], expected_uncertainties[param["name"]], rtol= 0.01)
 
 
 @pytest.mark.filterwarnings('ignore')

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -79,7 +79,7 @@ def test_register_model(specviz_helper, spectrum1d):
     expected_uncertainties = {'slope': 0.00038, 'intercept': 2.67}
     result_model = modelfit_plugin.component_models[0]
     for param in result_model["parameters"]:
-        assert np.allclose(param["std"], expected_uncertainties[param["name"]], rtol= 0.01)
+        assert np.allclose(param["std"], expected_uncertainties[param["name"]], rtol=0.01)
 
 
 @pytest.mark.filterwarnings('ignore')


### PR DESCRIPTION
Implements retrieving and displaying uncertainties from the fit models in the Model Fitting plugin. Opening as draft since I need to mess around with the plugin layout to accommodate the new information in a way that's visually appealing.