### PR TITLE
TST: temporary fix for spectrum1d mask containing None

### DIFF
--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -504,6 +504,9 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
                     continue
                 else:
                     spec_normalized = spectrum / continuum
+                    if spec_normalized.mask is not None:
+                        spec_normalized.mask = spec_normalized.mask.astype(bool)
+
                     temp_result = FUNCTIONS[function](spec_normalized)
             elif function == "Centroid":
                 # TODO: update specutils to be consistent with region vs regions and default to

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -436,6 +436,11 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
 
         temp_results = []
         spec_subtracted = spectrum - continuum
+
+        if spec_subtracted.mask is not None:
+            # temporary fix while mask may contain None:
+            spec_subtracted.mask = spec_subtracted.mask.astype(bool)
+
         for function in FUNCTIONS:
             # TODO: update specutils to allow ALL analysis to take regions and continuum so we
             # don't need these if statements


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

On [recent dev tests](https://github.com/spacetelescope/jdaviz/actions/runs/4315440387/jobs/7529820535), there's an error from within specutils saying:

```
    def _compute_equivalent_width(spectrum, continuum=1, regions=None,
                                  mask_interpolation=LinearInterpolatedResampler):
        if regions is not None:
            spectrum = extract_region(spectrum, regions)
    
        # Account for the existence of a mask.
        if hasattr(spectrum, 'mask') and spectrum.mask is not None:
            mask = spectrum.mask
            spectrum = Spectrum1D(
>               flux=spectrum.flux[~mask],
                spectral_axis=spectrum.spectral_axis[~mask])
E           TypeError: bad operand type for unary ~: 'NoneType'
```

This PR is a candidate fix for the spatial subset mask troubles caused by changes on dev. It seems some `Spectrum1D` objects have masks containing `None` in addition to True/False. Casting to `bool` dodges errors by interpreting `None` as `False`.
 
<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
