### PR TITLE
Histogram using glue-jupyter native viewer

### DIFF
--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -385,7 +385,7 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
         data_already_linked = [link.data2 for link in app.data_collection.external_links]
     else:
         for viewer in app._viewer_store.values():
-            if len(viewer._marktags):
+            if hasattr(viewer, '_marktags') and len(viewer._marktags) > 0:
                 raise ValueError(f"cannot change link_type (from '{app._link_type}' to "
                                  f"'{link_type}') when markers are present. "
                                  f" Clear markers with viewer.reset_markers() first")

--- a/jdaviz/configs/imviz/imviz.yaml
+++ b/jdaviz/configs/imviz/imviz.yaml
@@ -37,3 +37,6 @@ viewer_area:
           - name: imviz-0
             plot: imviz-image-viewer
             reference: imviz-0
+          - name: imviz-1
+            plot: imviz-histogram-viewer
+            reference: imviz-1

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -3,6 +3,7 @@ import numpy as np
 from astropy.wcs.utils import pixel_to_pixel
 from astropy.visualization import ImageNormalize, LinearStretch, PercentileInterval
 from glue.core.link_helpers import LinkSame
+from glue_jupyter.bqplot.histogram import BqplotHistogramView
 from glue_jupyter.bqplot.image import BqplotImageView
 
 from jdaviz.configs.imviz import wcs_utils
@@ -14,7 +15,38 @@ from jdaviz.core.registries import viewer_registry
 from jdaviz.core.freezable_state import FreezableBqplotImageViewerState
 from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
 
-__all__ = ['ImvizImageView']
+__all__ = ['ImvizImageView', 'ImvizHistogramView']
+
+
+@viewer_registry("imviz-histogram-viewer", label="Histogram (Imviz)")
+class ImvizHistogramView(JdavizViewerMixin, BqplotHistogramView):
+    # TODO: Use Jdaviz tools? Generalize and move to configs/default?
+    tools_nested = [
+                    ['jdaviz:homezoom'],
+                    ['bqplot:panzoom'],
+                    ['bqplot:xrange']
+                   ]
+    default_class = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.update_n_bin(25)  # Started out 15, not sure what set it
+
+    def update_n_bin(self, n_bin):
+        # TODO: Do we really need this method? Better way to expose viewer settings?
+        self.state.hist_n_bin = n_bin
+
+    def update_limits(self):
+        # TODO: Make this less hacky. Basically we want some reasonable min/max for X-axis.
+        # hv = imviz.app.get_viewer_by_id('imviz-1')
+        # hv.update_limits()
+        im_cuts = self.jdaviz_helper.default_viewer.cuts
+        self.state.hist_x_min = im_cuts[0]
+        self.state.hist_x_max = im_cuts[1]
+
+    # TODO: Need this so Imviz does not crash. Maybe there is a better way?
+    def on_limits_change(self, *args):
+        pass
 
 
 @viewer_registry("imviz-image-viewer", label="Image 2D (Imviz)")


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is an alternative to #2097 using native glue-jupyter histogram viewer rather than rolling our own. This way, hopefully we can take advantage of viewer magic from upstream. I know the histogram viewer works decently well in Qt version of glue, but not sure about this glue-jupyter version using bqplot (seems pretty barebone so we might need to patch it up over at glue-jupyter too).

![Screenshot 2023-04-11 125338](https://user-images.githubusercontent.com/2090236/231237380-617fe9d8-cea1-4247-b187-d1b3b8039d2b.jpg)

Plot Options is pretty useless right now (see TODO below) but you can programmatically customize the viewer like this:

```python
imviz.app.add_data_to_viewer('imviz-1', imviz.app.data_collection[0].label)
hv = imviz.app.get_viewer_by_id('imviz-1')
hv.update_n_bin(20)
hv.update_limits()
```

### TODO

- [ ] Hook this new viewer up properly to the rest of Jdaviz. Right now, it does not listen to our events and seems to have broken Subset selection over at image viewer. Might even have to patch the JdavizViewerMixin to account for this new type of viewer.
- [ ] Make the plot axes more readable.
- [ ] Some of the plot area picked up my PC's dark mode, which did not go well with notebook. Probably needs to patch its Vue.js element upstream.
- [ ] Have a way to let user re-open the histogram viewer from a button. Right now, if you click "x" on it, it goes way and does not come back easily.
- [ ] Plot options does not expose things like bins and limits, see here for all available settings under the hood (via `viewer.state`): https://github.com/glue-viz/glue/blob/bd257e5bb8cc83719645ede1b5beb344344e3677/glue/viewers/histogram/state.py#L20

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3174)
