### PR TITLE
Add note about python 3.8 and remove ipython pin

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,11 @@ spectra, typically the output of a multi-object spectrograph (e.g.,
 JWST NIRSpec), and includes viewers for 1D and 2D spectra as well as
 contextual information like on-sky views of the spectrograph slit.
 
+.. warning::
+
+   As of ``jdaviz`` version 3.5, python 3.8 is no longer supported. Please use python 3.9 or
+   greater to get the latest bug fixes and feature additions for ``jdaviz``.
+
 .. note::
 
    ``jdaviz`` is one tool that is part of STScI's larger

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ install_requires =
     glue-core>=1.6.0,!=v1.9.0
     glue-jupyter>=0.15.0
     echo>=0.5.0
-    ipython<8.13;python_version=='3.8'
     ipykernel>=6.19.4
     ipyvue>=1.6
     ipyvuetify>=1.7.0


### PR DESCRIPTION
As of #2152 , we no longer support python 3.8. This adds a warning to the home page of the docs, and drops a pin that was only needed because of 3.8 support. 