### PR TITLE
display units: cubeviz/slice plugin

### DIFF
--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -54,7 +54,7 @@ class UnitConversion(PluginTemplateMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if self.config not in ['specviz']:
+        if self.config not in ['specviz', 'cubeviz']:
             # TODO [specviz2d, mosviz] x_display_unit is not implemented in glue for image viewer
             # used by spectrum-2d-viewer
             # TODO [mosviz]: add to yaml file

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -413,6 +413,8 @@ class ConfigHelper(HubListener):
             if use_display_units:
                 if isinstance(data, Spectrum1D):
                     spectral_unit = self.app._get_display_unit('spectral')
+                    if not spectral_unit:
+                        return data
                     flux_unit = self.app._get_display_unit('flux')
                     # TODO: any other attributes (meta, wcs, etc)?
                     # TODO: implement uncertainty.to upstream

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -268,7 +268,7 @@ class SliceIndicatorMarks(BaseSpectrumVerticalLine, HubListener):
         self.colors = ["#c75109" if self._active else "#007BA1"]
         self.opacities = [1.0 if self._active else 0.9]
 
-    def _on_change_state(self, msg):
+    def _on_change_state(self, msg={}):
         if isinstance(msg, dict):
             changes = msg
         else:


### PR DESCRIPTION


<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request enables the unit conversion plugin in cubeviz and adds support for the slice plugin/indicator.  The slice slider is always in order of _increasing slice_, so will not necessarily correspond to the positive x-direction on the viewer if switched from wavelength > frequency (or vice versa, depending on the original native units).  


https://user-images.githubusercontent.com/877591/230168474-3b19792e-4d3a-4bde-bb96-8ccd250e812c.mov



Note that we might want to generalize some of this logic more into the mark's `_update_data` when adding support for spectral lines as well.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
