### PR TITLE
Allow mosviz load_data to load only 1d or 2d spectra

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -110,7 +110,7 @@ Mosviz
 
 - Data unassigned a row is hidden under the subdropdown in the data dropdown. [#1798, #1808]
 
-- Allow Mosviz `load_data` method to load only 1d or 2d spectra. [#1833]
+- Allow Mosviz ``load_data`` method to load only 1D or 2D spectra. [#1833]
 
 Specviz
 ^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -110,6 +110,8 @@ Mosviz
 
 - Data unassigned a row is hidden under the subdropdown in the data dropdown. [#1798, #1808]
 
+- Allow Mosviz `load_data` method to load only 1d or 2d spectra. [#1833]
+
 Specviz
 ^^^^^^^
 

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -464,6 +464,16 @@ class Mosviz(ConfigHelper, LineListMixin):
             self.load_metadata(spectra_2d, spectra=True)
             self.load_metadata(spectra_1d, spectra=True, sp1d=True, ids=spectra_1d)
 
+        elif spectra_1d and images:
+            self.load_1d_spectra(spectra_1d, spectra_1d_label)
+            self.load_images(images, images_label)
+            allow_link_table = False
+
+        elif spectra_2d and images:
+            self.load_2d_spectra(spectra_2d, spectra_2d_label)
+            self.load_images(images, images_label)
+            allow_link_table = False
+
         elif spectra_1d:
             self.load_1d_spectra(spectra_1d, spectra_1d_label)
             allow_link_table = False
@@ -473,14 +483,10 @@ class Mosviz(ConfigHelper, LineListMixin):
             allow_link_table = False
 
         else:
-            msg = "Warning: Please set valid values for the load_data() method"
-            msg = SnackbarMessage(msg, color='warning', sender=self)
-            self.app.hub.broadcast(msg)
+            self.app.hub.broadcast(SnackbarMessage(
+                "Warning: Please set valid values for the load_data() method",
+                color='warning', sender=self))
             return
-
-        if msg:
-            msg = SnackbarMessage(msg, color='warning', sender=self)
-            self.app.hub.broadcast(msg)
 
         if allow_link_table:
             self.link_table_data(None)

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -463,8 +463,17 @@ class Mosviz(ConfigHelper, LineListMixin):
             self.load_metadata(spectra_2d, spectra=True)
             self.load_metadata(spectra_1d, spectra=True, sp1d=True, ids=spectra_1d)
 
+        elif spectra_1d is not None:
+            self.load_1d_spectra(spectra_1d, spectra_1d_label)
+
+        elif spectra_2d is not None:
+            self.load_2d_spectra(spectra_2d, spectra_2d_label)
+
         else:
             msg = "Warning: Please set valid values for the load_data() method"
+            msg = SnackbarMessage(msg, color='warning', sender=self)
+            self.app.hub.broadcast(msg)
+            return
 
         if msg:
             msg = SnackbarMessage(msg, color='warning', sender=self)

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -422,6 +422,7 @@ class Mosviz(ConfigHelper, LineListMixin):
         """
         # Link data after everything is loaded
         self.app.auto_link = False
+        allow_link_table = True
 
         directory = kwargs.pop('directory', None)
         instrument = kwargs.pop('instrument', None)
@@ -465,9 +466,11 @@ class Mosviz(ConfigHelper, LineListMixin):
 
         elif spectra_1d:
             self.load_1d_spectra(spectra_1d, spectra_1d_label)
+            allow_link_table = False
 
         elif spectra_2d:
             self.load_2d_spectra(spectra_2d, spectra_2d_label)
+            allow_link_table = False
 
         else:
             msg = "Warning: Please set valid values for the load_data() method"
@@ -479,7 +482,8 @@ class Mosviz(ConfigHelper, LineListMixin):
             msg = SnackbarMessage(msg, color='warning', sender=self)
             self.app.hub.broadcast(msg)
 
-        self.link_table_data(None)
+        if allow_link_table:
+            self.link_table_data(None)
 
         self._add_redshift_column()
 

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -463,10 +463,10 @@ class Mosviz(ConfigHelper, LineListMixin):
             self.load_metadata(spectra_2d, spectra=True)
             self.load_metadata(spectra_1d, spectra=True, sp1d=True, ids=spectra_1d)
 
-        elif spectra_1d is not None:
+        elif spectra_1d:
             self.load_1d_spectra(spectra_1d, spectra_1d_label)
 
-        elif spectra_2d is not None:
+        elif spectra_2d:
             self.load_2d_spectra(spectra_2d, spectra_2d_label)
 
         else:

--- a/jdaviz/configs/mosviz/tests/test_data_loading.py
+++ b/jdaviz/configs/mosviz/tests/test_data_loading.py
@@ -128,6 +128,26 @@ def test_load_multi_image_spec(mosviz_helper, mos_image, spectrum1d, mos_spectru
         assert qtable["Images"][0] == "Test Label 0"
 
 
+def test_load_multi_image_and_spec1d_only(mosviz_helper, mos_image, spectrum1d):
+    spectra1d = [spectrum1d] * 3
+    images = [mos_image] * 3
+
+    mosviz_helper.load_data(spectra_1d=spectra1d, images=images)
+
+    assert mosviz_helper.app.get_viewer("table-viewer").figure_widget.highlighted == 0
+    assert len(mosviz_helper.app.data_collection) == 7
+
+
+def test_load_multi_image_and_spec2d_only(mosviz_helper, mos_image, mos_spectrum2d):
+    spectra2d = [mos_spectrum2d] * 3
+    images = [mos_image] * 3
+
+    mosviz_helper.load_data(spectra_2d=spectra2d, images=images)
+
+    assert mosviz_helper.app.get_viewer("table-viewer").figure_widget.highlighted == 0
+    assert len(mosviz_helper.app.data_collection) == 7
+
+
 @pytest.mark.parametrize('label', [None, "Test Label"])
 def test_load_single_image_multi_spec(mosviz_helper, mos_image, spectrum1d, mos_spectrum2d, label):
     spectra1d = [spectrum1d] * 3

--- a/jdaviz/configs/mosviz/tests/test_data_loading.py
+++ b/jdaviz/configs/mosviz/tests/test_data_loading.py
@@ -14,7 +14,7 @@ from jdaviz.utils import PRIHDR_KEY
 
 def test_load_spectrum1d(mosviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    mosviz_helper.load_1d_spectra(spectrum1d, data_labels=label)
+    mosviz_helper.load_data(spectra_1d=spectrum1d, spectra_1d_label=label)
 
     assert len(mosviz_helper.app.data_collection) == 2
     dc_0 = mosviz_helper.app.data_collection[0]
@@ -94,7 +94,7 @@ def test_load_list_of_spectrum1d(mosviz_helper, spectrum1d):
 def test_load_mos_spectrum2d(mosviz_helper, mos_spectrum2d):
 
     label = "Test 2D Spectrum"
-    mosviz_helper.load_2d_spectra(mos_spectrum2d, data_labels=label)
+    mosviz_helper.load_data(spectra_2d=mos_spectrum2d, spectra_2d_label=label)
 
     assert len(mosviz_helper.app.data_collection) == 2
     dc_0 = mosviz_helper.app.data_collection[0]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address `mosviz.load_data()` not working if only spectra 1d or 2d are provided. Also, if valid values are not provided in `load_data`, the method should return after sending a Snackbar message.

EDIT: This is only implemented for NIRSpec data since it is the only instrument with separate loaders for 1d and 2d spectra.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
