### PR TITLE
Do not set reference for Imviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -132,6 +132,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Viewer options in some plugins no longer displaying the wrong names. [#1920]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1673,7 +1673,7 @@ class Application(VuetifyTemplate, HubListener):
 
         # Create the viewer item dictionary
         if name is None:
-            name = viewer.__class__.__name__
+            name = vid
         new_viewer_item = self._create_viewer_item(
             viewer=viewer, vid=vid, name=name, reference=name
         )

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -16,9 +16,14 @@ def test_create_destroy_viewer(imviz_helper, desired_name, actual_name):
     assert imviz_helper.app.get_viewer_ids() == ['imviz-0']
 
     viewer = imviz_helper.create_image_viewer(viewer_name=desired_name)
+    viewer_names = sorted(['imviz-0', actual_name])
     assert isinstance(viewer, ImvizImageView)
     assert viewer is imviz_helper.app._viewer_store.get(actual_name), list(imviz_helper.app._viewer_store.keys())  # noqa
-    assert imviz_helper.app.get_viewer_ids() == sorted(['imviz-0', actual_name])
+    assert imviz_helper.app.get_viewer_ids() == viewer_names
+
+    # Make sure plugins that store viewer_items differently are consistent.
+    assert imviz_helper.plugins['Imviz Line Profiles (XY)']._obj.viewer_items == viewer_names
+    assert sorted(imviz_helper.plugins['Compass'].viewer.labels) == viewer_names
 
     imviz_helper.destroy_viewer(actual_name)
     assert imviz_helper.app.get_viewer_ids() == ['imviz-0']


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to fix #1919

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
