### PR TITLE
POC: Display Subset sky center

### DIFF
--- a/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.vue
+++ b/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.vue
@@ -37,6 +37,14 @@
              label="Data"
              hint="Select the data for centroiding."
             />
+            <v-row v-if="subset_sky_center_ra" no-gutters>
+              <v-col>RA center:</v-col>
+              <v-col>{{ subset_sky_center_ra }}</v-col>
+            </v-row>
+            <v-row v-if="subset_sky_center_dec" no-gutters>
+              <v-col>DEC center:</v-col>
+              <v-col>{{ subset_sky_center_dec }}</v-col>
+            </v-row>
             <v-row justify="end" no-gutters>
               <v-btn color="primary" text @click="recenter_subset">Recenter</v-btn>
             </v-row>


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to show how we might want to display sky info from a subset for Imviz.

I am not sure if this is the best approach because things get confusing real fast when you have many images with different sky pointings. When two images are linked by WCS, any given subset will show the same sky center no matter which image you pick. However, the shown pixel center is always w.r.t. the reference image (this is also what you extract via the API and also is generic for all the viz). I don't know how to make this less confusing and yet still general enough for the entire Jdaviz.

![Screenshot 2022-11-18 172612](https://user-images.githubusercontent.com/2090236/202814084-a154f73c-3203-4f7c-928b-83f25f818b1a.jpg)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Related issue: #1541 (discussions here would be useful for this issue)

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
