### PR TITLE
Filter HDUs before loading to SpectrumList

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,6 +114,9 @@ Mosviz
 
 - R-grism 2D spectrum data are now loaded with the correct orientation. [#1619]
 
+- Fixed a bug to skip targets not included in NIRISS source catalog, improving
+  lod times [#1696]
+
 Specviz
 ^^^^^^^
 

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -756,10 +756,10 @@ def mos_niriss_parser(app, data_dir):
 
             with fits.open(fname, memmap=False) as temp:
                 # Filter out HDUs we care about
-                source_ids = cat_id_dict.keys()
+                source_ids_to_filter = cat_id_dict.keys()
                 filtered_hdul = fits.HDUList([hdu for hdu in temp if (
                     (hdu.name in ('PRIMARY', 'ASDF')) or
-                    (hdu.header.get('SOURCEID', None) in source_ids))])
+                    (hdu.header.get('SOURCEID', None) in source_ids_to_filter))])
 
                 # SRCTYPE is required for the specutils JWST x1d reader. The reader will
                 # force this to POINT if not set. Under known cases, this field will be set

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -756,6 +756,12 @@ def mos_niriss_parser(app, data_dir):
 
             with fits.open(fname, memmap=False) as temp:
                 filtered_hdul = fits.HDUList()
+
+                # Manually copy over known extensions if they exist
+                for metahdu in ('PRIMARY', 'ASDF'):
+                    if metahdu in temp:
+                        filtered_hdul.append(temp[metahdu])
+
                 for hdu in temp:
                     # Only load the SOURCEIDs the user specified in the target catalog
                     if hdu.header.get('SOURCEID', None) in cat_id_dict.keys():

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -760,7 +760,7 @@ def mos_niriss_parser(app, data_dir):
                 # Manually copy over known extensions if they exist
                 for metahdu in ('PRIMARY', 'ASDF'):
                     if metahdu in temp:
-                        filtered_hdul.append(temp[metahdu])
+                        filtered_hdul.append(temp.pop(metahdu))
 
                 for hdu in temp:
                     # Only load the SOURCEIDs the user specified in the target catalog

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -755,29 +755,24 @@ def mos_niriss_parser(app, data_dir):
             print(f"Loading: {flabel} sources")
 
             with fits.open(fname, memmap=False) as temp:
-                filtered_hdul = fits.HDUList()
+                # Filter out HDUs we care about
+                filtered_hdul = fits.HDUList([hdu for hdu in temp if (
+                    (hdu.name in ('PRIMARY', 'ASDF')) or
+                    (hdu.header.get('SOURCEID', None) in cat_id_dict.keys()))])
 
-                # Manually copy over known extensions if they exist
-                for metahdu in ('PRIMARY', 'ASDF'):
-                    if metahdu in temp:
-                        filtered_hdul.append(temp.pop(metahdu))
-
-                for hdu in temp:
-                    # Only load the SOURCEIDs the user specified in the target catalog
-                    if hdu.header.get('SOURCEID', None) in cat_id_dict.keys():
-
-                        # Specutils parser requires SRCTYPE to be either POINT or EXTENDED
-                        # treat all HDUs missing SRCTYPE attribute as extended sources
-                        # TODO: Remove this once valid SRCTYPE values are present in all headers
-                        if hdu.header.get('SRCTYPE', None) not in ("POINT", "EXTENDED"):
-                            hdu.header["SRCTYPE"] = "EXTENDED"
-
-                        filtered_hdul.append(hdu)
-
-                # read all HDUs with SpectrumList, then only keep those that
-                # correspond with sources in catalog
-                # (read() is slow... would also LOVE to do this in one step!)
-                specs = SpectrumList.read(filtered_hdul, format="JWST x1d multi")
+                # SRCTYPE is required for the specutils JWST x1d reader. The reader will
+                # force this to POINT if not set. Under known cases, this field will be set
+                # for NIRISS programs; if it's not, something's gone wrong. Catch this
+                # warning and reraise as an error to warn users.
+                try:
+                    with warnings.catch_warnings():
+                        warnings.filterwarnings("error",
+                                                category=UserWarning,
+                                                message=".*SRCTYPE is missing or UNKNOWN*")
+                        specs = SpectrumList.read(filtered_hdul, format="JWST x1d multi")
+                except UserWarning as e:
+                    raise KeyError(f"The SRCTYPE keyword in the header of file {fname}"
+                                   "is not populated (expected values: EXTENDED or POINT)") from e
 
                 filter_name = fits.getheader(fname, ext=0).get('PUPIL')
 

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -756,9 +756,10 @@ def mos_niriss_parser(app, data_dir):
 
             with fits.open(fname, memmap=False) as temp:
                 # Filter out HDUs we care about
