### PR TITLE
Bug fixes for get_spectra in other configs

### DIFF
--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -95,9 +95,7 @@ class Specviz(ConfigHelper, LineListMixin):
                                                    subset_to_apply=subset_to_apply,
                                                    statistic=statistic,
                                                    cls=Spectrum1D)
-                        # Work around get_data returning Data even with cls specified
-                        if isinstance(spectrum, Spectrum1D):
-                            spectra[lyr.data.label] = spectrum
+                        spectra[lyr.data.label] = spectrum
                     else:
                         continue
                 else:
@@ -106,9 +104,7 @@ class Specviz(ConfigHelper, LineListMixin):
                                                    subset_to_apply=lyr.label,
                                                    statistic=statistic,
                                                    cls=Spectrum1D)
-                        # Work around get_data returning Data even with cls specified
-                        if isinstance(spectrum, Spectrum1D):
-                            spectra[f'{lyr.data.label} ({lyr.label})'] = spectrum
+                        spectra[f'{lyr.data.label} ({lyr.label})'] = spectrum
                     else:
                         spectrum = get_data_method(data_label=lyr.label,
                                                    statistic=statistic,

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -76,12 +76,15 @@ class Specviz(ConfigHelper, LineListMixin):
         # Just to save line length
         get_data_method = self.app._jdaviz_helper.get_data
         viewer = self.app.get_viewer(self._default_spectrum_viewer_reference_name)
-        statistic = getattr(viewer, "function", None)
+        statistic = None
+        if self.app.config == "cubeviz":
+            statistic = getattr(viewer.state, "function")
 
         if data_label is not None:
             spectrum = get_data_method(data_label=data_label,
                                        subset_to_apply=subset_to_apply,
-                                       statistic=statistic)
+                                       statistic=statistic,
+                                       cls=Spectrum1D)
             spectra[data_label] = spectrum
         else:
             for layer_state in viewer.state.layers:
@@ -90,19 +93,26 @@ class Specviz(ConfigHelper, LineListMixin):
                     if lyr.label == subset_to_apply:
                         spectrum = get_data_method(data_label=lyr.data.label,
                                                    subset_to_apply=subset_to_apply,
-                                                   statistic=statistic)
-                        spectra[lyr.data.label] = spectrum
+                                                   statistic=statistic,
+                                                   cls=Spectrum1D)
+                        # Work around get_data returning Data even with cls specified
+                        if isinstance(spectrum, Spectrum1D):
+                            spectra[lyr.data.label] = spectrum
                     else:
                         continue
                 else:
                     if isinstance(lyr, GroupedSubset):
                         spectrum = get_data_method(data_label=lyr.data.label,
                                                    subset_to_apply=lyr.label,
-                                                   statistic=statistic)
-                        spectra[f'{lyr.data.label} ({lyr.label})'] = spectrum
+                                                   statistic=statistic,
+                                                   cls=Spectrum1D)
+                        # Work around get_data returning Data even with cls specified
+                        if isinstance(spectrum, Spectrum1D):
+                            spectra[f'{lyr.data.label} ({lyr.label})'] = spectrum
                     else:
                         spectrum = get_data_method(data_label=lyr.label,
-                                                   statistic=statistic)
+                                                   statistic=statistic,
+                                                   cls=Spectrum1D)
                         spectra[lyr.label] = spectrum
 
         if not apply_slider_redshift:


### PR DESCRIPTION
This fixes two bugs:

- `cubeviz.specviz.get_spectra` now properly retrieves the collapsed spectra rather than the whole cubes.
- `mosviz.specviz.get_spectra` no longer hits an `AttributeError` if there's a spatial subset defined. 

In regards to the second one, I think that is actually a `get_data` bug, since it's returning a Glue Data objects even with `cls=Spectrum1D` set in the internal `get_data` call. A better fix would be to either filter out spatial subset here in `get_spectra` if the config is Mosviz, or to fix the underlying behavior in `get_data`. But this simple fix was the fastest thing to get in - if there are objections to this, I'll look into more later this afternoon.