### PR TITLE
Enable loading specific extension for 2D spectrum in Specviz2d

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,8 +29,12 @@ Specviz2d
 - Improved logic for initial guess for position of "Manual" background trace in spectral extraction
   plugin. [#1738]
 
+- Now supports loading a specific extension of the 2D spectrum file and 
+  transposing data on load. [#1705]
+
 - Spectral extraction plugin now supports visualizing and exporting the 1D spectrum associated
   with the background region. [#1682]
+
 
 API Changes
 -----------
@@ -188,7 +192,6 @@ Specviz2d
 
 - 2D spectrum viewer now has info panel for pixel coordinates and value. [#1608]
 
-Bug Fixes
 ---------
 
 - Fixed loading data via the Import Data button on top-left of the application.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,7 +35,6 @@ Specviz2d
 - Spectral extraction plugin now supports visualizing and exporting the 1D spectrum associated
   with the background region. [#1682]
 
-
 API Changes
 -----------
 
@@ -192,6 +191,7 @@ Specviz2d
 
 - 2D spectrum viewer now has info panel for pixel coordinates and value. [#1608]
 
+Bug Fixes
 ---------
 
 - Fixed loading data via the Import Data button on top-left of the application.

--- a/docs/specviz2d/import_data.rst
+++ b/docs/specviz2d/import_data.rst
@@ -61,4 +61,4 @@ to the ``extension`` keyword. In case you want to load an uncalibrated spectrum
 that is dispersed vertically, you can also set the ``transpose`` keyword to flip
 the spectrum to be horizontal::
 
-    specviz2d.load_data(fn, extension=7, transpose=True)
+    specviz2d.load_data(fn, ext=7, transpose=True)

--- a/docs/specviz2d/import_data.rst
+++ b/docs/specviz2d/import_data.rst
@@ -57,7 +57,7 @@ method, which takes as input a :class:`~specutils.Spectrum1D` object or filename
 
 By default, extension 1 of the 2D
 file is loaded, but you can specify another extension by providing an integer
-to the ``extension`` keyword. In case you want to load an uncalibrated spectrum
+to the ``ext`` keyword. In case you want to load an uncalibrated spectrum
 that is dispersed vertically, you can also set the ``transpose`` keyword to flip
 the spectrum to be horizontal::
 

--- a/docs/specviz2d/import_data.rst
+++ b/docs/specviz2d/import_data.rst
@@ -53,4 +53,12 @@ notebook can access the Specviz2D helper class API. Using this API, users can
 load data into the application through code with the
 :meth:`~jdaviz.configs.specviz2d.helper.Specviz2d.load_data`
 method, which takes as input a :class:`~specutils.Spectrum1D` object or filename for the
-2D spectrum and (optionally) the 1D spectrum.
+2D spectrum and (optionally) the 1D spectrum. 
+
+By default, extension 1 of the 2D
+file is loaded, but you can specify another extension by providing an integer
+to the ``extension`` keyword. In case you want to load an uncalibrated spectrum
+that is dispersed vertically, you can also set the ``transpose`` keyword to flip
+the spectrum to be horizontal::
+
+    specviz2d.load_data(fn, extension=7, transpose=True)

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -269,7 +269,7 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
     )
 
     # Note: This is also used by Specviz2D
-    def _parse_as_spectrum1d(hdulist, ext):
+    def _parse_as_spectrum1d(hdulist, ext, transpose):
         # Parse as a FITS file and assume the WCS is correct
         data = hdulist[ext].data
         header = hdulist[ext].header
@@ -316,10 +316,14 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
             # FITS file.
             if _check_is_file(data):
                 try:
-                    data = Spectrum1D.read(data)
+                    if ext != 1 or transpose:
+                        with fits.open(data) as hdulist:
+                            data = _parse_as_spectrum1d(hdulist, ext, transpose)
+                    else:
+                        data = Spectrum1D.read(data)
                 except IORegistryError:
                     with fits.open(data) as hdulist:
-                        data = _parse_as_spectrum1d(hdulist, ext)
+                        data = _parse_as_spectrum1d(hdulist, ext, transpose)
             elif isinstance(data, fits.HDUList):
                 data = _parse_as_spectrum1d(data, ext)
 

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -238,14 +238,14 @@ def mos_spec1d_parser(app, data_obj, data_labels=None,
 
 @data_parser_registry("mosviz-spec2d-parser")
 def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
-                      show_in_viewer=False, extension=1, transpose=False):
+                      show_in_viewer=False, ext=1, transpose=False):
     """
     Attempts to parse a 2D spectrum object.
 
     Notes
     -----
-    This assumes that the data is in the second hdu of the fits file unless
-    otherwise specified with the ``extension`` parameter.
+    This assumes that the data is in the second HDU of the FITS file unless
+    otherwise specified with the ``ext`` parameter.
 
     Parameters
     ----------
@@ -256,9 +256,9 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
         the mosviz table.
     data_labels : str, optional
         The label applied to the glue data component.
-    extension: int, optional
-        The extension in the fits file that contains the data to be loaded.
-    transpose: bool, optional
+    ext : int, optional
+        The extension in the FITS file that contains the data to be loaded.
+    transpose : bool, optional
         Flag to transpose the data array before loading.
     """
     spectrum_2d_viewer_reference_name = (
@@ -269,12 +269,12 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
     )
 
     # Note: This is also used by Specviz2D
-    def _parse_as_spectrum1d(hdulist, extension):
+    def _parse_as_spectrum1d(hdulist, ext):
         # Parse as a FITS file and assume the WCS is correct
-        data = hdulist[extension].data
+        data = hdulist[ext].data
         if transpose:
             data = data.T
-        header = hdulist[extension].header
+        header = hdulist[ext].header
         metadata = standardize_metadata(header)
         metadata[PRIHDR_KEY] = standardize_metadata(hdulist[0].header)
         wcs = WCS(header)

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -318,9 +318,9 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
                     data = Spectrum1D.read(data)
                 except IORegistryError:
                     with fits.open(data) as hdulist:
-                        data = _parse_as_spectrum1d(hdulist, extension)
+                        data = _parse_as_spectrum1d(hdulist, ext)
             elif isinstance(data, fits.HDUList):
-                data = _parse_as_spectrum1d(data, extension)
+                data = _parse_as_spectrum1d(data, ext)
 
             # Make metadata layout conform with other viz.
             data.meta = standardize_metadata(data.meta)

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -294,7 +294,8 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
         return Spectrum1D(flux=data * data_unit, meta=metadata, **kw)
 
     # Coerce into list-like object
-    if not isinstance(data_obj, (list, tuple, SpectrumCollection)):
+    if (not isinstance(data_obj, (list, tuple, SpectrumCollection)) or
+            isinstance(data_obj, fits.HDUList)):
         data_obj = [data_obj]
 
     # If we're given a string, repeat it for each object
@@ -325,7 +326,7 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
                     with fits.open(data) as hdulist:
                         data = _parse_as_spectrum1d(hdulist, ext, transpose)
             elif isinstance(data, fits.HDUList):
-                data = _parse_as_spectrum1d(data, ext)
+                data = _parse_as_spectrum1d(data, ext, transpose)
 
             # Make metadata layout conform with other viz.
             data.meta = standardize_metadata(data.meta)

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -277,7 +277,7 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
         header = hdulist[ext].header
         metadata = standardize_metadata(header)
         metadata[PRIHDR_KEY] = standardize_metadata(hdulist[0].header)
-        wcs = WCS(header)
+        wcs = WCS(header, hdulist)
 
         try:
             data_unit = u.Unit(header['BUNIT'])

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -244,7 +244,7 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
 
     Notes
     -----
-    This assumes that the data is in the second HDU of the FITS file unless
+    Default arguments assume that the data is in the second HDU of the FITS file unless
     otherwise specified with the ``ext`` parameter.
 
     Parameters

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -272,12 +272,13 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
     def _parse_as_spectrum1d(hdulist, ext):
         # Parse as a FITS file and assume the WCS is correct
         data = hdulist[ext].data
-        if transpose:
-            data = data.T
         header = hdulist[ext].header
         metadata = standardize_metadata(header)
         metadata[PRIHDR_KEY] = standardize_metadata(hdulist[0].header)
         wcs = WCS(header, hdulist)
+        if transpose:
+            data = data.T
+            wcs = wcs.swapaxes(0, 1)
 
         try:
             data_unit = u.Unit(header['BUNIT'])

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -238,7 +238,7 @@ def mos_spec1d_parser(app, data_obj, data_labels=None,
 
 @data_parser_registry("mosviz-spec2d-parser")
 def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
-                      show_in_viewer=False, extension=None):
+                      show_in_viewer=False, extension=1, transpose=False):
     """
     Attempts to parse a 2D spectrum object.
 
@@ -257,7 +257,9 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
     data_labels : str, optional
         The label applied to the glue data component.
     extension: int, optional
-        The extension in the fits file that contains the data to be loaded. 
+        The extension in the fits file that contains the data to be loaded.
+    transpose: bool, optional
+        Flag to transpose the data array before loading.
     """
     spectrum_2d_viewer_reference_name = (
         app._jdaviz_helper._default_spectrum_2d_viewer_reference_name
@@ -269,9 +271,9 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
     # Note: This is also used by Specviz2D
     def _parse_as_spectrum1d(hdulist, extension):
         # Parse as a FITS file and assume the WCS is correct
-        if extension is None:
-            extension = 1
         data = hdulist[extension].data
+        if transpose:
+            data = data.T
         header = hdulist[extension].header
         metadata = standardize_metadata(header)
         metadata[PRIHDR_KEY] = standardize_metadata(hdulist[0].header)

--- a/jdaviz/configs/specviz2d/helper.py
+++ b/jdaviz/configs/specviz2d/helper.py
@@ -144,7 +144,7 @@ class Specviz2d(ConfigHelper, LineListMixin):
             Show data in viewer(s).
 
         ext : int, optional
-            Extension of the input spectrum_2d file to load. Defaults to 1.
+            Extension of the input ``spectrum_2d`` file to load. Defaults to 1.
 
         transpose : bool, optional
             Flag to transpose the 2D data array before loading.

--- a/jdaviz/configs/specviz2d/helper.py
+++ b/jdaviz/configs/specviz2d/helper.py
@@ -115,7 +115,7 @@ class Specviz2d(ConfigHelper, LineListMixin):
                 setattr(scales['x'], name, val)
 
     def load_data(self, spectrum_2d=None, spectrum_1d=None, spectrum_1d_label=None,
-                  spectrum_2d_label=None, show_in_viewer=True, extension=1,
+                  spectrum_2d_label=None, show_in_viewer=True, ext=1,
                   transpose=False):
         """
         Load and parse a pair of corresponding 1D and 2D spectra.
@@ -143,10 +143,10 @@ class Specviz2d(ConfigHelper, LineListMixin):
         show_in_viewer : bool
             Show data in viewer(s).
 
-        extension: int, optional
+        ext : int, optional
             Extension of the input spectrum_2d file to load. Defaults to 1.
 
-        transpose: bool, optional
+        transpose : bool, optional
             Flag to transpose the 2D data array before loading.
         """
         if spectrum_2d is None and spectrum_1d is None:
@@ -166,7 +166,7 @@ class Specviz2d(ConfigHelper, LineListMixin):
             self.app.load_data(spectrum_2d, parser_reference="mosviz-spec2d-parser",
                                data_labels=spectrum_2d_label,
                                show_in_viewer=False, add_to_table=False,
-                               extension=extension, transpose=transpose)
+                               ext=ext, transpose=transpose)
 
             # Passing show_in_viewer into app.load_data does not work anymore,
             # so we force it to show here.

--- a/jdaviz/configs/specviz2d/helper.py
+++ b/jdaviz/configs/specviz2d/helper.py
@@ -115,7 +115,7 @@ class Specviz2d(ConfigHelper, LineListMixin):
                 setattr(scales['x'], name, val)
 
     def load_data(self, spectrum_2d=None, spectrum_1d=None, spectrum_1d_label=None,
-                  spectrum_2d_label=None, show_in_viewer=True):
+                  spectrum_2d_label=None, show_in_viewer=True, extension=None):
         """
         Load and parse a pair of corresponding 1D and 2D spectra.
 

--- a/jdaviz/configs/specviz2d/helper.py
+++ b/jdaviz/configs/specviz2d/helper.py
@@ -147,7 +147,8 @@ class Specviz2d(ConfigHelper, LineListMixin):
             Extension of the input ``spectrum_2d`` file to load. Defaults to 1.
 
         transpose : bool, optional
-            Flag to transpose the 2D data array before loading.
+            Flag to transpose the 2D data array before loading. Useful for uncalibrated
+            data that is dispersed vertically, to change it to horizontal dispersion.
         """
         if spectrum_2d is None and spectrum_1d is None:
             raise ValueError('Must provide spectrum_2d or spectrum_1d but none given.')

--- a/jdaviz/configs/specviz2d/helper.py
+++ b/jdaviz/configs/specviz2d/helper.py
@@ -115,7 +115,8 @@ class Specviz2d(ConfigHelper, LineListMixin):
                 setattr(scales['x'], name, val)
 
     def load_data(self, spectrum_2d=None, spectrum_1d=None, spectrum_1d_label=None,
-                  spectrum_2d_label=None, show_in_viewer=True, extension=None):
+                  spectrum_2d_label=None, show_in_viewer=True, extension=1,
+                  transpose=False):
         """
         Load and parse a pair of corresponding 1D and 2D spectra.
 
@@ -142,6 +143,11 @@ class Specviz2d(ConfigHelper, LineListMixin):
         show_in_viewer : bool
             Show data in viewer(s).
 
+        extension: int, optional
+            Extension of the input spectrum_2d file to load. Defaults to 1.
+
+        transpose: bool, optional
+            Flag to transpose the 2D data array before loading.
         """
         if spectrum_2d is None and spectrum_1d is None:
             raise ValueError('Must provide spectrum_2d or spectrum_1d but none given.')
@@ -159,8 +165,8 @@ class Specviz2d(ConfigHelper, LineListMixin):
         if spectrum_2d is not None:
             self.app.load_data(spectrum_2d, parser_reference="mosviz-spec2d-parser",
                                data_labels=spectrum_2d_label,
-                               show_in_viewer=False,
-                               add_to_table=False)
+                               show_in_viewer=False, add_to_table=False,
+                               extension=extension, transpose=transpose)
 
             # Passing show_in_viewer into app.load_data does not work anymore,
             # so we force it to show here.

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -39,7 +39,7 @@ def test_2d_parser_jwst(specviz2d_helper):
 
 @pytest.mark.remote_data
 def test_2d_parser_ext_transpose_file(specviz2d_helper):