+                source_ids = cat_id_dict.keys()
                 filtered_hdul = fits.HDUList([hdu for hdu in temp if (
                     (hdu.name in ('PRIMARY', 'ASDF')) or
-                    (hdu.header.get('SOURCEID', None) in cat_id_dict.keys()))])
+                    (hdu.header.get('SOURCEID', None) in source_ids))])
 
                 # SRCTYPE is required for the specutils JWST x1d reader. The reader will
                 # force this to POINT if not set. Under known cases, this field will be set

--- a/jdaviz/configs/mosviz/tests/test_data_loading.py
+++ b/jdaviz/configs/mosviz/tests/test_data_loading.py
@@ -193,26 +193,6 @@ def test_nirspec_loader(mosviz_helper, tmpdir):
     assert dc_15.meta['SOURCEID'] == 2315
 
 
-# This is another version of test_niriss_parser in test_parsers.py
-@pytest.mark.remote_data
-def test_niriss_loader(mosviz_helper, tmpdir):
-
-    test_data = 'https://stsci.box.com/shared/static/l2azhcqd3tvzhybdlpx2j2qlutkaro3z.zip'
-    fn = download_file(test_data, cache=True, timeout=30)
-    with ZipFile(fn, 'r') as sample_data_zip:
-        sample_data_zip.extractall(tmpdir)
-
-    level3_path = (pathlib.Path(tmpdir) / 'NIRISS_for_parser_p0171')
-
-    data_dir = level3_path
-
-    mosviz_helper.load_data(directory=data_dir, instrument='niriss')
-
-    assert len(mosviz_helper.app.data_collection) == 80
-    assert mosviz_helper.app.data_collection[0].label == "Image canucs F150W"
-    assert mosviz_helper.app.data_collection[-1].label == "MOS Table"
-
-
 @pytest.mark.remote_data
 def test_nirspec_fallback(mosviz_helper, tmpdir):
     '''

--- a/jdaviz/configs/mosviz/tests/test_parsers.py
+++ b/jdaviz/configs/mosviz/tests/test_parsers.py
@@ -71,9 +71,9 @@ def test_niriss_parser(mosviz_helper, tmpdir):
 def test_missing_srctype(mosviz_helper, tmpdir):
     '''
     Tests that data missing the SRCTYPE keyword raises a warning to the user.
-    
+
     SRCTYPE is required for Mosviz. We do not want to rely on the JWST x1d parser's
-    default behavior of overwriting with "POINT" if it doesn't exist, as all NIRISS data 
+    default behavior of overwriting with "POINT" if it doesn't exist, as all NIRISS data
     should have this populated; missing SRCTYPE indicates something went wrong.
 
     This dataset was our original simulated NIRISS dataset that is missing SRCTYPE.
@@ -93,4 +93,4 @@ def test_missing_srctype(mosviz_helper, tmpdir):
 
     with pytest.raises(KeyError, match=r".*The SRCTYPE keyword.*is not populated.*"):
         mosviz_helper.load_data(directory=(data_dir / 'NIRISS_for_parser_p0171'),
-                                           instrument="niriss")
+                                instrument="niriss")

--- a/jdaviz/configs/mosviz/tests/test_parsers.py
+++ b/jdaviz/configs/mosviz/tests/test_parsers.py
@@ -1,5 +1,6 @@
 from zipfile import ZipFile
-import pathlib
+from tempfile import TemporaryDirectory
+from pathlib import Path
 
 import pytest
 from astropy.utils.data import download_file
