### PR TITLE
Improve coordinates display panel for spectrum viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,6 +114,8 @@ Cubeviz
 
 - Added Slice plugin player control buttons. [#1848]
 
+- Improved mouseover info display for spectrum viewer. [#1894]
+
 Imviz
 ^^^^^
 
@@ -134,12 +136,16 @@ Mosviz
 
 - ``load_data`` method can now load JWST NIRCam and NIRSpec level 2 data. [#1835]
 
+- Improved mouseover info display for spectrum viewer. [#1894]
+
 Specviz
 ^^^^^^^
 
 - Spectrum viewer now shows X and Y values under cursor. [#1759]
 
 - Switch to opt-in concatenation for multi-order x1d spectra. [#1659]
+
+- Improved mouseover info display for spectrum viewer. [#1894]
 
 Specviz2d
 ^^^^^^^^^
@@ -148,6 +154,8 @@ Specviz2d
   with Polynomial, Spline, and Legendre options. [#1889]
 
 - Add dropdown for choosing background statistic (average or median). [#1922]
+
+- Improved mouseover info display for spectrum viewer. [#1894]
 
 API Changes
 -----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ New Features
 Cubeviz
 ^^^^^^^
 
+- Improved mouseover info display for spectrum viewer. [#1894]
+
 Imviz
 ^^^^^
 
@@ -14,11 +16,17 @@ Mosviz
 ^^^^^^
 - Reliably retrieves identifier using each datasets' metadata entry. [#1851]
 
+- Improved mouseover info display for spectrum viewer. [#1894]
+
 Specviz
 ^^^^^^^
 
+- Improved mouseover info display for spectrum viewer. [#1894]
+
 Specviz2d
 ^^^^^^^^^
+
+- Improved mouseover info display for spectrum viewer. [#1894]
 
 API Changes
 -----------
@@ -114,8 +122,6 @@ Cubeviz
 
 - Added Slice plugin player control buttons. [#1848]
 
-- Improved mouseover info display for spectrum viewer. [#1894]
-
 Imviz
 ^^^^^
 
@@ -136,16 +142,12 @@ Mosviz
 
 - ``load_data`` method can now load JWST NIRCam and NIRSpec level 2 data. [#1835]
 
-- Improved mouseover info display for spectrum viewer. [#1894]
-
 Specviz
 ^^^^^^^
 
 - Spectrum viewer now shows X and Y values under cursor. [#1759]
 
 - Switch to opt-in concatenation for multi-order x1d spectra. [#1659]
-
-- Improved mouseover info display for spectrum viewer. [#1894]
 
 Specviz2d
 ^^^^^^^^^
@@ -154,8 +156,6 @@ Specviz2d
   with Polynomial, Spline, and Legendre options. [#1889]
 
 - Add dropdown for choosing background statistic (average or median). [#1922]
-
-- Improved mouseover info display for spectrum viewer. [#1894]
 
 API Changes
 -----------

--- a/docs/specviz/displaying.rst
+++ b/docs/specviz/displaying.rst
@@ -41,6 +41,16 @@ data menu.
 
 .. image:: img/data_tab.png
 
+.. _specviz_cursor_info:
+
+Cursor Information
+==================
+
+By moving your cursor along the spectrum viewer, you will be able to see information on the
+index, spectral axis value, and flux value of the closest data point to the cursor
+(not to be confused with the actual cursor position).
+This information is displayed in the top bar of the UI, on the middle-right side.
+
 Home
 ====
 

--- a/docs/specviz/displaying.rst
+++ b/docs/specviz/displaying.rst
@@ -47,8 +47,8 @@ Cursor Information
 ==================
 
 By moving your cursor along the spectrum viewer, you will be able to see information on the
-index, spectral axis value, and flux value of the closest data point to the cursor
-(not to be confused with the actual cursor position).
+cursor position as well as the spectral axis value, pixel, and flux of the closest data point
+to the cursor.
 This information is displayed in the top bar of the UI, on the middle-right side.
 
 Home

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -258,6 +258,10 @@ class Application(VuetifyTemplate, HubListener):
         # Add a fitted_models dictionary that the helpers (or user) can access
         self.fitted_models = {}
 
+        # Internal cache so we don't have to keep calling get_object for the same Data.
+        # Key should be (data_label, statistic) and value the translated object.
+        self._get_object_cache = {}
+
         # Add new and inverse colormaps to Glue global state. Also see ColormapRegistry in
         # https://github.com/glue-viz/glue/blob/main/glue/config.py
         new_cms = (['Rainbow', cm.rainbow],
@@ -1500,6 +1504,9 @@ class Application(VuetifyTemplate, HubListener):
         for data_item in self.state.data_items:
             if data_item['name'] == msg.data.label:
                 self.state.data_items.remove(data_item)
+
+        # Hard to know what is associated with what, so just clear everything.
+        self._get_object_cache.clear()
 
     @staticmethod
     def _create_data_item(data):

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -28,6 +28,7 @@ from glue.plugins.wcs_autolinking.wcs_autolinking import WCSLink, IncompatibleWC
 from glue.core.message import (DataCollectionAddMessage,
                                DataCollectionDeleteMessage,
                                SubsetCreateMessage,
+                               SubsetUpdateMessage,
                                SubsetDeleteMessage)
 from glue.core.state_objects import State
 from glue.core.subset import Subset, RangeSubsetState, RoiSubsetState
@@ -261,6 +262,8 @@ class Application(VuetifyTemplate, HubListener):
         # Internal cache so we don't have to keep calling get_object for the same Data.
         # Key should be (data_label, statistic) and value the translated object.
         self._get_object_cache = {}
+        self.hub.subscribe(self, SubsetUpdateMessage,
+                           handler=lambda msg: self._clear_object_cache(msg.subset.label))
 
         # Add new and inverse colormaps to Glue global state. Also see ColormapRegistry in
         # https://github.com/glue-viz/glue/blob/main/glue/config.py
@@ -1490,6 +1493,14 @@ class Application(VuetifyTemplate, HubListener):
         data_item = self._create_data_item(msg.data)
         self.state.data_items.append(data_item)
 
+    def _clear_object_cache(self, data_label=None):
+        if data_label is None:
+            self._get_object_cache.clear()
+        else:
+            # keys are (data_label, statistic) tuples
+            self._get_object_cache = {k: v for k, v in self._get_object_cache.items()
+                                      if k[0] != data_label}
+
     def _on_data_deleted(self, msg):
         """
         Callback for when data is removed from the internal ``DataCollection``.
@@ -1505,8 +1516,7 @@ class Application(VuetifyTemplate, HubListener):
             if data_item['name'] == msg.data.label:
                 self.state.data_items.remove(data_item)
 
-        # Hard to know what is associated with what, so just clear everything.
-        self._get_object_cache.clear()
+        self._clear_object_cache(msg.data.label)
 
     @staticmethod
     def _create_data_item(data):

--- a/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
@@ -68,7 +68,7 @@ def test_linking_after_spectral_smooth(cubeviz_helper, spectrum1d_cube):
     # Mouseover should automatically jump from one spectrum
     # to another, depending on which one is closer.
 
-    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 4.633e-7, 'y': 60}})
+    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 4.6236e-7, 'y': 60}})
     assert spec_viewer.label_mouseover.pixel == 'x=01.0'
     assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
     assert spec_viewer.label_mouseover.world_ra == '4.62360e-07'
@@ -78,7 +78,7 @@ def test_linking_after_spectral_smooth(cubeviz_helper, spectrum1d_cube):
     assert spec_viewer.label_mouseover.world_dec_deg == 'Jy'
     assert spec_viewer.label_mouseover.icon == 'a'
 
-    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 4.633e-7, 'y': 20}})
+    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 4.6236e-7, 'y': 20}})
     assert spec_viewer.label_mouseover.pixel == 'x=01.0'
     assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
     assert spec_viewer.label_mouseover.world_ra == '4.62360e-07'
@@ -92,7 +92,7 @@ def test_linking_after_spectral_smooth(cubeviz_helper, spectrum1d_cube):
     for lyr in spec_viewer.layers:
         lyr.visible = False
 
-    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 4.633e-7, 'y': 60}})
+    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 4.6236e-7, 'y': 60}})
     assert spec_viewer.label_mouseover.pixel == ''
     assert spec_viewer.label_mouseover.world_label_prefix == '\xa0'
     assert spec_viewer.label_mouseover.world_ra == ''
@@ -161,13 +161,13 @@ def test_spectrum1d_smooth(specviz_helper, spectrum1d):
     assert spec_viewer.label_mouseover.world_dec_deg == 'Jy'
     assert spec_viewer.label_mouseover.icon == 'b'
 
-    # Out-of-bounds should lock to closest edge value.
+    # Out-of-bounds shows nothing.
     spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 5500, 'y': 120}})
-    assert spec_viewer.label_mouseover.pixel == 'x=00.0'
-    assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
-    assert spec_viewer.label_mouseover.world_ra == '6.00000e+03'
-    assert spec_viewer.label_mouseover.world_dec == 'Angstrom'
-    assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
-    assert spec_viewer.label_mouseover.world_ra_deg == '1.24967e+01'
-    assert spec_viewer.label_mouseover.world_dec_deg == 'Jy'
-    assert spec_viewer.label_mouseover.icon == 'a'
+    assert spec_viewer.label_mouseover.pixel == ''
+    assert spec_viewer.label_mouseover.world_label_prefix == '\xa0'
+    assert spec_viewer.label_mouseover.world_ra == ''
+    assert spec_viewer.label_mouseover.world_dec == ''
+    assert spec_viewer.label_mouseover.world_label_prefix_2 == '\xa0'
+    assert spec_viewer.label_mouseover.world_ra_deg == ''
+    assert spec_viewer.label_mouseover.world_dec_deg == ''
+    assert spec_viewer.label_mouseover.icon == ''

--- a/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
@@ -1,21 +1,18 @@
 import pytest
-from jdaviz import Application
+from astropy.utils.exceptions import AstropyUserWarning
 from specutils import Spectrum1D
 
-from jdaviz.configs.default.plugins.gaussian_smooth.gaussian_smooth import GaussianSmooth
 
-
-def test_linking_after_spectral_smooth(spectrum1d_cube):
-
-    app = Application(configuration="cubeviz")
+def test_linking_after_spectral_smooth(cubeviz_helper, spectrum1d_cube):
+    app = cubeviz_helper.app
     dc = app.data_collection
-    app.add_data(spectrum1d_cube, 'test')
-    app.add_data_to_viewer('flux-viewer', 'test')
+    cubeviz_helper.load_data(spectrum1d_cube, data_label='test')
+    spec_viewer = cubeviz_helper.app.get_viewer('spectrum-viewer')
 
     assert len(dc) == 1
 
-    gs = GaussianSmooth(app=app)
-    gs.dataset_selected = 'test'
+    gs = cubeviz_helper.plugins['Gaussian Smooth']._obj
+    gs.dataset_selected = 'test[FLUX]'
     gs.mode_selected = 'Spectral'
     gs.stddev = 3.2
     gs.add_to_viewer_selected = 'None'
@@ -40,8 +37,8 @@ def test_linking_after_spectral_smooth(spectrum1d_cube):
     # itself is prepended to the default label, and there is no longer
     # an overwrite warning.
     assert len(gs.dataset_items) == 2
-    assert gs.dataset_selected == 'test'
-    assert gs.results_label == 'test spectral-smooth stddev-3.2'
+    assert gs.dataset_selected == 'test[FLUX]'
+    assert gs.results_label == 'test[FLUX] spectral-smooth stddev-3.2'
     assert gs.results_label_overwrite is False
 
     assert len(dc) == 2
@@ -68,21 +65,109 @@ def test_linking_after_spectral_smooth(spectrum1d_cube):
     assert dc.external_links[2].cids1[0] == dc[0].pixel_component_ids[2]
     assert dc.external_links[2].cids2[0] == dc[-1].pixel_component_ids[2]
 
+    # Mouseover should automatically jump from one spectrum
+    # to another, depending on which one is closer.
 
-@pytest.mark.filterwarnings("ignore::UserWarning")
+    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 4.633e-7, 'y': 60}})
+    assert spec_viewer.label_mouseover.pixel == 'x=01.0'
+    assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
+    assert spec_viewer.label_mouseover.world_ra == '4.62360e-07'
+    assert spec_viewer.label_mouseover.world_dec == 'm'
+    assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
+    assert spec_viewer.label_mouseover.world_ra_deg == '9.20000e+01'
+    assert spec_viewer.label_mouseover.world_dec_deg == 'Jy'
+    assert spec_viewer.label_mouseover.icon == 'a'
+
+    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 4.633e-7, 'y': 20}})
+    assert spec_viewer.label_mouseover.pixel == 'x=01.0'
+    assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
+    assert spec_viewer.label_mouseover.world_ra == '4.62360e-07'
+    assert spec_viewer.label_mouseover.world_dec == 'm'
+    assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
+    assert spec_viewer.label_mouseover.world_ra_deg == '1.47943e+01'
+    assert spec_viewer.label_mouseover.world_dec_deg == 'Jy'
+    assert spec_viewer.label_mouseover.icon == 'b'
+
+    # Check mouseover behavior when we hide everything.
+    for lyr in spec_viewer.layers:
+        lyr.visible = False
+
+    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 4.633e-7, 'y': 60}})
+    assert spec_viewer.label_mouseover.pixel == ''
+    assert spec_viewer.label_mouseover.world_label_prefix == '\xa0'
+    assert spec_viewer.label_mouseover.world_ra == ''
+    assert spec_viewer.label_mouseover.world_dec == ''
+    assert spec_viewer.label_mouseover.world_label_prefix_2 == '\xa0'
+    assert spec_viewer.label_mouseover.world_ra_deg == ''
+    assert spec_viewer.label_mouseover.world_dec_deg == ''
+    assert spec_viewer.label_mouseover.icon == ''
+
+
 def test_spatial_convolution(cubeviz_helper, spectrum1d_cube):
     dc = cubeviz_helper.app.data_collection
-    cubeviz_helper.app.add_data(spectrum1d_cube, 'test')
-    cubeviz_helper.app.add_data_to_viewer('flux-viewer', 'test')
+    cubeviz_helper.load_data(spectrum1d_cube, data_label='test')
 
-    gs = GaussianSmooth(app=cubeviz_helper.app)
-    gs.dataset_selected = 'test'
+    gs = cubeviz_helper.plugins['Gaussian Smooth']._obj
+    gs.dataset_selected = 'test[FLUX]'
     gs.mode_selected = 'Spatial'
     gs.stddev = 3
     assert gs.results_label == 'spatial-smooth stddev-3.0'
-    gs.vue_apply()
+    with pytest.warns(
+            AstropyUserWarning,
+            match='The following attributes were set on the data object, but will be ignored'):
+        gs.vue_apply()
 
     assert len(dc) == 2
     assert dc[1].label == "spatial-smooth stddev-3.0"
+    assert dc[1].shape == (2, 4, 2)  # specutils moved spectral axis to last
     assert (dc["spatial-smooth stddev-3.0"].get_object(cls=Spectrum1D, statistic=None).shape
-            == (4, 2, 2))
+            == (2, 4, 2))
+
+
+def test_spectrum1d_smooth(specviz_helper, spectrum1d):
+    dc = specviz_helper.app.data_collection
+    specviz_helper.load_data(spectrum1d, data_label='test')
+    spec_viewer = specviz_helper.app.get_viewer('spectrum-viewer')
+
+    gs = specviz_helper.plugins['Gaussian Smooth']._obj
+    gs.dataset_selected = 'test'
+    gs.mode_selected = 'Spectral'
+    gs.stddev = 10
+    gs.vue_apply()
+
+    assert len(dc) == 2
+    assert dc[1].label == 'smooth stddev-10.0'
+
+    # Mouseover should automatically jump from one spectrum
+    # to another, depending on which one is closer.
+
+    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 6400, 'y': 120}})
+    assert spec_viewer.label_mouseover.pixel == 'x=02.0'
+    assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
+    assert spec_viewer.label_mouseover.world_ra == '6.44444e+03'
+    assert spec_viewer.label_mouseover.world_dec == 'Angstrom'
+    assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
+    assert spec_viewer.label_mouseover.world_ra_deg == '1.35366e+01'
+    assert spec_viewer.label_mouseover.world_dec_deg == 'Jy'
+    assert spec_viewer.label_mouseover.icon == 'a'
+
+    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 6400, 'y': 5}})
+    assert spec_viewer.label_mouseover.pixel == 'x=02.0'
+    assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
+    assert spec_viewer.label_mouseover.world_ra == '6.44444e+03'
+    assert spec_viewer.label_mouseover.world_dec == 'Angstrom'
+    assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
+    assert spec_viewer.label_mouseover.world_ra_deg == '5.34688e+00'
+    assert spec_viewer.label_mouseover.world_dec_deg == 'Jy'
+    assert spec_viewer.label_mouseover.icon == 'b'
+
+    # Out-of-bounds should lock to closest edge value.
+    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 5500, 'y': 120}})
+    assert spec_viewer.label_mouseover.pixel == 'x=00.0'
+    assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
+    assert spec_viewer.label_mouseover.world_ra == '6.00000e+03'
+    assert spec_viewer.label_mouseover.world_dec == 'Angstrom'
+    assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
+    assert spec_viewer.label_mouseover.world_ra_deg == '1.24967e+01'
+    assert spec_viewer.label_mouseover.world_dec_deg == 'Jy'
+    assert spec_viewer.label_mouseover.icon == 'a'

--- a/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
@@ -69,23 +69,19 @@ def test_linking_after_spectral_smooth(cubeviz_helper, spectrum1d_cube):
     # to another, depending on which one is closer.
 
     spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 4.6236e-7, 'y': 60}})
-    assert spec_viewer.label_mouseover.pixel == 'x=01.0'
+    assert spec_viewer.label_mouseover.pixel == '4.62360e-07, 6.00000e+01'
     assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
-    assert spec_viewer.label_mouseover.world_ra == '4.62360e-07'
-    assert spec_viewer.label_mouseover.world_dec == 'm'
+    assert spec_viewer.label_mouseover.world_ra == '4.62360e-07 m (1 pix)'
     assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
-    assert spec_viewer.label_mouseover.world_ra_deg == '9.20000e+01'
-    assert spec_viewer.label_mouseover.world_dec_deg == 'Jy'
+    assert spec_viewer.label_mouseover.world_ra_deg == '9.20000e+01 Jy'
     assert spec_viewer.label_mouseover.icon == 'a'
 
     spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 4.6236e-7, 'y': 20}})
-    assert spec_viewer.label_mouseover.pixel == 'x=01.0'
+    assert spec_viewer.label_mouseover.pixel == '4.62360e-07, 2.00000e+01'
     assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
-    assert spec_viewer.label_mouseover.world_ra == '4.62360e-07'
-    assert spec_viewer.label_mouseover.world_dec == 'm'
+    assert spec_viewer.label_mouseover.world_ra == '4.62360e-07 m (1 pix)'
     assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
-    assert spec_viewer.label_mouseover.world_ra_deg == '1.47943e+01'
-    assert spec_viewer.label_mouseover.world_dec_deg == 'Jy'
+    assert spec_viewer.label_mouseover.world_ra_deg == '1.47943e+01 Jy'
     assert spec_viewer.label_mouseover.icon == 'b'
 
     # Check mouseover behavior when we hide everything.
@@ -142,23 +138,18 @@ def test_spectrum1d_smooth(specviz_helper, spectrum1d):
     # to another, depending on which one is closer.
 
     spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 6400, 'y': 120}})
-    assert spec_viewer.label_mouseover.pixel == 'x=02.0'
+    assert spec_viewer.label_mouseover.pixel == '6.40000e+03, 1.20000e+02'
     assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
-    assert spec_viewer.label_mouseover.world_ra == '6.44444e+03'
-    assert spec_viewer.label_mouseover.world_dec == 'Angstrom'
+    assert spec_viewer.label_mouseover.world_ra == '6.44444e+03 Angstrom (2 pix)'
     assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
-    assert spec_viewer.label_mouseover.world_ra_deg == '1.35366e+01'
-    assert spec_viewer.label_mouseover.world_dec_deg == 'Jy'
+    assert spec_viewer.label_mouseover.world_ra_deg == '1.35366e+01 Jy'
     assert spec_viewer.label_mouseover.icon == 'a'
 
     spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 6400, 'y': 5}})
-    assert spec_viewer.label_mouseover.pixel == 'x=02.0'
     assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
-    assert spec_viewer.label_mouseover.world_ra == '6.44444e+03'
-    assert spec_viewer.label_mouseover.world_dec == 'Angstrom'
+    assert spec_viewer.label_mouseover.world_ra == '6.44444e+03 Angstrom (2 pix)'
     assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
-    assert spec_viewer.label_mouseover.world_ra_deg == '5.34688e+00'
-    assert spec_viewer.label_mouseover.world_dec_deg == 'Jy'
+    assert spec_viewer.label_mouseover.world_ra_deg == '5.34688e+00 Jy'
     assert spec_viewer.label_mouseover.icon == 'b'
 
     # Out-of-bounds shows nothing.

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -13,6 +13,7 @@ class CoordsInfo(TemplateMixin):
     pixel = Unicode("").tag(sync=True)
     value = Unicode("").tag(sync=True)
     world_label_prefix = Unicode("\u00A0").tag(sync=True)
+    world_label_prefix_2 = Unicode("\u00A0").tag(sync=True)
     world_label_icrs = Unicode("\u00A0").tag(sync=True)
     world_label_deg = Unicode("\u00A0").tag(sync=True)
     world_ra = Unicode("").tag(sync=True)
@@ -24,6 +25,7 @@ class CoordsInfo(TemplateMixin):
 
     def reset_coords_display(self):
         self.world_label_prefix = '\u00A0'
+        self.world_label_prefix_2 = '\u00A0'
         self.world_label_icrs = '\u00A0'
         self.world_label_deg = '\u00A0'
         self.world_ra = ''
@@ -53,3 +55,7 @@ class CoordsInfo(TemplateMixin):
             self.world_dec_deg = world_dec_deg
             self.unreliable_world = unreliable_world
             self.unreliable_pixel = unreliable_pixel
+            if unreliable_world:
+                self.world_label_prefix_2 = '(est.)'
+            else:
+                self.world_label_prefix_2 = '\u00A0'

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -43,7 +43,9 @@ class CoordsInfo(TemplateMixin):
         # for new viewers if dynamic creation of spectral viewers is ever supported)
         for id, viewer in self.app._viewer_store.items():
             if isinstance(viewer, SpecvizProfileView):
-                self._marks[id] = PluginScatter(viewer, visible=False)
+                self._marks[id] = PluginScatter(viewer,
+                                                marker='rectangle', stroke_width=1,
+                                                visible=False)
                 viewer.figure.marks = viewer.figure.marks + [self._marks[id]]
         return self._marks
 

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -12,6 +12,7 @@ __all__ = ['CoordsInfo']
 class CoordsInfo(TemplateMixin):
     template_file = __file__, "coords_info.vue"
     icon = Unicode("").tag(sync=True)
+    pixel_prefix = Unicode("Pixel").tag(sync=True)
     pixel = Unicode("").tag(sync=True)
     value = Unicode("").tag(sync=True)
     world_label_prefix = Unicode("\u00A0").tag(sync=True)
@@ -47,6 +48,7 @@ class CoordsInfo(TemplateMixin):
         return self._marks
 
     def reset_coords_display(self):
+        self.pixel_prefix = "Pixel"
         self.world_label_prefix = '\u00A0'
         self.world_label_prefix_2 = '\u00A0'
         self.world_label_icrs = '\u00A0'
@@ -69,6 +71,7 @@ class CoordsInfo(TemplateMixin):
         if "nan" in (world_ra, world_dec, world_ra_deg, world_dec_deg):
             self.reset_coords_display()
         else:
+            self.pixel_prefix = 'Pixel'
             self.world_label_prefix = 'World'
             self.world_label_icrs = '(ICRS)'
             self.world_label_deg = '(deg)'

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.vue
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.vue
@@ -13,13 +13,13 @@
         </tr>
         <tr :style="unreliable_world ? 'color: #B8B8B8' : ''">
           <td width="42"><b>{{ world_label_prefix }}</b></td>
-          <td width="115">{{ world_ra }}</td>
+          <td :width="world_label_prefix == 'Wave' ? 85 : 115">{{ world_ra }}</td>
           <td width="120">{{ world_dec }}</td>
           <td>{{ world_label_icrs }}</td>
         </tr>
         <tr :style="unreliable_world ? 'color: #B8B8B8' : ''">
-          <td width="42">{{ unreliable_world ? '(est.)' : '' }}</td>
-          <td width="115">{{ world_ra_deg }}</td>
+          <td width="42" :style="unreliable_world ? '' : 'font-weight: bold'">{{ world_label_prefix_2 }}</td>
+          <td :width="world_label_prefix == 'Wave' ? 85 : 115">{{ world_ra_deg }}</td>
           <td width="120">{{ world_dec_deg }}</td>
           <td>{{ world_label_deg }}</td>
         </tr>

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.vue
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.vue
@@ -7,7 +7,7 @@
       <table>
         <tr>
           <td colspan="4" :style="unreliable_pixel ? 'color: #B8B8B8' : ''">
-            <b v-if="pixel">Pixel </b>{{ pixel }}&nbsp;&nbsp;
+            <b v-if="pixel">{{ pixel_prefix }} </b>{{ pixel }}&nbsp;&nbsp;
             <b v-if="value">Value </b>{{ value }}
           </td>
         </tr>

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -271,6 +271,7 @@ class TestLink_WCS_GWCS(BaseImviz_WCS_GWCS):
         # but cursor is outside GWCS bounding box
         assert self.viewer.label_mouseover.unreliable_world
         assert self.viewer.label_mouseover.unreliable_pixel
+        assert self.viewer.label_mouseover.world_label_prefix_2 == '(est.)'
 
 
 class TestLink_GWCS_GWCS(BaseImviz_GWCS_GWCS):

--- a/jdaviz/configs/mosviz/tests/test_data_loading.py
+++ b/jdaviz/configs/mosviz/tests/test_data_loading.py
@@ -218,13 +218,11 @@ def test_load_single_image_multi_spec(mosviz_helper, mos_image, spectrum1d, mos_
     assert spec2d_viewer.label_mouseover.icon == 'b'
 
     spec1d_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 7000, 'y': 170}})
-    assert spec1d_viewer.label_mouseover.pixel == 'x=04.0'
+    assert spec1d_viewer.label_mouseover.pixel == '7.00000e+03, 1.70000e+02'
     assert spec1d_viewer.label_mouseover.world_label_prefix == 'Wave'
-    assert spec1d_viewer.label_mouseover.world_ra == '6.88889e+03'
-    assert spec1d_viewer.label_mouseover.world_dec == 'Angstrom'
+    assert spec1d_viewer.label_mouseover.world_ra == '6.88889e+03 Angstrom (4 pix)'
     assert spec1d_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
-    assert spec1d_viewer.label_mouseover.world_ra_deg == '1.35436e+01'
-    assert spec1d_viewer.label_mouseover.world_dec_deg == 'Jy'
+    assert spec1d_viewer.label_mouseover.world_ra_deg == '1.35436e+01 Jy'
     assert spec1d_viewer.label_mouseover.icon == 'c'
 
 

--- a/jdaviz/configs/mosviz/tests/test_data_loading.py
+++ b/jdaviz/configs/mosviz/tests/test_data_loading.py
@@ -157,6 +157,8 @@ def test_load_single_image_multi_spec(mosviz_helper, mos_image, spectrum1d, mos_
     spectra2d = [mos_spectrum2d] * 3
 
     image_viewer = mosviz_helper.app.get_viewer('image-viewer')
+    spec1d_viewer = mosviz_helper.app.get_viewer('spectrum-viewer')
+    spec2d_viewer = mosviz_helper.app.get_viewer('spectrum-2d-viewer')
 
     # Coordinates info panel should not crash even when nothing is loaded.
     image_viewer.on_mouse_or_key_event({'event': 'mouseover'})
@@ -180,14 +182,15 @@ def test_load_single_image_multi_spec(mosviz_helper, mos_image, spectrum1d, mos_
     assert len(qtable) == 3
 
     # Also check coordinates info panels for Mosviz image viewer.
-    # 1D spectrum viewer panel is already tested in Specviz.
-    # 2D spectrum viewer panel is already tested in Specviz2d.
+    # 1D spectrum viewer panel is also tested in Specviz.
+    # 2D spectrum viewer panel is also tested in Specviz2d.
 
     image_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
     assert image_viewer.label_mouseover.pixel == 'x=000.0 y=000.0'
     assert image_viewer.label_mouseover.value == '+3.74540e-01 Jy'
     assert image_viewer.label_mouseover.world_ra_deg == '5.0297844783'
     assert image_viewer.label_mouseover.world_dec_deg == '4.9918991917'
+    assert image_viewer.label_mouseover.icon == 'a'
 
     image_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': None, 'y': 0}})
     assert image_viewer.label_mouseover.pixel == ''
@@ -206,6 +209,23 @@ def test_load_single_image_multi_spec(mosviz_helper, mos_image, spectrum1d, mos_
     assert image_viewer.label_mouseover.value == ''
     assert image_viewer.label_mouseover.world_ra_deg == ''
     assert image_viewer.label_mouseover.world_dec_deg == ''
+
+    spec2d_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 10, 'y': 100}})
+    assert spec2d_viewer.label_mouseover.pixel == 'x=00010.0 y=00100.0'
+    assert spec2d_viewer.label_mouseover.value == '+8.12986e-01 '
+    assert spec2d_viewer.label_mouseover.world_ra_deg == ''
+    assert spec2d_viewer.label_mouseover.world_dec_deg == ''
+    assert spec2d_viewer.label_mouseover.icon == 'b'
+
+    spec1d_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 7000, 'y': 170}})
+    assert spec1d_viewer.label_mouseover.pixel == 'x=04.0'
+    assert spec1d_viewer.label_mouseover.world_label_prefix == 'Wave'
+    assert spec1d_viewer.label_mouseover.world_ra == '6.88889e+03'
+    assert spec1d_viewer.label_mouseover.world_dec == 'Angstrom'
+    assert spec1d_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
+    assert spec1d_viewer.label_mouseover.world_ra_deg == '1.35436e+01'
+    assert spec1d_viewer.label_mouseover.world_dec_deg == 'Jy'
+    assert spec1d_viewer.label_mouseover.icon == 'c'
 
 
 def test_zip_error(mosviz_helper, tmp_path):

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -128,6 +128,7 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
                 self.label_mouseover.pixel = ""
                 self.label_mouseover.reset_coords_display()
                 self.label_mouseover.value = ""
+                self.label_mouseover.marks[self._reference_id].visible = False
                 return
 
             fmt = 'x={:0' + str(closest_maxsize) + '.1f}'
@@ -140,12 +141,15 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
             self.label_mouseover.world_dec_deg = closest_flux.unit.to_string()
             self.label_mouseover.icon = closest_label
             self.label_mouseover.value = ""  # Not used
+            self.label_mouseover.marks[self._reference_id].update_xy([closest_wave.value], [closest_flux.value])
+            self.label_mouseover.marks[self._reference_id].visible = True
 
         elif data['event'] == 'mouseleave' or data['event'] == 'mouseenter':
             self.label_mouseover.icon = ""
             self.label_mouseover.pixel = ""
             self.label_mouseover.reset_coords_display()
             self.label_mouseover.value = ""
+            self.label_mouseover.marks[self._reference_id].visible = False
 
     def _expected_subset_layer_default(self, layer_state):
         super()._expected_subset_layer_default(layer_state)

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -131,18 +131,27 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
                 self.label_mouseover.marks[self._reference_id].visible = False
                 return
 
-            fmt = 'x={:0' + str(closest_maxsize) + '.1f}'
-            self.label_mouseover.pixel = fmt.format(closest_i)
-            self.label_mouseover.world_label_prefix = 'Wave'
-            self.label_mouseover.world_ra = f'{closest_wave.value:10.5e}'
-            self.label_mouseover.world_dec = closest_wave.unit.to_string()
-            self.label_mouseover.world_label_prefix_2 = 'Flux'
-            self.label_mouseover.world_ra_deg = f'{closest_flux.value:10.5e}'
-            self.label_mouseover.world_dec_deg = closest_flux.unit.to_string()
-            self.label_mouseover.icon = closest_label
-            self.label_mouseover.value = ""  # Not used
-            self.label_mouseover.marks[self._reference_id].update_xy([closest_wave.value], [closest_flux.value])
-            self.label_mouseover.marks[self._reference_id].visible = True
+            # show the locked marker/coords only if either no tool or the default tool is active
+            locking_active = self.toolbar.active_tool_id in self.toolbar.default_tool_priority + [None]  # noqa
+            if locking_active:
+                fmt = 'x={:0' + str(closest_maxsize) + '.1f}'
+                self.label_mouseover.pixel = fmt.format(closest_i)
+                self.label_mouseover.world_label_prefix = 'Wave'
+                self.label_mouseover.world_ra = f'{closest_wave.value:10.5e}'
+                self.label_mouseover.world_dec = closest_wave.unit.to_string()
+                self.label_mouseover.world_label_prefix_2 = 'Flux'
+                self.label_mouseover.world_ra_deg = f'{closest_flux.value:10.5e}'
+                self.label_mouseover.world_dec_deg = closest_flux.unit.to_string()
+                self.label_mouseover.icon = closest_label
+                self.label_mouseover.value = ""  # Not used
+                self.label_mouseover.marks[self._reference_id].update_xy([closest_wave.value], [closest_flux.value])  # noqa
+                self.label_mouseover.marks[self._reference_id].visible = True
+            else:
+                # show exact plot coordinates (useful for drawing spectral subsets or zoom ranges)
+                fmt = 'x={:+10.5e} y={:+10.5e}'
+                self.label_mouseover.icon = ""
+                self.label_mouseover.pixel = fmt.format(x, y)
+                self.label_mouseover.marks[self._reference_id].visible = False
 
         elif data['event'] == 'mouseleave' or data['event'] == 'mouseenter':
             self.label_mouseover.icon = ""

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -80,9 +80,9 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
 
             # Snap to the closest data point, not the actual mouse location.
             sp = None
-            closest_i = 0
-            closest_wave = 0
-            closest_flux = 0
+            closest_i = None
+            closest_wave = None
+            closest_flux = None
             closest_maxsize = 0
             closest_label = ''
             closest_distance = None
@@ -95,6 +95,10 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
                     # TODO: Is there a way to cache this?
                     sp = lyr.layer.get_object(
                         cls=Spectrum1D, statistic=getattr(self.state, 'function', None))
+
+                    # Out of range in spectral axis.
+                    if x < sp.spectral_axis.value.min() or x > sp.spectral_axis.value.max():
+                        continue
 
                     cur_i = np.argmin(abs(sp.spectral_axis.value - x))
                     cur_wave = sp.spectral_axis[cur_i]
@@ -110,10 +114,10 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
                         closest_flux = cur_flux
                         closest_maxsize = int(np.ceil(np.log10(sp.spectral_axis.size))) + 3
                         closest_label = self.jdaviz_app.state.layer_icons.get(lyr.layer.label)
-                except Exception:
+                except Exception:  # Something is loaded but not the right thing # pragma: no cover
                     sp = None
 
-            if sp is None:  # Something is loaded but not the right thing
+            if sp is None or closest_wave is None:
                 self.label_mouseover.icon = ""
                 self.label_mouseover.pixel = ""
                 self.label_mouseover.reset_coords_display()

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -105,8 +105,9 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
                     if cache_key in self.jdaviz_app._get_object_cache:
                         sp = self.jdaviz_app._get_object_cache[cache_key]
                     else:
-                        sp = self.jdaviz_app.get_data_from_viewer('spectrum-viewer',
-                                                                  lyr.layer.label)
+                        sp = self.jdaviz_app.get_data_from_viewer(
+                            self.jdaviz_app._default_spectrum_viewer_reference_name,
+                            lyr.layer.label)
                         self.jdaviz_app._get_object_cache[cache_key] = sp
 
                     # Out of range in spectral axis.

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -204,16 +204,43 @@ def test_get_spectral_regions_unit(specviz_helper, spectrum1d):
 
 
 def test_get_spectral_regions_unit_conversion(specviz_helper, spectrum1d):
+    spec_viewer = specviz_helper.app.get_viewer('spectrum-viewer')
+
+    # Mouseover without data should not crash.
+    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 6100, 'y': 12.5}})
+    assert spec_viewer.label_mouseover.pixel == ''
+    assert spec_viewer.label_mouseover.world_label_prefix == '\xa0'
+    assert spec_viewer.label_mouseover.world_ra == ''
+    assert spec_viewer.label_mouseover.world_dec == ''
+    assert spec_viewer.label_mouseover.world_label_prefix_2 == '\xa0'
+    assert spec_viewer.label_mouseover.world_ra_deg == ''
+    assert spec_viewer.label_mouseover.world_dec_deg == ''
+    assert spec_viewer.label_mouseover.icon == ''
+
     # If the reference (visible) data changes via unit conversion,
     # check that the region's units convert too
     specviz_helper.load_spectrum(spectrum1d)
 
-    # Also check coordinates info panel
-    spec_viewer = specviz_helper.app.get_viewer('spectrum-viewer')
+    # Also check coordinates info panel.
+    # x=0 -> 6000 A, x=1 -> 6222.222 A
     spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 6100, 'y': 12.5}})
-    assert spec_viewer.label_mouseover.pixel == 'x=+6.10000e+03 y=+1.25000e+01'
+    assert spec_viewer.label_mouseover.pixel == 'x=00.0'  # Actual: x=00.4
+    assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
+    assert spec_viewer.label_mouseover.world_ra == '6.00000e+03'
+    assert spec_viewer.label_mouseover.world_dec == 'Angstrom'
+    assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
+    assert spec_viewer.label_mouseover.world_ra_deg == '1.24967e+01'
+    assert spec_viewer.label_mouseover.world_dec_deg == 'Jy'
+    assert spec_viewer.label_mouseover.icon == 'a'
     spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': None, 'y': 12.5}})
     assert spec_viewer.label_mouseover.pixel == ''
+    assert spec_viewer.label_mouseover.world_label_prefix == '\xa0'
+    assert spec_viewer.label_mouseover.world_ra == ''
+    assert spec_viewer.label_mouseover.world_dec == ''
+    assert spec_viewer.label_mouseover.world_label_prefix_2 == '\xa0'
+    assert spec_viewer.label_mouseover.world_ra_deg == ''
+    assert spec_viewer.label_mouseover.world_dec_deg == ''
+    assert spec_viewer.label_mouseover.icon == 'a'
 
     # Convert the wavelength axis to microns
     new_spectral_axis = "micron"
@@ -238,9 +265,23 @@ def test_get_spectral_regions_unit_conversion(specviz_helper, spectrum1d):
 
     # Coordinates info panel should show new unit
     spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0.61, 'y': 12.5}})
-    assert spec_viewer.label_mouseover.pixel == 'x=+6.10000e-01 y=+1.25000e+01'
+    assert spec_viewer.label_mouseover.pixel == 'x=00.0'
+    assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
+    assert spec_viewer.label_mouseover.world_ra == '6.00000e-01'
+    assert spec_viewer.label_mouseover.world_dec == 'micron'
+    assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
+    assert spec_viewer.label_mouseover.world_ra_deg == '1.24967e+01'
+    assert spec_viewer.label_mouseover.world_dec_deg == 'Jy'
+    assert spec_viewer.label_mouseover.icon == 'b'
     spec_viewer.on_mouse_or_key_event({'event': 'mouseleave'})
     assert spec_viewer.label_mouseover.pixel == ''
+    assert spec_viewer.label_mouseover.world_label_prefix == '\xa0'
+    assert spec_viewer.label_mouseover.world_ra == ''
+    assert spec_viewer.label_mouseover.world_dec == ''
+    assert spec_viewer.label_mouseover.world_label_prefix_2 == '\xa0'
+    assert spec_viewer.label_mouseover.world_ra_deg == ''
+    assert spec_viewer.label_mouseover.world_dec_deg == ''
+    assert spec_viewer.label_mouseover.icon == ''
 
 
 def test_subset_default_thickness(specviz_helper, spectrum1d):

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -225,13 +225,11 @@ def test_get_spectral_regions_unit_conversion(specviz_helper, spectrum1d):
     # Also check coordinates info panel.
     # x=0 -> 6000 A, x=1 -> 6222.222 A
     spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 6100, 'y': 12.5}})
-    assert spec_viewer.label_mouseover.pixel == 'x=00.0'  # Actual: x=00.4
+    assert spec_viewer.label_mouseover.pixel == '6.10000e+03, 1.25000e+01'
     assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
-    assert spec_viewer.label_mouseover.world_ra == '6.00000e+03'
-    assert spec_viewer.label_mouseover.world_dec == 'Angstrom'
+    assert spec_viewer.label_mouseover.world_ra == '6.00000e+03 Angstrom (0 pix)'  # actual: 0.4
     assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
-    assert spec_viewer.label_mouseover.world_ra_deg == '1.24967e+01'
-    assert spec_viewer.label_mouseover.world_dec_deg == 'Jy'
+    assert spec_viewer.label_mouseover.world_ra_deg == '1.24967e+01 Jy'
     assert spec_viewer.label_mouseover.icon == 'a'
     spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': None, 'y': 12.5}})
     assert spec_viewer.label_mouseover.pixel == ''
@@ -266,13 +264,11 @@ def test_get_spectral_regions_unit_conversion(specviz_helper, spectrum1d):
 
     # Coordinates info panel should show new unit
     spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0.61, 'y': 12.5}})
-    assert spec_viewer.label_mouseover.pixel == 'x=00.0'
+    assert spec_viewer.label_mouseover.pixel == '6.10000e-01, 1.25000e+01'
     assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
-    assert spec_viewer.label_mouseover.world_ra == '6.00000e-01'
-    assert spec_viewer.label_mouseover.world_dec == 'micron'
+    assert spec_viewer.label_mouseover.world_ra == '6.00000e-01 micron (0 pix)'
     assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
-    assert spec_viewer.label_mouseover.world_ra_deg == '1.24967e+01'
-    assert spec_viewer.label_mouseover.world_dec_deg == 'Jy'
+    assert spec_viewer.label_mouseover.world_ra_deg == '1.24967e+01 Jy'
     assert spec_viewer.label_mouseover.icon == 'b'
     spec_viewer.on_mouse_or_key_event({'event': 'mouseleave'})
     assert spec_viewer.label_mouseover.pixel == ''
@@ -401,11 +397,9 @@ def test_spectra_partial_overlap(specviz_helper):
     # Test mouseover outside of left but in range for right.
     # Should show right spectrum even when mouse is near left flux.
     spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 7022, 'y': 1000}})
-    assert spec_viewer.label_mouseover.pixel == 'x=02.0'
+    assert spec_viewer.label_mouseover.pixel == '7.02200e+03, 1.00000e+03'
     assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
-    assert spec_viewer.label_mouseover.world_ra == '7.02222e+03'
-    assert spec_viewer.label_mouseover.world_dec == 'Angstrom'
+    assert spec_viewer.label_mouseover.world_ra == '7.02222e+03 Angstrom (2 pix)'
     assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
-    assert spec_viewer.label_mouseover.world_ra_deg == '6.00000e+01'
-    assert spec_viewer.label_mouseover.world_dec_deg == 'nJy'
+    assert spec_viewer.label_mouseover.world_ra_deg == '6.00000e+01 nJy'
     assert spec_viewer.label_mouseover.icon == 'b'

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -68,13 +68,26 @@ def test_2d_parser_no_unit(specviz2d_helper, mos_spectrum2d):
     assert dc_1.label == 'Spectrum 1D'
     assert dc_1.get_component('flux').units == dc_0.get_component('flux').units
 
-    # Also check the coordinates info panel.
+    # Also check the coordinates info panels.
+
     viewer_2d = specviz2d_helper.app.get_viewer('spectrum-2d-viewer')
     viewer_2d.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
     assert viewer_2d.label_mouseover.pixel == 'x=00000.0 y=00000.0'
     assert viewer_2d.label_mouseover.value == '+3.74540e-01 '
     assert viewer_2d.label_mouseover.world_ra_deg == ''
     assert viewer_2d.label_mouseover.world_dec_deg == ''
+    assert viewer_2d.label_mouseover.icon == 'a'
+
+    viewer_1d = specviz2d_helper.app.get_viewer('spectrum-viewer')
+    viewer_1d.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 6.5, 'y': 3}})
+    assert viewer_1d.label_mouseover.pixel == 'x=006.0'
+    assert viewer_1d.label_mouseover.world_label_prefix == 'Wave'
+    assert viewer_1d.label_mouseover.world_ra == '6.00000e+00'
+    assert viewer_1d.label_mouseover.world_dec == 'pix'
+    assert viewer_1d.label_mouseover.world_label_prefix_2 == 'Flux'
+    assert viewer_1d.label_mouseover.world_ra_deg == '-3.59571e+00'
+    assert viewer_1d.label_mouseover.world_dec_deg == ''
+    assert viewer_1d.label_mouseover.icon == 'b'
 
 
 def test_1d_parser(specviz2d_helper, spectrum1d):

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -80,13 +80,11 @@ def test_2d_parser_no_unit(specviz2d_helper, mos_spectrum2d):
 
     viewer_1d = specviz2d_helper.app.get_viewer('spectrum-viewer')
     viewer_1d.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 6.5, 'y': 3}})
-    assert viewer_1d.label_mouseover.pixel == 'x=006.0'
+    assert viewer_1d.label_mouseover.pixel == '6.50000e+00, 3.00000e+00'
     assert viewer_1d.label_mouseover.world_label_prefix == 'Wave'
-    assert viewer_1d.label_mouseover.world_ra == '6.00000e+00'
-    assert viewer_1d.label_mouseover.world_dec == 'pix'
+    assert viewer_1d.label_mouseover.world_ra == '6.00000e+00 pix'
     assert viewer_1d.label_mouseover.world_label_prefix_2 == 'Flux'
-    assert viewer_1d.label_mouseover.world_ra_deg == '-3.59571e+00'
-    assert viewer_1d.label_mouseover.world_dec_deg == ''
+    assert viewer_1d.label_mouseover.world_ra_deg == '-3.59571e+00 '  # extra space for no unit
     assert viewer_1d.label_mouseover.icon == 'b'
 
 

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -13,7 +13,7 @@ from jdaviz.core.events import (SliceToolStateMessage, LineIdentifyMessage,
 
 __all__ = ['OffscreenLinesMarks', 'BaseSpectrumVerticalLine', 'SpectralLine',
            'SliceIndicatorMarks', 'ShadowMixin', 'ShadowLine', 'ShadowLabelFixedY',
-           'PluginLine',
+           'PluginMark', 'PluginLine', 'PluginScatter',
            'LineAnalysisContinuum', 'LineAnalysisContinuumCenter',
            'LineAnalysisContinuumLeft', 'LineAnalysisContinuumRight',
            'LineUncertainties', 'ScatterMask', 'SelectedSpaxel']
@@ -484,17 +484,29 @@ class ShadowLabelFixedY(Label, ShadowMixin):
             self._update_align()
 
 
-class PluginLine(Lines, HubListener):
-    def __init__(self, viewer, x=[], y=[], **kwargs):
-        # color is same blue as import button
-        super().__init__(x=x, y=y, colors=["#007BA1"], scales=viewer.scales, **kwargs)
-
+class PluginMark():
     def update_xy(self, x, y):
         self.x = np.asarray(x)
         self.y = np.asarray(y)
 
+    def append_xy(self, x, y):
+        self.x = np.append(self.x, x)
+        self.y = np.append(self.y, y)
+
     def clear(self):
         self.update_xy([], [])
+
+
+class PluginLine(Lines, PluginMark, HubListener):
+    def __init__(self, viewer, x=[], y=[], **kwargs):
+        # color is same blue as import button
+        super().__init__(x=x, y=y, colors=["#007BA1"], scales=viewer.scales, **kwargs)
+
+
+class PluginScatter(Scatter, PluginMark, HubListener):
+    def __init__(self, viewer, x=[], y=[], **kwargs):
+        # color is same blue as import button
+        super().__init__(x=x, y=y, colors=["#007BA1"], scales=viewer.scales, **kwargs)
 
 
 class LineAnalysisContinuum(PluginLine):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to implement the following feature request:

* The display should show the pixel in x on the first line and spectral axis and flux on the second line with appropriate units.
* The cursor should lock to the spectrum in x only.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### TODO

- [x] Fix Cubeviz. It uses `PaddedSpectrumWCS` and not `SpectralCoordinates`.
- [x] Fix Mosviz.
- [x] Specviz2d? Need #1889 
- [x] Generalize the new code?
- [x] Make it work on collapsed Subset
- [x] Visualization like https://tradingeconomics.com/commodity/lumber minus the dashed lines. See https://github.com/pllim/jdaviz/pull/8
  - Is marker behavior acceptable? Is it too confusing to have both marker and the cursor?
  - Are different display formats acceptable when tool is toggled on and off?
- [ ] Acceptable performance (especially using MANGA cube in Cubeviz)

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-2947)
