### PR TITLE
BUG: Pressing HOME no longer crashes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,9 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Pressing "Home" button on empty additional viewer when images are linked
+  by WCS no longer crashes. [#2082]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -328,6 +328,11 @@ class TestLink_GWCS_GWCS(BaseImviz_GWCS_GWCS):
         assert label_mouseover.row2_unreliable
         assert label_mouseover.row3_unreliable
 
+        # Regression test for https://github.com/spacetelescope/jdaviz/issues/2079 to
+        # make sure this does not crash.
+        viewer2 = self.imviz.create_image_viewer(viewer_name='second')
+        viewer2.state.reset_limits()
+
     def test_pixel_linking(self):
         self.imviz.link_data(link_type='pixels')
 

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -58,6 +58,9 @@ class FreezableBqplotImageViewerState(BqplotImageViewerState, FreezableState):
         super().__init__(*args, **kwargs)
 
     def reset_limits(self, *event):
+        if self.reference_data is None:  # Nothing to do
+            return
+
         wcs_success = False
         if self.linked_by_wcs and self.reference_data.coords is not None:
             x_min, x_max = np.inf, -np.inf


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Pressing HOME no longer crashes when images are linked by WCS and viewer is additional viewer and is empty. This bug is so obscure that I don't see much point in backporting.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #2079 

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