-    fn = download_file('https://stsci.box.com/shared/static/e3n30l8vr7hkpnuy7g0t8c5nbl70632b.fits', cache=True) # noqa
+    fn = download_file('https://stsci.box.com/shared/static/e3n30l8vr7hkpnuy7g0t8c5nbl70632b.fits', cache=True)  # noqa
 
     specviz2d_helper.load_data(spectrum_2d=fn, ext=2, transpose=True)
 
@@ -49,7 +49,7 @@ def test_2d_parser_ext_transpose_file(specviz2d_helper):
 
 @pytest.mark.remote_data
 def test_2d_parser_ext_transpose_hdulist(specviz2d_helper):
-    fn = download_file('https://stsci.box.com/shared/static/e3n30l8vr7hkpnuy7g0t8c5nbl70632b.fits', cache=True) # noqa
+    fn = download_file('https://stsci.box.com/shared/static/e3n30l8vr7hkpnuy7g0t8c5nbl70632b.fits', cache=True)  # noqa
     with fits.open(fn) as hdulist:
         specviz2d_helper.load_data(spectrum_2d=hdulist, ext=2, transpose=True)
     dc_0 = specviz2d_helper.app.data_collection[0]

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -35,6 +35,14 @@ def test_2d_parser_jwst(specviz2d_helper):
     assert viewer_2d.label_mouseover.world_ra_deg == ''
     assert viewer_2d.label_mouseover.world_dec_deg == ''
 
