### PR TITLE
aperture photometry: do not hide prev results when resetting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,9 @@ Cubeviz
 Imviz
 ^^^^^
 
+* Do not hide previous results in aperture photometry when there is a failure, but rather show
+  the failure message within the plugin UI to indicate the shown results are "out of date". [#2112]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -45,6 +45,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin, TableMix
     counts_factor = Any(0).tag(sync=True)
     flux_scaling = Any(0).tag(sync=True)
     result_available = Bool(False).tag(sync=True)
+    result_failed_msg = Unicode("").tag(sync=True)
     results = List().tag(sync=True)
     plot_types = List([]).tag(sync=True)
     current_plot_type = Unicode().tag(sync=True)
@@ -420,10 +421,11 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin, TableMix
 
         except Exception as e:  # pragma: no cover
             bqplot_clear_figure(self._fig)
-            self.hub.broadcast(SnackbarMessage(
-                f"Aperture photometry failed: {repr(e)}", color='error', sender=self))
-
+            msg = f"Aperture photometry failed: {repr(e)}"
+            self.hub.broadcast(SnackbarMessage(msg, color='error', sender=self))
+            self.result_failed_msg = msg
         else:
+            self.result_failed_msg = ''
             self._fig.marks = bqplot_marks
 
             # Parse results for GUI.

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -139,6 +139,12 @@
       </div>
     </div>
 
+    <v-row v-if="result_failed_msg.length > 0">
+      <span class="v-messages v-messages__message text--secondary" style="color: red !important">
+          <b>WARNING</b>: {{result_failed_msg}}
+      </span>
+    </v-row>
+
     <v-row v-if="plot_available">
       <!-- NOTE: the internal bqplot widget defaults to 480 pixels, so if choosing something else,
            we will likely need to override that with custom CSS rules in order to avoid the initial


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request prevents resetting the internal traitlets in aperture photometry when failing to find a dataset/subset or raising an error, and only clears them when needed for the next successful run.  This also then keeps the log table visible.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #2111

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
