### PR TITLE
Avoid installation error by pinning y_py < 0.5.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     sidecar>=0.5.2
     ipypopout>=0.0.11
     astroquery
-    y_py<0.5.5
+    y_py<0.5.5;python_version=='3.9'
 
 [options.extras_require]
 test =

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ install_requires =
     sidecar>=0.5.2
     ipypopout>=0.0.11
     astroquery
+    y_py<0.5.5
 
 [options.extras_require]
 test =


### PR DESCRIPTION
Once https://github.com/y-crdt/ypy/issues/114 and https://github.com/jupyterlab/jupyterlab/issues/13920 are resolved we can unpin this. Currently this is causing users to be unable to install Jdaviz on python 3.9.