### PR TITLE
Restore console log for Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -115,6 +115,8 @@ Bug Fixes
 - Avoid a non-finite error in model fitting by not passing spectrum uncertainties as
   weights if the uncertainty values are all 0. [#1880]
 
+- Console logging is restored for "Desktop Mode" Windows users [#1887]
+
 Cubeviz
 ^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -115,7 +115,7 @@ Bug Fixes
 - Avoid a non-finite error in model fitting by not passing spectrum uncertainties as
   weights if the uncertainty values are all 0. [#1880]
 
-- Console logging is restored for "Desktop Mode" Windows users [#1887]
+- Console logging is restored for "Desktop Mode" Windows users. [#1887]
 
 Cubeviz
 ^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,8 +72,8 @@ jdaviz.configs.imviz.tests = data/*
 
 [options.entry_points]
 console_scripts =
-gui_scripts =
     jdaviz = jdaviz.cli:_main
+gui_scripts =
 jdaviz_plugins =
     default = jdaviz.configs.default
     cubeviz = jdaviz.configs.cubeviz


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

HOOOLLEY CRAP I finally fixed it!!

At some point in the past (probably a year), I completely lost console logging whenever I launched jdaviz in "desktop" mode. I was going to report it as a bug, but no one else was complaining about it, so I figured it was just me. And I've been flying blind ever since!

But then I found a little gem in the [python docs](https://packaging.python.org/en/latest/specifications/entry-points/#use-for-scripts):

> The difference between console_scripts and gui_scripts only affects Windows systems. console_scripts are wrapped in a console executable, so they are attached to a console and can use sys.stdin, sys.stdout and sys.stderr for input and output. gui_scripts are wrapped in a GUI executable, so they can be started without a console, but cannot use standard streams unless application code redirects them. Other platforms do not have the same distinction.

specifically:

> [gui_scripts on Windows] cannot use standard streams unless application code redirects them. Other platforms do not have the same distinction.

Turns out it probably wasn't just me; this probably affected all native windows users, all 2 of us!

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
