### PR TITLE
Enable editing of composite subsets in the subset plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ New Features
 
 - Vertical (y-range) zoom tool for all spectrum and spectrum-2d viewers. [#2206]
 
+- Allow Subset Plugin to edit composite subsets. [#2182]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
+++ b/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
@@ -39,7 +39,7 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
 
     subplugins_opened = Any().tag(sync=True)
 
-    is_editable = Bool(False).tag(sync=True)
+    is_centerable = Bool(False).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -96,7 +96,7 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
         self.subset_definitions = []
         self.subset_types = []
         self.glue_state_types = []
-        self.is_editable = False
+        self.is_centerable = False
 
         if not hasattr(self, 'subset_select'):
             # during initial init, this can trigger before the component is initialized
@@ -132,9 +132,9 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
         if not subset_information:
             return
         if len(subset_information) == 1:
-            self.is_editable = True
+            self.is_centerable = True
         else:
-            self.is_editable = False
+            self.is_centerable = False
 
         for spec in subset_information:
             subset_definition = []
@@ -200,35 +200,75 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
         self._unpack_get_subsets_for_ui()
 
     def vue_update_subset(self, *args):
+        status, reason = self._check_input()
+        if not status:
+            self.hub.broadcast(SnackbarMessage(reason, color='error', sender=self))
+            return
+
         for index, sub in enumerate(self.subset_definitions):
+            if len(self.subset_states) <= index:
+                return
             sub_states = self.subset_states[index]
             for d_att in sub:
                 if d_att["att"] == 'theta':  # Humans use degrees but glue uses radians
                     d_val = np.radians(d_att["value"])
                 else:
                     d_val = float(d_att["value"])
+
                 if float(d_att["orig"]) != d_val:
                     if self.subset_types[index] == "Range":
                         setattr(sub_states, d_att["att"], d_val)
                     else:
                         setattr(sub_states.roi, d_att["att"], d_val)
-            try:
-                # TODO: This commented out section is "more correct" because it
-                #  adds the changed subregion to the data_collection.subset_groups
-                #  tree. However, it still needs improvement and the section below
-                #  allows updating similar to `main`.
-                # self.session.edit_subset_mode._combine_data(sub_states,
-                # override_mode=SUBSET_MODES[self.glue_state_types[index]])
-                self.session.edit_subset_mode._combine_data(sub_states, override_mode=ReplaceMode)
-            except Exception as err:  # pragma: no cover
-                self.hub.broadcast(SnackbarMessage(
-                    f"Failed to update Subset: {repr(err)}", color='error', sender=self))
+        try:
+            dc = self.data_collection
+            subsets = dc.subset_groups
+            self.session.edit_subset_mode._combine_data(
+                subsets[[x.label for x in subsets].index(self.subset_selected)].subset_state,
+                override_mode=ReplaceMode)
+        except Exception as err:  # pragma: no cover
+            self.hub.broadcast(SnackbarMessage(
+                f"Failed to update Subset: {repr(err)}", color='error', sender=self))
+
+    def _check_input(self):
+        status = True
+        reason = ""
+        for index, sub in enumerate(self.subset_definitions):
+            lo = hi = xmin = xmax = ymin = ymax = None
+            for d_att in sub:
+                if d_att["att"] == "lo":
+                    lo = d_att["value"]
+                elif d_att["att"] == "hi":
+                    hi = d_att["value"]
+                elif d_att["att"] == "radius" and d_att["value"] <= 0:
+                    status = False
+                    reason = "Failed to update Subset: radius must be a positive scalar"
+                    break
+                elif d_att["att"] == "xmin":
+                    xmin = d_att["value"]
+                elif d_att["att"] == "xmax":
+                    xmax = d_att["value"]
+                elif d_att["att"] == "ymin":
+                    ymin = d_att["value"]
+                elif d_att["att"] == "ymax":
+                    ymax = d_att["value"]
+
+                if lo and hi and hi <= lo:
+                    status = False
+                    reason = "Failed to update Subset: lower bound must be less than upper bound"
+                    break
+                elif xmin and xmax and ymin and ymax and (xmax - xmin <= 0 or ymax - ymin <= 0):
+                    status = False
+                    reason = "Failed to update Subset: width and length must be positive scalars"
+                    break
+
+        return status, reason
 
     def vue_recenter_subset(self, *args):
-        # Composite region cannot be edited. This only works for Imviz.
-        if not self.is_editable or self.config != 'imviz':  # no-op
+        # Composite region cannot be centered. This only works for Imviz.
+        if not self.is_centerable or self.config != 'imviz':  # no-op
             raise NotImplementedError(
-                f'Cannot recenter: is_editable={self.is_editable}, config={self.config}')
+                f'Cannot recenter: is_centerable={self.is_centerable}, config={self.config}')
 
         from photutils.aperture import ApertureStats
         from jdaviz.core.region_translators import regions2aperture, _get_region_from_spatial_subset
@@ -265,7 +305,7 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
         cen : number, tuple of numbers, or `None`
             The center of the Subset in ``x`` or ``(x, y)``,
             depending on the Subset type, if applicable.
-            If Subset is not editable, this returns `None`.
+            If Subset is not centerable, this returns `None`.
 
         Raises
         ------
@@ -273,8 +313,8 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
             Subset type is not supported.
 
         """
-        # Composite region cannot be edited.
-        if not self.is_editable:  # no-op
+        # Composite region cannot be centered.
+        if not self.is_centerable:  # no-op
             return
 
         subset_state = self.subset_select.selected_subset_state
@@ -303,7 +343,7 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
 
     def set_center(self, new_cen, update=False):
         """Set the desired center for the selected Subset, if applicable.
-        If Subset is not editable, nothing is done.
+        If Subset is not centerable, nothing is done.
 
         Parameters
         ----------
@@ -322,8 +362,8 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
             Subset type is not supported.
 
         """
-        # Composite region cannot be edited, so just grab first element.
-        if not self.is_editable:  # no-op
+        # Composite region cannot be centered, so just grab first element.
+        if not self.is_centerable:  # no-op
             return
 
         subset_state = self.subset_select.selected_subset_state

--- a/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.vue
+++ b/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.vue
@@ -23,7 +23,7 @@
     </v-row>
 
     <!-- Sub-plugin for recentering of spatial subset (Imviz only) -->
-    <v-row v-if="config=='imviz' && is_editable">
+    <v-row v-if="config=='imviz' && is_centerable">
       <v-expansion-panels accordion v-model="subplugins_opened">
         <v-expansion-panel>
           <v-expansion-panel-header >
@@ -58,13 +58,12 @@
           :label="item.name"
           v-model.number="item.value"
           type="number"
-          :disabled="!is_editable"
         ></v-text-field>
       </v-row>
     </div>
 
       <v-row justify="end" no-gutters>
-        <v-btn color="primary" text @click="update_subset" :disabled="!is_editable">Update</v-btn>
+        <v-btn color="primary" text @click="update_subset">Update</v-btn>
       </v-row>
   </j-tray-plugin>
 </template>

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -170,7 +170,7 @@ class TestSpecvizHelper:
     def test_get_spectral_regions_composite_region(self):
         spectrum_viewer = self.spec_app.app.get_viewer("spectrum-viewer")
 
-        self.spec_app.app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(6000, 6400))
+        self.spec_app.app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(6000, 7400))
 
         spectrum_viewer.session.edit_subset_mode._mode = AndNotMode
 
@@ -187,7 +187,7 @@ class TestSpecvizHelper:
         assert_quantity_allclose(spec_region['Subset 1'].subregions[0][0].value,
                                  7300., atol=1e-5)
         assert_quantity_allclose(spec_region['Subset 1'].subregions[0][1].value,
-                                 7800., atol=1e-5)
+                                 7400., atol=1e-5)
 
     def test_get_spectral_regions_composite_region_multiple_and_nots(self):
         spectrum_viewer = self.spec_app.app.get_viewer("spectrum-viewer")

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -5,7 +5,7 @@ from astropy.tests.helper import assert_quantity_allclose
 from glue.core import Data
 from glue.core.roi import CircularROI, EllipticalROI, RectangularROI, XRangeROI
 
-from glue.core.edit_subset_mode import AndMode, AndNotMode, OrMode
+from glue.core.edit_subset_mode import AndMode, AndNotMode, OrMode, XorMode
 from regions import PixCoord, CirclePixelRegion, RectanglePixelRegion, EllipsePixelRegion
 
 from numpy.testing import assert_allclose
@@ -38,7 +38,7 @@ def test_region_from_subset_2d(cubeviz_helper):
 
     assert subset_plugin.subset_selected == "Subset 1"
     assert subset_plugin.subset_types == ["EllipticalROI"]
-    assert subset_plugin.is_editable
+    assert subset_plugin.is_centerable
     for key in ("orig", "value"):
         assert subset_plugin._get_value_from_subset_definition(0, "X Center", key) == 1
         assert subset_plugin._get_value_from_subset_definition(0, "Y Center", key) == 3.5
@@ -76,7 +76,7 @@ def test_region_from_subset_3d(cubeviz_helper):
 
     assert subset_plugin.subset_selected == "Subset 1"
     assert subset_plugin.subset_types == ["RectangularROI"]
-    assert subset_plugin.is_editable
+    assert subset_plugin.is_centerable
     assert subset_plugin.get_center() == (2.25, 1.55)
     for key in ("orig", "value"):
         assert subset_plugin._get_value_from_subset_definition(0, "Xmin", key) == 1
@@ -127,7 +127,7 @@ def test_region_from_subset_3d(cubeviz_helper):
     cubeviz_helper.app.get_viewer('flux-viewer').apply_roi(CircularROI(xc=3, yc=4, radius=2.4))
     assert subset_plugin.subset_selected == "Subset 2"
     assert subset_plugin.subset_types == ["CircularROI"]
-    assert subset_plugin.is_editable
+    assert subset_plugin.is_centerable
     for key in ("orig", "value"):
         assert subset_plugin._get_value_from_subset_definition(0, "X Center", key) == 3
         assert subset_plugin._get_value_from_subset_definition(0, "Y Center", key) == 4
@@ -154,7 +154,7 @@ def test_region_from_subset_profile(cubeviz_helper, spectral_cube_wcs):
 
     assert subset_plugin.subset_selected == "Subset 1"
     assert subset_plugin.subset_types == ["Range"]
-    assert subset_plugin.is_editable
+    assert subset_plugin.is_centerable
     assert_allclose(subset_plugin.get_center(), 10.25)
     for key in ("orig", "value"):
         assert subset_plugin._get_value_from_subset_definition(0, "Lower bound", key) == 5
@@ -285,31 +285,26 @@ def test_disjoint_spectral_subset(cubeviz_helper, spectral_cube_wcs):
     assert subset_plugin.subset_selected == "Subset 1"
     assert subset_plugin.subset_types == ["Range", "Range"]
     assert subset_plugin.glue_state_types == ["RangeSubsetState", "OrState"]
-    # assert not subset_plugin.is_editable
+
+    # Make sure that certain things are not possible because we are
+    # dealing with a composite spectral subset
+    subset_plugin.set_center(99, update=True)   # This is no-op
     assert subset_plugin.get_center() is None
-    # TODO: Should this be changed to something else?
-    # subset_plugin.set_center(99, update=True)   # This is no-op
+
     for key in ("orig", "value"):
         assert subset_plugin._get_value_from_subset_definition(1, "Lower bound", key) == 30
         assert subset_plugin._get_value_from_subset_definition(1, "Upper bound", key) == 35
         assert subset_plugin._get_value_from_subset_definition(0, "Lower bound", key) == 5
         assert subset_plugin._get_value_from_subset_definition(0, "Upper bound", key) == 15.5
 
-    # This should not be possible via GUI but here we change
-    # something to make sure no-op is really no-op.
-    subset_plugin._set_value_in_subset_definition(0, "Lower bound", "value", 25)
-    # subset_plugin.vue_update_subset()
-    # "value" here does not matter. It is going to get overwritten next time Subset is processed.
-    assert subset_plugin._get_value_from_subset_definition(0, "Lower bound", "value") == 25
-    assert subset_plugin._get_value_from_subset_definition(0, "Lower bound", "orig") == 5
+    # We will now update one of the bounds of the composite subset
+    subset_plugin._set_value_in_subset_definition(1, "Lower bound", "value", 25)
+    subset_plugin.vue_update_subset()
+    assert subset_plugin._get_value_from_subset_definition(1, "Lower bound", "value") == 25
+    assert subset_plugin._get_value_from_subset_definition(1, "Lower bound", "orig") == 25
 
     reg = cubeviz_helper.app.get_subsets('Subset 1')
-    assert_quantity_allclose(reg[1].lower, 30.0*u.Hz)  # Still the old value
-
-    # See, never happened.
-    subset_plugin.subset_selected = "Create New"
-    subset_plugin.subset_selected = "Subset 1"
-    assert subset_plugin._get_value_from_subset_definition(0, "Lower bound", "value") == 5
+    assert_quantity_allclose(reg[1].lower, 25.0*u.Hz)  # It is now the updated value
 
 
 def test_composite_region_from_subset_3d(cubeviz_helper):
@@ -410,6 +405,23 @@ def test_composite_region_with_consecutive_and_not_states(cubeviz_helper):
     assert subset_plugin.subset_types == ['CircularROI', 'RectangularROI', 'EllipticalROI']
     assert subset_plugin.glue_state_types == ['AndState', 'AndNotState', 'AndNotState']
 
+    # This should be prevented since radius must be positive
+    subset_plugin._set_value_in_subset_definition(0, "Radius", "value", 0)
+    subset_plugin.vue_update_subset()
+    # assert subset_plugin._get_value_from_subset_definition(0, "Radius", "value") == 5
+
+    # This should also be prevented since a rectangle must have positive width
+    # and length
+    subset_plugin._set_value_in_subset_definition(1, "Xmin", "value", 0)
+    subset_plugin._set_value_in_subset_definition(1, "Xmax", "value", 0)
+    subset_plugin.vue_update_subset()
+
+    # Make sure changes were not propagated
+    reg = cubeviz_helper.app.get_subsets("Subset 1")
+    assert reg[0]['subset_state'].roi.radius == 5
+    assert reg[1]['subset_state'].roi.xmin == 25
+    assert reg[1]['subset_state'].roi.xmax == 30
+
 
 def test_composite_region_with_imviz(imviz_helper, image_2d_wcs):
     arr = np.ones((10, 10))
@@ -492,3 +504,50 @@ def test_composite_region_from_subset_2d(specviz_helper, spectrum1d):
     assert subset_plugin.subset_selected == "Subset 1"
     assert subset_plugin.subset_types == ['Range', 'Range', 'Range', 'Range']
     assert subset_plugin.glue_state_types == ['AndState', 'AndNotState', 'OrState', 'AndState']
+
+
+def test_edit_composite_spectral_subset(specviz_helper, spectrum1d):
+    specviz_helper.load_spectrum(spectrum1d)
+    viewer = specviz_helper.app.get_viewer(specviz_helper._default_spectrum_viewer_reference_name)
+
+    viewer.apply_roi(XRangeROI(6200, 6800))
+    specviz_helper.app.session.edit_subset_mode.mode = OrMode
+    viewer.apply_roi(XRangeROI(7200, 7600))
+
+    specviz_helper.app.session.edit_subset_mode.mode = XorMode
+    viewer.apply_roi(XRangeROI(6200, 7600))
+
+    reg = specviz_helper.app.get_subsets("Subset 1")
+    assert reg.lower.value == 6800 and reg.upper.value == 7200
+
+    subset_plugin = specviz_helper.app.get_tray_item_from_name('g-subset-plugin')
+
+    # We will now update one of the bounds of the composite subset
+    subset_plugin._set_value_in_subset_definition(0, "Lower bound", "value", 6000)
+    subset_plugin.vue_update_subset()
+
+    # Since we updated one of the Range objects and it's lower bound
+    # is now lower than the XOR region bound, the region from 6000 to
+    # 6200 should now be visible in the viewer.
+    reg = specviz_helper.app.get_subsets("Subset 1")
+    assert reg[0].lower.value == 6000 and reg[0].upper.value == 6200
+    assert reg[1].lower.value == 6800 and reg[1].upper.value == 7200
+
+    # This makes it so that only spectral regions within this bound
+    # are visible, so the API should reflect that.
+    specviz_helper.app.session.edit_subset_mode.mode = AndMode
+    viewer.apply_roi(XRangeROI(6600, 7400))
+
+    reg = specviz_helper.app.get_subsets("Subset 1")
+    assert reg.lower.value == 6800 and reg[0].upper.value == 7200
+
+    # This should be prevented by the _check_inputs method
+    subset_plugin._set_value_in_subset_definition(0, "Lower bound", "value", 8000)
+    subset_plugin.vue_update_subset()
+    reg2 = specviz_helper.app.get_subsets("Subset 1")
+    assert reg.lower.value == reg2.lower.value
+    assert reg.upper.value == reg2.upper.value
+
+    viewer.apply_roi(XRangeROI(7800, 8000))
+    with pytest.raises(ValueError, match="AND mode should overlap with existing subset"):
+        specviz_helper.app.get_subsets("Subset 1")

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -408,7 +408,6 @@ def test_composite_region_with_consecutive_and_not_states(cubeviz_helper):
     # This should be prevented since radius must be positive
     subset_plugin._set_value_in_subset_definition(0, "Radius", "value", 0)
     subset_plugin.vue_update_subset()
-    # assert subset_plugin._get_value_from_subset_definition(0, "Radius", "value") == 5
 
     # This should also be prevented since a rectangle must have positive width
     # and length


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address editing of composite subsets in the Subset Plugin. ~~Still working on issues related to spectral subsets but updating is at least possible, if not a little inconvenient at the moment.~~ That issue is being tracked [here](https://github.com/spacetelescope/jdaviz/issues/2061) and on slack. It is not introduced by this PR.

XOR functionality has been added to this PR and the ADD mode has been fixed. A previous version did not cover all possible cases and tests have been added to make sure those cases are covered for the future.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #2162 
Fixes #1568 

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
