### PR TITLE
Change nan fallback in MOS Table to avoid JSON Serialization Warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -87,7 +87,7 @@ Mosviz
 - Fix broken slit overlay plugin which resulted in a snackbar error being raised complaining about
   ``S_REGION``. [#1957]
 
-- RA Dec fallback values changed to "Unspecified" to avoid json serialization warning [#1958]
+- RA/Dec fallback values changed to "Unspecified" to avoid JSON serialization warning when loading data. [#1958]
 
 Specviz
 ^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,8 +58,6 @@ Imviz
 Mosviz
 ^^^^^^
 
-- RA Dec fallback values changed to "Unspecified" to avoid json serialization warning [#1958]
-
 Specviz
 ^^^^^^^
 
@@ -88,6 +86,8 @@ Mosviz
 
 - Fix broken slit overlay plugin which resulted in a snackbar error being raised complaining about
   ``S_REGION``. [#1957]
+
+- RA Dec fallback values changed to "Unspecified" to avoid json serialization warning [#1958]
 
 Specviz
 ^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,8 @@ Imviz
 Mosviz
 ^^^^^^
 
+- RA Dec fallback values changed to "Unspecified" to avoid json serialization warning [#1958]
+
 Specviz
 ^^^^^^^
 

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -19,6 +19,7 @@ from jdaviz.configs.specviz import Specviz
 from jdaviz.configs.specviz.helper import _apply_redshift_to_spectra
 from jdaviz.configs.specviz2d import Specviz2d
 from jdaviz.configs.mosviz.plugins import jwst_header_to_skyregion
+from jdaviz.configs.mosviz.plugins.parsers import FALLBACK_NAME
 from jdaviz.configs.default.plugins.line_lists.line_list_mixin import LineListMixin
 
 __all__ = ['Mosviz']
@@ -333,7 +334,10 @@ class Mosviz(ConfigHelper, LineListMixin):
             return None, None
 
         ra = table_data["R.A."][msg.selected_index]
-        dec = table_data["Dec."][msg.selected_index]
+        dec = table_data["R.A."][msg.selected_index]
+
+        if (ra == FALLBACK_NAME) or (dec == FALLBACK_NAME):
+            return None, None
 
         pixel_height = 0.5*(specview.axis_y.scale.max - specview.axis_y.scale.min)
         point = SkyCoord(ra*u.deg, dec*u.deg)

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -492,8 +492,8 @@ def mos_meta_parser(app, data_obj=None, ids=None):
 
         # source name and coordinates are taken from image headers, if present
         if "Images" in current_columns:
-            ra = query_metadata_by_component(app, "OBJ_RA", "Images", float("nan"))
-            dec = query_metadata_by_component(app, "OBJ_DEC", "Images", float("nan"))
+            ra = query_metadata_by_component(app, "OBJ_RA", "Images", FALLBACK_NAME)
+            dec = query_metadata_by_component(app, "OBJ_DEC", "Images", FALLBACK_NAME)
             _add_to_table(app, ra, "R.A.")
             _add_to_table(app, dec, "Dec.")
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Our traitlet messaging infrastructure does not support `nans` in the payload, as they are not JSON serializable. I changed the default fallback for missing RA/Dec values from `nan` to our default `Unspecified` we use for the Filter and Grating. Unfortunately this means it's a string rather than a float, and thereby a different type, but oh well.

I also add a preemptive sanitization check in `_add_to_table` to convert any `nans` to string 'nan's in case the user actually provides a `nan` directly. The issue/slightly controversial step here is the need to add `pandas` to our dependencies to actually perform the nan check. `numpy.isnan` doesn't support complex objects and will spit an error, as opposed to `pandas.isna`. We can debate whether we want this or not; I can easily remove it

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
