### PR TITLE
feat: remove vue_relayout, this is no longer needed

### DIFF
--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -71,7 +71,7 @@
       :class="checkNotebookContext() ? '' : 'jdaviz__content--not-in-notebook'"
     >
       <v-container class="fill-height pa-0" fluid>
-        <splitpanes @resize="relayout">
+        <splitpanes>
           <pane size="75">
             <golden-layout
               style="height: 100%;"
@@ -88,7 +88,6 @@
                   :icons="state.icons"
                   :viewer_icons="state.viewer_icons"
                   :layer_icons="state.layer_icons"
-                  @resize="relayout"
                   :closefn="destroy_viewer_item"
                   @data-item-selected="data_item_selected($event)"
                   @data-item-visibility="data_item_visibility($event)"


### PR DESCRIPTION
Triggering a resize/rerender of bqplot is done in the front-end since 3dcfe344.

See: #1720

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-2839)