@@ -9,40 +10,58 @@ from jdaviz.utils import PRIHDR_KEY, COMMENTCARD_KEY
 
 # This is another version of test_niriss_loader in test_data_loading.py
 @pytest.mark.remote_data
+@pytest.mark.filterwarnings('ignore', match="'(MJy/sr)^2' did not parse as fits unit")
 def test_niriss_parser(mosviz_helper, tmpdir):
+    '''
+    Tests loading a NIRISS dataset
+    This data set is a shortened version of the ERS program GLASS (Program 1324)
+    provided by Camilla Pacifici. This is in-flight, "real" JWST data
 
-    test_data = 'https://stsci.box.com/shared/static/l2azhcqd3tvzhybdlpx2j2qlutkaro3z.zip'
+    The spectra are jw01324001001_15101_00001_nis
+    The direct image is jw01324-o001_t001_niriss_clear-f200w
+    Please see JWST naming conventions for the above
+
+    The dataset was uploaded to box by Duy Nguyen
+    '''
+
+    # Download data
+    test_data = 'https://stsci.box.com/shared/static/cr14xijcg572dglacochctr1kblsr89a.zip'
     fn = download_file(test_data, cache=True, timeout=30)
+
+    # Extract to a known, temporary folder
+    data_dir = Path(TemporaryDirectory(dir=tmpdir).name)
     with ZipFile(fn, 'r') as sample_data_zip:
-        sample_data_zip.extractall(tmpdir)
+        sample_data_zip.extractall(data_dir)
 
-    level3_path = (pathlib.Path(tmpdir) / 'NIRISS_for_parser_p0171')
+    mosviz_helper.load_data(directory=data_dir, instrument="niriss")
+    assert len(mosviz_helper.app.data_collection) == 10
 
-    data_dir = level3_path
-
-    mosviz_helper.load_niriss_data(data_dir)
-
-    assert len(mosviz_helper.app.data_collection) == 80
-
+    # The image should be the first in the data collection
     dc_0 = mosviz_helper.app.data_collection[0]
-    assert dc_0.label == "Image canucs F150W"
+    assert dc_0.label == "Image jw01324-o001 F200W"
     assert PRIHDR_KEY not in dc_0.meta
     assert COMMENTCARD_KEY not in dc_0.meta
     assert dc_0.meta['bunit_data'] == 'MJy/sr'  # ASDF metadata
 
-    dc_1 = mosviz_helper.app.data_collection[1]
-    assert dc_1.label == 'F150W Source 1 spec2d C'
-    assert PRIHDR_KEY in dc_1.meta
-    assert COMMENTCARD_KEY in dc_1.meta
-    assert dc_1.meta['SOURCEID'] == 1
-
-    dc_40 = mosviz_helper.app.data_collection[40]
-    assert dc_40.label == 'F150W Source 1 spec1d C'
-    assert PRIHDR_KEY not in dc_40.meta
-    assert COMMENTCARD_KEY in dc_40.meta
-    assert 'header' not in dc_40.meta
-    assert dc_40.meta['FILTER'] == 'GR150C'
-
+    # The MOS Table should be last in the data collection
     dc_tab = mosviz_helper.app.data_collection[-1]
     assert dc_tab.label == "MOS Table"
     assert len(dc_tab.meta) == 0
+
+    # Test all the spectra exist
+    for dispersion in ('R', 'C'):
+        for sourceid in (243, 249):
+            for spec_type in ('spec2d', 'spec1d'):
+                data_label = f"F200W Source {sourceid} {spec_type} {dispersion}"
+                data = mosviz_helper.app.data_collection[data_label]
+                assert data.meta['SOURCEID'] == sourceid
+
+                # Header should be imported from the spec2d files, not spec1d
+                if spec_type == 'spec2d':
+                    assert PRIHDR_KEY in data.meta
+                    assert COMMENTCARD_KEY in data.meta
+                else:
+                    assert PRIHDR_KEY not in data.meta
+                    assert COMMENTCARD_KEY in data.meta
+                    assert 'header' not in data.meta
+                    assert data.meta['FILTER'] == f'GR150{dispersion}'