+@pytest.mark.remote_data
+def test_2d_parser_jwst(specviz2d_helper):
+    fn = download_file('https://stsci.box.com/shared/static/exnkul627fcuhy5akf2gswytud5tazmw.fits', cache=True)  #    noqa
+
+    specviz2d_helper.load_data(spectrum_2d=fn, ext=2, transpose=True)
+
+    dc_0 = specviz2d_helper.app.data_collection[0]
+    assert dc_0.get_component('flux').shape == (387, 44)
 
 def test_2d_parser_no_unit(specviz2d_helper, mos_spectrum2d):
     specviz2d_helper.load_data(mos_spectrum2d, spectrum_2d_label='my_2d_spec')

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -1,5 +1,6 @@
 import pytest
 from asdf.asdf import AsdfWarning
+from astropy.io import fits
 from astropy.utils.data import download_file
 
 from jdaviz.utils import PRIHDR_KEY
@@ -37,11 +38,20 @@ def test_2d_parser_jwst(specviz2d_helper):
 
 
 @pytest.mark.remote_data
-def test_2d_parser_ext_transpose(specviz2d_helper):
+def test_2d_parser_ext_transpose_file(specviz2d_helper):
     fn = download_file('https://stsci.box.com/shared/static/e3n30l8vr7hkpnuy7g0t8c5nbl70632b.fits', cache=True) # noqa
 
     specviz2d_helper.load_data(spectrum_2d=fn, ext=2, transpose=True)
 
