### PR TITLE
plot options: spinner for contour settings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ New Features
 
 - New rainbow, reversed rainbow, and seismic (blue-red) colormaps for images. [#1785]
 
+- Spinner in plot options while processing changes to contour settings. [#1794]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -159,6 +159,8 @@ class PlotOptions(PluginTemplateMixin):
     image_bias_value = Float().tag(sync=True)
     image_bias_sync = Dict().tag(sync=True)
 
+    contour_spinner = Bool().tag(sync=True)
+
     contour_visible_value = Bool().tag(sync=True)
     contour_visible_sync = Dict().tag(sync=True)
 
@@ -275,17 +277,23 @@ class PlotOptions(PluginTemplateMixin):
                                                'image_bias_value', 'image_bias_sync')
 
         self.contour_visible = PlotOptionsSyncState(self, self.viewer, self.layer, 'contour_visible',  # noqa
-                                                    'contour_visible_value', 'contour_visible_sync')
+                                                    'contour_visible_value', 'contour_visible_sync',
+                                                    spinner='contour_spinner')
         self.contour_mode = PlotOptionsSyncState(self, self.viewer, self.layer, 'level_mode',
-                                                 'contour_mode_value', 'contour_mode_sync')
+                                                 'contour_mode_value', 'contour_mode_sync',
+                                                 spinner='contour_spinner')
         self.contour_min = PlotOptionsSyncState(self, self.viewer, self.layer, 'c_min',
-                                                'contour_min_value', 'contour_min_sync')
+                                                'contour_min_value', 'contour_min_sync',
+                                                spinner='contour_spinner')
         self.contour_max = PlotOptionsSyncState(self, self.viewer, self.layer, 'c_max',
-                                                'contour_max_value', 'contour_max_sync')
+                                                'contour_max_value', 'contour_max_sync',
+                                                spinner='contour_spinner')
         self.contour_nlevels = PlotOptionsSyncState(self, self.viewer, self.layer, 'n_levels',
-                                                    'contour_nlevels_value', 'contour_nlevels_sync')
+                                                    'contour_nlevels_value', 'contour_nlevels_sync',
+                                                    spinner='contour_spinner')
         self.contour_custom_levels = PlotOptionsSyncState(self, self.viewer, self.layer, 'levels',
-                                                          'contour_custom_levels_value', 'contour_custom_levels_sync')  # noqa
+                                                          'contour_custom_levels_value', 'contour_custom_levels_sync',   # noqa
+                                                          spinner='contour_spinner')
 
         # Axes options:
         # axes_visible hidden for imviz in plot_options.vue

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -263,62 +263,81 @@
 
     <!-- IMAGE:CONTOUR -->
     <j-plugin-section-header v-if="contour_visible_sync.in_subscribed_states">Contours</j-plugin-section-header>
-    <glue-state-sync-wrapper :sync="contour_visible_sync" :multiselect="multiselect" @unmix-state="unmix_state('contour_visible')">
-      <span>
-        <v-btn icon @click.stop="contour_visible_value = !contour_visible_value">
-          <v-icon>mdi-eye{{ contour_visible_value ? '' : '-off' }}</v-icon>
-        </v-btn>
-        Show Contours
-      </span>
-    </glue-state-sync-wrapper>
-
-    <div v-if="contour_visible_sync.in_subscribed_states && contour_visible_value">
-      <glue-state-sync-wrapper :sync="contour_mode_sync" :multiselect="multiselect" @unmix-state="unmix_state('contour_mode')">
-        <v-btn-toggle dense v-model="contour_mode_value" style="margin-right: 8px; margin-top: 8px">
-            <v-tooltip bottom>
-                <template v-slot:activator="{ on }">
-                    <v-btn v-on="on" small value="Linear">
-                        <v-icon>mdi-call-made</v-icon>
-                    </v-btn>
-                </template>
-                <span>linear</span>
-            </v-tooltip>
-
-            <v-tooltip bottom>
-                <template v-slot:activator="{ on }">
-                    <v-btn v-on="on" small value="Custom">
-                        <v-icon>mdi-wrench</v-icon>
-                    </v-btn>
-                </template>
-                <span>custom</span>
-            </v-tooltip>
-        </v-btn-toggle>
-      </glue-state-sync-wrapper>
-
-      <div v-if="contour_mode_value === 'Linear'">
-        <glue-state-sync-wrapper :sync="contour_min_sync" :multiselect="multiselect" @unmix-state="unmix_state('contour_min')">
-          <glue-float-field label="Contour Min" :value.sync="contour_min_value" />
+    <div style="display: grid"> <!-- overlay container -->
+      <div style="grid-area: 1/1">        
+        <glue-state-sync-wrapper :sync="contour_visible_sync" :multiselect="multiselect" @unmix-state="unmix_state('contour_visible')">
+          <span>
+            <v-btn icon @click.stop="contour_visible_value = !contour_visible_value">
+              <v-icon>mdi-eye{{ contour_visible_value ? '' : '-off' }}</v-icon>
+            </v-btn>
+            Show Contours
+          </span>
         </glue-state-sync-wrapper>
 
