### PR TITLE
Avoid astropy model fitting error if all uncertainties are 0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -110,6 +110,9 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Avoid a non-finite error in model fitting by not passing spectrum uncertainties as
+  weights if there are uncertainty values of 0. [#1880]
+
 Cubeviz
 ^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -111,7 +111,7 @@ Bug Fixes
 ---------
 
 - Avoid a non-finite error in model fitting by not passing spectrum uncertainties as
-  weights if there are uncertainty values of 0. [#1880]
+  weights if the uncertainty values are all 0. [#1880]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
+++ b/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
@@ -100,11 +100,8 @@ def _fit_1D(initial_model, spectrum, run_fitter, window=None):
 
     """
     if run_fitter:
-        if spectrum.uncertainty:
-            if np.all(spectrum.uncertainty.array == 0):
-                weights = None
-            else:
-                weights = 'unc'
+        if spectrum.uncertainty and not np.all(spectrum.uncertainty.array == 0):
+            weights = 'unc'
         else:
             weights = None
         output_model = fit_lines(spectrum, initial_model, weights=weights, window=window)
@@ -270,11 +267,8 @@ class SpaxelWorker:
 
             sp = Spectrum1D(spectral_axis=self.wave, flux=flux, mask=mask)
 
-            if sp.uncertainty:
-                if np.all(sp.uncertainty.array == 0):
-                    weights = None
-                else:
-                    weights = 'unc'
+            if sp.uncertainty and not np.all(sp.uncertainty.array == 0):
+                weights = 'unc'
             else:
                 weights = None
             fitted_model = fit_lines(sp, self.model, window=self.window, weights=weights)

--- a/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
+++ b/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
@@ -100,8 +100,11 @@ def _fit_1D(initial_model, spectrum, run_fitter, window=None):
 
     """
     if run_fitter:
-        if spectrum.uncertainty and np.all(spectrum.uncertainty.array != 0):
-            weights = 'unc'
+        if spectrum.uncertainty:
+            if np.all(spectrum.uncertainty.array == 0):
+                weights = None
+            else:
+                weights = 'unc'
         else:
             weights = None
         output_model = fit_lines(spectrum, initial_model, weights=weights, window=window)
@@ -267,8 +270,11 @@ class SpaxelWorker:
 
             sp = Spectrum1D(spectral_axis=self.wave, flux=flux, mask=mask)
 
-            if sp.uncertainty and np.all(sp.uncertainty.array != 0):
-                weights = 'unc'
+            if sp.uncertainty:
+                if np.all(sp.uncertainty.array == 0):
+                    weights = None
+                else:
+                    weights = 'unc'
             else:
                 weights = None
             fitted_model = fit_lines(sp, self.model, window=self.window, weights=weights)

--- a/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
+++ b/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
@@ -100,7 +100,10 @@ def _fit_1D(initial_model, spectrum, run_fitter, window=None):
 
     """
     if run_fitter:
-        weights = 'unc' if spectrum.uncertainty else None
+        if spectrum.uncertainty and np.all(spectrum.uncertainty.array != 0):
+            weights = 'unc'
+        else:
+            weights = None
         output_model = fit_lines(spectrum, initial_model, weights=weights, window=window)
         output_values = output_model(spectrum.spectral_axis)
     else:
@@ -264,7 +267,10 @@ class SpaxelWorker:
 
             sp = Spectrum1D(spectral_axis=self.wave, flux=flux, mask=mask)
 
-            weights = 'unc' if sp.uncertainty else None
+            if sp.uncertainty and np.all(sp.uncertainty.array != 0):
+                weights = 'unc'
+            else:
+                weights = None
             fitted_model = fit_lines(sp, self.model, window=self.window, weights=weights)
 
             fitted_values = fitted_model(self.wave)

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -1,5 +1,6 @@
 import astropy.modeling.models as models
 import astropy.modeling.parameters as params
+from astropy.nddata import StdDevUncertainty
 import astropy.units as u
 import numpy as np
 import pytest
@@ -77,7 +78,9 @@ def test_fitting_backend():
 
     x, y = build_spectrum()
 
-    spectrum = Spectrum1D(flux=y*u.Jy, spectral_axis=x*u.um)
+    # The uncertainty array of all zero should be ignored when fitting
+    uncertainties = StdDevUncertainty(np.zeros(y.shape)*u.Jy)
+    spectrum = Spectrum1D(flux=y*u.Jy, spectral_axis=x*u.um, uncertainty=uncertainties)
 
     g1f = models.Gaussian1D(0.7*u.Jy, 4.65*u.um, 0.3*u.um, name='g1')
     g2f = models.Gaussian1D(2.0*u.Jy, 5.55*u.um, 0.3*u.um, name='g2')
@@ -138,7 +141,11 @@ def test_cube_fitting_backend():
     mask = np.zeros_like(flux_cube).astype(bool)
     mask[..., :SPECTRUM_SIZE // 10] = True
 
-    spectrum = Spectrum1D(flux=flux_cube*u.Jy, spectral_axis=x*u.um, mask=mask)
+    # The uncertainty array of all zero should be ignored when fitting
+    uncertainties = StdDevUncertainty(np.zeros(flux_cube.shape)*u.Jy)
+
+    spectrum = Spectrum1D(flux=flux_cube*u.Jy, spectral_axis=x*u.um,
+                          uncertainty=uncertainties, mask=mask)
 
     # Initial model for fit.
     g1f = models.Gaussian1D(0.7*u.Jy, 4.65*u.um, 0.3*u.um, name='g1')

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -73,13 +73,17 @@ def test_model_ids(cubeviz_helper, spectral_cube_wcs):
         plugin.vue_add_model({})
 
 
-def test_fitting_backend():
+@pytest.mark.parametrize('unc', ('zeros', None))
+def test_fitting_backend(unc):
     np.random.seed(42)
 
     x, y = build_spectrum()
 
     # The uncertainty array of all zero should be ignored when fitting
-    uncertainties = StdDevUncertainty(np.zeros(y.shape)*u.Jy)
+    if unc == "zeros":
+        uncertainties = StdDevUncertainty(np.zeros(y.shape)*u.Jy)
+    elif unc is None:
+        uncertainties = None
     spectrum = Spectrum1D(flux=y*u.Jy, spectral_axis=x*u.um, uncertainty=uncertainties)
 
     g1f = models.Gaussian1D(0.7*u.Jy, 4.65*u.um, 0.3*u.um, name='g1')
@@ -111,7 +115,8 @@ def test_fitting_backend():
 # When pytest turns warnings into errors, this silently fails with
 # len(fitted_parameters) == 0
 @pytest.mark.filterwarnings('ignore')
-def test_cube_fitting_backend():
+@pytest.mark.parametrize('unc', ('zeros', None))
+def test_cube_fitting_backend(unc):
     np.random.seed(42)
 
     SIGMA = 0.1  # noise in data
@@ -142,7 +147,10 @@ def test_cube_fitting_backend():
     mask[..., :SPECTRUM_SIZE // 10] = True
 
     # The uncertainty array of all zero should be ignored when fitting
-    uncertainties = StdDevUncertainty(np.zeros(flux_cube.shape)*u.Jy)
+    if unc == "zeros":
+        uncertainties = StdDevUncertainty(np.zeros(flux_cube.shape)*u.Jy)
+    elif unc is None:
+        uncertainties = None
 
     spectrum = Spectrum1D(flux=flux_cube*u.Jy, spectral_axis=x*u.um,
                           uncertainty=uncertainties, mask=mask)


### PR DESCRIPTION
Specutils tries to use 1/sigma as weights if `weights='unc'`, leading to non-finite weights if we pass 0s in `spectrum.uncertainty`. This fixes the model fitting problem that @kecnry encountered in Mosviz, but the ultimate fix should probably be upstream in `specutils`.