### PR TITLE
Bugfix for #1740: add/remove data from user-created viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,7 +81,7 @@ Bug Fixes
 
 - Prevent `app.add_data_to_viewer` from loading data from disk [#1725]
 
-- Fix bug in creating and removing new image viewers from Imviz [#1740]
+- Fix bug in creating and removing new image viewers from Imviz [#1741]
 
 Cubeviz
 ^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,8 @@ Bug Fixes
 
 - Prevent `app.add_data_to_viewer` from loading data from disk [#1725]
 
+- Fix bug in creating and removing new image viewers from Imviz [#1740]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1677,7 +1677,9 @@ class Application(VuetifyTemplate, HubListener):
         # Create the viewer item dictionary
         if name is None:
             name = viewer.__class__.__name__
-        new_viewer_item = self._create_viewer_item(viewer=viewer, vid=vid, name=name)
+        new_viewer_item = self._create_viewer_item(
+            viewer=viewer, vid=vid, name=name, reference=name
+        )
 
         new_stack_item = self._create_stack_item(
             container='gl-stack',

--- a/jdaviz/configs/imviz/tests/test_helper.py
+++ b/jdaviz/configs/imviz/tests/test_helper.py
@@ -1,3 +1,4 @@
+import numpy as np
 
 
 def test_plugin_user_apis(imviz_helper):
@@ -5,3 +6,28 @@ def test_plugin_user_apis(imviz_helper):
         plugin = plugin_api._obj
         for attr in plugin_api._expose:
             assert hasattr(plugin, attr)
+
+
+def test_create_new_viewer(imviz_helper, image_2d_wcs):
+    # starts with one (default) viewer
+    assert len(imviz_helper.app.get_viewer_ids()) == 1
+    arr = np.ones((10, 10))
+
+    data_label = 'image-data'
+    viewer_name = 'user-created-viewer'
+    imviz_helper.load_data(arr, data_label=data_label, show_in_viewer=False)
+    imviz_helper.create_image_viewer(viewer_name=viewer_name)
+
+    # new image viewer created
+    assert len(imviz_helper.app.get_viewer_ids()) == 2
+
+    # there should be no data in the new viewer
+    assert len(imviz_helper.app.get_data_from_viewer(viewer_name)) == 0
+
+    # then add data, and check that data were added to the new viewer
+    imviz_helper.app.add_data_to_viewer(viewer_name, data_label)
+    assert len(imviz_helper.app.get_data_from_viewer(viewer_name)) == 1
+
+    # remove data from the new viewer, check that it was removed
+    imviz_helper.app.remove_data_from_viewer(viewer_name, data_label)
+    assert len(imviz_helper.app.get_data_from_viewer(viewer_name)) == 0


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->
If the user creates a new image viewer from `Imviz` like so:
```python
imviz = Imviz()
viewer_2 = imviz.create_image_viewer(...)
imviz.app.add_data_to_viewer(...)
imviz.app.remove_data_from_viewer(...)
```
the `Application.remove_data_from_viewer` method calls `Application._viewer_item_by_reference` to find the viewer to remove. But in the first line, when `Imviz.create_image_viewer` initializes a new viewer, it calls `Application._on_new_viewer`, which until now only defines the following kwargs: `viewer=viewer, vid=vid, name=name`. There's one last kwarg in the call signature for the method, which by default is `reference=None`. Since we don't yet specify `reference` in the `_on_new_viewer` method, the default is passed as `None`, triggering the bug in #1740.

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This PR passes the missing keyword argument to get the expected behavior (the data are successfully removed from the viewer).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1740

### Change log entry

- [X] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
