### PR TITLE
Suppress Units warnings from Line Analysis plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,7 +78,7 @@ Specviz2d
 Other Changes and Additions
 ---------------------------
 
-- Suppressed astropy.units warnings in Line Analysis plugin. [#1648]
+- Changed unit formatting to avoid astropy.units warnings in Line Analysis plugin. [#1648]
 
 2.10 (2022-08-26)
 =================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,8 @@ Specviz2d
 Other Changes and Additions
 ---------------------------
 
+- Suppressed astropy.units warnings in Line Analysis plugin. [#1648]
+
 2.10 (2022-08-26)
 =================
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -276,6 +276,11 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
             # in which case we'll default to the identified line
             self.selected_line = self.identified_line
 
+    def _unit_ignore_warnings(self, unit):
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            return u.Unit(unit)
+
     @observe("spatial_subset_selected", "spectral_subset_selected", "dataset_selected",
              "continuum_subset_selected", "width")
     def _calculate_statistics(self, *args, **kwargs):
@@ -425,7 +430,8 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
                     raw_result = analysis.line_flux(freq_spec)
                     # When flux is equivalent to Jy, lineflux result should be shown in W/m2
                     if flux_unit.is_equivalent(u.Jy/u.sr):
-                        final_unit = u.Unit('W/m2/sr')
+
+                        final_unit = self._unit_ignore_warnings('W/m2/sr')
                     else:
                         final_unit = u.Unit('W/m2')
 
@@ -446,7 +452,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
                     raw_result = analysis.line_flux(wave_spec)
                     # When flux is equivalent to Jy, lineflux result should be shown in W/m2
                     if flux_unit.is_equivalent(u.Unit('W/m2/m'/u.sr)):
-                        final_unit = u.Unit('W/m2/sr')
+                        final_unit = self._unit_ignore_warnings('W/m2/sr')
                     else:
                         final_unit = u.Unit('W/m2')
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -276,11 +276,6 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
             # in which case we'll default to the identified line
             self.selected_line = self.identified_line
 
-    def _unit_ignore_warnings(self, unit):
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            return u.Unit(unit)
-
     @observe("spatial_subset_selected", "spectral_subset_selected", "dataset_selected",
              "continuum_subset_selected", "width")
     def _calculate_statistics(self, *args, **kwargs):
@@ -431,7 +426,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
                     # When flux is equivalent to Jy, lineflux result should be shown in W/m2
                     if flux_unit.is_equivalent(u.Jy/u.sr):
 
-                        final_unit = self._unit_ignore_warnings('W/m2/sr')
+                        final_unit = u.Unit('W/(m2 sr)')
                     else:
                         final_unit = u.Unit('W/m2')
 
@@ -441,8 +436,8 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
 
                 # If the flux unit is instead equivalent to power density
                 # (Jy, but defined in wavelength), enforce integration in wavelength space
-                elif (flux_unit.is_equivalent(u.Unit('W/m2/m')) or
-                        flux_unit.is_equivalent(u.Unit('W/m2/m/sr'))):
+                elif (flux_unit.is_equivalent(u.Unit('W/(m2 m)')) or
+                        flux_unit.is_equivalent(u.Unit('W/(m2 m sr)'))):
                     # Perform integration in wavelength space using MKS unit (meters)
                     wave_spec = Spectrum1D(
                         spectral_axis=spec_subtracted.spectral_axis.to(u.m,
@@ -451,8 +446,8 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
                         uncertainty=spec_subtracted.uncertainty)
                     raw_result = analysis.line_flux(wave_spec)
                     # When flux is equivalent to Jy, lineflux result should be shown in W/m2
-                    if flux_unit.is_equivalent(u.Unit('W/m2/m'/u.sr)):
-                        final_unit = self._unit_ignore_warnings('W/m2/sr')
+                    if flux_unit.is_equivalent(u.Unit('W/(m2 m)'/u.sr)):
+                        final_unit = u.Unit('W/(m2 sr)')
                     else:
                         final_unit = u.Unit('W/m2')
 


### PR DESCRIPTION
Suppresses the `W/m2/m` warning from astropy.units when using the line analysis plugin.