### PR TITLE
(minimal) user API for catalog search

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ New Features
   in Jy [#1564]
 
 - User-friendly API access to plugins, with exposed functionality for:  line analysis, gaussian
-  smooth, moment maps, and compass. [#1401, #1642, #1643]
+  smooth, moment maps, and compass. [#1401, #1642, #1643, #1636]
 
 Cubeviz
 ^^^^^^^

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -111,6 +111,9 @@ Plugins
 .. automodapi:: jdaviz.configs.imviz.plugins.aper_phot_simple.aper_phot_simple
    :no-inheritance-diagram:
 
+.. automodapi:: jdaviz.configs.imviz.plugins.catalogs.catalogs
+   :no-inheritance-diagram:
+
 .. automodapi:: jdaviz.configs.imviz.plugins.compass.compass
    :no-inheritance-diagram:
 

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -10,7 +10,6 @@ from astroquery.sdss import SDSS
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin, ViewerSelectMixin,
                                         SelectPluginComponent)
-from jdaviz.core.user_api import PluginUserApi
 
 __all__ = ['Catalogs']
 
@@ -25,9 +24,6 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin):
 
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.show`
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.open_in_tray`
-    * ``viewer`` (`~jdaviz.core.template_mixin.ViewerSelect`)
-    * ``catalog`` (`~jdaviz.core.template_mixin.SelectPluginComponent`)
-    * :meth:`search`
     """
     template_file = __file__, "catalogs.vue"
     catalog_items = List([]).tag(sync=True)
@@ -42,10 +38,6 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin):
                                              items='catalog_items',
                                              selected='catalog_selected',
                                              manual_options=['SDSS'])
-
-    @property
-    def user_api(self):
-        return PluginUserApi(self, expose=('viewer', 'catalog', 'search', 'clear'))
 
     def search(self):
         """

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
@@ -14,7 +14,7 @@
 
      <v-row>
        <v-select
-         :items="catalog_items"
+         :items="catalog_items.map(i => i.label)"
          v-model="catalog_selected"
          label="Catalog"
          hint="Select a catalog to search with."


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request extends on #1401 and provides user-API access to the catalog search plugin.

[Plugin User API docs](https://jdaviz--1636.org.readthedocs.build/en/1636/api/jdaviz.configs.imviz.plugins.catalogs.catalogs.Catalogs.html#jdaviz.configs.imviz.plugins.catalogs.catalogs.Catalogs)

**TODO**:
- [x] figure out why catalogs API are not being built in RTD
- [ ] add PR to changelog if before next release, otherwise add new entry (waiting until PR is accepted otherwise to avoid constant merge conflicts)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
