### PR TITLE
fix initial slice of uncert-viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,6 +89,8 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+* Fix initial slice of uncertainty viewer. [#2056]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.py
@@ -114,6 +114,7 @@ class Slice(PluginTemplateMixin):
             if len(msg.data.shape) == 3:
                 self.max_value = msg.data.shape[-1] - 1
                 self._watch_viewer(msg.viewer, True)
+                msg.viewer.state.slices = (0, 0, int(self.slice))
 
         elif isinstance(msg.viewer, BqplotProfileView):
             self._watch_viewer(msg.viewer, True)

--- a/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
@@ -18,9 +18,12 @@ def test_slice(cubeviz_helper, spectrum1d_cube):
     app.add_data(spectrum1d_cube, 'test')
     app.add_data_to_viewer("spectrum-viewer", "test")
     app.add_data_to_viewer("flux-viewer", "test")
+    app.add_data_to_viewer("uncert-viewer", "test")
 
     # sample cube only has 2 slices with wavelengths [4.62280007e-07 4.62360028e-07] m
     assert sl.slice == 1
+    assert cubeviz_helper.app.get_viewer("flux-viewer").state.slices[-1] == 1
+    assert cubeviz_helper.app.get_viewer("uncert-viewer").state.slices[-1] == 1
     cubeviz_helper.select_slice(0)
     assert sl.slice == 0
 
@@ -47,9 +50,8 @@ def test_slice(cubeviz_helper, spectrum1d_cube):
     sl._on_wavelength_updated({'new': '1.2.3'})
     assert sl.slice == 0
 
-    # there is only one watched viewer, since the uncertainty/mask viewers are empty
-    assert len(sl._watched_viewers) == 1
-    assert len(sl._indicator_viewers) == 1
+    assert len(sl._watched_viewers) == 2  # flux-viewer, uncert-viewer
+    assert len(sl._indicator_viewers) == 1  # spectrum-viewer
 
     # test setting a static 2d image to the "watched" flux viewer to make sure it disconnects
     mm = app.get_tray_item_from_name('cubeviz-moment-maps')
@@ -57,7 +59,7 @@ def test_slice(cubeviz_helper, spectrum1d_cube):
     with pytest.warns(UserWarning, match='No observer defined on WCS'):
         mm.vue_calculate_moment()
 
-    assert len(sl._watched_viewers) == 1
+    assert len(sl._watched_viewers) == 2
     assert len(sl._indicator_viewers) == 1
 
     # test in conjunction with as_steps


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes the initial state of the uncertainty viewer (and any additional viewers created after).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #2045

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
