### PR TITLE
Make get_interactive_regions snackbar message less alarming

### DIFF
--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -627,7 +627,7 @@ class ImageConfigHelper(ConfigHelper):
         This does not return masked regions added via :meth:`load_regions`.
 
         Unsupported region shapes will be skipped. When that happens,
-        a red snackbar message will appear on display.
+        a yellow snackbar message will appear on display.
 
         Returns
         -------
@@ -663,8 +663,8 @@ class ImageConfigHelper(ConfigHelper):
 
         if len(failed_regs) > 0:
             self.app.hub.broadcast(SnackbarMessage(
-                f"Failed to get regions: {', '.join(sorted(failed_regs))}",
-                color="error", timeout=8000, sender=self.app))
+                f"Regions skipped: {', '.join(sorted(failed_regs))}",
+                color="warning", timeout=8000, sender=self.app))
 
         return regions
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to downgrade the snackbar message from error to warning when some Subsets are unable to be processed by `get_interactive_regions` that is supposed to only work for spatial Subsets.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3075)
