### PR TITLE
Manual backport PR #1908: set bounding box to None to avoid layer cropping

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Imviz
 
 - Viewer options in some plugins no longer displaying the wrong names. [#1920]
 
+- Fixes cropped image layer with WCS linking without fast-approximation, mouseover display
+  for GWCS now shows when information is outside original bounding box, if applicable. [#1908]
+
 Mosviz
 ^^^^^^
 

--- a/docs/imviz/displayimages.rst
+++ b/docs/imviz/displayimages.rst
@@ -35,6 +35,38 @@ cursor's location in pixel space (X and Y), the RA and Dec at that point, and th
 of the data there. This information is displayed in the top bar of the UI, on the
 middle-right side.
 
+Notes on GWCS
+-------------
+
+If your *reference data* has GWCS with a bounding box, any coordinates transformation
+outside that bounding box is less reliable. This still applies even when you are
+looking at some other data that is not the reference data if they are linked by WCS
+because all transformations in glue go through the reference data. Such a situation
+is indicated by "(est.)" and the affected coordinates becoming gray.
+
+If your data of interest also has a GWCS with a bounding box, only
+the mouseover data where it overlaps with the reference data's
+bounding box is completely reliable. Unreliable coordinates transformation here
+will also gray out in a similar fashion as above.
+
+To avoid inaccurate transforms, consider one of the following workflows:
+
+* Make sure your reference data's GWCS has a bounding box that encompasses all
+  the other data you are trying to visualize together.
+* If the above is not possible, avoid overlaying different data with GWCS that
+  do not overlap.
+
+.. warning::
+
+    If you rely on the GWCS bounding box, it will be set to None when
+    you data is loaded into Imviz, but the original bounding box,
+    if available, is now in a hidden ``_orig_bounding_box``
+    attribute of the GWCS object. You can restore the bounding box by
+    assigning the value of ``_orig_bounding_box`` back to its
+    ``bounding_box`` attribute.
+
+Note that FITS WCS has no similar concept of bounding box.
+
 Home
 ====
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -154,7 +154,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin):
                         # not loaded in all the viewers, so use default viewer.
                         viewer = self.app._jdaviz_helper.default_viewer
 
-                        x, y, _ = viewer._get_real_xy(
+                        x, y, _, _ = viewer._get_real_xy(
                             self.app.data_collection[self.dataset_selected],
                             reg.center.x, reg.center.y)
                         reg.center.x = x

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -1,4 +1,4 @@
-from traitlets import Unicode
+from traitlets import Bool, Unicode
 
 from jdaviz.core.registries import tool_registry
 from jdaviz.core.template_mixin import TemplateMixin
@@ -19,6 +19,8 @@ class CoordsInfo(TemplateMixin):
     world_dec = Unicode("").tag(sync=True)
     world_ra_deg = Unicode("").tag(sync=True)
     world_dec_deg = Unicode("").tag(sync=True)
+    unreliable_world = Bool(False).tag(sync=True)
+    unreliable_pixel = Bool(False).tag(sync=True)
 
     def reset_coords_display(self):
         self.world_label_prefix = '\u00A0'
@@ -28,8 +30,10 @@ class CoordsInfo(TemplateMixin):
         self.world_dec = ''
         self.world_ra_deg = ''
         self.world_dec_deg = ''
+        self.unreliable_world = False
+        self.unreliable_pixel = False
 
-    def set_coords(self, sky):
+    def set_coords(self, sky, unreliable_world=False, unreliable_pixel=False):
         celestial_coordinates = sky.to_string('hmsdms', precision=4, pad=True).split()
         celestial_coordinates_deg = sky.to_string('decimal', precision=10, pad=True).split()
         world_ra = celestial_coordinates[0]
@@ -47,3 +51,5 @@ class CoordsInfo(TemplateMixin):
             self.world_dec = world_dec
             self.world_ra_deg = world_ra_deg
             self.world_dec_deg = world_dec_deg
+            self.unreliable_world = unreliable_world
+            self.unreliable_pixel = unreliable_pixel

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.vue
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.vue
@@ -6,18 +6,19 @@
     <div style="display: inline-block; white-space: nowrap; line-height: 14pt; margin: 0; position: absolute; margin-left: 26px; top: 50%; transform: translateY(-50%); -ms-transform: translateY(-50%);">
       <table>
         <tr>
-          <td colspan="4">
-            <b v-if="pixel">Pixel </b>{{ pixel }}&nbsp;&nbsp;<b v-if="value">Value </b>{{ value }}
+          <td colspan="4" :style="unreliable_pixel ? 'color: #B8B8B8' : ''">
+            <b v-if="pixel">Pixel </b>{{ pixel }}&nbsp;&nbsp;
+            <b v-if="value">Value </b>{{ value }}
           </td>
         </tr>
-        <tr>
+        <tr :style="unreliable_world ? 'color: #B8B8B8' : ''">
           <td width="42"><b>{{ world_label_prefix }}</b></td>
           <td width="115">{{ world_ra }}</td>
           <td width="120">{{ world_dec }}</td>
           <td>{{ world_label_icrs }}</td>
         </tr>
-        <tr>
-          <td width="42"></td>
+        <tr :style="unreliable_world ? 'color: #B8B8B8' : ''">
+          <td width="42">{{ unreliable_world ? '(est.)' : '' }}</td>
           <td width="115">{{ world_ra_deg }}</td>
           <td width="120">{{ world_dec_deg }}</td>
           <td>{{ world_label_deg }}</td>

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -7,6 +7,7 @@ from astropy.io import fits
 from astropy.nddata import NDData
 from astropy.wcs import WCS
 from glue.core.data import Component, Data
+from gwcs.wcs import WCS as GWCS
 
 from jdaviz.core.registries import data_parser_registry
 from jdaviz.core.events import SnackbarMessage
@@ -124,6 +125,15 @@ def _parse_image(app, file_obj, data_label, ext=None):
     data_iter = get_image_data_iterator(app, file_obj, data_label, ext=ext)
 
     for data, data_label in data_iter:
+        if data.coords is not None:
+            if isinstance(data.coords, GWCS) and (data.coords.bounding_box is not None):
+                # keep a copy of the original bounding box so we can detect
+                # when extrapolating beyond, but then remove the bounding box
+                # so that image layers are not cropped.
+                # NOTE: if extending this beyond GWCS, the mouseover logic
+                # for outside_*_bounding_box should also be updated.
+                data.coords._orig_bounding_box = data.coords.bounding_box
+                data.coords.bounding_box = None
         data_label = app.return_data_label(data_label, alt_name="image_data")
         app.add_data(data, data_label)
 

--- a/jdaviz/configs/imviz/plugins/tools.py
+++ b/jdaviz/configs/imviz/plugins/tools.py
@@ -101,7 +101,7 @@ class ImagePanZoom(PanZoom):
         y = data['domain']['y']
         if x is None or y is None:  # Out of bounds
             return
-        x, y, _ = self.viewer._get_real_xy(image, x, y)
+        x, y, _, _ = self.viewer._get_real_xy(image, x, y)
         self.viewer.center_on((x, y))
 
 

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -8,7 +8,7 @@ from regions import PixCoord, CirclePixelRegion, PolygonPixelRegion
 
 from jdaviz.configs.imviz.helper import get_reference_image_data
 from jdaviz.configs.imviz.tests.utils import (
-    BaseImviz_WCS_NoWCS, BaseImviz_WCS_WCS, BaseImviz_WCS_GWCS)
+    BaseImviz_WCS_NoWCS, BaseImviz_WCS_WCS, BaseImviz_WCS_GWCS, BaseImviz_GWCS_GWCS)
 
 
 class BaseLinkHandler:
@@ -212,6 +212,8 @@ class TestLink_WCS_GWCS(BaseImviz_WCS_GWCS):
         assert self.viewer.label_mouseover.value == '+1.00000e+00 '
         assert self.viewer.label_mouseover.world_ra_deg == ''
         assert self.viewer.label_mouseover.world_dec_deg == ''
+        assert not self.viewer.label_mouseover.unreliable_world
+        assert not self.viewer.label_mouseover.unreliable_pixel
 
         self.viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b',
                                            'domain': {'x': 0, 'y': 0}})
