### PR TITLE
DOC: What you see is not what you get when it comes to Subset shape in aperture photometry

### DIFF
--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -230,6 +230,10 @@ an interactively selected region. A typical workflow is as follows:
 
 .. note::
 
+    The shape you see drawn from :ref:`imviz_defining_spatial_regions` is not
+    exactly the aperture mask being used by ``photutils``. This is because
+    ``photutils`` uses sub-pixel sampling that is not reflected in the display.
+
     Masking and weights by uncertainty are currently not supported.
     However, if NaN exists in data, it will be treated as 0.
 

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -232,7 +232,7 @@ an interactively selected region. A typical workflow is as follows:
 
     The shape you see drawn from :ref:`imviz_defining_spatial_regions` is not
     exactly the aperture mask being used by ``photutils``. This is because
-    ``photutils`` uses sub-pixel sampling that is not reflected in the display.
+    ``photutils`` uses fractional pixels and this is not reflected in the display.
 
     Masking and weights by uncertainty are currently not supported.
     However, if NaN exists in data, it will be treated as 0.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to clarify that `photutils` does not use the Subset mask being displayed. Well, not exactly. 🤪 

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3305)
