### PR TITLE
Let app.get_viewer() fallback to ID when reference is None

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -572,25 +572,24 @@ class Application(VuetifyTemplate, HubListener):
 
         Notes
         -----
-            This is only used in cases where the viewers have been pre-defined
-            in the configuration file. Otherwise, viewers are not stored via
-            reference.
+        If viewer does not have a reference, it is going to try to look
+        up the viewer using the given reference as ID.
 
         Parameters
         ----------
         viewer_reference : str
             The reference to the viewer defined with the ``reference`` key
-            in the yaml configuration file.
+            in the YAML configuration file.
 
         Returns
         -------
-        `~glue_jupyter.bqplot.common.BqplotBaseView`
+        viewer : `~glue_jupyter.bqplot.common.BqplotBaseView`
             The viewer class instance.
         """
-        return self._viewer_by_reference(viewer_reference)
+        return self._viewer_by_reference(viewer_reference, fallback_to_id=True)
 
     def get_viewer_by_id(self, vid):
-        """Like :meth:`get_viewer` but use ID instead of reference name.
+        """Like :meth:`get_viewer` but use ID directly instead of reference name.
         This is useful when reference name is `None`.
         """
         return self._viewer_store.get(vid)
@@ -1460,7 +1459,7 @@ class Application(VuetifyTemplate, HubListener):
 
         return viewer_item
 
-    def _viewer_by_reference(self, reference):
+    def _viewer_by_reference(self, reference, fallback_to_id=False):
         """
         Viewer instance by reference defined in the yaml configuration file.
 
@@ -1475,6 +1474,9 @@ class Application(VuetifyTemplate, HubListener):
             The viewer class instance.
         """
         viewer_item = self._viewer_item_by_reference(reference)
+
+        if viewer_item is None and fallback_to_id:
+            return self._viewer_by_id(reference)
 
         return self._viewer_store[viewer_item['id']]
 

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -30,6 +30,13 @@ def test_create_destroy_viewer(imviz_helper, desired_name, actual_name):
     assert imviz_helper.app.get_viewer_ids() == ['imviz-0']
 
 
+def test_get_viewer_created(imviz_helper):
+    # This viewer has no reference but has ID.
+    viewer1 = imviz_helper.create_image_viewer()
+    viewer2 = imviz_helper.app.get_viewer('imviz-1')
+    assert viewer1 is viewer2
+
+
 def test_destroy_viewer_invalid(imviz_helper):
     assert imviz_helper.app.get_viewer_ids() == ['imviz-0']
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to implement something that has been annoying me.

When you create a second viewer in Imviz, it has no reference. But the generic call `imviz.app.get_viewer()` chokes on that fact and then I have to do one extra call to `imviz.app.get_viewer_by_id()` when I forget about that and it happens to me again.

Since we told ourselves that `.app` stuff is not "public," I didn't bother with a change log.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3302)
