### PR TITLE
Use get_data internally instead of get_data_from_viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,9 @@ API Changes
 
 - Export plot plugin now exposes the ``viewer`` dropdown in the user API. [#2037]
 
+- Replaced internal ``get_data_from_viewer()`` calls, ``specviz.get_spectra`` now returns
+  spectra for all data+subset combinations. [#2072]
+
 Cubeviz
 ^^^^^^^
 

--- a/docs/cubeviz/export_data.rst
+++ b/docs/cubeviz/export_data.rst
@@ -33,8 +33,9 @@ An example without accessing Specviz:
                                       statistic="mean")
 
 Note that in the above example, the ``statistic`` keyword is used to tell Cubeviz
-how to collapse the flux cube down to a one dimensional spectrum - this does not
-automatically match the collapse function used in the spectrum viewer.
+how to collapse the flux cube down to a one dimensional spectrum - this is not 
+necessarily equivalent to the collapsed spectrum in the spectrum viewer, which 
+may have used a different collapse statistic.
 
 To get all subsets from the spectrum viewer:
 

--- a/docs/cubeviz/export_data.rst
+++ b/docs/cubeviz/export_data.rst
@@ -28,7 +28,7 @@ An example without accessing Specviz:
 
 .. code-block:: python
 
-    subset1_spec1d = cubeviz.get_data(data_label = flux_data_label, 
+    subset1_spec1d = cubeviz.get_data(data_label=flux_data_label, 
                                       subset_to_apply="Subset 1",
                                       statistic="mean")
 

--- a/docs/cubeviz/export_data.rst
+++ b/docs/cubeviz/export_data.rst
@@ -22,13 +22,19 @@ can be used to extract the *spectrum* of a spatial subset named "Subset 1":
 
 .. code-block:: python
 
-    subset1_spec1d = cubeviz.specviz.get_spectra("Subset 1")
+    subset1_spec1d = cubeviz.specviz.get_spectra(subset_to_apply="Subset 1")
 
 An example without accessing Specviz:
 
 .. code-block:: python
 
-    subset1_spec1d = cubeviz.app.get_data_from_viewer("flux-viewer", data_label="Subset 1")
+    subset1_spec1d = cubeviz.get_data(data_label = flux_data_label, 
+                                      subset_to_apply="Subset 1",
+                                      statistic="mean")
+
+Note that in the above example, the ``statistic`` keyword is used to tell Cubeviz
+how to collapse the flux cube down to a one dimensional spectrum - this does not
+automatically match the collapse function used in the spectrum viewer.
 
 To get all subsets from the spectrum viewer:
 
@@ -57,42 +63,17 @@ The following line of code can be used to extract a spectral subset named "Subse
 
     subset2_spec1d = cubeviz.specviz.get_spectra("Subset 2")
 
-2D Images and 3D Data Cubes
-===========================
+3D Data Cubes
+=============
 
-2D images and 3D data cubes can be extracted from their respective
-:ref:`viewers <cubeviz-viewers>`. The viewer options in the Cubeviz configuration are
-``flux-viewer``, ``uncert-viewer``, and ``mask-viewer``.
-For example, to list the data available in a particular viewer:
+To extract the entire cube, you can run the following code (replace "data_name"
+with the name of the data you want to extract):
 
 .. code-block:: python
 
-    mydata = cubeviz.app.get_data_from_viewer("flux-viewer")
+    mydata = cubeviz.get_data(data_label="data_name")
 
-To extract the data you want (replace "data_name" with the name of your data):
-
-.. code-block:: python
-
-    mydata = cubeviz.app.get_data_from_viewer("uncert-viewer", "data_name")
-
-The data is returned as a ``glue-jupyter`` object.  To convert to a numpy array:
-
-.. code-block:: python
-
-    mydata_flux = mydata["flux"]
-
-To retrieve the data cube as a `specutils.Spectrum1D` object, you can do the following:
-
-.. code-block:: python
-
-    from specutils import Spectrum1D
-    mydata.get_object(cls=Spectrum1D, statistic=None)
-
-Alternatively, you can wrap this all into a single command:
-
-.. code-block:: python
-
-    mydata = cubeviz.app.get_data_from_viewer("uncert-viewer", "data_name")
+The data is returned as a 3D `specutils.Spectrum1D` object.
 
 To write out a `specutils.Spectrum1D` cube from Cubeviz
 (e.g., a fitted cube from :ref:`model-fitting`),

--- a/docs/specviz/export_data.rst
+++ b/docs/specviz/export_data.rst
@@ -35,6 +35,10 @@ To extract a spectrum with a spectral subset applied:
 
     specviz.get_data(spectrum_to_apply='Subset 1')
 
+In this case, the returned `specutils.Spectrum1D` object will have a ``mask``
+attribute, where ``True`` corresponds to the region outside the selected subset
+(i.e., the region that has been masked out).
+
 .. seealso::
 
     :ref:`Export From Plugins <specviz-plugins>`

--- a/docs/specviz/export_data.rst
+++ b/docs/specviz/export_data.rst
@@ -33,11 +33,19 @@ To extract a spectrum with a spectral subset applied:
 
 .. code-block:: python
 
-    specviz.get_data(spectrum_to_apply='Subset 1')
+    specviz.get_data(subset_to_apply='Subset 1')
 
 In this case, the returned `specutils.Spectrum1D` object will have a ``mask``
 attribute, where ``True`` corresponds to the region outside the selected subset
-(i.e., the region that has been masked out).
+(i.e., the region that has been masked out). You could load back in a copy of the
+spectrum containing only your subset by running:
+
+.. code-block:: python
+
+    spec = specviz.get_data(subset_to_apply='Subset 1')
+    subset_spec = Spectrum1D(flux=spec.flux[~spec.mask],
+                             spectral_axis=spec.spectral_axis[~spec.mask])
+    specviz.load_spectrum(subset_spec)
 
 .. seealso::
 

--- a/docs/specviz/export_data.rst
+++ b/docs/specviz/export_data.rst
@@ -14,28 +14,26 @@ those data currently back into your Jupyter notebook:
 
     specviz.get_spectra()
 
-which yields a `specutils.Spectrum1D` object that you can manipulate however
-you wish.  You can then load the modified spectrum back into the notebook via
-the API described in :ref:`specviz-import-api`.
+which yields a either a single `specutils.Spectrum1D` object or a dictionary of 
+`specutils.Spectrum1D` (if there are multiple displayed spectra) that you can
+manipulate however you wish.  You can then load the modified spectrum back into
+the notebook via the API described in :ref:`specviz-import-api`.
 
 Alternatively, if you want more control over Specviz, you can access it the
-via the lower-level application interface that connects to the ``glue-jupyter``
-application level.  This is accessed via the ``.app`` attribute of the
-:py:class:`~jdaviz.configs.specviz.helper.Specviz` helper class.  For example:
+via the ``get_data`` method of the
+:py:class:`~jdaviz.configs.specviz.helper.Specviz` helper class. This method always
+returns a single spectrum; if there are multiple spectra loaded you must supply a
+label to the ``data_label`` argument. For example:
 
 .. code-block:: python
 
-    specviz.app.get_data_from_viewer('spectrum-viewer')
+    specviz.get_data(data_label='Spectrum 1')
 
-To extract a specific spectral subset:
+To extract a spectrum with a spectral subset applied:
 
 .. code-block:: python
 
-    specviz.app.get_data_from_viewer('spectrum-viewer', 'Subset 1')
-
-For more on what you can do with this lower-level object, see the API sections
-and the
-`glue-jupyter documentation <https://glue-jupyter.readthedocs.io/en/latest/>`_.
+    specviz.get_data(spectrum_to_apply='Subset 1')
 
 .. seealso::
 

--- a/docs/specviz/plugins.rst
+++ b/docs/specviz/plugins.rst
@@ -213,9 +213,8 @@ The redshift itself can be set from the notebook using the ``set_redshift`` meth
 
 Any set redshift values are applied to spectra output using the
 :py:meth:`~jdaviz.configs.specviz.helper.Specviz.get_spectra` helper method.
-Note that using the lower-level app data retrieval (e.g.,
-``specviz.app.get_data_from_viewer()``) will return the data as
-originally loaded, with the redshift unchanged.
+Note that using the lower-level app data retrieval (e.g., ``specviz.get_data()``)
+will return the data as originally loaded, with the redshift unchanged.
 
 .. _line-analysis:
 

--- a/docs/specviz2d/export_data.rst
+++ b/docs/specviz2d/export_data.rst
@@ -10,19 +10,11 @@ Exporting Data From Specviz2D
 ==========
 
 Images in the 2D spectrum viewer can be exported as `specutils.Spectrum1D` objects into
-the notebook:
+the notebook (replace "2D data" with the lable of the desired data):
 
 .. code-block:: python
 
-    specviz2d.app.get_data_from_viewer('spectrum-2d-viewer')
-
-which returns a dictionary, with the loaded data labels as keywords and `specutils.Spectrum1D`
-objects as values.  To return only a single `specutils.Spectrum1D` object, pass the data label:
-
-.. code-block:: python
-
-    specviz2d.app.get_data_from_viewer('spectrum-2d-viewer', 'my-data-label')
-
+    specviz2d.get_data(data_label="2D data")
 
 .. _specviz2d-export-data-1d:
 
@@ -33,14 +25,7 @@ Similarly, the 1D spectrum data objects can be exported into the notebook:
 
 .. code-block:: python
 
-    specviz2d.app.get_data_from_viewer('spectrum-viewer')
-
-or:
-
-.. code-block:: python
-
-    specviz2d.app.get_data_from_viewer('spectrum-viewer', 'my-data-label')
-
+    specviz2d.get_data(data_label='1D data')
 
 An instance of Specviz can also be accessed, which exposes some helper methods from Specviz:
 

--- a/docs/specviz2d/export_data.rst
+++ b/docs/specviz2d/export_data.rst
@@ -10,7 +10,7 @@ Exporting Data From Specviz2D
 ==========
 
 Images in the 2D spectrum viewer can be exported as `specutils.Spectrum1D` objects into
-the notebook (replace "2D data" with the lable of the desired data):
+the notebook (replace "2D data" with the label of the desired data):
 
 .. code-block:: python
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
@@ -69,6 +69,8 @@ class TestLoadRegions(BaseRegionHandler):
         # https://github.com/spacetelescope/jdaviz/issues/1584
         with pytest.warns(UserWarning, match='Applying the value from the redshift slider'):
             spectral_subsets = self.cubeviz.specviz.get_spectra()
-        assert list(spectral_subsets.keys()) == ['has_microns[FLUX]', 'Subset 1', 'Subset 2'], spectral_subsets  # noqa
+        assert list(spectral_subsets.keys()) == ['has_microns[FLUX]',
+                                                 'has_microns[FLUX] (Subset 1)',
+                                                 'has_microns[FLUX] (Subset 2)'], spectral_subsets  # noqa
         for sp in spectral_subsets.values():
             assert isinstance(sp, Spectrum1D)

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -166,9 +166,7 @@ class LineListTool(PluginTemplateMixin):
 
         label = msg.data.label
         try:
-            viewer_data = self.app.get_data_from_viewer(
-                self._default_spectrum_viewer_reference_name
-            ).get(label)
+            viewer_data = self.app._jdaviz_helper.get_data(data_label=label)
         except TypeError:
             warn_message = SnackbarMessage("Line list plugin could not retrieve data from viewer",
                                            sender=self, color="error")

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -294,15 +294,20 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
     def _get_1d_spectrum(self):
         # retrieves the 1d spectrum (accounting for spatial subset for cubeviz, if necessary)
-        if self.config == 'cubeviz' and self.spatial_subset_selected != 'Entire Cube':
-            # then we're acting on the auto-collapsed data in the spectrum-viewer
-            # of a spatial subset.  In the future, we may want to expose on-the-fly
-            # collapse options... but right now these will follow the settings of the
-            # spectrum-viewer itself
-            return self.app.get_data_from_viewer(
-                                                 self._default_spectrum_viewer_reference_name,
-                                                 self.spatial_subset_selected
-                                                 )
+        if self.config == 'cubeviz':
+            stat = self.app.get_viewer(self._default_spectrum_viewer_reference_name).state.function
+            if self.spatial_subset_selected == 'Entire Cube':
+                return self.app._jdaviz_helper.get_data(data_label=self.dataset_selected,
+                                                        statistic=stat)
+            else:
+                # then we're acting on the auto-collapsed data in the spectrum-viewer
+                # of a spatial subset.  In the future, we may want to expose on-the-fly
+                # collapse options... but right now these will follow the settings of the
+                # spectrum-viewer itself
+                kwargs = {"data_label": self.dataset_selected,
+                          "subset_to_apply": self.spatial_subset_selected,
+                          "statistic": stat}
+                return self.app._jdaviz_helper.get_data(**kwargs)
         else:
             return self.dataset.selected_obj
 
@@ -321,7 +326,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
             IPyWidget callback event object. In this case, represents the data
             label of the data collection object selected by the user.
         """
-        if not hasattr(self, 'dataset'):
+        if not hasattr(self, 'dataset') or self.app._jdaviz_helper is None:
             # during initial init, this can trigger before the component is initialized
             return
 

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -327,9 +327,14 @@ class CoordsInfo(TemplateMixin):
                 if not isinstance(lyr.layer.subset_state, RoiSubsetState):
                     # then this is a SPECTRAL subset
                     continue
-            elif ((not isinstance(lyr.layer, BaseData)) or (lyr.layer.ndim not in (1, 3))
-                    or (not lyr.visible)):
+                # For use later in data retrieval
+                subset_label = lyr.layer.label
+                data_label = lyr.layer.data.label
+            elif ((not isinstance(lyr.layer, BaseData)) or (lyr.layer.ndim not in (1, 3))):
                 continue
+            else:
+                subset_label = None
+                data_label = lyr.layer.label
 
             try:
                 # Cache should have been populated when spectrum was first plotted.
@@ -339,7 +344,9 @@ class CoordsInfo(TemplateMixin):
                 if cache_key in self.app._get_object_cache:
                     sp = self.app._get_object_cache[cache_key]
                 else:
-                    sp = self.app.get_data_from_viewer('spectrum-viewer', lyr.layer.label)
+                    sp = self.app._jdaviz_helper.get_data(data_label=data_label,
+                                                          statistic=statistic,
+                                                          subset_to_apply=subset_label)
                     self.app._get_object_cache[cache_key] = sp
 
                 # Out of range in spectral axis.

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -106,6 +106,8 @@ class Specviz(ConfigHelper, LineListMixin):
                         spectra[lyr.label] = spectrum
 
         if not apply_slider_redshift:
+            if data_label is not None:
+                return spectra[data_label]
             return spectra
         else:
             output_spectra = {}

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -2,6 +2,7 @@ import warnings
 
 from astropy import units as u
 from astropy.utils.decorators import deprecated
+from glue.core.subset_group import GroupedSubset
 from specutils import SpectralRegion, Spectrum1D
 
 from jdaviz.core.helpers import ConfigHelper
@@ -67,20 +68,48 @@ class Specviz(ConfigHelper, LineListMixin):
                           show_in_viewer=show_in_viewer,
                           concat_by_file=concat_by_file)
 
-    def get_spectra(self, data_label=None, apply_slider_redshift="Warn"):
+    def get_spectra(self, data_label=None, subset_to_apply=None, apply_slider_redshift="Warn"):
         """Returns the current data loaded into the main viewer
 
         """
-        spectra = self.app.get_data_from_viewer(
-            self._default_spectrum_viewer_reference_name, data_label=data_label
-        )
+        spectra = {}
+        # Just to save line length
+        get_data_method = self.app._jdaviz_helper.get_data
+        viewer = self.app.get_viewer(self._default_spectrum_viewer_reference_name)
+        statistic = getattr(viewer, "function", None)
+
+        if data_label is not None:
+            spectrum = get_data_method(data_label=data_label,
+                                       subset_to_apply=subset_to_apply,
+                                       statistic=statistic)
+            spectra[data_label] = spectrum
+        else:
+            for layer_state in viewer.state.layers:
+                lyr = layer_state.layer
+                if subset_to_apply is not None:
+                    if lyr.label == subset_to_apply:
+                        spectrum = get_data_method(data_label=lyr.data.label,
+                                                   subset_to_apply=subset_to_apply,
+                                                   statistic=statistic)
+                        spectra[lyr.data.label] = spectrum
+                    else:
+                        continue
+                else:
+                    if isinstance(lyr, GroupedSubset):
+                        spectrum = get_data_method(data_label=lyr.data.label,
+                                                   subset_to_apply=lyr.label,
+                                                   statistic=statistic)
+                        spectra[f'{lyr.data.label} ({lyr.label})'] = spectrum
+                    else:
+                        spectrum = get_data_method(data_label=lyr.label,
+                                                   statistic=statistic)
+                        spectra[lyr.label] = spectrum
+
         if not apply_slider_redshift:
             return spectra
         else:
             output_spectra = {}
             # We need to create new Spectrum1D outputs with the redshifts set
-            if data_label is not None:
-                spectra = {data_label: spectra}
             for key in spectra.keys():
                 output_spectra[key] = _apply_redshift_to_spectra(spectra[key], self._redshift)
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -173,7 +173,10 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         if msg is None or msg.viewer_id != viewer_id or msg.data is None:
             return
 
-        viewer_data = self.app._jdaviz_helper.get_data(data_label=msg.data.label)
+        viewer = self.app.get_viewer(self._default_spectrum_viewer_reference_name)
+        statistic = getattr(viewer, 'function', None)
+        viewer_data = self.app._jdaviz_helper.get_data(data_label=msg.data.label,
+                                                       statistic=statistic)
 
         # If no data is currently plotted, don't attempt to update
         if viewer_data is None:
@@ -298,7 +301,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         Run the line analysis functions on the selected data/subset and
         display the results.
         """
-        if not hasattr(self, 'dataset'):
+        if not hasattr(self, 'dataset') or self.app._jdaviz_helper is None:
             # during initial init, this can trigger before the component is initialized
             return
 
@@ -312,14 +315,25 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         # show spinner with overlay
         self.results_computing = True
 
-        if (self.config == 'cubeviz' and self.spatial_subset_selected not in
-                (SPATIAL_DEFAULT_TEXT, "")):
-            # then we're acting on the auto-collapsed data in the spectrum-viewer
-            # of a spatial subset.  In the future, we may want to expose on-the-fly
-            # collapse options... but right now these will follow the settings of the
-            # spectrum-viewer itself
+        if self.config == 'cubeviz':
+            statistic = None
+            for viewer in self.dataset.viewers:
+                if hasattr(viewer.state, "function"):
+                    statistic = viewer.state.function
+                    break
+            subset_to_apply = None
+            if self.spatial_subset_selected not in (SPATIAL_DEFAULT_TEXT, ""):
+                # then we're acting on the auto-collapsed data in the spectrum-viewer
+                # of a spatial subset.  In the future, we may want to expose on-the-fly
+                # collapse options... but right now these will follow the settings of the
+                # spectrum-viewer itself
+                subset_to_apply = self.spatial_subset_selected
+
             full_spectrum = self.app._jdaviz_helper.get_data(
-                subset_to_apply=self.spatial_subset_selected)
+                data_label=self.dataset.selected,
+                subset_to_apply=subset_to_apply,
+                statistic=statistic)
+
         else:
             full_spectrum = self.dataset.selected_obj
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -173,9 +173,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         if msg is None or msg.viewer_id != viewer_id or msg.data is None:
             return
 
-        viewer_data = self.app.get_data_from_viewer(
-            self._default_spectrum_viewer_reference_name
-        ).get(msg.data.label)
+        viewer_data = self.app._jdaviz_helper.get_data(data_label=msg.data.label)
 
         # If no data is currently plotted, don't attempt to update
         if viewer_data is None:
@@ -320,10 +318,8 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
             # of a spatial subset.  In the future, we may want to expose on-the-fly
             # collapse options... but right now these will follow the settings of the
             # spectrum-viewer itself
-            full_spectrum = self.app.get_data_from_viewer(
-                self._default_spectrum_viewer_reference_name,
-                self.spatial_subset_selected
-            )
+            full_spectrum = self.app._jdaviz_helper.get_data(
+                subset_to_apply=self.spatial_subset_selected)
         else:
             full_spectrum = self.dataset.selected_obj
 
@@ -390,10 +386,8 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
                       'right': np.array([sr.upper.value, max(spectral_axis.value[continuum_mask])])}
 
         else:
