### PR TITLE
numpy deprecation warning filter for v1.24.0

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
@@ -72,6 +72,9 @@ def test_slice(cubeviz_helper, spectrum1d_cube):
 
     # Test player buttons API
 
+    sl.vue_goto_first()
+    assert sl.slice == 0
+
     sl.vue_goto_last()
     assert sl.slice == sl.max_value
 
@@ -88,9 +91,6 @@ def test_slice(cubeviz_helper, spectrum1d_cube):
     assert not sl.is_playing
     assert not sl._player
     # NOTE: Hard to check sl.slice here because it is non-deterministic.
-
-    sl.vue_goto_first()
-    assert sl.slice == 0
 
 
 def test_indicator_settings(cubeviz_helper, spectrum1d_cube):

--- a/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
@@ -17,8 +17,8 @@ __all__ = ['SlitOverlay', 'jwst_header_to_skyregion']
 def jwst_header_to_skyregion(header):
     s_region = header['S_REGION']
     footprint = s_region.split("POLYGON ICRS")[1].split()
-    ra = np.array(footprint[::2], dtype=float)
-    dec = np.array(footprint[1::2], dtype=float)
+    ra = np.array(footprint[::2], dtype=np.float)
+    dec = np.array(footprint[1::2], dtype=np.float)
 
     # Find center of slit
     cra = (max(ra) + min(ra)) / 2

--- a/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
@@ -17,8 +17,8 @@ __all__ = ['SlitOverlay', 'jwst_header_to_skyregion']
 def jwst_header_to_skyregion(header):
     s_region = header['S_REGION']
     footprint = s_region.split("POLYGON ICRS")[1].split()
-    ra = np.array(footprint[::2], dtype=np.float_)
-    dec = np.array(footprint[1::2], dtype=np.float_)
+    ra = np.array(footprint[::2], dtype=float)
+    dec = np.array(footprint[1::2], dtype=float)
 
     # Find center of slit
     cra = (max(ra) + min(ra)) / 2

--- a/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
@@ -17,8 +17,8 @@ __all__ = ['SlitOverlay', 'jwst_header_to_skyregion']
 def jwst_header_to_skyregion(header):
     s_region = header['S_REGION']
     footprint = s_region.split("POLYGON ICRS")[1].split()
-    ra = np.array(footprint[::2], dtype=np.float)
-    dec = np.array(footprint[1::2], dtype=np.float)
+    ra = np.array(footprint[::2], dtype=np.float_)
+    dec = np.array(footprint[1::2], dtype=np.float_)
 
     # Find center of slit
     cra = (max(ra) + min(ra)) / 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -99,6 +99,7 @@ filterwarnings =
     ignore:.*With traitlets 4\.1, metadata should be set using the \.tag\(\) method:DeprecationWarning
     ignore:.*np\.bool8.*is a deprecated alias for:DeprecationWarning
     ignore:.*np\.uint0.*is a deprecated alias for:DeprecationWarning
+    ignore:.*np\.int0.*is a deprecated alias for:DeprecationWarning
     ignore::DeprecationWarning:glue
     ignore::DeprecationWarning:bqplot
     ignore::DeprecationWarning:bqplot_image_gl

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,6 +97,7 @@ filterwarnings =
     ignore:distutils Version classes are deprecated:DeprecationWarning
     ignore:Passing unrecognized arguments to super:DeprecationWarning
     ignore:.*With traitlets 4\.1, metadata should be set using the \.tag\(\) method:DeprecationWarning
+    ignore:.*(Deprecated NumPy 1.24):DeprecationWarning
     ignore::DeprecationWarning:glue
     ignore::DeprecationWarning:bqplot
     ignore::DeprecationWarning:bqplot_image_gl

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,7 +97,7 @@ filterwarnings =
     ignore:distutils Version classes are deprecated:DeprecationWarning
     ignore:Passing unrecognized arguments to super:DeprecationWarning
     ignore:.*With traitlets 4\.1, metadata should be set using the \.tag\(\) method:DeprecationWarning
-    ignore:`np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24):DeprecationWarning
+    ignore:is a deprecated alias for:DeprecationWarning
     ignore::DeprecationWarning:glue
     ignore::DeprecationWarning:bqplot
     ignore::DeprecationWarning:bqplot_image_gl

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,7 +97,7 @@ filterwarnings =
     ignore:distutils Version classes are deprecated:DeprecationWarning
     ignore:Passing unrecognized arguments to super:DeprecationWarning
     ignore:.*With traitlets 4\.1, metadata should be set using the \.tag\(\) method:DeprecationWarning
-    ignore:.*(Deprecated NumPy 1.24):DeprecationWarning
+    ignore:`np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24):DeprecationWarning
     ignore::DeprecationWarning:glue
     ignore::DeprecationWarning:bqplot
     ignore::DeprecationWarning:bqplot_image_gl

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,7 +97,7 @@ filterwarnings =
     ignore:distutils Version classes are deprecated:DeprecationWarning
     ignore:Passing unrecognized arguments to super:DeprecationWarning
     ignore:.*With traitlets 4\.1, metadata should be set using the \.tag\(\) method:DeprecationWarning
-    ignore:is a deprecated alias for:DeprecationWarning
+    ignore:.*np\.bool8.*is a deprecated alias for:DeprecationWarning
     ignore::DeprecationWarning:glue
     ignore::DeprecationWarning:bqplot
     ignore::DeprecationWarning:bqplot_image_gl

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,7 +98,7 @@ filterwarnings =
     ignore:Passing unrecognized arguments to super:DeprecationWarning
     ignore:.*With traitlets 4\.1, metadata should be set using the \.tag\(\) method:DeprecationWarning
     ignore:.*np\.bool8.*is a deprecated alias for:DeprecationWarning
-    ignore:.*np\.unit0.*is a deprecated alias for:DeprecationWarning
+    ignore:.*np\.uint0.*is a deprecated alias for:DeprecationWarning
     ignore::DeprecationWarning:glue
     ignore::DeprecationWarning:bqplot
     ignore::DeprecationWarning:bqplot_image_gl

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,6 +98,7 @@ filterwarnings =
     ignore:Passing unrecognized arguments to super:DeprecationWarning
     ignore:.*With traitlets 4\.1, metadata should be set using the \.tag\(\) method:DeprecationWarning
     ignore:.*np\.bool8.*is a deprecated alias for:DeprecationWarning
+    ignore:.*np\.unit0.*is a deprecated alias for:DeprecationWarning
     ignore::DeprecationWarning:glue
     ignore::DeprecationWarning:bqplot
     ignore::DeprecationWarning:bqplot_image_gl


### PR DESCRIPTION
Numpy v1.24.0 triggers several deprecation warnings in scikit-image. See progress on fixes in scikit-image/scikit-image#6633, and failure in #1834.

This PR tries to filter out that specific deprecation warning.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
