### PR TITLE
TST: Test against Python 3.11

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -62,10 +62,10 @@ jobs:
 
           # This also runs on cron but we want to make sure new changes
           # won't break this job at the PR stage.
-          - name: Python 3.10 with latest dev versions of key dependencies, and remote data
+          - name: Python 3.11 with latest dev versions of key dependencies, and remote data
             os: ubuntu-latest
-            python: '3.10'
-            toxenv: py310-test-devdeps
+            python: '3.11'
+            toxenv: py311-test-devdeps
             toxposargs: --remote-data
             allow_failure: true
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}-test{,-alldeps,-devdeps}{,-cov}
+    py{38,39,310,311}-test{,-alldeps,-devdeps}{,-cov}
     linkcheck
     codestyle
     pep517
@@ -12,7 +12,9 @@ isolated_build = true
 
 [testenv]
 # Suppress display of matplotlib plots generated during docs build
-setenv = MPLBACKEND=agg
+setenv =
+    MPLBACKEND=agg
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 
 # Pass through the following environment variables which may be needed for the CI
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI
@@ -38,6 +40,9 @@ description =
 # The following provides some specific pinnings for key packages
 deps =
     # NOTE: Add/remove as needed
+    devdeps: scipy>=0.0.dev0
+    devdeps: numpy>=0.0.dev0
+    devdeps: git+https://github.com/astropy/regions.git
     devdeps: git+https://github.com/astropy/specutils.git
     devdeps: git+https://github.com/astropy/photutils.git
     devdeps: git+https://github.com/spacetelescope/gwcs.git
@@ -57,8 +62,6 @@ extras =
     #alldeps: all
 
 commands =
-    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
-    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
     devdeps: pip install -U -i https://pypi.anaconda.org/astropy/simple astropy --pre
     pip freeze
     !cov: pytest --pyargs jdaviz {toxinidir}/docs {posargs}


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to see how badly things break in Python 3.11 (using RC2).

### Blocked by

* https://github.com/glue-viz/glue/issues/2340
* https://github.com/astropy/regions/issues/475
    * https://github.com/astropy/regions/pull/476

### No longer an issue

* https://github.com/h5py/h5py/issues/2146 (glue stopped pulling it for Python 3.11, see https://github.com/glue-viz/glue/pull/2321)

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set?
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
