### PR TITLE
POC: Attempt to package jdaviz in Pyinstaller

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ New Features
 
 - Model fitting plugin can optionally expose the residuals as an additional data collection entry.
   [#1864]
+- CLI launchers no longer require data to be specified [#1890]
+
+- Added direct launchers for each config (e.g. ``specviz``) [#1890]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -85,14 +85,15 @@ def main(filename, layout='default', instrument=None, browser='default',
         os.chdir(start_dir)
 
 
-def _main():
+def _main(force_layout=None):
     import argparse
     import sys
 
     parser = argparse.ArgumentParser(description='Start a Jdaviz application instance with data '
                                      'loaded from FILENAME.')
-    parser.add_argument('layout', choices=['cubeviz', 'specviz', 'specviz2d', 'mosviz', 'imviz'],
-                        help='Configuration to use.')
+    if force_layout == None:
+        parser.add_argument('layout', choices=['cubeviz', 'specviz', 'specviz2d', 'mosviz', 'imviz'],
+                            help='Configuration to use.')
     parser.add_argument('filename', type=str,
                         help='The path to the file to be loaded into the Jdaviz application.')
     parser.add_argument('--instrument', type=str, default='nirspec',
@@ -115,6 +116,30 @@ def _main():
     parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
     args = parser.parse_args()
 
-    main(args.filename, layout=args.layout, instrument=args.instrument, browser=args.browser,
+    if force_layout == None:
+        layout = args.layout
+    else:
+        layout = force_layout
+
+    main(args.filename, layout=layout, instrument=args.instrument, browser=args.browser,
          theme=args.theme, verbosity=args.verbosity, history_verbosity=args.history_verbosity,
          hotreload=args.hotreload)
+
+def _specviz():
+    _main(force_layout='specviz')
+
+
+def _specviz2d():
+    _main(force_layout='specviz2d')
+
+
+def _imviz():
+    _main(force_layout='imviz')
+
+
+def _cubeviz():
+    _main(force_layout='cubeviz')
+
+
+def _mosviz():
+    _main(force_layout='mosviz')

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -94,11 +94,14 @@ def _main(config=None):
 
     parser = argparse.ArgumentParser(description='Start a Jdaviz application instance with data '
                                      'loaded from FILENAME.')
+    filename_nargs = '?'
     if config is None:
         parser.add_argument('layout', choices=['cubeviz', 'specviz', 'specviz2d',
                                                'mosviz', 'imviz'],
                             help='Configuration to use.')
-    parser.add_argument('filename', type=str, nargs='?', default=None,
+    if (config == "mosviz") or ("mosviz" in sys.argv):
+        filename_nargs = 1
+    parser.add_argument('filename', type=str, nargs=filename_nargs, default=None,
                         help='The path to the file to be loaded into the Jdaviz application.')
     parser.add_argument('--instrument', type=str, default='nirspec',
                         help='Manually specifies which instrument parser to use, for Mosviz')

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -1,5 +1,6 @@
 # Command-line interface for jdaviz
 
+import inspect
 import os
 import pathlib
 import sys
@@ -13,10 +14,11 @@ from jdaviz.app import _verbosity_levels
 
 __all__ = ['main']
 
-CONFIGS_DIR = os.path.join(os.path.dirname(__file__), 'configs')
+from jdaviz import configs
+CONFIGS_DIR = str(pathlib.Path(inspect.getfile(configs)).parent)
 
 
-def main(filename=None, layout='default', instrument=None, browser='default',
+def main(filename='', layout='default', instrument='', browser='default',
          theme='light', verbosity='warning', history_verbosity='info',
          hotreload=False):
     """
@@ -151,3 +153,7 @@ def _cubeviz():
 
 def _mosviz():
     _main(config='mosviz')
+
+
+if __name__ == "__main__":
+    main()

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -16,7 +16,7 @@ __all__ = ['main']
 CONFIGS_DIR = os.path.join(os.path.dirname(__file__), 'configs')
 
 
-def main(filename, layout='default', instrument=None, browser='default',
+def main(filename=None, layout='default', instrument=None, browser='default',
          theme='light', verbosity='warning', history_verbosity='info',
          hotreload=False):
     """
@@ -24,7 +24,7 @@ def main(filename, layout='default', instrument=None, browser='default',
 
     Parameters
     ----------
-    filename : str
+    filename : str, optional
         The path to the file to be loaded into the Jdaviz application.
     layout : str, optional
         Optional specification for which configuration to use on startup.
@@ -49,8 +49,11 @@ def main(filename, layout='default', instrument=None, browser='default',
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
     # Support comma-separate file list
-    filepath = ','.join([str(pathlib.Path(f).absolute()).replace('\\', '/')
-                         for f in filename.split(',')])
+    if filename:
+        filepath = ','.join([str(pathlib.Path(f).absolute()).replace('\\', '/')
+                            for f in filename.split(',')])
+    else:
+        filepath = ''
 
     with open(os.path.join(CONFIGS_DIR, layout, layout + '.ipynb')) as f:
         notebook_template = f.read()
@@ -94,7 +97,7 @@ def _main(force_layout=None):
     if force_layout == None:
         parser.add_argument('layout', choices=['cubeviz', 'specviz', 'specviz2d', 'mosviz', 'imviz'],
                             help='Configuration to use.')
-    parser.add_argument('filename', type=str,
+    parser.add_argument('--filename', type=str, default=None,
                         help='The path to the file to be loaded into the Jdaviz application.')
     parser.add_argument('--instrument', type=str, default='nirspec',
                         help='Manually specifies which instrument parser to use, for Mosviz')
@@ -121,7 +124,7 @@ def _main(force_layout=None):
     else:
         layout = force_layout
 
-    main(args.filename, layout=layout, instrument=args.instrument, browser=args.browser,
+    main(filename=args.filename, layout=layout, instrument=args.instrument, browser=args.browser,
          theme=args.theme, verbosity=args.verbosity, history_verbosity=args.history_verbosity,
          hotreload=args.hotreload)
 

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -98,7 +98,7 @@ def _main(config=None):
         parser.add_argument('layout', choices=['cubeviz', 'specviz', 'specviz2d',
                                                'mosviz', 'imviz'],
                             help='Configuration to use.')
-    parser.add_argument('--filename', type=str, default=None,
+    parser.add_argument('filename', type=str, nargs='?', default=None,
                         help='The path to the file to be loaded into the Jdaviz application.')
     parser.add_argument('--instrument', type=str, default='nirspec',
                         help='Manually specifies which instrument parser to use, for Mosviz')

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -88,14 +88,15 @@ def main(filename=None, layout='default', instrument=None, browser='default',
         os.chdir(start_dir)
 
 
-def _main(force_layout=None):
+def _main(config=None):
     import argparse
     import sys
 
     parser = argparse.ArgumentParser(description='Start a Jdaviz application instance with data '
                                      'loaded from FILENAME.')
-    if force_layout == None:
-        parser.add_argument('layout', choices=['cubeviz', 'specviz', 'specviz2d', 'mosviz', 'imviz'],
+    if config is None:
+        parser.add_argument('layout', choices=['cubeviz', 'specviz', 'specviz2d',
+                                               'mosviz', 'imviz'],
                             help='Configuration to use.')
     parser.add_argument('--filename', type=str, default=None,
                         help='The path to the file to be loaded into the Jdaviz application.')
@@ -119,30 +120,31 @@ def _main(force_layout=None):
     parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
     args = parser.parse_args()
 
-    if force_layout == None:
+    if config is None:
         layout = args.layout
     else:
-        layout = force_layout
+        layout = config
 
     main(filename=args.filename, layout=layout, instrument=args.instrument, browser=args.browser,
          theme=args.theme, verbosity=args.verbosity, history_verbosity=args.history_verbosity,
          hotreload=args.hotreload)
 
+
 def _specviz():
-    _main(force_layout='specviz')
+    _main(config='specviz')
 
 
 def _specviz2d():
-    _main(force_layout='specviz2d')
+    _main(config='specviz2d')
 
 
 def _imviz():
-    _main(force_layout='imviz')
+    _main(config='imviz')
 
 
 def _cubeviz():
-    _main(force_layout='cubeviz')
+    _main(config='cubeviz')
 
 
 def _mosviz():
-    _main(force_layout='mosviz')
+    _main(config='mosviz')

--- a/jdaviz/cli.spec
+++ b/jdaviz/cli.spec
@@ -1,0 +1,63 @@
+# -*- mode: python ; coding: utf-8 -*-
+from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.utils.hooks import collect_all
+
+datas = [('..\\envmain\\Lib\\site-packages\\glue', 'glue\\'), ('..\\envmain\\Lib\\site-packages\\glue_jupyter\\', 'glue_jupyter\\'), ('..\\envmain\\Lib\\site-packages\\bqplot\\', 'bqplot\\'), ('..\\envmain\\Lib\\site-packages\\regions\\CITATION.rst', 'regions\\'), ('.\\components\\', 'jdaviz\\components'), ('.\\configs\\', 'jdaviz\\configs'), ('.\\container.vue', 'jdaviz\\'), ('.\\data\\', 'jdaviz\\data'), ('..\\envmain\\Lib\\site-packages\\photutils\\CITATION.rst', 'photutils'), ('..\\envmain\\Lib\\site-packages\\debugpy\\_vendored\\', 'debugpy\\_vendored'), ('..\\share\\', 'share\\')]
+binaries = []
+hiddenimports = []
+hiddenimports += collect_submodules('regions')
+hiddenimports += collect_submodules('photutils')
+hiddenimports += collect_submodules('jupyter_client')
+tmp_ret = collect_all('astropy')
+datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
+tmp_ret = collect_all('.')
+datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
+
+
+block_cipher = None
+
+
+a = Analysis(
+    ['cli.py'],
+    pathex=[],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='cli',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='cli',
+)

--- a/jdaviz/configs/cubeviz/cubeviz.ipynb
+++ b/jdaviz/configs/cubeviz/cubeviz.ipynb
@@ -10,14 +10,16 @@
     "from jdaviz import Cubeviz\n",
     "\n",
     "cubeviz = Cubeviz(verbosity='JDAVIZ_VERBOSITY', history_verbosity='JDAVIZ_HISTORY_VERBOSITY')\n",
-    "cubeviz.load_data('DATA_FILENAME')\n",
+    "data_path = 'DATA_FILENAME'\n",
+    "if data_path:\n",
+    "    cubeviz.load_data('DATA_FILENAME')\n",
     "cubeviz.app"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.7 ('envmain': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -31,7 +33,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6-final"
+   "version": "3.10.7"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
+   }
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/cubeviz/cubeviz.ipynb
+++ b/jdaviz/configs/cubeviz/cubeviz.ipynb
@@ -19,7 +19,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.7 ('envmain': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -33,12 +33,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.7"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
-   }
+   "version": "3.7.6-final"
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/default/default.ipynb
+++ b/jdaviz/configs/default/default.ipynb
@@ -2,49 +2,19 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: FITSFixedWarning: PLATEID = 7495 / Current plate \n",
-      "a string value was expected. [astropy.wcs.wcs]\n",
-      "WARNING:astropy:FITSFixedWarning: PLATEID = 7495 / Current plate \n",
-      "a string value was expected.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'label': 'Image 2D', 'cls': <class 'glue_jupyter.bqplot.image.viewer.BqplotImageView'>}\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "49d5f6d8c5a24df690f53c8c2bd57cff",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Application(components={'g-viewer-area': ViewerArea(), 'g-default-toolbar': DefaultToolbar(components={'g-subs…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from jdaviz.app import Application\n",
     "app = Application(configuration='default')\n",
     "app.verbosity = 'JDAVIZ_VERBOSITY'\n",
     "app.history_verbosity = 'JDAVIZ_HISTORY_VERBOSITY'\n",
-    "app.load_data('DATA_FILENAME')\n",
+    "data_path = 'DATA_FILENAME'\n",
+    "if data_path:\n",
+    "    app.load_data('DATA_FILENAME')\n",
     "app"
    ]
   },

--- a/jdaviz/configs/imviz/imviz.ipynb
+++ b/jdaviz/configs/imviz/imviz.ipynb
@@ -10,14 +10,16 @@
     "from jdaviz import Imviz\n",
     "\n",
     "imviz = Imviz(verbosity='JDAVIZ_VERBOSITY', history_verbosity='JDAVIZ_HISTORY_VERBOSITY')\n",
-    "imviz.load_data('DATA_FILENAME')\n",
+    "data_path = 'DATA_FILENAME'\n",
+    "if data_path:\n",
+    "    imviz.load_data('DATA_FILENAME')\n",
     "imviz.app"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.7 ('envmain': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -31,7 +33,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.10.7"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
+   }
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/imviz/imviz.ipynb
+++ b/jdaviz/configs/imviz/imviz.ipynb
@@ -19,7 +19,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.7 ('envmain': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -33,12 +33,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.7"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
-   }
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/mosviz/mosviz.ipynb
+++ b/jdaviz/configs/mosviz/mosviz.ipynb
@@ -24,7 +24,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.7 ('envmain': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -38,12 +38,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.7"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
-   }
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/mosviz/mosviz.ipynb
+++ b/jdaviz/configs/mosviz/mosviz.ipynb
@@ -15,14 +15,16 @@
     "data_path = pathlib.Path('DATA_FILENAME')\n",
     "\n",
     "mosviz = Mosviz(verbosity='JDAVIZ_VERBOSITY', history_verbosity='JDAVIZ_HISTORY_VERBOSITY')\n",
-    "mosviz.load_data(directory=data_path, instrument='INSTRUMENT')\n",
+    "data_path = 'DATA_FILENAME'\n",
+    "if data_path:\n",
+    "    mosviz.load_data(directory=data_path, instrument='INSTRUMENT')\n",
     "mosviz.app"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.7 ('envmain': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -36,7 +38,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.7"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
+   }
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/specviz/specviz.ipynb
+++ b/jdaviz/configs/specviz/specviz.ipynb
@@ -10,14 +10,16 @@
     "from jdaviz import Specviz\n",
     "\n",
     "specviz = Specviz(verbosity='JDAVIZ_VERBOSITY', history_verbosity='JDAVIZ_HISTORY_VERBOSITY')\n",
-    "specviz.load_data('DATA_FILENAME')\n",
+    "data_path = 'DATA_FILENAME'\n",
+    "if data_path:\n",
+    "    specviz.load_data(data_path)\n",
     "specviz.app"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.7 ('envmain': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -31,7 +33,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6-final"
+   "version": "3.10.7"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
+   }
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/specviz/specviz.ipynb
+++ b/jdaviz/configs/specviz/specviz.ipynb
@@ -19,7 +19,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.7 ('envmain': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -33,12 +33,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.7"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
-   }
+   "version": "3.7.6-final"
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/specviz2d/specviz2d.ipynb
+++ b/jdaviz/configs/specviz2d/specviz2d.ipynb
@@ -10,14 +10,16 @@
     "from jdaviz import Specviz2d\n",
     "\n",
     "specviz = Specviz2d(verbosity='JDAVIZ_VERBOSITY', history_verbosity='JDAVIZ_HISTORY_VERBOSITY')\n",
-    "specviz.load_data('DATA_FILENAME')\n",
+    "data_path = 'DATA_FILENAME'\n",
+    "if data_path:\n",
+    "    specviz.load_data('DATA_FILENAME')\n",
     "specviz.app"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.7 ('envmain': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -31,7 +33,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6-final"
+   "version": "3.10.7"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
+   }
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/specviz2d/specviz2d.ipynb
+++ b/jdaviz/configs/specviz2d/specviz2d.ipynb
@@ -19,7 +19,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.7 ('envmain': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -33,12 +33,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.7"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
-   }
+   "version": "3.7.6-final"
   }
  },
  "nbformat": 4,

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,11 @@ jdaviz.configs.imviz.tests = data/*
 [options.entry_points]
 console_scripts =
     jdaviz = jdaviz.cli:_main
+    specviz = jdaviz.cli:_specviz
+    specviz2d = jdaviz.cli:_specviz2d
+    imviz = jdaviz.cli:_imviz
+    cubeviz = jdaviz.cli:_cubeviz
+    mosviz = jdaviz.cli:_mosviz
 gui_scripts =
 jdaviz_plugins =
     default = jdaviz.configs.default


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This PR encompasses the learning lessons I've made to package jdaviz in pyinstaller. Requires #1890 

Some background:
The goal of pyinstaller is great: it produces either a single executable, or a "portable folder" with an executable that contains everything necessary to run your program. No python, no dependencies, no installing necessary; you just run the executable. 

Pyinstaller is "script-oriented", that being it doesn't simply hook into our existing `setuptools.entry_point`s. It effectively runs a `.py` file "with no arguments" (quotes will be explained later). To start, I added a `if name == '__main__'` flag at the bottom of `cli.py` as the starting point.

Pyinstaller encodes all the arguments in a `.spec` configuration file. This `spec` config file should live "as close" to the script as possible, hence why the `cli.spec` file is in `jdaviz/jdaviz`:

> set the current directory to the location of your program
https://pyinstaller.org/en/stable/usage.html

Pyinstaller tries to identify all the necessary modules by traversing your script through all its imports and finding all the modules called by all its imports recursively. The side-effect of this approach is the following:

**_Anything that is not directly imported is not included by default_**

This can include icons, data files (like our line lists), ALL of our `.vue` files, etc. These need to be listed and included manually. To expedite the development of this PR, any repository with missing assets, I copied over the whole package, rather than try and isolate each and every file that was missing. This by consequence increases the size of the packaged executable. If we were to actually deploy this, care could be taken to locate all the individual files, rather than blindly copying over the entire repo.

To build the executable:

```
pip install pyinstaller
cd jdaviz/jdaviz
pyinstaller ./cli.spec
```

This will build the executable in `jdaviz/dist`. It should be as simple as calling `jdaviz/dist/cli/cli.exe`

This results in the following bug I'm stuck on: the exe enters an infinite loop where it attempts to open multiple copies of jdaviz. None of these copies load properly and just hang on the loading screen:

![image](https://user-images.githubusercontent.com/25206008/207104017-5e775dd8-36c4-4cbe-aac6-32a3809abaa6.png)

<details>
<summary> Console snippet </summary>

```
(envhacking) PS E:\STScI\gitRepos\jdaviz\jdaviz> .\dist\cli\cli.exe
[Voila] Using C:\Users\Duy\AppData\Local\Temp to store connection files
[Voila] Storing connection files in C:\Users\Duy\AppData\Local\Temp\voila_zoe9pi_l.
[Voila] Serving static files from E:\STScI\gitRepos\jdaviz\jdaviz\dist\cli\voila\static.
[Voila] Voilà is running at:
http://localhost:8866/
[Voila] WARNING | Notebook notebook.ipynb is not trusted
0.02s - Debugger warning: The os.path.realpath.__code__.co_filename (ntpath.py)
0.00s - is not absolute, which may make the debugger miss breakpoints.
0.00s - Note: Debugging will proceed. Set PYDEVD_DISABLE_FILE_VALIDATION=1 to disable this validation.
[Voila] WARNING | Kernel Provisioning: The 'local-provisioner' is not found.  This is likely due to the presence of multiple jupyter_client distributions and a previous distribution is being used as the source for entrypoints - which does not include 'local-provisioner'.  That distribution should be removed such that only the version-appropriate distribution remains (version >= 7).  Until then, a 'local-provisioner' entrypoint will be automatically constructed and used.
The candidate distribution locations are: []
[Voila] Kernel started: 4c1d15b1-0f37-4cd4-82ee-17e483791b64
[Voila] Using C:\Users\Duy\AppData\Local\Temp to store connection files
[Voila] Storing connection files in C:\Users\Duy\AppData\Local\Temp\voila_eg9w5mlj.
[Voila] Serving static files from E:\STScI\gitRepos\jdaviz\jdaviz\dist\cli\voila\static.
[Voila] The port 8866 is already in use, trying another port.
[Voila] Voilà is running at:
http://localhost:8867/
[Voila] WARNING | Notebook notebook.ipynb is not trusted
0.00s - Debugger warning: The os.path.realpath.__code__.co_filename (ntpath.py)
0.00s - is not absolute, which may make the debugger miss breakpoints.
0.00s - Note: Debugging will proceed. Set PYDEVD_DISABLE_FILE_VALIDATION=1 to disable this validation.
[Voila] WARNING | Kernel Provisioning: The 'local-provisioner' is not found.  This is likely due to the presence of multiple jupyter_client distributions and a previous distribution is being used as the source for entrypoints - which does not include 'local-provisioner'.  That distribution should be removed such that only the version-appropriate distribution remains (version >= 7).  Until then, a 'local-provisioner' entrypoint will be automatically constructed and used.
The candidate distribution locations are: []
[Voila] Kernel started: ecaf82f1-d9ef-4588-a2da-6f175ae5e15a
[Voila] Using C:\Users\Duy\AppData\Local\Temp to store connection files
[Voila] Storing connection files in C:\Users\Duy\AppData\Local\Temp\voila_nqqte4qf.
[Voila] Serving static files from E:\STScI\gitRepos\jdaviz\jdaviz\dist\cli\voila\static.
[Voila] The port 8866 is already in use, trying another port.
[Voila] The port 8867 is already in use, trying another port.
[Voila] Voilà is running at:
http://localhost:8868/
[Voila] WARNING | Notebook notebook.ipynb is not trusted
0.00s - Debugger warning: The os.path.realpath.__code__.co_filename (ntpath.py)
0.00s - is not absolute, which may make the debugger miss breakpoints.
0.00s - Note: Debugging will proceed. Set PYDEVD_DISABLE_FILE_VALIDATION=1 to disable this validation.
[Voila] WARNING | Kernel Provisioning: The 'local-provisioner' is not found.  This is likely due to the presence of multiple jupyter_client distributions and a previous distribution is being used as the source for entrypoints - which does not include 'local-provisioner'.  That distribution should be removed such that only the version-appropriate distribution remains (version >= 7).  Until then, a 'local-provisioner' entrypoint will be automatically constructed and used.
The candidate distribution locations are: []
[Voila] Kernel started: 7ef9a815-bf98-405a-9d1a-7724803dbd64
[Voila] Using C:\Users\Duy\AppData\Local\Temp to store connection files
[Voila] Storing connection files in C:\Users\Duy\AppData\Local\Temp\voila_4jdmrrvh.
[Voila] Serving static files from E:\STScI\gitRepos\jdaviz\jdaviz\dist\cli\voila\static.
[Voila] The port 8866 is already in use, trying another port.
[Voila] The port 8867 is already in use, trying another port.
[Voila] The port 8868 is already in use, trying another port.
[Voila] Voilà is running at:
http://localhost:8869/
....
```

</details>

If you wait long enough, the jupyter client times out waiting for the kernel:

<details>

<summary> Timeout Traceback </summary>

```
Task exception was never retrieved
future: <Task finished name='Task-9' coro=<VoilaHandler.get_generator.<locals>.put_html() done, defined at voila\handler.py:201> exception=RuntimeError("Kernel didn't respond in 60 seconds")>
Traceback (most recent call last):
  File "voila\handler.py", line 202, in put_html
  File "voila\exporter.py", line 101, in generate_from_notebook_node
  File "jinja2\environment.py", line 1367, in generate_async
  File "jinja2\environment.py", line 925, in handle_exception
  File "E:\STScI\gitRepos\jdaviz\jdaviz\dist\cli\share\jupyter\voila\templates\jdaviz-default\index.html.j2", line 1, in top-level template code
    {%- extends 'nbconvert/templates/jdaviz-default/index.html.j2' -%}
  File "E:\STScI\gitRepos\jdaviz\jdaviz\dist\cli\share\jupyter\nbconvert\templates\jdaviz-default\index.html.j2", line 43, in top-level template code
    {% block notebook_execute %}
  File "E:\STScI\gitRepos\jdaviz\jdaviz\dist\cli\share\jupyter\voila\templates\jdaviz-default\index.html.j2", line 4, in block 'notebook_execute'
    {%- set kernel_id = kernel_start(nb) -%}
  File "jinja2\async_utils.py", line 56, in auto_await
  File "voila\notebook_renderer.py", line 152, in inner_kernel_start
  File "voila\notebook_renderer.py", line 213, in _jinja_kernel_start
  File "nbclient\client.py", line 532, in async_start_new_kernel_client
  File "nbclient\util.py", line 96, in ensure_async
  File "jupyter_client\client.py", line 205, in _async_wait_for_ready
RuntimeError: Kernel didn't respond in 60 seconds
```

</details>

I can't explain why this is happening... My best guess is that pyinstaller is getting confused at which executable it should be calling (we call multiple in the background: jdaviz, voila, jupyter). At this point, I think it would be worth it to pivot to explore other options rather than continue down this route. I'll preserve it here in case we want to pick it up later

Other things to note:
1. I'm running off of astropy dev because of an issue where pyinstaller wasn't including the `astropy.convolution` C code. This issue went away when moving to astropy dev
2. Pyinstaller seemed to not work with `argparse`, hence why I skipped the argument parsing in `cli._main` and called `cli.main` directly (see the underline). I kept getting a `unrecognized arguments: -m path/to/some/file`. Calling `cli.main` directly seemed to sidestep this issue

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
