### PR TITLE
BUG: Line list to not crash when no data is loaded

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,6 +114,8 @@ Mosviz
 Specviz
 ^^^^^^^
 
+- Fixed viewer crashing when a line list is loaded before the data. [#1690]
+
 Specviz2d
 ^^^^^^^^^
 

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -542,6 +542,11 @@ class LineListTool(PluginTemplateMixin):
         # Adds line style parameters that can be changed on the front end
         temp_table["colors"] = "#FF0000FF"
 
+        if len(self.app.data_collection) == 0:
+            viewer_has_data = False
+        else:
+            viewer_has_data = True
+
         # Load the table into the main astropy table and get it back, to make
         # sure all values match between the main table and local plugin
         temp_table = self._viewer.load_line_list(temp_table, return_table=True,
@@ -575,14 +580,15 @@ class LineListTool(PluginTemplateMixin):
         self.loaded_lists = []
         self.loaded_lists = loaded_lists
 
-        self._viewer.plot_spectral_lines()
-        self.update_line_mark_dict()
+        if viewer_has_data:
+            self._viewer.plot_spectral_lines()
+            self.update_line_mark_dict()
 
-        msg_text = ("Spectral lines loaded from preset. Lines can be shown/hidden"
-                    f" in the {self.list_to_load} dropdown in the Line Lists plugin")
-        lines_loaded_message = SnackbarMessage(msg_text, sender=self,
-                                               color="success", timeout=15000)
-        self.hub.broadcast(lines_loaded_message)
+            msg_text = ("Spectral lines loaded from preset. Lines can be shown/hidden"
+                        f" in the {self.list_to_load} dropdown in the Line Lists plugin")
+            lines_loaded_message = SnackbarMessage(msg_text, sender=self,
+                                                   color="success", timeout=15000)
+            self.hub.broadcast(lines_loaded_message)
 
     def vue_add_custom_line(self, event):
         """

--- a/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
@@ -1,12 +1,20 @@
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
-import astropy.units as u
+from astropy import units as u
 from astropy.table import QTable
 from specutils import Spectrum1D
 
 from jdaviz.core.linelists import get_available_linelists
+
+
+def test_line_lists_no_data(specviz_helper):
+    """Loading line lists without data should succeed."""
+    plg = specviz_helper.plugins['Line Lists']
+    plg._obj.list_to_load = 'Galactic 700A-2000A'
+    plg._obj.vue_load_list({})
+    assert plg._obj.loaded_lists == ['Custom', 'Galactic 700A-2000A']
 
 
 def test_line_lists(specviz_helper):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to fix #1669.

I did not test various possible line list workflows but I did confirm the added test was failing before and not fail anymore with this patch.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