--- a/jdaviz/configs/mosviz/tests/test_parsers.py
+++ b/jdaviz/configs/mosviz/tests/test_parsers.py
@@ -64,7 +64,6 @@ def test_niriss_parser(mosviz_helper, tmp_path):
 
 
 @pytest.mark.remote_data
-@pytest.mark.filterwarnings('ignore', match="Implicitly cleaning up <TemporaryDirectory")
 def test_missing_srctype(mosviz_helper, tmp_path):
     '''
     Tests that data missing the SRCTYPE keyword raises a warning to the user.

--- a/jdaviz/configs/mosviz/tests/test_parsers.py
+++ b/jdaviz/configs/mosviz/tests/test_parsers.py
@@ -1,6 +1,4 @@
 from zipfile import ZipFile
-from tempfile import TemporaryDirectory
-from pathlib import Path
 
 import pytest
 from astropy.utils.data import download_file
@@ -10,7 +8,7 @@ from jdaviz.utils import PRIHDR_KEY, COMMENTCARD_KEY
 
 @pytest.mark.remote_data
 @pytest.mark.filterwarnings('ignore', match="'(MJy/sr)^2' did not parse as fits unit")
-def test_niriss_parser(mosviz_helper, tmpdir):
+def test_niriss_parser(mosviz_helper, tmp_path):
     '''
     Tests loading a NIRISS dataset
     This data set is a shortened version of the ERS program GLASS (Program 1324)
@@ -28,11 +26,10 @@ def test_niriss_parser(mosviz_helper, tmpdir):
     fn = download_file(test_data, cache=True, timeout=30)
 
     # Extract to a known, temporary folder
-    data_dir = Path(TemporaryDirectory(dir=tmpdir).name)
     with ZipFile(fn, 'r') as sample_data_zip:
-        sample_data_zip.extractall(data_dir)
+        sample_data_zip.extractall(tmp_path)
 
-    mosviz_helper.load_data(directory=data_dir, instrument="niriss")
+    mosviz_helper.load_data(directory=tmp_path, instrument="niriss")
     assert len(mosviz_helper.app.data_collection) == 10
 
     # The image should be the first in the data collection
@@ -68,7 +65,7 @@ def test_niriss_parser(mosviz_helper, tmpdir):
 
 @pytest.mark.remote_data
 @pytest.mark.filterwarnings('ignore', match="Implicitly cleaning up <TemporaryDirectory")
