### PR TITLE
Catalogs plugin: support loading catalog from ecsv

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Catalogs plugin now supports loading a JWST catalog from a local ecsv file. [#1707]
+
 Mosviz
 ^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Cubeviz
 Imviz
 ^^^^^
 
-- Catalogs plugin now supports loading a JWST catalog from a local ecsv file. [#1707]
+- Catalogs plugin now supports loading a JWST catalog from a local ECSV file. [#1707]
 
 Mosviz
 ^^^^^^

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -260,7 +260,6 @@ for line in open('nitpick-exceptions'):
     nitpick_ignore.append((dtype, target))
 
 # Extra intersphinx in addition to what is already in sphinx-astropy
-intersphinx_mapping['astropy'] = ('https://docs.astropy.org/en/stable/', None)
 intersphinx_mapping['glue'] = ('http://docs.glueviz.org/en/stable/', None)
 intersphinx_mapping['glue_jupyter'] = ('https://glue-jupyter.readthedocs.io/en/stable/', None)
 intersphinx_mapping['regions'] = ('https://astropy-regions.readthedocs.io/en/stable/', None)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -260,6 +260,7 @@ for line in open('nitpick-exceptions'):
     nitpick_ignore.append((dtype, target))
 
 # Extra intersphinx in addition to what is already in sphinx-astropy
+intersphinx_mapping['astropy'] = ('https://docs.astropy.org/en/stable/', None)
 intersphinx_mapping['glue'] = ('http://docs.glueviz.org/en/stable/', None)
 intersphinx_mapping['glue_jupyter'] = ('https://glue-jupyter.readthedocs.io/en/stable/', None)
 intersphinx_mapping['regions'] = ('https://astropy-regions.readthedocs.io/en/stable/', None)

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -223,9 +223,9 @@ catalog dropdown menu.
     This plugin is still under active development. As a result, the search only uses the SDSS DR17 catalog
     and works best when you only have a single image loaded in a viewer.
 
-To load a catalog from an ecsv file, choose "From File..." and choose a valid file.  The file must be able
-to be parsed by `astropy.table.Table.read` and contain a column labeled 'sky_centroid'.  Clicking
-:guilabel:`SEARCH` will show markers for any entry within the filtered zoom window.
+To load a catalog from a supported `JWST ecsv catalog file <https://jwst-pipeline.readthedocs.io/en/latest/jwst/source_catalog/main.html#output-products>`_, choose "From File...".  
+The file must be able to be parsed by `astropy.table.Table.read` and contain a column labeled 'sky_centroid'.
+Clicking :guilabel:`SEARCH` will show markers for any entry within the filtered zoom window.
 
 If you have multiple viewers open, you will see another dropdown menu to select the active
 viewer.

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -223,6 +223,10 @@ catalog dropdown menu.
     This plugin is still under active development. As a result, the search only uses the SDSS DR17 catalog
     and works best when you only have a single image loaded in a viewer.
 
+To load a catalog from an ecsv file, choose "From File..." and choose a valid file.  The file must be able
+to be parsed by `astropy.table.Table.read` and contain a column labeled 'sky_centroid'.  Clicking
+:guilabel:`SEARCH` will show markers for any entry within the filtered zoom window.
+
 If you have multiple viewers open, you will see another dropdown menu to select the active
 viewer.
 

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -223,7 +223,7 @@ catalog dropdown menu.
     This plugin is still under active development. As a result, the search only uses the SDSS DR17 catalog
     and works best when you only have a single image loaded in a viewer.
 
-To load a catalog from a supported `JWST ecsv catalog file <https://jwst-pipeline.readthedocs.io/en/latest/jwst/source_catalog/main.html#output-products>`_, choose "From File...".  
+To load a catalog from a supported `JWST ECSV catalog file <https://jwst-pipeline.readthedocs.io/en/latest/jwst/source_catalog/main.html#output-products>`_, choose "From File...".  
 The file must be able to be parsed by `astropy.table.Table.read` and contain a column labeled 'sky_centroid'.
 Clicking :guilabel:`SEARCH` will show markers for any entry within the filtered zoom window.
 

--- a/jdaviz/configs/default/plugins/data_tools/data_tools.py
+++ b/jdaviz/configs/default/plugins/data_tools/data_tools.py
@@ -29,10 +29,8 @@ class DataTools(TemplateMixin):
         if (self._file_upload.file_path is not None
                 and not os.path.exists(self._file_upload.file_path)
                 or not os.path.isfile(self._file_upload.file_path)):
-            self.error_message = "No file exists at given path"
             self.valid_path = False
         else:
-            self.error_message = ""
             self.valid_path = True
 
     def vue_load_data(self, *args, **kwargs):

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -65,7 +65,7 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin):
             self.from_file_message = 'Could not parse file with astropy.table.QTable.read'
             return
 
-        if 'sky_centroid' not in table.keys():
+        if 'sky_centroid' not in table.colnames:
             self.from_file_message = 'Table does not contain required sky_centroid column'
             return
 

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
@@ -50,13 +50,19 @@
                  <g-file-import id="file-uploader"></g-file-import>
                </v-col>
              </v-row>
+             <v-row v-if="from_file_message.length > 0" :style='"color: red"'>
+               {{from_file_message}}
+             </v-row>
+             <v-row v-else>
+               Valid catalog file
+             </v-row>
            </v-container>
          </v-card-text>
 
          <v-card-actions>
            <div class="flex-grow-1"></div>
            <v-btn color="primary" text @click="catalog_selected = catalog_items[0].label">Cancel</v-btn>
-           <v-btn color="primary" text @click="set_file_from_dialog" :disabled="!valid_path">Select</v-btn>
+           <v-btn color="primary" text @click="set_file_from_dialog" :disabled="from_file_message.length > 0">Select</v-btn>
          </v-card-actions>
 
        </v-card>

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
@@ -27,15 +27,40 @@
          close
          close-icon="mdi-close"
          label
-         @click:close="() => from_file = ''"
+         @click:close="() => {if (from_file.length) {from_file = ''} else {catalog_selected = catalog_items[0].label}}"
          style="margin-top: -50px; width: 100%"
        >
+        <!-- @click:close resets from_file and relies on the @observe in python to reset catalog 
+             to its default, but the traitlet change wouldn't be fired if from_file is already
+             empty (which should only happen if setting from the API but not setting from_file) -->
           <span style="overflow-x: hidden; whitespace: nowrap; text-overflow: ellipsis; width: 100%">
             {{from_file.split("/").slice(-1)[0]}}
           </span>
        </v-chip>
-
      </v-row>
+
+     <v-dialog :value="catalog_selected === 'From File...' && from_file.length === 0" height="400" width="600">
+       <v-card>
+         <v-card-title class="headline" color="primary" primary-title>Load Catalog</v-card-title>
+         <v-card-text>
+           Select a file containing a catalog.
+           <v-container>
+             <v-row>
+               <v-col>
+                 <g-file-import id="file-uploader"></g-file-import>
+               </v-col>
+             </v-row>
+           </v-container>
+         </v-card-text>
+
+         <v-card-actions>
+           <div class="flex-grow-1"></div>
+           <v-btn color="primary" text @click="catalog_selected = catalog_items[0].label">Cancel</v-btn>
+           <v-btn color="primary" text @click="set_file_from_dialog" :disabled="!valid_path">Select</v-btn>
+         </v-card-actions>
+
+       </v-card>
+    </v-dialog>
 
      <v-row class="row-no-outside-padding">
        <v-col>

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
@@ -62,7 +62,7 @@
          <v-card-actions>
            <div class="flex-grow-1"></div>
            <v-btn color="primary" text @click="catalog_selected = catalog_items[0].label">Cancel</v-btn>
-           <v-btn color="primary" text @click="set_file_from_dialog" :disabled="from_file_message.length > 0">Select</v-btn>
+           <v-btn color="primary" text @click="set_file_from_dialog" :disabled="from_file_message.length > 0">Load</v-btn>
          </v-card-actions>
 
        </v-card>

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
@@ -13,6 +13,7 @@
      />
 
      <v-row>
+
        <v-select
          :menu-props="{ left: true }"
          attach
@@ -22,6 +23,18 @@
          hint="Select a catalog to search with."
          persistent-hint
        ></v-select>
+       <v-chip v-if="catalog_selected === 'From File...'"
+         close
+         close-icon="mdi-close"
+         label
+         @click:close="() => from_file = ''"
+         style="margin-top: -50px; width: 100%"
+       >
+          <span style="overflow-x: hidden; whitespace: nowrap; text-overflow: ellipsis; width: 100%">
+            {{from_file.split("/").slice(-1)[0]}}
+          </span>
+       </v-chip>
+
      </v-row>
 
      <v-row class="row-no-outside-padding">
@@ -40,3 +53,9 @@
 
    </j-tray-plugin>
  </template>
+ 
+ <style scoped>
+ .v-chip__content {
+   width: 100%
+ }
+ </style>

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -118,30 +118,31 @@ class TestCatalogs:
         assert catalogs_plugin.results_available
         assert catalogs_plugin.number_of_results == 2473
 
-    def test_from_file_parsing(self, imviz_helper, tmp_path):
-        catalogs_plugin = imviz_helper.app.get_tray_item_from_name('imviz-catalogs')
 
-        # _on_file_path_changed is fired when changing the selection in the file dialog
-        catalogs_plugin._on_file_path_changed({'new': './invalid_path'})
-        assert catalogs_plugin.from_file_message == 'File path does not exist'
+def test_from_file_parsing(imviz_helper, tmp_path):
+    catalogs_plugin = imviz_helper.app.get_tray_item_from_name('imviz-catalogs')
 
-        # observe('from_file') is fired when setting from_file from the API (or after clicking
-        # select in the file dialog)
-        with pytest.raises(ValueError, match='./invalid_path does not exist'):
-            catalogs_plugin.from_file = './invalid_path'
+    # _on_file_path_changed is fired when changing the selection in the file dialog
+    catalogs_plugin._on_file_path_changed({'new': './invalid_path'})
+    assert catalogs_plugin.from_file_message == 'File path does not exist'
 
-        # setting to a blank string from the API resets the catalog selection to the
-        # default/first entry
-        catalogs_plugin.from_file = ''
-        assert catalogs_plugin.catalog.selected == catalogs_plugin.catalog.choices[0]
+    # observe('from_file') is fired when setting from_file from the API (or after clicking
+    # select in the file dialog)
+    with pytest.raises(ValueError, match='./invalid_path does not exist'):
+        catalogs_plugin.from_file = './invalid_path'
 
-        not_table_file = tmp_path / 'not_table.tst'
-        not_table_file.touch()
-        catalogs_plugin._on_file_path_changed({'new': not_table_file})
-        assert catalogs_plugin.from_file_message == 'Could not parse file with astropy.table.QTable.read'  # noqa
+    # setting to a blank string from the API resets the catalog selection to the
+    # default/first entry
+    catalogs_plugin.from_file = ''
+    assert catalogs_plugin.catalog.selected == catalogs_plugin.catalog.choices[0]
 
-        qtable = QTable({'not_sky_centroid': [1, 2, 3]})
-        not_valid_table = tmp_path / 'not_valid_table.ecsv'
-        qtable.write(not_valid_table, overwrite=True)
-        catalogs_plugin._on_file_path_changed({'new': not_valid_table})
-        assert catalogs_plugin.from_file_message == 'Table does not contain required sky_centroid column'  # noqa
+    not_table_file = tmp_path / 'not_table.tst'
+    not_table_file.touch()
+    catalogs_plugin._on_file_path_changed({'new': not_table_file})
+    assert catalogs_plugin.from_file_message == 'Could not parse file with astropy.table.QTable.read'  # noqa
+
+    qtable = QTable({'not_sky_centroid': [1, 2, 3]})
+    not_valid_table = tmp_path / 'not_valid_table.ecsv'
+    qtable.write(not_valid_table, overwrite=True)
+    catalogs_plugin._on_file_path_changed({'new': not_valid_table})
+    assert catalogs_plugin.from_file_message == 'Table does not contain required sky_centroid column'  # noqa

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -26,6 +26,8 @@ import pytest
 
 from astropy.io import fits
 from astropy.nddata import NDData
+from astropy.coordinates import SkyCoord
+from astropy.table import QTable
 
 
 @pytest.mark.remote_data
@@ -63,7 +65,7 @@ class TestCatalogs:
     # data used: information based on this image -
     # https://dr12.sdss.org/fields/runCamcolField?field=76&camcol=5&run=7674
     # the z-band FITS image was downloaded and used
-    def test_plugin_image_with_result(self, imviz_helper):
+    def test_plugin_image_with_result(self, imviz_helper, tmp_path):
         arr = np.ones((1489, 2048))
 
         # header is based on the data provided above
@@ -99,3 +101,47 @@ class TestCatalogs:
         catalogs_plugin.vue_do_clear()
 
         assert not catalogs_plugin.results_available
+
+        # test loading from file
+        table = imviz_helper.app._catalog_source_table
+        skycoord_table = SkyCoord(table['ra'],
+                                  table['dec'],
+                                  unit='deg')
+        qtable = QTable({'sky_centroid': skycoord_table})
+        tmp_file = tmp_path / 'test.ecsv'
+        qtable.write(tmp_file, overwrite=True)
+
+        catalogs_plugin.from_file = str(tmp_file)
+        # setting filename from API will automatically set catalog to 'From File...'
+        assert catalogs_plugin.catalog.selected == 'From File...'
+        catalogs_plugin.vue_do_search()
+        assert catalogs_plugin.results_available
+        assert catalogs_plugin.number_of_results == 2473
+
+    def test_from_file_parsing(self, imviz_helper, tmp_path):
+        catalogs_plugin = imviz_helper.app.get_tray_item_from_name('imviz-catalogs')
+
+        # _on_file_path_changed is fired when changing the selection in the file dialog
+        catalogs_plugin._on_file_path_changed({'new': './invalid_path'})
+        assert catalogs_plugin.from_file_message == 'File path does not exist'
+
+        # observe('from_file') is fired when setting from_file from the API (or after clicking
+        # select in the file dialog)
+        with pytest.raises(ValueError, match='./invalid_path does not exist'):
+            catalogs_plugin.from_file = './invalid_path'
+
+        # setting to a blank string from the API resets the catalog selection to the
+        # default/first entry
+        catalogs_plugin.from_file = ''
+        assert catalogs_plugin.catalog.selected == catalogs_plugin.catalog.choices[0]
+
+        not_table_file = tmp_path / 'not_table.tst'
+        not_table_file.touch()
+        catalogs_plugin._on_file_path_changed({'new': not_table_file})
+        assert catalogs_plugin.from_file_message == 'Could not parse file with astropy.table.QTable.read'  # noqa
+
+        qtable = QTable({'not_sky_centroid': [1, 2, 3]})
+        not_valid_table = tmp_path / 'not_valid_table.ecsv'
+        qtable.write(not_valid_table, overwrite=True)
+        catalogs_plugin._on_file_path_changed({'new': not_valid_table})
+        assert catalogs_plugin.from_file_message == 'Table does not contain required sky_centroid column'  # noqa


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request adds the capability to search and display markers from a catalog in an ecsv selected from the local machine.

[Updated plugin docs](https://jdaviz--1707.org.readthedocs.build/en/1707/imviz/plugins.html#catalog-search)


https://user-images.githubusercontent.com/877591/194627281-a9c7aef4-ce9b-4fe6-bc61-e810de5e1cd8.mov

TODO:
- [x] rebase on top of #1708 once merged
- [x] text in file dialog and docs stating file requirements (formats and expected column names)
- [x] checks in code and exposed error messages when file fails to load or meet these requirements
- [x] test coverage
- [ ] Bug @pllim to write an offline test for the table support.

Out-of-scope (deferred for later):
* spinner while searching: pressing search/clear can take a few seconds depending on the size of the catalog so should really have some UI feedback.  Since we're intending a redesign in the near future to support loading multiple catalogs and changing marker colors similar to line lists, I propose we defer this to be a part of that effort.
* styling of file dialog (this is the same dialog used for importing data... so we should consider restyling all instances at once)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
