### PR TITLE
Add caveat to Cubeviz line analysis docs on uncertainties

### DIFF
--- a/docs/cubeviz/plugins.rst
+++ b/docs/cubeviz/plugins.rst
@@ -167,6 +167,13 @@ Line Analysis
     :ref:`Line Analysis <line-analysis>`
         Specviz documentation on line analysis.
 
+Currently the Line Analysis plugin in Cubeviz will calculate statistics
+for spectral features in the collapsed spectrum, which is visualized in
+the spectrum viewer. The plugin is unaware of the observational uncertainties
+that are displayed in the uncertainty viewer (top-right). As a result,
+uncertainties on values provided by the Line Analysis plugin are
+not provided.
+
 
 .. _moment-maps:
 

--- a/docs/cubeviz/plugins.rst
+++ b/docs/cubeviz/plugins.rst
@@ -169,8 +169,8 @@ Line Analysis
 
 Currently the Line Analysis plugin in Cubeviz will calculate statistics
 for spectral features in the collapsed spectrum, which is visualized in
-the spectrum viewer. The plugin is unaware of the observational uncertainties
-that are displayed in the uncertainty viewer (top-right). As a result,
+the spectrum viewer. The propagation of uncertainties from the uncertainty
+cube to the collapsed spectrum is still work in progress. As a result,
 uncertainties on values provided by the Line Analysis plugin are
 not provided.
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description

While investigating #1869, @camipacifici suggested we put a caveat in the docs so users understand that the uncertainties are being visualized in the `uncert-viewer` but not propagated in the collapsed spectrum calculations. This PR adds such a note to the Cubeviz Line Analysis plugin docs. 

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
