### PR TITLE
future-proof slicing logic for glue-jupyter as_steps support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Future proof slicing logic for as_steps implementation in upcoming glue-jupyter release. [#1599]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -1,4 +1,5 @@
 import numpy as np
+from astropy.utils.introspection import minversion
 
 from glue.core import BaseData
 from jdaviz.core.helpers import ImageConfigHelper
@@ -6,6 +7,10 @@ from jdaviz.configs.default.plugins.line_lists.line_list_mixin import LineListMi
 from jdaviz.configs.specviz import Specviz
 from jdaviz.core.events import (AddDataMessage,
                                 SliceSelectSliceMessage)
+
+# NOTE: this and the if-statement that uses it can be removed if/once
+# the version of glue-jupyter with as_steps support is pinned as min-version
+GLUEJUPYTER_GE_0_13 = minversion('glue_jupyter', '0.13.0')
 
 __all__ = ['Cubeviz', 'CubeViz']
 
@@ -80,7 +85,11 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
         if not isinstance(wavelength, (int, float)):
             raise TypeError("wavelength must be a float or int")
         # Retrieve the x slices from the spectrum viewer's marks
-        x_all = self.app.get_viewer('spectrum-viewer').native_marks[0].x
+        sv = self.app.get_viewer('spectrum-viewer')
+        x_all = sv.native_marks[0].x
+        if sv.state.layers[0].as_steps and GLUEJUPYTER_GE_0_13:
+            # then the marks have been doubled in length (each point duplicated)
+            x_all = x_all[::2]
         index = np.argmin(abs(x_all - wavelength))
         return self.select_slice(int(index))
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request future-proofs the slicing wavelength to slice logic for when a future release of glue-jupyter includes https://github.com/glue-viz/glue-jupyter/pull/309.  That PR, when `layer.as_steps=True`, doubles the length of the bqplot Lines object, which has been used since #1550 to quickly access the wavelength array to map wavelength to slice.

I suspect this will fail coverage, as we have no way within CI to force entering that if-statement.  Covering the if-statement within CI should probably be added to #1595 (I added a TODO entry there to make sure that is done once that is rebased on top of this).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
