### PR TITLE
Markers stay when adding new data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ Imviz
 
 - Subset Tools plugin now allows recentering of editable spatial subset. [#1823]
 
+- Links control plugin shows a confirmation overlay to clear markers when changing linking type. 
+  [#1838]
+
 Mosviz
 ^^^^^^
 
@@ -75,6 +78,8 @@ Imviz
 
 - Clearing markers in Catalog Search will only hide them, which improves
   "Clear" performance. [#1774]
+
+- Adding data will not result in clearing existing markers. [#1848]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -543,7 +543,7 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
             if len(viewer._marktags):
                 raise ValueError(f"cannot change link_type (from '{app._link_type}' to "
                                  f"'{link_type}') when markers are present. "
-                                 f" Clear markers with viewer.remove_markers() first")
+                                 f" Clear markers with viewer.reset_markers() first")
         data_already_linked = []
 
     refdata, iref = get_reference_image_data(app)

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -476,12 +476,12 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
     """(Re)link loaded data in Imviz with the desired link type.
     All existing links will be replaced.
 
-    .. warning::
+    .. note::
 
-        Any markers added in Imviz would be removed automatically.
+        Any markers added in Imviz will need to be removed manually before changing linking type.
         You can add back the markers using
         :meth:`~jdaviz.core.astrowidgets_api.AstrowidgetsImageViewerMixin.add_markers`
-        for the relevant viewer(s). During the markers removal, pan/zoom will also reset.
+        for the relevant viewer(s).
 
     Parameters
     ----------

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -541,7 +541,7 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
     else:
         for viewer in app._viewer_store.values():
             if len(viewer._marktags):
-                raise ValueError(f"cannot change link-type (from '{app._link_type}' to "
+                raise ValueError(f"cannot change link_type (from '{app._link_type}' to "
                                  f"'{link_type}') when markers are present. "
                                  f" Clear markers with viewer.remove_markers() first")
         data_already_linked = []

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -543,7 +543,7 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
             if len(viewer._marktags):
                 raise ValueError(f"cannot change link-type (from '{app._link_type}' to "
                                  f"'{link_type}') when markers are present. "
-                                 f" Clear markers with viewer.reset_markers() first")
+                                 f" Clear markers with viewer.remove_markers() first")
         data_already_linked = []
 
     refdata, iref = get_reference_image_data(app)

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -562,7 +562,6 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
 
         if data in data_already_linked:
             # links already exist for this entry and we're not changing the type
-            # TODO: account for toggling wcs_use_affine
             continue
 
         ids1 = data.pixel_component_ids

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -80,6 +80,7 @@ class LinksControl(PluginTemplateMixin):
         with the selected parameters.
         """
         if not hasattr(self, 'link_type'):
+            # could happen before plugin is fully initialized
             return
 
         if msg.get('name', None) == 'wcs_use_affine' and self.link_type.selected == 'Pixels':

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -16,6 +16,13 @@ class LinksControl(PluginTemplateMixin):
     """
     See the :ref:`Links Control Plugin Documentation <imviz-link-control>` for more details.
 
+    .. note::
+       Changing linking after adding markers via
+       `~jdaviz.core.astrowidgets_api.AstrowidgetsImageViewerMixin.add_markers` is unsupported and
+       will raise an error requiring resetting the markers manually via
+       `~jdaviz.core.astrowidgets_api.AstrowidgetsImageViewerMixin.add_markers`
+       or clicking a button in the plugin first.
+
     Only the following attributes and methods are available through the
     :ref:`public plugin API <plugin-apis>`:
 

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -57,8 +57,7 @@
 
            <v-card-actions>
              <v-row justify="end">
-               <v-btn tile small color="primary" class="mr-2" @click="cancel_link">Cancel</v-btn>
-               <v-btn tile small color="accent" class="mr-4" @click="clear_markers_and_link" >Clear Markers</v-btn>
+               <v-btn tile small color="accent" class="mr-4" @click="reset_markers" >Clear Markers</v-btn>
              </v-row>
            </v-card-actions>
          </v-card>

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -40,6 +40,29 @@
           </v-switch>
         </v-row>
       </div>
+      <div v-if="need_clear_markers"
+            class="text-center"
+            style="grid-area: 1/1; 
+                   z-index:2;
+                   margin-left: -24px;
+                   margin-right: -24px;
+                   padding-top: 60px;
+                   background-color: rgb(0 0 0 / 80%)">
+         <v-card color="transparent" elevation=0 >
+           <v-card-text width="100%">
+             <div class="white--text">
+               Markers must be cleared before re-linking
+             </div>
+           </v-card-text>
+
+           <v-card-actions>
+             <v-row justify="end">
+               <v-btn tile small color="primary" class="mr-2" @click="cancel_link">Cancel</v-btn>
+               <v-btn tile small color="accent" class="mr-4" @click="clear_markers_and_link" >Clear Markers</v-btn>
+             </v-row>
+           </v-card-actions>
+         </v-card>
+      </div>      
       <div v-if="linking_in_progress"
            class="text-center"
            style="grid-area: 1/1; 

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -111,7 +111,8 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
         self.viewer.add_markers(tbl, marker_name='xy_markers')
         assert 'xy_markers' in self.imviz.app.data_collection.labels
 
-        # Run linking again, does not matter what kind.
+        # Run linking again with the same options as before (otherwise would fail with an error
+        # since markers now exist)
         self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None, error_on_fail=True)
 
         # Ensure display is still customized.

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -126,10 +126,10 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
         assert 'MaskedSubset 1' in all_labels
         assert 'MaskedSubset 2' in all_labels
 
-        # Ensure markers are deleted.
+        # Markers should still exist since the type has not changed
         # Zoom and pan will reset in this case, so we do not check those.
-        assert 'xy_markers' not in self.imviz.app.data_collection.labels
-        assert len(self.viewer._marktags) == 0
+        assert 'xy_markers' in self.imviz.app.data_collection.labels
+        assert len(self.viewer._marktags) == 1
 
         # Pan/zoom.
         self.viewer.center_on((5, 5))
@@ -160,6 +160,15 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
         assert self.viewer.label_mouseover.value == '+1.00000e+00 '
         assert self.viewer.label_mouseover.world_ra_deg == '337.5202808000'
         assert self.viewer.label_mouseover.world_dec_deg == '-20.8333330600'
+
+        # Changing link type will raise an error
+        with pytest.raises(ValueError, match="cannot change link_type"):
+            self.imviz.link_data(link_type='pixels', wcs_fallback_scheme=None, error_on_fail=True)
+
+        self.viewer.remove_markers()
+        self.imviz.link_data(link_type='pixels', wcs_fallback_scheme=None, error_on_fail=True)
+        assert 'xy_markers' not in self.imviz.app.data_collection.labels
+        assert len(self.viewer._marktags) == 0
 
     def test_wcslink_fullblown(self):
         self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None, wcs_use_affine=False,

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -165,7 +165,7 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
         with pytest.raises(ValueError, match="cannot change link_type"):
             self.imviz.link_data(link_type='pixels', wcs_fallback_scheme=None, error_on_fail=True)
 
-        self.viewer.remove_markers()
+        self.viewer.reset_markers()
         self.imviz.link_data(link_type='pixels', wcs_fallback_scheme=None, error_on_fail=True)
         assert 'xy_markers' not in self.imviz.app.data_collection.labels
         assert len(self.viewer._marktags) == 0

--- a/jdaviz/configs/imviz/tests/test_links_control.py
+++ b/jdaviz/configs/imviz/tests/test_links_control.py
@@ -1,3 +1,6 @@
+import pytest
+
+from astropy.table import Table
 from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_WCS
 
 
@@ -11,3 +14,18 @@ class TestLinksControl(BaseImviz_WCS_WCS):
 
         # wcs_use_affine should revert/default to True
         assert lc_plugin.wcs_use_affine is True
+
+        # adding markers should disable changing linking from both UI and API
+        assert lc_plugin.need_clear_markers is False
+        tbl = Table({'x': (0, 0), 'y': (0, 1)})
+        self.viewer.add_markers(tbl, marker_name='xy_markers')
+
+        assert lc_plugin.need_clear_markers is True
+        with pytest.raises(ValueError, match="cannot change linking"):
+            lc_plugin.link_type.selected = 'WCS'
+        assert lc_plugin.link_type.selected == 'Pixels'
+
+        lc_plugin.vue_reset_markers()
+
+        assert lc_plugin.need_clear_markers is False
+        lc_plugin.link_type.selected = 'WCS'

--- a/jdaviz/core/astrowidgets_api.py
+++ b/jdaviz/core/astrowidgets_api.py
@@ -396,6 +396,10 @@ class AstrowidgetsImageViewerMixin:
 
         .. note:: Use `marker` to change marker appearance.
 
+        .. note::
+           Once markers are added, linking cannot be changed.  To change linking options,
+           remove and re-add the markers manually.
+
         Parameters
         ----------
         table : `~astropy.table.Table`

--- a/jdaviz/core/astrowidgets_api.py
+++ b/jdaviz/core/astrowidgets_api.py
@@ -476,6 +476,9 @@ class AstrowidgetsImageViewerMixin:
                     for key, val in self.marker.items():
                         setattr(lyr, {'markersize': 'size'}.get(key, key), val)
 
+            self.jdaviz_app.set_data_visibility(self.reference_id, marker_name,
+                                                visible=True, replace=False)
+
             self._marktags.add(marker_name)
 
     def remove_markers(self, marker_name=None):

--- a/jdaviz/core/astrowidgets_api.py
+++ b/jdaviz/core/astrowidgets_api.py
@@ -10,7 +10,7 @@ from glue.config import colormaps
 from glue.core import Data
 
 from jdaviz.configs.imviz.helper import data_has_valid_wcs, get_top_layer_index
-from jdaviz.core.events import SnackbarMessage
+from jdaviz.core.events import SnackbarMessage, MarkersChangedMessage
 
 __all__ = ['AstrowidgetsImageViewerMixin']
 
@@ -482,6 +482,8 @@ class AstrowidgetsImageViewerMixin:
 
             self._marktags.add(marker_name)
 
+            self.session.hub.broadcast(MarkersChangedMessage(True, sender=self))
+
     def remove_markers(self, marker_name=None):
         """Remove some but not all of the markers by name used when
         adding the markers.
@@ -514,6 +516,8 @@ class AstrowidgetsImageViewerMixin:
         data = self.session.application.data_collection[i]
         self.session.application.data_collection.remove(data)
         self._marktags.remove(marker_name)
+
+        self.session.hub.broadcast(MarkersChangedMessage(len(self._marktags) > 0, sender=self))
 
     def reset_markers(self):
         """Delete all markers."""

--- a/jdaviz/core/astrowidgets_api.py
+++ b/jdaviz/core/astrowidgets_api.py
@@ -475,6 +475,7 @@ class AstrowidgetsImageViewerMixin:
                 if isinstance(lyr, BqplotScatterLayerState) and lyr.layer.label == marker_name:
                     for key, val in self.marker.items():
                         setattr(lyr, {'markersize': 'size'}.get(key, key), val)
+                    break
 
             self.jdaviz_app.set_data_visibility(self.reference_id, marker_name,
                                                 visible=True, replace=False)

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -5,7 +5,8 @@ __all__ = ['NewViewerMessage', 'ViewerAddedMessage', 'ViewerRemovedMessage', 'Lo
            'AddLineListMessage', 'RowLockMessage',
            'SliceSelectSliceMessage',
            'SliceToolStateMessage',
-           'TableClickMessage', 'LinkUpdatedMessage', 'ExitBatchLoadMessage']
+           'TableClickMessage', 'LinkUpdatedMessage', 'ExitBatchLoadMessage',
+           'MarkersChangedMessage']
 
 
 class NewViewerMessage(Message):
@@ -304,3 +305,14 @@ class ExitBatchLoadMessage(Message):
     '''Message generated when exiting the outermost batch_load context manager'''
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+
+class MarkersChangedMessage(Message):
+    '''Message generated when markers are added/removed from an image viewer'''
+    def __init__(self, has_markers, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._has_markers = has_markers
+
+    @property
+    def has_markers(self):
+        return self._has_markers


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request makes waaaay more small changes than I'd like so that markers can stay in place when adding new data to Imviz.  The expected behavior when changing linking type is not clear so is deferred until a refactor - for now a new confirmation overlay is added to the links control plugin to clear markers.  When interacting from the API, markers will need to be cleared manually first (as stated in the error message if failing to do so).  This also fixes a bug where the markers data_collection entry was not showing as loaded in the data menu.

Note: using the plugin API to change the link type will still result in the overlay (and no error).  Calling the astrowidgets API will raise an error (if applicable) and suggest calling `viewer.remove_markers()`.  We could consider other API alternatives for the plugin if this is a concern.

Out of scope but possible follow-up efforts:
* layer icon for marker entry
* plot options support for markers


<img width="993" alt="image" src="https://user-images.githubusercontent.com/877591/201688599-24fba15b-818f-484a-bc90-30e13cb16f8a.png">



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
