### PR TITLE
fix subset layer default behavior

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 New Features
 ------------
 
-- Profile viewers now support plotting with profiles "as steps". [#1595]
+- Profile viewers now support plotting with profiles "as steps". [#1595, #1624]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1334,7 +1334,8 @@ class Application(VuetifyTemplate, HubListener):
         for data in viewer_data:
             if data.label not in active_data_labels:
                 viewer.remove_data(data)
-                viewer._layers_with_defaults_applied.remove(data.label)
+                viewer._layers_with_defaults_applied= [layer_info for layer_info in viewer._layers_with_defaults_applied  # noqa
+                                                       if layer_info['data_label'] != data.label]
                 remove_data_message = RemoveDataMessage(data, viewer,
                                                         viewer_id=viewer_id,
                                                         sender=self)

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1334,6 +1334,7 @@ class Application(VuetifyTemplate, HubListener):
         for data in viewer_data:
             if data.label not in active_data_labels:
                 viewer.remove_data(data)
+                viewer._layers_with_defaults_applied.remove(data.label)
                 remove_data_message = RemoveDataMessage(data, viewer,
                                                         viewer_id=viewer_id,
                                                         sender=self)

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -148,8 +148,10 @@ class JdavizViewerMixin:
         # to avoid recursion, but also handle multiple layers for the same subset
         expected_subset_layers = self._expected_subset_layers[:]
         for layer in self.state.layers:
-            if layer.layer.label not in self._layers_with_defaults_applied:
-                self._layers_with_defaults_applied.append(layer.layer.label)
+            layer_info = {'data_label': layer.layer.data.label,
+                          'layer_label': layer.layer.label}
+            if layer_info not in self._layers_with_defaults_applied:
+                self._layers_with_defaults_applied.append(layer_info)
                 self._apply_layer_defaults(layer)
 
             if layer.layer.label in expected_subset_layers:


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes the case where removing and then re-adding a data layer in a viewer results in "as steps" being enabled by default.  Plot options are lost anyways when the layer is deleted, so we need to re-apply any jdaviz-implemented layer defaults (as-steps, line-width, etc) when a data layer is removed and then re-added to a viewer.

This also fixes the case of "as steps" defaults only being applied to the first subset layer when the same subset is being drawn on multiple data layers simultaneously.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
