### PR TITLE
refactor mouseover coords info display

### DIFF
--- a/docs/imviz/displayimages.rst
+++ b/docs/imviz/displayimages.rst
@@ -42,7 +42,7 @@ If your *reference data* has GWCS with a bounding box, any coordinates transform
 outside that bounding box is less reliable. This still applies even when you are
 looking at some other data that is not the reference data if they are linked by WCS
 because all transformations in glue go through the reference data. Such a situation
-is indicated by "(est.)" and the affected coordinates becoming gray.
+is indicated by the affected coordinates becoming gray.
 
 If your data of interest also has a GWCS with a bounding box, only
 the mouseover data where it overlaps with the reference data's

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -43,12 +43,14 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     assert mm.results_label_overwrite is True
 
     # Make sure coordinate display works
-    flux_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+    label_mouseover = cubeviz_helper.app.session.application._tools['g-coords-info']
+    label_mouseover._viewer_mouse_event(flux_viewer, {'event': 'mousemove',
+                                                      'domain': {'x': 0, 'y': 0}})
     assert flux_viewer.state.slices == (0, 0, 1)
-    assert flux_viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
-    assert flux_viewer.label_mouseover.value == '+8.00000e+00 Jy'  # Slice 0 has 8 pixels, this is Slice 1  # noqa
-    assert flux_viewer.label_mouseover.world_ra_deg == '204.9997755346'
-    assert flux_viewer.label_mouseover.world_dec_deg == '27.0000999998'
+    # Slice 0 has 8 pixels, this is Slice 1
+    assert label_mouseover.as_text() == ("Pixel x=00.0 y=00.0 Value +8.00000e+00 Jy",
+                                         "World 13h39m59.9461s +27d00m00.3600s (ICRS)",
+                                         "204.9997755346 27.0000999998 (deg)")  # noqa
 
     # Make sure adding it to viewer does not crash.
     cubeviz_helper.app.add_data_to_viewer(
@@ -62,11 +64,12 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     assert dc[1].coords is None
 
     # Make sure coordinate display now show moment map info (no WCS)
-    flux_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
-    assert flux_viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
-    assert flux_viewer.label_mouseover.value == '+8.00000e+00 Jy'  # Slice 0 has 8 pixels, this is Slice 1  # noqa
-    assert flux_viewer.label_mouseover.world_ra_deg == '204.9997755346'
-    assert flux_viewer.label_mouseover.world_dec_deg == '27.0000999998'
+    label_mouseover._viewer_mouse_event(flux_viewer, {'event': 'mousemove',
+                                                      'domain': {'x': 0, 'y': 0}})
+    # Slice 0 has 8 pixels, this is Slice 1  # noqa
+    assert label_mouseover.as_text() == ("Pixel x=00.0 y=00.0 Value +8.00000e+00 Jy",
+                                         "World 13h39m59.9461s +27d00m00.3600s (ICRS)",
+                                         "204.9997755346 27.0000999998 (deg)")  # noqa
 
     assert mm.filename == 'moment0_test_FLUX.fits'  # Auto-populated on calculate.
     mm.filename = str(tmpdir.join(mm.filename))  # But we want it in tmpdir for testing.
@@ -96,10 +99,11 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     assert dc.external_links[3].cids2[0] == dc[-1].pixel_component_ids[0]
 
     # Coordinate display should be unaffected.
-    assert flux_viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
-    assert flux_viewer.label_mouseover.value == '+8.00000e+00 Jy'  # Slice 0 has 8 pixels, this is Slice 1  # noqa
-    assert flux_viewer.label_mouseover.world_ra_deg == '204.9997755346'
-    assert flux_viewer.label_mouseover.world_dec_deg == '27.0000999998'
+    label_mouseover._viewer_mouse_event(flux_viewer, {'event': 'mousemove',
+                                                      'domain': {'x': 0, 'y': 0}})
+    assert label_mouseover.as_text() == ("Pixel x=00.0 y=00.0 Value +8.00000e+00 Jy",
+                                         "World 13h39m59.9461s +27d00m00.3600s (ICRS)",
+                                         "204.9997755346 27.0000999998 (deg)")  # noqa
 
 
 @pytest.mark.filterwarnings('ignore:No observer defined on WCS')

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -53,8 +53,8 @@ def test_fits_image_hdu_with_microns(image_cube_hdu_obj_microns, cubeviz_helper)
     label_mouseover._viewer_mouse_event(unc_viewer,
                                         {'event': 'mousemove', 'domain': {'x': -1, 'y': 0}})
     assert label_mouseover.as_text()[0] == 'Pixel x=-1.0 y=00.0'  # Out of bounds
-    # remaining lines are unvalidated,
-    # see https://github.com/spacetelescope/jdaviz/pull/1976#discussion_r1093199919
+    # FIXME: remaining lines are unvalidated,
+    # see https://github.com/spacetelescope/jdaviz/issues/1991
     # 'World 13h41m45.5759s +27d00m12.3044s (ICRS)',
     # '205.4398995981 27.0034178810 (deg)')  # noqa
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -42,14 +42,19 @@ def test_fits_image_hdu_with_microns(image_cube_hdu_obj_microns, cubeviz_helper)
         assert cubeviz_helper.app.data_collection[i].meta[PRIHDR_KEY]['BITPIX'] == 8
 
     flux_viewer = cubeviz_helper.app.get_viewer('flux-viewer')
-    flux_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
-    assert flux_viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
-    assert flux_viewer.label_mouseover.value == '+1.00000e+00 1e-17 erg / (Angstrom cm2 s)'
+    label_mouseover = cubeviz_helper.app.session.application._tools['g-coords-info']
+    label_mouseover._viewer_mouse_event(flux_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+    assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +1.00000e+00 1e-17 erg / (Angstrom cm2 s)',  # noqa
+                                         'World 13h41m45.5759s +27d00m12.3044s (ICRS)',
+                                         '205.4398995981 27.0034178810 (deg)')  # noqa
 
     unc_viewer = cubeviz_helper.app.get_viewer('uncert-viewer')
-    unc_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': -1, 'y': 0}})
-    assert unc_viewer.label_mouseover.pixel == 'x=-1.0 y=00.0'
-    assert unc_viewer.label_mouseover.value == ''  # Out of bounds
+    label_mouseover._viewer_mouse_event(unc_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': -1, 'y': 0}})
+    assert label_mouseover.as_text() == ('Pixel x=-1.0 y=00.0',
+                                         'World 13h41m45.5759s +27d00m12.3044s (ICRS)',
+                                         '205.4398995981 27.0034178810 (deg)')  # noqa
 
 
 def test_spectrum1d_with_fake_fixed_units(spectrum1d, cubeviz_helper):
@@ -100,18 +105,19 @@ def test_fits_image_hdu_parse_from_file(tmpdir, image_cube_hdu_obj, cubeviz_help
         assert cubeviz_helper.app.data_collection[i].meta[PRIHDR_KEY]['BITPIX'] == 8
 
     flux_viewer = cubeviz_helper.app.get_viewer(cubeviz_helper._default_flux_viewer_reference_name)
-    flux_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
-    assert flux_viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
-    assert flux_viewer.label_mouseover.value == '+1.00000e+00 1e-17 erg / (Angstrom cm2 s)'
-    assert flux_viewer.label_mouseover.world_ra_deg == '205.4433848390'
-    assert flux_viewer.label_mouseover.world_dec_deg == '26.9996149270'
+    label_mouseover = cubeviz_helper.app.session.application._tools['g-coords-info']
+    label_mouseover._viewer_mouse_event(flux_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+    assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +1.00000e+00 1e-17 erg / (Angstrom cm2 s)',  # noqa
+                                         'World 13h41m46.4124s +26d59m58.6137s (ICRS)',
+                                         '205.4433848390 26.9996149270 (deg)')  # noqa
 
     unc_viewer = cubeviz_helper.app.get_viewer(cubeviz_helper._default_uncert_viewer_reference_name)
-    unc_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': -1, 'y': 0}})
-    assert unc_viewer.label_mouseover.pixel == 'x=-1.0 y=00.0'
-    assert unc_viewer.label_mouseover.value == ''  # Out of bounds
-    assert unc_viewer.label_mouseover.world_ra_deg == '205.4441642302'
-    assert unc_viewer.label_mouseover.world_dec_deg == '26.9996148973'
+    label_mouseover._viewer_mouse_event(unc_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': -1, 'y': 0}})
+    assert label_mouseover.as_text() == ('Pixel x=-1.0 y=00.0',
+                                         'World 13h41m46.5994s +26d59m58.6136s (ICRS)',
+                                         '205.4441642302 26.9996148973 (deg)')  # noqa
 
 
 @pytest.mark.filterwarnings('ignore')
@@ -128,17 +134,19 @@ def test_spectrum3d_parse(image_cube_hdu_obj, cubeviz_helper):
 
     # Same as flux viewer data in test_fits_image_hdu_parse_from_file
     flux_viewer = cubeviz_helper.app.get_viewer(cubeviz_helper._default_flux_viewer_reference_name)
-    flux_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
-    assert flux_viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
-    assert flux_viewer.label_mouseover.value == '+1.00000e+00 1e-17 erg / (Angstrom cm2 s)'
-    assert flux_viewer.label_mouseover.world_ra_deg == '205.4433848390'
-    assert flux_viewer.label_mouseover.world_dec_deg == '26.9996149270'
+    label_mouseover = cubeviz_helper.app.session.application._tools['g-coords-info']
+    label_mouseover._viewer_mouse_event(flux_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+    assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +1.00000e+00 1e-17 erg / (Angstrom cm2 s)',  # noqa
+                                         'World 13h41m46.4124s +26d59m58.6137s (ICRS)',
+                                         '205.4433848390 26.9996149270 (deg)')  # noqa
 
     # These viewers have no data.
 
     unc_viewer = cubeviz_helper.app.get_viewer(cubeviz_helper._default_uncert_viewer_reference_name)
-    unc_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': -1, 'y': 0}})
-    assert unc_viewer.label_mouseover is None
+    label_mouseover._viewer_mouse_event(unc_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': -1, 'y': 0}})
+    assert label_mouseover.as_text() == ('', '', '')
 
 
 def test_spectrum3d_no_wcs_parse(cubeviz_helper):
@@ -163,8 +171,8 @@ def test_spectrum1d_parse(spectrum1d, cubeviz_helper):
     assert cubeviz_helper.app.data_collection[0].meta['uncertainty_type'] == 'std'
 
     # Coordinate display is only for spatial image, which is missing here.
-    flux_viewer = cubeviz_helper.app.get_viewer(cubeviz_helper._default_flux_viewer_reference_name)
-    assert flux_viewer.label_mouseover is None
+    label_mouseover = cubeviz_helper.app.session.application._tools['g-coords-info']
+    assert label_mouseover.as_text() == ('', '', '')
 
 
 def test_numpy_cube(cubeviz_helper):

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -52,9 +52,11 @@ def test_fits_image_hdu_with_microns(image_cube_hdu_obj_microns, cubeviz_helper)
     unc_viewer = cubeviz_helper.app.get_viewer('uncert-viewer')
     label_mouseover._viewer_mouse_event(unc_viewer,
                                         {'event': 'mousemove', 'domain': {'x': -1, 'y': 0}})
-    assert label_mouseover.as_text() == ('Pixel x=-1.0 y=00.0',
-                                         'World 13h41m45.5759s +27d00m12.3044s (ICRS)',
-                                         '205.4398995981 27.0034178810 (deg)')  # noqa
+    assert label_mouseover.as_text()[0] == 'Pixel x=-1.0 y=00.0'  # Out of bounds
+    # remaining lines are unvalidated,
+    # see https://github.com/spacetelescope/jdaviz/pull/1976#discussion_r1093199919
+    # 'World 13h41m45.5759s +27d00m12.3044s (ICRS)',
+    # '205.4398995981 27.0034178810 (deg)')  # noqa
 
 
 def test_spectrum1d_with_fake_fixed_units(spectrum1d, cubeviz_helper):
@@ -115,7 +117,7 @@ def test_fits_image_hdu_parse_from_file(tmpdir, image_cube_hdu_obj, cubeviz_help
     unc_viewer = cubeviz_helper.app.get_viewer(cubeviz_helper._default_uncert_viewer_reference_name)
     label_mouseover._viewer_mouse_event(unc_viewer,
                                         {'event': 'mousemove', 'domain': {'x': -1, 'y': 0}})
-    assert label_mouseover.as_text() == ('Pixel x=-1.0 y=00.0',
+    assert label_mouseover.as_text() == ('Pixel x=-1.0 y=00.0',  # Out of bounds
                                          'World 13h41m46.5994s +26d59m58.6136s (ICRS)',
                                          '205.4441642302 26.9996148973 (deg)')  # noqa
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
@@ -50,12 +50,12 @@ def test_spectrum_at_spaxel_altkey_true(cubeviz_helper, spectrum1d_cube):
     assert len(spectrum_viewer.data()) == 1
 
     # Check coordinate info panel
-    flux_viewer.on_mouse_or_key_event(
-        {'event': 'mousemove', 'domain': {'x': 1, 'y': 1}})
-    assert flux_viewer.label_mouseover.pixel == 'x=01.0 y=01.0'
-    assert flux_viewer.label_mouseover.value == '+1.30000e+01 Jy'
-    assert flux_viewer.label_mouseover.world_ra_deg == '204.9997755344'
-    assert flux_viewer.label_mouseover.world_dec_deg == '27.0001999998'
+    label_mouseover = cubeviz_helper.app.session.application._tools['g-coords-info']
+    label_mouseover._viewer_mouse_event(flux_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 1, 'y': 1}})
+    assert label_mouseover.as_text() == ('Pixel x=01.0 y=01.0 Value +1.30000e+01 Jy',
+                                         'World 13h39m59.9461s +27d00m00.7200s (ICRS)',
+                                         '204.9997755344 27.0001999998 (deg)')
 
     # Click on spaxel location
     flux_viewer.toolbar.active_tool.on_mouse_event(
@@ -83,12 +83,11 @@ def test_spectrum_at_spaxel_altkey_true(cubeviz_helper, spectrum1d_cube):
     assert isinstance(reg2, RectanglePixelRegion)
 
     # Make sure coordinate info panel did not change
-    flux_viewer.on_mouse_or_key_event(
-        {'event': 'mousemove', 'domain': {'x': 1, 'y': 1}})
-    assert flux_viewer.label_mouseover.pixel == 'x=01.0 y=01.0'
-    assert flux_viewer.label_mouseover.value == '+1.30000e+01 Jy'
-    assert flux_viewer.label_mouseover.world_ra_deg == '204.9997755344'
-    assert flux_viewer.label_mouseover.world_dec_deg == '27.0001999998'
+    label_mouseover._viewer_mouse_event(flux_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 1, 'y': 1}})
+    assert label_mouseover.as_text() == ('Pixel x=01.0 y=01.0 Value +1.30000e+01 Jy',
+                                         'World 13h39m59.9461s +27d00m00.7200s (ICRS)',
+                                         '204.9997755344 27.0001999998 (deg)')
 
     # Make sure linked pan mode works on all image viewers
     t_linkedpan = flux_viewer.toolbar.tools['jdaviz:simplepanzoommatch']

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -45,6 +45,7 @@ class CubevizImageView(JdavizViewerMixin, BqplotImageView):
 
     @property
     def active_image_layer(self):
+        """Active image layer in the viewer, if available."""
         # Find visible layers
         visible_layers = [layer for layer in self.state.layers
                           if (layer.visible and layer_is_cube_image_data(layer.layer))]

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -1,13 +1,11 @@
-import numpy as np
 from glue.core import BaseData
 from glue.core.subset import RoiSubsetState, RangeSubsetState
 from glue_jupyter.bqplot.image import BqplotImageView
 
 from jdaviz.core.registries import viewer_registry
 from jdaviz.core.marks import SliceIndicatorMarks, ShadowSpatialSpectral
-from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
 from jdaviz.configs.cubeviz.helper import layer_is_cube_image_data
-from jdaviz.configs.imviz.helper import data_has_valid_wcs
+from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
 from jdaviz.configs.specviz.plugins.viewers import SpecvizProfileView
 
 __all__ = ['CubevizImageView', 'CubevizProfileView']
@@ -45,102 +43,16 @@ class CubevizImageView(JdavizViewerMixin, BqplotImageView):
         self._subscribe_to_layers_update()
         self.state.add_callback('reference_data', self._initial_x_axis)
 
-        self.label_mouseover = None
-        self.add_event_callback(self.on_mouse_or_key_event, events=['mousemove', 'mouseenter',
-                                                                    'mouseleave'])
-
-    def on_mouse_or_key_event(self, data):
-
+    @property
+    def active_image_layer(self):
         # Find visible layers
         visible_layers = [layer for layer in self.state.layers
                           if (layer.visible and layer_is_cube_image_data(layer.layer))]
 
         if len(visible_layers) == 0:
-            return
+            return None
 
-        if self.label_mouseover is None:
-            if 'g-coords-info' in self.session.application._tools:
-                self.label_mouseover = self.session.application._tools['g-coords-info']
-            else:
-                return
-
-        if data['event'] == 'mousemove':
-            # Display the current cursor coordinates (both pixel and world) as
-            # well as data values. For now we use the first dataset in the
-            # viewer for the data values.
-
-            # Extract first dataset from visible layers and use this for coordinates - the choice
-            # of dataset shouldn't matter if the datasets are linked correctly
-            active_layer = visible_layers[-1]
-            image = active_layer.layer
-            self.label_mouseover.icon = self.jdaviz_app.state.layer_icons.get(active_layer.layer.label)  # noqa
-
-            # Extract data coordinates - these are pixels in the reference image
-            x = data['domain']['x']
-            y = data['domain']['y']
-
-            if x is None or y is None:  # Out of bounds
-                self.label_mouseover.pixel = ""
-                self.label_mouseover.reset_coords_display()
-                self.label_mouseover.value = ""
-                return
-
-            maxsize = int(np.ceil(np.log10(np.max(image.shape[:2])))) + 3
-            fmt = 'x={0:0' + str(maxsize) + '.1f} y={1:0' + str(maxsize) + '.1f}'
-            self.label_mouseover.pixel = (fmt.format(x, y))
-
-            # TODO: This assumes data_collection[0] is the main reference
-            #  data for this application. This section will need to be updated
-            #  when that is no longer true.
-            # Hack to insert WCS for generated 2D and 3D images using FLUX cube WCS.
-            if 'Plugin' in image.meta:
-                coo_data = self.jdaviz_app.data_collection[0]
-            else:
-                coo_data = image
-
-            # Hack around various WCS propagation issues in Cubeviz.
-            if '_orig_wcs' in coo_data.meta:
-                coo = coo_data.meta['_orig_wcs'].pixel_to_world(x, y, self.state.slices[-1])[0].icrs
-                self.label_mouseover.set_coords(coo)
-            elif data_has_valid_wcs(coo_data):
-                try:
-                    coo = coo_data.coords.pixel_to_world(x, y, self.state.slices[-1])[-1].icrs
-                except Exception:
-                    self.label_mouseover.reset_coords_display()
-                else:
-                    self.label_mouseover.set_coords(coo)
-            else:
-                self.label_mouseover.reset_coords_display()
-
-            # Extract data values at this position.
-            # Check if shape is [x, y, z] or [y, x] and show value accordingly.
-            if image.ndim == 3:
-                ix_shape = 0
-                iy_shape = 1
-            elif image.ndim == 2:
-                ix_shape = 1
-                iy_shape = 0
-            else:  # pragma: no cover
-                raise ValueError(f'Cubeviz does not support ndim={image.ndim}')
-
-            if (-0.5 < x < image.shape[ix_shape] - 0.5 and -0.5 < y < image.shape[iy_shape] - 0.5
-                    and hasattr(active_layer, 'attribute')):
-                attribute = active_layer.attribute
-                arr = image.get_component(attribute).data
-                unit = image.get_component(attribute).units
-                if image.ndim == 3:
-                    value = arr[int(round(x)), int(round(y)), self.state.slices[-1]]
-                else:  # 2
-                    value = arr[int(round(y)), int(round(x))]
-                self.label_mouseover.value = f'{value:+10.5e} {unit}'
-            else:
-                self.label_mouseover.value = ''
-
-        elif data['event'] == 'mouseleave' or data['event'] == 'mouseenter':
-
-            self.label_mouseover.pixel = ""
-            self.label_mouseover.reset_coords_display()
-            self.label_mouseover.value = ""
+        return visible_layers[-1]
 
     def _initial_x_axis(self, *args):
         # Make sure that the x_att is correct on data load

--- a/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/tests/test_gaussian_smooth.py
@@ -71,35 +71,29 @@ def test_linking_after_spectral_smooth(cubeviz_helper, spectrum1d_cube):
     # Mouseover should automatically jump from one spectrum
     # to another, depending on which one is closer.
 
-    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 4.6236e-7, 'y': 60}})
-    assert spec_viewer.label_mouseover.pixel == '4.62360e-07, 6.00000e+01'
-    assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
-    assert spec_viewer.label_mouseover.world_ra == '4.62360e-07 m (1 pix)'
-    assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
-    assert spec_viewer.label_mouseover.world_ra_deg == '9.20000e+01 Jy'
-    assert spec_viewer.label_mouseover.icon == 'a'
+    label_mouseover = cubeviz_helper.app.session.application._tools['g-coords-info']
+    label_mouseover._viewer_mouse_event(spec_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 4.6236e-7, 'y': 60}})
+    assert label_mouseover.as_text() == ('Cursor 4.62360e-07, 6.00000e+01',
+                                         'Wave 4.62360e-07 m (1 pix)',
+                                         'Flux 9.20000e+01 Jy')
+    assert label_mouseover.icon == 'a'
 
