### PR TITLE
fix redshift slider enabled/disabled from helper methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,6 +86,9 @@ Bug Fixes
 
 * Fixed linking issue preventing smoothed spectrum from showing in Specviz2D. [#2023]
 
+* Fixed redshift slider enabling/disabling when calling ``load_line_list``, ``plot_spectral_line``,
+  ``plot_spectral_lines``, or ``erase_spectral_lines``. [#2055] 
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -16,7 +16,8 @@ from jdaviz.core.events import (AddDataMessage,
                                 AddLineListMessage,
                                 LineIdentifyMessage,
                                 SnackbarMessage,
-                                RedshiftMessage)
+                                RedshiftMessage,
+                                SpectralMarksChangedMessage)
 from jdaviz.core.linelists import load_preset_linelist, get_linelist_metadata
 from jdaviz.core.marks import SpectralLine
 from jdaviz.core.registries import tray_registry
@@ -116,6 +117,9 @@ class LineListTool(PluginTemplateMixin):
 
         self.hub.subscribe(self, LineIdentifyMessage,
                            handler=self._process_identify_change)
+
+        self.hub.subscribe(self, SpectralMarksChangedMessage,
+                           handler=lambda x: self.update_line_mark_dict())
 
         # if set to auto (default), update the slider range when zooming on the spectrum viewer
         self._viewer.state.add_callback("x_min",

--- a/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
@@ -28,10 +28,11 @@ def test_line_lists(specviz_helper):
     assert len(specviz_helper.spectral_lines) == 2
     assert specviz_helper.spectral_lines.loc["linename", "Halpha"]["listname"] == "Custom"
     assert np.all(specviz_helper.spectral_lines["show"])
+    assert specviz_helper.plugins['Line Lists']._obj.rs_enabled is True
 
     specviz_helper.erase_spectral_lines()
-
     assert np.all(specviz_helper.spectral_lines["show"] == False)  # noqa
+    assert specviz_helper.plugins['Line Lists']._obj.rs_enabled is False
 
     specviz_helper.plot_spectral_line("Halpha")
     specviz_helper.plot_spectral_line("O III 5007.0")

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -181,6 +181,8 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
         self.spectral_lines.add_index("linename")
         self.spectral_lines.add_index("listname")
 
+        self._broadcast_plotted_lines()
+
         if return_table:
             return line_table
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes the redshift slider re-acting to helper methods: ``load_line_list``, ``plot_spectral_line``, ``plot_spectral_lines``, or ``erase_spectral_lines``.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #2013

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
