### PR TITLE
fix: workaround for blank tabbed viewers after selection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,8 @@ Bug Fixes
 
 - Fix subset selection tool conflicts caused by a duplicate toolbar. [#1679]
 
+- Fixed blank tabbed viewers. [#1718]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -76,6 +76,7 @@
             <golden-layout
               style="height: 100%;"
               :has-headers="state.settings.visible.tab_headers"
+              @state="onLayoutChange"
             >
               <gl-row :closable="false">
                 <g-viewer-tab
@@ -178,6 +179,10 @@ export default {
       }
       // simple exact text search match on the plugin title for now.
       return trayItem.label.toLowerCase().indexOf(tray_items_filter.toLowerCase()) !== -1
+    },
+    onLayoutChange() {
+      /* Workaround for #1677, can be removed when bqplot/bqplot#1531 is released */
+      window.dispatchEvent(new Event('resize'));
     }
   },
   created() {


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1677

### After merging this

- Open a follow-up issue to revert this PR when https://github.com/bqplot/bqplot/pull/1531 is released upstream and we also would have to bump our bqplot minversion.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
