### PR TITLE
fix nested toolbar in specviz2d/mosviz 2d profile viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -101,11 +101,15 @@ Imviz
 Mosviz
 ^^^^^^
 
+- Fixed toolbar on 2d profile viewer. [#1778]
+
 Specviz
 ^^^^^^^
 
 Specviz2d
 ^^^^^^^^^
+
+- Fixed toolbar on 2d spectrum viewer. [#1778]
 
 3.0.2 (2022-10-18)
 ==================

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -797,7 +797,7 @@ def mos_niriss_parser(app, data_dir, table_viewer_reference_name='table-viewer')
                                                 message=".*SRCTYPE is missing or UNKNOWN*")
                         specs = SpectrumList.read(filtered_hdul, format="JWST x1d multi")
                 except UserWarning as e:
-                    raise KeyError(f"The SRCTYPE keyword in the header of file {fname}"
+                    raise KeyError(f"The SRCTYPE keyword in the header of file {fname} "
                                    "is not populated (expected values: EXTENDED or POINT)") from e
 
                 filter_name = fits.getheader(fname, ext=0).get('PUPIL')

--- a/jdaviz/configs/mosviz/plugins/viewers.py
+++ b/jdaviz/configs/mosviz/plugins/viewers.py
@@ -99,7 +99,7 @@ class MosvizImageView(JdavizViewerMixin, BqplotImageView):
 
 
 @viewer_registry("mosviz-profile-2d-viewer", label="Spectrum 2D (Mosviz)")
-class MosvizProfile2DView(BqplotImageView, JdavizViewerMixin):
+class MosvizProfile2DView(JdavizViewerMixin, BqplotImageView):
     # Due to limitations in CCDData and 2D data that has spectral and spatial
     #  axes, the default conversion class must handle cubes
     default_class = Spectrum1D


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes the nested toolbar in the 2d spectrum viewers in specviz2d and mosviz (see #1679 - which was supposed to replace the original toolbar with the nested toolbar, but forgot to change the inheritance order of this viewer).

**Before**:
<img width="995" alt="Screen Shot 2022-10-25 at 2 20 00 PM" src="https://user-images.githubusercontent.com/877591/197851288-fed9d243-f1e6-40e7-8697-cd2fc74f66df.png">

**After**:
<img width="995" alt="Screen Shot 2022-10-25 at 2 18 14 PM" src="https://user-images.githubusercontent.com/877591/197851058-9fb0a0ef-e836-4c0a-96b4-846b14c3ab5a.png">



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
