### PR TITLE
Use stdatamodels for ASDF-in-FITS support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -70,6 +70,7 @@ body:
         import scipy; print("scipy", scipy.__version__)
         import skimage; print("scikit-image", skimage.__version__)
         import asdf; print("asdf", asdf.__version__)
+        import stdatamodels; print("stdatamodels", stdatamodels.__version__)
         import gwcs; print("gwcs", gwcs.__version__)
         import regions; print("regions", regions.__version__)
         import specutils; print("specutils", specutils.__version__)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,7 +41,7 @@ Cubeviz
 Imviz
 ^^^^^
 
-- ASDF parser for JWST images now uses ``stdatamodels``. [#2052]
+- ASDF-in-FITS parser for JWST images now uses ``stdatamodels``. [#2052]
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- ASDF parser for JWST images now uses ``stdatamodels``. [#2052]
+
 Mosviz
 ^^^^^^
 

--- a/conftest.py
+++ b/conftest.py
@@ -32,5 +32,6 @@ def pytest_configure(config):
     PYTEST_HEADER_MODULES['vispy'] = 'vispy'
     PYTEST_HEADER_MODULES['gwcs'] = 'gwcs'
     PYTEST_HEADER_MODULES['asdf'] = 'asdf'
+    PYTEST_HEADER_MODULES['stdatamodels'] = 'stdatamodels'
 
     TESTED_VERSIONS['jdaviz'] = __version__

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -122,7 +122,8 @@ class MetadataViewer(PluginTemplateMixin, DatasetSelectMixin):
             self.reset()
 
 
-# TODO: If this is natively supported by asdf in the future, replace with native function.
+# TODO: If this generalized in stdatamodels in the future, replace with native function.
+#       See https://github.com/spacetelescope/stdatamodels/issues/131
 # This code below is taken code from stdatamodels/model_base.py, and the method to_flat_dict()
 def flatten_nested_dict(asdfnode, include_arrays=True):
     """

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -87,7 +87,7 @@ class Imviz(ImageConfigHelper):
             * ``'filename.fits[SCI,2]'`` (loads the second SCI extension)
             * ``'filename.jpg'`` (requires ``scikit-image``; grayscale only)
             * ``'filename.png'`` (requires ``scikit-image``; grayscale only)
-            * JWST ASDF-in-FITS file (requires ``asdf`` and ``gwcs``; ``data`` or given
+            * JWST ASDF-in-FITS file (requires ``stdatamodels`` and ``gwcs``; ``data`` or given
               ``ext`` + GWCS)
             * `~astropy.io.fits.HDUList` object (first image extension found
               is loaded unless ``ext`` keyword is also given)

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -1,13 +1,13 @@
 import os
 
 import numpy as np
-from asdf.fits_embed import AsdfInFits
 from astropy import units as u
 from astropy.io import fits
 from astropy.nddata import NDData
 from astropy.wcs import WCS
 from glue.core.data import Component, Data
 from gwcs.wcs import WCS as GWCS
+from stdatamodels import asdf_in_fits
 
 from jdaviz.core.registries import data_parser_registry
 from jdaviz.core.events import SnackbarMessage
@@ -229,7 +229,7 @@ def _jwst2data(file_obj, ext, data_label):
 
     try:
         # This is very specific to JWST pipeline image output.
-        with AsdfInFits.open(file_obj) as af:
+        with asdf_in_fits.open(file_obj) as af:
             dm = af.tree
             dm_meta = af.tree["meta"]
             data.meta.update(standardize_metadata(dm_meta))

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -1,5 +1,4 @@
 import pytest
-from asdf.asdf import AsdfWarning
 from astropy.io import fits
 from astropy.utils.data import download_file
 
@@ -10,8 +9,7 @@ from jdaviz.utils import PRIHDR_KEY
 def test_2d_parser_jwst(specviz2d_helper):
     fn = download_file('https://stsci.box.com/shared/static/exnkul627fcuhy5akf2gswytud5tazmw.fits', cache=True)  # noqa
 
-    with pytest.warns(AsdfWarning, match='jwextension'):
-        specviz2d_helper.load_data(spectrum_2d=fn)
+    specviz2d_helper.load_data(spectrum_2d=fn)
     assert len(specviz2d_helper.app.data_collection) == 2
 
     dc_0 = specviz2d_helper.app.data_collection[0]

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -309,5 +309,6 @@ def pytest_configure(config):
     PYTEST_HEADER_MODULES['vispy'] = 'vispy'
     PYTEST_HEADER_MODULES['gwcs'] = 'gwcs'
     PYTEST_HEADER_MODULES['asdf'] = 'asdf'
+    PYTEST_HEADER_MODULES['stdatamodels'] = 'stdatamodels'
 
     TESTED_VERSIONS['jdaviz'] = __version__

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     # vispy is an indirect dependency, but older vispy's don't play nice with jdaviz install
     vispy>=0.6.5
     asdf>=2.14.3
+    stdatamodels>=1.3
     gwcs>=0.16.1
     regions>=0.6
     scikit-image
@@ -98,7 +99,6 @@ filterwarnings =
     ignore:.*With traitlets 4\.1, metadata should be set using the \.tag\(\) method:DeprecationWarning
     ignore:Widget.* is deprecated:DeprecationWarning
     ignore:zmq\.eventloop\.ioloop is deprecated in pyzmq:DeprecationWarning
-    ignore:AsdfInFits has been deprecated
     ignore:The unit 'Angstrom' has been deprecated in the VOUnit standard\. Suggested.* 0\.1nm\.
     ignore:specutils uses the deprecated entry point asdf_extensions
     ignore::DeprecationWarning:glue

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ deps =
     devdeps: git+https://github.com/astropy/photutils.git
     devdeps: git+https://github.com/spacetelescope/gwcs.git
     devdeps: git+https://github.com/asdf-format/asdf.git
+    devdeps: git+https://github.com/spacetelescope/stdatamodels.git
     devdeps: git+https://github.com/bqplot/bqplot.git@0.12.x
     devdeps: git+https://github.com/glue-viz/glue.git
     devdeps: git+https://github.com/voila-dashboards/voila.git


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to use ASDF-in-FITS code from `stdatamodels` instead of `asdf`.

~Unfortunately, this is blocked by~:

* https://github.com/spacetelescope/stdatamodels/issues/133 that needs https://github.com/spacetelescope/stdatamodels/pull/134
* https://github.com/spacetelescope/stdatamodels/issues/135

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1980

### TODO

- [x] Fix test failures (needs upstream fix, see above)
- [x] Update pin when stdatamodel releases.
- [x] Make sure `stcal` is not installed.
- [x] Wait for https://github.com/astropy/specutils/pull/1038 to get merged for devdeps

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