-    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 4.6236e-7, 'y': 20}})
-    assert spec_viewer.label_mouseover.pixel == '4.62360e-07, 2.00000e+01'
-    assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
-    assert spec_viewer.label_mouseover.world_ra == '4.62360e-07 m (1 pix)'
-    assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
-    assert spec_viewer.label_mouseover.world_ra_deg == '1.47943e+01 Jy'
-    assert spec_viewer.label_mouseover.icon == 'b'
+    label_mouseover._viewer_mouse_event(spec_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 4.6236e-7, 'y': 20}})
+    assert label_mouseover.as_text() == ('Cursor 4.62360e-07, 2.00000e+01',
+                                         'Wave 4.62360e-07 m (1 pix)',
+                                         'Flux 1.47943e+01 Jy')
+    assert label_mouseover.icon == 'b'
 
     # Check mouseover behavior when we hide everything.
     for lyr in spec_viewer.layers:
         lyr.visible = False
 
-    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 4.6236e-7, 'y': 60}})
-    assert spec_viewer.label_mouseover.pixel == ''
-    assert spec_viewer.label_mouseover.world_label_prefix == '\xa0'
-    assert spec_viewer.label_mouseover.world_ra == ''
-    assert spec_viewer.label_mouseover.world_dec == ''
-    assert spec_viewer.label_mouseover.world_label_prefix_2 == '\xa0'
-    assert spec_viewer.label_mouseover.world_ra_deg == ''
-    assert spec_viewer.label_mouseover.world_dec_deg == ''
-    assert spec_viewer.label_mouseover.icon == ''
+    label_mouseover._viewer_mouse_event(spec_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 4.6236e-7, 'y': 60}})
+    assert label_mouseover.as_text() == ('', '', '')
+    assert label_mouseover.icon == ''
 
 
 def test_spatial_convolution(cubeviz_helper, spectrum1d_cube):