@@ -219,6 +221,8 @@ class TestLink_WCS_GWCS(BaseImviz_WCS_GWCS):
         assert self.viewer.label_mouseover.value == '+1.00000e+00 electron / s'
         assert self.viewer.label_mouseover.world_ra_deg == '3.5817255823'
         assert self.viewer.label_mouseover.world_dec_deg == '-30.3920580740'
+        assert not self.viewer.label_mouseover.unreliable_world
+        assert not self.viewer.label_mouseover.unreliable_pixel
 
         self.viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b',
                                            'domain': {'x': 0, 'y': 0}})
@@ -226,6 +230,88 @@ class TestLink_WCS_GWCS(BaseImviz_WCS_GWCS):
         assert self.viewer.label_mouseover.value == ''
         assert self.viewer.label_mouseover.world_ra_deg == '3.5817255823'
         assert self.viewer.label_mouseover.world_dec_deg == '-30.3920580740'
+        assert not self.viewer.label_mouseover.unreliable_world
+        assert not self.viewer.label_mouseover.unreliable_pixel
+
+        # Make sure GWCS now can extrapolate. Domain x,y is for FITS WCS data
+        # but they are linked by WCS.
+        self.viewer.on_mouse_or_key_event({'event': 'mousemove',
+                                           'domain': {'x': 11.281551269520731,
+                                                      'y': 2.480347927198246}})
+        assert self.viewer.label_mouseover.pixel == 'x=-1.0 y=-1.0'
+        assert self.viewer.label_mouseover.value == ''
+        assert self.viewer.label_mouseover.world_ra_deg == '3.5815955408'
+        assert self.viewer.label_mouseover.world_dec_deg == '-30.3919405616'
+        # FITS WCS is reference data and has no concept of bounding box
+        # but cursor is outside GWCS bounding box
+        assert self.viewer.label_mouseover.unreliable_world
+        assert self.viewer.label_mouseover.unreliable_pixel
+
+
+class TestLink_GWCS_GWCS(BaseImviz_GWCS_GWCS):
+    def test_wcslink_offset(self):
+        self.imviz.link_data(link_type='wcs', error_on_fail=True)
+
+        # Check the coordinates display: Last loaded is on top.
+        # Within bounds of non-reference image but out of bounds of reference image.
+        self.viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 10, 'y': 3}})
+        assert self.viewer.label_mouseover.pixel in ('x=07.0 y=00.0', 'x=07.0 y=-0.0')
+        assert self.viewer.label_mouseover.value == '+0.00000e+00 '
+        assert self.viewer.label_mouseover.world_ra_deg == '3.5817877198'
+        assert self.viewer.label_mouseover.world_dec_deg == '-30.3919358920'
+        assert self.viewer.label_mouseover.unreliable_world
+        assert self.viewer.label_mouseover.unreliable_pixel
+
+        # Non-reference image out of bounds of its own bounds but not of the
+        # reference image's bounds. Head hurting yet?
+        self.viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0.5, 'y': 0.5}})
+        assert self.viewer.label_mouseover.pixel == 'x=-2.5 y=-2.5'
+        assert self.viewer.label_mouseover.value == ''
+        assert self.viewer.label_mouseover.world_ra_deg == '3.5816283341'
+        assert self.viewer.label_mouseover.world_dec_deg == '-30.3919519949'
+        assert self.viewer.label_mouseover.unreliable_world
+        assert self.viewer.label_mouseover.unreliable_pixel
+
+        # Back to reference image
+        self.viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b',
+                                           'domain': {'x': 0, 'y': 0}})
+        assert self.viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
+        assert self.viewer.label_mouseover.value == '+1.00000e+00 electron / s'
+        assert self.viewer.label_mouseover.world_ra_deg == '3.5816174030'
+        assert self.viewer.label_mouseover.world_dec_deg == '-30.3919481838'
+        assert not self.viewer.label_mouseover.unreliable_world
+        assert not self.viewer.label_mouseover.unreliable_pixel
+
+        # Still reference image but outside its own bounds.
+        self.viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 10, 'y': 3}})
+        assert self.viewer.label_mouseover.pixel == 'x=10.0 y=03.0'
+        assert self.viewer.label_mouseover.value == ''
+        assert self.viewer.label_mouseover.world_ra_deg == '3.5817877198'
+        assert self.viewer.label_mouseover.world_dec_deg == '-30.3919358920'
+        assert self.viewer.label_mouseover.unreliable_world
+        assert not self.viewer.label_mouseover.unreliable_pixel
+
+    def test_pixel_linking(self):
+        self.imviz.link_data(link_type='pixels')
+
+        # Check the coordinates display: Last loaded is on top.
+        self.viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': -1, 'y': -1}})
+        assert self.viewer.label_mouseover.pixel == 'x=-1.0 y=-1.0'
+        assert self.viewer.label_mouseover.value == ''
+        assert self.viewer.label_mouseover.world_ra_deg == '3.5816611274'
+        assert self.viewer.label_mouseover.world_dec_deg == '-30.3919634282'
+        assert self.viewer.label_mouseover.unreliable_world
+        assert not self.viewer.label_mouseover.unreliable_pixel
+
+        # Back to reference image with bounds check.
+        self.viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b',
+                                           'domain': {'x': -1, 'y': -1}})
+        assert self.viewer.label_mouseover.pixel == 'x=-1.0 y=-1.0'
+        assert self.viewer.label_mouseover.value == ''
+        assert self.viewer.label_mouseover.world_ra_deg == '3.5815955408'
+        assert self.viewer.label_mouseover.world_dec_deg == '-30.3919405616'
+        assert self.viewer.label_mouseover.unreliable_world
+        assert not self.viewer.label_mouseover.unreliable_pixel
 
 
 def test_imviz_no_data(imviz_helper):

