### PR TITLE
BUG: Avoid redshift slider warning when setting y_limits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,6 +89,8 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+* Calling ``cubeviz.specviz.y_limits(...)`` no longer emits irrelevant warning. [#2033]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
@@ -31,6 +31,10 @@ def test_invalid_statistic(cubeviz_helper, spectrum1d_cube):
     with pytest.raises(ValueError, match='statistic 42 not in list of valid '):
         cubeviz_helper.get_data(data_label="test[FLUX]", subset_to_apply='Subset 1', statistic=42)
 
+    # Also make sure specviz redshift slider warning does not show up.
+    # https://github.com/spacetelescope/jdaviz/issues/2029
+    cubeviz_helper.specviz.y_limits(0, 3)
+
 
 def test_valid_statistic(cubeviz_helper, spectrum1d_cube):
     cubeviz_helper.load_data(spectrum1d_cube, "test")

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -150,7 +150,7 @@ class Specviz(ConfigHelper, LineListMixin):
         ref_index = self.app.get_viewer(
             self._default_spectrum_viewer_reference_name
         ).state.reference_data.label
-        flux_axis = self.get_spectra(ref_index).flux
+        flux_axis = self.get_spectra(ref_index, apply_slider_redshift=False).flux
         self._set_scale(scale, flux_axis, y_min, y_max)
 
     def _set_scale(self, scale, axis, min_val=None, max_val=None):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to avoid redshift slider warning when setting `[cubeviz.]specviz.y_limits(...)`. The added test is confirmed to fail in current `main` without this patch.

I am not familiar with redshift slider logic, so please double check the code. Thanks!

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #2029 

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
