### PR TITLE
DOC: Imviz plot options example with select all

### DIFF
--- a/notebooks/concepts/imviz_load_fits_hdu.ipynb
+++ b/notebooks/concepts/imviz_load_fits_hdu.ipynb
@@ -104,6 +104,64 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "7dddb1d6",
+   "metadata": {},
+   "source": [
+    "To programmatically control Plot Options so you can set some stuff for all data at once, see https://jdaviz.readthedocs.io/en/latest/api/jdaviz.configs.default.plugins.plot_options.plot_options.PlotOptions.html.\n",
+    "\n",
+    "The example below sets the same colormap for all images."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "436974df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_options = imviz.plugins['Plot Options']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b1d2bdf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dir(plot_options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dabf30e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_options.select_all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a57719f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_options.image_colormap = 'Viridis'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1cce96a",
+   "metadata": {},
+   "source": [
+    "Close the FITS file pointer when you are done with this notebook."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "cf112d5f-e10a-420e-9144-d8883d8dc2cf",
@@ -130,7 +188,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to add to concept notebook how to change colormap for all images in Imviz all at once. Since Astrowidgets API is specific to the image being displayed only, this uses the new Plot Options API that Kyle implemented in #1637 .

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set?
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
