### PR TITLE
Update to new MAST URIs in example notebooks

### DIFF
--- a/notebooks/CubevizExample.ipynb
+++ b/notebooks/CubevizExample.ipynb
@@ -77,7 +77,7 @@
     "data_dir = tempfile.gettempdir()\n",
     "#data_dir = \"/User/username/Data/\"\n",
     "\n",
-    "fn = \"jw02732-c1001_t004_miri_ch1-longmediumshort-_s3d.fits\"\n",
+    "fn = \"jw02732-o004_t004_miri_ch1-shortmediumlong_s3d.fits\"\n",
     "result = Observations.download_file(f\"mast:JWST/product/{fn}\", local_path=f'{data_dir}/{fn}')\n",
     "\n",
     "with warnings.catch_warnings():\n",

--- a/notebooks/SpecvizExample.ipynb
+++ b/notebooks/SpecvizExample.ipynb
@@ -97,7 +97,7 @@
     "data_dir = tempfile.gettempdir()\n",
     "#data_dir = \"/User/username/Data/\"\n",
     "\n",
-    "fn = \"jw02732-c1001_t004_miri_ch1-longmediumshort-_x1d.fits\"\n",
+    "fn = \"jw02732-o004_t004_miri_ch1-shortmediumlong_x1d.fits\"\n",
     "result = Observations.download_file(f\"mast:JWST/product/{fn}\", local_path=f'{data_dir}/{fn}')\n",
     "\n",
     "specviz.load_spectrum(f'{data_dir}/{fn}', \"myfile\")"


### PR DESCRIPTION
Apparently MAST changed these paths....

Fix https://github.com/spacetelescope/jdaviz/issues/1758