### PR TITLE
BUG: Pressing l no longer update when Line Profiles plugin is closed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -104,6 +104,8 @@ Imviz
 * Fixed aperture and background dropdowns validation for Simple Aperture Photometry
   plugin. [#2032]
 
+* Line Profiles plugin no longer updates when "l" key is pressed while plugin is not opened. [#2073]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -79,7 +79,7 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
             if key_pressed in ('b', 'B'):
                 self.blink_once(reversed=key_pressed=='B')  # noqa: E225
 
-            elif key_pressed == 'l':
+            elif key_pressed == 'l' and self.line_profile_xy.plugin_opened:
                 # Same data as mousemove above.
                 image = self.active_image_layer.layer
                 x = data['domain']['x']

--- a/jdaviz/configs/imviz/tests/test_line_profile_xy.py
+++ b/jdaviz/configs/imviz/tests/test_line_profile_xy.py
@@ -64,3 +64,10 @@ class TestLineProfileXY(BaseImviz_WCS_NoWCS):
         assert lp_plugin.line_plot_across_x
         assert lp_plugin.line_plot_across_y
         assert lp_plugin.plot_available
+
+        # Nothing should update on "l" when plugin closed.
+        lp_plugin.plugin_opened = False
+        self.viewer.on_mouse_or_key_event(
+            {'event': 'keydown', 'key': 'l', 'domain': {'x': 5.1, 'y': 5}})
+        lp_plugin.selected_x = '1.1'
+        lp_plugin.selected_y = '9'


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to:

* fix #2064

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
