### PR TITLE
MNT: Deprecate CubeViz, MosViz, and SpecViz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ API Changes
 Cubeviz
 ^^^^^^^
 
+- ``CubeViz`` is deprecated, use ``Cubeviz``. [#1809]
+
 Imviz
 ^^^^^
 
@@ -37,8 +39,12 @@ Mosviz
 
 - Removed unused ``MosvizProfileView`` viewer class. [#1797]
 
+- ``MosViz`` is deprecated, use ``Mosviz``. [#1809]
+
 Specviz
 ^^^^^^^
+
+- ``SpecViz`` is deprecated, use ``Specviz``. [#1809]
 
 Specviz2d
 ^^^^^^^^^

--- a/jdaviz/__init__.py
+++ b/jdaviz/__init__.py
@@ -8,9 +8,9 @@ from ._astropy_init import *   # noqa
 
 # top-level API as exposed to users
 from jdaviz.app import *  # noqa
-from jdaviz.configs.specviz import Specviz, SpecViz  # noqa
+from jdaviz.configs.specviz import Specviz  # noqa
 from jdaviz.configs.specviz2d import Specviz2d  # noqa
-from jdaviz.configs.mosviz import Mosviz, MosViz  # noqa
-from jdaviz.configs.cubeviz import Cubeviz, CubeViz  # noqa
+from jdaviz.configs.mosviz import Mosviz  # noqa
+from jdaviz.configs.cubeviz import Cubeviz  # noqa
 from jdaviz.configs.imviz import Imviz  # noqa
 from jdaviz.utils import enable_hot_reloading  # noqa

--- a/jdaviz/configs/cubeviz/__init__.py
+++ b/jdaviz/configs/cubeviz/__init__.py
@@ -1,2 +1,2 @@
 from .plugins import *  # noqa
-from .helper import Cubeviz, CubeViz  # noqa
+from .helper import Cubeviz  # noqa

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -1,14 +1,14 @@
 import numpy as np
-
+from astropy.utils.decorators import deprecated
 from glue.core import BaseData
+
 from jdaviz.core.helpers import ImageConfigHelper
 from jdaviz.configs.default.plugins.line_lists.line_list_mixin import LineListMixin
 from jdaviz.configs.specviz import Specviz
 from jdaviz.core.events import (AddDataMessage,
                                 SliceSelectSliceMessage)
 
-
-__all__ = ['Cubeviz', 'CubeViz']
+__all__ = ['Cubeviz']
 
 
 class Cubeviz(ImageConfigHelper, LineListMixin):
@@ -113,8 +113,7 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
         return self._specviz
 
 
-# TODO: Officially deprecate this with coordination with JDAT notebooks team.
-# For backward compatibility only.
+@deprecated('3.2', alternative='Cubeviz')
 class CubeViz(Cubeviz):
     """This class is pending deprecation. Please use `Cubeviz` instead."""
     pass

--- a/jdaviz/configs/mosviz/__init__.py
+++ b/jdaviz/configs/mosviz/__init__.py
@@ -1,2 +1,2 @@
 from .plugins import *  # noqa
-from .helper import Mosviz, MosViz  # noqa
+from .helper import Mosviz  # noqa

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -8,6 +8,7 @@ import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import QTable
+from astropy.utils.decorators import deprecated
 from echo import delay_callback
 from glue.core.exceptions import IncompatibleAttribute
 
@@ -19,7 +20,7 @@ from jdaviz.configs.specviz2d import Specviz2d
 from jdaviz.configs.mosviz.plugins import jwst_header_to_skyregion
 from jdaviz.configs.default.plugins.line_lists.line_list_mixin import LineListMixin
 
-__all__ = ['Mosviz', 'MosViz']
+__all__ = ['Mosviz']
 
 
 class Mosviz(ConfigHelper, LineListMixin):
@@ -989,8 +990,7 @@ class Mosviz(ConfigHelper, LineListMixin):
         return self._get_spectrum('2D Spectra', row, apply_slider_redshift)
 
 
-# TODO: Officially deprecate this with coordination with JDAT notebooks team.
-# For backward compatibility only.
+@deprecated('3.2', alternative='Mosviz')
 class MosViz(Mosviz):
     """This class is pending deprecation. Please use `Mosviz` instead."""
     pass

--- a/jdaviz/configs/specviz/__init__.py
+++ b/jdaviz/configs/specviz/__init__.py
@@ -1,2 +1,2 @@
 from .plugins import *  # noqa
-from .helper import Specviz, SpecViz  # noqa
+from .helper import Specviz  # noqa

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -1,13 +1,14 @@
 import warnings
 
 from astropy import units as u
+from astropy.utils.decorators import deprecated
 from specutils import SpectralRegion, Spectrum1D
 
 from jdaviz.core.helpers import ConfigHelper
 from jdaviz.core.events import RedshiftMessage
 from jdaviz.configs.default.plugins.line_lists.line_list_mixin import LineListMixin
 
-__all__ = ['Specviz', 'SpecViz']
+__all__ = ['Specviz']
 
 
 def _apply_redshift_to_spectra(spectra, redshift):
@@ -235,8 +236,7 @@ class Specviz(ConfigHelper, LineListMixin):
         ).figure.axes[axis].tick_format = fmt
 
 
-# TODO: Officially deprecate this with coordination with JDAT notebooks team.
-# For backward compatibility only.
+@deprecated('3.2', alternative='Specviz')
 class SpecViz(Specviz):
     """This class is pending deprecation. Please use `Specviz` instead."""
     pass


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to formally deprecate old helper classes with capital V. That includes CubeViz, MosViz, and SpecViz.
This emits deprecation warning and removes them from high-level imports like `from jdaviz import CubeViz` but the classes are still there for a few more releases.

I think @orifox and @ojustino are both active in JDAT notebooks, so they can confirm whether we can go ahead with this or not.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #857

### After merge

- Open follow-up issue to completely remove the deprecated classes after a few releases.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
