### PR TITLE
ENH: Imviz parser optimizations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -97,8 +97,10 @@ Cubeviz
 Imviz
 ^^^^^
 
-* Do not hide previous results in aperture photometry when there is a failure, but rather show
+- Do not hide previous results in aperture photometry when there is a failure, but rather show
   the failure message within the plugin UI to indicate the shown results are "out of date". [#2112]
+
+- More efficient parser for Roman data products in Imviz [#2176]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -505,7 +505,7 @@ def test_load_valid_not_valid(imviz_helper):
     assert_allclose(imviz_helper.app.data_collection[0].get_component('DATA').data, 1)
 
 
-@pytest.mark.skipif(not HAS_ROMAN_DATAMODELS, reason="roman_datamodels is installed")
+@pytest.mark.skipif(not HAS_ROMAN_DATAMODELS, reason="roman_datamodels is not installed")
 def test_roman_parser(imviz_helper):
     filename = get_pkg_data_filename('data/roman_wfi_image_model.asdf')
     imviz_helper.load_data(filename)

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -505,12 +505,8 @@ def test_load_valid_not_valid(imviz_helper):
     assert_allclose(imviz_helper.app.data_collection[0].get_component('DATA').data, 1)
 
 
-@pytest.mark.skipif(HAS_ROMAN_DATAMODELS, reason="roman_datamodels is installed")
-def test_roman_no_roman(imviz_helper):
-    from asdf.exceptions import AsdfConversionWarning
-
+@pytest.mark.skipif(not HAS_ROMAN_DATAMODELS, reason="roman_datamodels is installed")
+def test_roman_parser(imviz_helper):
     filename = get_pkg_data_filename('data/roman_wfi_image_model.asdf')
-    with pytest.warns(AsdfConversionWarning, match=r".*not recognized"), \
-         pytest.raises(ImportError,
-                       match="Roman ASDF detected but roman-datamodels is not installed"):
-        imviz_helper.load_data(filename)
+    imviz_helper.load_data(filename)
+    assert len(imviz_helper.app.data_collection) == 1


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description

Imviz, and especially its parser, will do some heavy lifting for Roman files. I'm doing some profiling, and found that the parser tweaks in this PR speed up the parser by a factor of 3 on my machine (the machine matters for reasons I'll explain below).

The speedups come from the following corrections:
* The top-level image parser decides how to parse a given file based on its file extension. This doesn't work on astropy-cached files, since they all have the file name `contents`. I worked around this earlier by making a reverse-lookup dict to find source URLs for each file in the cache (see below), which is actually quite slow if the cache is heavily used. Since I have *12,000* files in my cache (😱), this lookup took up a lot of time. In this PR, I avoid the lookup unless the filename is `contents` (no extension).

https://github.com/spacetelescope/jdaviz/blob/aec6ed15b8489bbb71bef8f344dc9f164e88da9a/jdaviz/configs/imviz/plugins/parsers.py#L55-L66

* The parser did several checks on ASDF files. First it opens the file with `asdf.open` to check if it looks like a Roman data file. If not it raises and error, and if it's a Roman file it passes the open file object to `roman_datamodels.datamodels.open` to extract an `ImageModel`. This double-open incurs unnecessary overhead and is probably more thorough than it ought to be – I'd prefer a faster parser with a less-informative traceback when it fails to open an ASDF file with unknown provenance. Our docs say we only (partially) support Roman ASDF files.

https://github.com/spacetelescope/jdaviz/blob/aec6ed15b8489bbb71bef8f344dc9f164e88da9a/jdaviz/configs/imviz/plugins/parsers.py#L79-L91

Here's a breakdown of the time spent in loading a single Roman file, which decreases from 3 to 1 seconds after this PR on my laptop. The first bullet above describes the `path_to_url_mapping` change, the second bullet results in removing the `asdf.open` call. I've also included a note on the one call that gets slower as a result of these changes, which is `_parse_image`. Since we had passed an open filestream from `asdf.open` to `_parse_image` before, the update in this PR slows down the call to `_parse_image` which now must open the file stream. 

|Method|Before|After |Reason for difference|
|------|------|------|------|
| **Total** | 2.75 s | 0.94 s | --- |
| `path_to_url_mapping` | 0.716 s | 0.000 s  | avoided unless needed |
| `asdf.open` | 0.278 s | 0.000 s | not strictly necessary |
| `_parse_image` | 0.006 s | 0.019 s | now slower by skipping `asdf.open` |


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3149)
