### PR TITLE
Disable 1D linking and Simultaneous Row Plotting in Mosviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ Mosviz
 ^^^^^^
 
 - Disable simultaneous row plotting and 1D linking in Mosviz
-  to substantially decrease load times [#1790]
+  to substantially decrease load times. [#1790]
 
 - Added coordinates display panels for Mosviz viewers. [#1795]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,8 @@ Imviz
 Mosviz
 ^^^^^^
 
-- Disable Data Dropdowns and 1D linking in Mosviz to substantially decrease load times [#1790]
+- Disable simultaneous row plotting and 1D linking in Mosviz
+  to substantially decrease load times [#1790]
 
 - Added coordinates display panels for Mosviz viewers. [#1795]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Imviz
 Mosviz
 ^^^^^^
 
+- Disable Data Dropdowns and 1D linking in Mosviz to substantially decrease load times [#1790]
+
 - Added coordinates display panels for Mosviz viewers. [#1795]
 
 Specviz

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1027,11 +1027,11 @@ class Application(VuetifyTemplate, HubListener):
             defined data set.
         """
         if 'mosviz_row' in self.state.settings:
-            if not ((self.get_viewer("table-viewer").row_selection_in_progress) and
-                    (self.data_collection[data_label].meta['mosviz_row'] !=
-                        self.state.settings['mosviz_row'])):
-                raise NotImplementedError("Intra-row plotting not supported. "
-                                          "Please use the table viewer to change rows")
+            if not (self.get_viewer("table-viewer").row_selection_in_progress):
+                if (self.data_collection[data_label].meta['mosviz_row'] !=
+                        self.state.settings['mosviz_row']):
+                    raise NotImplementedError("Intra-row plotting not supported. "
+                                              "Please use the table viewer to change rows")
 
         viewer_item = self._get_viewer_item(viewer_reference)
         if viewer_item is None:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1026,6 +1026,13 @@ class Application(VuetifyTemplate, HubListener):
             Removes all other currently plotted data and only shows the newly
             defined data set.
         """
+        if 'mosviz_row' in self.state.settings:
+            if not ((self.get_viewer("table-viewer").row_selection_in_progress) and 
+                    (self.data_collection[data_label].meta['mosviz_row'] != 
+                        self.state.settings['mosviz_row'])):
+                raise NotImplementedError("Intra-row plotting not supported. "
+                                          "Please use the table viewer to change rows")
+
         viewer_item = self._get_viewer_item(viewer_reference)
         if viewer_item is None:
             raise ValueError(f"Could not identify viewer with reference {viewer_reference}")

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1027,8 +1027,8 @@ class Application(VuetifyTemplate, HubListener):
             defined data set.
         """
         if 'mosviz_row' in self.state.settings:
-            if not ((self.get_viewer("table-viewer").row_selection_in_progress) and 
-                    (self.data_collection[data_label].meta['mosviz_row'] != 
+            if not ((self.get_viewer("table-viewer").row_selection_in_progress) and
+                    (self.data_collection[data_label].meta['mosviz_row'] !=
                         self.state.settings['mosviz_row'])):
                 raise NotImplementedError("Intra-row plotting not supported. "
                                           "Please use the table viewer to change rows")

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1026,12 +1026,12 @@ class Application(VuetifyTemplate, HubListener):
             Removes all other currently plotted data and only shows the newly
             defined data set.
         """
-        if 'mosviz_row' in self.state.settings:
-            if not (self.get_viewer("table-viewer").row_selection_in_progress):
-                if (self.data_collection[data_label].meta['mosviz_row'] !=
-                        self.state.settings['mosviz_row']):
-                    raise NotImplementedError("Intra-row plotting not supported. "
-                                              "Please use the table viewer to change rows")
+        if ('mosviz_row' in self.state.settings and
+            not (self.get_viewer("table-viewer").row_selection_in_progress) and
+            self.data_collection[data_label].meta['mosviz_row'] !=
+                self.state.settings['mosviz_row']):
+            raise NotImplementedError("Intra-row plotting not supported. "
+                                      "Please use the table viewer to change rows")
 
         viewer_item = self._get_viewer_item(viewer_reference)
         if viewer_item is None:

--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -65,7 +65,7 @@
             >
               <v-icon class='invert-if-dark'>{{showExtraItems ? 'mdi-chevron-double-up' : 'mdi-chevron-double-down'}}</v-icon>
               <span v-if="viewer.config === 'mosviz'">
-                {{showExtraItems ? 'hide data not in viewer (incl other MOS rows)' : 'show data not in viewer (incl other MOS rows)'}}
+                {{showExtraItems ? 'hide other row data not in viewer' : 'show other row data not in viewer'}}
               </span>
               <span v-else>
                 {{showExtraItems ? 'hide data not in viewer' : 'show data not in viewer'}}                
@@ -129,7 +129,7 @@ module.exports = {
       const inViewer = Object.keys(this.$props.viewer.selected_data_items).includes(item.id)
       //console.log(item.name+"  "+inViewer)
       if (returnExtraItems) {
-        return !inViewer
+        return (!inViewer && (item.meta.mosviz_row === this.$props.app_settings.mosviz_row))
       }
       return inViewer
     },
@@ -142,8 +142,6 @@ module.exports = {
           return false
         } else if (this.$props.viewer.reference === 'image-viewer' && item.type !== 'image') {
           return false
-        } else if (item.meta.mosviz_row === this.$props.app_settings.mosviz_row) {
-          return true
         } else {
           return this.dataItemInViewer(item, returnExtraItems)
         }
@@ -196,9 +194,6 @@ module.exports = {
       return this.$props.data_items.filter((item) => this.itemIsVisible(item, false))
     },
     extraDataItems() {
-      if (this.$props.viewer.config === 'mosviz') {
-        return []
-      }
       return this.$props.data_items.filter((item) => this.itemIsVisible(item, true))
     },
   }

--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -120,7 +120,7 @@ module.exports = {
   },
   methods: {
     menuButtonAvailable() {
-      if (this.$props.viewer.reference === 'table-viewer' || this.$props.viewer.config === 'mosviz') {
+      if (this.$props.viewer.reference === 'table-viewer') {
         return false
       }
       return true
@@ -142,6 +142,8 @@ module.exports = {
           return false
         } else if (this.$props.viewer.reference === 'image-viewer' && item.type !== 'image') {
           return false
+        } else if (item.meta.mosviz_row === this.$props.app_settings.mosviz_row) {
+          return true
         } else {
           return this.dataItemInViewer(item, returnExtraItems)
         }
@@ -194,6 +196,9 @@ module.exports = {
       return this.$props.data_items.filter((item) => this.itemIsVisible(item, false))
     },
     extraDataItems() {
+      if (this.$props.viewer.config === 'mosviz') {
+        return []
+      }
       return this.$props.data_items.filter((item) => this.itemIsVisible(item, true))
     },
   }

--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -120,7 +120,7 @@ module.exports = {
   },
   methods: {
     menuButtonAvailable() {
-      if (this.$props.viewer.reference === 'table-viewer') {
+      if (this.$props.viewer.reference === 'table-viewer' || this.$props.viewer.config === 'mosviz') {
         return false
       }
       return true

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -133,15 +133,6 @@ def link_data_in_table(app, data_obj=None):
 
             wc_spec_ids.append(LinkSame(wc_spec_1d[0], wc_spec_2d[1]))
 
-        # Link each 1D spectrum to all other 1D spectra
-        first_spec_1d = spectra_1d[0]
-        wc_first_spec_1d = app.session.data_collection[first_spec_1d].world_component_ids
-
-        for index in range(1, len(spectra_1d)):
-            spec_1d = spectra_1d[index]
-            wc_spec_1d = app.session.data_collection[spec_1d].world_component_ids
-            wc_spec_ids.append(LinkSame(wc_spec_1d[0], wc_first_spec_1d[0]))
-
     app.session.data_collection.add_link(wc_spec_ids)
 
 

--- a/jdaviz/configs/mosviz/tests/test_data_loading.py
+++ b/jdaviz/configs/mosviz/tests/test_data_loading.py
@@ -235,7 +235,8 @@ def test_nirspec_loader(mosviz_helper, tmpdir):
 
     # Check to make sure our test case isn't from the same row
     table = mosviz_helper.app.get_viewer('table-viewer')
-    data_label = mosviz_helper.app.data_collection[1].label
+    table.select_row(0)
+    data_label = "1D Spectrum 4"
     assert mosviz_helper.app.data_collection[data_label].meta['mosviz_row'] != table.current_row
 
     print(mosviz_helper.app.data_collection)

--- a/jdaviz/configs/mosviz/tests/test_data_loading.py
+++ b/jdaviz/configs/mosviz/tests/test_data_loading.py
@@ -239,7 +239,6 @@ def test_nirspec_loader(mosviz_helper, tmpdir):
     data_label = "1D Spectrum 4"
     assert mosviz_helper.app.data_collection[data_label].meta['mosviz_row'] != table.current_row
 
-    print(mosviz_helper.app.data_collection)
     with pytest.raises(NotImplementedError, match='Intra-row plotting not supported'):
         mosviz_helper.app.add_data_to_viewer(viewer_reference='spectrum-viewer',
                                              data_label=data_label)

--- a/jdaviz/configs/mosviz/tests/test_data_loading.py
+++ b/jdaviz/configs/mosviz/tests/test_data_loading.py
@@ -241,7 +241,7 @@ def test_nirspec_loader(mosviz_helper, tmpdir):
     print(mosviz_helper.app.data_collection)
     with pytest.raises(NotImplementedError, match='Intra-row plotting not supported'):
         mosviz_helper.app.add_data_to_viewer(viewer_reference='spectrum-viewer',
-                                             data_label=data_label)  
+                                             data_label=data_label)
 
 
 @pytest.mark.remote_data

--- a/jdaviz/configs/mosviz/tests/test_data_loading.py
+++ b/jdaviz/configs/mosviz/tests/test_data_loading.py
@@ -57,13 +57,14 @@ def test_load_spectrum_collection(mosviz_helper, spectrum_collection):
     labels = [f"Test Spectrum Collection {i}" for i in range(5)]
     mosviz_helper.load_1d_spectra(spectrum_collection, data_labels=labels)
 
-    assert len(mosviz_helper.app.data_collection) == 6
+    # +1 for the table viewer
+    assert len(mosviz_helper.app.data_collection) == len(spectrum_collection) + 1
     dc_0 = mosviz_helper.app.data_collection[0]
     assert dc_0.label == labels[0]
     assert dc_0.meta['uncertainty_type'] == 'std'
 
     table = mosviz_helper.app.get_viewer('table-viewer')
-    table.widget_table.vue_on_row_clicked(0)
+    table.select_row(0)
 
     data = mosviz_helper.app.get_data_from_viewer('spectrum-viewer')
 
@@ -190,6 +191,7 @@ def test_load_single_image_multi_spec(mosviz_helper, mos_image, spectrum1d, mos_
 def test_nirspec_loader(mosviz_helper, tmpdir):
     '''
     Tests loading our default MosvizExample notebook data
+    Also tests IntraRow linking
     '''
 
     test_data = 'https://stsci.box.com/shared/static/ovyxi5eund92yoadvv01mynwt8t5n7jv.zip'
@@ -225,6 +227,21 @@ def test_nirspec_loader(mosviz_helper, tmpdir):
     assert PRIHDR_KEY not in dc_15.meta
     assert 'header' not in dc_15.meta
     assert dc_15.meta['SOURCEID'] == 2315
+
+    # Test IntraRow linking:
+    # Attempts to add the spectrum of another row into the current row's viewers
+    # Currently, intrarow linking is disabled. Attemps to load another spectrum into
+    # the current spectrum viewer should result in an error
+
+    # Check to make sure our test case isn't from the same row
+    table = mosviz_helper.app.get_viewer('table-viewer')
+    data_label = mosviz_helper.app.data_collection[1].label
+    assert mosviz_helper.app.data_collection[data_label].meta['mosviz_row'] != table.current_row
+
+    print(mosviz_helper.app.data_collection)
+    with pytest.raises(NotImplementedError, match='Intra-row plotting not supported'):
+        mosviz_helper.app.add_data_to_viewer(viewer_reference='spectrum-viewer',
+                                             data_label=data_label)  
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

You may be asking yourself, why in {insert deity name of choice}'s name would you want that!? I think a picture is worth 1000 words (even if it's a picture of words :P)

![image](https://user-images.githubusercontent.com/25206008/198470738-bf39ef1a-b934-4579-97f5-4509b367297e.png)

You're reading that right; 200 targets, which used to take 1 hour and 11 minutes (!!) loaded in under two minutes.

This PR is part of a 3 part strategy in changing the linking strategy in Mosviz, developed with @camipacifici. In Mosviz, data navigation is mainly intended to be done with the Table Viewer. I recall us having discussions about removing the data dropdowns from Mosviz because of this. Though it may have been stopped due to a desire to plot multiple 1D spectrum in the same viewer.

After some profiling, I discovered supporting multi-plotting 1D spectrum was a VAST majority of the load time issues with Mosviz parser (in the GLASS dataset's case, 97.5% of the load time!). This is because the linking tree grows much faster than N for N number of targets, since we need to back link each target to each other one. This PR disables the intra 1D spectra linking to vastly improve loading times. It then hides other rows' data and disables the ability to load them simultaneously:

![image](https://user-images.githubusercontent.com/25206008/199825033-86abbb02-8cda-4389-8c5d-7dbebd9753c7.png)

![image](https://user-images.githubusercontent.com/25206008/199825239-f4cde9b3-5d8d-4e3c-9a4e-cdd95d595344.png)


What about the multi-plotting spectrum? That's the last part of this 3-part strategy: (EDIT: Modified to include https://github.com/spacetelescope/jdaviz/pull/1790#issuecomment-1295130196)
1. Disable 1D linking
2. Investigate whether batch linking produces a similar benefit to removing linking entirely (https://github.com/spacetelescope/jdaviz/pull/1790#issuecomment-1295542053)
4. Re-enable the data dropdown with filtering to only the current row's data
5. Benchmark the remaining two minutes to see whether lazy data loading could help
6. If the above comes back true, investigate lazy data loading to further improve data loading/parsing time
7. Investigate Dynamic linking of data, and re-enable intra-row/simultaneous-row plotting

I propose we investigate the possibility of dynamic linking of data. That being we only link data together IF and WHEN the user actually requests to show the data at the same time. Effectively, when the user clicks on the data dropdown and tries to add a second spectrum to the spectrum viewer, link AT THAT TIME, not in advance. That way, we only end up with links that we actually need. Overall, this will result in a link tree that is "sub-optimal" as compared to one created with "batch loading". But what we sacrifice in optimal linking, we gain in efficiency and parsing speed. I have no idea if this is possible, as it's just an idea I came up with much past my bedtime. But here we are!

I got the green light from @camipacifici to proceed with 1 and 2 now, and investigate 3 later. So I invite eyes and comments!

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
