### PR TITLE
Aperture photometry table (with popout support)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Table exposing past results in the aperture photometry plugin. [#1985]
+
 Mosviz
 ^^^^^^
 

--- a/docs/imviz/export_data.rst
+++ b/docs/imviz/export_data.rst
@@ -30,8 +30,9 @@ See :ref:`astropy:astropy-modeling` on how to manipulate the model:
 
     my_gaussian1d = imviz.app.fitted_models['phot_radial_profile']
 
-You can also retrieve the photometry results as `~astropy.table.QTable` as follows,
-assuming ``imviz`` is the instance of your Imviz application:
+The bottom of the plugin shows a table of past results, along with the subset
+and data used to compute them.  These results can be exported as an `~astropy.table.QTable`
+as follows, assuming ``imviz`` is the instance of your Imviz application:
 
 .. code-block:: python
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -77,6 +77,7 @@ custom_components = {'j-tooltip': 'components/tooltip.vue',
                      'j-plugin-section-header': 'components/plugin_section_header.vue',
                      'j-number-uncertainty': 'components/number_uncertainty.vue',
                      'j-plugin-popout': 'components/plugin_popout.vue',
+                     'plugin-table': 'components/plugin_table.vue',
                      'plugin-dataset-select': 'components/plugin_dataset_select.vue',
                      'plugin-subset-select': 'components/plugin_subset_select.vue',
                      'plugin-viewer-select': 'components/plugin_viewer_select.vue',
@@ -1827,6 +1828,9 @@ class Application(VuetifyTemplate, HubListener):
                 app=self, **optional_tray_kwargs
             )
             tray_item_label = tray.get('label')
+            # store a copy of the tray name in the instance so it can be accessed by the
+            # plugin itself
+            tray_item_instance._plugin_name = tray_item_label
 
             self.state.tray_items.append({
                 'name': name,

--- a/jdaviz/components/plugin_table.vue
+++ b/jdaviz/components/plugin_table.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="plugin-table-component">
+    <v-row style="margin: 0px 0px -8px 0px !important">
+      <div class="row-select">
+        <v-select
+          class="no-hint"
+          v-model="headers_visible"
+          :items="headers_avail"
+          @change="$emit('update:headers_visible', $event)"
+          label="Columns"
+          multiple
+        >
+        <template v-slot:selection="{ item, index }">
+          <span
+            v-if="index === 0"
+            class="grey--text text-caption"
+          >
+            ({{ headers_visible.length}} selected)
+          </span>
+        </template>
+        <template v-slot:prepend-item>
+          <v-list-item
+            ripple
+            @mousedown.prevent
+            @click="() => {if (headers_visible.length < headers_avail.length) { headers_visible = headers_avail} else {headers_visible = []}}"
+          >
+            <v-list-item-action>
+              <v-icon>
+                {{ headers_visible.length == headers_avail.length ? 'mdi-close-box' : headers_visible.length ? 'mdi-minus-box' : 'mdi-checkbox-blank-outline' }}
+              </v-icon>
+            </v-list-item-action>
+            <v-list-item-content>
+              <v-list-item-title>
+                {{ headers_visible.length < headers_avail.length ? "Select All" : "Clear All" }}
+              </v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+          <v-divider class="mt-2"></v-divider>
+        </template>
+        </v-select>
+      </div>
+      <div style="line-height: 64px; width=32px" class="only-show-in-tray">
+        <j-plugin-popout :popout_button="popout_button"></j-plugin-popout>
+      </div>
+    </v-row>
+
+    <v-row style="margin: 0px 0px 8px 0px !important">
+      <v-data-table
+        dense
+        :headers="headers_visible.map(item => {return {'text': item, 'value': item}})"
+        :items="items"
+        class="elevation-1 width-100"
+      ></v-data-table>
+    </v-row>
+
+    <v-row v-if="clear_table" justify="end">
+      <v-btn
+        color="primary"
+        text
+        @click="clear_table"
+        >Clear Table
+      </v-btn>
+    </v-row>
+  </div>
+</template>
+
+<style scoped>
+  .v-data-table {
+    width: 100% !important
+  }
+
+  .only-show-in-tray {
+    display: none;
+  }
+  .tray-plugin .only-show-in-tray {
+    display: inline-block;
+  }
+
+
+  .row-select {
+    width: 100%;
+  }
+  .tray-plugin .row-select {
+    width: calc(100% - 40px)
+  }
+
+  .plugin-table-component {
+    margin: 12px;
+  }
+  .tray-plugin .plugin-table-component {
+    margin: 0px -12px 0px -12px;
+  }
+
+</style>

--- a/jdaviz/components/plugin_table.vue
+++ b/jdaviz/components/plugin_table.vue
@@ -76,7 +76,6 @@
     display: inline-block;
   }
 
-
   .row-select {
     width: 100%;
   }

--- a/jdaviz/components/tooltip.vue
+++ b/jdaviz/components/tooltip.vue
@@ -31,7 +31,7 @@ const tooltips = {
       some ad blockers or browser settings may block popup windows,
       causing this feature not to work.
     </div>`,
-  'plugin-popout': `Display plugin in a new window<br /><br />
+  'plugin-popout': `Display in a new window<br /><br />
     <div style="width: 200px; border: 1px solid gray;" class="pa-2">
       <strong>Note:</strong>
       some ad blockers or browser settings may block popup windows,

--- a/jdaviz/components/tray_plugin.vue
+++ b/jdaviz/components/tray_plugin.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container style="padding-left: 24px; padding-right: 24px; padding-top: 12px">
+  <v-container class="tray-plugin" style="padding-left: 24px; padding-right: 24px; padding-top: 12px">
     <v-row v-if="isDisabled()">
       <span> {{ getDisabledMsg() }}</span>
     </v-row>

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -378,7 +378,7 @@ class Imviz(ImageConfigHelper):
             Photometry results if available or `None` otherwise.
 
         """
-        return getattr(self.app, '_aper_phot_results', None)
+        return self.plugins['Imviz Simple Aperture Photometry']._obj.export_table()
 
     def get_catalog_source_results(self):
         """Return table of sources given by querying from a catalog, if any.

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -348,11 +348,11 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin, TableMix
 
             try:
                 phot_table['id'][0] = self.table._qtable['id'].max() + 1
-                self.table.add_row(phot_table)
+                self.table.add_item(phot_table)
             except Exception:  # Discard incompatible QTable
                 self.table.clear_table()
                 phot_table['id'][0] = 1
-                self.table.add_row(phot_table)
+                self.table.add_item(phot_table)
 
             # Plots.
             # TODO: Jenn wants title at bottom.

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -160,6 +160,7 @@
 
     <div v-if="result_available">
       <j-plugin-section-header>Photometry Results</j-plugin-section-header>
+
       <v-row no-gutters>
         <v-col cols=6><U>Result</U></v-col>
         <v-col cols=6><U>Value</U></v-col>
@@ -173,6 +174,9 @@
         </v-col>
         <v-col cols=6>{{ item.result }}</v-col>
       </v-row>
+
+      <j-plugin-section-header>Results History</j-plugin-section-header>
+      <jupyter-widget :widget="table_widget"></jupyter-widget> 
     </div>
   </j-tray-plugin>
 </template>

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2214,6 +2214,16 @@ class PluginSubcomponent(VuetifyTemplate):
 
 class Table(PluginSubcomponent):
     """
+    Table subcomponent.  For most cases where a plugin only requires a single table, use the mixin
+    instead.
+
+    To use in a plugin, define ``plugin.table = Table(plugin)``, create a ``table_widget`` Unicode
+    traitlet, and set ``plugin.table_widget = 'IPY_MODEL_'+self.table.model_id``.
+
+    To render in the plugin's vue file::
+
+      <jupyter-widget :widget="table_widget"></jupyter-widget>
+
     """
     template_file = __file__, "../components/plugin_table.vue"
 
@@ -2226,6 +2236,13 @@ class Table(PluginSubcomponent):
         super().__init__(plugin, 'Table', *args, **kwargs)
 
     def add_item(self, item):
+        """
+        Add an item/row to the table.
+
+        Parameters
+        ----------
+        item : QTable, QTableRow, or dictionary of row-name, value pairs
+        """
         def json_safe(item):
             if hasattr(item, 'to_string'):
                 return item.to_string()
@@ -2264,6 +2281,7 @@ class Table(PluginSubcomponent):
 
     def export_table(self):
         """
+        Export the QTable representation of the table.
         """
         # TODO: default to only showing selected columns?
         return self._qtable
@@ -2271,6 +2289,17 @@ class Table(PluginSubcomponent):
 
 class TableMixin(VuetifyTemplate, HubListener):
     """
+    Table subcomponent mixin.
+
+    In addition to ``table``, this provides the following methods at the plugin-level:
+
+    * :meth:`clear_table`
+    * :meth:`export_table`
+
+    To render in the plugin's vue file::
+
+      <jupyter-widget :widget="table_widget"></jupyter-widget>
+
     """
     table_widget = Unicode().tag(sync=True)
 
@@ -2280,6 +2309,9 @@ class TableMixin(VuetifyTemplate, HubListener):
         self.table_widget = 'IPY_MODEL_'+self.table.model_id
 
     def clear_table(self):
+        """
+        Clear all entries/markers from the current table.
+        """
         self.table.clear_table()
 
     def vue_clear_table(self, data=None):
@@ -2288,4 +2320,7 @@ class TableMixin(VuetifyTemplate, HubListener):
         self.clear_table()
 
     def export_table(self):
+        """
+        Export the QTable representation of the table.
+        """
         return self.table.export_table()

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1,3 +1,5 @@
+from astropy.table import QTable
+from astropy.table.row import Row as QTableRow
 import numpy as np
 
 from functools import cached_property
@@ -25,11 +27,13 @@ from jdaviz.core.user_api import UserApiWrapper, PluginUserApi
 
 __all__ = ['show_widget', 'TemplateMixin', 'PluginTemplateMixin',
            'BasePluginComponent', 'SelectPluginComponent',
+           'PluginSubcomponent',
            'SubsetSelect', 'SpatialSubsetSelectMixin', 'SpectralSubsetSelectMixin',
            'DatasetSpectralSubsetValidMixin',
            'ViewerSelect', 'ViewerSelectMixin',
            'LayerSelect', 'LayerSelectMixin',
            'DatasetSelect', 'DatasetSelectMixin',
+           'Table', 'TableMixin',
            'AutoTextField', 'AutoTextFieldMixin',
            'AddResults', 'AddResultsMixin',
            'PlotOptionsSyncState']
@@ -2136,3 +2140,152 @@ class PlotOptionsSyncState(BasePluginComponent):
         self._on_value_changed({'new': self.value})
         self.sync = {**self.sync,
                      'mixed': False}
+
+
+# SUBCOMPONENTS (will not have top-level plugin traitlets but can be rendered on their own in
+# popout windows or in the app)
+
+class PluginSubcomponent(VuetifyTemplate):
+    popout_button = Any().tag(sync=True, **widget_serialization)
+
+    def __init__(self, plugin, component_type='table', *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._plugin = plugin
+        self._component_type = component_type
+        self.popout_button = PopoutButton(self, window_features='popup,width=800,height=300')
+
+    @property
+    def display_name(self):
+        return f'{self._plugin._plugin_name}: {self._component_type}'
+
+    def vue_popout(self, data=None):
+        self.show(loc='popout')
+
+    def show(self, loc="inline", title=None):  # pragma: no cover
+        """Display the component UI.
+
+        Parameters
+        ----------
+        loc : str
+            The display location determines where to present the viz app.
+            Supported locations:
+
+            "inline": Display the component inline in a notebook.
+
+            "app": Display below the viewers in the main app.
+
+            "sidecar": Display the component in a separate JupyterLab window from the
+            notebook, the location of which is decided by the 'anchor.' right is the default
+
+                Other anchors:
+
+                * ``sidecar:right`` (The default, opens a tab to the right of display)
+                * ``sidecar:tab-before`` (Full-width tab before the current notebook)
+                * ``sidecar:tab-after`` (Full-width tab after the current notebook)
+                * ``sidecar:split-right`` (Split-tab in the same window right of the notebook)
+                * ``sidecar:split-left`` (Split-tab in the same window left of the notebook)
+                * ``sidecar:split-top`` (Split-tab in the same window above the notebook)
+                * ``sidecar:split-bottom`` (Split-tab in the same window below the notebook)
+
+                See `jupyterlab-sidecar <https://github.com/jupyter-widgets/jupyterlab-sidecar>`_
+                for the most up-to-date options.
+
+            "popout": Display the component in a detached display. By default, a new
+            window will open. Browser popup permissions required.
+
+                Other anchors:
+
+                * ``popout:window`` (The default, opens Jdaviz in a new, detached popout)
+                * ``popout:tab`` (Opens Jdaviz in a new, detached tab in your browser)
+
+        title : str, optional
+            The title of the sidecar tab.  Defaults to the name of the component.
+
+            NOTE: Only applicable to a "sidecar" display.
+
+        Notes
+        -----
+        If "sidecar" is requested in the "classic" Jupyter notebook, the component will appear
+        inline, as only JupyterLab has a mechanism to have multiple tabs.
+        """
+        title = title if title is not None else self.display_name
+        show_widget(self, loc=loc, title=title)
+
+
+class Table(PluginSubcomponent):
+    """
+    """
+    template_file = __file__, "../components/plugin_table.vue"
+
+    headers_visible = List([]).tag(sync=True)  # list of strings
+    headers_avail = List([]).tag(sync=True)   # list of strings
+    items = List().tag(sync=True)  # list of dictionaries, pass single dict to add_row
+
+    def __init__(self, plugin, *args, **kwargs):
+        self._qtable = None
+        super().__init__(plugin, 'Table', *args, **kwargs)
+
+    def add_row(self, item):
+        def json_safe(item):
+            if hasattr(item, 'to_string'):
+                return item.to_string()
+            return item
+
+        if isinstance(item, QTable):
+            for row in item:
+                self.add_row(row)
+            return
+        if isinstance(item, QTableRow):
+            # Row does not have .items() implemented
+            item = {k: v for k, v in zip(item.keys(), item.values())}
+
+        # save original sent values to the cached QTable object
+        if self._qtable is None:
+            self._qtable = QTable([item])
+        else:
+            # NOTE: this does not support adding columns that did not exist in the first
+            # call to add_row since the last call to clear_table
+            self._qtable.add_row(item)
+
+        # clean data to show in the UI
+        self.items = self.items + [{k: json_safe(v) for k, v in item.items()}]
+
+    def clear_table(self):
+        """
+        Clear all entries/markers from the current table.
+        """
+        self.items = []
+        self._qtable = None
+
+    def vue_clear_table(self, data=None):
+        # if the plugin (or via the TableMixin) has its own clear_table implementation,
+        # call that, otherwise call the one defined here
+        getattr(self._plugin, 'clear_table', self.clear_table)()
+
+    def export_table(self):
+        """
+        """
+        # TODO: default to only showing selected columns?
+        return self._qtable
+
+
+class TableMixin(VuetifyTemplate, HubListener):
+    """
+    """
+    table_widget = Unicode().tag(sync=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.table = Table(self)
+        self.table_widget = 'IPY_MODEL_'+self.table.model_id
+
+    def clear_table(self):
+        self.table.clear_table()
+
+    def vue_clear_table(self, data=None):
+        # call clear_table directly in case the class overloads that method
+        # (to also clear markers, etc)
+        self.clear_table()
+
+    def export_table(self):
+        return self.table.export_table()

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2225,7 +2225,7 @@ class Table(PluginSubcomponent):
         self._qtable = None
         super().__init__(plugin, 'Table', *args, **kwargs)
 
-    def add_row(self, item):
+    def add_item(self, item):
         def json_safe(item):
             if hasattr(item, 'to_string'):
                 return item.to_string()
@@ -2233,7 +2233,7 @@ class Table(PluginSubcomponent):
 
         if isinstance(item, QTable):
             for row in item:
-                self.add_row(row)
+                self.add_item(row)
             return
         if isinstance(item, QTableRow):
             # Row does not have .items() implemented


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements a user-clearable table which displays the history of results from the aperture photometry plugin.  The previous `imviz.get_aperture_photometry_results` still works, but now serves as a shortcut to `plugin.export_table()` (once the user API is enabled for the aperture photometry plugin).

Future planned work includes the ability to display the table in a panel in the golden-layout section of the main app (below all other viewers), but for now support for popping out into a new window exists.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
