### PR TITLE
skip viewer.add_data if already in viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -92,6 +92,9 @@ Specviz2d
 
 - Fixed padding on logger overlay. [#1722]
 
+- Changing the visibility of a data entry from the data menu no longer re-adds the data to the viewer
+  if it is already present, which avoids resetting defaults on the percentile and/or color or the
+  layer. [#1724]
 
 3.0.1 (2022-10-10)
 ==================

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1422,6 +1422,8 @@ class Application(VuetifyTemplate, HubListener):
 
         color_cycler = ColorCycler()
 
+        viewer_data_labels = [layer.layer.label for layer in viewer.layers]
+
         # Include any selected data in the viewer
         for data_id, visibility in selected_items.items():
             data_item = self._get_data_item_by_id(data_id)
@@ -1434,14 +1436,14 @@ class Application(VuetifyTemplate, HubListener):
                 label = self._get_data_item_by_id(data_id)['name']
             active_data_labels.append(label)
 
-            [data] = [x for x in self.data_collection if x.label == label]
+            if label not in viewer_data_labels:
+                [data] = [x for x in self.data_collection if x.label == label]
+                viewer.add_data(data, percentile=95, color=color_cycler())
 
-            viewer.add_data(data, percentile=95, color=color_cycler())
-
-            add_data_message = AddDataMessage(data, viewer,
-                                              viewer_id=viewer_id,
-                                              sender=self)
-            self.hub.broadcast(add_data_message)
+                add_data_message = AddDataMessage(data, viewer,
+                                                  viewer_id=viewer_id,
+                                                  sender=self)
+                self.hub.broadcast(add_data_message)
 
             for layer in viewer.layers:
                 if layer.layer.data.label == label:

--- a/jdaviz/core/tests/test_data_menu.py
+++ b/jdaviz/core/tests/test_data_menu.py
@@ -49,3 +49,33 @@ def test_data_menu_toggles(specviz_helper, spectrum1d):
     selected_data_items = app._viewer_item_by_id('specviz-0')['selected_data_items']
     assert selected_data_items[data_ids[0]] == 'visible'
     assert selected_data_items[data_ids[1]] == 'mixed'
+
+
+def test_visibility_toggle(imviz_helper):
+    arr = np.arange(4).reshape((2, 2))
+    imviz_helper.load_data(arr, data_label='no_results_data')
+    app = imviz_helper.app
+    iv = app.get_viewer('imviz-0')
+
+    # regression test for https://github.com/spacetelescope/jdaviz/issues/1723
+    # test to make sure plot options (including percentile) stick when toggling visibility
+    # via the data menu checkboxes
+    selected_data_items = app._viewer_item_by_id('imviz-0')['selected_data_items']
+    data_ids = list(selected_data_items.keys())
+    assert selected_data_items[data_ids[0]] == 'visible'
+    assert iv.layers[0].visible is True
+    po = imviz_helper.plugins['Plot Options']
+    po.stretch_preset = 90
+    assert po.stretch_preset.value == 90
+
+    app.vue_data_item_visibility({'id': 'imviz-0',
+                                  'item_id': data_ids[0],
+                                  'visible': False})
+
+    assert iv.layers[0].visible is False
+
+    app.vue_data_item_visibility({'id': 'imviz-0',
+                                  'item_id': data_ids[0],
+                                  'visible': True})
+    assert iv.layers[0].visible is True
+    assert po.stretch_preset.value == 90


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request avoids re-calling `viewer.add_data` if the data is already loaded in the viewer.  This both saves time and avoids resetting some plot options that are passed as default (percentile and color from the cycler).  Note that unloading and re-loading data from the viewer (either through the API or with the "x" button) will still reset plot options as that entirely destroys the layer.


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1723

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
