### PR TITLE
FIX: shadowing/subsets after adding plugin data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -111,6 +111,10 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Fix spatial-spectral highlighting after adding spectral data set (either manually or by loading
+  and results from plugins into the spectral-viewer) which had prevented new subsets from being
+  created. [#1856]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -195,7 +195,7 @@ class CubevizProfileView(SpecvizProfileView):
 
     def _is_spatial_subset(self, layer):
         # spatial subset layers will have the same data-label as the collapsed flux cube
-        ref_data_label = self.layers[0].layer.data.label
+        ref_data_label = self.state.reference_data.label
         return (isinstance(getattr(layer.layer, 'subset_state', None), RoiSubsetState)
                 and layer.layer.data.label == ref_data_label)
 

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -406,9 +406,11 @@ class ShadowSpatialSpectral(Lines, HubListener, ShadowMixin):
     def _on_shadowing_changed(self, change):
         if hasattr(self, '_spectral_mark_id'):
             if change['name'] == 'y':
-                # force a copy or else we'll overwrite the mask to the spatial mark!
-                change['new'] = deepcopy(self.spatial_spectrum_mark.y)
-                change['new'][np.isnan(self.spectral_subset_mark.y)] = np.nan
+                # at initial setup, the arrays may not be populated yet
+                if self.spatial_spectrum_mark.y.shape == self.spectral_subset_mark.y.shape:
+                    # force a copy or else we'll overwrite the mask to the spatial mark!
+                    change['new'] = deepcopy(self.spatial_spectrum_mark.y)
+                    change['new'][np.isnan(self.spectral_subset_mark.y)] = np.nan
 
             elif change['name'] == 'visible':
                 # only show if BOTH shadowing marks are set to visible

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -188,6 +188,10 @@ def test_region_spectral_spatial(cubeviz_helper, spectral_cube_wcs):
     cubeviz_helper.app.add_data_to_viewer('spectrum-viewer', 'Test Flux')
     cubeviz_helper.app.add_data_to_viewer('flux-viewer', 'Test Flux')
 
+    # use gaussian smooth plugin as a regression test for
+    # https://github.com/spacetelescope/jdaviz/issues/1853
+    cubeviz_helper.plugins['Gaussian Smooth'].smooth(add_data=True)
+
     spectrum_viewer = cubeviz_helper.app.get_viewer("spectrum-viewer")
     spectrum_viewer.apply_roi(XRangeROI(5, 15.5))
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request prevents the shadowing logic introduced in #1528 from crashing (with a traceback in the viewer output-widget) when creating a subset after adding another spectral data-entry, including from plugins such as model fitting or gaussian smooth, which was then interfering with future subset creation.

Previous workflows to reproduce:
* add results from gaussian smooth to the spectral-viewer
* create spectral subset (originally crashed with traceback in output-widget and future clicks would create multiple subsets simultaneously)
* create spatial subset

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1853

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