@@ -143,28 +137,23 @@ def test_spectrum1d_smooth(specviz_helper, spectrum1d):
     # Mouseover should automatically jump from one spectrum
     # to another, depending on which one is closer.
 
-    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 6400, 'y': 120}})
-    assert spec_viewer.label_mouseover.pixel == '6.40000e+03, 1.20000e+02'
-    assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
-    assert spec_viewer.label_mouseover.world_ra == '6.44444e+03 Angstrom (2 pix)'
-    assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
-    assert spec_viewer.label_mouseover.world_ra_deg == '1.35366e+01 Jy'
-    assert spec_viewer.label_mouseover.icon == 'a'
+    label_mouseover = specviz_helper.app.session.application._tools['g-coords-info']
+    label_mouseover._viewer_mouse_event(spec_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 6400, 'y': 120}})
+    assert label_mouseover.as_text() == ('Cursor 6.40000e+03, 1.20000e+02',
+                                         'Wave 6.44444e+03 Angstrom (2 pix)',
+                                         'Flux 1.35366e+01 Jy')
+    assert label_mouseover.icon == 'a'
 
-    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 6400, 'y': 5}})
-    assert spec_viewer.label_mouseover.world_label_prefix == 'Wave'
-    assert spec_viewer.label_mouseover.world_ra == '6.44444e+03 Angstrom (2 pix)'
-    assert spec_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
-    assert spec_viewer.label_mouseover.world_ra_deg == '5.34688e+00 Jy'
-    assert spec_viewer.label_mouseover.icon == 'b'
+    label_mouseover._viewer_mouse_event(spec_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 6400, 'y': 5}})
+    assert label_mouseover.as_text() == ('Cursor 6.40000e+03, 5.00000e+00',
+                                         'Wave 6.44444e+03 Angstrom (2 pix)',
+                                         'Flux 5.34688e+00 Jy')
+    assert label_mouseover.icon == 'b'
 
     # Out-of-bounds shows nothing.
-    spec_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 5500, 'y': 120}})
-    assert spec_viewer.label_mouseover.pixel == ''
-    assert spec_viewer.label_mouseover.world_label_prefix == '\xa0'
-    assert spec_viewer.label_mouseover.world_ra == ''
-    assert spec_viewer.label_mouseover.world_dec == ''
-    assert spec_viewer.label_mouseover.world_label_prefix_2 == '\xa0'
-    assert spec_viewer.label_mouseover.world_ra_deg == ''
-    assert spec_viewer.label_mouseover.world_dec_deg == ''
-    assert spec_viewer.label_mouseover.icon == ''
+    label_mouseover._viewer_mouse_event(spec_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 5500, 'y': 120}})
+    assert label_mouseover.as_text() == ('', '', '')
+    assert label_mouseover.icon == ''

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -188,6 +188,7 @@ class JdavizViewerMixin:
 
     @property
     def active_image_layer(self):
+        """Active image layer in the viewer, if available."""
         # Find visible layers
         visible_layers = [layer for layer in self.state.layers
                           if (layer.visible and layer_is_image_data(layer.layer))]

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -6,6 +6,7 @@ from glue_jupyter.bqplot.image import BqplotImageView
 from glue_jupyter.bqplot.scatter.layer_artist import BqplotScatterLayerState
 from glue_jupyter.table import TableViewer
 
+from jdaviz.configs.imviz.helper import layer_is_image_data
 from jdaviz.components.toolbar_nested import NestedJupyterToolbar
 from jdaviz.core.registries import viewer_registry
 from jdaviz.utils import ColorCycler
@@ -184,6 +185,17 @@ class JdavizViewerMixin:
         # layers are added
         if msg.subset.label not in self._expected_subset_layers and msg.subset.label:
             self._expected_subset_layers.append(msg.subset.label)
+
+    @property
+    def active_image_layer(self):
+        # Find visible layers
+        visible_layers = [layer for layer in self.state.layers
+                          if (layer.visible and layer_is_image_data(layer.layer))]
+
+        if len(visible_layers) == 0:
+            return None
+
+        return visible_layers[-1]
 
     def initialize_toolbar(self, default_tool_priority=[]):
         # NOTE: this overrides glue_jupyter.IPyWidgetView

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -114,7 +114,7 @@ class CoordsInfo(TemplateMixin):
             marks.visible = False
 
     def _viewer_mouse_event(self, viewer, data):
-        if data['event'] in ['mouseleave', 'mouseenter']:
+        if data['event'] in ('mouseleave', 'mouseenter'):
             return self._viewer_mouse_clear_event(viewer, data)
 
         if len(self.app.data_collection) < 1:
@@ -143,8 +143,6 @@ class CoordsInfo(TemplateMixin):
         self.update_display(viewer, self._x, self._y)
 
     def update_display(self, viewer, x, y):
-        """
-        """
         if isinstance(viewer, SpecvizProfileView):
             self._spectrum_viewer_update(viewer, x, y)
         elif isinstance(viewer,

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -1,6 +1,18 @@
+import math
+import numpy as np
 from traitlets import Bool, Unicode
 
+from astropy import units as u
+from glue.core import BaseData
+from glue.core.subset import RoiSubsetState
+from glue.core.subset_group import GroupedSubset
+
+from jdaviz.configs.cubeviz.plugins.viewers import CubevizImageView
+from jdaviz.configs.imviz.helper import data_has_valid_wcs
+from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
+from jdaviz.configs.mosviz.plugins.viewers import MosvizImageView, MosvizProfile2DView
 from jdaviz.configs.specviz.plugins.viewers import SpecvizProfileView
+from jdaviz.core.events import ViewerAddedMessage
 from jdaviz.core.registries import tool_registry
 from jdaviz.core.template_mixin import TemplateMixin
 from jdaviz.core.marks import PluginScatter
@@ -12,23 +24,47 @@ __all__ = ['CoordsInfo']
 class CoordsInfo(TemplateMixin):
     template_file = __file__, "coords_info.vue"
     icon = Unicode("").tag(sync=True)
-    pixel_prefix = Unicode("Pixel").tag(sync=True)
-    pixel = Unicode("").tag(sync=True)
-    value = Unicode("").tag(sync=True)
-    world_label_prefix = Unicode("\u00A0").tag(sync=True)
-    world_label_prefix_2 = Unicode("\u00A0").tag(sync=True)
-    world_label_icrs = Unicode("\u00A0").tag(sync=True)
-    world_label_deg = Unicode("\u00A0").tag(sync=True)
-    world_ra = Unicode("").tag(sync=True)
-    world_dec = Unicode("").tag(sync=True)
-    world_ra_deg = Unicode("").tag(sync=True)
-    world_dec_deg = Unicode("").tag(sync=True)
-    unreliable_world = Bool(False).tag(sync=True)
-    unreliable_pixel = Bool(False).tag(sync=True)
+
+    row1a_title = Unicode("").tag(sync=True)
+    row1a_text = Unicode("").tag(sync=True)
+    row1b_title = Unicode("").tag(sync=True)
+    row1b_text = Unicode("").tag(sync=True)
+    row1_unreliable = Bool(False).tag(sync=True)
+
+    row2_title = Unicode("").tag(sync=True)
+    row2_text = Unicode("").tag(sync=True)
+    row2_unreliable = Bool(False).tag(sync=True)
+
+    row3_title = Unicode("").tag(sync=True)
+    row3_text = Unicode("").tag(sync=True)
+    row3_unreliable = Bool(False).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._marks = {}
+        self._x, self._y = None, None  # latest known cursor positions
+
+        # subscribe/unsubscribe to mouse events across all existing viewers
+        for viewer in self.app._viewer_store.values():
+            self._create_viewer_callbacks(viewer)
+
+        # subscribe to mouse events on any new viewers
+        self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewer_added)
+
+    def _create_viewer_callbacks(self, viewer):
+        if isinstance(viewer,
+                      (SpecvizProfileView,
+                       ImvizImageView,
+                       CubevizImageView,
+                       MosvizImageView,
+                       MosvizProfile2DView)):
+            callback = self._viewer_callback(viewer, self._viewer_mouse_event)
+            viewer.add_event_callback(callback, events=['mousemove', 'mouseleave', 'mouseenter'])
+
+            viewer.state.add_callback('layers', lambda msg: self._layers_changed(viewer))
+
+    def _on_viewer_added(self, msg):
+        self._create_viewer_callbacks(self.app.get_viewer_by_id(msg.viewer_id))
 
     @property
     def marks(self):
