### PR TITLE
POC: Speed tests for uncertainties in Specviz 

### DIFF
--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -439,10 +439,9 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
 
                 # The shaded band around the spectrum trace is bounded by
                 # two lines, above and below the spectrum trace itself.
-                data_x_list = np.ndarray.tolist(data_x)
-                x = [data_x_list, data_x_list]
-                y = [np.ndarray.tolist(data_y - error),
-                     np.ndarray.tolist(data_y + error)]
+                x = np.ndarray.tolist(data_x)
+                y = [np.ndarray.tolist(data_y + error),
+                     np.ndarray.tolist(data_y - error)]
 
                 if layer_state.as_steps:
                     for i in (0, 1):
@@ -451,7 +450,7 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
                         edges = (a + b) / 2
                         x[i] = np.concatenate((edges[:1], np.repeat(edges[1:-1], 2), edges[-1:]))
                         y[i] = np.repeat(y[i], 2)
-                x, y = np.asarray(x), np.asarray(y)
+                x, y = np.asarray(x), np.asarray(y).T
 
                 # A subclass of the bqplot Lines object, LineUncertainties keeps
                 # track of uncertainties plotted in the viewer. LineUncertainties
@@ -459,17 +458,14 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
                 color = layer_state.color
                 alpha_shade = layer_state.alpha / 3
                 error_line_mark = LineUncertainties(viewer=self,
-                                                    x=[x],
-                                                    y=[y],
+                                                    x=x,
+                                                    y=y,
                                                     scales=self.scales,
                                                     stroke_width=1,
-                                                    colors=[color, color],
-                                                    fill_colors=[color, color],
-                                                    opacities=[0.0, 0.0],
-                                                    fill_opacities=[alpha_shade,
-                                                                    alpha_shade],
-                                                    fill='between',
-                                                    close_path=False
+                                                    colors=[color],
+                                                    opacities=[alpha_shade],
+                                                    format='hl',
+                                                    marker='bar'
                                                     )
 
                 # Add error lines to viewer

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from astropy import units as u
 from bqplot import LinearScale
-from bqplot.marks import Lines, Label, Scatter
+from bqplot.marks import Lines, Label, Scatter, OHLC
 from copy import deepcopy
 from glue.core import HubListener
 from specutils import Spectrum1D
@@ -529,7 +529,7 @@ class LineAnalysisContinuumRight(LineAnalysisContinuumLeft):
     pass
 
 
-class LineUncertainties(Lines):
+class LineUncertainties(OHLC):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->
In #2039, @javerbukh commented that viewing spectra with uncertainties seemed a bit laggy (https://github.com/spacetelescope/jdaviz/pull/2039#issuecomment-1462720975). I did a tiny bit of recon to figure out if there's a simple fix. 

Currently uncertainties in Specviz are plotted as a filled ±one-sigma region. This PR implements an alternative uncertainty plotting method. 

There's a [mark in bqplot called `OHLC`](https://bqplot.readthedocs.io/en/stable/_generate/bqplot.marks.OHLC.html#bqplot.marks.OHLC) for making plots which look like this: https://github.com/bqplot/bqplot/issues/622#issuecomment-371568092. There are four vertical length properties that can be set on this type of marker: "Open, High, Low, and Close". If you call `OHLC(x, y, format='hl')`, it will generate vertical bars at each data point, spanning from "high" to "low" values given as a 2D vector `y`. This workaround might be the closest bqplot method to matplotlib's `errorbar` method. 

### Speed testing

The plot below shows the full runtime for loading a spectrum with uncertainties into Specviz and `show()`ing it, for spectra of different lengths:

![plot_uncertainties_ohlc](https://user-images.githubusercontent.com/3497584/225126693-d59fcaf6-4d61-42c7-9bc7-69dd1952cb80.png)

For reasons I don't yet understand, the shading implementation via `bqplot.marks.Lines` on `main` doesn't slow down much at all with more observations. The `OHLC` implementation appears to be up to 20% faster for very large spectra, but it's not clear based on JWST observations if we ever need to support that case. 

### Questions for discussion

1. Do we want a (possibly insignificantly) faster implementation (in the most common JWST use-cases)? 
2. Do we think the vertical errorbars are more distracting than shading? (Personally I think vertical errorbars are messier, but I'm also accustomed to looking at errorbars that way, so the messiness isn't troubling to me.)

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
