### PR TITLE
POC: Attempt to package jdaviz in cx_Freeze

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ New Features
 
 - Model fitting plugin can optionally expose the residuals as an additional data collection entry.
   [#1864]
+- CLI launchers no longer require data to be specified [#1890]
+
+- Added direct launchers for each config (e.g. ``specviz``) [#1890]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -85,14 +85,15 @@ def main(filename, layout='default', instrument=None, browser='default',
         os.chdir(start_dir)
 
 
-def _main():
+def _main(force_layout=None):
     import argparse
     import sys
 
     parser = argparse.ArgumentParser(description='Start a Jdaviz application instance with data '
                                      'loaded from FILENAME.')
-    parser.add_argument('layout', choices=['cubeviz', 'specviz', 'specviz2d', 'mosviz', 'imviz'],
-                        help='Configuration to use.')
+    if force_layout == None:
+        parser.add_argument('layout', choices=['cubeviz', 'specviz', 'specviz2d', 'mosviz', 'imviz'],
+                            help='Configuration to use.')
     parser.add_argument('filename', type=str,
                         help='The path to the file to be loaded into the Jdaviz application.')
     parser.add_argument('--instrument', type=str, default='nirspec',
@@ -115,6 +116,30 @@ def _main():
     parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
     args = parser.parse_args()
 
-    main(args.filename, layout=args.layout, instrument=args.instrument, browser=args.browser,
+    if force_layout == None:
+        layout = args.layout
+    else:
+        layout = force_layout
+
+    main(args.filename, layout=layout, instrument=args.instrument, browser=args.browser,
          theme=args.theme, verbosity=args.verbosity, history_verbosity=args.history_verbosity,
          hotreload=args.hotreload)
+
+def _specviz():
+    _main(force_layout='specviz')
+
+
+def _specviz2d():
+    _main(force_layout='specviz2d')
+
+
+def _imviz():
+    _main(force_layout='imviz')
+
+
+def _cubeviz():
+    _main(force_layout='cubeviz')
+
+
+def _mosviz():
+    _main(force_layout='mosviz')

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -94,11 +94,14 @@ def _main(config=None):
 
     parser = argparse.ArgumentParser(description='Start a Jdaviz application instance with data '
                                      'loaded from FILENAME.')
+    filename_nargs = '?'
     if config is None:
         parser.add_argument('layout', choices=['cubeviz', 'specviz', 'specviz2d',
                                                'mosviz', 'imviz'],
                             help='Configuration to use.')
-    parser.add_argument('filename', type=str, nargs='?', default=None,
+    if (config == "mosviz") or ("mosviz" in sys.argv):
+        filename_nargs = 1
+    parser.add_argument('filename', type=str, nargs=filename_nargs, default=None,
                         help='The path to the file to be loaded into the Jdaviz application.')
     parser.add_argument('--instrument', type=str, default='nirspec',
                         help='Manually specifies which instrument parser to use, for Mosviz')

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -16,7 +16,7 @@ __all__ = ['main']
 CONFIGS_DIR = os.path.join(os.path.dirname(__file__), 'configs')
 
 
-def main(filename, layout='default', instrument=None, browser='default',
+def main(filename=None, layout='default', instrument=None, browser='default',
          theme='light', verbosity='warning', history_verbosity='info',
          hotreload=False):
     """
@@ -24,7 +24,7 @@ def main(filename, layout='default', instrument=None, browser='default',
 
     Parameters
     ----------
-    filename : str
+    filename : str, optional
         The path to the file to be loaded into the Jdaviz application.
     layout : str, optional
         Optional specification for which configuration to use on startup.
@@ -49,8 +49,11 @@ def main(filename, layout='default', instrument=None, browser='default',
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
     # Support comma-separate file list
-    filepath = ','.join([str(pathlib.Path(f).absolute()).replace('\\', '/')
-                         for f in filename.split(',')])
+    if filename:
+        filepath = ','.join([str(pathlib.Path(f).absolute()).replace('\\', '/')
+                            for f in filename.split(',')])
+    else:
+        filepath = ''
 
     with open(os.path.join(CONFIGS_DIR, layout, layout + '.ipynb')) as f:
         notebook_template = f.read()
@@ -94,7 +97,7 @@ def _main(force_layout=None):
     if force_layout == None:
         parser.add_argument('layout', choices=['cubeviz', 'specviz', 'specviz2d', 'mosviz', 'imviz'],
                             help='Configuration to use.')
-    parser.add_argument('filename', type=str,
+    parser.add_argument('--filename', type=str, default=None,
                         help='The path to the file to be loaded into the Jdaviz application.')
     parser.add_argument('--instrument', type=str, default='nirspec',
                         help='Manually specifies which instrument parser to use, for Mosviz')
@@ -121,7 +124,7 @@ def _main(force_layout=None):
     else:
         layout = force_layout
 
-    main(args.filename, layout=layout, instrument=args.instrument, browser=args.browser,
+    main(filename=args.filename, layout=layout, instrument=args.instrument, browser=args.browser,
          theme=args.theme, verbosity=args.verbosity, history_verbosity=args.history_verbosity,
          hotreload=args.hotreload)
 

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -98,7 +98,7 @@ def _main(config=None):
         parser.add_argument('layout', choices=['cubeviz', 'specviz', 'specviz2d',
                                                'mosviz', 'imviz'],
                             help='Configuration to use.')
-    parser.add_argument('--filename', type=str, default=None,
+    parser.add_argument('filename', type=str, nargs='?', default=None,
                         help='The path to the file to be loaded into the Jdaviz application.')
     parser.add_argument('--instrument', type=str, default='nirspec',
                         help='Manually specifies which instrument parser to use, for Mosviz')

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -16,7 +16,7 @@ __all__ = ['main']
 CONFIGS_DIR = os.path.join(os.path.dirname(__file__), 'configs')
 
 
-def main(filename=None, layout='default', instrument=None, browser='default',
+def main(filename='', layout='default', instrument='', browser='default',
          theme='light', verbosity='warning', history_verbosity='info',
          hotreload=False):
     """

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -88,14 +88,15 @@ def main(filename=None, layout='default', instrument=None, browser='default',
         os.chdir(start_dir)
 
 
-def _main(force_layout=None):
+def _main(config=None):
     import argparse
     import sys
 
     parser = argparse.ArgumentParser(description='Start a Jdaviz application instance with data '
                                      'loaded from FILENAME.')
-    if force_layout == None:
-        parser.add_argument('layout', choices=['cubeviz', 'specviz', 'specviz2d', 'mosviz', 'imviz'],
+    if config is None:
+        parser.add_argument('layout', choices=['cubeviz', 'specviz', 'specviz2d',
+                                               'mosviz', 'imviz'],
                             help='Configuration to use.')
     parser.add_argument('--filename', type=str, default=None,
                         help='The path to the file to be loaded into the Jdaviz application.')
@@ -119,30 +120,31 @@ def _main(force_layout=None):
     parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
     args = parser.parse_args()
 
-    if force_layout == None:
+    if config is None:
         layout = args.layout
     else:
-        layout = force_layout
+        layout = config
 
     main(filename=args.filename, layout=layout, instrument=args.instrument, browser=args.browser,
          theme=args.theme, verbosity=args.verbosity, history_verbosity=args.history_verbosity,
          hotreload=args.hotreload)
 
+
 def _specviz():
-    _main(force_layout='specviz')
+    _main(config='specviz')
 
 
 def _specviz2d():
-    _main(force_layout='specviz2d')
+    _main(config='specviz2d')
 
 
 def _imviz():
-    _main(force_layout='imviz')
+    _main(config='imviz')
 
 
 def _cubeviz():
-    _main(force_layout='cubeviz')
+    _main(config='cubeviz')
 
 
 def _mosviz():
-    _main(force_layout='mosviz')
+    _main(config='mosviz')

--- a/jdaviz/configs/cubeviz/cubeviz.ipynb
+++ b/jdaviz/configs/cubeviz/cubeviz.ipynb
@@ -10,14 +10,16 @@
     "from jdaviz import Cubeviz\n",
     "\n",
     "cubeviz = Cubeviz(verbosity='JDAVIZ_VERBOSITY', history_verbosity='JDAVIZ_HISTORY_VERBOSITY')\n",
-    "cubeviz.load_data('DATA_FILENAME')\n",
+    "data_path = 'DATA_FILENAME'\n",
+    "if data_path:\n",
+    "    cubeviz.load_data('DATA_FILENAME')\n",
     "cubeviz.app"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.7 ('envmain': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -31,7 +33,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6-final"
+   "version": "3.10.7"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
+   }
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/cubeviz/cubeviz.ipynb
+++ b/jdaviz/configs/cubeviz/cubeviz.ipynb
@@ -19,7 +19,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.7 ('envmain': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -33,12 +33,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.7"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
-   }
+   "version": "3.7.6-final"
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/default/default.ipynb
+++ b/jdaviz/configs/default/default.ipynb
@@ -2,49 +2,19 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: FITSFixedWarning: PLATEID = 7495 / Current plate \n",
-      "a string value was expected. [astropy.wcs.wcs]\n",
-      "WARNING:astropy:FITSFixedWarning: PLATEID = 7495 / Current plate \n",
-      "a string value was expected.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'label': 'Image 2D', 'cls': <class 'glue_jupyter.bqplot.image.viewer.BqplotImageView'>}\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "49d5f6d8c5a24df690f53c8c2bd57cff",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Application(components={'g-viewer-area': ViewerArea(), 'g-default-toolbar': DefaultToolbar(components={'g-subs…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from jdaviz.app import Application\n",
     "app = Application(configuration='default')\n",
     "app.verbosity = 'JDAVIZ_VERBOSITY'\n",
     "app.history_verbosity = 'JDAVIZ_HISTORY_VERBOSITY'\n",
-    "app.load_data('DATA_FILENAME')\n",
+    "data_path = 'DATA_FILENAME'\n",
+    "if data_path:\n",
+    "    app.load_data('DATA_FILENAME')\n",
     "app"
    ]
   },

--- a/jdaviz/configs/imviz/imviz.ipynb
+++ b/jdaviz/configs/imviz/imviz.ipynb
@@ -10,14 +10,16 @@
     "from jdaviz import Imviz\n",
     "\n",
     "imviz = Imviz(verbosity='JDAVIZ_VERBOSITY', history_verbosity='JDAVIZ_HISTORY_VERBOSITY')\n",
-    "imviz.load_data('DATA_FILENAME')\n",
+    "data_path = 'DATA_FILENAME'\n",
+    "if data_path:\n",
+    "    imviz.load_data('DATA_FILENAME')\n",
     "imviz.app"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.7 ('envmain': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -31,7 +33,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.10.7"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
+   }
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/imviz/imviz.ipynb
+++ b/jdaviz/configs/imviz/imviz.ipynb
@@ -19,7 +19,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.7 ('envmain': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -33,12 +33,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.7"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
-   }
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/mosviz/mosviz.ipynb
+++ b/jdaviz/configs/mosviz/mosviz.ipynb
@@ -24,7 +24,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.7 ('envmain': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -38,12 +38,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.7"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
-   }
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/mosviz/mosviz.ipynb
+++ b/jdaviz/configs/mosviz/mosviz.ipynb
@@ -15,14 +15,16 @@
     "data_path = pathlib.Path('DATA_FILENAME')\n",
     "\n",
     "mosviz = Mosviz(verbosity='JDAVIZ_VERBOSITY', history_verbosity='JDAVIZ_HISTORY_VERBOSITY')\n",
-    "mosviz.load_data(directory=data_path, instrument='INSTRUMENT')\n",
+    "data_path = 'DATA_FILENAME'\n",
+    "if data_path:\n",
+    "    mosviz.load_data(directory=data_path, instrument='INSTRUMENT')\n",
     "mosviz.app"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.7 ('envmain': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -36,7 +38,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.7"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
+   }
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/specviz/specviz.ipynb
+++ b/jdaviz/configs/specviz/specviz.ipynb
@@ -10,14 +10,16 @@
     "from jdaviz import Specviz\n",
     "\n",
     "specviz = Specviz(verbosity='JDAVIZ_VERBOSITY', history_verbosity='JDAVIZ_HISTORY_VERBOSITY')\n",
-    "specviz.load_data('DATA_FILENAME')\n",
+    "data_path = 'DATA_FILENAME'\n",
+    "if data_path:\n",
+    "    specviz.load_data(data_path)\n",
     "specviz.app"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.7 ('envmain': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -31,7 +33,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6-final"
+   "version": "3.10.7"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
+   }
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/specviz/specviz.ipynb
+++ b/jdaviz/configs/specviz/specviz.ipynb
@@ -19,7 +19,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.7 ('envmain': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -33,12 +33,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.7"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
-   }
+   "version": "3.7.6-final"
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/specviz2d/specviz2d.ipynb
+++ b/jdaviz/configs/specviz2d/specviz2d.ipynb
@@ -10,14 +10,16 @@
     "from jdaviz import Specviz2d\n",
     "\n",
     "specviz = Specviz2d(verbosity='JDAVIZ_VERBOSITY', history_verbosity='JDAVIZ_HISTORY_VERBOSITY')\n",
-    "specviz.load_data('DATA_FILENAME')\n",
+    "data_path = 'DATA_FILENAME'\n",
+    "if data_path:\n",
+    "    specviz.load_data('DATA_FILENAME')\n",
     "specviz.app"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.7 ('envmain': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -31,7 +33,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6-final"
+   "version": "3.10.7"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
+   }
   }
  },
  "nbformat": 4,

--- a/jdaviz/configs/specviz2d/specviz2d.ipynb
+++ b/jdaviz/configs/specviz2d/specviz2d.ipynb
@@ -19,7 +19,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.7 ('envmain': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -33,12 +33,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.7"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "f917e879dca01012f092e44ceeb72fc316d3b188a12a493299dc2bd49905dadb"
-   }
+   "version": "3.7.6-final"
   }
  },
  "nbformat": 4,

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,11 @@ jdaviz.configs.imviz.tests = data/*
 [options.entry_points]
 console_scripts =
     jdaviz = jdaviz.cli:_main
+    specviz = jdaviz.cli:_specviz
+    specviz2d = jdaviz.cli:_specviz2d
+    imviz = jdaviz.cli:_imviz
+    cubeviz = jdaviz.cli:_cubeviz
+    mosviz = jdaviz.cli:_mosviz
 gui_scripts =
 jdaviz_plugins =
     default = jdaviz.configs.default

--- a/setup_cxfreeze.py
+++ b/setup_cxfreeze.py
@@ -1,0 +1,24 @@
+from cx_Freeze import setup, Executable
+
+# Dependencies are automatically detected, but it might need
+# fine tuning.
+build_options = {'include_files': [("E:\\STScI\\gitRepos\\jdaviz\\envhacking\\Lib\\site-packages\\astropy", "lib\\astropy"),
+                                   ("E:\\STScI\\gitRepos\\jdaviz\\envhacking\\Lib\\site-packages\\scipy", "lib\\scipy"),
+                                   ("E:\\STScI\\gitRepos\\jdaviz\\envhacking\\Lib\\site-packages\\gwcs", "lib\\gwcs"),
+                                   ("E:\\STScI\\gitRepos\\jdaviz\\jdaviz", "lib\\jdaviz")
+                                  ],
+                 'excludes': []}
+
+base = 'console'
+
+executables = [
+    Executable('start_jdaviz.py', base=base)
+]
+
+setup(name='jdaviz',
+      version = '1.0',
+      description = '',
+      options = {'build_exe': build_options},
+      executables = executables)
+
+#Manual copies: astropy, scipy, gwcs, jdaviz

--- a/start_jdaviz.py
+++ b/start_jdaviz.py
@@ -1,0 +1,3 @@
+from jdaviz.cli import main
+
+main()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This PR encompasses the learning lessons I've made to package jdaviz in cx_Freeze. Requires #1890 

Some background:
cx_Freeze's dependency identification appears to be much more comprehensive, that is, it just bundles all your packages installed in your environment (I was initially confused why I saw pyinstaller packaged 😅). No guessing, no games, it just includes all your environment packages. 

cx_Freeze's approach to building is most similar to the, now deprecated, distutils process; that is it embeds itself into a setup.py and is built by invoking `python setup.py build`. cx_Freeze actually compiles all `.py` files in all dependencies into python compiled `.pyc` files and copies those over to the executable. If packages import modules properly, this is absolutely fine and shouldn't create any issue. But for the packages that directly reference/read the source code and EXPECT the `.py` file to exist, it breaks entirely *tsk tsk*. On top of this, the story is similar with #1923 and #1914, where I've had to copy over repos with assets that are loaded manually and not through proper import channels.

Ultimately, I was able to get past these challenges and *ALMOST* get voila to load, but we run into the issue presented by @bmorris3 in #1729 and the voila templates. Unlike `PyInstaller`, cx_Freeze does not provide a directory for `my_venv/share`, where the templates are expected to live. As a result, voila doesn't even know where to search for its templates (returns an empty list in the traceback for expected path locations)

<details>
<summary> Voila Template Traceback </summary>

```
Traceback (most recent call last):
  File "E:\STScI\gitRepos\jdaviz\envhacking\Lib\site-packages\cx_Freeze\initscripts\__startup__.py", line 138, in run
    module_init.run(name + "__main__")
  File "E:\STScI\gitRepos\jdaviz\envhacking\Lib\site-packages\cx_Freeze\initscripts\console.py", line 16, in run
    exec(code, module_main.__dict__)  # pylint: disable=exec-used
  File "start_jdaviz.py", line 3, in <module>
    main()
  File "E:\STScI\gitRepos\jdaviz\build\exe.win-amd64-3.10\lib\jdaviz\cli.py", line 86, in main
    sys.exit(Voila().launch_instance(argv=[]))
  File "E:\STScI\gitRepos\jdaviz\envhacking\lib\site-packages\traitlets\config\application.py", line 975, in launch_instance
    app.initialize(argv)
  File "E:\STScI\gitRepos\jdaviz\envhacking\lib\site-packages\voila\app.py", line 374, in initialize
    self.setup_template_dirs()
  File "E:\STScI\gitRepos\jdaviz\envhacking\lib\site-packages\voila\app.py", line 380, in setup_template_dirs
    self.template_paths = collect_template_paths(['voila', 'nbconvert'], template_name, prune=True)
  File "E:\STScI\gitRepos\jdaviz\envhacking\lib\site-packages\voila\paths.py", line 24, in collect_template_paths
    return collect_paths(app_names, template_name, include_root_paths=True, prune=prune, root_dirs=root_dirs)
  File "E:\STScI\gitRepos\jdaviz\envhacking\lib\site-packages\voila\paths.py", line 90, in collect_paths
    raise ValueError(
ValueError: No template sub-directory with name 'base' found in the following paths:

(envhacking) PS E:\STScI\gitRepos\jdaviz>
```

</details>

If I hack voila and hardcode the template path, Voila actually successfully loads, but then is missing other templates as well, indicating multiple overrides would be necessary in order to properly masquerade voila's template discovery algorithm.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