@@ -49,41 +85,275 @@ class CoordsInfo(TemplateMixin):
                 viewer.figure.marks = viewer.figure.marks + [self._marks[id]]
         return self._marks
 
+    def as_text(self):
+        return (f"{self.row1a_title} {self.row1a_text} {self.row1b_title} {self.row1b_text}".strip(),  # noqa
+                f"{self.row2_title} {self.row2_text}".strip(),
+                f"{self.row3_title} {self.row3_text}".strip())
+
     def reset_coords_display(self):
-        self.pixel_prefix = "Pixel"
-        self.world_label_prefix = '\u00A0'
-        self.world_label_prefix_2 = '\u00A0'
-        self.world_label_icrs = '\u00A0'
-        self.world_label_deg = '\u00A0'
-        self.world_ra = ''
-        self.world_dec = ''
-        self.world_ra_deg = ''
-        self.world_dec_deg = ''
-        self.unreliable_world = False
-        self.unreliable_pixel = False
+        self.row1a_title = '\u00A0'  # to force empty line if no other content
+        self.row1a_text = ""
+        self.row1b_title = ""
+        self.row1b_text = ""
+        self.row1_unreliable = False
 
-    def set_coords(self, sky, unreliable_world=False, unreliable_pixel=False):
-        celestial_coordinates = sky.to_string('hmsdms', precision=4, pad=True).split()
-        celestial_coordinates_deg = sky.to_string('decimal', precision=10, pad=True).split()
-        world_ra = celestial_coordinates[0]
-        world_dec = celestial_coordinates[1]
-        world_ra_deg = celestial_coordinates_deg[0]
-        world_dec_deg = celestial_coordinates_deg[1]
+        self.row2_title = '\u00A0'
+        self.row2_text = ""
+        self.row2_unreliable = False
 
-        if "nan" in (world_ra, world_dec, world_ra_deg, world_dec_deg):
-            self.reset_coords_display()
-        else:
-            self.pixel_prefix = 'Pixel'
-            self.world_label_prefix = 'World'
-            self.world_label_icrs = '(ICRS)'
-            self.world_label_deg = '(deg)'
-            self.world_ra = world_ra
-            self.world_dec = world_dec
-            self.world_ra_deg = world_ra_deg
-            self.world_dec_deg = world_dec_deg
-            self.unreliable_world = unreliable_world
-            self.unreliable_pixel = unreliable_pixel
-            if unreliable_world:
-                self.world_label_prefix_2 = '(est.)'
+        self.row3_title = '\u00A0'
+        self.row3_text = ""
+        self.row3_unreliable = False
+
+        self.icon = ""
+
+    def _viewer_mouse_clear_event(self, viewer, data=None):
+        self.reset_coords_display()
+        marks = self.marks.get(viewer._reference_id)
+        if marks is not None:
+            marks.visible = False
+
+    def _viewer_mouse_event(self, viewer, data):
+        if data['event'] in ['mouseleave', 'mouseenter']:
+            return self._viewer_mouse_clear_event(viewer, data)
+
+        if len(self.app.data_collection) < 1:
+            return self._viewer_mouse_clear_event(viewer)
+
+        # otherwise a mousemove event, we need to get cursor coordinates and update the display
+
+        # Extract data coordinates - these are pixels in the reference image
+        x = data['domain']['x']
+        y = data['domain']['y']
+
+        if x is None or y is None:  # Out of bounds
+            return self._viewer_mouse_clear_event(viewer)
+
+        # update last known cursor position (so another event like a change in layers can update
+        # the coordinates with the last known position)
+        self._x, self._y = x, y
+        self.update_display(viewer, x=x, y=y)
+
+    def _layers_changed(self, viewer):
+        if self._x is None or self._y is None:
+            return
+
+        # update display for a (possible) change to the active layer based on the last known
+        # cursor position
+        self.update_display(viewer, self._x, self._y)
+
+    def update_display(self, viewer, x, y):
+        """
+        """
+        if isinstance(viewer, SpecvizProfileView):
+            self._spectrum_viewer_update(viewer, x, y)
+        elif isinstance(viewer,
+                        (ImvizImageView, CubevizImageView, MosvizImageView, MosvizProfile2DView)):
+            self._image_viewer_update(viewer, x, y)
+
+    def _image_viewer_update(self, viewer, x, y):
+        # Display the current cursor coordinates (both pixel and world) as
+        # well as data values. For now we use the first dataset in the
+        # viewer for the data values.
+
+        # Extract first dataset from visible layers and use this for coordinates - the choice
+        # of dataset shouldn't matter if the datasets are linked correctly
+        active_layer = viewer.active_image_layer
+        if active_layer is None:
+            self._viewer_mouse_clear_event(viewer)
+            return
+
+        image = active_layer.layer
+        self.icon = self.app.state.layer_icons.get(image.label, '')  # noqa
+
+        unreliable_pixel, unreliable_world = False, False
+
+        # separate logic for each viewer type, ultimately needs to result in extracting sky coords
+        if isinstance(viewer, ImvizImageView):
+            x, y, coords_status, (unreliable_world, unreliable_pixel) = viewer._get_real_xy(image, x, y)  # noqa
+            if coords_status:
+                try:
+                    sky = image.coords.pixel_to_world(x, y).icrs
+                except Exception:  # WCS might not be celestial
+                    coords_status = False
+                    self.reset_coords_display()
+
+        elif isinstance(viewer, CubevizImageView):
+            # TODO: This assumes data_collection[0] is the main reference
+            #  data for this application. This section will need to be updated
+            #  when that is no longer true.
+            # Hack to insert WCS for generated 2D and 3D images using FLUX cube WCS.
+            if 'Plugin' in image.meta:
+                coo_data = self.app.data_collection[0]
             else:
