### PR TITLE
do not interpret return from parsers as message

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -527,15 +527,7 @@ class Application(VuetifyTemplate, HubListener):
                     parser = data_parser_registry.members.get(data_parser)
 
             if parser is not None:
-                # If the parser returns something other than known, assume it's
-                #  a message we want to make the user aware of.
-                msg = parser(self, file_obj, **kwargs)
-
-                if msg is not None:
-                    snackbar_message = SnackbarMessage(
-                        msg, color='error', sender=self)
-                    self.hub.broadcast(snackbar_message)
-                    return
+                parser(self, file_obj, **kwargs)
             else:
                 self._application_handler.load_data(file_obj)
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request removes the unused functionality of parsers returning a string to be emitted as a snackbar message.  The only parser with a return statement is in mosviz from #1835, but that return is used elsewhere and is not expected to be exposed to the user as a snackbar message.

If we ever want a parser to warn the user, they have access to `app` so can emit snackbar messages themselves.

Note: since #1835 is milestoned as 3.2 and not yet released, this doesn't qualify as a bugfix and isn't user-facing, so I don't think a changelog entry is necessary.  If anyone thinks otherwise, let me know where you think it should belong.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1888

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