+    dc_0 = specviz2d_helper.app.data_collection[0]
+    assert dc_0.get_component('flux').shape == (3416, 29)
+
+
+@pytest.mark.remote_data
+def test_2d_parser_ext_transpose_hdulist(specviz2d_helper):
+    fn = download_file('https://stsci.box.com/shared/static/e3n30l8vr7hkpnuy7g0t8c5nbl70632b.fits', cache=True) # noqa
+    with fits.open(fn) as hdulist:
+        specviz2d_helper.load_data(spectrum_2d=hdulist, ext=2, transpose=True)
     dc_0 = specviz2d_helper.app.data_collection[0]
     assert dc_0.get_component('flux').shape == (3416, 29)
 

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -38,12 +38,12 @@ def test_2d_parser_jwst(specviz2d_helper):
 
 @pytest.mark.remote_data
 def test_2d_parser_ext_transpose(specviz2d_helper):
-    fn = download_file('https://stsci.box.com/shared/static/exnkul627fcuhy5akf2gswytud5tazmw.fits', cache=True) # noqa
+    fn = download_file('https://stsci.box.com/shared/static/e3n30l8vr7hkpnuy7g0t8c5nbl70632b.fits', cache=True) # noqa
 
     specviz2d_helper.load_data(spectrum_2d=fn, ext=2, transpose=True)
 
     dc_0 = specviz2d_helper.app.data_collection[0]