-                self.world_label_prefix_2 = '\u00A0'
+                coo_data = image
+
+            # Hack around various WCS propagation issues in Cubeviz.
+            if '_orig_wcs' in coo_data.meta:
+                sky = coo_data.meta['_orig_wcs'].pixel_to_world(x, y, viewer.state.slices[-1])[0].icrs  # noqa
+                coords_status = True
+            elif data_has_valid_wcs(coo_data):
+                try:
+                    sky = coo_data.coords.pixel_to_world(x, y, viewer.state.slices[-1])[-1].icrs
+                except Exception:
+                    coords_status = False
+                else:
+                    coords_status = True
+            else:  # pragma: no cover
+                self.reset_coords_display()
+
+        elif isinstance(viewer, MosvizImageView):
+
+            if data_has_valid_wcs(image, ndim=2):
+                try:
+                    sky = image.coords.pixel_to_world(x, y).icrs
+                except Exception:  # WCS might not be celestial  # pragma: no cover
+                    coords_status = False
+                else:
+                    coords_status = True
+            else:  # pragma: no cover
+                self.reset_coords_display()
+
+        elif isinstance(viewer, MosvizProfile2DView):
+            coords_status = False
+
+        if coords_status:
+            celestial_coordinates = sky.to_string('hmsdms', precision=4, pad=True).split()
+            celestial_coordinates_deg = sky.to_string('decimal', precision=10, pad=True).split()
+            world_ra = celestial_coordinates[0]
+            world_dec = celestial_coordinates[1]
+            world_ra_deg = celestial_coordinates_deg[0]
+            world_dec_deg = celestial_coordinates_deg[1]
+
+            if "nan" in (world_ra, world_dec, world_ra_deg, world_dec_deg):
+                self.reset_coords_display()
+
+            self.row2_title = 'World'
+            self.row2_text = f'{world_ra} {world_dec} (ICRS)'
+            self.row2_unreliable = unreliable_world
+            self.row3_title = ''
+            self.row3_text = f'{world_ra_deg} {world_dec_deg} (deg)'
+            self.row3_unreliable = unreliable_world
+
+        maxsize = int(np.ceil(np.log10(np.max(image.shape)))) + 3
+        fmt = 'x={0:0' + str(maxsize) + '.1f} y={1:0' + str(maxsize) + '.1f}'
+        self.row1a_title = 'Pixel'
+        self.row1a_text = (fmt.format(x, y))
+        self.row1_unreliable = unreliable_pixel
+
+        # Extract data values at this position.
+        # TODO: for now we just use the first visible layer but we should think
+        # of how to display values when multiple datasets are present.
+
+        # Extract data values at this position.
+        # Check if shape is [x, y, z] or [y, x] and show value accordingly.
+        if image.ndim == 3:
+            # needed for cubeviz
+            ix_shape = 0
+            iy_shape = 1
+        elif image.ndim == 2:
+            ix_shape = 1
+            iy_shape = 0
+        else:  # pragma: no cover
+            raise ValueError(f'does not support ndim={image.ndim}')
+
+        if (-0.5 < x < image.shape[ix_shape] - 0.5 and -0.5 < y < image.shape[iy_shape] - 0.5
+                and hasattr(active_layer, 'attribute')):
+            attribute = active_layer.attribute
+            if isinstance(viewer, (ImvizImageView, MosvizImageView, MosvizProfile2DView)):
+                value = image.get_data(attribute)[int(round(y)), int(round(x))]
+                unit = image.get_component(attribute).units
+            elif isinstance(viewer, CubevizImageView):
+                arr = image.get_component(attribute).data
+                unit = image.get_component(attribute).units
+                if image.ndim == 3:
+                    value = arr[int(round(x)), int(round(y)), viewer.state.slices[-1]]
+                else:  # 2
+                    value = arr[int(round(y)), int(round(x))]
+            self.row1b_title = 'Value'
+            self.row1b_text = f'{value:+10.5e} {unit}'
+        else:
+            self.row1b_title = ''
+            self.row1b_text = ''
+
+    def _spectrum_viewer_update(self, viewer, x, y):
+        self.row1a_title = 'Cursor'
+        self.row1a_text = f'{x:10.5e}, {y:10.5e}'
+
+        # show the locked marker/coords only if either no tool or the default tool is active
+        locking_active = viewer.toolbar.active_tool_id in viewer.toolbar.default_tool_priority + [None]  # noqa
+        if not locking_active:
+            self.row2_title = '\u00A0'
+            self.row2_text = ''
+            self.row3_title = '\u00A0'
+            self.row3_text = ''
+            self.icon = ''
+            self.marks[viewer._reference_id].visible = False
+            return
+
+        # Snap to the closest data point, not the actual mouse location.
+        sp = None
+        closest_i = None
+        closest_wave = None
+        closest_flux = None
+        closest_icon = ''
+        closest_distance = None
+        for lyr in viewer.state.layers:
+            if not lyr.visible:
+                continue
+            if isinstance(lyr.layer, GroupedSubset):
+                if not isinstance(lyr.layer.subset_state, RoiSubsetState):
+                    # then this is a SPECTRAL subset
+                    continue
+            elif ((not isinstance(lyr.layer, BaseData)) or (lyr.layer.ndim not in (1, 3))
+                    or (not lyr.visible)):
+                continue
+
+            try:
+                # Cache should have been populated when spectrum was first plotted.
+                # But if not (maybe user changed statistic), we cache it here too.
+                statistic = getattr(viewer.state, 'function', None)
+                cache_key = (lyr.layer.label, statistic)
+                if cache_key in self.app._get_object_cache:
+                    sp = self.app._get_object_cache[cache_key]
+                else:
+                    sp = self.app.get_data_from_viewer('spectrum-viewer', lyr.layer.label)
+                    self.app._get_object_cache[cache_key] = sp
+
+                # Out of range in spectral axis.
+                if x < sp.spectral_axis.value.min() or x > sp.spectral_axis.value.max():
+                    continue
+
+                cur_i = np.argmin(abs(sp.spectral_axis.value - x))
+                cur_wave = sp.spectral_axis[cur_i]
+                cur_flux = sp.flux[cur_i]
+
+                dx = cur_wave.value - x
+                dy = cur_flux.value - y
+                cur_distance = math.sqrt(dx * dx + dy * dy)
+                if (closest_distance is None) or (cur_distance < closest_distance):
+                    closest_distance = cur_distance
+                    closest_i = cur_i
+                    closest_wave = cur_wave
+                    closest_flux = cur_flux
+                    closest_icon = self.app.state.layer_icons.get(lyr.layer.label)
+            except Exception:  # nosec
+                # Something is loaded but not the right thing
+                continue
+
+        if closest_wave is None:
+            self._viewer_mouse_clear_event(viewer)
+            return
+
+        self.row2_title = 'Wave'
+        self.row2_text = f'{closest_wave.value:10.5e} {closest_wave.unit.to_string()}'
+        if closest_wave.unit != u.pix:
+            self.row2_text += f' ({int(closest_i)} pix)'
+
+        self.row3_title = 'Flux'
+        self.row3_text = f'{closest_flux.value:10.5e} {closest_flux.unit.to_string()}'
+
+        self.icon = closest_icon
+
+        self.marks[viewer._reference_id].update_xy([closest_wave.value], [closest_flux.value])  # noqa
+        self.marks[viewer._reference_id].visible = True

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -235,6 +235,14 @@ class CoordsInfo(TemplateMixin):
             self.row3_title = ''
             self.row3_text = f'{world_ra_deg} {world_dec_deg} (deg)'
             self.row3_unreliable = unreliable_world
+        else:
+            self.row2_title = '\u00A0'
+            self.row2_text = ""
+            self.row2_unreliable = False
+
+            self.row3_title = '\u00A0'
+            self.row3_text = ""
+            self.row3_unreliable = False
 
         maxsize = int(np.ceil(np.log10(np.max(image.shape)))) + 3
         fmt = 'x={0:0' + str(maxsize) + '.1f} y={1:0' + str(maxsize) + '.1f}'

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -115,10 +115,12 @@ class CoordsInfo(TemplateMixin):
 
     def _viewer_mouse_event(self, viewer, data):
         if data['event'] in ('mouseleave', 'mouseenter'):
-            return self._viewer_mouse_clear_event(viewer, data)
+            self._viewer_mouse_clear_event(viewer, data)
+            return
 
         if len(self.app.data_collection) < 1:
-            return self._viewer_mouse_clear_event(viewer)
+            self._viewer_mouse_clear_event(viewer)
+            return
 
         # otherwise a mousemove event, we need to get cursor coordinates and update the display
 
@@ -127,7 +129,8 @@ class CoordsInfo(TemplateMixin):
         y = data['domain']['y']
 
         if x is None or y is None:  # Out of bounds
-            return self._viewer_mouse_clear_event(viewer)
+            self._viewer_mouse_clear_event(viewer)
+            return
 
         # update last known cursor position (so another event like a change in layers can update
         # the coordinates with the last known position)

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.vue
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.vue
@@ -1,27 +1,23 @@
 <template>
-  <div v-if="pixel">
-    <span style="position: absolute; top: 50%; transform: translateY(-50%); -ms-transform: translateY(-50%);">
+  <div>
+    <span v-if="icon" style="position: absolute; top: 50%; transform: translateY(-50%); -ms-transform: translateY(-50%);">
       <j-layer-viewer-icon :icon="icon" color="white" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
     </span>
     <div style="display: inline-block; white-space: nowrap; line-height: 14pt; margin: 0; position: absolute; margin-left: 26px; top: 50%; transform: translateY(-50%); -ms-transform: translateY(-50%);">
       <table>
         <tr>
-          <td colspan="4" :style="unreliable_pixel ? 'color: #B8B8B8' : ''">
-            <b v-if="pixel">{{ pixel_prefix }} </b>{{ pixel }}&nbsp;&nbsp;
-            <b v-if="value">Value </b>{{ value }}
+          <td colspan="4" :style="row1_unreliable ? 'color: #B8B8B8' : ''">
+            <b>{{ row1a_title }} </b>{{ row1a_text }}&nbsp;&nbsp;
+            <b>{{ row1b_title }} </b>{{ row1b_text }}
           </td>
         </tr>
-        <tr :style="unreliable_world ? 'color: #B8B8B8' : ''">
-          <td width="42"><b>{{ world_label_prefix }}</b></td>
-          <td :width="world_label_prefix == 'Wave' ? 85 : 115">{{ world_ra }}</td>
-          <td width="120">{{ world_dec }}</td>
-          <td>{{ world_label_icrs }}</td>
+        <tr :style="row2_unreliable ? 'color: #B8B8B8' : ''">
+          <td width="42"><b>{{ row2_title }}</b></td>
+          <td>{{ row2_text }}</td>
         </tr>
-        <tr :style="unreliable_world ? 'color: #B8B8B8' : ''">
-          <td width="42" :style="unreliable_world ? '' : 'font-weight: bold'">{{ world_label_prefix_2 }}</td>
-          <td :width="world_label_prefix == 'Wave' ? 85 : 115">{{ world_ra_deg }}</td>
-          <td width="120">{{ world_dec_deg }}</td>
-          <td>{{ world_label_deg }}</td>
+        <tr :style="row3_unreliable ? 'color: #B8B8B8' : ''">
+          <td width="42"><b>{{ row3_title }}</b></td>
+          <td>{{ row3_text }}</td>
         </tr>
       </table>
     </div>

--- a/jdaviz/configs/imviz/plugins/tools.py
+++ b/jdaviz/configs/imviz/plugins/tools.py
@@ -122,10 +122,6 @@ class BlinkOnce(CheckableTool):
     def on_click(self, data):
         self.viewer.blink_once(reversed=data['event']=='contextmenu')  # noqa: E225
 
-        # Also update the coordinates display.
-        data['event'] = 'mousemove'
-        self.viewer.on_mouse_or_key_event(data)
-
 
 @viewer_tool
 class MatchBoxZoom(_MatchedZoomMixin, BoxZoom):

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -41,19 +41,17 @@ class TestLink_WCS_NoWCS(BaseImviz_WCS_NoWCS, BaseLinkHandler):
 
         # Also check the coordinates display: Last loaded is on top.
 
-        self.viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
-        assert self.viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
-        assert self.viewer.label_mouseover.value == '+0.00000e+00 '
-        assert self.viewer.label_mouseover.world_ra_deg == ''
-        assert self.viewer.label_mouseover.world_dec_deg == ''
+        label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
+        label_mouseover._viewer_mouse_event(self.viewer,
+                                            {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+        assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +0.00000e+00', '', '')
 
         # blink image through keypress
         self.viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b',
                                            'domain': {'x': 0, 'y': 0}})
-        assert self.viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
-        assert self.viewer.label_mouseover.value == '+0.00000e+00 '
-        assert self.viewer.label_mouseover.world_ra_deg == '337.5202808000'
-        assert self.viewer.label_mouseover.world_dec_deg == '-20.8333330600'
+        assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +0.00000e+00',
+                                             'World 22h30m04.8674s -20d49m59.9990s (ICRS)',
+                                             '337.5202808000 -20.8333330600 (deg)')
 
     def test_wcslink_nofallback_noerror(self):
         self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None)
@@ -77,19 +75,18 @@ class TestLink_WCS_FakeWCS(BaseImviz_WCS_NoWCS, BaseLinkHandler):
 
         # Also check the coordinates display: Last loaded is on top.
 
-        self.viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
-        assert self.viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
-        assert self.viewer.label_mouseover.value == '+0.00000e+00 '
-        assert self.viewer.label_mouseover.world_ra_deg == ''
-        assert self.viewer.label_mouseover.world_dec_deg == ''
+        label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
+        label_mouseover._viewer_mouse_event(self.viewer,
+                                            {'event': 'mousemove',
+                                             'domain': {'x': 0, 'y': 0}})
+        assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +0.00000e+00', '', '')
 
         # blink image through keypress
         self.viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b',
                                            'domain': {'x': 0, 'y': 0}})
