### PR TITLE
Mosviz Retrieve SourceID from meta

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Imviz
 
 Mosviz
 ^^^^^^
+- Reliably retrieves identifier using each datasets' metadata entry. [#1851]
 
 Specviz
 ^^^^^^^

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -405,7 +405,11 @@ class Application(VuetifyTemplate, HubListener):
 
         dc = self.data_collection
         # This will need to be changed for cubeviz to support multiple cubes
-        ref_data = dc[reference_data] if reference_data else dc[0]
+        default_refdata_index = 0
+        if self.config == 'mosviz':
+            # In Mosviz, first data is always MOS Table. Use the next data
+            default_refdata_index = 1
+        ref_data = dc[reference_data] if reference_data else dc[default_refdata_index]
         linked_data = dc[data_to_be_linked] if data_to_be_linked else dc[-1]
 
         if 'Trace' in linked_data.meta:

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -90,7 +90,7 @@ class Mosviz(ConfigHelper, LineListMixin):
     def _initialize_table(self, label="MOS Table", table_viewer_reference_name='table-viewer'):
         '''
         Setup the MOS Table data container and add it to the viewer
-        
+
         Parameters
         ----------
         label : str

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -10,6 +10,7 @@ from astropy.coordinates import SkyCoord
 from astropy.table import QTable
 from astropy.utils.decorators import deprecated
 from echo import delay_callback
+from glue.core.data import Data
 from glue.core.exceptions import IncompatibleAttribute
 
 from jdaviz.core.helpers import ConfigHelper
@@ -83,7 +84,25 @@ class Mosviz(ConfigHelper, LineListMixin):
 
         self._update_in_progress = False
 
+        self._initialize_table()
         self._default_visible_columns = []
+
+    def _initialize_table(self, label="MOS Table", table_viewer_reference_name='table-viewer'):
+        '''
+        Setup the MOS Table data container and add it to the viewer
+        
+        Parameters
+        ----------
+        label : str
+            The Glue Data Label to reference the table data as
+        table_viewer_reference_name : str
+            The reference name of the table viewer to add this data to
+        '''
+        table_data = Data(label=label)
+        self.app.add_data(table_data, notify_done=False)
+
+        # Add the table to the table viewer
+        self.app.get_viewer(table_viewer_reference_name).add_data(table_data)
 
     def _row_lock_changed(self, msg):
         self._freeze_states_on_row_change = msg.is_locked
@@ -378,7 +397,7 @@ class Mosviz(ConfigHelper, LineListMixin):
 
         table_data = self.app.data_collection['MOS Table']
         redshifts = np.asarray([_get_sp_attribute(table_data, row, 'redshift', 0)
-                                for row in range(table_data.size)])
+                                for row in range(int(table_data.size))])
         self._add_or_update_column(column_name='Redshift', data=redshifts,
                                    show=np.any(redshifts != 0))
 
@@ -458,18 +477,14 @@ class Mosviz(ConfigHelper, LineListMixin):
             else:
                 self.load_images(images, images_label)
 
-            if images is not None and not self._shared_image:
-                self.load_metadata(images, ids=images)
-
             self.load_2d_spectra(spectra_2d, spectra_2d_label)
             self.load_1d_spectra(spectra_1d, spectra_1d_label)
-            self.load_metadata(spectra_2d, spectra=True)
+            self.load_metadata()
 
         elif spectra_1d is not None and spectra_2d is not None:
-            self.load_2d_spectra(spectra_2d, spectra_2d_label)
             self.load_1d_spectra(spectra_1d, spectra_1d_label)
-            self.load_metadata(spectra_2d, spectra=True)
-            self.load_metadata(spectra_1d, spectra=True, sp1d=True, ids=spectra_1d)
+            self.load_2d_spectra(spectra_2d, spectra_2d_label)
+            self.load_metadata()
 
         elif spectra_1d and images:
             self.load_1d_spectra(spectra_1d, spectra_1d_label)
@@ -566,25 +581,11 @@ class Mosviz(ConfigHelper, LineListMixin):
         """
         self.load_data(directory=directory, instrument=instrument)
 
-    def load_metadata(self, data_obj, ids=None, spectra=False, sp1d=False):
+    def load_metadata(self):
         """
-        Load and parse a set of FITS objects to extract any relevant metadata.
-
-        Parameters
-        ----------
-        data_obj : list or str
-            A list of FITS objects with parseable headers. Alternatively,
-            can be a string file path.
-        ids : list of str
-            A list with identification strings to be used to label mosviz
-            table rows. Typically, a list with file names.
-        spectra : Boolean
-            In case the FITS objects are related to spectral data.
-        sp1d : Boolean
-            In case the FITS objects are related to 1d spectral data.
+        Parse the internal meta for our expected information
         """
-        self.app.load_data(data_obj, ids=ids, spectra=spectra, sp1d=sp1d,
-                           parser_reference="mosviz-metadata-parser")
+        self.app.load_data(file_obj=None, parser_reference="mosviz-metadata-parser")
 
     def load_1d_spectra(self, data_obj, data_labels=None):
         """

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -483,11 +483,11 @@ def mos_meta_parser(app, data_obj=None, ids=None):
 
         # metadata taken from 2d spectra
         if "2D Spectra" in current_columns:
-            filters = query_metadata_by_component(app, "FILTER", "2D Spectra", FALLBACK_NAME) 
+            filters = query_metadata_by_component(app, "FILTER", "2D Spectra", FALLBACK_NAME)
             gratings = query_metadata_by_component(app, "GRATING", "2D Spectra", FALLBACK_NAME)
 
             filters_gratings = [(f+'/'+g) for f, g in zip(filters, gratings)]
-            
+
             _add_to_table(app, filters_gratings, "Filter/Grating")
 
         # source name and coordinates are taken from image headers, if present
@@ -576,7 +576,7 @@ def _get_source_identifiers(app, data_type, hdus=None, filepaths=None,
     except Exception:
         pass
     # If we fellback for ALL sources, try searching by hdu, if provided any
-    if ids == None or set(ids) == set(FALLBACK_NAME):
+    if ids is None or set(ids) == set(FALLBACK_NAME):
         if hdus is not None:
             ids = _get_source_identifiers_by_hdu(hdus, filepaths, header_keys)
         # If we weren't given hdus to fallback on, then just return our Fallback value
@@ -612,7 +612,7 @@ def _get_source_identifiers_by_hdu(data_obj, filepaths=None,
     # one for the upcoming loop
     if not (isinstance(header_keys, Iterable) and not isinstance(header_keys, (str, dict))):
         header_keys = [header_keys]
- 
+
     # Prepare HDUs:
     # Coerce into list if needed
     if not isinstance(data_obj, (list, tuple, SpectrumCollection)):

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -5,7 +5,6 @@ import os
 from pathlib import Path
 import warnings
 
-import numpy as np
 from astropy import units as u
 from astropy.io import fits
 from astropy.io.registry import IORegistryError
@@ -161,6 +160,11 @@ def mos_nirspec_directory_parser(app, data_obj, data_labels=None):
         elif 's2d' in file_path:
             spectra_2d.append(file_path)
 
+    spectra_1d.sort()
+    spectra_2d.sort()
+    mos_spec1d_parser(app, spectra_1d)
+    mos_spec2d_parser(app, spectra_2d)
+
     # Load images, if present
     image_path = None
 
@@ -175,7 +179,6 @@ def mos_nirspec_directory_parser(app, data_obj, data_labels=None):
         # The amount of images needs to be equal to the amount of rows
         # of the other columns in the table
         if len(images) == len(spectra_1d):
-            mos_meta_parser(app, images, ids=images)
             mos_image_parser(app, images)
         else:
             msg = ("The number of images in this directory does not match the"
@@ -184,19 +187,7 @@ def mos_nirspec_directory_parser(app, data_obj, data_labels=None):
             msg = SnackbarMessage(msg, color='warning', sender=app)
             app.hub.broadcast(msg)
 
-    spectra_1d.sort()
-    spectra_2d.sort()
-    n_1d_loaded = mos_spec1d_parser(app, spectra_1d)
-    n_2d_loaded = mos_spec2d_parser(app, spectra_2d)
-    # Handle applying metadata to multiple rows, for multi-object files
-    repeat_1d = 1
-    repeat_2d = 1
-    if len(spectra_1d) == 1 and n_1d_loaded > 1:
-        repeat_1d = n_1d_loaded
-    if len(spectra_2d) == 1 and n_2d_loaded > 1:
-        repeat_2d = n_2d_loaded
-    mos_meta_parser(app, spectra_2d, spectra=True, repeat=repeat_2d)
-    mos_meta_parser(app, spectra_1d, spectra=True, sp1d=True, repeat=repeat_1d)
+    mos_meta_parser(app)
 
 
 @data_parser_registry("mosviz-spec1d-parser")
@@ -463,90 +454,148 @@ def mos_image_parser(app, data_obj, data_labels=None, share_image=0,
 
 
 @data_parser_registry("mosviz-metadata-parser")
-def mos_meta_parser(app, data_obj, ids=None, spectra=False, sp1d=False, repeat=1):
+def mos_meta_parser(app, data_obj=None, ids=None):
     """
-    Attempts to parse MOS FITS header metadata.
+    Extracts specific metadata from each data entry's .meta
 
     Parameters
     ----------
     app : `~jdaviz.app.Application`
         The application-level object used to reference the viewers.
     data_obj : str or list or HDUList
-        File path, list, or an HDUList to extract metadata from.
+        Optional fallback arg for Identifier column
+        File path, list, or an HDUList to extract metadata from if
+        metadata isn't found in Data.meta, search for metadata
     ids : list of str
+        Optional fallback arg for Identifier column
         A list with identification strings to be used to label mosviz
-        table rows. Typically, a list with file names.
-    spectra : bool, optional
-        In case the FITS objects are related to spectral data.
-    sp1d : bool, optional
-        Indicates if the input ``data_obj`` is a 1D rather than 2D spectrum.
-    repeat : int, optional
-        If greater than 1, indicates that the input file metadata applies
-        to multiple table rows.
+        table rows. Typically, a list with file names. Used in combination
+        with data_obj for fallback
     """
-
-    if data_obj is None:
-        return
-
-    # Coerce into list if needed
-    if not isinstance(data_obj, (list, tuple, SpectrumCollection)):
-        data_obj = [data_obj]
-
-    data_obj = [fits.open(x) if _check_is_file(x) else x for x in data_obj]
-
-    if np.all([isinstance(x, fits.HDUList) for x in data_obj]):
-
-        # metadata taken from 2d spectra
-        if spectra and not sp1d:
-            filters = [x[0].header.get("FILTER", FALLBACK_NAME) for x in data_obj]
-            gratings = [x[0].header.get("GRATING", FALLBACK_NAME) for x in data_obj]
-
-            filters_gratings = [(f+'/'+g) for f, g in zip(filters, gratings)] * repeat
-
-            [x.close() for x in data_obj]
-
-        # source name can be taken from 1d spectra
-        elif spectra and sp1d:
-            names = _get_source_identifiers_by_hdu([x[0] for x in data_obj], ids) * repeat
-
-        # source name and coordinates are taken from image headers, if present
-        else:
-            ra = [x[0].header.get("OBJ_RA", float("nan")) for x in data_obj] * repeat
-            dec = [x[0].header.get("OBJ_DEC", float("nan")) for x in data_obj] * repeat
-            names = _get_source_identifiers_by_hdu([x[0] for x in data_obj], ids) * repeat
-
-        [x.close() for x in data_obj]
-
-    else:
-        # TODO: Come up with more robust metadata parsing, perhaps from
-        # the spectra files.
-        warnings.warn("Could not parse metadata from input images.")
-        return
 
     with app.data_collection.delay_link_manager_update():
 
-        # this conditional must mirror the one above
-        if spectra and not sp1d:
+        current_columns = [comp.label for comp in app.data_collection['MOS Table'].main_components]
+        # source name can be taken from 1d spectra
+        if "1D Spectra" in current_columns:
+            names = _get_source_identifiers(app, "1D Spectra", data_obj, ids)
+            _add_to_table(app, names, "Identifier")
+
+        # metadata taken from 2d spectra
+        if "2D Spectra" in current_columns:
+            filters = query_metadata_by_component(app, "FILTER", "2D Spectra", FALLBACK_NAME) 
+            gratings = query_metadata_by_component(app, "GRATING", "2D Spectra", FALLBACK_NAME)
+
+            filters_gratings = [(f+'/'+g) for f, g in zip(filters, gratings)]
+            
             _add_to_table(app, filters_gratings, "Filter/Grating")
-        elif spectra and sp1d:
-            _add_to_table(app, names, "Identifier")
-        else:
-            _add_to_table(app, names, "Identifier")
+
+        # source name and coordinates are taken from image headers, if present
+        if "Images" in current_columns:
+            ra = query_metadata_by_component(app, "OBJ_RA", "Images", float("nan"))
+            dec = query_metadata_by_component(app, "OBJ_DEC", "Images", float("nan"))
             _add_to_table(app, ra, "R.A.")
             _add_to_table(app, dec, "Dec.")
 
 
-def _get_source_identifiers_by_hdu(hdus, filepaths=None,
+def query_metadata_by_component(app, keys, data_type, fallback=FALLBACK_NAME):
+    """
+    Searches and returns metadata values for a specific data component (type)
+
+    If multiple keys are specified, the first found will be returned based on the order
+    keys are provided
+
+    Parameters
+    ----------
+    app : `~jdaviz.app.Application`
+        The application-level object used to reference the viewers.
+    keys : str or list
+        Metadata keywords to search for
+    data_type : str
+        The type of data to search for the Source ID keywords in. Can be one of:
+        "1D Spectra", "2D Spectra", "Images"
+    fallback : str
+        The value to return in the event the keyword could not be found
+    """
+
+    metadata_list = list()
+    # If the user only provided a key that's not already in a container or list, put it in
+    # one for the upcoming loop
+    if not isinstance(keys, Iterable) or isinstance(keys, str):
+        keys = [keys]
+
+    for data in app._jdaviz_helper.get_column(data_type):
+        meta = app.data_collection[data].meta
+
+        # Search all given keys to see if they exist. Return the first hit
+        key_found = False
+        for key in keys:
+            if key in meta:
+                metadata_list.append(meta.get(key))
+                key_found = True
+                break
+            elif key in meta.get(PRIHDR_KEY, ()):
+                metadata_list.append(meta[PRIHDR_KEY].get(key))
+                key_found = True
+                break
+
+        # If none exist, default to fallback
+        if not key_found:
+            metadata_list.append(fallback)
+
+    return metadata_list
+
+
+def _get_source_identifiers(app, data_type, hdus=None, filepaths=None,
+                            header_keys=['SOURCEID', 'OBJECT']):
+    """
+    Helper method to search for the Source Identifier fields.
+    Searches the metadata first, then falls back to manually searching hdus (if given any).
+    Missing Source IDs should not prevent mosviz from loading
+
+    Parameters
+    ----------
+    app : `~jdaviz.app.Application`
+        The application-level object used to reference the viewers.
+    data_type : str
+        The type of data to search for the Source ID keywords in. Can be one of:
+        "1D Spectra", "2D Spectra", "Images"
+    hdus : str or list or HDUList
+        Optional fallback arg
+        File path, list, or an HDUList to extract metadata from if
+        metadata isn't found in Data.meta, search for metadata
+    filepaths : list of str
+        Optional fallback arg
+        A list with identification strings to be used to label mosviz
+        table rows. Typically, a list with file names. Used in combination
+        with data_obj for fallback
+    """
+    ids = None
+    try:
+        ids = query_metadata_by_component(app, keys=header_keys, data_type=data_type)
+    except Exception:
+        pass
+    # If we fellback for ALL sources, try searching by hdu, if provided any
+    if ids == None or set(ids) == set(FALLBACK_NAME):
+        if hdus is not None:
+            ids = _get_source_identifiers_by_hdu(hdus, filepaths, header_keys)
+        # If we weren't given hdus to fallback on, then just return our Fallback value
+        else:
+            ids = [FALLBACK_NAME] * len(app._jdaviz_helper.get_column(data_type))
+    return ids
+
+
+def _get_source_identifiers_by_hdu(data_obj, filepaths=None,
                                    header_keys=['SOURCEID', 'OBJECT'],
                                    allow_duplicates=False):
     """
     Attempts to extract a list of source identifiers via different header values.
+    Searches HDU 0 for each HDUL provided
 
     Parameters
     ----------
-    hdus : list of HDU
-        A list of HDUs (NOT an HDUList!) to check the header of. Filtering should
-        be done in advance to decide which HDUs to check against (e.g., SCI only).
+    data_obj : str or list or HDUList
+        File path, list, or an HDUList to extract metadata from.
     filepaths : list of str, optional
         A list of filepaths to fallback on if no header values are identified.
     header_keys: str or list of str, optional
@@ -563,28 +612,34 @@ def _get_source_identifiers_by_hdu(hdus, filepaths=None,
     # one for the upcoming loop
     if not (isinstance(header_keys, Iterable) and not isinstance(header_keys, (str, dict))):
         header_keys = [header_keys]
+ 
+    # Prepare HDUs:
+    # Coerce into list if needed
+    if not isinstance(data_obj, (list, tuple, SpectrumCollection)):
+        data_obj = [data_obj]
+    hdus = [fits.open(x)[0] if _check_is_file(x) else x for x in data_obj]
     for indx, hdu in enumerate(hdus):
         try:
-            src_name = None
             # Search all given keys to see if they exist. Return the first hit
+            key_found = False
             for key in header_keys:
                 if key in hdu.header:
+                    key_found = True
                     src_name = hdu.header.get(key)
+                    if not allow_duplicates and src_name in src_names:
+                        continue
+                    else:
+                        src_names.append(src_name)
                     break
             # If none exist, default to fallback
-            if not src_name:
-                # Fallback 1: filepath if only one is given
-                # Fallback 2: filepath at indx, if list of files given
-                # Fallback 3: If nothing else, just our fallback value
-                src_name = (
+            # Fallback 1: filepath if only one is given
+            # Fallback 2: filepath at indx, if list of files given
+            # Fallback 3: If nothing else, just our fallback value
+            if not key_found:
+                src_names.append(
                     os.path.basename(filepaths) if type(filepaths) is str
                     else os.path.basename(filepaths[indx]) if type(filepaths) is list
                     else FALLBACK_NAME)
-                src_names.append(src_name)
-                continue
-            if not allow_duplicates and src_name in src_names:
-                continue
-            src_names.append(src_name)
         except Exception:
             # Source ID lookup shouldn't ever prevent target from loading. Downgrade all errors to
             # warnings and use fallback
@@ -759,13 +814,11 @@ def mos_niriss_parser(app, data_dir, instrument=None,
             add_to_glue[image_label] = image_data
 
     # initialize lists of data to be shown in table viewer
-    source_ids = []
     ras = []
     decs = []
     image_add = []
     spec_labels_1d = []
     spec_labels_2d = []
-    filters = []
 
     # Parse 2D spectra
     file_labels_2d = [k for k in files_by_labels.keys() if k.startswith("2D")]
@@ -787,8 +840,6 @@ def mos_niriss_parser(app, data_dir, instrument=None,
                 sci_hdus = []
                 wav_hdus = {}
                 for i in range(len(temp)):
-                    if i == 0:
-                        filter = temp[0].header["FILTER"]
                     if "EXTNAME" in temp[i].header:
                         if temp[i].header["EXTNAME"] == "SCI":
                             if cat_id_dict is not None:
@@ -796,9 +847,6 @@ def mos_niriss_parser(app, data_dir, instrument=None,
                                     continue
                             sci_hdus.append(i)
                             wav_hdus[i] = ('WAVELENGTH', temp[i].header['EXTVER'])
-
-                # Now get a Spectrum1D object for each matching SCI HDU
-                source_ids.extend(_get_source_identifiers_by_hdu([temp[sci] for sci in sci_hdus]))
 
                 for sci in sci_hdus:
                     if temp[sci].header["SPORDER"] == 1:
@@ -830,6 +878,9 @@ def mos_niriss_parser(app, data_dir, instrument=None,
                         # update labels for table viewer
                         if cat_id_dict is not None:
                             ra, dec = cat_id_dict[temp[sci].header["SOURCEID"]]
+                            # Store catalog's RA/Dec entry to be available later
+                            spec2d.meta['catalog_ra'] = ra
+                            spec2d.meta['catalog_dec'] = dec
                             ras.append(ra)
                             decs.append(dec)
 
@@ -837,7 +888,6 @@ def mos_niriss_parser(app, data_dir, instrument=None,
                             image_add.append(image_dict[filter_name])
 
                         spec_labels_2d.append(label)
-                        filters.append(filter)
 
     # Parse 1D spectra
     file_labels_1d = [k for k in files_by_labels.keys() if k.startswith("1D")]
@@ -896,15 +946,19 @@ def mos_niriss_parser(app, data_dir, instrument=None,
     with app.data_collection.delay_link_manager_update():
         for label, data in add_to_glue.items():
             app.add_data(data, label, notify_done=False)
+        _add_to_table(app, spec_labels_1d, "1D Spectra")
+        _add_to_table(app, spec_labels_2d, "2D Spectra")
+        _add_to_table(app, image_add, "Images")
 
         # We then populate the table inside this context manager as
         # _add_to_table does operations that also trigger link manager updates.
-        _add_to_table(app, source_ids, "Identifier")
-        _add_to_table(app, ras, "R.A.")
-        _add_to_table(app, decs, "Dec.")
-        _add_to_table(app, image_add, "Images")
-        _add_to_table(app, spec_labels_1d, "1D Spectra")
-        _add_to_table(app, spec_labels_2d, "2D Spectra")
-        _add_to_table(app, filters, "Filter/Grating")
+        meta_names = _get_source_identifiers(app, "2D Spectra")
+        _add_to_table(app, meta_names, "Identifier")
+        meta_filters = query_metadata_by_component(app, 'FILTER', "2D Spectra")
+        _add_to_table(app, meta_filters, "Filter/Grating")
+        meta_ra = query_metadata_by_component(app, 'catalog_ra', "2D Spectra")
+        _add_to_table(app, meta_ra, "R.A.")
+        meta_dec = query_metadata_by_component(app, 'catalog_dec', "2D Spectra")
+        _add_to_table(app, meta_dec, "Dec.")
 
     app.get_viewer(table_viewer_reference_name)._shared_image = True

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -573,10 +573,10 @@ def _get_source_identifiers(app, data_type, hdus=None, filepaths=None,
     ids = None
     try:
         ids = query_metadata_by_component(app, keys=header_keys, data_type=data_type)
+        if ids is None or set(ids) == set(FALLBACK_NAME):
+            raise LookupError
     except Exception:
-        pass
-    # If we fellback for ALL sources, try searching by hdu, if provided any
-    if ids is None or set(ids) == set(FALLBACK_NAME):
+        # If we fellback for ALL sources, try searching by hdu, if provided any
         if hdus is not None:
             ids = _get_source_identifiers_by_hdu(hdus, filepaths, header_keys)
         # If we weren't given hdus to fallback on, then just return our Fallback value

--- a/jdaviz/configs/mosviz/tests/test_data_loading.py
+++ b/jdaviz/configs/mosviz/tests/test_data_loading.py
@@ -15,9 +15,10 @@ def test_load_spectrum1d(mosviz_helper, spectrum1d):
     mosviz_helper.load_data(spectra_1d=spectrum1d, spectra_1d_label=label)
 
     assert len(mosviz_helper.app.data_collection) == 2
-    dc_0 = mosviz_helper.app.data_collection[0]
-    assert dc_0.label == label
-    assert dc_0.meta['uncertainty_type'] == 'std'
+    assert mosviz_helper.app.data_collection[0].label == "MOS Table"
+    dc_1 = mosviz_helper.app.data_collection[1]
+    assert dc_1.label == label
+    assert dc_1.meta['uncertainty_type'] == 'std'
 
     table = mosviz_helper.app.get_viewer('table-viewer')
     table.widget_table.vue_on_row_clicked(0)
@@ -36,10 +37,11 @@ def test_load_image(mosviz_helper, mos_image):
     mosviz_helper.load_images(mos_image, data_labels=label)
 
     assert len(mosviz_helper.app.data_collection) == 2
-    dc_0 = mosviz_helper.app.data_collection[0]
-    assert dc_0.label == f"{label} 0"
-    assert PRIHDR_KEY not in dc_0.meta
-    assert dc_0.meta['RADESYS'] == 'ICRS'
+    assert mosviz_helper.app.data_collection[0].label == "MOS Table"
+    dc_1 = mosviz_helper.app.data_collection[1]
+    assert dc_1.label == f"{label} 0"
+    assert PRIHDR_KEY not in dc_1.meta
+    assert dc_1.meta['RADESYS'] == 'ICRS'
 
     table = mosviz_helper.app.get_viewer('table-viewer')
     table.widget_table.vue_on_row_clicked(0)
@@ -57,9 +59,10 @@ def test_load_spectrum_collection(mosviz_helper, spectrum_collection):
 
     # +1 for the table viewer
     assert len(mosviz_helper.app.data_collection) == len(spectrum_collection) + 1
-    dc_0 = mosviz_helper.app.data_collection[0]
-    assert dc_0.label == labels[0]
-    assert dc_0.meta['uncertainty_type'] == 'std'
+    assert mosviz_helper.app.data_collection[0].label == "MOS Table"
+    dc_1 = mosviz_helper.app.data_collection[1]
+    assert dc_1.label == labels[0]
+    assert dc_1.meta['uncertainty_type'] == 'std'
 
     table = mosviz_helper.app.get_viewer('table-viewer')
     table.select_row(0)
@@ -76,9 +79,10 @@ def test_load_list_of_spectrum1d(mosviz_helper, spectrum1d):
     mosviz_helper.load_1d_spectra(spectra, data_labels=labels)
 
     assert len(mosviz_helper.app.data_collection) == 4
-    dc_0 = mosviz_helper.app.data_collection[0]
-    assert dc_0.label == labels[0]
-    assert dc_0.meta['uncertainty_type'] == 'std'
+    assert mosviz_helper.app.data_collection[0].label == "MOS Table"
+    dc_1 = mosviz_helper.app.data_collection[1]
+    assert dc_1.label == labels[0]
+    assert dc_1.meta['uncertainty_type'] == 'std'
 
     table = mosviz_helper.app.get_viewer('table-viewer')
     table.widget_table.vue_on_row_clicked(0)
@@ -95,9 +99,10 @@ def test_load_mos_spectrum2d(mosviz_helper, mos_spectrum2d):
     mosviz_helper.load_data(spectra_2d=mos_spectrum2d, spectra_2d_label=label)
 
     assert len(mosviz_helper.app.data_collection) == 2
-    dc_0 = mosviz_helper.app.data_collection[0]
-    assert dc_0.label == label
-    assert dc_0.meta['INSTRUME'] == 'nirspec'
+    assert mosviz_helper.app.data_collection[0].label == "MOS Table"
+    dc_1 = mosviz_helper.app.data_collection[1]
+    assert dc_1.label == label
+    assert dc_1.meta['INSTRUME'] == 'nirspec'
 
     table = mosviz_helper.app.get_viewer('table-viewer')
     table.widget_table.vue_on_row_clicked(0)
@@ -159,11 +164,10 @@ def test_load_single_image_multi_spec(mosviz_helper, mos_image, spectrum1d, mos_
 
     # Test that loading is still possible after previous crash:
     # https://github.com/spacetelescope/jdaviz/issues/364
-    with pytest.raises(ValueError, match="No data found with the label 'MOS Table'"):
+    with pytest.raises(ValueError, match="incompatible with the dimensions of this data:"):
         mosviz_helper.load_data(spectra1d, spectra2d, images=[])
 
-    with pytest.warns(UserWarning, match='Could not parse metadata from input images'):
-        mosviz_helper.load_data(spectra1d, spectra2d, images=mos_image, images_label=label)
+    mosviz_helper.load_data(spectra1d, spectra2d, images=mos_image, images_label=label)
 
     assert mosviz_helper.app.get_viewer("table-viewer").figure_widget.highlighted == 0
     assert len(mosviz_helper.app.data_collection) == 8

--- a/jdaviz/configs/mosviz/tests/test_parsers.py
+++ b/jdaviz/configs/mosviz/tests/test_parsers.py
@@ -41,18 +41,20 @@ def test_nirspec_parser(mosviz_helper, tmp_path, instrument_arg):
     assert len(mosviz_helper.app.data_collection["MOS Table"].meta) == 0
 
     # Check that the data was loaded in the same order we expect.
-    # MOS table always loads first, followed by 5 sets of Images, 1D, then 2D spectra
-    #   which results in Images beginning at index 1, 1D at index 6, 2D at index 11
-    assert mosviz_helper.app.data_collection[15].meta['SOURCEID'] == 2315
+    # MOS table always loads first, followed by 5 sets of 1D Spectra, 2D Spectra, then Images
+    #   which results in 1D beginning at index 1, 2D at index 6, and Images at index 11
+    assert mosviz_helper.app.data_collection[5].meta['SOURCEID'] == 2315
     for i in range(0, 5):
-        assert mosviz_helper.app.data_collection[i+1].label == f"Image {i}"
-
-        spec1d = mosviz_helper.app.data_collection[i+6]
+        # Check 1D spectra
+        spec1d = mosviz_helper.app.data_collection[i+1]
         assert spec1d.label == f"1D Spectrum {i}"
-        spec2d = mosviz_helper.app.data_collection[i+11]
+        # Check 2D spectra
+        spec2d = mosviz_helper.app.data_collection[i+6]
         assert spec2d.label == f"2D Spectrum {i}"
         assert int(spec1d.meta['SOURCEID']) == int(spec2d.meta['SOURCEID'])
         assert int(spec1d.meta['mosviz_row']) == int(spec2d.meta['mosviz_row'])
+        # Check images
+        assert mosviz_helper.app.data_collection[i+11].label == f"Image {i}"
 
     # Check for expected metadata values
     for data in mosviz_helper.app.data_collection:
@@ -128,17 +130,17 @@ def test_niriss_parser(mosviz_helper, tmp_path):
     mosviz_helper.load_data(directory=tmp_path, instrument="niriss")
     assert len(mosviz_helper.app.data_collection) == 10
 
-    # The image should be the first in the data collection
-    dc_0 = mosviz_helper.app.data_collection[0]
-    assert dc_0.label == "Image jw01324-o001 F200W"
-    assert PRIHDR_KEY not in dc_0.meta
-    assert COMMENTCARD_KEY not in dc_0.meta
-    assert dc_0.meta['bunit_data'] == 'MJy/sr'  # ASDF metadata
-
-    # The MOS Table should be last in the data collection
-    dc_tab = mosviz_helper.app.data_collection[-1]
+    # The MOS Table should be first in the data collection
+    dc_tab = mosviz_helper.app.data_collection[0]
     assert dc_tab.label == "MOS Table"
     assert len(dc_tab.meta) == 0
+
+    # The image should be the first "real data" in the data collection
+    dc_1 = mosviz_helper.app.data_collection[1]
+    assert dc_1.label == "Image jw01324-o001 F200W"
+    assert PRIHDR_KEY not in dc_1.meta
+    assert COMMENTCARD_KEY not in dc_1.meta
+    assert dc_1.meta['bunit_data'] == 'MJy/sr'  # ASDF metadata
 
     # Test all the spectra exist
     for dispersion in ('R', 'C'):
@@ -182,16 +184,16 @@ def test_nircam_parser(mosviz_helper, tmp_path):
 
     mosviz_helper.load_data(directory=tmp_path / "trimmed_nircam_data", instrument="nircam")
 
-    # The MOS Table should be last in the data collection
-    dc_tab = mosviz_helper.app.data_collection[-1]
+    # The MOS Table should be first in the data collection
+    dc_tab = mosviz_helper.app.data_collection[0]
     assert dc_tab.label == "MOS Table"
     assert len(dc_tab.meta) == 0
 
     # Check that the correct amount of spectra got loaded in the correct order
     assert len(mosviz_helper.app.data_collection) == 31
     assert mosviz_helper.app.data_collection['MOS Table']['Identifier'][0] == 1112
-    assert mosviz_helper.app.data_collection[0].label == 'F322W2 Source 1112 spec2d R'
-    assert mosviz_helper.app.data_collection[15].label == 'F322W2 Source 1112 spec1d R'
+    assert mosviz_helper.app.data_collection[1].label == 'F322W2 Source 1112 spec2d R'
+    assert mosviz_helper.app.data_collection[16].label == 'F322W2 Source 1112 spec1d R'
 
 
 @pytest.mark.remote_data

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     bqplot>=0.12.36
     bqplot-image-gl>=1.4.11
     glue-core>=1.6.0
-    glue-jupyter>=0.14.2
+    glue-jupyter>=0.15.0
     echo>=0.5.0
     ipykernel<6.18
     ipyvue>=1.6


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This PR fixes a bug found by a user with a private dataset where mosviz fails to find and populate the `SOURCEID` column, despite `SOURCEID` being registered in the metadata plugin. The main fix does this by introducing a new, preferred method of finding the `SOURCEID` by searching through the `.meta` attached to the data object rather than re-reading the file and searching through the header. This requires https://github.com/glue-viz/glue-jupyter/pull/336 to ensure the `.meta` is available before the metadata is parsed

This new strategy requires the data to be parsed and loaded first, to populate the data collection and associated `.meta` entries. Then, after all the data is loaded, then search for the metadata afterwards. Because the data already has its metadata attached to it, no need to reopen/pass around hdus anymore.

This PR also cleans up the metadata detection by explicitly requiring the parsers to specify the `data_type` of the data's metadata being parsed. We were kind of already requiring this, but in a convoluted way (relying on a `spectra` and `sp1d` flag, where if `spectra` and `sp1d` were both true, it's 1D spectra, if `spectra` was true, but not `sp1d`, it's 2D spectra, and if neither were true, it was an image 😖)

As a stretch goal, I also switch both the NIRISS and Generic/NIRspec parsers to using this new metadata parsing strategy. Notice how the metadata block at the bottom looks almost identical to the `mos_metadata_parser` used for the generic/nirspec strategy.... how interesting.... 😉 (Future PR)

Tests are failing due to the need of this upstream patch. Please install https://github.com/glue-viz/glue-jupyter/pull/336 when doing your local testing!

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Blocked by

* https://github.com/glue-viz/glue-jupyter/pull/336

- [x] Need to bump `glue-jupyter` minversion in `setup.cfg` after upstream fix is merged and released.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
