### PR TITLE
Fix obscure mouseover bug when empty WCS is used for Imviz

### DIFF
--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -242,7 +242,6 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                     sky = image.coords.pixel_to_world(x, y).icrs
                 except Exception:  # WCS might not be celestial
                     coords_status = False
-                    self.reset_coords_display()
 
         elif isinstance(viewer, CubevizImageView):
             # TODO: This assumes data_collection[0] is the main reference


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Without this patch, when you run `notebooks/concepts/imviz_compass_mpl.ipynb` for the first use case (where I pass in `WCS()` as the image WCS), you mouse over the data in Imviz, mouseover display will blink a lot but always go back to "auto". This is because while the WCS still has enough info to draw a compass, its `pixel_to_world` returns a tuple of dimensionless Quantity, not SkyCoord, causing mouseover logic to go into a special place in the logic route.

With this patch, mouseover will still display pixel coords and value but not the sky coordinates. 

I tried to add a test like this but I could not get it to fail even without this patch, so I decided not to include it. I also decided not to include a change log since this should not happen with real data.

```diff
--- a/jdaviz/configs/imviz/tests/test_tools.py
+++ b/jdaviz/configs/imviz/tests/test_tools.py
@@ -1,4 +1,6 @@
 import numpy as np
+from astropy.nddata import NDData
+from astropy.wcs import WCS
 from numpy.testing import assert_allclose
 from regions import RectanglePixelRegion

@@ -135,5 +137,12 @@ def test_compass_open_while_load(imviz_helper):
     plg.open_in_tray()

     # Should not crash even if Compass is open in tray.
-    imviz_helper.load_data(np.ones((2, 2)))
+    ndd = NDData(np.ones((2, 2)), wcs=WCS())
+    imviz_helper.load_data(ndd)
     assert len(imviz_helper.app.data_collection) == 1
+
+    # Also check that empty WCS does not crash mouseover
+    label_mouseover = imviz_helper.app.session.application._tools['g-coords-info']
+    label_mouseover._viewer_mouse_event(imviz_helper.default_viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+    assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +1.00000e+00', '', '')
```

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
