### PR TITLE
POC: Factor out subset recursion

### DIFF
--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -258,3 +258,29 @@ class ColorCycler:
         color = self.default_color_palette[cycle_index]
 
         return color
+
+
+def _unpack_nested_subset(subset_state, result=[]):
+    '''Return a list of ``subset_state`` object(s)
+    by navigating through the tree of subset states for composite
+    subsets made up of multiple regions.
+
+    Examples
+    --------
+    In this example, ``result`` will be updated in-place
+    with subset state object(s) for the given ``subset_state``.
+    If the subset is a compound subset, the list will have multiple
+    entries, otherwise only one:
+
+    >>> from jdaviz.utils import _unpack_nested_subset
+    >>> result = []
+    >>> _unpack_nested_subset(subset_state, result=result)
+
+    '''
+    from glue.core.subset import CompositeSubsetState
+
+    if isinstance(subset_state, CompositeSubsetState):
+        _unpack_nested_subset(subset_state.state1, result=result)
+        _unpack_nested_subset(subset_state.state2, result=result)
+    elif subset_state is not None:
+        result.append(subset_state)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to factor out subset recursion into low-level utility function so it can be used by app or by plugin.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This came up in discussions related to #1858 . Also see #1886 .

cc @javerbukh @rosteen 

### Example

Let's say you have loaded data into your favorite viz and have different kinds of subsets (simple, compound, spatial, spectral) drawn already.

If you are accessing the subset via Subset Tools plugin, it would be like this:

```python
plg = cubeviz.plugins['Subset Tools']
subset_state = plg._obj.subset_select.selected_subset_state
```

**OR** you can also access the same info without the plugin like this:

```python
subset_label = 'Subset 1'  # Change this to subset of interest

# This is copied from template_mixin.py
subset_group = [s for s in cubeviz.app.data_collection.subset_groups if
                s.label == subset_label][0]
subset_state = subset_group.subset_state
```

Once you have `subset_state`, you can run the recursion like this:

```python
from jdaviz.utils import _unpack_nested_subset

result = []  # This is updated in-place
_unpack_nested_subset(subset_state, result=result)
```

For a simple Subset, you will see something like this:

```python
>>> result
[<glue.core.subset.RoiSubsetState at ...>]
```

For a compound Subset (this is spectral region with 2 sub-regions):

```python
>>> result
[<glue.core.subset.RangeSubsetState at ...>,
 <glue.core.subset.RangeSubsetState at ...>,
 <glue.core.subset.RangeSubsetState at ...>]
```

Then the app can do whatever it wants with the objects, and the plugin can do something completely different.

Cons:

* If `app` needs the subset *group* that is one-level higher, this will not give that kind of info. It is not immediately clear to me how to use `glue-astronomy` to convert subset *state* to region shape. Maybe you know.
* Subset Tools plugin will need some rewrite to use this but I don't think it is too bad.
* Probably using more memory since you return the whole object in a list, and not just the attributes of interest. Also more processing because you get the list first, and then iterate through the list again to get what you really want. But the benefit of flexibility might outweigh the cost?

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?