### PR TITLE
BOT: Labeler to not remove labels

### DIFF
--- a/.github/workflows/open_actions.yml
+++ b/.github/workflows/open_actions.yml
@@ -9,7 +9,9 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
+    # NOTE: sync-labels due to https://github.com/actions/labeler/issues/112
     - name: Label PR
       uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: ''


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to tell the auto PR labeler bot to not remove a label if it was added manually prior to opening the PR. This is the same setting as `astropy` so should be uncontroversial.

Currently, if you manually apply a label but it is not defined in the rules for that label when the bot runs, it removes the label. This is annoying in cases where you already know what label you want so you manually apply it when you open the PR. Only affects contributors who can apply labels.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
