### PR TITLE
Reproject plugin for Imviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Imviz
 
 - Table exposing past results in the aperture photometry plugin. [#1985]
 
+- New Reproject plugin. [#1949]
+
 Mosviz
 ^^^^^^
 
@@ -66,7 +68,7 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
-* Auto-label component no longer disables the automatic labeling behavior on any keypress, but only when changing the
+- Auto-label component no longer disables the automatic labeling behavior on any keypress, but only when changing the
   label [#2007].
 
 Cubeviz

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -263,6 +263,27 @@ are not stored. To save the current result before submitting a new query, you ca
     The table returned from the API above may cover more sources than shown in the currently zoomed-in
     portion of the image. Additional steps will be needed to filter out these points, if necessary.
 
+.. _imviz-reproject:
+
+Reproject
+=========
+
+.. note:: This plugin requires ``reproject`` to be installed.
+
+.. warning::
+
+    This operation is not recommended if the input image has not been
+    corrected for distortion.
+
+    Reprojecting a large image may be resource intensive.
+
+Use the `reproject <https://reproject.readthedocs.io/>`_ package to create a new image
+that is the input image reprojected to its optimal celestial WCS.
+
+Choose the desired image from the data selection menu, if applicable.
+Then click on the :guilabel:`REPROJECT` button.
+If successful, a new reprojected image will be displayed in Imviz.
+
 .. _imviz-export-plot:
 
 Export Plot

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -281,8 +281,14 @@ Use the `reproject <https://reproject.readthedocs.io/>`_ package to create a new
 that is the input image reprojected to its optimal celestial WCS.
 
 Choose the desired image from the data selection menu, if applicable.
-Then click on the :guilabel:`REPROJECT` button.
-If successful, a new reprojected image will be displayed in Imviz.
+Then enter the desired data label for the result.
+Next, click on the :guilabel:`REPROJECT` button
+(this might take a while to complete, please be patient).
+
+If successful, a new reprojected image with the given label will be
+displayed in Imviz's default viewer and is now the viewer's reference data.
+The original image before reprojection is also removed from the viewer
+(but still available in the application's underlying data collection).
 
 .. _imviz-export-plot:
 

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -277,6 +277,9 @@ Reproject
 
     Reprojecting a large image may be resource intensive.
 
+    Compass zoom box might be inaccurate on data linked to the reprojected
+    image.
+
 Use the `reproject <https://reproject.readthedocs.io/>`_ package to create a new image
 that is the input image reprojected to its optimal celestial WCS.
 

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -285,7 +285,7 @@ Then enter the desired data label for the result.
 Next, click on the :guilabel:`REPROJECT` button
 (this might take a while to complete, please be patient).
 
-If successful, a new reprojected image with the given label will be
+If successful, a new reprojected image (N-up, E-left) with the given label will be
 displayed in Imviz's default viewer and is now the viewer's reference data.
 The original image before reprojection is also removed from the viewer
 (but still available in the application's underlying data collection).

--- a/jdaviz/configs/imviz/imviz.yaml
+++ b/jdaviz/configs/imviz/imviz.yaml
@@ -26,6 +26,7 @@ tray:
   - imviz-line-profile-xy
   - imviz-aper-phot-simple
   - imviz-catalogs
+  - imviz-reproject
   - g-export-plot
 viewer_area:
   - container: col

--- a/jdaviz/configs/imviz/plugins/__init__.py
+++ b/jdaviz/configs/imviz/plugins/__init__.py
@@ -8,3 +8,4 @@ from .compass import *  # noqa
 from .aper_phot_simple import *  # noqa
 from .line_profile_xy import *  # noqa
 from .catalogs import *  # noqa
+from .reproject import *  # noqa

--- a/jdaviz/configs/imviz/plugins/reproject/__init__.py
+++ b/jdaviz/configs/imviz/plugins/reproject/__init__.py
@@ -1,0 +1,1 @@
+from .reproject import *  # noqa

--- a/jdaviz/configs/imviz/plugins/reproject/reproject.py
+++ b/jdaviz/configs/imviz/plugins/reproject/reproject.py
@@ -1,7 +1,7 @@
 import numpy as np
 import time
 from glue.core.data import Data
-from traitlets import Bool
+from traitlets import Bool, observe
 
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import tray_registry
@@ -31,6 +31,22 @@ class Reproject(PluginTemplateMixin, DatasetSelectMixin, AutoTextFieldMixin):
         if not HAS_REPROJECT:
             self.disabled_msg = 'Please install reproject and restart Jdaviz to use this plugin'
             return
+
+    @observe("dataset_selected")
+    def _set_default_results_label(self, event={}):
+        '''Generate a label and set the results field to that value'''
+        self.label_default = f"{self.dataset_selected} (reprojected)"
+
+    @observe('label')
+    def _label_changed(self, event={}):
+        if not len(self.label.strip()):
+            # strip will raise the same error for a label of all spaces
+            self.label_invalid_msg = 'label must be provided'
+            return
+        if self.label.strip() in self.data_collection:
+            self.label_invalid_msg = 'label already in use'
+            return
+        self.label_invalid_msg = ''
 
     def vue_do_reproject(self, *args, **kwargs):
         if (not HAS_REPROJECT or self.dataset_selected not in self.data_collection

--- a/jdaviz/configs/imviz/plugins/reproject/reproject.py
+++ b/jdaviz/configs/imviz/plugins/reproject/reproject.py
@@ -7,6 +7,7 @@ from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin, DatasetSelectMixin,
                                         AutoTextFieldMixin)
+from jdaviz.core.user_api import PluginUserApi
 
 try:
     from reproject import reproject_interp
@@ -32,6 +33,10 @@ class Reproject(PluginTemplateMixin, DatasetSelectMixin, AutoTextFieldMixin):
             self.disabled_msg = 'Please install reproject and restart Jdaviz to use this plugin'
             return
 
+    @property
+    def user_api(self):
+        return PluginUserApi(self, expose=('dataset', 'label', 'reproject'))
+
     @observe("dataset_selected")
     def _set_default_results_label(self, event={}):
         '''Generate a label and set the results field to that value'''
@@ -48,7 +53,11 @@ class Reproject(PluginTemplateMixin, DatasetSelectMixin, AutoTextFieldMixin):
             return
         self.label_invalid_msg = ''
 
-    def vue_do_reproject(self, *args, **kwargs):
+    def reproject(self):
+        """
+        Reproject ``dataset`` so that North is up in a new entry labeled ``label`` and set as the
+        reference image.
+        """
         if (not HAS_REPROJECT or self.dataset_selected not in self.data_collection
                 or self.reproject_in_progress):
             return
@@ -108,3 +117,6 @@ class Reproject(PluginTemplateMixin, DatasetSelectMixin, AutoTextFieldMixin):
 
         finally:
             self.reproject_in_progress = False
+
+    def vue_do_reproject(self, *args, **kwargs):
+        self.reproject()

--- a/jdaviz/configs/imviz/plugins/reproject/reproject.py
+++ b/jdaviz/configs/imviz/plugins/reproject/reproject.py
@@ -42,7 +42,6 @@ class Reproject(PluginTemplateMixin, DatasetSelectMixin):
 
         self.reproject_in_progress = True
         try:
-            # TODO: Support GWCS (https://github.com/astropy/reproject/issues/328)
             # Find WCS where North is pointing up.
             wcs_out, shape_out = find_optimal_celestial_wcs([(data.shape, wcs_in)], frame='icrs')
 

--- a/jdaviz/configs/imviz/plugins/reproject/reproject.py
+++ b/jdaviz/configs/imviz/plugins/reproject/reproject.py
@@ -1,0 +1,69 @@
+from traitlets import Bool
+
+from jdaviz.core.events import SnackbarMessage
+from jdaviz.core.registries import tray_registry
+from jdaviz.core.template_mixin import PluginTemplateMixin, DatasetSelectMixin
+
+try:
+    from reproject import reproject_interp
+    from reproject.mosaicking import find_optimal_celestial_wcs
+except ImportError:
+    HAS_REPROJECT = False
+else:
+    HAS_REPROJECT = True
+
+__all__ = ['Reproject']
+
+
+@tray_registry('imviz-reproject', label="Reproject")
+class Reproject(PluginTemplateMixin, DatasetSelectMixin):
+    template_file = __file__, "reproject.vue"
+
+    reproject_in_progress = Bool(False).tag(sync=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not HAS_REPROJECT:
+            self.disabled_msg = 'Please install reproject and restart Jdaviz to use this plugin'
+            return
+
+    def vue_do_reproject(self, *args, **kwargs):
+        if (not HAS_REPROJECT or self.dataset_selected not in self.data_collection
+                or self.reproject_in_progress):
+            return
+
+        data = self.data_collection[self.dataset_selected]
+        wcs_in = data.coords
+        if wcs_in is None:
+            return
+
+        from astropy.nddata import NDData
+
+        self.reproject_in_progress = True
+        try:
+            # TODO: Support GWCS (https://github.com/astropy/reproject/issues/328)
+            # Find WCS where North is pointing up.
+            wcs_out, shape_out = find_optimal_celestial_wcs([(data.shape, wcs_in)], frame='icrs')
+
+            # Reproject image to new WCS.
+            comp = data.get_component(data.main_components[0])
+            new_arr = reproject_interp((comp.data, wcs_in), wcs_out, shape_out=shape_out,
+                                       return_footprint=False)
+
+            # TODO: Let user customize new label; have default label not be so ugly.
+            new_label = f'{self.dataset_selected} (reprojected)'
+
+            # Stuff it back into Imviz.
+            # We don't want to inherit input metadata because it might have wrong (unrotated)
+            # WCS info in the header metadata.
+            ndd = NDData(new_arr, wcs=wcs_out)
+            self.app._jdaviz_helper.load_data(ndd, data_label=new_label)
+
+        except Exception as e:
+            self.hub.broadcast(SnackbarMessage(
+                f"Failed to reproject {self.dataset_selected}: {repr(e)}",
+                color='error', sender=self))
+
+        finally:
+            self.reproject_in_progress = False

--- a/jdaviz/configs/imviz/plugins/reproject/reproject.py
+++ b/jdaviz/configs/imviz/plugins/reproject/reproject.py
@@ -1,4 +1,7 @@
-from traitlets import Bool
+import numpy as np
+import time
+from glue.core.data import Data
+from traitlets import Bool, Unicode
 
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import tray_registry
@@ -19,6 +22,7 @@ __all__ = ['Reproject']
 class Reproject(PluginTemplateMixin, DatasetSelectMixin):
     template_file = __file__, "reproject.vue"
 
+    results_label = Unicode("Reprojected").tag(sync=True)
     reproject_in_progress = Bool(False).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
@@ -33,15 +37,21 @@ class Reproject(PluginTemplateMixin, DatasetSelectMixin):
                 or self.reproject_in_progress):
             return
 
+        import reproject
+
         data = self.data_collection[self.dataset_selected]
         wcs_in = data.coords
         if wcs_in is None:
             return
 
-        from astropy.nddata import NDData
-
+        viewer_reference = f"{self.app.config}-0"
         self.reproject_in_progress = True
+        t_start = time.time()
         try:
+            if self.results_label in self.app.data_collection.labels:
+                raise ValueError(
+                    f'{self.results_label} is already used, choose another label name.')
+
             # Find WCS where North is pointing up.
             wcs_out, shape_out = find_optimal_celestial_wcs([(data.shape, wcs_in)], frame='icrs')
 
@@ -50,19 +60,35 @@ class Reproject(PluginTemplateMixin, DatasetSelectMixin):
             new_arr = reproject_interp((comp.data, wcs_in), wcs_out, shape_out=shape_out,
                                        return_footprint=False)
 
-            # TODO: Let user customize new label; have default label not be so ugly.
-            new_label = f'{self.dataset_selected} (reprojected)'
-
-            # Stuff it back into Imviz.
+            # Stuff it back into Imviz and show in default viewer.
             # We don't want to inherit input metadata because it might have wrong (unrotated)
             # WCS info in the header metadata.
-            ndd = NDData(new_arr, wcs=wcs_out)
-            self.app._jdaviz_helper.load_data(ndd, data_label=new_label)
+            new_data = Data(label=self.results_label,
+                            coords=wcs_out,
+                            data=np.nan_to_num(new_arr, copy=False))
+            new_data.meta.update({'orig_label': data.label,
+                                  'reproject_version': reproject.__version__})
+            self.app.add_data(new_data, self.results_label)
+            self.app.add_data_to_viewer(viewer_reference, self.results_label)
+
+            # We unload the unrotated image from default viewer.
+            # Only do this after we add the reprojected data to avoid JSON warning.
+            self.app.remove_data_from_viewer(viewer_reference, data.label)
+
+            # Make the reprojected image the reference data for the default viewer.
+            viewer = self.app.get_viewer(viewer_reference)
+            viewer.state.reference_data = new_data
 
         except Exception as e:
             self.hub.broadcast(SnackbarMessage(
-                f"Failed to reproject {self.dataset_selected}: {repr(e)}",
+                f"Failed to reproject {data.label}: {repr(e)}",
                 color='error', sender=self))
+
+        else:
+            t_end = time.time()
+            self.hub.broadcast(SnackbarMessage(
+                f"Reprojection of {data.label} took {t_end - t_start:.1f} seconds.",
+                color='info', sender=self))
 
         finally:
             self.reproject_in_progress = False

--- a/jdaviz/configs/imviz/plugins/reproject/reproject.vue
+++ b/jdaviz/configs/imviz/plugins/reproject/reproject.vue
@@ -14,15 +14,13 @@
     />
 
     <div v-if='dataset_selected'>
-      <v-row>
-        <v-col>
-          <v-text-field
-            v-model='results_label'
-            hint="Data label for reprojected data"
-            persistent-hint
-          ></v-text-field>
-        </v-col>
-      </v-row>
+      <plugin-auto-label
+        :value.sync="label"
+        :default="label_default"
+        :auto.sync="label_auto"
+        :invalid_msg="invalid_msg"
+        hint="Data label for reprojected data."
+      ></plugin-auto-label>
       <v-row justify="end">
         <v-btn color="primary" text @click="do_reproject">Reproject</v-btn>
       </v-row>

--- a/jdaviz/configs/imviz/plugins/reproject/reproject.vue
+++ b/jdaviz/configs/imviz/plugins/reproject/reproject.vue
@@ -5,16 +5,17 @@
     :disabled_msg="disabled_msg"
     :popout_button="popout_button">
 
+
+    <plugin-dataset-select
+      :items="dataset_items"
+      :selected.sync="dataset_selected"
+      :show_if_single_entry="false"
+      label="Data"
+      hint="Select the data for reprojection."
+    />
+
     <div style="display: grid"> <!-- overlay container -->
       <div style="grid-area: 1/1">
-        <plugin-dataset-select
-          :items="dataset_items"
-          :selected.sync="dataset_selected"
-          :show_if_single_entry="false"
-          label="Data"
-          hint="Select the data for reprojection."
-        />
-
         <div v-if='dataset_selected'>
           <plugin-auto-label
             :value.sync="label"

--- a/jdaviz/configs/imviz/plugins/reproject/reproject.vue
+++ b/jdaviz/configs/imviz/plugins/reproject/reproject.vue
@@ -18,11 +18,16 @@
         :value.sync="label"
         :default="label_default"
         :auto.sync="label_auto"
-        :invalid_msg="invalid_msg"
+        :invalid_msg="label_invalid_msg"
         hint="Data label for reprojected data."
       ></plugin-auto-label>
       <v-row justify="end">
-        <v-btn color="primary" text @click="do_reproject">Reproject</v-btn>
+        <v-btn color="primary" 
+          text
+          :disabled="label_invalid_msg.length > 0"
+          @click="do_reproject">
+            Reproject
+          </v-btn>
       </v-row>
     </div>
 

--- a/jdaviz/configs/imviz/plugins/reproject/reproject.vue
+++ b/jdaviz/configs/imviz/plugins/reproject/reproject.vue
@@ -1,6 +1,6 @@
 <template>
   <j-tray-plugin
-    description='Perform reprojection for a single image to align display to celestial axes.'
+    description='Perform reprojection for a single image to align X/Y to N-up/E-left.'
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#reproject'"
     :disabled_msg="disabled_msg"
     :popout_button="popout_button">

--- a/jdaviz/configs/imviz/plugins/reproject/reproject.vue
+++ b/jdaviz/configs/imviz/plugins/reproject/reproject.vue
@@ -5,46 +5,50 @@
     :disabled_msg="disabled_msg"
     :popout_button="popout_button">
 
-    <plugin-dataset-select
-      :items="dataset_items"
-      :selected.sync="dataset_selected"
-      :show_if_single_entry="false"
-      label="Data"
-      hint="Select the data for reprojection."
-    />
+    <div style="display: grid"> <!-- overlay container -->
+      <div style="grid-area: 1/1">
+        <plugin-dataset-select
+          :items="dataset_items"
+          :selected.sync="dataset_selected"
+          :show_if_single_entry="false"
+          label="Data"
+          hint="Select the data for reprojection."
+        />
 
-    <div v-if='dataset_selected'>
-      <plugin-auto-label
-        :value.sync="label"
-        :default="label_default"
-        :auto.sync="label_auto"
-        :invalid_msg="label_invalid_msg"
-        hint="Data label for reprojected data."
-      ></plugin-auto-label>
-      <v-row justify="end">
-        <v-btn color="primary" 
-          text
-          :disabled="label_invalid_msg.length > 0"
-          @click="do_reproject">
-            Reproject
-          </v-btn>
-      </v-row>
-    </div>
+        <div v-if='dataset_selected'>
+          <plugin-auto-label
+            :value.sync="label"
+            :default="label_default"
+            :auto.sync="label_auto"
+            :invalid_msg="label_invalid_msg"
+            hint="Data label for reprojected data."
+          ></plugin-auto-label>
+          <v-row justify="end">
+            <v-btn color="primary" 
+              text
+              :disabled="label_invalid_msg.length > 0"
+              @click="do_reproject">
+                Reproject
+              </v-btn>
+          </v-row>
+        </div>
+      </div>
 
-    <div v-if="reproject_in_progress"
-         class="text-center"
-         style="grid-area: 1/1;
-                z-index:2;
-                margin-left: -24px;
-                margin-right: -24px;
-                padding-top: 60px;
-                background-color: rgb(0 0 0 / 20%)">
-      <v-progress-circular
-        indeterminate
-        color="spinner"
-        size="50"
-        width="6"
-      ></v-progress-circular>
+      <div v-if="reproject_in_progress"
+           class="text-center"
+           style="grid-area: 1/1;
+                  z-index:2;
+                  margin-left: -24px;
+                  margin-right: -24px;
+                  padding-top: 60px;
+                  background-color: rgb(0 0 0 / 20%)">
+        <v-progress-circular
+          indeterminate
+          color="spinner"
+          size="50"
+          width="6"
+        ></v-progress-circular>
+      </div>
     </div>
   </j-tray-plugin>
 </template>

--- a/jdaviz/configs/imviz/plugins/reproject/reproject.vue
+++ b/jdaviz/configs/imviz/plugins/reproject/reproject.vue
@@ -1,6 +1,6 @@
 <template>
   <j-tray-plugin
-    description='Perform reprojection for a single image.'
+    description='Perform reprojection for a single image to align display to celestial axes.'
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#reproject'"
     :disabled_msg="disabled_msg"
     :popout_button="popout_button">
@@ -14,6 +14,15 @@
     />
 
     <div v-if='dataset_selected'>
+      <v-row>
+        <v-col>
+          <v-text-field
+            v-model='results_label'
+            hint="Data label for reprojected data"
+            persistent-hint
+          ></v-text-field>
+        </v-col>
+      </v-row>
       <v-row justify="end">
         <v-btn color="primary" text @click="do_reproject">Reproject</v-btn>
       </v-row>

--- a/jdaviz/configs/imviz/plugins/reproject/reproject.vue
+++ b/jdaviz/configs/imviz/plugins/reproject/reproject.vue
@@ -1,0 +1,38 @@
+<template>
+  <j-tray-plugin
+    description='Perform reprojection for a single image.'
+    :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#reproject'"
+    :disabled_msg="disabled_msg"
+    :popout_button="popout_button">
+
+    <plugin-dataset-select
+      :items="dataset_items"
+      :selected.sync="dataset_selected"
+      :show_if_single_entry="false"
+      label="Data"
+      hint="Select the data for reprojection."
+    />
+
+    <div v-if='dataset_selected'>
+      <v-row justify="end">
+        <v-btn color="primary" text @click="do_reproject">Reproject</v-btn>
+      </v-row>
+    </div>
+
+    <div v-if="reproject_in_progress"
+         class="text-center"
+         style="grid-area: 1/1;
+                z-index:2;
+                margin-left: -24px;
+                margin-right: -24px;
+                padding-top: 60px;
+                background-color: rgb(0 0 0 / 20%)">
+      <v-progress-circular
+        indeterminate
+        color="spinner"
+        size="50"
+        width="6"
+      ></v-progress-circular>
+    </div>
+  </j-tray-plugin>
+</template>

--- a/jdaviz/configs/imviz/tests/test_reproject.py
+++ b/jdaviz/configs/imviz/tests/test_reproject.py
@@ -24,7 +24,8 @@ class TestReproject_WCS_GWCS(BaseImviz_WCS_GWCS):
                                                          'Reprojected']
         assert self.imviz.app.data_collection['Reprojected'].meta['orig_label'] == 'fits_wcs[DATA]'
         # Original data should not be loaded in the viewer anymore.
-        assert [data.label for data in self.viewer.data()] == ['gwcs[DATA]', 'no_wcs', 'Reprojected']
+        assert [data.label for data in self.viewer.data()] == ['gwcs[DATA]', 'no_wcs',
+                                                               'Reprojected']
         # Reprojected data now is the viewer reference.
         assert self.viewer.state.reference_data.label == 'Reprojected'
 

--- a/jdaviz/configs/imviz/tests/test_reproject.py
+++ b/jdaviz/configs/imviz/tests/test_reproject.py
@@ -1,0 +1,8 @@
+import pytest
+
+reproject = pytest.importorskip("reproject")
+
+
+def test_reproject_plugin():
+    # FIXME
+    raise NotImplementedError

--- a/jdaviz/configs/imviz/tests/test_reproject.py
+++ b/jdaviz/configs/imviz/tests/test_reproject.py
@@ -1,8 +1,51 @@
 import pytest
 
-reproject = pytest.importorskip("reproject")
+from jdaviz.configs.imviz.plugins.reproject.reproject import HAS_REPROJECT
+from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_GWCS
 
 
-def test_reproject_plugin():
-    # FIXME
-    raise NotImplementedError
+@pytest.mark.skipif(not HAS_REPROJECT, reason='reproject not installed')
+class TestReproject_WCS_GWCS(BaseImviz_WCS_GWCS):
+    def test_reproject_fits_wcs(self):
+        self.imviz.link_data(link_type='wcs', error_on_fail=True)
+
+        plg = self.imviz.plugins["Reproject"]
+        assert not plg._obj.disabled_msg
+
+        # Attempt to reproject without WCS should be silent no-op.
+        plg._obj.dataset_selected = "no_wcs"
+        plg._obj.vue_do_reproject()
+        assert self.imviz.app.data_collection.labels == ['fits_wcs[DATA]', 'gwcs[DATA]', 'no_wcs']
+
+        # Reproject FITS WCS. We do not test the actual reprojection algorithm.
+        plg._obj.dataset_selected = 'fits_wcs[DATA]'
+        plg._obj.vue_do_reproject()
+        assert self.imviz.app.data_collection.labels == ['fits_wcs[DATA]', 'gwcs[DATA]', 'no_wcs',
+                                                         'Reprojected']
+        assert self.imviz.app.data_collection['Reprojected'].meta['orig_label'] == 'fits_wcs[DATA]'
+        # Original data should not be loaded in the viewer anymore.
+        assert [data.label for data in self.viewer.data()] == ['gwcs[DATA]', 'no_wcs', 'Reprojected']
+        # Reprojected data now is the viewer reference.
+        assert self.viewer.state.reference_data.label == 'Reprojected'
+
+        # Reproject again using existing label is not allowed.
+        # Only snackbar message is shown, so that is not tested here. Result should be unchanged.
+        plg._obj.dataset_selected = 'gwcs[DATA]'
+        plg._obj.vue_do_reproject()
+        assert self.imviz.app.data_collection.labels == ['fits_wcs[DATA]', 'gwcs[DATA]', 'no_wcs',
+                                                         'Reprojected']
+        assert self.imviz.app.data_collection['Reprojected'].meta['orig_label'] == 'fits_wcs[DATA]'
+
+
+@pytest.mark.skipif(not HAS_REPROJECT, reason='reproject not installed')
+def test_reproject_no_data(imviz_helper):
+    """This should be silent no-op."""
+    plg = imviz_helper.plugins["Reproject"]
+    plg._obj.vue_do_reproject()
+    assert len(imviz_helper.app.data_collection) == 0
+
+
+@pytest.mark.skipif(HAS_REPROJECT, reason='reproject is installed')
+def test_reproject_no_reproject(imviz_helper):
+    plg = imviz_helper.plugins["Reproject"]
+    assert "Please install reproject" in plg._obj.disabled_msg

--- a/jdaviz/configs/imviz/tests/test_reproject.py
+++ b/jdaviz/configs/imviz/tests/test_reproject.py
@@ -12,14 +12,16 @@ class TestReproject_WCS_GWCS(BaseImviz_WCS_GWCS):
         plg = self.imviz.plugins["Reproject"]
         assert not plg._obj.disabled_msg
 
-        # Attempt to reproject without WCS should be silent no-op.
-        plg._obj.dataset_selected = "no_wcs"
-        plg._obj.vue_do_reproject()
+        # Attempt to reproject without WCS should be no-op.
+        plg.dataset = "no_wcs"
+        plg.reproject()
         assert self.imviz.app.data_collection.labels == ['fits_wcs[DATA]', 'gwcs[DATA]', 'no_wcs']
 
         # Reproject FITS WCS. We do not test the actual reprojection algorithm.
-        plg._obj.dataset_selected = 'fits_wcs[DATA]'
-        plg._obj.vue_do_reproject()
+        plg.dataset = 'fits_wcs[DATA]'
+        assert plg.label == 'fits_wcs[DATA] (reprojected)'
+        plg.label = 'Reprojected'  # Overwrite default label
+        plg.reproject()
         assert self.imviz.app.data_collection.labels == ['fits_wcs[DATA]', 'gwcs[DATA]', 'no_wcs',
                                                          'Reprojected']
         assert self.imviz.app.data_collection['Reprojected'].meta['orig_label'] == 'fits_wcs[DATA]'
@@ -31,8 +33,9 @@ class TestReproject_WCS_GWCS(BaseImviz_WCS_GWCS):
 
         # Reproject again using existing label is not allowed.
         # Only snackbar message is shown, so that is not tested here. Result should be unchanged.
-        plg._obj.dataset_selected = 'gwcs[DATA]'
-        plg._obj.vue_do_reproject()
+        plg.dataset = 'gwcs[DATA]'
+        plg.label = 'Reprojected'  # Reuse existing label
+        plg.reproject()
         assert self.imviz.app.data_collection.labels == ['fits_wcs[DATA]', 'gwcs[DATA]', 'no_wcs',
                                                          'Reprojected']
         assert self.imviz.app.data_collection['Reprojected'].meta['orig_label'] == 'fits_wcs[DATA]'
@@ -42,7 +45,7 @@ class TestReproject_WCS_GWCS(BaseImviz_WCS_GWCS):
 def test_reproject_no_data(imviz_helper):
     """This should be silent no-op."""
     plg = imviz_helper.plugins["Reproject"]
-    plg._obj.vue_do_reproject()
+    plg.reproject()
     assert len(imviz_helper.app.data_collection) == 0
 
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1599,7 +1599,7 @@ class AutoTextFieldMixin(VuetifyTemplate, HubListener):
         :value.sync="label"
         :default="label_default"
         :auto.sync="label_auto"
-        :invalid_msg="invalid_msg"
+        :invalid_msg="label_invalid_msg"
         hint="Label hint."
       ></plugin-auto-label>
     """
@@ -1610,9 +1610,9 @@ class AutoTextFieldMixin(VuetifyTemplate, HubListener):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.auto_label = AddResults(self, 'label',
-                                     'label_default', 'label_auto',
-                                     'label_invalid_msg')
+        self.auto_label = AutoTextField(self, 'label',
+                                        'label_default', 'label_auto',
+                                        'label_invalid_msg')
 
 
 class AddResults(BasePluginComponent):

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,8 @@ test =
 docs =
     sphinx-rtd-theme
     sphinx-astropy
+all =
+    reproject>=0.10
 
 [options.package_data]
 jdaviz =

--- a/tox.ini
+++ b/tox.ini
@@ -60,8 +60,7 @@ deps =
 # The following indicates which extras_require from setup.cfg will be installed
 extras =
     test
-    # Uncomment when we have all again in setup.cfg
-    #alldeps: all
+    alldeps: all
 
 commands =
     devdeps: pip install -U -i https://pypi.anaconda.org/astropy/simple astropy --pre


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to implement a plugin to call `reproject` in Imviz, as requested by user.

Pro:

* Can run reproject from GUI (even though reproject is a completely separate package). See https://reproject.readthedocs.io/

Con:

* This plugin does not make sense for the following workflow: The data generated by reproject will align back with the original (reference) data when you link by WCS, defeating the purpose of reprojection. 
* Not performant: It took almost 30 seconds on my machine to rotate a single 2k by 4k image (the first one in `ImvizDitheredExample.ipynb`)
* See "Blocker(s)" below.

Blocker(s):

* ~Does not work on GWCS until this issue is addressed:~ https://github.com/astropy/reproject/issues/328

### TODO

- [x] What to do with original (unrotated) image?
- [x] `Out of range float values are not JSON compliant`
- [x] Let user customize new label; have default label not be so ugly.
- [x] Add tests.
- [x] Make sure change log in next release section.
- [x] Is it okay to not expose things as public API yet?
- [ ] Do we have to rename this plugin?
- [ ] Any way to make sure Compass zoom box is always correct? Seems to only happen when you reproject the smaller image and then use the reprojected smaller image as reference, and then view a larger image. We'll just open a follow-up ticket for this one to deal with later.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3016)