-        <glue-state-sync-wrapper :sync="contour_max_sync" :multiselect="multiselect" @unmix-state="unmix_state('contour_max')">
-          <glue-float-field label="Contour Max" :value.sync="contour_max_value" />
-        </glue-state-sync-wrapper>
+        <div v-if="contour_visible_sync.in_subscribed_states && contour_visible_value">
+          <glue-state-sync-wrapper :sync="contour_mode_sync" :multiselect="multiselect" @unmix-state="unmix_state('contour_mode')">
+            <v-btn-toggle dense v-model="contour_mode_value" style="margin-right: 8px; margin-top: 8px">
+                <v-tooltip bottom>
+                    <template v-slot:activator="{ on }">
+                        <v-btn v-on="on" small value="Linear">
+                            <v-icon>mdi-call-made</v-icon>
+                        </v-btn>
+                    </template>
+                    <span>linear</span>
+                </v-tooltip>
 
-        <glue-state-sync-wrapper :sync="contour_nlevels_sync" :multiselect="multiselect" @unmix-state="unmix_state('contour_nlevels')">
-          <glue-float-field label="Number of Contour Levels" :value.sync="contour_nlevels_value" />
-        </glue-state-sync-wrapper>
+                <v-tooltip bottom>
+                    <template v-slot:activator="{ on }">
+                        <v-btn v-on="on" small value="Custom">
+                            <v-icon>mdi-wrench</v-icon>
+                        </v-btn>
+                    </template>
+                    <span>custom</span>
+                </v-tooltip>
+            </v-btn-toggle>
+          </glue-state-sync-wrapper>
+
+          <div v-if="contour_mode_value === 'Linear'">
+            <glue-state-sync-wrapper :sync="contour_min_sync" :multiselect="multiselect" @unmix-state="unmix_state('contour_min')">
+              <glue-float-field label="Contour Min" :value.sync="contour_min_value" />
+            </glue-state-sync-wrapper>
+
+            <glue-state-sync-wrapper :sync="contour_max_sync" :multiselect="multiselect" @unmix-state="unmix_state('contour_max')">
+              <glue-float-field label="Contour Max" :value.sync="contour_max_value" />
+            </glue-state-sync-wrapper>
+
+            <glue-state-sync-wrapper :sync="contour_nlevels_sync" :multiselect="multiselect" @unmix-state="unmix_state('contour_nlevels')">
+              <glue-float-field label="Number of Contour Levels" :value.sync="contour_nlevels_value" />
+            </glue-state-sync-wrapper>
+          </div>
+          <div v-else>
+            <glue-state-sync-wrapper :sync="contour_custom_levels_sync" :multiselect="multiselect" @unmix-state="unmix_state('contour_levels')">
+              <v-text-field 
+                label="Contour Levels"
+                :value="contour_custom_levels_txt"
+                @focus="contour_custom_levels_focus"
+                @blur="contour_custom_levels_blur"
+                @input="contour_custom_levels_set_value"/>
+            </glue-state-sync-wrapper>
+          </div>
+        </div>
+
       </div>
-      <div v-else>
-        <glue-state-sync-wrapper :sync="contour_custom_levels_sync" :multiselect="multiselect" @unmix-state="unmix_state('contour_levels')">
-          <v-text-field 
-            label="Contour Levels"
-            :value="contour_custom_levels_txt"
-            @focus="contour_custom_levels_focus"
-            @blur="contour_custom_levels_blur"
-            @input="contour_custom_levels_set_value"/>
-        </glue-state-sync-wrapper>
+      <div v-if="contour_spinner"
+           class="text-center"
+           style="grid-area: 1/1; 
+                  z-index:2;
+                  margin-left: -24px;
+                  margin-right: -24px;
+                  padding-top: 60px;
+                  background-color: rgb(0 0 0 / 20%)">
+        <v-progress-circular
+          indeterminate
+          color="spinner"
+          size="50"
+          width="6"
+        ></v-progress-circular>
       </div>
-    </div>
 
     <!-- GENERAL:AXES -->
     <j-plugin-section-header v-if="axes_visible_sync.in_subscribed_states && config !== 'imviz'">Axes</j-plugin-section-header>

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -107,3 +107,7 @@ def test_user_api(cubeviz_helper, spectrum1d_cube):
     # try eq on both text and value
     assert po.image_colormap == 'gray'
     assert po.image_colormap == 'Gray'
+
+    # toggle contour (which has a spinner implemented)
+    po.contour_visible = True
+    assert po._obj.contour_spinner is False


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request adds a spinner overlay in the contour setting of plot options when there is a change in any of the contour settings (as they can take a while to be processed).

Approximately 85% of the time spent during this is in skimage `find_contours` so although it would be nice to optimize, it might be difficult for us to do so.  If contours are ever optimized to the point where the lag would not result in user-confusion, the overlay can easily be removed (or this entire PR reverted if no other plot option makes use of the infrastructure for a spinner).


https://user-images.githubusercontent.com/877591/199064421-b8c3ab63-3c64-44a7-9fc6-f780053f2e08.mov



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
