### PR TITLE
Correcting Zenodo link in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ which is licensed under the BSD 3-clause licence. See the
 `licenses <https://github.com/spacetelescope/jdaviz/tree/main/licenses>`_
 folder for more information.
 
-Cite ``jdaviz`` via our Zenodo record: https://doi.org/10.5281/zenodo.6824713.
+Cite ``jdaviz`` via our Zenodo record: https://doi.org/10.5281/zenodo.5513927.
 
 Contributing
 ------------


### PR DESCRIPTION
In #1743 we changed the Zenodo links to always point to the latest release. I found one remaining URL to change in the README, which is fixed in this PR.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
