### PR TITLE
No more centroiding in Simple Aperture Photometry plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,11 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Simple Aperture Photometry plugin no longer performs centroiding.
+  For radial profile, curve of growth, and table reporting, the aperture
+  center is used instead. For centroiding, use "Recenter" feature in
+  the Subset Tools plugin. [#1841]
+
 Mosviz
 ^^^^^^
 

--- a/docs/imviz/export_data.rst
+++ b/docs/imviz/export_data.rst
@@ -51,11 +51,8 @@ The columns are as follow:
 
 * :attr:`~photutils.aperture.ApertureStats.id`: ID number assigned to the row,
   starting from 1.
-* :attr:`~photutils.aperture.ApertureStats.xcentroid`,
-  :attr:`~photutils.aperture.ApertureStats.ycentroid`: Pixel centroids
-  calculated using moments. This might differ from center of the aperture.
-* :attr:`~photutils.aperture.ApertureStats.sky_centroid`:
-  `~astropy.coordinates.SkyCoord` associated with the centroid.
+* ``xcenter``, ``ycenter``: Center of the aperture (0-indexed).
+* ``sky_center``: `~astropy.coordinates.SkyCoord` associated with the center.
   If WCS is not available, this field is `None`.
 * ``background``: The value from :guilabel:`Background value`, with unit attached.
 * :attr:`~photutils.aperture.ApertureStats.sum`: Sum of flux in the aperture.
@@ -108,9 +105,8 @@ The columns are as follow:
 .. note::
 
     Aperture sum and statistics are done on the originally drawn aperture only.
-    Even though centroid is calculated, it is not used to move the aperture
-    to the new center. However, radial profiles (including Gaussian fitting, if any)
-    and curve of growth do use the centroid as zero-point on the X-axis.
+    You can use the :ref:`imviz-subset-plugin` plugin to center it first on the
+    object of interest, if you wish.
 
 Once you have the results in a table, you can further manipulated them as
 documented in :ref:`astropy:astropy-table`.

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -137,8 +137,8 @@ an interactively selected region. A typical workflow is as follows:
 4. Select the desired region using the :guilabel:`Subset` dropdown menu.
    You can use the :ref:`imviz-subset-plugin` plugin to center it first on the
    object of interest using its center of mass, if you wish.
-   Depending on the object, that may take several interations for recentering
-   to converge; or it may never converge at all.
+   Depending on the object, it may take several iterations for re-centering
+   to converge, or it may never converge at all.
 5. If you want to subtract background before performing photometry,
    you have the following 3 options. Otherwise if your image is already
    background subtracted, choose "Manual" and leave the background set at 0:

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -135,6 +135,10 @@ an interactively selected region. A typical workflow is as follows:
 2. Draw a region over the object of interest (see :ref:`imviz_defining_spatial_regions`).
 3. Select the desired image using the :guilabel:`Data` dropdown menu.
 4. Select the desired region using the :guilabel:`Subset` dropdown menu.
+   You can use the :ref:`imviz-subset-plugin` plugin to center it first on the
+   object of interest using its center of mass, if you wish.
+   Depending on the object, that may take several interations for recentering
+   to converge; or it may never converge at all.
 5. If you want to subtract background before performing photometry,
    you have the following 3 options. Otherwise if your image is already
    background subtracted, choose "Manual" and leave the background set at 0:
@@ -232,7 +236,7 @@ catalog dropdown menu.
     This plugin is still under active development. As a result, the search only uses the SDSS DR17 catalog
     and works best when you only have a single image loaded in a viewer.
 
-To load a catalog from a supported `JWST ECSV catalog file <https://jwst-pipeline.readthedocs.io/en/latest/jwst/source_catalog/main.html#output-products>`_, choose "From File...".  
+To load a catalog from a supported `JWST ECSV catalog file <https://jwst-pipeline.readthedocs.io/en/latest/jwst/source_catalog/main.html#output-products>`_, choose "From File...".
 The file must be able to be parsed by `astropy.table.Table.read` and contain a column labeled 'sky_centroid'.
 Clicking :guilabel:`SEARCH` will show markers for any entry within the filtered zoom window.
 

--- a/docs/known_bugs.rst
+++ b/docs/known_bugs.rst
@@ -143,14 +143,6 @@ to show the markers, or not at all. This is a known bug reported in
 https://github.com/glue-viz/glue-jupyter/issues/243 . If you encounter this,
 try a different OS/browser combo.
 
-Simple Aperture Photometry Plugin and dithered images
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Due to a known bug reported in https://github.com/glue-viz/glue-astronomy/issues/52 ,
-aperture photometry and radial profile will report inaccurate results when you
-calculate them on dithered images linked by WCS *unless* you are on the reference image
-(this is usually the first loaded image).
-
 .. _known_issues_specviz:
 
 Specviz

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -141,7 +141,7 @@
       <jupyter-widget :widget="radial_plot" style="width: 100%; height: 480px" />
     </v-row>
 
-    <div v-if="plot_available && fit_radial_profile">
+    <div v-if="plot_available && fit_radial_profile && current_plot_type != 'Curve of Growth'">
       <j-plugin-section-header>Gaussian Fit Results</j-plugin-section-header>
       <v-row no-gutters>
         <v-col cols=6><U>Result</U></v-col>

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -277,11 +277,11 @@ class TestParseImage:
         assert_allclose(phot_plugin.flux_scaling, 0.003631)
         phot_plugin.vue_do_aper_phot()
         tbl = imviz_helper.get_aperture_photometry_results()
-        assert_quantity_allclose(tbl[0]['xcentroid'], 970.935492 * u.pix)
-        assert_quantity_allclose(tbl[0]['ycentroid'], 1116.967619 * u.pix)
-        sky = tbl[0]['sky_centroid']
+        assert_quantity_allclose(tbl[0]['xcenter'], 970.95 * u.pix)
+        assert_quantity_allclose(tbl[0]['ycenter'], 1116.05 * u.pix)
+        sky = tbl[0]['sky_center']
         assert_allclose(sky.ra.deg, 80.48419863)
-        assert_allclose(sky.dec.deg, -69.494592)
+        assert_allclose(sky.dec.deg, -69.494608)
         data_unit = u.MJy / u.sr
         assert_quantity_allclose(tbl[0]['background'], 0.1741226315498352 * data_unit)
         assert_quantity_allclose(tbl[0]['sum'], 4.486487e-11 * u.MJy, rtol=1e-6)
@@ -402,9 +402,9 @@ class TestParseImage:
         assert_allclose(phot_plugin.pixel_area, 0.0025)  # Not used but still auto-populated
         phot_plugin.vue_do_aper_phot()
         tbl = imviz_helper.get_aperture_photometry_results()
-        assert_quantity_allclose(tbl[0]['xcentroid'], 1487.60825422 * u.pix, atol=2 * u.pix)
-        assert_quantity_allclose(tbl[0]['ycentroid'], 2573.83983184 * u.pix, atol=2 * u.pix)
-        sky = tbl[0]['sky_centroid']
+        assert_quantity_allclose(tbl[0]['xcenter'], 1488.5 * u.pix, atol=2 * u.pix)
+        assert_quantity_allclose(tbl[0]['ycenter'], 2576 * u.pix, atol=2 * u.pix)
+        sky = tbl[0]['sky_center']
         assert_allclose(sky.ra.deg, 3.684062989070131, rtol=1e-3)
         assert_allclose(sky.dec.deg, 10.802045612042956, rtol=1e-3)
         data_unit = u.electron / u.s


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to remove partial centroiding in Simple Aperture Photometry plugin. We reintroduce fitting of `mean` in Gaussian (the code was in one of the commits in #1409 but later removed before merged but still in Git history). Radial profile was added in #1030 and this plugin in #938 (there were other PRs too in between).

Also removes an outdated known issue that was already fixed in #1524 .

Fixed a minor bug where Gaussian Fit section shows on GUI even when not applicable. This happens when user enables Gaussian fitting for radial profile, and then redid the calculation with Curve of Growth immediately after without disabling Gaussian fitting option.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1442 

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-2914)
