### PR TITLE
prohibit subsets that do not overlap data range within plugins

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ New Features
 
 - Linear1D model component now estimates slope and intercept. [#1947]
 
+- Model fitting and line analysis plugins provide a warning and prohibit calculating results if the
+  selected data entry and spectral subset do not overlap on the spectral axis. [#1935]
+
 - Model fitting: API and UI to re-estimate model parameters based on current data/subset selection.
   [#1952]
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -694,7 +694,8 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         residuals (if ``residuals_calculate`` is set to ``True``)
         """
         if not self.spectral_subset_valid:
-            raise ValueError("spectral subset is outside data range")
+            valid, spec_range, subset_range = self._check_dataset_spectral_subset_valid(return_ranges=True)  # noqa
+            raise ValueError(f"spectral subset '{self.spectral_subset.selected}' {subset_range} is outside data range of '{self.dataset.selected}' {spec_range}")  # noqa
 
         if self.cube_fit:
             return self._fit_model_to_cube(add_data=add_data)

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -15,6 +15,7 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         SpectralSubsetSelectMixin,
                                         SubsetSelect,
                                         DatasetSelectMixin,
+                                        DatasetSpectralSubsetValidMixin,
                                         AutoTextField,
                                         AddResultsMixin)
 from jdaviz.core.custom_traitlets import IntHandleEmpty
@@ -37,7 +38,8 @@ class _EmptyParam:
 
 @tray_registry('g-model-fitting', label="Model Fitting", viewer_requirements='spectrum')
 class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
-                   SpectralSubsetSelectMixin, AddResultsMixin):
+                   SpectralSubsetSelectMixin, DatasetSpectralSubsetValidMixin,
+                   AddResultsMixin):
     """
     See the :ref:`Model Fitting Plugin Documentation <specviz-model-fitting>` for more details.
 
@@ -691,6 +693,9 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         fitted spectrum/cube
         residuals (if ``residuals_calculate`` is set to ``True``)
         """
+        if not self.spectral_subset_valid:
+            raise ValueError("spectral subset is outside data range")
+
         if self.cube_fit:
             return self._fit_model_to_cube(add_data=add_data)
         else:

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -31,6 +31,12 @@
       hint="Select spectral region to fit."
     />
 
+    <v-row v-if="!spectral_subset_valid">
+      <span class="v-messages v-messages__message text--secondary" style="color: red !important">
+          Selected dataset and spectral subset do not overlap
+      </span>
+    </v-row>
+
     <j-plugin-section-header>Model Components</j-plugin-section-header>
     <v-form v-model="form_valid_model_component">
       <v-row v-if="model_comp_items">
@@ -212,7 +218,7 @@
           persistent-hint
         ></v-switch>
       </v-row>
-      
+
       <plugin-add-results
         :label.sync="results_label"
         :label_default="results_label_default"
@@ -224,7 +230,7 @@
         :add_to_viewer_selected.sync="add_to_viewer_selected"
         action_label="Fit Model"
         action_tooltip="Fit the model to the data"
-        :action_disabled="model_equation_invalid_msg.length > 0"
+        :action_disabled="model_equation_invalid_msg.length > 0 || !spectral_subset_valid"
         @click:action="apply"
       >
         <div v-if="config!=='cubeviz' || !cube_fit">
@@ -246,6 +252,12 @@
             label="Residuals Data Label"
             hint="Label for the residuals.  Data entry will not be loaded into the viewer automatically."
           ></plugin-auto-label>
+
+          <v-row v-if="!spectral_subset_valid">
+            <span class="v-messages v-messages__message text--secondary" style="color: red !important">
+                Cannot calculate fit: selected dataset and spectral subset do not overlap
+            </span>
+          </v-row>
 
         </div>
       </plugin-add-results>

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -346,7 +346,7 @@ def test_invalid_subset(specviz_helper, spectrum1d):
     plugin.spectral_subset = 'Subset 1'
     assert not plugin._obj.spectral_subset_valid
 
-    with pytest.raises(ValueError, match='spectral subset is outside data range'):
+    with pytest.raises(ValueError, match=r"spectral subset 'Subset 1' \(5000.0, 5888.888888888889\) is outside data range of 'right_spectrum' \(6000.0, 8000.0\)"):  # noqa
         plugin.calculate_fit()
 
     plugin.dataset = 'left_spectrum'

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -319,3 +319,35 @@ def test_subset_masks(cubeviz_helper, spectrum1d_cube_larger):
 
     # Check that both masks are applied correctly
     assert np.all(masked_data.mask == (expected_spectral_mask | expected_spatial_mask))
+
+
+def test_invalid_subset(specviz_helper, spectrum1d):
+    # 6000-8000
+    specviz_helper.load_spectrum(spectrum1d, data_label="right_spectrum")
+
+    # 5000-7000
+    sp2 = Spectrum1D(spectral_axis=spectrum1d.spectral_axis - 1000*spectrum1d.spectral_axis.unit,
+                     flux=spectrum1d.flux * 1.25)
+    specviz_helper.load_spectrum(sp2, data_label="left_spectrum")
+
+    # apply subset that overlaps on left_spectrum, but not right_spectrum
+    # NOTE: using a subset that overlaps the right_spectrum (reference) results in errors when
+    # retrieving the subset (https://github.com/spacetelescope/jdaviz/issues/1868)
+    specviz_helper.app.get_viewer('spectrum-viewer').apply_roi(XRangeROI(5000, 6000))
+
+    plugin = specviz_helper.plugins['Model Fitting']
+    plugin.create_model_component('Linear1D')
+
+    plugin.dataset = 'right_spectrum'
+    assert plugin.dataset == 'right_spectrum'
+    assert plugin.spectral_subset == 'Entire Spectrum'
+    assert plugin._obj.spectral_subset_valid
+
+    plugin.spectral_subset = 'Subset 1'
+    assert not plugin._obj.spectral_subset_valid
+
+    with pytest.raises(ValueError, match='spectral subset is outside data range'):
+        plugin.calculate_fit()
+
+    plugin.dataset = 'left_spectrum'
+    assert plugin._obj.spectral_subset_valid

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -271,7 +271,8 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         # is closed
 
         if not self.spectral_subset_valid:
-            raise ValueError("spectral subset is outside data range")
+            valid, spec_range, subset_range = self._check_dataset_spectral_subset_valid(return_ranges=True)  # noqa
+            raise ValueError(f"spectral subset '{self.spectral_subset.selected}' {subset_range} is outside data range of '{self.dataset.selected}' {spec_range}")  # noqa
 
         self._calculate_statistics(ignore_plugin_closed=True)
         return self.results

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -37,6 +37,12 @@
       hint="Select spectral region that defines the line."
     />
 
+    <v-row v-if="!spectral_subset_valid">
+      <span class="v-messages v-messages__message text--secondary" style="color: red !important">
+          Selected dataset and spectral subset do not overlap
+      </span>
+    </v-row>
+
     <j-plugin-section-header>Continuum</j-plugin-section-header>
     <v-row>
       <j-docs-link>

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -427,7 +427,7 @@ def test_invalid_subset(specviz_helper, spectrum1d):
     plugin.spectral_subset = 'Subset 1'
     assert not plugin._obj.spectral_subset_valid
 
-    with pytest.raises(ValueError, match='spectral subset is outside data range'):
+    with pytest.raises(ValueError, match=r"spectral subset 'Subset 1' \(5000.0, 5888.888888888889\) is outside data range of 'right_spectrum' \(6000.0, 8000.0\)"):  # noqa
         plugin.get_results()
 
     plugin.dataset = 'left_spectrum'

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -5,6 +5,7 @@ from astropy.table import QTable
 from glue.core.roi import XRangeROI
 from glue.core.edit_subset_mode import NewMode
 from regions import RectanglePixelRegion, PixCoord
+from specutils import Spectrum1D
 
 from jdaviz.configs.specviz.plugins.line_analysis.line_analysis import _coerce_unit
 from jdaviz.core.events import LineIdentifyMessage
@@ -401,3 +402,33 @@ def test_subset_changed(specviz_helper, spectrum1d):
 
     # Values have not yet been validated
     np.testing.assert_allclose(float(plugin.results[0]['result']), 2.153181e-13, atol=1e-15)
+
+
+def test_invalid_subset(specviz_helper, spectrum1d):
+    # 6000-8000
+    specviz_helper.load_spectrum(spectrum1d, data_label="right_spectrum")
+
+    # 5000-7000
+    sp2 = Spectrum1D(spectral_axis=spectrum1d.spectral_axis - 1000*spectrum1d.spectral_axis.unit,
+                     flux=spectrum1d.flux * 1.25)
+    specviz_helper.load_spectrum(sp2, data_label="left_spectrum")
+
+    # apply subset that overlaps on left_spectrum, but not right_spectrum
+    # NOTE: using a subset that overlaps the right_spectrum (reference) results in errors when
+    # retrieving the subset (https://github.com/spacetelescope/jdaviz/issues/1868)
+    specviz_helper.app.get_viewer('spectrum-viewer').apply_roi(XRangeROI(5000, 6000))
+
+    plugin = specviz_helper.plugins['Line Analysis']
+    plugin.dataset = 'right_spectrum'
+    assert plugin.dataset == 'right_spectrum'
+    assert plugin.spectral_subset == 'Entire Spectrum'
+    assert plugin._obj.spectral_subset_valid
+
+    plugin.spectral_subset = 'Subset 1'
+    assert not plugin._obj.spectral_subset_valid
+
+    with pytest.raises(ValueError, match='spectral subset is outside data range'):
+        plugin.get_results()
+
+    plugin.dataset = 'left_spectrum'
+    assert plugin._obj.spectral_subset_valid

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1072,8 +1072,6 @@ class DatasetSpectralSubsetValidMixin(VuetifyTemplate, HubListener):
 
     @observe("dataset_selected", "spectral_subset_selected")
     def _check_dataset_spectral_subset_valid(self, event={}):
-        # TODO: does this window not account for gaps?  Should we add the warning?
-        # or can this be removed (see note above in _dataset_selected_changed)
         if self.spectral_subset_selected == "Entire Spectrum":
             self.spectral_subset_valid = True
         else:

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1071,7 +1071,7 @@ class DatasetSpectralSubsetValidMixin(VuetifyTemplate, HubListener):
     spectral_subset_valid = Bool(True).tag(sync=True)
 
     @observe("dataset_selected", "spectral_subset_selected")
-    def _check_dataset_spectral_subset_valid(self, event={}):
+    def _check_dataset_spectral_subset_valid(self, event={}, return_ranges=False):
         if self.spectral_subset_selected == "Entire Spectrum":
             self.spectral_subset_valid = True
         else:
@@ -1079,7 +1079,12 @@ class DatasetSpectralSubsetValidMixin(VuetifyTemplate, HubListener):
             spec_min, spec_max = np.nanmin(spec.spectral_axis), np.nanmax(spec.spectral_axis)
             subset_min, subset_max = self.spectral_subset.selected_min_max(spec)
             self.spectral_subset_valid = bool(subset_min < spec_max and subset_max > spec_min)
-        return self.spectral_subset_valid
+        if return_ranges:
+            return (self.spectral_subset_valid,
+                    (spec_min.value, spec_max.value),
+                    (subset_min.value, subset_max.value))
+        else:
+            return self.spectral_subset_valid
 
 
 class ViewerSelect(SelectPluginComponent):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request prohibits the user selecting a spectral subset that does not overlap at all with the selected dataset.  This is done through a new plugin mixin which is then used in both model fitting and line analysis, showing red text in the plugin UIs, disabling the "fit" button in model fitting, and raising a traceback if calling the `fit` or `get_results` API methods, respectively.

**IMPORTANT NOTE**: adding the subset to the right (reference) data will result in a traceback because of #1868.  Once that bug is fixed, this logic should then handle that case as well.  Notes are added in the test cases if we want to update the test for either line analysis or model fitting to handle the opposite scenario as a regression test for #1868.

https://user-images.githubusercontent.com/877591/208512556-b84fb679-c877-4600-b81b-c2293f15af0b.mov


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1911

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->


This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
