### PR TITLE
Fix bad MAST URI

### DIFF
--- a/jdaviz/core/tests/test_data_menu.py
+++ b/jdaviz/core/tests/test_data_menu.py
@@ -12,7 +12,7 @@ example_uri_helper = [
      ['mast:HST/product/id4301ouq_drz.fits', 'imviz'],
      ['mast:HST/product/ldq601030_x1dsum.fits', 'specviz'],
      ['mast:HST/product/o4xw01dkq_flt.fits', 'specviz2d'],
-     ['mast:JWST/product/jw01324-o001_s00094_niriss_f200w-gr150c-gr150r_x1d.fits',
+     ['mast:JWST/product/jw02072-c1003_s00002_nirspec_clear-prism-s200a1_x1d.fits',
       'specviz'],
      ['mast:JWST/product/jw01324-o006_s00005_nirspec_f100lp-g140h_s2d.fits',
       'specviz2d'],
@@ -108,7 +108,7 @@ def test_visibility_toggle(imviz_helper):
 )
 def test_auto_config_detection(uri, expected_helper):
     url = f'https://mast.stsci.edu/api/v0.1/Download/file/?uri={uri}'
-    fn = download_file(url, cache=True, timeout=100)
+    fn = download_file(url, timeout=100)
     helper_name = identify_helper(fn)
     assert helper_name == expected_helper
 


### PR DESCRIPTION
### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

The tests are currently failing because MAST removed a deprecated data product, which we happened to be using in a remote-data test to verify that the automatic config detector would choose Specviz. 

In this PR, I substitute the deprecated URI with another URI for a `JWST x1d` data product, which should also be opened with Specviz. I changed the cache setting to "update" to make for easier local debugging if/when other URIs are no longer available on MAST.

I also reverted a single change in the Imviz parser tests from https://github.com/spacetelescope/jdaviz/pull/2069 to match updated (recalibrated?) files from MAST.


### Change log entry

- [X] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [X] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [X] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [X] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [X] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [X] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [X] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
