### PR TITLE
spectral extraction: live-preview and export of background spectrum

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ Specviz2d
 - Improved logic for initial guess for position of "Manual" background trace in spectral extraction
   plugin. [#1738]
 
+- Spectral extraction plugin now supports visualizing and exporting the 1D spectrum associated
+  with the background region. [#1682]
+
 API Changes
 -----------
 

--- a/docs/specviz2d/plugins.rst
+++ b/docs/specviz2d/plugins.rst
@@ -96,7 +96,7 @@ images via `specreduce.background <https://specreduce.readthedocs.io/en/latest/#
 Once you interact with any of the inputs in the background step or hover over that area
 of the plugin, the live visualization in the 2d spectrum viewer will change to show the center 
 (dotted line) and edges (solid lines) of the background region(s).  The 1D representation of the
-background will also be visualized in the 1D spectrum viewer (dotted line).
+background will also be visualized in the 1D spectrum viewer (thin solid line).
 
 Choose between creating the background around the trace defined in the Trace section, or around a "Manual" flat trace.
 

--- a/docs/specviz2d/plugins.rst
+++ b/docs/specviz2d/plugins.rst
@@ -94,9 +94,11 @@ The background step of the plugin allows for creating background and background-
 images via `specreduce.background <https://specreduce.readthedocs.io/en/latest/#module-specreduce.background>`_.
 
 Once you interact with any of the inputs in the background step or hover over that area
-of the plugin, the live visualization will change to show the center (dotted line) and edges
-(solid lines) of the background region(s).  Choose between creating the background
-around the trace defined in the Trace section, or around a "Manual" flat trace.
+of the plugin, the live visualization in the 2d spectrum viewer will change to show the center 
+(dotted line) and edges (solid lines) of the background region(s).  The 1D representation of the
+background will also be visualized in the 1D spectrum viewer (dotted line).
+
+Choose between creating the background around the trace defined in the Trace section, or around a "Manual" flat trace.
 
 To visualize the resulting background or background-subtracted image, click on the respective panel,
 and choose a label for the new data entry.  The exported images will now appear in the data dropdown
@@ -108,7 +110,10 @@ To export and access the specreduce Background object defined in the plugin, cal
 
   bg = sp_ext.export_bg()
 
-To access the background image or background-subtracted image as a :class:`~specutils.Spectrum1D` object, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_bg_img` or :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_bg_img`, respectively.
+To access the background image, background spectrum, or background-subtracted image as a :class:`~specutils.Spectrum1D` object,
+call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_bg_img`,
+:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_bg_spectrum`,
+or :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_bg_sub`, respectively.
 
 To import the parameters from a specreduce Background object into the plugin, whether it's new or was exported and modified in the notebook, call :meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.import_bg`::
 

--- a/docs/specviz2d/plugins.rst
+++ b/docs/specviz2d/plugins.rst
@@ -94,11 +94,12 @@ The background step of the plugin allows for creating background and background-
 images via `specreduce.background <https://specreduce.readthedocs.io/en/latest/#module-specreduce.background>`_.
 
 Once you interact with any of the inputs in the background step or hover over that area
-of the plugin, the live visualization in the 2d spectrum viewer will change to show the center 
+of the plugin, the live visualization in the 2D spectrum viewer will change to show the center 
 (dotted line) and edges (solid lines) of the background region(s).  The 1D representation of the
-background will also be visualized in the 1D spectrum viewer (thin solid line).
+background will also be visualized in the 1D spectrum viewer (thin, solid line).
 
-Choose between creating the background around the trace defined in the Trace section, or around a "Manual" flat trace.
+Backgrounds can either be created around the trace defined in the earlier Trace section or around a new,
+flat trace by selecting "Manual" in the Background Type dropdown.
 
 To visualize the resulting background or background-subtracted image, click on the respective panel,
 and choose a label for the new data entry.  The exported images will now appear in the data dropdown

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -464,7 +464,7 @@ class SpectralExtraction(PluginTemplateMixin):
         viewer2d.figure.marks = viewer2d.figure.marks + list(self._marks.values())
 
         self._marks['extract'] = PluginLine(viewer1d, visible=self.plugin_opened)
-        self._marks['bg_spec'] = PluginLine(viewer1d, visible=self.plugin_opened, line_style='dotted')  # noqa
+        self._marks['bg_spec'] = PluginLine(viewer1d, visible=self.plugin_opened, stroke_width=1)  # noqa
 
         # NOTE: += won't trigger the figure to notice new marks
         viewer1d.figure.marks = viewer1d.figure.marks + [self._marks['extract'],

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -230,7 +230,7 @@
         <v-expansion-panels popout>
           <v-expansion-panel>
             <v-expansion-panel-header v-slot="{ open }">
-              <span style="padding: 6px">Export Background</span>
+              <span style="padding: 6px">Export Background Image</span>
             </v-expansion-panel-header>
             <v-expansion-panel-content>
               <plugin-add-results
@@ -254,7 +254,31 @@
         <v-expansion-panels popout>
           <v-expansion-panel>
             <v-expansion-panel-header v-slot="{ open }">
-              <span style="padding: 6px">Export Subtracted</span>
+              <span style="padding: 6px">Export Background Spectrum</span>
+            </v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <plugin-add-results
+                :label.sync="bg_spec_results_label"
+                :label_default="bg_spec_results_label_default"
+                :label_auto.sync="bg_spec_results_label_auto"
+                :label_invalid_msg="bg_spec_results_label_invalid_msg"
+                :label_overwrite="bg_spec_results_label_overwrite"
+                label_hint="Label for the background spectrum"
+                :add_to_viewer_items="bg_spec_add_to_viewer_items"
+                :add_to_viewer_selected.sync="bg_spec_add_to_viewer_selected"
+                action_label="Export"
+                action_tooltip="Create Background Spectrum"
+                @click:action="create_bg_spec"
+              ></plugin-add-results>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </v-row>
+      <v-row>
+        <v-expansion-panels popout>
+          <v-expansion-panel>
+            <v-expansion-panel-header v-slot="{ open }">
+              <span style="padding: 6px">Export Background-Subtracted Image</span>
             </v-expansion-panel-header>
             <v-expansion-panel-content>
               <plugin-add-results

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -97,6 +97,8 @@ def test_plugin(specviz2d_helper):
     assert pext.bg_width == 4
     bg_img = pext.export_bg_img()
     assert isinstance(bg_img, Spectrum1D)
+    bg_spec = pext.export_bg_spectrum()
+    assert isinstance(bg_spec, Spectrum1D)
     bg_sub = pext.export_bg_sub()
     assert isinstance(bg_sub, Spectrum1D)
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request adds live-visualization and export (UI and API) support for the 1D spectrum representing the background region within the spectral extraction plugin.

~NOTE: this requires https://github.com/astropy/specreduce/pull/143 (until then, the new test coverage will fail)~

[Rendered updated plugin docs](https://jdaviz--1682.org.readthedocs.build/en/1682/specviz2d/plugins.html#background)

https://user-images.githubusercontent.com/877591/192842956-2fba147d-d027-48e7-96e2-fc0f75d7cb77.mov


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

New Features > Specviz2d:

Spectral extraction plugin now supports visualizing and exporting the 1D spectrum associated with the background region.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
