### PR TITLE
Fix size calculation for model parameters array

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -94,6 +94,8 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Fixed get_model_parameters error when retrieving parameters for a cube fit. [2171]
+
 Imviz
 ^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -94,7 +94,7 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
-- Fixed get_model_parameters error when retrieving parameters for a cube fit. [2171]
+- Fixed get_model_parameters error when retrieving parameters for a cube fit. [#2171]
 
 Imviz
 ^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,9 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Fixed get_model_parameters error when retrieving parameters for a cube fit. This
+  also removed the "_3d" previously appended to model labels in the returned dict. [#2171]
+
 Imviz
 ^^^^^
 
@@ -93,8 +96,6 @@ Bug Fixes
 
 Cubeviz
 ^^^^^^^
-
-- Fixed get_model_parameters error when retrieving parameters for a cube fit. [#2171]
 
 Imviz
 ^^^^^

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -231,6 +231,12 @@ class ConfigHelper(HubListener):
         elif models is None:
             models = self.fitted_models
 
+        data_shapes = {}
+        for label in models:
+            data_label = label.split(" (")[0]
+            if data_label not in data_shapes:
+                data_shapes[data_label] = self.app.data_collection[data_label].data.shape
+
         param_dict = {}
         parameters_cube = {}
         param_x_y = {}
@@ -241,7 +247,7 @@ class ConfigHelper(HubListener):
             # looks for that style and separates out the pertinent information.
             if " (" in label:
                 label_split = label.split(" (")
-                model_name = label_split[0] + "_3d"
+                model_name = label_split[0]
                 x = int(label_split[1].split(", ")[0])
                 y = int(label_split[1].split(", ")[1][:-1])
 
@@ -268,10 +274,7 @@ class ConfigHelper(HubListener):
         # on whether the model in question is 3d or 1d, respectively.
         for model_name in param_dict:
             if model_name in param_x_y:
-                x_size = len(param_x_y[model_name]['x'])
-                y_size = len(param_x_y[model_name]['y'])
-
-                parameters_cube[model_name] = {x: np.zeros(shape=(x_size, y_size))
+                parameters_cube[model_name] = {x: np.zeros(shape=data_shapes[model_name][:2])
                                                for x in param_dict[model_name]}
             else:
                 parameters_cube[model_name] = {x: 0
@@ -282,7 +285,7 @@ class ConfigHelper(HubListener):
         for label in models:
             if " (" in label:
                 label_split = label.split(" (")
-                model_name = label_split[0] + "_3d"
+                model_name = label_split[0]
 
                 # If the get_models method is used to build a dictionary of
                 # models and a value is set for the x or y parameters, that


### PR DESCRIPTION
Fixes #2158 . I also removed the `_3d` that was getting tacked on to the label for the cube models, since by default the labels for those in the plugin now get `cube-fit ` prepended to the suggested label. Basically, there might not be fitted parameters for every spaxel (due to masking and such), so relying on the length of the arrays of x and y spaxel locations was unreliable.