--- a/jdaviz/configs/imviz/tests/utils.py
+++ b/jdaviz/configs/imviz/tests/utils.py
@@ -9,7 +9,7 @@ from astropy.nddata import NDData
 from astropy.wcs import WCS
 from gwcs import coordinate_frames as cf
 
-__all__ = ['BaseImviz_WCS_NoWCS', 'BaseImviz_WCS_WCS']
+__all__ = ['BaseImviz_WCS_NoWCS', 'BaseImviz_WCS_WCS', 'BaseImviz_WCS_GWCS', 'BaseImviz_GWCS_GWCS']
 
 
 class BaseImviz_WCS_NoWCS:
@@ -134,6 +134,7 @@ class BaseImviz_WCS_GWCS:
         sky_frame = cf.CelestialFrame(reference_frame=ICRS(), name='icrs', unit=(u.deg, u.deg))
         pipeline = [(detector_frame, det2sky), (sky_frame, None)]
         w_gwcs = gwcs.WCS(pipeline)
+        w_gwcs.bounding_box = ((0, 8), (0, 10)) * u.pix  # x, y
 
         # Load data into Imviz:
         # 1. Data with FITS WCS and unit.
@@ -145,6 +146,56 @@ class BaseImviz_WCS_GWCS:
 
         self.wcs_1 = w_fits
         self.wcs_2 = w_gwcs
