### PR TITLE
MNT: Unpin maxversion of ipywidgets now that voila 0.4 is out, minversion ipywidgets now 8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -96,6 +96,7 @@ filterwarnings =
     ignore:distutils Version classes are deprecated:DeprecationWarning
     ignore:Passing unrecognized arguments to super:DeprecationWarning
     ignore:.*With traitlets 4\.1, metadata should be set using the \.tag\(\) method:DeprecationWarning
+    ignore:Widget.* is deprecated:DeprecationWarning
     ignore:.*np\.bool8.*is a deprecated alias for:DeprecationWarning
     ignore:.*np\.uint0.*is a deprecated alias for:DeprecationWarning
     ignore:.*np\.int0.*is a deprecated alias for:DeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     glue-core>=1.6.0
     glue-jupyter>=0.14.2
     echo>=0.5.0
-    ipykernel<6.18
+    ipykernel>=6.19.4
     ipyvue>=1.6
     ipyvuetify>=1.7.0
     ipysplitpanes>=0.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,8 +32,8 @@ install_requires =
     ipyvuetify>=1.7.0
     ipysplitpanes>=0.1.0
     ipygoldenlayout>=0.3.0
-    ipywidgets<8.0
-    voila>=0.3.5,<0.4
+    ipywidgets>=8
+    voila>=0.4
     pyyaml>=5.4.1
     specutils>=1.9
     specreduce>=1.3.0,<1.4.0
@@ -47,7 +47,7 @@ install_requires =
     gwcs>=0.16.1
     regions>=0.6
     scikit-image
-    sidecar>=0.5.1
+    sidecar>=0.5.2
     ipypopout>=0.0.11
     astroquery
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to fix #1613 and fix https://github.com/spacetelescope/jdaviz/issues/1787 and fix #1926 and fix #1938

xref #1791 .

Multiple devs should check that things are truly fixed by this new voila release since several things were broken before. Make sure your ipywidgets is at least v8 and voila is v0.4 when you test.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Blocked by

* https://github.com/jupyter-widgets/ipywidgets/issues/3635 that requires reverting https://github.com/jupyter-widgets/ipywidgets/pull/3271, see https://github.com/jupyter-widgets/ipywidgets/pull/3642
* https://github.com/jupyter-widgets/jupyterlab-sidecar/pull/86
* #1937

### Bugs check list

- [ ] Spinner shows in Link Control when click on WCS.
- [ ] Standalone app still works.
- [ ] Viewer resizes display when popped out.
- [ ] Display not empty when popped out?
- [ ] Does sidecar work?  Does content in sidecar resize correctly? (#1926)

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-2988)
