### PR TITLE
Backport PR #1915: don't reset redshift when adding results from plugins

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 Bug Fixes
 ---------
 
+- Redshift is no longer reset to zero when adding results from plugins to app. [#1915]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -193,9 +193,10 @@ class LineListTool(PluginTemplateMixin):
         self._bounds["max"] = viewer_data.spectral_axis[-1]
 
         # set redshift slider to redshift stored in Spectrum1D object
-        self.rs_redshift = (viewer_data.redshift.value
-                            if hasattr(viewer_data.redshift, 'value')
-                            else viewer_data.redshift)
+        if viewer_data.meta.get('plugin', None) is not None:
+            self.rs_redshift = (viewer_data.redshift.value
+                                if hasattr(viewer_data.redshift, 'value')
+                                else viewer_data.redshift)
         self._on_spectrum_viewer_limits_changed()  # will also trigger _auto_slider_step
 
         # set the choices (and default) for the units for new custom lines

--- a/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
@@ -79,10 +79,17 @@ def test_redshift(specviz_helper, spectrum1d):
     ll_plugin.rs_rv = 30000
     assert ll_plugin.rs_redshift == 0.10561890816244568
 
+    # https://github.com/spacetelescope/jdaviz/issues/1692
+    # adding new data entry from a plugin should not reset redshift
+    specviz_helper.plugins['Gaussian Smooth'].smooth()
+    assert ll_plugin.rs_redshift == 0.10561890816244568
+
+    # test that setting observed wavelength works
     ll_plugin.vue_change_line_obs({'list_name': 'Test List',
                                    'line_ind': 0,
                                    'obs_new': 5508})
     assert_allclose(line['obs'], 5508)
+    assert ll_plugin.rs_redshift == 0.10005991611743559
 
     # https://github.com/spacetelescope/jdaviz/issues/1168
     ll_plugin.vue_set_identify(('Test List', line, 0))


### PR DESCRIPTION
manual backport of #1915 onto 3.1.x