### PR TITLE
Pin ipwidgets to avoid breaking standalone app

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     ipyvuetify>=1.7.0
     ipysplitpanes>=0.1.0
     ipygoldenlayout>=0.3.0
+    ipywidgets<8.0
     voila>=0.3.5
     pyyaml>=5.4.1
     specutils>=1.7.0


### PR DESCRIPTION
`ipywidgets` 8.0 broke compatibility with `voila`, so we'll have to pin it at least for now. I got a jinja2 error after a fresh install with this pin though, could someone else test and see if that's just something messed up in my local env?

* https://github.com/voila-dashboards/voila/issues/1188