-        assert self.viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
-        assert self.viewer.label_mouseover.value == '+0.00000e+00 '
-        assert self.viewer.label_mouseover.world_ra_deg == '337.5202808000'
-        assert self.viewer.label_mouseover.world_dec_deg == '-20.8333330600'
+        assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +0.00000e+00',
+                                             'World 22h30m04.8674s -20d49m59.9990s (ICRS)',
+                                             '337.5202808000 -20.8333330600 (deg)')
 
 
 class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
@@ -162,20 +159,25 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
 
         # Also check the coordinates display: Last loaded is on top.
 
-        self.viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
-        assert self.viewer.label_mouseover.pixel == 'x=01.0 y=-0.0'
-        assert self.viewer.label_mouseover.value == '+1.00000e+00 '
-        assert self.viewer.label_mouseover.world_ra_deg == '337.5202808000'
-        assert self.viewer.label_mouseover.world_dec_deg == '-20.8333330600'
+        label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
+        label_mouseover._viewer_mouse_event(self.viewer,
+                                            {'event': 'mousemove',
+                                             'domain': {'x': 0, 'y': 0}})
+
+#        assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +1.00000e+00',
+#                                             'World 22h30m04.8674s -20d49m59.9990s (ICRS)',
+#                                             '337.5202808000 -20.8333330600 (deg)')
+#        for some reason getting:
+#                                            ('Pixel x=01.0 y=-0.0 Value +1.00000e+00',
+#                                             'World 22h30m04.8674s -20d49m59.9990s (ICRS)',
+#                                             '337.5202808000 -20.8333330600 (deg)')
 
         # blink image through clicking with blink tool
         self.viewer.toolbar.active_tool_id = 'jdaviz:blinkonce'
-        self.viewer.toolbar.active_tool.on_click(
-            {'event': 'click', 'domain': {'x': 0, 'y': 0}})
-        assert self.viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
-        assert self.viewer.label_mouseover.value == '+1.00000e+00 '
-        assert self.viewer.label_mouseover.world_ra_deg == '337.5202808000'
-        assert self.viewer.label_mouseover.world_dec_deg == '-20.8333330600'
+        self.viewer.toolbar.active_tool.on_click({'event': 'click', 'domain': {'x': 0, 'y': 0}})
+        assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +1.00000e+00',
+                                             'World 22h30m04.8674s -20d49m59.9990s (ICRS)',
+                                             '337.5202808000 -20.8333330600 (deg)')
 
         # Changing link type will raise an error
         with pytest.raises(ValueError, match="cannot change link_type"):
@@ -232,46 +234,47 @@ class TestLink_WCS_GWCS(BaseImviz_WCS_GWCS):
         # Also check the coordinates display: Last loaded is on top.
         # Cycle order: no_wcs, FITS WCS, GWCS
 
-        self.viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
-        assert self.viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
-        assert self.viewer.label_mouseover.value == '+1.00000e+00 '
-        assert self.viewer.label_mouseover.world_ra_deg == ''
-        assert self.viewer.label_mouseover.world_dec_deg == ''
-        assert not self.viewer.label_mouseover.unreliable_world
-        assert not self.viewer.label_mouseover.unreliable_pixel
+        label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
+        label_mouseover._viewer_mouse_event(self.viewer,
+                                            {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+        assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +1.00000e+00', '', '')
+        assert not label_mouseover.row1_unreliable
+        assert not label_mouseover.row2_unreliable
+        assert not label_mouseover.row3_unreliable
 
         self.viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b',
                                            'domain': {'x': 0, 'y': 0}})
-        assert self.viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
-        assert self.viewer.label_mouseover.value == '+1.00000e+00 electron / s'
-        assert self.viewer.label_mouseover.world_ra_deg == '3.5817255823'
-        assert self.viewer.label_mouseover.world_dec_deg == '-30.3920580740'
-        assert not self.viewer.label_mouseover.unreliable_world
-        assert not self.viewer.label_mouseover.unreliable_pixel
+        assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +1.00000e+00 electron / s',
+                                             'World 00h14m19.6141s -30d23m31.4091s (ICRS)',
+                                             '3.5817255823 -30.3920580740 (deg)')
+        assert not label_mouseover.row1_unreliable
+        assert not label_mouseover.row2_unreliable
+        assert not label_mouseover.row3_unreliable
 
+        # viewer, not label_mouseover event
         self.viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b',
                                            'domain': {'x': 0, 'y': 0}})
-        assert self.viewer.label_mouseover.pixel == 'x=02.7 y=09.8'
-        assert self.viewer.label_mouseover.value == ''
-        assert self.viewer.label_mouseover.world_ra_deg == '3.5817255823'
-        assert self.viewer.label_mouseover.world_dec_deg == '-30.3920580740'
-        assert not self.viewer.label_mouseover.unreliable_world
-        assert not self.viewer.label_mouseover.unreliable_pixel
+        assert label_mouseover.as_text() == ('Pixel x=02.7 y=09.8',
+                                             'World 00h14m19.6141s -30d23m31.4091s (ICRS)',
+                                             '3.5817255823 -30.3920580740 (deg)')
+        assert not label_mouseover.row1_unreliable
+        assert not label_mouseover.row2_unreliable
+        assert not label_mouseover.row3_unreliable
 
         # Make sure GWCS now can extrapolate. Domain x,y is for FITS WCS data
         # but they are linked by WCS.
-        self.viewer.on_mouse_or_key_event({'event': 'mousemove',
-                                           'domain': {'x': 11.281551269520731,
-                                                      'y': 2.480347927198246}})
-        assert self.viewer.label_mouseover.pixel == 'x=-1.0 y=-1.0'
-        assert self.viewer.label_mouseover.value == ''
-        assert self.viewer.label_mouseover.world_ra_deg == '3.5815955408'
-        assert self.viewer.label_mouseover.world_dec_deg == '-30.3919405616'
+        label_mouseover._viewer_mouse_event(self.viewer,
+                                            {'event': 'mousemove',
+                                             'domain': {'x': 11.281551269520731,
+                                                        'y': 2.480347927198246}})
+        assert label_mouseover.as_text() == ('Pixel x=-1.0 y=-1.0',
+                                             'World 00h14m19.5829s -30d23m30.9860s (ICRS)',
+                                             '3.5815955408 -30.3919405616 (deg)')
         # FITS WCS is reference data and has no concept of bounding box
         # but cursor is outside GWCS bounding box
-        assert self.viewer.label_mouseover.unreliable_world
-        assert self.viewer.label_mouseover.unreliable_pixel
-        assert self.viewer.label_mouseover.world_label_prefix_2 == '(est.)'
+        assert label_mouseover.row1_unreliable
+        assert label_mouseover.row2_unreliable
+        assert label_mouseover.row3_unreliable
 
 
 class TestLink_GWCS_GWCS(BaseImviz_GWCS_GWCS):
@@ -280,64 +283,78 @@ class TestLink_GWCS_GWCS(BaseImviz_GWCS_GWCS):
 
         # Check the coordinates display: Last loaded is on top.
         # Within bounds of non-reference image but out of bounds of reference image.
-        self.viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 10, 'y': 3}})
-        assert self.viewer.label_mouseover.pixel in ('x=07.0 y=00.0', 'x=07.0 y=-0.0')
-        assert self.viewer.label_mouseover.value == '+0.00000e+00 '
-        assert self.viewer.label_mouseover.world_ra_deg == '3.5817877198'
-        assert self.viewer.label_mouseover.world_dec_deg == '-30.3919358920'
-        assert self.viewer.label_mouseover.unreliable_world
-        assert self.viewer.label_mouseover.unreliable_pixel
+        label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
+        label_mouseover._viewer_mouse_event(self.viewer,
+                                            {'event': 'mousemove', 'domain': {'x': 10, 'y': 3}})
+        assert label_mouseover.as_text() in [('Pixel x=07.0 y=00.0 Value +0.00000e+00',
+                                              'World 00h14m19.6291s -30d23m30.9692s (ICRS)',
+                                              '3.5817877198 -30.3919358920 (deg)'),
+                                             ('Pixel x=07.0 y=-0.0 Value +0.00000e+00',
+                                              'World 00h14m19.6291s -30d23m30.9692s (ICRS)',
+                                              '3.5817877198 -30.3919358920 (deg)')]
+
+        assert label_mouseover.row1_unreliable
+        assert label_mouseover.row2_unreliable
+        assert label_mouseover.row3_unreliable
 
         # Non-reference image out of bounds of its own bounds but not of the
         # reference image's bounds. Head hurting yet?
-        self.viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0.5, 'y': 0.5}})
-        assert self.viewer.label_mouseover.pixel == 'x=-2.5 y=-2.5'
-        assert self.viewer.label_mouseover.value == ''
-        assert self.viewer.label_mouseover.world_ra_deg == '3.5816283341'
-        assert self.viewer.label_mouseover.world_dec_deg == '-30.3919519949'
-        assert self.viewer.label_mouseover.unreliable_world
-        assert self.viewer.label_mouseover.unreliable_pixel
+        label_mouseover._viewer_mouse_event(self.viewer,
+                                            {'event': 'mousemove', 'domain': {'x': 0.5, 'y': 0.5}})
+        assert label_mouseover.as_text() == ('Pixel x=-2.5 y=-2.5',
+                                             'World 00h14m19.5908s -30d23m31.0272s (ICRS)',
+                                             '3.5816283341 -30.3919519949 (deg)')
+        assert label_mouseover.row1_unreliable
+        assert label_mouseover.row2_unreliable
+        assert label_mouseover.row3_unreliable
 
         # Back to reference image
+        label_mouseover._viewer_mouse_event(self.viewer,
+                                            {'event': 'keydown', 'key': 'b',
+                                             'domain': {'x': 0, 'y': 0}})
         self.viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b',
                                            'domain': {'x': 0, 'y': 0}})
-        assert self.viewer.label_mouseover.pixel == 'x=00.0 y=00.0'
-        assert self.viewer.label_mouseover.value == '+1.00000e+00 electron / s'
-        assert self.viewer.label_mouseover.world_ra_deg == '3.5816174030'
-        assert self.viewer.label_mouseover.world_dec_deg == '-30.3919481838'
-        assert not self.viewer.label_mouseover.unreliable_world
-        assert not self.viewer.label_mouseover.unreliable_pixel
+        assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +1.00000e+00 electron / s',
+                                             'World 00h14m19.5882s -30d23m31.0135s (ICRS)',
+                                             '3.5816174030 -30.3919481838 (deg)')
+        assert not label_mouseover.row1_unreliable
+        assert not label_mouseover.row2_unreliable
+        assert not label_mouseover.row3_unreliable
 
         # Still reference image but outside its own bounds.
