### PR TITLE
don't reset redshift when adding results from plugins

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -120,6 +120,8 @@ Bug Fixes
 - Avoid a non-finite error in model fitting by not passing spectrum uncertainties as
   weights if the uncertainty values are all 0. [#1880]
 
+- Redshift is no longer reset to zero when adding results from plugins to app. [#1915]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -193,9 +193,10 @@ class LineListTool(PluginTemplateMixin):
         self._bounds["max"] = viewer_data.spectral_axis[-1]
 
         # set redshift slider to redshift stored in Spectrum1D object
-        self.rs_redshift = (viewer_data.redshift.value
-                            if hasattr(viewer_data.redshift, 'value')
-                            else viewer_data.redshift)
+        if viewer_data.meta.get('plugin', None) is not None:
+            self.rs_redshift = (viewer_data.redshift.value
+                                if hasattr(viewer_data.redshift, 'value')
+                                else viewer_data.redshift)
         self._on_spectrum_viewer_limits_changed()  # will also trigger _auto_slider_step
 
         # set the choices (and default) for the units for new custom lines

--- a/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
@@ -79,10 +79,17 @@ def test_redshift(specviz_helper, spectrum1d):
     ll_plugin.rs_rv = 30000
     assert ll_plugin.rs_redshift == 0.10561890816244568
 
+    # https://github.com/spacetelescope/jdaviz/issues/1692
+    # adding new data entry from a plugin should not reset redshift
+    specviz_helper.plugins['Gaussian Smooth'].smooth()
+    assert ll_plugin.rs_redshift == 0.10561890816244568
+
+    # test that setting observed wavelength works
     ll_plugin.vue_change_line_obs({'list_name': 'Test List',
                                    'line_ind': 0,
                                    'obs_new': 5508})
     assert_allclose(line['obs'], 5508)
+    assert ll_plugin.rs_redshift == 0.10005991611743559
 
     # https://github.com/spacetelescope/jdaviz/issues/1168
     ll_plugin.vue_set_identify(('Test List', line, 0))


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request avoids resetting the redshift to zero everytime results from a plugin are added back to the app/viewer.  Note that adding new data _not from a plugin_ will reset the app-wide redshift to the value (defaulting to zero) in that spectrum - we may want to reconsider this behavior in the future.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1692

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
