### PR TITLE
spectral extraction: improved logic for initial position of "Manual" background trace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ Specviz
 Specviz2d
 ^^^^^^^^^
 
+- Improved logic for initial guess for position of "Manual" background trace in spectral extraction
+  plugin. [#1738]
+
 API Changes
 -----------
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -318,17 +318,19 @@ class SpectralExtraction(PluginTemplateMixin):
         default_bg_width = int(np.ceil(width / 10))
         default_width = min(default_bg_width, distance_from_edge * 2)
 
+        # sign for one-sided and single trace-pixel depending on whether the brightest pixel is
+        # above or below the middle of the image
+        sign = 1 if (brightest_pixel < width / 2) else -1
+
         if self.trace_pixel == 0:
             self.trace_pixel = brightest_pixel
         if self.trace_window == 0:
             self.trace_window = default_width
         if self.bg_trace_pixel == 0:
-            self.bg_trace_pixel = brightest_pixel
+            self.bg_trace_pixel = brightest_pixel + sign * default_bg_width * 2
         if self.bg_separation == 0:
             if default_bg_width * 2 >= distance_from_edge:
                 self.bg_type_selected = 'OneSided'
-                # we want positive separation if brightest_pixel near bottom
-                sign = 1 if (brightest_pixel < width / 2) else -1
                 self.bg_separation = sign * default_bg_width * 2
             else:
                 self.bg_separation = default_bg_width * 2

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -320,20 +320,22 @@ class SpectralExtraction(PluginTemplateMixin):
 
         # sign for one-sided and single trace-pixel depending on whether the brightest pixel is
         # above or below the middle of the image
-        sign = 1 if (brightest_pixel < width / 2) else -1
+        if default_bg_width * 2 >= distance_from_edge:
+            sign = 1 if (brightest_pixel < width / 2) else -1
+            default_bg_separation = sign * default_bg_width * 2
+        else:
+            default_bg_separation = default_bg_width * 2
 
         if self.trace_pixel == 0:
             self.trace_pixel = brightest_pixel
         if self.trace_window == 0:
             self.trace_window = default_width
         if self.bg_trace_pixel == 0:
-            self.bg_trace_pixel = brightest_pixel + sign * default_bg_width * 2
+            self.bg_trace_pixel = brightest_pixel + default_bg_separation
         if self.bg_separation == 0:
             if default_bg_width * 2 >= distance_from_edge:
                 self.bg_type_selected = 'OneSided'
-                self.bg_separation = sign * default_bg_width * 2
-            else:
-                self.bg_separation = default_bg_width * 2
+            self.bg_separation = default_bg_separation
         if self.bg_width == 0:
             self.bg_width = default_bg_width
         if self.ext_width == 0:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request improves the logic for the initial guess for the position of the "Manual" background trace.  Previously it started at the same guess as the extraction trace (based on the brightest flux medianed over the dispersion direction).  Now it uses the same location that would be adopted for a OneSided background, with the "direction" determined on whether the extraction trace is in the top or bottom half of the image, and the separation at 10% of the cross-dispersion "height".

Motivated by @ojustino's comment: https://github.com/spacetelescope/jdaviz/pull/1682#pullrequestreview-1142409128

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