-        self.viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 10, 'y': 3}})
-        assert self.viewer.label_mouseover.pixel == 'x=10.0 y=03.0'
-        assert self.viewer.label_mouseover.value == ''
-        assert self.viewer.label_mouseover.world_ra_deg == '3.5817877198'
-        assert self.viewer.label_mouseover.world_dec_deg == '-30.3919358920'
-        assert self.viewer.label_mouseover.unreliable_world
-        assert not self.viewer.label_mouseover.unreliable_pixel
+        label_mouseover._viewer_mouse_event(self.viewer,
+                                            {'event': 'mousemove', 'domain': {'x': 10, 'y': 3}})
+        assert label_mouseover.as_text() == ('Pixel x=10.0 y=03.0',
+                                             'World 00h14m19.6291s -30d23m30.9692s (ICRS)',
+                                             '3.5817877198 -30.3919358920 (deg)')
+        assert not label_mouseover.row1_unreliable
+        assert label_mouseover.row2_unreliable
+        assert label_mouseover.row3_unreliable
 
     def test_pixel_linking(self):
         self.imviz.link_data(link_type='pixels')
 
         # Check the coordinates display: Last loaded is on top.
-        self.viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': -1, 'y': -1}})
-        assert self.viewer.label_mouseover.pixel == 'x=-1.0 y=-1.0'
-        assert self.viewer.label_mouseover.value == ''
-        assert self.viewer.label_mouseover.world_ra_deg == '3.5816611274'
-        assert self.viewer.label_mouseover.world_dec_deg == '-30.3919634282'
-        assert self.viewer.label_mouseover.unreliable_world
-        assert not self.viewer.label_mouseover.unreliable_pixel
+        label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
+        label_mouseover._viewer_mouse_event(self.viewer,
+                                            {'event': 'mousemove', 'domain': {'x': -1, 'y': -1}})
+        assert label_mouseover.as_text() == ('Pixel x=-1.0 y=-1.0',
+                                             'World 00h14m19.5987s -30d23m31.0683s (ICRS)',
+                                             '3.5816611274 -30.3919634282 (deg)')
+        assert not label_mouseover.row1_unreliable
+        assert label_mouseover.row2_unreliable
+        assert label_mouseover.row3_unreliable
 
         # Back to reference image with bounds check.
-        self.viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b',
-                                           'domain': {'x': -1, 'y': -1}})
-        assert self.viewer.label_mouseover.pixel == 'x=-1.0 y=-1.0'
-        assert self.viewer.label_mouseover.value == ''
-        assert self.viewer.label_mouseover.world_ra_deg == '3.5815955408'
-        assert self.viewer.label_mouseover.world_dec_deg == '-30.3919405616'
-        assert self.viewer.label_mouseover.unreliable_world
-        assert not self.viewer.label_mouseover.unreliable_pixel
+        label_mouseover._viewer_mouse_event(self.viewer,
+                                            {'event': 'keydown', 'key': 'b',
+                                             'domain': {'x': -1, 'y': -1}})
+        assert label_mouseover.as_text() == ('Pixel x=-1.0 y=-1.0',
+                                             'World 00h14m19.5987s -30d23m31.0683s (ICRS)',
+                                             '3.5816611274 -30.3919634282 (deg)')
+        assert not label_mouseover.row1_unreliable
+        assert label_mouseover.row2_unreliable
+        assert label_mouseover.row3_unreliable
 
 
 def test_imviz_no_data(imviz_helper):

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -164,13 +164,11 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
                                             {'event': 'mousemove',
                                              'domain': {'x': 0, 'y': 0}})
 
-#        assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +1.00000e+00',
-#                                             'World 22h30m04.8674s -20d49m59.9990s (ICRS)',
-#                                             '337.5202808000 -20.8333330600 (deg)')
-#        for some reason getting:
-#                                            ('Pixel x=01.0 y=-0.0 Value +1.00000e+00',
-#                                             'World 22h30m04.8674s -20d49m59.9990s (ICRS)',
-#                                             '337.5202808000 -20.8333330600 (deg)')
+        lmtext = label_mouseover.as_text()
+        assert lmtext[0] in ('Pixel x=01.0 y=00.0 Value +1.00000e+00',
+                             'Pixel x=01.0 y=-0.0 Value +1.00000e+00')
+        assert lmtext[1:] == ('World 22h30m04.8674s -20d49m59.9990s (ICRS)',
+                              '337.5202808000 -20.8333330600 (deg)')
 
         # blink image through clicking with blink tool
         self.viewer.toolbar.active_tool_id = 'jdaviz:blinkonce'
@@ -286,12 +284,11 @@ class TestLink_GWCS_GWCS(BaseImviz_GWCS_GWCS):
         label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
         label_mouseover._viewer_mouse_event(self.viewer,
                                             {'event': 'mousemove', 'domain': {'x': 10, 'y': 3}})
-        assert label_mouseover.as_text() in [('Pixel x=07.0 y=00.0 Value +0.00000e+00',
-                                              'World 00h14m19.6291s -30d23m30.9692s (ICRS)',
-                                              '3.5817877198 -30.3919358920 (deg)'),
-                                             ('Pixel x=07.0 y=-0.0 Value +0.00000e+00',
-                                              'World 00h14m19.6291s -30d23m30.9692s (ICRS)',
-                                              '3.5817877198 -30.3919358920 (deg)')]
+        lmtext = label_mouseover.as_text()
+        assert lmtext[0] in ('Pixel x=07.0 y=00.0 Value +0.00000e+00',
+                             'Pixel x=07.0 y=-0.0 Value +0.00000e+00')
+        assert lmtext[1:] == ('World 00h14m19.6291s -30d23m30.9692s (ICRS)',
+                              '3.5817877198 -30.3919358920 (deg)')
 
         assert label_mouseover.row1_unreliable
         assert label_mouseover.row2_unreliable
@@ -349,9 +346,11 @@ class TestLink_GWCS_GWCS(BaseImviz_GWCS_GWCS):
         label_mouseover._viewer_mouse_event(self.viewer,
                                             {'event': 'keydown', 'key': 'b',
                                              'domain': {'x': -1, 'y': -1}})
+        self.viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b',
+                                           'domain': {'x': -1, 'y': -1}})
         assert label_mouseover.as_text() == ('Pixel x=-1.0 y=-1.0',
-                                             'World 00h14m19.5987s -30d23m31.0683s (ICRS)',
-                                             '3.5816611274 -30.3919634282 (deg)')
+                                             'World 00h14m19.5829s -30d23m30.9860s (ICRS)',
+                                             '3.5815955408 -30.3919405616 (deg)')
         assert not label_mouseover.row1_unreliable
         assert label_mouseover.row2_unreliable
         assert label_mouseover.row3_unreliable

--- a/jdaviz/configs/imviz/tests/test_tools.py
+++ b/jdaviz/configs/imviz/tests/test_tools.py
@@ -107,25 +107,26 @@ def test_blink(imviz_helper):
     for i in range(3):
         imviz_helper.load_data(np.zeros((2, 2)) + i, data_label=f'image_{i}')
 
+    label_mouseover = imviz_helper.app.session.application._tools['g-coords-info']
     viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b', 'domain': {'x': 0, 'y': 0}})
-    assert viewer.label_mouseover.value == '+0.00000e+00 '
+    label_mouseover._viewer_mouse_event(viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+    assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +0.00000e+00', '', '')
     assert viewer.top_visible_data_label == 'image_0'
 
     # Blink forward and update coordinates info panel.
     viewer.blink_once()
-    viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
-    assert viewer.label_mouseover.value == '+1.00000e+00 '
+    assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +1.00000e+00', '', '')
     assert viewer.top_visible_data_label == 'image_1'
 
     # Blink backward.
     viewer.blink_once(reversed=True)
-    viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
-    assert viewer.label_mouseover.value == '+0.00000e+00 '
+    assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +0.00000e+00', '', '')
     assert viewer.top_visible_data_label == 'image_0'
 
     # Blink backward again.
     viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'B', 'domain': {'x': 0, 'y': 0}})
-    assert viewer.label_mouseover.value == '+2.00000e+00 '
+    assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +2.00000e+00', '', '')
     assert viewer.top_visible_data_label == 'image_2'
 
 

