### PR TITLE
Fix Zenodo link to always resolve latest version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,7 @@ Other Changes and Additions
 
 - Updated example notebooks (except MosvizExample) to use in-flight JWST data. [#1680]
 
+
 3.0.2 (unreleased)
 ==================
 
@@ -82,6 +83,8 @@ Bug Fixes
 - Prevent `app.add_data_to_viewer` from loading data from disk [#1725]
 
 - Fix bug in creating and removing new image viewers from Imviz [#1741]
+
+- Updated Zenodo link in docs to resolve to latest version. [#1743]
 
 Cubeviz
 ^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -210,4 +210,4 @@ which is licensed under the BSD 3-clause licence. See the
 `licenses <https://github.com/spacetelescope/jdaviz/tree/main/licenses>`_
 folder for more information.
 
-Cite ``jdaviz`` via our Zenodo record: https://doi.org/10.5281/zenodo.6824713.
+Cite ``jdaviz`` via our Zenodo record: https://doi.org/10.5281/zenodo.5513927.


### PR DESCRIPTION
The link at the bottom of the RTD homepage was linking to a static older version's Zenodo link. This will now properly link to the "cite all version" link, which resolves to the latest version of the Zenodo record.