### PR TITLE
support cubeviz.get_data(function=True)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ New Features
 Cubeviz
 ^^^^^^^
 
+* get_data now supports ``function=True`` to adopt the collapse-function from the spectrum viewer
+  [#2117].
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -133,9 +133,11 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
             The type that data will be returned as.
         subset_to_apply : str, optional
             Subset that is to be applied to data before it is returned.
-        function : {'minimum', 'maximum', 'mean', 'median', 'sum'}, optional
-            If provided and not ``None`` and ``data_label`` points to cube-like data, the cube will
-            be collapsed with the provided function.  Otherwise the entire cube will be returned.
+        function : {True, False, 'minimum', 'maximum', 'mean', 'median', 'sum'}, optional
+            Ignored if ``data_label`` does not point to cube-like data.
+            If True, will collapse according to the current collapse function defined in the
+            spectrum viewer.  If provided as a string, the cube will be collapsed with the provided
+            function.  If False, None, or not passed, the entire cube will be returned.
 
         Returns
         -------
@@ -143,6 +145,11 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
             Data is returned as type cls with subsets applied.
 
         """
+        if function is True:
+            return self.specviz.get_data(data_label=data_label, cls=cls,
+                                         subset_to_apply=subset_to_apply)
+        elif function is False:
+            function = None
         return self._get_data(data_label=data_label, cls=cls, subset_to_apply=subset_to_apply,
                               function=function)
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
@@ -40,6 +40,17 @@ def test_valid_function(cubeviz_helper, spectrum1d_cube):
     cubeviz_helper.load_data(spectrum1d_cube, "test")
     cubeviz_helper._apply_interactive_region('bqplot:ellipse', (0, 0), (9, 8))
 
+    results_cube = cubeviz_helper.get_data(data_label="test[FLUX]",
+                                           subset_to_apply='Subset 1')
+    assert results_cube.flux.ndim == 3
+    results_false = cubeviz_helper.get_data(data_label="test[FLUX]",
+                                            subset_to_apply='Subset 1', function=False)
+    assert results_false.flux.ndim == 3
+
+    results_def = cubeviz_helper.get_data(data_label="test[FLUX]",
+                                          subset_to_apply='Subset 1', function=True)
+    assert results_def.flux.ndim == 1
+
     results_min = cubeviz_helper.get_data(data_label="test[FLUX]",
                                           subset_to_apply='Subset 1', function="minimum")
     results_max = cubeviz_helper.get_data(data_label="test[FLUX]",


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request extends #1984, #2072, and #2106 to add support for `cubeviz.get_data(..., function=True)` which looks up and adopts the collapse-function from the spectrum-viewer to return the collapsed spectrum.

Compare the following:
```
cubeviz.get_data(...) # cube
cubeviz.get_data(..., function=True) # collapsed spectrum
cubeviz.specviz.get_data(...) # collapsed spectrum, same as above
cubeviz.get_data(..., funtion='minimum') # collapsed spectrum, overrides function from that set in the viewer
```

Should this motivate changing the kwarg from "function" to "collapse"?  Would that be more intuitive to the user?  (Ah, but that was already released in 3.4 so probably shouldn't break existing API... would `function='viewer'` be better?

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