+        self.imviz = imviz_helper
+        self.viewer = imviz_helper.default_viewer
+
+        # Since we are not really displaying, need this to test zoom.
+        self.viewer.shape = (100, 100)
+        self.viewer.state._set_axes_aspect_ratio(1)
+
+
+class BaseImviz_GWCS_GWCS:
+    @pytest.fixture(autouse=True)
+    def setup_class(self, imviz_helper):
+        arr = np.zeros((10, 8))  # (ny, nx)
+        arr[0, 0] = 1  # Bright corner for sanity check
+
+        # GWCS that is adapted from its Getting Started.
+        shift_by_crpix = models.Shift(-(5 - 1) * u.pix) & models.Shift(-(5 - 1) * u.pix)
+        matrix = np.array([[1.290551569736E-05, 5.9525007864732E-06],
+                           [5.0226382102765E-06, -1.2644844123757E-05]])
+        rotation = models.AffineTransformation2D(matrix * u.deg, translation=[0, 0] * u.deg)
+        rotation.input_units_equivalencies = {"x": u.pixel_scale(1 * (u.deg / u.pix)),
+                                              "y": u.pixel_scale(1 * (u.deg / u.pix))}
+        rotation.inverse = models.AffineTransformation2D(np.linalg.inv(matrix) * u.pix,
+                                                         translation=[0, 0] * u.pix)
+        rotation.inverse.input_units_equivalencies = {"x": u.pixel_scale(1 * (u.pix / u.deg)),
+                                                      "y": u.pixel_scale(1 * (u.pix / u.deg))}
+        tan = models.Pix2Sky_TAN()
+        celestial_rotation = models.RotateNative2Celestial(
+            3.581704851882 * u.deg, -30.39197867265 * u.deg, 180 * u.deg)
+        det2sky = shift_by_crpix | rotation | tan | celestial_rotation
+        det2sky.name = "linear_transform"
+        detector_frame = cf.Frame2D(name="detector", axes_names=("x", "y"), unit=(u.pix, u.pix))
+        sky_frame = cf.CelestialFrame(reference_frame=ICRS(), name='icrs', unit=(u.deg, u.deg))
+        pipeline = [(detector_frame, det2sky), (sky_frame, None)]
+        w_gwcs_1 = gwcs.WCS(pipeline)
+        w_gwcs_1.bounding_box = ((0, 8), (0, 10)) * u.pix  # x, y
+
+        # Second GWCS that is offset
+        shift_by_crpix = models.Shift(-1 * u.pix) & models.Shift(-1 * u.pix)
+        det2sky = shift_by_crpix | rotation | tan | celestial_rotation
+        det2sky.name = "linear_transform"
+        pipeline = [(detector_frame, det2sky), (sky_frame, None)]
+        w_gwcs_2 = gwcs.WCS(pipeline)
+        w_gwcs_2.bounding_box = ((0, 8), (0, 10)) * u.pix  # x, y
+
+        # Load data into Imviz
+        imviz_helper.load_data(NDData(arr, wcs=w_gwcs_1, unit='electron/s'), data_label='gwcs1')
+        imviz_helper.load_data(NDData(arr, wcs=w_gwcs_2), data_label='gwcs2')
+
+        self.wcs_1 = w_gwcs_1
+        self.wcs_2 = w_gwcs_2
         self.imviz = imviz_helper
         self.viewer = imviz_helper.default_viewer
 

