### PR TITLE
Use spectrum's uncertainty as weight when doing model fitting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ New Features
 
 - Use spectrum's uncertainty as weight when doing model fitting. [#1630]
 
+- Line flux in the Line Analysis plugin are reported in W/m2 if Spectral Flux is given
+  in Jy [#1564]
+
+- User-friendly API access to plugins. [#1401]
+
 Cubeviz
 ^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ New Features
 
 - Profile viewers now support plotting with profiles "as steps". [#1595]
 
+- Use spectrum's uncertainty as weight when doing model fitting. [#1630]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
+++ b/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
@@ -100,7 +100,8 @@ def _fit_1D(initial_model, spectrum, run_fitter, window=None):
 
     """
     if run_fitter:
-        output_model = fit_lines(spectrum, initial_model, weights='unc', window=window)
+        weights = 'unc' if spectrum.uncertainty else None
+        output_model = fit_lines(spectrum, initial_model, weights=weights, window=window)
         output_values = output_model(spectrum.spectral_axis)
     else:
         # Return without fitting.
@@ -252,7 +253,8 @@ class SpaxelWorker:
             flux = self.cube[x, y, :]
             sp = Spectrum1D(spectral_axis=self.wave, flux=flux)
 
-            fitted_model = fit_lines(sp, self.model, window=self.window, weights='unc')
+            weights = 'unc' if sp.uncertainty else None
+            fitted_model = fit_lines(sp, self.model, window=self.window, weights=weights)
 
             fitted_values = fitted_model(self.wave)
 

--- a/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
+++ b/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
@@ -100,7 +100,7 @@ def _fit_1D(initial_model, spectrum, run_fitter, window=None):
 
     """
     if run_fitter:
-        output_model = fit_lines(spectrum, initial_model, window=window)
+        output_model = fit_lines(spectrum, initial_model, weights='unc', window=window)
         output_values = output_model(spectrum.spectral_axis)
     else:
         # Return without fitting.
@@ -252,7 +252,7 @@ class SpaxelWorker:
             flux = self.cube[x, y, :]
             sp = Spectrum1D(spectral_axis=self.wave, flux=flux)
 
-            fitted_model = fit_lines(sp, self.model, window=self.window)
+            fitted_model = fit_lines(sp, self.model, window=self.window, weights='unc')
 
             fitted_values = fitted_model(self.wave)
 

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -81,7 +81,7 @@ def test_register_model_with_uncertainty_weighting(specviz_helper, spectrum1d):
     expected_uncertainties = {'slope': 0.0003657, 'intercept': 2.529}
     result_model = modelfit_plugin.component_models[0]
     for param in result_model["parameters"]:
-        assert np.allclose(param["std"], expected_uncertainties[param["name"]], atol=0.01)
+        assert np.allclose(param["std"], expected_uncertainties[param["name"]], rtol=0.01)
 
 
 @pytest.mark.filterwarnings('ignore')
@@ -111,7 +111,7 @@ def test_register_model_uncertainty_is_none(specviz_helper, spectrum1d):
     expected_uncertainties = {'slope': 0.00038, 'intercept': 2.67}
     result_model = modelfit_plugin.component_models[0]
     for param in result_model["parameters"]:
-        assert np.allclose(param["std"], expected_uncertainties[param["name"]], atol=0.01)
+        assert np.allclose(param["std"], expected_uncertainties[param["name"]], rtol=0.01)
 
 
 @pytest.mark.filterwarnings('ignore')

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -78,9 +78,9 @@ def test_register_model(specviz_helper, spectrum1d):
     # Test that the parameter uncertainties were updated
     expected_uncertainties = {'slope': 0.00038, 'intercept': 2.67}
     result_model = modelfit_plugin.component_models[0]
-    for param in result_model["parameters"]:
-        # print(param["std"], expected_uncertainties[param["name"]])
-        # assert np.allclose(param["std"], expected_uncertainties[param["name"]], atol=0.01)
+    # for param in result_model["parameters"]:
+    #     print(param["std"], expected_uncertainties[param["name"]])
+    #     # assert np.allclose(param["std"], expected_uncertainties[param["name"]], atol=0.01)
 
 
 @pytest.mark.filterwarnings('ignore')

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -4,6 +4,7 @@ This does NOT test the actual fitting self (see test_fitting.py for that)
 """
 
 import numpy as np
+from astropy.nddata import StdDevUncertainty
 import pytest
 
 from jdaviz.configs.default.plugins.model_fitting.initializers import MODELS
@@ -55,7 +56,38 @@ def test_custom_model_labels(specviz_helper, spectrum1d):
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_register_model(specviz_helper, spectrum1d):
+def test_register_model_with_uncertainty_weighting(specviz_helper, spectrum1d):
+    spectrum1d.uncertainty = StdDevUncertainty(spectrum1d.flux * 0.1)
+    specviz_helper.load_data(spectrum1d)
+    modelfit_plugin = specviz_helper.app.get_tray_item_from_name('g-model-fitting')
+
+    # Test registering a simple linear fit
+    modelfit_plugin.comp_selected = 'Linear1D'
+    modelfit_plugin.vue_add_model()
+    modelfit_plugin.vue_model_fitting()
+    assert len(specviz_helper.app.data_collection) == 2
+
+    # Test fitting again overwrites original fit
+    modelfit_plugin.vue_model_fitting()
+    assert len(specviz_helper.app.data_collection) == 2
+
+    # Test custom model label
+    test_label = 'my_Linear1D'
+    modelfit_plugin.results_label = test_label
+    modelfit_plugin.vue_model_fitting()
+    assert test_label in specviz_helper.app.data_collection
+
+    # Test that the parameter uncertainties were updated
+    expected_uncertainties = {'slope': 0.0003657, 'intercept': 2.529}
+    result_model = modelfit_plugin.component_models[0]
+    for param in result_model["parameters"]:
+        assert np.allclose(param["std"], expected_uncertainties[param["name"]], atol=0.01)
+
+
+@pytest.mark.filterwarnings('ignore')
+def test_register_model_uncertainty_is_none(specviz_helper, spectrum1d):
+    # Set uncertainty to None
+    spectrum1d.uncertainty = None
     specviz_helper.load_data(spectrum1d)
     modelfit_plugin = specviz_helper.app.get_tray_item_from_name('g-model-fitting')
 
@@ -78,9 +110,8 @@ def test_register_model(specviz_helper, spectrum1d):
     # Test that the parameter uncertainties were updated
     expected_uncertainties = {'slope': 0.00038, 'intercept': 2.67}
     result_model = modelfit_plugin.component_models[0]
-    # for param in result_model["parameters"]:
-    #     print(param["std"], expected_uncertainties[param["name"]])
-    #     # assert np.allclose(param["std"], expected_uncertainties[param["name"]], atol=0.01)
+    for param in result_model["parameters"]:
+        assert np.allclose(param["std"], expected_uncertainties[param["name"]], atol=0.01)
 
 
 @pytest.mark.filterwarnings('ignore')

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -78,8 +78,9 @@ def test_register_model(specviz_helper, spectrum1d):
     # Test that the parameter uncertainties were updated
     expected_uncertainties = {'slope': 0.00038, 'intercept': 2.67}
     result_model = modelfit_plugin.component_models[0]
-    # for param in result_model["parameters"]:
-    #     assert np.allclose(param["std"], expected_uncertainties[param["name"]], atol=0.01)
+    for param in result_model["parameters"]:
+        # print(param["std"], expected_uncertainties[param["name"]])
+        # assert np.allclose(param["std"], expected_uncertainties[param["name"]], atol=0.01)
 
 
 @pytest.mark.filterwarnings('ignore')

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -78,8 +78,8 @@ def test_register_model(specviz_helper, spectrum1d):
     # Test that the parameter uncertainties were updated
     expected_uncertainties = {'slope': 0.00038, 'intercept': 2.67}
     result_model = modelfit_plugin.component_models[0]
-    for param in result_model["parameters"]:
-        assert np.allclose(param["std"], expected_uncertainties[param["name"]], rtol=0.01)
+    # for param in result_model["parameters"]:
+    #     assert np.allclose(param["std"], expected_uncertainties[param["name"]], atol=0.01)
 
 
 @pytest.mark.filterwarnings('ignore')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

Requires: https://github.com/astropy/specutils/pull/979

Allows model fitting to use the uncertainty of spectra as weights.

This does not work for a 0 order polynomial in Specviz and does not work at all with Cubeviz since we split the uncertainty and flux data into separate cubes. Is re-adding the uncertainty information into the flux cube part of this PR?

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