-            continuum_mask = ~self.app.get_data_from_viewer(
-                self._default_spectrum_viewer_reference_name,
-                data_label=self.continuum_subset_selected
-            ).mask
+            continuum_mask = ~self.app._jdaviz_helper.get_data(
+                subset_to_apply=self.continuum_subset_selected).mask
             spectral_axis_nanmasked = spectral_axis.value.copy()
             spectral_axis_nanmasked[~continuum_mask] = np.nan
             if self.spectral_subset_selected == "Entire Spectrum":

--- a/jdaviz/configs/specviz/plugins/parsers.py
+++ b/jdaviz/configs/specviz/plugins/parsers.py
@@ -76,13 +76,13 @@ def specviz_spectrum1d_parser(app, data, data_label=None, format=None, show_in_v
             raise ValueError(f"Length of data labels list ({len(data_label)}) is different"
                              f" than length of list of data ({len(data)})")
 
-    # If there's already data in the viewer, convert units if needed
+    # If there's already visible data in the viewer, convert units if needed
     current_unit = None
     if spectrum_viewer_reference_name in app.get_viewer_reference_names():
-        current_spec = app.get_data_from_viewer(spectrum_viewer_reference_name)
-        if current_spec != {} and current_spec is not None:
-            spec_key = list(current_spec.keys())[0]
-            current_unit = current_spec[spec_key].spectral_axis.unit
+        sv = app.get_viewer(spectrum_viewer_reference_name)
+        for layer_state in sv.state.layers:
+            if layer_state.visible:
+                current_unit = sv.state.x_display_unit
 
     with app.data_collection.delay_link_manager_update():
         # these are used to build a combined spectrum with all

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -175,13 +175,13 @@ def test_get_spectra_no_spectra_redshift_error(specviz_helper, spectrum1d):
 
 def test_get_spectra_no_spectra_label(specviz_helper, spectrum1d):
     label = "label"
-    with pytest.raises(AttributeError):
+    with pytest.raises(ValueError):
         specviz_helper.get_spectra(data_label=label)
 
 
 def test_get_spectra_no_spectra_label_redshift_error(specviz_helper, spectrum1d):
     label = "label"
-    with pytest.raises(AttributeError):
+    with pytest.raises(ValueError):
         specviz_helper.get_spectra(data_label=label, apply_slider_redshift=True)
 
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -985,29 +985,20 @@ class SubsetSelect(SelectPluginComponent):
     @property
     def selected_subset_mask(self):
         if self._allowed_type == 'spatial':
-            viewer_ref = getattr(self.plugin,
-                                 '_default_flux_viewer_reference_name',
-                                 self.viewers[0].reference_id)
+            statistic = None
         elif self._allowed_type == 'spectral':
             viewer_ref = getattr(self.plugin,
                                  '_default_spectrum_viewer_reference_name',
                                  self.viewers[0].reference_id)
+            statistic = self.app.get_viewer(viewer_ref).state.function
 
-        subset = self.app.get_data_from_viewer(
-            viewer_ref, data_label=self.selected
-        )
+        data_label = self.plugin.dataset.selected
 
-        if hasattr(subset, 'mask'):
-            # the mask attr is available for spectral subsets:
-            subset_mask = subset.mask
-        else:
-            # `subset` is a GroupedSubset.
-            # We take the logical-not of the mask here, since the glue subset masks
-            # are True in selected regions and False outside. This is the opposite of
-            # the numpy/astropy/specutils convention where True is masked-out.
-            subset_mask = ~subset.to_mask()
+        subset = self.app._jdaviz_helper.get_data(data_label=data_label,
+                                                  subset_to_apply=self.selected,
+                                                  statistic=statistic)
 
-        return subset_mask
+        return subset.mask
 
     def selected_min_max(self, spectrum1d):
         if self.selected_obj is None:
@@ -1420,17 +1411,9 @@ class DatasetSelect(SelectPluginComponent):
         if self.selected not in self.labels:
             # _apply_default_selection will override shortly anyways
             return None
-        for viewer_ref in self.viewer_refs:
-            if viewer_ref is None:
-                # image viewers might not have a reference, but get_data_from_viewer
-                # does not take id
-                continue
-            match = self.app.get_data_from_viewer(viewer_ref, data_label=self.selected)
-            if match is not None:
-                if hasattr(match, 'get_object'):
-                    # cube viewers return the data collection instance from get_data_from_viewer
-                    return match.get_object(cls=self.default_data_cls)
-                return match
+        match = self.app._jdaviz_helper.get_data(data_label=self.selected)
+        if match is not None:
+            return match
         # handle the case of empty Application with no viewer, we'll just pull directly
         # from the data collection
         return self.get_object(cls=self.default_data_cls)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -984,7 +984,7 @@ class SubsetSelect(SelectPluginComponent):
 
     @property
     def selected_subset_mask(self):
-        if self._allowed_type == 'spatial':
+        if self._allowed_type == 'spatial' or self.app.config != 'cubeviz':
             statistic = None
         elif self._allowed_type == 'spectral':
             viewer_ref = getattr(self.plugin,

--- a/notebooks/CubevizExample.ipynb
+++ b/notebooks/CubevizExample.ipynb
@@ -161,7 +161,7 @@
     "my_aper = CircularAperture((15, 10), r=5)\n",
     "\n",
     "# regions shape\n",
-    "my_reg = CirclePixelRegion(center=PixCoord(x=35, y=40), radius=20)\n",
+    "my_reg = CirclePixelRegion(center=PixCoord(x=35, y=35), radius=10)\n",
     "\n",
     "my_regions = [my_aper, my_reg]\n",
     "cubeviz.load_regions(my_regions)"
@@ -197,9 +197,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "subset1_spec1d = spectra_dict['Subset 1']\n",
+    "subset1_spec1d = spectra_dict['jw02732-o004_t004_miri_ch1-shortmediumlong_s3d.fits[SCI] (Subset 1)']\n",
     "subset1_spec1d"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -218,7 +225,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/SpecvizExample.ipynb
+++ b/notebooks/SpecvizExample.ipynb
@@ -120,7 +120,7 @@
    "outputs": [],
    "source": [
     "# Returns a version of the whole spectra, with a mask applied\n",
-    "specviz.get_spectra('Subset 1')"
+    "specviz.get_spectra(data_label='myfile', subset_to_apply='Subset 1')"
    ]
   },
   {
@@ -281,7 +281,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Note that I left the call in `app.get_subsets_from_viewer`, since I think that will be part of @javerbukh's subset work, although I did implement something rather related in `specviz.get_spectra`. 

I believe there is one last failing test, and I probably need to get rid of some references to the old method in the docs. Other than that I think this is ready for other eyes.