--- a/notebooks/concepts/imviz_dithered_gwcs.ipynb
+++ b/notebooks/concepts/imviz_dithered_gwcs.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8a6a099a",
+   "metadata": {},
+   "source": [
+    "This notebook show how Imviz can visualized dithered JWST data, all of them have GWCS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cdcac3b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "from astroquery.mast import Observations \n",
+    "\n",
+    "from jdaviz import Imviz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5024c064",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_dir = \"/Users/username/Data\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd35669a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "files = ['jw01345-o001_t021_nircam_clear-f200w_i2d.fits',\n",
+    "         #'jw01345-o002_t022_nircam_clear-f200w_i2d.fits',\n",
+    "         #'jw01345-o003_t023_nircam_clear-f200w_i2d.fits',\n",
+    "         #'jw01345-o004_t024_nircam_clear-f200w_i2d.fits',\n",
+    "         'jw01345-o052_t022_nircam_clear-f200w_i2d.fits'\n",
+    "        ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b151dc2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for fn in files:\n",
+    "    uri = f\"mast:JWST/product/{fn}\"\n",
+    "    result = Observations.download_file(uri, local_path=f'{data_dir}/{fn}', cache=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a8c0a4e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz = Imviz()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72de03f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with warnings.catch_warnings():\n",
+    "    warnings.simplefilter('ignore')\n",
+    "    with imviz.batch_load():\n",
+    "        for fn in files:\n",
+    "            imviz.load_data(f'{data_dir}/{fn}', data_label=fn[:17])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4b77fcb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fab70d10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Link by WCS\n",
+    "imviz.plugins['Links Control'].link_type = 'WCS'\n",
+    "imviz.plugins['Links Control'].wcs_use_affine = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e7d1198",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set color mode to easily distinguish between them\n",
+    "imviz.plugins['Plot Options'].image_color_mode = 'Monochromatic'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fdd56dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Home button\n",
+    "imviz.default_viewer.state.reset_limits()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a07e9de9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Manual backport of #1908, removing logic for `if reverse` introduced by #1823 which is milestoned for 3.2.