### PR TITLE
Model fitting table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 New Features
 ------------
 
+* Model fitting results are logged in a table within the plugin [#2093].
+
 Cubeviz
 ^^^^^^^
 

--- a/docs/specviz/export_data.rst
+++ b/docs/specviz/export_data.rst
@@ -96,6 +96,17 @@ To extract all of the model parameters:
     myparams
 
 where the ``model_label`` parameter identifies which model should be returned.
+
+Alternatively, the table of logged parameter values in the model fitting plugin can be exported to
+an :ref:`astropy table <astropy:astropy-table>`
+by calling :meth:`~jdaviz.core.template_mixin.TableMixin.export_table` (see :ref:`plugin-apis`):
+
+.. code-block:: python
+
+    model_fitting = specviz.plugins['Model Fitting']
+    model_fitting.export_table()
+
+
 .. _specviz-export-markers:
 
 Markers Table

--- a/docs/specviz/plugins.rst
+++ b/docs/specviz/plugins.rst
@@ -103,6 +103,11 @@ show the fitted value of each parameter rather than the initial value, and
 will additionally show the standard deviation uncertainty of the fitted
 parameter value if the parameter was not set to be fixed to the initial value.
 
+Parameter values for each fitting run are stored in the plugin table.  
+To export the table into the notebook via the API, call
+:meth:`~jdaviz.core.template_mixin.TableMixin.export_table`
+(see :ref:`plugin-apis`).
+
 .. seealso::
 
     :ref:`Export Models <specviz-export-model>`

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -72,6 +72,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
 
         self.table.headers_avail = headers
         self.table.headers_visible = headers
+        self.table._default_values_by_colname = _default_table_values
 
         # subscribe to mouse events on any new viewers
         self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewer_added)

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -64,6 +64,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
     * :meth:`set_model_component`
     * :meth:`reestimate_model_parameters`
     * ``equation`` (:class:`~jdaviz.core.template_mixin.AutoTextField`)
+    * :meth:`equation_components`
     * ``cube_fit``
       Only exposed for Cubeviz.  Whether to fit the model to the cube instead of to the
       collapsed spectrum.
@@ -155,7 +156,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         self.residuals = AutoTextField(self, 'residuals_label', 'residuals_label_default',
                                        'residuals_label_auto', 'residuals_label_invalid_msg')
 
-        headers = ['model', 'data_label', 'spectral_subset']
+        headers = ['model', 'data_label', 'spectral_subset', 'equation']
         if self.config == 'cubeviz':
             headers += ['spatial_subset', 'cube_fit']
 
@@ -173,7 +174,8 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         expose += ['spectral_subset', 'model_component', 'poly_order', 'model_component_label',
                    'model_components', 'create_model_component', 'remove_model_component',
                    'get_model_component', 'set_model_component', 'reestimate_model_parameters',
-                   'equation', 'add_results', 'residuals_calculate', 'residuals']
+                   'equation', 'equation_components',
+                   'add_results', 'residuals_calculate', 'residuals']
         if self.config == "cubeviz":
             expose += ['cube_fit']
         expose += ['calculate_fit', 'clear_table', 'export_table']
@@ -637,6 +639,13 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         List of the labels of existing model components
         """
         return [x["id"] for x in self.component_models]
+
+    @property
+    def equation_components(self):
+        """
+        List of the labels of model components in the current equation
+        """
+        return re.split('[+*/-]', self.equation.value)
 
     def vue_add_model(self, event):
         self.create_model_component()

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -713,7 +713,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         else:
             ret = self._fit_model_to_spectrum(add_data=add_data)
 
-        if ret is None:
+        if ret is None:  # pragma: no cover
             # something went wrong in the fitting call and (hopefully) already raised a warning,
             # but we don't have anything to add to the table
             return ret
@@ -740,7 +740,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         return ret
 
     def vue_apply(self, event):
-        return self.calculate_fit()
+        self.calculate_fit()
 
     def _fit_model_to_spectrum(self, add_data):
         """

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -718,6 +718,10 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
             # but we don't have anything to add to the table
             return ret
 
