### PR TITLE
plugin components support for == and != comparisons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New Features
 - User-friendly API access to plugins, with exposed functionality for:  line analysis, gaussian
   smooth, moment maps, compass, collapse, metadata, slice, plot options, model fitting, links
   control, export plot, and spectral extraction.
-  [#1401, #1642, #1643, #1636, #1641, #1634, #1635, #1637, #1658, #1640, #1657, #1639]
+  [#1401, #1642, #1643, #1636, #1641, #1634, #1635, #1637, #1658, #1640, #1657, #1639, #1701]
 
 - Line Lists show which medium the catalog wavelengths were measured in,
   in accordance to the metadata entry. Lists without medium information

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -153,7 +153,9 @@ def test_user_api(specviz_helper, spectrum1d):
 
     # even though the default label is set to C, adding Linear1D should default to its automatic
     # default label of 'L'
+    assert p.model_component == 'Const1D'  # tests SelectPluginComponent's __eq__
     assert p.model_component_label.value == 'C'
+    assert p.model_component_label == 'C'  # tests AutoTextField's __eq__
     p.create_model_component('Linear1D')
     assert p.model_components == ['L']
 

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -96,3 +96,7 @@ def test_user_api(cubeviz_helper, spectrum1d_cube):
     # try setting with both label and value
     po.stretch_preset = 90
     po.stretch_preset = 'Min/Max'
+
+    # try eq on both text and value
+    assert po.image_colormap == 'gray'
+    assert po.image_colormap == 'Gray'

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -19,6 +19,9 @@ class UserApiWrapper:
     def __repr__(self):
         return self._obj.__repr__()
 
+    def __eq__(self, other):
+        return self._obj.__eq__(other)
+
     def __getattr__(self, attr):
         if attr in ['_obj', '_expose', '_readonly', '__doc__'] or attr not in self._expose:
             return super().__getattribute__(attr)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements the ability for:
* `SelectPluginComponent` (and all inheriting classes) and `AutoTextField` supports == and !=
* `PlotOptionsSyncState` support == and != and compares against both the user-friendly (text shown in dropdown in UI) and glue values.  For example, `image_colormap` would support checking against both 'Yellow-Green-Blue' and 'YlGnBu' (does not currently implement other operators (for float glue state objects to have >, <, >=, <=, etc) - these will still raise a TypeError)

The general motivation is to allow common logic on these objects without the user needing to know whether they need to compare against `plugin.component.selected` or `plugin.component.value` and also don't need to think about the difference between user-facing text in a dropdown and the corresponding internal value.

example:
```
plugin = cubeviz.plugins['Plot Options']
if plugin.image_colormap == 'gray':
    plugin.image_colormap = 'viridis
```

or 

```
plugin = specviz.plugins['Model Fitting']
if plugin.model_component == 'Polynomial1D':
    plugin.poly_order = 2
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
