### PR TITLE
TST: Omit specreduce dev from devdeps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,6 @@ deps =
     devdeps: git+https://github.com/glue-viz/bqplot-image-gl.git
     devdeps: git+https://github.com/glue-viz/glue-jupyter.git
     devdeps: git+https://github.com/glue-viz/glue-astronomy.git
-    devdeps: git+https://github.com/astropy/specreduce.git
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,8 @@ deps =
     devdeps: git+https://github.com/glue-viz/bqplot-image-gl.git
     devdeps: git+https://github.com/glue-viz/glue-jupyter.git
     devdeps: git+https://github.com/glue-viz/glue-astronomy.git
+    # TODO: Enable this when specreduce becomes stable.
+    #devdeps: git+https://github.com/astropy/specreduce.git
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to omit dev version of specreduce from devdeps because that package is undergoing a lot of API changes.

Close #1877 

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
