### PR TITLE
Backport of PR 1928 to v3.1.x (Fix viewer.center_on for dithered images)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Imviz
 
 - Viewer options in some plugins no longer displaying the wrong names. [#1920]
 
+- ``viewer.center_on()`` now behaves correctly on non-reference data. [#1928]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -219,6 +219,17 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
             return
         self.set_compass(self.state.layers[i].layer)
 
+    @property
+    def top_visible_data_label(self):
+        """Data label of the top visible layer in the viewer."""
+        try:
+            i = get_top_layer_index(self)
+        except IndexError:
+            data_label = ''
+        else:
+            data_label = self.state.layers[i].layer.label
+        return data_label
+
     def _get_real_xy(self, image, x, y):
         """Return real (X, Y) position and status in case of dithering.
 

--- a/jdaviz/configs/imviz/tests/test_tools.py
+++ b/jdaviz/configs/imviz/tests/test_tools.py
@@ -106,20 +106,24 @@ def test_blink(imviz_helper):
 
     viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b', 'domain': {'x': 0, 'y': 0}})
     assert viewer.label_mouseover.value == '+0.00000e+00 '
+    assert viewer.top_visible_data_label == 'image_0'
 
     # Blink forward and update coordinates info panel.
     viewer.blink_once()
     viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
     assert viewer.label_mouseover.value == '+1.00000e+00 '
+    assert viewer.top_visible_data_label == 'image_1'
 
     # Blink backward.
     viewer.blink_once(reversed=True)
     viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
     assert viewer.label_mouseover.value == '+0.00000e+00 '
+    assert viewer.top_visible_data_label == 'image_0'
 
     # Blink backward again.
     viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'B', 'domain': {'x': 0, 'y': 0}})
     assert viewer.label_mouseover.value == '+2.00000e+00 '
+    assert viewer.top_visible_data_label == 'image_2'
 
 
 def test_compass_open_while_load(imviz_helper):

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -17,6 +17,7 @@ def test_create_destroy_viewer(imviz_helper, desired_name, actual_name):
 
     viewer = imviz_helper.create_image_viewer(viewer_name=desired_name)
     viewer_names = sorted(['imviz-0', actual_name])
+    assert viewer.top_visible_data_label == ''
     assert isinstance(viewer, ImvizImageView)
     assert viewer is imviz_helper.app._viewer_store.get(actual_name), list(imviz_helper.app._viewer_store.keys())  # noqa
     assert imviz_helper.app.get_viewer_ids() == viewer_names

--- a/jdaviz/configs/imviz/tests/utils.py
+++ b/jdaviz/configs/imviz/tests/utils.py
@@ -70,7 +70,6 @@ class BaseImviz_WCS_WCS:
         imviz_helper.load_data(hdu1, data_label='has_wcs_1')
 
         # Second data with WCS, similar to above but dithered by 1 pixel in X.
-        # TODO: Use GWCS when https://github.com/spacetelescope/gwcs/issues/99 is possible.
         hdu2 = fits.ImageHDU(arr, name='SCI')
         hdu2.header.update({'CTYPE1': 'RA---TAN',
                             'CUNIT1': 'deg',


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to manually backport #1928 to v3.1.x

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
