### PR TITLE
large subset warnings in aperture photometry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Warnings in aperture photometry plugin when using raw profile with large subsets. [#1801]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -18,7 +18,7 @@ from photutils.aperture import (ApertureStats, CircularAperture, EllipticalApert
                                 RectangularAperture)
 from regions import (CircleAnnulusPixelRegion, CirclePixelRegion, EllipsePixelRegion,
                      RectanglePixelRegion)
-from traitlets import Any, Bool, List, Unicode, observe
+from traitlets import Any, Bool, Integer, List, Unicode, observe
 
 from jdaviz.core.custom_traitlets import FloatHandleEmpty
 from jdaviz.core.events import SnackbarMessage, LinkUpdatedMessage
@@ -35,6 +35,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin):
     template_file = __file__, "aper_phot_simple.vue"
     subset_items = List([]).tag(sync=True)
     subset_selected = Unicode("").tag(sync=True)
+    subset_area = Integer().tag(sync=True)
     bg_subset_items = List().tag(sync=True)
     bg_subset_selected = Unicode("").tag(sync=True)
     background_value = Any(0).tag(sync=True)
@@ -201,6 +202,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin):
                                                   self._selected_subset.height ** 2) * 0.5
             else:  # pragma: no cover
                 raise TypeError(f'Unsupported region shape: {self._selected_subset.__class__}')
+
+            self.subset_area = int(np.ceil(self._selected_subset.area))
 
         except Exception as e:
             self._selected_subset = None

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -112,6 +112,12 @@
           ></v-select>
         </v-row>
 
+        <v-row v-if="current_plot_type==='Radial Profile (Raw)' && subset_area > 5000">
+          <span class="v-messages v-messages__message text--secondary">
+              <b>WARNING</b>: Computing and displaying raw profile of an aperture containing ~{{subset_area}} pixels may be slow or unresponsive.
+          </span>
+        </v-row>
+
         <v-row v-if="current_plot_type.indexOf('Radial Profile') != -1">
 
           <v-switch


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address slow performance for the raw profile plot in aperture photometry when using large subsets.  This does ~two things~ the following to attempt to address this case:
1. ~reorders so the results table appears above the plots.  Any size image/subset that jdaviz currently handles _should_ return the results almost immediately... if this is ever not the case, then we should consider adding a spinner while computing the results.~
2. adds a warning below the dropdown box if the user selected the raw profile AND the selected aperture has an area of over 5000 pixels.  This is a somewhat arbitrary cutoff, but can be adjusted if reviewers/users see significant performance degradation at smaller subsets.


https://user-images.githubusercontent.com/877591/199300596-96c72fda-3b0f-4093-9d4f-45c38db1f084.mov


Unfortunately a spinner for just the plot isn't obviously feasible as the drawing is handled in bqplot and the browser... although it might be possible to implement from javascript callbacks if we want to explore that further.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
