### PR TITLE
DOC: Add warning to aperture photometry plugin about apertures

### DIFF
--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -163,11 +163,11 @@ Simple Aperture Photometry
 
 .. warning::
 
+    Regardless of your workflow, any WCS distortion in an image is ignored.
+
     When you have multiple images linked by WCS and they have different
     pixel scales or sky orientation, the selected aperture may be incorrectly defined
     for images that are not the reference image (usually the first loaded one).
-
-    Regardless of the above, any WCS distortion in an image is ignored.
 
 This plugin performs simple aperture photometry
 and plots a radial profile for one object within

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -161,6 +161,14 @@ This plugin only considers pixel locations, not sky coordinates.
 Simple Aperture Photometry
 ==========================
 
+.. warning::
+
+    When you have multiple images linked by WCS and they have different
+    pixel scales or sky orientation, aperture may be incorrectly defined
+    for images that are not the reference image (usually the first loaded one).
+
+    Regardless of the above, any WCS distortion in an image is ignored.
+
 This plugin performs simple aperture photometry
 and plots a radial profile for one object within
 an interactively selected region. A typical workflow is as follows:

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -164,7 +164,7 @@ Simple Aperture Photometry
 .. warning::
 
     When you have multiple images linked by WCS and they have different
-    pixel scales or sky orientation, aperture may be incorrectly defined
+    pixel scales or sky orientation, the selected aperture may be incorrectly defined
     for images that are not the reference image (usually the first loaded one).
 
     Regardless of the above, any WCS distortion in an image is ignored.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to slap a warning on the doc until we can properly fix it over at #2154 since that one is dragging on much longer than I had hoped for and now also #2164 is in play and needs upstream fixes in glue-core and glue-astronomy.

[🐱](https://jira.stsci.edu/browse/JDAT-3272)

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
