### PR TITLE
Prevent unneeded get_data_from_viewer call on app startup

### DIFF
--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -314,7 +314,8 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         # show spinner with overlay
         self.results_computing = True
 
-        if self.config == 'cubeviz' and self.spatial_subset_selected != SPATIAL_DEFAULT_TEXT:
+        if (self.config == 'cubeviz' and self.spatial_subset_selected not in
+                (SPATIAL_DEFAULT_TEXT, "")):
             # then we're acting on the auto-collapsed data in the spectrum-viewer
             # of a spatial subset.  In the future, we may want to expose on-the-fly
             # collapse options... but right now these will follow the settings of the


### PR DESCRIPTION
This code block was getting triggered on app startup while the traitlet was still the default empty string rather than the assigned default value. This is a negligible performance increase but avoiding this block on startup matters for some other work I'm doing.