-    assert dc_0.get_component('flux').shape == (387, 44)
+    assert dc_0.get_component('flux').shape == (3416, 29)
 
 
 def test_2d_parser_no_unit(specviz2d_helper, mos_spectrum2d):

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -35,14 +35,16 @@ def test_2d_parser_jwst(specviz2d_helper):
     assert viewer_2d.label_mouseover.world_ra_deg == ''
     assert viewer_2d.label_mouseover.world_dec_deg == ''
 
+
 @pytest.mark.remote_data
-def test_2d_parser_jwst(specviz2d_helper):
-    fn = download_file('https://stsci.box.com/shared/static/exnkul627fcuhy5akf2gswytud5tazmw.fits', cache=True)  #    noqa
+def test_2d_parser_ext_transpose(specviz2d_helper):
+    fn = download_file('https://stsci.box.com/shared/static/exnkul627fcuhy5akf2gswytud5tazmw.fits', cache=True) # noqa
 
     specviz2d_helper.load_data(spectrum_2d=fn, ext=2, transpose=True)
 
     dc_0 = specviz2d_helper.app.data_collection[0]
     assert dc_0.get_component('flux').shape == (387, 44)
+
 
 def test_2d_parser_no_unit(specviz2d_helper, mos_spectrum2d):
     specviz2d_helper.load_data(mos_spectrum2d, spectrum_2d_label='my_2d_spec')


### PR DESCRIPTION
Rather than always loading extension 1, Specviz2d will now allow the user to specify an `extension` keyword in the `load_data` method, which will be applied to the input 2D spectrum file. The user can also set `transpose=True` to transpose the data in that extension in case it isn't in the correct orientation. See https://stsci.box.com/s/cocuykc0bqivkz5rtl7kexrrrk84y8hb for an example file to test this with.