### PR TITLE
MNT: Update license year

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright 2020-2021 JDADF Developers
+Copyright 2020-2022 JDADF Developers
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
I want to see if the new directive to skip RTD works. Might as well update the license year while I am at it.