### PR TITLE
TST: Use new remote data for test_spectrum_on_top

### DIFF
--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -1,8 +1,11 @@
+import gwcs
 import pytest
 from astropy.utils.data import download_file
-
+from packaging.version import Version
 from specreduce import tracing, background, extract
 from specutils import Spectrum1D
+
+GWCS_LT_0_18_1 = Version(gwcs.__version__) < Version('0.18.1')
 
 
 @pytest.mark.remote_data
@@ -167,6 +170,7 @@ def test_user_api(specviz2d_helper):
 
 
 @pytest.mark.remote_data
+@pytest.mark.skipif(GWCS_LT_0_18_1, reason='Needs GWCS 0.18.1 or later')
 def test_spectrum_on_top(specviz2d_helper):
     fn = download_file('https://mast.stsci.edu/api/v0.1/Download/file/?uri=mast:jwst/product/jw01529-o004_t002_miri_p750l_s2d.fits', cache=True)  # noqa
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -166,10 +166,9 @@ def test_user_api(specviz2d_helper):
     pext.bg_sub_add_results.auto = True
 
 
-@pytest.mark.skip(reason='Data disappeared on MAST')
 @pytest.mark.remote_data
 def test_spectrum_on_top(specviz2d_helper):
-    fn = download_file('https://mast.stsci.edu/api/v0.1/Download/file/?uri=mast:jwst/product/jw01529-c1002_t002_miri_p750l_s2d.fits', cache=True)  # noqa
+    fn = download_file('https://mast.stsci.edu/api/v0.1/Download/file/?uri=mast:jwst/product/jw01529-o004_t002_miri_p750l_s2d.fits', cache=True)  # noqa
 
     specviz2d_helper.load_data(spectrum_2d=fn)
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to re-enable the remote test skipped in #1736 by replacing it with another file suggested by Tyler Pauly from pipeline team.

*[The old file] should no longer be created - it was the result of a duplicate association created (`jw01529-o004_spec3_001_asn.json == jw01529-c1002_spec3_001_asn.json`), and so the file `jw01529-o004_t002_miri_p750l_s2d.fits` should hold the relevant data. The duplicate association bug has been fixed, so some `c1xxx` associations are intentionally no longer created. If the old `c` type association is on hand, you can check to see if it fell under this issue by checking the full member list - if all listed members fall under one observation group (i.e., `o004`), the association will no longer be generated.*

Out of scope:
* #1739

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set?
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
