### PR TITLE
BUG: Fix Line Profile when NaN exists

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -107,6 +107,9 @@ Imviz
 
 - ``viewer.center_on()`` now behaves correctly on non-reference data. [#1928]
 
+- Imviz Line Profiles (XY) plugin now treats NaNs as zeros in plotting.
+  However, underlying data is unchanged. [#1951]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
+++ b/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
@@ -1,4 +1,5 @@
 import bqplot
+import numpy as np
 from ipywidgets import widget_serialization
 from traitlets import Any, Bool, List, Unicode, observe
 
@@ -98,7 +99,8 @@ class LineProfileXY(PluginTemplateMixin):
         fig_x.fig_margin = {'top': 60, 'bottom': 60, 'left': 40, 'right': 10}
         line_x_x_sc = bqplot.LinearScale()
         line_x_y_sc = bqplot.LinearScale()
-        line_x = bqplot.Lines(x=range(comp.data.shape[0]), y=comp.data[:, x],
+        line_y_data = np.nan_to_num(comp.data[:, x])
+        line_x = bqplot.Lines(x=range(comp.data.shape[0]), y=line_y_data,
                               scales={'x': line_x_x_sc, 'y': line_x_y_sc}, colors='gray')
         fig_x.marks = [line_x]
         fig_x.axes = [bqplot.Axis(scale=line_x_x_sc, label='Y (pix)'),
@@ -107,7 +109,7 @@ class LineProfileXY(PluginTemplateMixin):
         line_x.scales['x'].max = y_max
         y_min = max(int(y_min), 0)
         y_max = min(int(y_max), ny)
-        zoomed_data_x = comp.data[y_min:y_max, x]
+        zoomed_data_x = line_y_data[y_min:y_max]
         if zoomed_data_x.size > 0:
             line_x.scales['y'].min = zoomed_data_x.min() * 0.95
             line_x.scales['y'].max = zoomed_data_x.max() * 1.05
@@ -117,7 +119,8 @@ class LineProfileXY(PluginTemplateMixin):
         fig_y.fig_margin = {'top': 60, 'bottom': 60, 'left': 40, 'right': 10}
         line_y_x_sc = bqplot.LinearScale()
         line_y_y_sc = bqplot.LinearScale()
-        line_y = bqplot.Lines(x=range(comp.data.shape[1]), y=comp.data[y, :],
+        line_x_data = np.nan_to_num(comp.data[y, :])
+        line_y = bqplot.Lines(x=range(comp.data.shape[1]), y=line_x_data,
                               scales={'x': line_y_x_sc, 'y': line_y_y_sc}, colors='gray')
         fig_y.marks = [line_y]
         fig_y.axes = [bqplot.Axis(scale=line_y_x_sc, label='X (pix)'),
@@ -126,7 +129,7 @@ class LineProfileXY(PluginTemplateMixin):
         line_y.scales['x'].max = x_max
         x_min = max(int(x_min), 0)
         x_max = min(int(x_max), nx)
-        zoomed_data_y = comp.data[y, x_min:x_max]
+        zoomed_data_y = line_x_data[x_min:x_max]
         if zoomed_data_y.size > 0:
             line_y.scales['y'].min = zoomed_data_y.min() * 0.95
             line_y.scales['y'].max = zoomed_data_y.max() * 1.05

--- a/jdaviz/configs/imviz/tests/test_line_profile_xy.py
+++ b/jdaviz/configs/imviz/tests/test_line_profile_xy.py
@@ -9,7 +9,7 @@ from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_NoWCS
 class TestLineProfileXY(BaseImviz_WCS_NoWCS):
     def test_plugin_linked_by_pixel(self):
         """Go through plugin logic but does not check plot contents."""
-        lp_plugin = self.imviz.app.get_tray_item_from_name('imviz-line-profile-xy')
+        lp_plugin = self.imviz.plugins['Imviz Line Profiles (XY)']._obj
         lp_plugin.plugin_opened = True
 
         lp_plugin._on_viewers_changed()  # Populate plugin menu items.
@@ -64,3 +64,17 @@ class TestLineProfileXY(BaseImviz_WCS_NoWCS):
         assert lp_plugin.line_plot_across_x
         assert lp_plugin.line_plot_across_y
         assert lp_plugin.plot_available
+
+
+def test_line_profile_with_nan(imviz_helper):
+    arr = np.ones((10, 10))
+    arr[5, 5] = np.nan
+    imviz_helper.load_data(arr)
+
+    lp_plugin = imviz_helper.plugins['Imviz Line Profiles (XY)']
+    lp_plugin.open_in_tray()
+    lp_plugin._obj.selected_x = 5
+    lp_plugin._obj.selected_y = 5
+    lp_plugin._obj.vue_draw_plot()
+    assert lp_plugin._obj.plot_available
+    assert np.all(np.isfinite(lp_plugin._obj.line_plot_across_x.marks[0].y))


### PR DESCRIPTION
Add test that fails on main without this patch.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to plot NaN as zero in Imviz Line Profile.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-2961)
