### PR TITLE
Backport PR 2073 to v3.3.x (BUG: Pressing l no longer update when Line Profiles plugin is closed)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ Imviz
 * Fixed aperture and background dropdowns validation for Simple Aperture Photometry
   plugin. [#2032]
 
+* Line Profiles plugin no longer updates when "l" key is pressed while plugin is not opened. [#2073]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -153,7 +153,7 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
                 data['event'] = 'mousemove'
                 self.on_mouse_or_key_event(data)
 
-            elif key_pressed == 'l':
+            elif key_pressed == 'l' and self.line_profile_xy.plugin_opened:
                 # Same data as mousemove above.
                 image = active_layer.layer
                 x = data['domain']['x']

--- a/jdaviz/configs/imviz/tests/test_line_profile_xy.py
+++ b/jdaviz/configs/imviz/tests/test_line_profile_xy.py
@@ -64,3 +64,10 @@ class TestLineProfileXY(BaseImviz_WCS_NoWCS):
         assert lp_plugin.line_plot_across_x
         assert lp_plugin.line_plot_across_y
         assert lp_plugin.plot_available
+
+        # Nothing should update on "l" when plugin closed.
+        lp_plugin.plugin_opened = False
+        self.viewer.on_mouse_or_key_event(
+            {'event': 'keydown', 'key': 'l', 'domain': {'x': 5.1, 'y': 5}})
+        lp_plugin.selected_x = '1.1'
+        lp_plugin.selected_y = '9'


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to manually backport #2073 to v3.3.x branch.
