### PR TITLE
Pinning min version of asdf-transform-schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -82,6 +82,8 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Fix ASDF-related warning by pinning minimum version for asdf-transform-schemas [#1763]
+
 Cubeviz
 ^^^^^^^
 
@@ -112,8 +114,6 @@ Bug Fixes
 - Fix bug in creating and removing new image viewers from Imviz [#1741]
 
 - Updated Zenodo link in docs to resolve to latest version. [#1743]
-
-- Fix ASDF-related warning by pinning minimum version for asdf-transform-schemas [#1763]
 
 Imviz
 ^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -113,6 +113,8 @@ Bug Fixes
 
 - Updated Zenodo link in docs to resolve to latest version. [#1743]
 
+- Fix ASDF-related warning by pinning minimum version for asdf-transform-schemas [#1763]
+
 Imviz
 ^^^^^
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ install_requires =
     sidecar>=0.5.1
     ipypopout>=0.0.11
     astroquery
+    asdf-transform-schemas>=0.3
 
 [options.extras_require]
 test =


### PR DESCRIPTION
This PR specifies a minimum version for `asdf-transform-schemas`. @mustaric pointed out that if a user loads
JWST/MIRI i2d observations into Imviz like so:
```python
from jdaviz import Imviz

imviz = Imviz()
imviz.load_data('JWST_Data_PID????/jw*_miri_f770w_i2d.fits')
imviz.show()
```
with `asdf-transform-schemas==0.2.2` installed, the `load_data` call produces the following two warnings:
```
2022-10-21 12:53:34,247 - stpipe - WARNING - /Users/bmmorris/miniconda3/envs/jdaviz/lib/python3.9/site-packages/asdf/schema.py:301: AsdfWarning: Unable to locate schema file for 'tag:stsci.edu:asdf/transform/property/bounding_box-1.0.0': 'http://stsci.edu/schemas/asdf/transform/property/bounding_box-1.0.0'
  warnings.warn(msg.format(tag, schema_uri), AsdfWarning)

2022-10-21 12:53:34,324 - stpipe - WARNING - /Users/bmmorris/miniconda3/envs/jdaviz/lib/python3.9/site-packages/asdf/yamlutil.py:300: AsdfConversionWarning: tag:stsci.edu:asdf/transform/property/bounding_box-1.0.0 is not recognized, converting to raw Python data structure
  warnings.warn(
```
`asdf-transform-schemas==0.3` introduced schemas for supporting bounding boxes (see astropy/asdf-astropy#69 and their [release notes](https://github.com/asdf-format/asdf-transform-schemas/releases/tag/0.3.0)), which prevents the warnings from being raised on load in jdaviz.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set?
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
