### PR TITLE
fix default spectrum 2d viewer assignment for slit overlay plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,9 @@ Imviz
 Mosviz
 ^^^^^^
 
+- Fix broken slit overlay plugin which resulted in a snackbar error being raised complaining about
+  ``S_REGION``. [#1957]
+
 Specviz
 ^^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1159,8 +1159,8 @@ class Application(VuetifyTemplate, HubListener):
         viewer has not yet loaded data, or e.g. ``require_spectrum_viewer``
         to require that the viewer supports spectrum visualization.
         """
+        from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
         from jdaviz.configs.specviz.plugins.viewers import SpecvizProfileView
-        from jdaviz.configs.specviz2d.plugins import SpectralExtraction
         from jdaviz.configs.cubeviz.plugins.viewers import CubevizProfileView, CubevizImageView
         from jdaviz.configs.mosviz.plugins.viewers import (
             MosvizTableViewer, MosvizProfile2DView
@@ -1169,7 +1169,7 @@ class Application(VuetifyTemplate, HubListener):
         spectral_viewers = (SpecvizProfileView, CubevizProfileView)
         spectral_2d_viewers = (MosvizProfile2DView, )
         table_viewers = (MosvizTableViewer, )
-        image_viewers = (MosvizProfile2DView, CubevizImageView, SpectralExtraction)
+        image_viewers = (ImvizImageView, CubevizImageView)
         flux_viewers = (CubevizImageView, )
 
         for vid in self._viewer_store:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1167,6 +1167,7 @@ class Application(VuetifyTemplate, HubListener):
         )
 
         spectral_viewers = (SpecvizProfileView, CubevizProfileView)
+        spectral_2d_viewers = (MosvizProfile2DView, )
         table_viewers = (MosvizTableViewer, )
         image_viewers = (MosvizProfile2DView, CubevizImageView, SpectralExtraction)
         flux_viewers = (CubevizImageView, )
@@ -1179,6 +1180,9 @@ class Application(VuetifyTemplate, HubListener):
             )
             if require_spectrum_viewer:
                 if isinstance(self._viewer_store[vid], spectral_viewers) and is_returnable:
+                    return viewer_item['reference']
+            elif require_spectrum_2d_viewer:
+                if isinstance(self._viewer_store[vid], spectral_2d_viewers) and is_returnable:
                     return viewer_item['reference']
             elif require_table_viewer:
                 if isinstance(self._viewer_store[vid], table_viewers) and is_returnable:

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -29,7 +29,7 @@ __all__ = ['LineListTool']
 
 @tray_registry(
     'g-line-list', label="Line Lists",
-    viewer_requirements=['spectrum', 'image', 'flux']
+    viewer_requirements=['spectrum']
 )
 class LineListTool(PluginTemplateMixin):
     dialog = Bool(False).tag(sync=True)
@@ -73,9 +73,6 @@ class LineListTool(PluginTemplateMixin):
         )
         self._default_flux_viewer_reference_name = kwargs.get(
             "flux_viewer_reference_name", "flux-viewer"
-        )
-        self._default_image_viewer_reference_name = kwargs.get(
-            "image_viewer_reference_name", "image-viewer"
         )
         self._viewer = self.app.get_viewer(self._default_spectrum_viewer_reference_name)
         self._spectrum1d = None

--- a/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
@@ -43,7 +43,7 @@ def jwst_header_to_skyregion(header):
 
 
 @tray_registry('g-slit-overlay', label="Slit Overlay",
-               viewer_requirements=['table', 'flux', 'spectrum-2d', 'spectrum'])
+               viewer_requirements=['table', 'image', 'spectrum-2d', 'spectrum'])
 class SlitOverlay(PluginTemplateMixin):
     template_file = __file__, "slit_overlay.vue"
     visible = Bool(True).tag(sync=True)
@@ -147,7 +147,7 @@ class SlitOverlay(PluginTemplateMixin):
     def remove_slit_overlay(self):
         if self._slit_overlay_mark is not None:
             image_figure = self.app.get_viewer(
-                self._default_flux_viewer_reference_name
+                self._default_image_viewer_reference_name
             ).figure
             # We need to do the following instead of just removing directly on
             # the marks otherwise traitlets doesn't register a change in the


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes a bug in the slit overlay plugin in Mosviz which resulted in a snackbar error being raised complaining about `S_REGION`.  The underlying cause was that the plugin was accessing data from the image viewer instead of the spectrum-2d-viewer because of faulty default viewer assignment introduced in #1681.  This PR does not change the actual parsing or treatment of the slit itself, which still needs validation/testing.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
