### PR TITLE
Exclude bad ipykernel version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     glue-core>=1.6.0
     glue-jupyter>=0.14.2
     echo>=0.5.0
+    ipykernel!=6.19.3
     ipyvue>=1.6
     ipyvuetify>=1.7.0
     ipysplitpanes>=0.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     glue-core>=1.6.0
     glue-jupyter>=0.14.2
     echo>=0.5.0
-    ipykernel!=6.19.3
+    ipykernel<6.18
     ipyvue>=1.6
     ipyvuetify>=1.7.0
     ipysplitpanes>=0.1.0


### PR DESCRIPTION
Jdaviz won't show in the notebook with ipykernel 6.19.3, pinning to avoid that version.