### PR TITLE
Generate Gaussian Smooth data labels via App-wide data labeler

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,8 @@ Specviz2d
 Other Changes and Additions
 ---------------------------
 
+- Gaussian Smooth products are always labeled with the original data [#1973]
+
 3.2.1 (unreleased)
 ==================
 

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -90,8 +90,10 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
     def _set_default_results_label(self, event={}):
         '''Generate a label and set the results field to that value'''
         if (hasattr(self, 'dataset') and (len(self.dataset.labels) >= 1) or self.app.config == 'mosviz'):  # noqa
-            dataset = self.dataset_selected
+            dataset = f'{self.dataset_selected} '
         else:
+            # This should only happen at initialization. Will be overwritten with above
+            # once data is loaded
             dataset = ''
 
         smooth_type = (f"{self.mode_selected.lower()}-smooth" if self.config == "cubeviz"
@@ -100,7 +102,7 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
 
         # Overriding is allowed, so do not check for uniqueness
         self.results_label_default = (
-            self.app.return_data_label(f"{dataset} {smooth_type} {stddev}", check_unique=False))
+            self.app.return_data_label(f"{dataset}{smooth_type} {stddev}", check_unique=False))
 
     @observe("dataset_selected")
     def _on_data_selected(self, event={}):

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -88,15 +88,19 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
 
     @observe("dataset_selected", "dataset_items", "stddev", "mode_selected")
     def _set_default_results_label(self, event={}):
-        label_comps = []
-        if hasattr(self, 'dataset') and (len(self.dataset.labels) > 1 or self.app.config == 'mosviz'):  # noqa
-            label_comps += [self.dataset_selected]
-        if self.config == "cubeviz":
-            label_comps += [f"{self.mode_selected.lower()}-smooth"]
+        '''Generate a label and set the results field to that value'''
+        if (hasattr(self, 'dataset') and (len(self.dataset.labels) >= 1) or self.app.config == 'mosviz'):  # noqa
+            dataset = self.dataset_selected
         else:
-            label_comps += ["smooth"]
-        label_comps += [f"stddev-{self.stddev}"]
-        self.results_label_default = " ".join(label_comps)
+            dataset = ''
+
+        smooth_type = (f"{self.mode_selected.lower()}-smooth" if self.config == "cubeviz"
+                       else "smooth")
+        stddev = f"stddev-{self.stddev}"
+
+        # Overriding is allowed, so do not check for uniqueness
+        self.results_label_default = (
+            self.app.return_data_label(f"{dataset} {smooth_type} {stddev}", check_unique=False))
 
     @observe("dataset_selected")
     def _on_data_selected(self, event={}):

--- a/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
@@ -36,7 +36,8 @@ def test_linking_after_spectral_smooth(cubeviz_helper, spectrum1d_cube):
     
     # FOR HISTORICAL CONTEXT:
     # The data label used to be prepended to the results_label ONLY if there were multiple
-    # smoothed spectra. As of PR#1973, POs requested the data label to always be present
+    # smoothed spectra. As of PR#1973, POs requested the data label to always be present.
+    # As a result, label will overwrite here
     assert len(gs.dataset_items) == 2
     assert gs.dataset_selected == f'{data_label}[FLUX]'
     assert gs.results_label == f'{data_label}[FLUX] spectral-smooth stddev-3.2'

--- a/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
@@ -40,7 +40,7 @@ def test_linking_after_spectral_smooth(cubeviz_helper, spectrum1d_cube):
     assert len(gs.dataset_items) == 2
     assert gs.dataset_selected == f'{data_label}[FLUX]'
     assert gs.results_label == f'{data_label}[FLUX] spectral-smooth stddev-3.2'
-    assert gs.results_label_overwrite is False
+    assert gs.results_label_overwrite is True
 
     assert len(dc) == 2
     assert dc[1].label == f'{data_label}[FLUX] spectral-smooth stddev-3.2'

--- a/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
@@ -29,11 +29,12 @@ def test_linking_after_spectral_smooth(cubeviz_helper, spectrum1d_cube):
     assert len(gs.dataset_items) == 1
     # by removing the data entry, the overwrite will no longer apply
     app.remove_data_from_viewer('spectrum-viewer', f'{data_label}[FLUX] spectral-smooth stddev-3.2')
-    app.data_collection.remove(app.data_collection[f'{data_label}[FLUX] spectral-smooth stddev-3.2'])
+    app.data_collection.remove(
+        app.data_collection[f'{data_label}[FLUX] spectral-smooth stddev-3.2'])
 
     gs.add_to_viewer_selected = 'spectrum-viewer'
     gs.vue_apply()
-    
+
     # FOR HISTORICAL CONTEXT:
     # The data label used to be prepended to the results_label ONLY if there were multiple
     # smoothed spectra. As of PR#1973, POs requested the data label to always be present.
@@ -119,7 +120,8 @@ def test_spatial_convolution(cubeviz_helper, spectrum1d_cube):
     assert len(dc) == 2
     assert dc[1].label == f'{data_label}[FLUX] spatial-smooth stddev-3.0'
     assert dc[1].shape == (2, 4, 2)  # specutils moved spectral axis to last
-    assert (dc[f'{data_label}[FLUX] spatial-smooth stddev-3.0'].get_object(cls=Spectrum1D, statistic=None).shape
+    assert (dc[f'{data_label}[FLUX] spatial-smooth stddev-3.0'].get_object(cls=Spectrum1D,
+                                                                           statistic=None).shape
             == (2, 4, 2))
 
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This is a quick PR to fix a (potential?) bug where the first smoothed dataset generated by the Gaussian Smooth plugin is missing the dataset name. As requested by Cami, all smoothed datasets should have consistent naming by having the original dataset represented in its name. I replaced the custom labeling logic with Jesse's app-wide data label generator for consistency.

Before:
![image](https://user-images.githubusercontent.com/25206008/214070145-35e2502a-6cc5-4052-8f1f-177cf0ccaf1d.png)

After:
![image](https://user-images.githubusercontent.com/25206008/214070995-74ab895a-4b3b-4896-b098-df94050f7553.png)

This is due to some weird (potentially buggy) behavior where the dataset field is unavailable until multiple "smoothable" data products are available:

![image](https://user-images.githubusercontent.com/25206008/214076300-08648ed5-af90-48a6-921f-fccb44e6f407.png)


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
