### PR TITLE
BUG: Specviz2d to load both s2d and x1d when both provided separately

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,8 @@ Specviz
 Specviz2d
 ^^^^^^^^^
 
+- Fixed parser not loading x1d when s2d is provided. [#1717]
+
 Other Changes and Additions
 ---------------------------
 

--- a/jdaviz/configs/specviz2d/helper.py
+++ b/jdaviz/configs/specviz2d/helper.py
@@ -143,6 +143,9 @@ class Specviz2d(ConfigHelper, LineListMixin):
             Show data in viewer(s).
 
         """
+        if spectrum_2d is None and spectrum_1d is None:
+            raise ValueError('Must provide spectrum_2d or spectrum_1d but none given.')
+
         if spectrum_2d_label is None:
             spectrum_2d_label = "Spectrum 2D"
         elif spectrum_2d_label[-2:] != "2D":

--- a/jdaviz/configs/specviz2d/helper.py
+++ b/jdaviz/configs/specviz2d/helper.py
@@ -151,6 +151,8 @@ class Specviz2d(ConfigHelper, LineListMixin):
         if spectrum_1d_label is None:
             spectrum_1d_label = spectrum_2d_label.replace("2D", "1D")
 
+        load_1d = False
+
         if spectrum_2d is not None:
             self.app.load_data(spectrum_2d, parser_reference="mosviz-spec2d-parser",
                                data_labels=spectrum_2d_label,
@@ -195,7 +197,13 @@ class Specviz2d(ConfigHelper, LineListMixin):
                         color='warning', sender=self, timeout=10000)
                 self.app.hub.broadcast(msg)
 
+            else:
+                load_1d = True
+
         else:
+            load_1d = True
+
+        if load_1d:
             self.app.load_data(
                 spectrum_1d, data_label=spectrum_1d_label,
                 parser_reference="specviz-spectrum1d-parser",

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -63,3 +63,8 @@ def test_1d_parser(specviz2d_helper, spectrum1d):
     dc_0 = specviz2d_helper.app.data_collection[0]
     assert dc_0.label == 'Spectrum 1D'
     assert dc_0.meta['uncertainty_type'] == 'std'
+
+
+def test_2d_1d_parser(specviz2d_helper, mos_spectrum2d, spectrum1d):
+    specviz2d_helper.load_data(spectrum_2d=mos_spectrum2d, spectrum_1d=spectrum1d)
+    assert specviz2d_helper.app.data_collection.labels == ['Spectrum 2D', 'Spectrum 1D']

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -68,3 +68,8 @@ def test_1d_parser(specviz2d_helper, spectrum1d):
 def test_2d_1d_parser(specviz2d_helper, mos_spectrum2d, spectrum1d):
     specviz2d_helper.load_data(spectrum_2d=mos_spectrum2d, spectrum_1d=spectrum1d)
     assert specviz2d_helper.app.data_collection.labels == ['Spectrum 2D', 'Spectrum 1D']
+
+
+def test_parser_no_data(specviz2d_helper):
+    with pytest.raises(ValueError, match='Must provide spectrum_2d or spectrum_1d'):
+        specviz2d_helper.load_data()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to fix #1711 .

![Screenshot 2022-10-10 205721](https://user-images.githubusercontent.com/2090236/194979990-23229bf4-a58c-405f-b053-67a8f0075466.jpg)

I don't know if we want to backport this or not. Feel free to change the milestone if we need to backport this.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