+        if self.cube_fit:
+            # cube fits are currently unsupported in tables
+            return ret
+
         row = {'model': self.results_label if add_data else '',
                'data_label': self.dataset_selected,
                'spectral_subset': self.spectral_subset_selected,

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -164,7 +164,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         self.table.headers_visible = headers
         # when model parameters are added as columns, only show the value columns by default
         # (other columns can be show in the dropdown by the user)
-        self.table._new_col_visible = lambda colname: colname.split(':')[-1] not in ('unit', 'fixed', 'uncert')  # noqa
+        self.table._new_col_visible = lambda colname: colname.split(':')[-1] not in ('unit', 'fixed', 'uncert', 'std')  # noqa
 
         # set the filter on the viewer options
         self._update_viewer_filters()
@@ -544,6 +544,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         comp = {"model_type": model_component['model_type'],
                 "parameters": {p['name']: {'value': p['value'],
                                            'unit': p['unit'],
+                                           'std': p.get('std', np.nan),
                                            'fixed': p['fixed']} for p in model_component['parameters']}}  # noqa
 
         if parameter is not None:
@@ -732,7 +733,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
                 row[colprefix] = param_dict.get('value')
                 row[f"{colprefix}:unit"] = param_dict.get('unit')
                 row[f"{colprefix}:fixed"] = param_dict.get('fixed')
-#                row[f"{colprefix}:uncert"] = param_dict.get('uncert')
+                row[f"{colprefix}:std"] = param_dict.get('std')
 
         self.table.add_item(row)
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -219,6 +219,12 @@
         ></v-switch>
       </v-row>
 
+      <v-row v-if="cube_fit">
+        <span class="v-messages v-messages__message text--secondary">
+            Note: cube fit results are not logged to table.
+        </span>
+      </v-row>
+
       <plugin-add-results
         :label.sync="results_label"
         :label_default="results_label_default"

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -267,6 +267,9 @@
             If fit is not sufficiently converged, click Fit Model again to run additional iterations.
         </span>
       </v-row>
+
+      <j-plugin-section-header>Results History</j-plugin-section-header>
+      <jupyter-widget :widget="table_widget"></jupyter-widget> 
     </div>
   </j-tray-plugin>
 </template>

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -263,3 +263,42 @@ def test_cube_fitting_backend(cubeviz_helper, unc, tmp_path):
     data_mask = cubeviz_helper.app.data_collection["fitted_cube.fits[MASK]"]
     flux_mask = data_mask.get_component("flux")
     assert_array_equal(flux_mask.data, mask)
+
+
+@pytest.mark.filterwarnings(r"ignore:Model is linear in parameters.*")
+@pytest.mark.filterwarnings(r"ignore:The fit may be unsuccessful.*")
+def test_results_table(specviz_helper, spectrum1d):
+    data_label = 'test'
+    specviz_helper.load_data(spectrum1d, data_label=data_label)
+
+    mf = specviz_helper.plugins['Model Fitting']
+    mf.create_model_component('Linear1D')
+
+    mf.add_results.label = 'linear model'
+    mf.calculate_fit(add_data=True)
+    mf_table = mf.export_table()
+    assert len(mf_table) == 1
+    assert mf_table['equation'][-1] == 'L'
+    assert mf_table.colnames == ['model', 'data_label', 'spectral_subset', 'equation',
+                                 'L:slope_0', 'L:slope_0:unit',
+                                 'L:slope_0:fixed', 'L:slope_0:std',
+                                 'L:intercept_0', 'L:intercept_0:unit',
+                                 'L:intercept_0:fixed', 'L:intercept_0:std']
+
+    mf.create_model_component('Gaussian1D')
+    mf.add_results.label = 'composite model'
+    mf.calculate_fit(add_data=True)
+    mf_table = mf.export_table()
+    assert len(mf_table) == 2
+    assert mf_table['equation'][-1] == 'L+G'
+    assert mf_table.colnames == ['model', 'data_label', 'spectral_subset', 'equation',
+                                 'L:slope_0', 'L:slope_0:unit',
+                                 'L:slope_0:fixed', 'L:slope_0:std',
+                                 'L:intercept_0', 'L:intercept_0:unit',
+                                 'L:intercept_0:fixed', 'L:intercept_0:std',
+                                 'G:amplitude_1', 'G:amplitude_1:unit',
+                                 'G:amplitude_1:fixed', 'G:amplitude_1:std',
+                                 'G:mean_1', 'G:mean_1:unit',
+                                 'G:mean_1:fixed', 'G:mean_1:std',
+                                 'G:stddev_1', 'G:stddev_1:unit',
+                                 'G:stddev_1:fixed', 'G:stddev_1:std']

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2293,6 +2293,8 @@ class Table(PluginSubcomponent):
     """
     template_file = __file__, "../components/plugin_table.vue"
 
+    _default_values_by_colname = {}
+
     headers_visible = List([]).tag(sync=True)  # list of strings
     headers_avail = List([]).tag(sync=True)   # list of strings
     items = List().tag(sync=True)  # list of dictionaries, pass single dict to add_row
@@ -2300,6 +2302,17 @@ class Table(PluginSubcomponent):
     def __init__(self, plugin, *args, **kwargs):
         self._qtable = None
         super().__init__(plugin, 'Table', *args, **kwargs)
+
+    def default_value_for_column(self, colname=None, value=None):
+        if colname in self._default_values_by_colname:
+            return self._default_values_by_colname.get(colname)
+        if isinstance(value, (tuple, list)):
+            return [self.default_value_for_column(value=v) for v in value]
+        if isinstance(value, (float, int)):
+            return np.nan
+        if isinstance(value, str):
+            return ''
+        return None
 
     def add_item(self, item):
         """
@@ -2351,9 +2364,20 @@ class Table(PluginSubcomponent):
         if self._qtable is None:
             self._qtable = QTable([item])
         else:
-            # NOTE: this does not support adding columns that did not exist in the first
-            # call to add_row since the last call to clear_table
+            # add any missing columns with a default value for all previous rows
+            for colname, value in item.items():
+                if colname in self._qtable.colnames:
+                    continue
+                default_value = self.default_value_for_column(colname=colname,
+                                                              value=value)
+                self._qtable.add_column(default_value, name=colname)
+
             self._qtable.add_row(item)
+
+        missing_headers = [k for k in item.keys() if k not in self.headers_avail]
+        if len(missing_headers):
+            self.headers_avail = self.headers_avail + missing_headers
+            self.headers_visible = self.headers_visible + missing_headers
 
         # clean data to show in the UI
         self.items = self.items + [{k: json_safe(k, v) for k, v in item.items()}]

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2314,6 +2314,10 @@ class Table(PluginSubcomponent):
             return ''
         return None
 
+    @staticmethod
+    def _new_col_visible(colname):
+        return True
+
     def add_item(self, item):
         """
         Add an item/row to the table.
@@ -2377,7 +2381,7 @@ class Table(PluginSubcomponent):
         missing_headers = [k for k in item.keys() if k not in self.headers_avail]
         if len(missing_headers):
             self.headers_avail = self.headers_avail + missing_headers
-            self.headers_visible = self.headers_visible + missing_headers
+            self.headers_visible = self.headers_visible + [m for m in missing_headers if self._new_col_visible(m)]  # noqa
 
         # clean data to show in the UI
         self.items = self.items + [{k: json_safe(k, v) for k, v in item.items()}]

--- a/setup.cfg
+++ b/setup.cfg
@@ -108,7 +108,6 @@ filterwarnings =
     ignore::DeprecationWarning:bqscales
     ignore::DeprecationWarning:traittypes
     ignore::DeprecationWarning:voila
-    ignore::DeprecationWarning:ipykernel
     ignore:::specutils.spectra.spectrum1d
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -108,6 +108,7 @@ filterwarnings =
     ignore::DeprecationWarning:bqscales
     ignore::DeprecationWarning:traittypes
     ignore::DeprecationWarning:voila
+    ignore::DeprecationWarning:ipykernel
     ignore:::specutils.spectra.spectrum1d
 
 [flake8]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request uses the table subcomponent to log results from model fitting.

[updated model fitting plugin docs](https://jdaviz--2093.org.readthedocs.build/en/2093/specviz/plugins.html#model-fitting)

#### Caveats:
* does not store initial state ~or fixed state~ of parameters (do we want this?)
* ~does not account for the possibility of different model components having the same parameter name and index combination.  This just stores the information as it is stored internally in astropy (see video for example)~
* "model" is stored when it is added.  If the user overwrites an existing model, there will be two table entries with the same model label and would need to realize that the later one corresponds to the one currently loaded in the app (and available via `viz.get_models()`.
* doesn't really translate well to cube fit models (~currently resulting in failed tests~, cube fits are not added to the table)... how do we want to represent these in the table?  ~Or do we just skip them?~  Or transpose the information and have each parameter be an array (single parameter-value per-fitted-pixel)?

https://user-images.githubusercontent.com/877591/225989685-a572d0d6-0e64-439c-9ade-eb9dfe74f488.mov

#### TODO:
- [x] add support for uncertainties (https://github.com/spacetelescope/jdaviz/pull/2093#issuecomment-1474312662)
- [x] handle (or skip) cube fit case
- [x] documentation
- [x] test coverage

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

```
* Model fitting results are logged in a table within the plugin [#2093].
```

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
