### PR TITLE
Change RA/Dec significant figures from 4 to 6 in aperture photometry plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,7 @@ Other Changes and Additions
 ---------------------------
 
 - Updated example notebooks (except MosvizExample) to use in-flight JWST data. [#1680]
+- Change RA/Dec significant figures from 4 to 6 in aperture photometry plugin. [#1750]
 
 3.0.3 (unreleased)
 ==================
@@ -119,7 +120,7 @@ Specviz2d
 - Changing the visibility of a data entry from the data menu no longer re-adds the data to the viewer
   if it is already present, which avoids resetting defaults on the percentile and/or color or the
   layer. [#1724]
-  
+
 - Fixed handling of "Manual" background type in spectral extraction plugin. [#1737]
 
 3.0.1 (2022-10-10)

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -456,8 +456,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin):
                                     'aperture_sum_counts', 'aperture_sum_mag')):
                     tmp.append({'function': key, 'result': f'{x:.4e}'})
                 elif key == 'sky_centroid' and x is not None:
-                    tmp.append({'function': 'RA centroid', 'result': f'{x.ra.deg:.4f} deg'})
-                    tmp.append({'function': 'Dec centroid', 'result': f'{x.dec.deg:.4f} deg'})
+                    tmp.append({'function': 'RA centroid', 'result': f'{x.ra.deg:.6f} deg'})
+                    tmp.append({'function': 'Dec centroid', 'result': f'{x.dec.deg:.6f} deg'})
                 elif key in ('xcentroid', 'ycentroid', 'sum_aper_area'):
                     tmp.append({'function': key, 'result': f'{x:.1f}'})
                 elif key == 'aperture_sum_counts' and x is not None:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This addresses the issue of not having enough significant figures in the coordinates in the aperture photometry plugin.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
