### PR TITLE
BUG: Home after markers no longer crash Imviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,6 +79,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Fixed crashing when clicking Home button after markers are added. [#1971]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -323,6 +323,10 @@ class TestMarkers(BaseImviz_WCS_NoWCS):
         # TODO: How to check imviz.app.data_collection.links is correct?
         assert len(self.imviz.app.data_collection.links) == 14
 
+        # Just want to make sure nothing crashes. Zooming already testing elsewhere.
+        # https://github.com/spacetelescope/jdaviz/pull/1971
+        self.viewer.zoom_level = 'fit'
+
         # Remove markers with default name.
         self.viewer.remove_markers()
         assert self.imviz.app.data_collection.labels == [

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -88,7 +88,7 @@ class FreezableBqplotImageViewerState(BqplotImageViewerState, FreezableState):
             x_min, x_max = -0.5, -np.inf
             y_min, y_max = -0.5, -np.inf
             for layer in self.layers:
-                if not layer.visible:
+                if not layer.visible or layer.layer.data.ndim == 1:
                     continue
                 pixel_ids = layer.layer.pixel_component_ids
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to prevent crashing in Imviz when Home is clicked on after markers are added.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1964 

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
