### PR TITLE
BUG: Fix astropy version check for filter_non_finite in modeling within aper phot plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Fixed Simple Aperture Photometry plugin compatibility with astropy v5.1.1. [#1769]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -417,7 +417,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin):
                     gs = Gaussian1D(amplitude=y_max, mean=0, stddev=std,
                                     fixed={'mean': True, 'amplitude': True},
                                     bounds={'amplitude': (y_max * 0.5, y_max)})
-                    if Version(astropy.__version__) <= Version('5.1'):
+                    if Version(astropy.__version__) < Version('5.2'):
                         fitter_kw = {}
                     else:
                         fitter_kw = {'filter_non_finite': True}


### PR DESCRIPTION
 <!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Hopefully this will make CI green again. astropy v5.1.1 was released this morning.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set?
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
