### PR TITLE
basic single-viewer/layer histogram in plot options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ New Features
 
 - Update Subset Plugin to utilize ``get_subsets()``. [#2157]
 
+- Histogram showing image values in stretch limits section of plot options plugin. [#2153]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -444,6 +444,10 @@ class PlotOptions(PluginTemplateMixin):
             # include all data, regardless of zoom limits
             sub_data = comp.data.ravel()
 
+        # filter out nans (or else bqplot will fail)
+        if np.any(np.isnan(sub_data)):
+            sub_data = sub_data[~np.isnan(sub_data)]
+
         if self.stretch_histogram is None:
             # first time the figure is requested, need to build from scratch
             self.stretch_histogram = bqplot.Figure(padding_y=0)

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -415,9 +415,10 @@ class PlotOptions(PluginTemplateMixin):
             hist_x_sc = bqplot.LinearScale()
             hist_y_sc = bqplot.LinearScale()
             # TODO: Let user change the number of bins?
-            hist_mark = bqplot.Hist(sample=sub_data, bins=50, colors="gray",
-                                    scales={"sample": hist_x_sc, "count": hist_y_sc})
-            hist_mark.fig_margin = {'top': 60, 'bottom': 60, 'left': 40, 'right': 10}
+            # TODO: Let user set y-scale to log
+            hist_mark = bqplot.Bins(sample=sub_data, bins=50, colors="gray",
+                                    scales={'x': hist_x_sc,
+                                            'y': hist_y_sc})
 
             self.stretch_histogram.marks = [hist_mark]
             self.stretch_histogram.axes = [bqplot.Axis(scale=hist_x_sc,
@@ -435,9 +436,8 @@ class PlotOptions(PluginTemplateMixin):
             hist_mark.sample = sub_data
 
             # TODO: Let user change the number of bins?
+            # TODO: Let user set y-scale to log
 
         interval = PercentileInterval(95)
         hist_lims = interval.get_limits(sub_data)
-
-        hist_mark.scales['sample'].min = hist_lims[0]
-        hist_mark.scales['sample'].max = hist_lims[1]
+        hist_mark.min, hist_mark.max = hist_lims

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -435,17 +435,20 @@ class PlotOptions(PluginTemplateMixin):
             hist_y_sc = bqplot.LinearScale()
             # TODO: Let user change the number of bins?
             # TODO: Let user set y-scale to log
-            hist_mark = bqplot.Bins(sample=sub_data, bins=50, colors="gray",
+            hist_mark = bqplot.Bins(sample=sub_data, bins=25,
+                                    density=True, colors="gray",
                                     scales={'x': hist_x_sc,
                                             'y': hist_y_sc})
 
             self.stretch_histogram.marks = [hist_mark]
             self.stretch_histogram.axes = [bqplot.Axis(scale=hist_x_sc,
+                                                       num_ticks=3,
                                                        tick_format='0.1e',
-                                                       label='Value'),
+                                                       label='pixel value'),
                                            bqplot.Axis(scale=hist_y_sc,
+                                                       num_ticks=2,
                                                        orientation='vertical',
-                                                       label='N')]
+                                                       label='density')]
 
             self.bqplot_figs_resize = [self.stretch_histogram]
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -373,23 +373,26 @@ class PlotOptions(PluginTemplateMixin):
     @observe('plugin_opened', 'layer_selected', 'viewer_selected',
              'stretch_hist_zoom_limits')
     def _update_stretch_histogram(self, msg={}):
-        if not self.stretch_function_sync.get('in_subscribed_states'):
+        if not self.stretch_function_sync.get('in_subscribed_states'):  # pragma: no cover
             # no (image) viewer with stretch function options
             return
-        if not hasattr(self, 'viewer'):
+        if not hasattr(self, 'viewer'):  # pragma: no cover
             # plugin hasn't been fully initialized yet
             return
-        if not self.plugin_opened or not self.viewer.selected or not self.layer.selected:
+        if (not self.plugin_opened
+                or not self.viewer.selected
+                or not self.layer.selected):  # pragma: no cover
             # no need to make updates, updates will be redrawn when plugin is opened
             # NOTE: this won't update when the plugin is shown but not open in the tray
             return
-        if not isinstance(msg, dict) and not self.stretch_hist_zoom_limits:
+        if not isinstance(msg, dict) and not self.stretch_hist_zoom_limits:  # pragma: no cover
             # then this is from the limits callbacks and we don't want to waste resources
             # IMPORTANT: this assumes the only non-observe callback to this method comes
             # from state callbacks from zoom limits.
             return
 
-        if self.multiselect and (len(self.viewer.selected) > 1 or len(self.layer.selected) > 1):
+        if self.multiselect and (len(self.viewer.selected) > 1
+                                 or len(self.layer.selected) > 1):  # pragma: no cover
             # currently only support single-layer/viewer.  For now we'll just clear and return.
             # TODO: add support for multi-layer/viewer
             bqplot_clear_figure(self.stretch_histogram)

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -419,12 +419,11 @@ class PlotOptions(PluginTemplateMixin):
                 xy_limits = viewer._get_zoom_limits(data).astype(int)
                 x_limits = xy_limits[:, 0]
                 y_limits = xy_limits[:, 1]
-                x_min = x_limits.min()
+                x_min = max(x_limits.min(), 0)
                 x_max = x_limits.max()
-                y_min = y_limits.min()
+                y_min = max(y_limits.min(), 0)
                 y_max = y_limits.max()
 
-                # TODO: this doesn't seem to exactly match the full image when zoom is reset
                 sub_data = comp.data[y_min:y_max, x_min:x_max].ravel()
 
             else:

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -482,5 +482,6 @@ class PlotOptions(PluginTemplateMixin):
             # TODO: Let user set y-scale to log
 
         interval = PercentileInterval(95)
-        hist_lims = interval.get_limits(sub_data)
-        hist_mark.min, hist_mark.max = hist_lims
+        if len(sub_data) > 0:
+            hist_lims = interval.get_limits(sub_data)
+            hist_mark.min, hist_mark.max = hist_lims

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -186,6 +186,13 @@
       <glue-float-field label="Stretch VMax" :value.sync="stretch_vmax_value" />
     </glue-state-sync-wrapper>
 
+    <v-row v-if="config==='imviz' && stretch_function_sync.in_subscribed_states">
+      <!-- NOTE: the internal bqplot widget defaults to 480 pixels, so if choosing something else,
+           we will likely need to override that with custom CSS rules in order to avoid the initial
+           rendering of the plot from overlapping with content below -->
+      <jupyter-widget :widget="stretch_histogram" style="width: 100%; height: 480px" />
+    </v-row>
+
     <!-- IMAGE:IMAGE -->
     <j-plugin-section-header v-if="image_visible_sync.in_subscribed_states">Image</j-plugin-section-header>
     <glue-state-sync-wrapper :sync="image_visible_sync" :multiselect="multiselect" @unmix-state="unmix_state('image_visible')">

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -186,7 +186,7 @@
       <glue-float-field label="Stretch VMax" :value.sync="stretch_vmax_value" />
     </glue-state-sync-wrapper>
 
-    <v-row v-if="config==='imviz' && stretch_function_sync.in_subscribed_states">
+    <v-row v-if="stretch_function_sync.in_subscribed_states">
       <v-switch
         v-model="stretch_hist_zoom_limits"
         class="hide-input"

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -187,15 +187,16 @@
     </glue-state-sync-wrapper>
 
     <v-row v-if="stretch_function_sync.in_subscribed_states">
+      <!-- z-index to ensure on top of the jupyter widget with negative margin-top -->
       <v-switch
         v-model="stretch_hist_zoom_limits"
         class="hide-input"
         label="Limit histogram to current zoom limits"
+        style="z-index: 1"
       ></v-switch>
-      <!-- NOTE: the internal bqplot widget defaults to 480 pixels, so if choosing something else,
-           we will likely need to override that with custom CSS rules in order to avoid the initial
-           rendering of the plot from overlapping with content below -->
-      <jupyter-widget :widget="stretch_histogram" style="width: 100%; height: 480px" />
+      <!-- NOTE: height defined here should match that in the custom CSS rules
+           below for the bqplot class -->
+      <jupyter-widget :widget="stretch_histogram" class="stretch-hist" style="width: 100%; height: 320px; margin-top: -60px; margin-bottom: -40px" />
     </v-row>
 
     <!-- IMAGE:IMAGE -->
@@ -397,10 +398,13 @@ module.exports = {
 }
 </script>
 
-<style>
+<style scoped>
 .color-menu {
     font-size: 16px;
     padding-left: 16px;
     border: 2px solid rgba(0,0,0,0.54);
+}
+.stretch-hist > .bqplot {
+  height: 320px !important;
 }
 </style>

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -187,6 +187,11 @@
     </glue-state-sync-wrapper>
 
     <v-row v-if="config==='imviz' && stretch_function_sync.in_subscribed_states">
+      <v-switch
+        v-model="stretch_hist_zoom_limits"
+        class="hide-input"
+        label="Limit histogram to current zoom limits"
+      ></v-switch>
       <!-- NOTE: the internal bqplot widget defaults to 480 pixels, so if choosing something else,
            we will likely need to override that with custom CSS rules in order to avoid the initial
            rendering of the plot from overlapping with content below -->

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -58,6 +58,22 @@ def test_multiselect(cubeviz_helper, spectrum1d_cube):
 
 
 @pytest.mark.filterwarnings('ignore')
+def test_stretch_histogram(cubeviz_helper, spectrum1d_cube):
+    cubeviz_helper.load_data(spectrum1d_cube)
+    po = cubeviz_helper.app.get_tray_item_from_name('g-plot-options')
+    po.open_in_tray()  # forces histogram to draw
+
+    # default selection for viewer should be flux-viewer (first in list) and nothing for layer
+    assert po.multiselect is False
+    assert po.viewer.multiselect is False
+    assert po.layer.multiselect is False
+    assert po.viewer.selected == 'flux-viewer'
+    assert po.layer.selected == 'Unknown spectrum object[FLUX]'
+
+    assert po.stretch_histogram is not None
+
+
+@pytest.mark.filterwarnings('ignore')
 def test_user_api(cubeviz_helper, spectrum1d_cube):
     cubeviz_helper.load_data(spectrum1d_cube)
     po = cubeviz_helper.plugins['Plot Options']

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -179,7 +179,7 @@ def multi_order_spectrum_list(spectrum1d, spectral_orders=10):
     return SpectrumList(sc)
 
 
-def _create_spectrum1d_cube_with_fluxunit(fluxunit=u.Jy, shape=(2, 2, 4)):
+def _create_spectrum1d_cube_with_fluxunit(fluxunit=u.Jy, shape=(2, 2, 4), with_uncerts=False):
 
     flux = np.arange(np.prod(shape)).reshape(shape) * fluxunit
     wcs_dict = {"CTYPE1": "RA---TAN", "CTYPE2": "DEC--TAN", "CTYPE3": "WAVE-LOG",
@@ -187,13 +187,24 @@ def _create_spectrum1d_cube_with_fluxunit(fluxunit=u.Jy, shape=(2, 2, 4)):
                 "CDELT1": -0.0001, "CDELT2": 0.0001, "CDELT3": 8e-11,
                 "CRPIX1": 0, "CRPIX2": 0, "CRPIX3": 0}
     w = WCS(wcs_dict)
+    if with_uncerts:
+        uncert = StdDevUncertainty(np.abs(np.random.normal(flux) * u.Jy))
 
-    return Spectrum1D(flux=flux, wcs=w)
+        return Spectrum1D(flux=flux,
+                          uncertainty=uncert,
+                          wcs=w)
+    else:
+        return Spectrum1D(flux=flux, wcs=w)
 
 
 @pytest.fixture
 def spectrum1d_cube():
     return _create_spectrum1d_cube_with_fluxunit(fluxunit=u.Jy)
+
+
+@pytest.fixture
+def spectrum1d_cube_with_uncerts():
+    return _create_spectrum1d_cube_with_fluxunit(fluxunit=u.Jy, with_uncerts=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request ports the histogram from #2097 into the plot options plugin.  This is currently limited to a single layer (in a single viewer) and will clear itself when that is not the case.

(Note: shouldn't be this laggy in real life)

https://user-images.githubusercontent.com/877591/232864726-6bd3af42-727e-4fee-914d-bd7b7863945d.mov




**TODO**:
- [x] ~fix bins when shown in tray (popping out and expanding size does show bins as expected) - we are seeing a similar behavior with tables having different responsiveness in the tray than when in an independent window... so may be some upstream behavior/bug to look into.~
- [x] update on zoom limits change (and possibly a switch to control whether it uses zoom limits or not?)
- [x] optimization (cache raveled data, update marks data instead of recreating entire figure, etc)
- [x] axes label readability
- [x] enable for image viewers outside imviz (2d spectrum, cube) and logic for disabling plot logic when layer is not an image
- [ ] determine how this is expected to behave in cubeviz (consider all slices or just current slice)?  Current implementation is laggy on a cube and needs to be tested for accuracy.
- [x] ~reconsider 95% cutoff on x-axis limits~ (will be able to remove once we have log-scale on y-axis, but cannot until then)
- [ ] test coverage

Future efforts:
* display current vmin/max on histogram [:cat:](https://jira.stsci.edu/browse/JDAT-3270)
* multiviewer/layer support [:cat:](https://jira.stsci.edu/browse/JDAT-3277)
* ability to set bin size and limits of histogram [:cat:](https://jira.stsci.edu/browse/JDAT-3269)
* logarithmic scale [:cat:](https://jira.stsci.edu/browse/JDAT-3268) (blocked by https://github.com/bqplot/bqplot/issues/1300)
* interactivity (ability to click/drag to set stretch limits)?
* show locations of presets/percentiles?
* react to stretch function (by setting scale-type of x-axis)?
* ability to popout figure independent of plugin (similar to what is done for plugin tables)?



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Closes #2097

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
