### PR TITLE
SubsetSelect: fix type-detection of composite subsets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,6 +89,8 @@ Bug Fixes
 * Fixed redshift slider enabling/disabling when calling ``load_line_list``, ``plot_spectral_line``,
   ``plot_spectral_lines``, or ``erase_spectral_lines``. [#2055] 
 
+* Fixed detecting correct type of composite subsets in subset dropdowns in plugins. [#2058]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -897,6 +897,11 @@ class SubsetSelect(SelectPluginComponent):
 
     @staticmethod
     def _subset_type(subset):
+        while hasattr(subset.subset_state, 'state1'):
+            # this assumes no mixing between spatial and spectral subsets and just
+            # taking the first component (down the hierarchical tree) to determine the type
+            subset = subset.subset_state.state1
+
         if isinstance(subset.subset_state, RoiSubsetState):
             return 'spatial'
         else:

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -233,6 +233,29 @@ def test_region_spectral_spatial(cubeviz_helper, spectral_cube_wcs):
     assert len([m for m in spectrum_viewer.figure.marks if isinstance(m, ShadowSpatialSpectral)]) == 2  # noqa
 
 
+def test_disjoint_spatial_subset(cubeviz_helper, spectral_cube_wcs):
+    data = Data(flux=np.ones((128, 128, 256)), label='Test Flux', coords=spectral_cube_wcs)
+    cubeviz_helper.app.data_collection.append(data)
+
+    cubeviz_helper.app.add_data_to_viewer('spectrum-viewer', 'Test Flux')
+    cubeviz_helper.app.add_data_to_viewer('flux-viewer', 'Test Flux')
+
+    flux_viewer = cubeviz_helper.app.get_viewer("flux-viewer")
+    flux_viewer.apply_roi(CircularROI(xc=3, yc=4, radius=1))
+
+    mf = cubeviz_helper.plugins['Model Fitting']
+    assert len(mf.spatial_subset.choices) == 2  # 'Entire Cube' and Subset 1
+    assert len(mf.spectral_subset.choices) == 1  # 'Entire Spectrum'
+
+    # Add second region to Subset 1
+    cubeviz_helper.app.session.edit_subset_mode.mode = OrMode
+    flux_viewer.apply_roi(CircularROI(xc=1, yc=1, radius=1))
+
+    # regression test for https://github.com/spacetelescope/jdaviz/pull/2058
+    assert len(mf.spatial_subset.choices) == 2  # 'Entire Cube' and Subset 1
+    assert len(mf.spectral_subset.choices) == 1  # 'Entire Spectrum'
+
+
 def test_disjoint_spectral_subset(cubeviz_helper, spectral_cube_wcs):
     subset_plugin = cubeviz_helper.app.get_tray_item_from_name('g-subset-plugin')
     data = Data(flux=np.ones((128, 128, 256)), label='Test Flux', coords=spectral_cube_wcs)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes assigning composite subsets to the correct dropdowns (spatial vs spectral) by _assuming_ the subset is not mixed and taking the first item in the composite's tree and checking that type.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #2046

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
