### PR TITLE
Make mosviz visibility fallback more robust

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,7 +86,7 @@ Imviz
 Mosviz
 ^^^^^^
 
-- Data unassigned a row is hidden under the subdropdown in the data dropdown. [#1798]
+- Data unassigned a row is hidden under the subdropdown in the data dropdown. [#1798, #1808]
 
 Specviz
 ^^^^^^^

--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -142,10 +142,9 @@ module.exports = {
           return false
         } else if (this.$props.viewer.reference === 'image-viewer' && item.type !== 'image') {
           return false
-        } else if ((item.meta.mosviz_row !== undefined) && (item.meta.mosviz_row !== null)) {
+        } else {
           return this.dataItemInViewer(item, returnExtraItems)
         }
-        return !returnExtraItems
       } else if (this.$props.viewer.config === 'cubeviz') {
         if (this.$props.viewer.reference === 'spectrum-viewer') {
           if (item.meta.Plugin === undefined) {


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Hi again... 😅

So #1798 didn't quite do what @kecnry and I were expecting, so I'm going to reintroduce the original solution I was proposing. After a much thorough second lookthrough, I'm further convinced this is the correct logic we want.

The reason why the missing row elements were visible was because the mosviz visibility fallback for when the object's row is `None` was to return `!returnExtraItems`. This flag is intended for the "show/hide all other data" dropdown. Effectively, if it the row information was missing, it would always show the item as visible.

Instead, I propose any data without a row should follow the same visibility rules of whether the user manually visualizes the dataset or not. FWIW, this PR brings the mosviz visibility logic in line with the default fallback: https://github.com/spacetelescope/jdaviz/blob/105de83f45ebb97de678014961766cef5127aea3/jdaviz/components/viewer_data_select.vue#L173-L174

As penance, I won't be marking this one as `trivial` 😅 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
