### PR TITLE
Pin ipykernel so Jdaviz doesn't crash

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     glue-core>=1.6.0
     glue-jupyter>=0.14.2
     echo>=0.5.0
+    ipykernel<6.18
     ipyvue>=1.6
     ipyvuetify>=1.7.0
     ipysplitpanes>=0.1.0


### PR DESCRIPTION
Ipykernel 6.18 changed the way comm messages are handled apparently, which completely broke Jdaviz. @maartenbreddels is looking into it, but in the meantime we need to pin this to a working version. Might need to cut a new bugfix release with this.