### PR TITLE
Attach select menus

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,7 +78,7 @@ Bug Fixes
 - Fixed loading data via the Import Data button on top-left of the application.
   [#1608]
 
-- Floating dropdowns are now attached to their menus. [#1673]
+- Floating menus are now attached to their selector element. [#1673]
 
 Cubeviz
 ^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,8 @@ Bug Fixes
 - Fixed loading data via the Import Data button on top-left of the application.
   [#1608]
 
+- Floating dropdowns are now attached to their menus [#1673]
+
 Cubeviz
 ^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,7 +78,7 @@ Bug Fixes
 - Fixed loading data via the Import Data button on top-left of the application.
   [#1608]
 
-- Floating dropdowns are now attached to their menus [#1673]
+- Floating dropdowns are now attached to their menus. [#1673]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/components/plugin_dataset_select.vue
+++ b/jdaviz/components/plugin_dataset_select.vue
@@ -3,6 +3,7 @@
   <v-row v-if="items.length > 1 || show_if_single_entry">
     <v-select
       :menu-props="{ left: true }"
+      attach
       :items="items"
       v-model="selected"
       @change="$emit('update:selected', $event)"

--- a/jdaviz/components/plugin_layer_select.vue
+++ b/jdaviz/components/plugin_layer_select.vue
@@ -3,6 +3,7 @@
   <v-row v-if="items.length > 1 || show_if_single_entry">
     <v-select
       :menu-props="{ left: true }"
+      attach
       :items="items"
       v-model="selected"
       @change="$emit('update:selected', $event)"

--- a/jdaviz/components/plugin_subset_select.vue
+++ b/jdaviz/components/plugin_subset_select.vue
@@ -3,6 +3,7 @@
   <v-row v-if="items.length > 1 || show_if_single_entry">
     <v-select
       :menu-props="{ left: true }"
+      attach
       :items="items"
       v-model="selected"
       @change="$emit('update:selected', $event)"

--- a/jdaviz/components/plugin_viewer_select.vue
+++ b/jdaviz/components/plugin_viewer_select.vue
@@ -3,6 +3,7 @@
   <v-row v-if="items.length > 1 || show_if_single_entry">
     <v-select
       :menu-props="{ left: true }"
+      attach
       :items="items"
       v-model="selected"
       @change="$emit('update:selected', $event)"

--- a/jdaviz/configs/default/plugins/collapse/collapse.vue
+++ b/jdaviz/configs/default/plugins/collapse/collapse.vue
@@ -15,6 +15,7 @@
     <v-row>
       <v-select
         :menu-props="{ left: true }"
+        attach
         :items="method_items.map(i => i.label)"
         v-model="method_selected"
         label="Method"

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.vue
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.vue
@@ -17,6 +17,7 @@
       <v-row v-if="show_modes">
         <v-select
           :menu-props="{ left: true }"
+          attach
           :items="smooth_modes"
           v-model="selected_mode"
           label="Smoothing Type"

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.vue
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.vue
@@ -95,6 +95,7 @@
     <v-row>
       <v-select
         :menu-props="{ left: true }"
+        attach
         :items="available_lists"
         @change="list_selected"
         label="Available Line Lists"
@@ -178,6 +179,7 @@
                 <j-tooltip tipid='plugin-line-lists-custom-unit'>
                     <v-select
                       :menu-props="{ left: true }"
+                      attach
                       :items="custom_unit_choices"
                       v-model="custom_unit"
                       label="Unit"

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -35,6 +35,7 @@
     <v-form v-model="form_valid_model_component">
       <v-row v-if="model_comp_items">
         <v-select
+          attach
           :menu-props="{ left: true }"
           :items="model_comp_items.map(i => i.label)"
           v-model="model_comp_selected"

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -101,6 +101,7 @@
     <glue-state-sync-wrapper v-if="config === 'cubeviz'" :sync="collapse_func_sync" :multiselect="multiselect" @unmix-state="unmix_state('function')">
       <v-select
         :menu-props="{ left: true }"
+        attach
         :items="collapse_func_sync.choices"
         v-model="collapse_func_value"
         label="Collapse Function"
@@ -157,6 +158,7 @@
     <j-plugin-section-header v-if="stretch_function_sync.in_subscribed_states">Stretch</j-plugin-section-header>
     <glue-state-sync-wrapper :sync="stretch_function_sync" :multiselect="multiselect" @unmix-state="unmix_state('stretch_function')">
       <v-select
+        attach
         :menu-props="{ left: true }"
         :items="stretch_function_sync.choices"
         v-model="stretch_function_value"
@@ -167,6 +169,7 @@
 
     <glue-state-sync-wrapper :sync="stretch_preset_sync" :multiselect="multiselect" @unmix-state="unmix_state('stretch_preset')">
       <v-select
+        attach
         :menu-props="{ left: true }"
         :items="stretch_preset_sync.choices"
         v-model="stretch_preset_value"
@@ -197,6 +200,7 @@
     <div v-if="image_visible_sync.in_subscribed_states && image_visible_value">
       <glue-state-sync-wrapper :sync="image_color_mode_sync" :multiselect="multiselect" @unmix-state="unmix_state('image_color_mode')">
         <v-select
+          attach
           :menu-props="{ left: true }"
           :items="image_color_mode_sync.choices"
           v-model="image_color_mode_value"
@@ -209,6 +213,7 @@
 
       <glue-state-sync-wrapper v-if="image_color_mode_value === 'Colormaps'" :sync="image_colormap_sync" :multiselect="multiselect" @unmix-state="unmix_state('image_colormap')">
         <v-select
+          attach
           :menu-props="{ left: true }"
           :items="image_colormap_sync.choices"
           v-model="image_colormap_value"

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -103,6 +103,7 @@
         <v-row>
           <v-select
             :menu-props="{ left: true }"
+            attach
             :items="plot_types"
             v-model="current_plot_type"
             label="Plot Type"

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
@@ -15,6 +15,7 @@
      <v-row>
        <v-select
          :menu-props="{ left: true }"
+         attach
          :items="catalog_items.map(i => i.label)"
          v-model="catalog_selected"
          label="Catalog"

--- a/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.vue
+++ b/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.vue
@@ -6,6 +6,7 @@
 
     <v-row>
       <v-select
+        attach
         :menu-props="{ left: true }"
         :items="viewer_items"
         v-model="selected_viewer"

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -142,6 +142,7 @@
         <v-col cols=10>
           <v-select
             :menu-props="{ left: true }"
+            attach
             :items="line_items"
             v-model="selected_line"
             label="Line"

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -65,6 +65,7 @@
 
         <v-row>
           <v-select
+            attach
             :menu-props="{ left: true }"
             :items="trace_type_items.map(i => i.label)"
             v-model="trace_type_selected"
@@ -112,6 +113,7 @@
 
         <v-row v-if="trace_type_selected==='Auto'">
           <v-select
+            attach
             :menu-props="{ left: true }"
             :items="trace_peak_method_items.map(i => i.label)"
             v-model="trace_peak_method_selected"
@@ -170,6 +172,7 @@
 
       <v-row>
         <v-select
+          attach
           :menu-props="{ left: true }"
           :items="bg_type_items.map(i => i.label)"
           v-model="bg_type_selected"
@@ -299,6 +302,7 @@
 
       <v-row>
         <v-select
+          attach
           :menu-props="{ left: true }"
           :items="ext_type_items"
           v-model="ext_type_selected"

--- a/jdaviz/data/linelists/linelist_metadata.json
+++ b/jdaviz/data/linelists/linelist_metadata.json
@@ -9,13 +9,13 @@
     "filename_base": "Common_nebular",
     "Citations/Notes": " Common nebular lines.\n\n Copyright (C) 1999-2004 by Christian Buil\n http://www.astrosurf.com/buil/us/spe2/hresol5.htm"
   },
-  "Common Galactic 700A-2000A": {
+  "Galactic 700A-2000A": {
     "units": "Angstrom",
     "medium": "vacuum",
     "filename_base": "Common_Galactic_700A-2000A",
     "Citations/Notes": "http://astronomy.nmsu.edu/drewski/tableofemissionlines.html"
   },
-  "Common Galactic 2000A-11000A": {
+  "Galactic 2000A-11000A": {
     "units": "Angstrom",
     "medium": "air",
     "filename_base": "Common_Galactic_2000A-11000A",


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Historically, we've always had an issue with dropdown menus floating around when the user scrolls the notebook. When working on #1656, I found an `attach` property that effectively docks the dropdown menu to the `v-select`:

Before:

https://user-images.githubusercontent.com/25206008/191856631-a79393ee-2892-4d06-add1-5ce9a9d06e94.mp4

After:

https://user-images.githubusercontent.com/25206008/191853995-8c469bc2-9be6-4f47-b12e-3b32b518dd2a.mp4

The only consequence that we have to consider here is entries whose names are larger than the plugin bar. Before, the floating menu could accommodate any sized item by overflowing:
![image](https://user-images.githubusercontent.com/25206008/191854710-8db90e4c-f5d6-421e-b879-3fc91616ff18.png)

When the menu is attached, the menu is restricted to the size of the `v-select`:
![image](https://user-images.githubusercontent.com/25206008/191854958-1e3b45e4-f500-47b1-add6-b7c043a3ef31.png)

Ideally, we could combine the two, attach the menu and allow the overflow, but I haven't found how to do that. I've created this PR as a POC, and to encourage discussion on how we can handle this side-effect

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