-def test_missing_srctype(mosviz_helper, tmpdir):
+def test_missing_srctype(mosviz_helper, tmp_path):
     '''
     Tests that data missing the SRCTYPE keyword raises a warning to the user.
 
@@ -87,10 +84,9 @@ def test_missing_srctype(mosviz_helper, tmpdir):
     fn = download_file(test_data, cache=True, timeout=30)
 
     # Extract to a known, temporary folder
-    data_dir = Path(TemporaryDirectory(dir=tmpdir).name)
     with ZipFile(fn, 'r') as sample_data_zip:
-        sample_data_zip.extractall(data_dir)
+        sample_data_zip.extractall(tmp_path)
 
     with pytest.raises(KeyError, match=r".*The SRCTYPE keyword.*is not populated.*"):
-        mosviz_helper.load_data(directory=(data_dir / 'NIRISS_for_parser_p0171'),
+        mosviz_helper.load_data(directory=(tmp_path / 'NIRISS_for_parser_p0171'),
                                 instrument="niriss")


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This PR improves the loadtime performance of the Mosviz NIRISS parser. It addresses a specific inefficiency brought up by @ojustino from the viz stress test hack hour regarding redundant loading. Currently, the parser loads all hdus into Spectrum1Ds via SpectrumList.read(), regardless of whether the user specified those hdus in the provided catalog. This PR modifies the logic to, instead, filter out the relevant SOURCEIDs (and metadata hdus) before passing them to specutils, rather than after. In testing, this leads to a speed up of roughly 20% in parsing time:

<details>
<summary>Before: 102033062 function calls (100890412 primitive calls) in 49.951 seconds</summary>

```
   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      492    8.429    0.017   24.057    0.049 link_manager.py:54(discover_links)
    51052    8.066    0.000   10.686    0.000 link_manager.py:50(<listcomp>)
 28467365    3.619    0.000    3.619    0.000 component_link.py:208(get_from_ids)
  5960297    1.305    0.000    1.305    0.000 link_manager.py:82(<listcomp>)
     2600    1.240    0.000    6.484    0.002 misc.py:424(did_you_mean)
  1469000    1.142    0.000    1.950    0.000 difflib.py:651(real_quick_ratio)
11567329/11410347    1.122    0.000    2.500    0.000 {built-in method builtins.len}
  5963687    0.987    0.000    0.989    0.000 {built-in method builtins.max}
  5960297    0.967    0.000    0.967    0.000 component_link.py:235(get_to_id)
   308800    0.839    0.000    1.225    0.000 difflib.py:622(quick_ratio)
     2600    0.806    0.000    4.469    0.002 difflib.py:666(get_close_matches)
   212004    0.647    0.000    2.444    0.000 configuration.py:406(__call__)
436504/109126    0.552    0.000    0.730    0.000 app.py:1105(find_viewer_item)
  3754403    0.517    0.000    0.598    0.000 {built-in method builtins.isinstance}
   412181    0.504    0.000    0.504    0.000 {method 'match' of 're.Pattern' objects}
   262582    0.496    0.000    0.847    0.000 configuration.py:510(get_config)
  3766242    0.484    0.000    0.485    0.000 {method 'get' of 'dict' objects}
  1471600    0.436    0.000    0.436    0.000 difflib.py:196(set_seq1)
  1777800    0.336    0.000    0.336    0.000 difflib.py:39(_calculate_ratio)
  2004015    0.323    0.000    0.323    0.000 {method 'setdefault' of 'dict' objects}
  2887274    0.321    0.000    0.321    0.000 {method 'append' of 'list' objects}
    14604    0.268    0.000    0.273    0.000 header.py:1839(_updateindices)
```
</details>

<details>
<summary>After: 80686669 function calls (79799537 primitive calls) in 40.327 seconds</summary>

```
   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      492    9.919    0.020   26.508    0.054 link_manager.py:54(discover_links)
    51052    8.431    0.000   11.246    0.000 link_manager.py:50(<listcomp>)
 29403860    3.767    0.000    3.767    0.000 component_link.py:208(get_from_ids)
  6896792    1.539    0.000    1.539    0.000 link_manager.py:82(<listcomp>)
  6900176    1.187    0.000    1.190    0.000 {built-in method builtins.max}
8964337/8825777    0.903    0.000    2.434    0.000 {built-in method builtins.len}
  6896792    0.876    0.000    0.876    0.000 component_link.py:235(get_to_id)
436504/109126    0.579    0.000    0.763    0.000 app.py:1105(find_viewer_item)
   121658    0.345    0.000    0.514    0.000 configuration.py:510(get_config)
  2391432    0.334    0.000    0.386    0.000 {built-in method builtins.isinstance}
    99676    0.307    0.000    1.283    0.000 configuration.py:406(__call__)
  2186484    0.282    0.000    0.283    0.000 {method 'get' of 'dict' objects}
      520    0.246    0.000    1.281    0.002 misc.py:424(did_you_mean)
   157935    0.241    0.000    0.241    0.000 {method 'match' of 're.Pattern' objects}
   110433    0.237    0.000    0.443    0.000 containers.py:174(_default_getter)
   293800    0.225    0.000    0.386    0.000 difflib.py:651(real_quick_ratio)
     1628    0.177    0.000    0.598    0.000 header.py:340(fromstring)
    61760    0.169    0.000    0.245    0.000 difflib.py:622(quick_ratio)
      520    0.162    0.000    0.884    0.002 difflib.py:666(get_close_matches)
```
</details>

One thing to note: unsurprisingly, the largest time-eater according to the profiling tests above is data linking. I provide the top of the profiling stack above for future reference

As an additional stretch goal, I also cleaned up some of the NIRISS parsing logic and tests. Chiefly among them, I removed the patch we previously had to force `SRCTYPE` to `EXTENDED` after conversations with @camipacifici that concluded with us being able to depend on this keyword being set now from the pipeline.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