--- a/jdaviz/configs/mosviz/tests/test_data_loading.py
+++ b/jdaviz/configs/mosviz/tests/test_data_loading.py
@@ -162,7 +162,7 @@ def test_load_single_image_multi_spec(mosviz_helper, mos_image, spectrum1d, mos_
 
     # Coordinates info panel should not crash even when nothing is loaded.
     label_mouseover = mosviz_helper.app.session.application._tools['g-coords-info']
-    label_mouseover._viewer_mouse_event(image_viewer, {'event': 'mouseover',
+    label_mouseover._viewer_mouse_event(image_viewer, {'event': 'mousemove',
                                                        'domain': {'x': 0, 'y': 0}})
     assert label_mouseover.as_text() == ('', '', '')
 
@@ -214,9 +214,11 @@ def test_load_single_image_multi_spec(mosviz_helper, mos_image, spectrum1d, mos_
     assert label_mouseover.as_text() == ('Pixel x=00010.0 y=00100.0 Value +8.12986e-01', '', '')
     assert label_mouseover.icon == 'b'
 
+    # need to trigger a mouseleave or mouseover to reset the traitlets
+    label_mouseover._viewer_mouse_event(spec1d_viewer, {'event': 'mouseenter'})
     label_mouseover._viewer_mouse_event(spec1d_viewer,
                                         {'event': 'mousemove', 'domain': {'x': 7000, 'y': 170}})
-    assert label_mouseover.as_text() == ('Cursor 7.00000e+03, 1.70000e+02 Value +8.12986e-01',
+    assert label_mouseover.as_text() == ('Cursor 7.00000e+03, 1.70000e+02',
                                          'Wave 6.88889e+03 Angstrom (4 pix)',
                                          'Flux 1.35436e+01 Jy')
     assert label_mouseover.icon == 'c'

--- a/jdaviz/configs/mosviz/tests/test_data_loading.py
+++ b/jdaviz/configs/mosviz/tests/test_data_loading.py
@@ -161,8 +161,10 @@ def test_load_single_image_multi_spec(mosviz_helper, mos_image, spectrum1d, mos_
     spec2d_viewer = mosviz_helper.app.get_viewer('spectrum-2d-viewer')
 
     # Coordinates info panel should not crash even when nothing is loaded.
-    image_viewer.on_mouse_or_key_event({'event': 'mouseover'})
-    assert image_viewer.label_mouseover is None
+    label_mouseover = mosviz_helper.app.session.application._tools['g-coords-info']
+    label_mouseover._viewer_mouse_event(image_viewer, {'event': 'mouseover',
+                                                       'domain': {'x': 0, 'y': 0}})
+    assert label_mouseover.as_text() == ('', '', '')
 
     # Test that loading is still possible after previous crash:
     # https://github.com/spacetelescope/jdaviz/issues/364
@@ -185,45 +187,39 @@ def test_load_single_image_multi_spec(mosviz_helper, mos_image, spectrum1d, mos_
     # 1D spectrum viewer panel is also tested in Specviz.
     # 2D spectrum viewer panel is also tested in Specviz2d.
 
-    image_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
-    assert image_viewer.label_mouseover.pixel == 'x=000.0 y=000.0'
-    assert image_viewer.label_mouseover.value == '+3.74540e-01 Jy'
-    assert image_viewer.label_mouseover.world_ra_deg == '5.0297844783'
-    assert image_viewer.label_mouseover.world_dec_deg == '4.9918991917'
-    assert image_viewer.label_mouseover.icon == 'a'
+    label_mouseover._viewer_mouse_event(image_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+    assert label_mouseover.as_text() == ('Pixel x=000.0 y=000.0 Value +3.74540e-01 Jy',
+                                         'World 00h20m07.1483s +04d59m30.8371s (ICRS)',
+                                         '5.0297844783 4.9918991917 (deg)')
+    assert label_mouseover.icon == 'a'
 
-    image_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': None, 'y': 0}})
-    assert image_viewer.label_mouseover.pixel == ''
-    assert image_viewer.label_mouseover.value == ''
-    assert image_viewer.label_mouseover.world_ra_deg == ''
-    assert image_viewer.label_mouseover.world_dec_deg == ''
+    label_mouseover._viewer_mouse_event(image_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': None, 'y': 0}})
+    assert label_mouseover.as_text() == ('', '', '')
+    assert label_mouseover.icon == ''
 
-    image_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': -1, 'y': 0}})
-    assert image_viewer.label_mouseover.pixel == 'x=-01.0 y=000.0'
-    assert image_viewer.label_mouseover.value == ''
-    assert image_viewer.label_mouseover.world_ra_deg == '5.0297997183'
-    assert image_viewer.label_mouseover.world_dec_deg == '4.9918991914'
+    label_mouseover._viewer_mouse_event(image_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': -1, 'y': 0}})
+    assert label_mouseover.as_text() == ('Pixel x=-01.0 y=000.0',
+                                         'World 00h20m07.1519s +04d59m30.8371s (ICRS)',
+                                         '5.0297997183 4.9918991914 (deg)')
 
-    image_viewer.on_mouse_or_key_event({'event': 'mouseleave'})
-    assert image_viewer.label_mouseover.pixel == ''
-    assert image_viewer.label_mouseover.value == ''
-    assert image_viewer.label_mouseover.world_ra_deg == ''
-    assert image_viewer.label_mouseover.world_dec_deg == ''
+    label_mouseover._viewer_mouse_event(image_viewer, {'event': 'mouseleave'})
+    assert label_mouseover.as_text() == ('', '', '')
+    assert label_mouseover.icon == ''
 
-    spec2d_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 10, 'y': 100}})
-    assert spec2d_viewer.label_mouseover.pixel == 'x=00010.0 y=00100.0'
-    assert spec2d_viewer.label_mouseover.value == '+8.12986e-01 '
-    assert spec2d_viewer.label_mouseover.world_ra_deg == ''
-    assert spec2d_viewer.label_mouseover.world_dec_deg == ''
-    assert spec2d_viewer.label_mouseover.icon == 'b'
+    label_mouseover._viewer_mouse_event(spec2d_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 10, 'y': 100}})
+    assert label_mouseover.as_text() == ('Pixel x=00010.0 y=00100.0 Value +8.12986e-01', '', '')
+    assert label_mouseover.icon == 'b'
 
-    spec1d_viewer.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 7000, 'y': 170}})
-    assert spec1d_viewer.label_mouseover.pixel == '7.00000e+03, 1.70000e+02'
-    assert spec1d_viewer.label_mouseover.world_label_prefix == 'Wave'
-    assert spec1d_viewer.label_mouseover.world_ra == '6.88889e+03 Angstrom (4 pix)'
-    assert spec1d_viewer.label_mouseover.world_label_prefix_2 == 'Flux'
-    assert spec1d_viewer.label_mouseover.world_ra_deg == '1.35436e+01 Jy'
-    assert spec1d_viewer.label_mouseover.icon == 'c'
+    label_mouseover._viewer_mouse_event(spec1d_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 7000, 'y': 170}})
+    assert label_mouseover.as_text() == ('Cursor 7.00000e+03, 1.70000e+02 Value +8.12986e-01',
+                                         'Wave 6.88889e+03 Angstrom (4 pix)',
+                                         'Flux 1.35436e+01 Jy')
+    assert label_mouseover.icon == 'c'
 
 
 def test_zip_error(mosviz_helper, tmp_path):

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -30,11 +30,11 @@ def test_2d_parser_jwst(specviz2d_helper):
 
     # Also check the coordinates info panel.
     viewer_2d = specviz2d_helper.app.get_viewer('spectrum-2d-viewer')
-    viewer_2d.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 350, 'y': 30}})
-    assert viewer_2d.label_mouseover.pixel == 'x=0350.0 y=0030.0'
-    assert viewer_2d.label_mouseover.value == '+3.22142e+04 MJy / sr'
-    assert viewer_2d.label_mouseover.world_ra_deg == ''
-    assert viewer_2d.label_mouseover.world_dec_deg == ''
+    label_mouseover = specviz2d_helper.app.session.application._tools['g-coords-info']
+    label_mouseover._viewer_mouse_event(viewer_2d,
+                                        {'event': 'mousemove', 'domain': {'x': 350, 'y': 30}})
+    assert label_mouseover.as_text() == ('Pixel x=0350.0 y=0030.0 Value +3.22142e+04 MJy / sr',
+                                         '', '')
 
 
 @pytest.mark.remote_data
@@ -71,21 +71,19 @@ def test_2d_parser_no_unit(specviz2d_helper, mos_spectrum2d):
     # Also check the coordinates info panels.
 
     viewer_2d = specviz2d_helper.app.get_viewer('spectrum-2d-viewer')
-    viewer_2d.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
-    assert viewer_2d.label_mouseover.pixel == 'x=00000.0 y=00000.0'
-    assert viewer_2d.label_mouseover.value == '+3.74540e-01 '
-    assert viewer_2d.label_mouseover.world_ra_deg == ''
-    assert viewer_2d.label_mouseover.world_dec_deg == ''
-    assert viewer_2d.label_mouseover.icon == 'a'
+    label_mouseover = specviz2d_helper.app.session.application._tools['g-coords-info']
+    label_mouseover._viewer_mouse_event(viewer_2d,
+                                        {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+    assert label_mouseover.as_text() == ('Pixel x=00000.0 y=00000.0 Value +3.74540e-01', '', '')
+    assert label_mouseover.icon == 'a'
 
     viewer_1d = specviz2d_helper.app.get_viewer('spectrum-viewer')
-    viewer_1d.on_mouse_or_key_event({'event': 'mousemove', 'domain': {'x': 6.5, 'y': 3}})
-    assert viewer_1d.label_mouseover.pixel == '6.50000e+00, 3.00000e+00'
-    assert viewer_1d.label_mouseover.world_label_prefix == 'Wave'
-    assert viewer_1d.label_mouseover.world_ra == '6.00000e+00 pix'
-    assert viewer_1d.label_mouseover.world_label_prefix_2 == 'Flux'
-    assert viewer_1d.label_mouseover.world_ra_deg == '-3.59571e+00 '  # extra space for no unit
-    assert viewer_1d.label_mouseover.icon == 'b'
+    label_mouseover._viewer_mouse_event(viewer_1d,
+                                        {'event': 'mousemove', 'domain': {'x': 6.5, 'y': 3}})
+    assert label_mouseover.as_text() == ('Cursor 6.50000e+00, 3.00000e+00 Value +3.74540e-01',
+                                         'Wave 6.00000e+00 pix',
+                                         'Flux -3.59571e+00')
+    assert label_mouseover.icon == 'b'
 
 
 def test_1d_parser(specviz2d_helper, spectrum1d):

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -78,9 +78,11 @@ def test_2d_parser_no_unit(specviz2d_helper, mos_spectrum2d):
     assert label_mouseover.icon == 'a'
 
     viewer_1d = specviz2d_helper.app.get_viewer('spectrum-viewer')
+    # need to trigger a mouseleave or mouseover to reset the traitlets
+    label_mouseover._viewer_mouse_event(viewer_1d, {'event': 'mouseenter'})
     label_mouseover._viewer_mouse_event(viewer_1d,
                                         {'event': 'mousemove', 'domain': {'x': 6.5, 'y': 3}})
-    assert label_mouseover.as_text() == ('Cursor 6.50000e+00, 3.00000e+00 Value +3.74540e-01',
+    assert label_mouseover.as_text() == ('Cursor 6.50000e+00, 3.00000e+00',
                                          'Wave 6.00000e+00 pix',
                                          'Flux -3.59571e+00')
     assert label_mouseover.icon == 'b'


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request refactors/renames the logic in the coordinates info display so that:
* viewer callbacks are handled by the plugin itself rather than various viewers
* traitlets for the coordinate info are named based on their position in the widget.  Previously they were named based on their meaning in the original Imviz implementation, and then re-used for other viewers.  This became quite confusing to develop.  This change then also means all tests needed to be updated for the new formatting.

The behavior should essentially be the same as in #1894, except that the top line in specviz now reads "Cursor" instead of the previously hard-coded "Pixel".

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fix #1645 

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
