### PR TITLE
Disable Canvas Rotation Plugin in non-Chromium Browsers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Imviz
 - Preliminary support for Roman ASDF data products. This requires
   ``roman-datamodels`` to be installed separately by the user. [#1822]
 
+- Canvas Rotation plugin is now disabled for non-Chromium based browsers [#2192]
 
 Mosviz
 ^^^^^^

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -318,6 +318,8 @@ right or the left, as well as a slider and input to set the angle and a switch t
 axes should be flipped horizontally after applying the rotation (a vertical flip can be achieved
 via a 180 deg rotation and a horizontal flip).
 
+Due to known issues, Canvas Rotation is only available on Chromium-based browsers.
+
 
 .. _imviz-export-plot:
 

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -318,7 +318,7 @@ right or the left, as well as a slider and input to set the angle and a switch t
 axes should be flipped horizontally after applying the rotation (a vertical flip can be achieved
 via a 180 deg rotation and a horizontal flip).
 
-Due to known issues, Canvas Rotation is only available on Chromium-based browsers.
+Due to browser limitations, Canvas Rotation is only available on Chromium-based browsers.
 
 
 .. _imviz-export-plot:

--- a/jdaviz/components/tray_plugin.vue
+++ b/jdaviz/components/tray_plugin.vue
@@ -1,17 +1,18 @@
 <template>
   <v-container class="tray-plugin" style="padding-left: 24px; padding-right: 24px; padding-top: 12px">
+    <v-row>
+      <div style="width: calc(100% - 32px)">
+        <j-docs-link :link="link">{{ description }}</j-docs-link>
+      </div>
+      <div style="width: 32px">
+        <j-plugin-popout :popout_button="popout_button"></j-plugin-popout>
+      </div>
+    </v-row>
+    
     <v-row v-if="isDisabled()">
       <span> {{ getDisabledMsg() }}</span>
     </v-row>
     <div v-else>
-      <v-row>
-        <div style="width: calc(100% - 32px)">
-          <j-docs-link :link="link">{{ description }}</j-docs-link>
-        </div>
-        <div style="width: 32px">
-          <j-plugin-popout :popout_button="popout_button"></j-plugin-popout>
-        </div>
-      </v-row>
       <slot></slot>
     </div>
   </v-container>

--- a/jdaviz/configs/imviz/plugins/rotate_canvas/rotate_canvas.vue
+++ b/jdaviz/configs/imviz/plugins/rotate_canvas/rotate_canvas.vue
@@ -1,9 +1,9 @@
 <template>
-  <j-tray-plugin        
+  <j-tray-plugin  
     description="Rotate viewer canvas to any orientation (note: this does not affect the underlying data)."
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#canvas-rotation'"
+    :disabled_msg="isChromium() ? '' : 'Image rotation is not supported by your browser. Please see our docs for more information.'"
     :popout_button="popout_button">
-
     <plugin-viewer-select
       :items="viewer_items"
       :selected.sync="viewer_selected"
@@ -11,61 +11,60 @@
       hint="Select viewer."
     />
 
-    <div v-if="isChromium()">
-      <v-row>
-        <span style="line-height: 36px">Presets:</span>
-        <j-tooltip tooltipcontent="reset rotation and flip">
-          <v-btn icon @click="reset">
-            <v-icon>mdi-restore</v-icon>
-          </v-btn>
-        </j-tooltip>
-        <j-tooltip v-if="has_wcs" tooltipcontent="north up, east right">
-          <v-btn icon @click="set_north_up_east_right">
-            <img :src="icon_nuer" width="24" class="invert-if-dark" style="opacity: 0.65"/>
-          </v-btn>
-        </j-tooltip>
-        <j-tooltip v-if="has_wcs" tooltipcontent="north up, east left">
-          <v-btn icon @click="set_north_up_east_left">
-            <img :src="icon_nuel" width="24" class="invert-if-dark" style="opacity: 0.65"/>
-          </v-btn>
-        </j-tooltip>
-      </v-row>
-      
-      <v-row>
-        <v-slider
-          v-model="angle"
-          class="align-center"
-          max="180"
-          min="-180"
-          step="1"
-          color="#00617E"
-          track-color="#00617E"
-          thumb-color="#153A4B"
-          hide-details
-        >
-        </v-slider>
-      </v-row>
+    <v-row>
+      <span style="line-height: 36px">Presets:</span>
+      <j-tooltip tooltipcontent="reset rotation and flip">
+        <v-btn icon @click="reset">
+          <v-icon>mdi-restore</v-icon>
+        </v-btn>
+      </j-tooltip>
+      <j-tooltip v-if="has_wcs" tooltipcontent="north up, east right">
+        <v-btn icon @click="set_north_up_east_right">
+          <img :src="icon_nuer" width="24" class="invert-if-dark" style="opacity: 0.65"/>
+        </v-btn>
+      </j-tooltip>
+      <j-tooltip v-if="has_wcs" tooltipcontent="north up, east left">
+        <v-btn icon @click="set_north_up_east_left">
+          <img :src="icon_nuel" width="24" class="invert-if-dark" style="opacity: 0.65"/>
+        </v-btn>
+      </j-tooltip>
+    </v-row>
+    
+    <v-row>
+      <v-slider
+        v-model="angle"
+        class="align-center"
+        max="180"
+        min="-180"
+        step="1"
+        color="#00617E"
+        track-color="#00617E"
+        thumb-color="#153A4B"
+        hide-details
+      >
+      </v-slider>
+    </v-row>
 
-      <v-row>
-        <v-col>
-          <v-text-field
-            v-model.number="angle"
-            type="number"
-            label="Angle"
-            hint="Rotation angle in degrees clockwise"
-          ></v-text-field>
-        </v-col>
-      </v-row>
+    <v-row>
+      <v-col>
+        <v-text-field
+          v-model.number="angle"
+          type="number"
+          label="Angle"
+          hint="Rotation angle in degrees clockwise"
+        ></v-text-field>
+      </v-col>
+    </v-row>
 
-      <v-row>
-        <v-switch v-model="flip_horizontal" label="Flip horizontally after rotation"></v-switch>
-      </v-row>
-    </div>
-    <div v-else>Image rotation is not supported by your browser. Please see our docs for more information.</div>
+    <v-row>
+      <v-switch v-model="flip_horizontal" label="Flip horizontally after rotation"></v-switch>
+    </v-row>
+
   </j-tray-plugin>
 </template>
 
 <script>
+module.exports = {
   methods: {
     isChromium() {
       try {
@@ -81,4 +80,5 @@
       }
     }
   }
+}
 </script>

--- a/jdaviz/configs/imviz/plugins/rotate_canvas/rotate_canvas.vue
+++ b/jdaviz/configs/imviz/plugins/rotate_canvas/rotate_canvas.vue
@@ -10,55 +10,75 @@
       label="Viewer"
       hint="Select viewer."
     />
-    
-    <v-row>
-      <span style="line-height: 36px">Presets:</span>
-      <j-tooltip tooltipcontent="reset rotation and flip">
-        <v-btn icon @click="reset">
-          <v-icon>mdi-restore</v-icon>
-        </v-btn>
-      </j-tooltip>
-      <j-tooltip v-if="has_wcs" tooltipcontent="north up, east right">
-        <v-btn icon @click="set_north_up_east_right">
-          <img :src="icon_nuer" width="24" class="invert-if-dark" style="opacity: 0.65"/>
-        </v-btn>
-      </j-tooltip>
-      <j-tooltip v-if="has_wcs" tooltipcontent="north up, east left">
-        <v-btn icon @click="set_north_up_east_left">
-          <img :src="icon_nuel" width="24" class="invert-if-dark" style="opacity: 0.65"/>
-        </v-btn>
-      </j-tooltip>
-    </v-row>
-    
-    <v-row>
-      <v-slider
-        v-model="angle"
-        class="align-center"
-        max="180"
-        min="-180"
-        step="1"
-        color="#00617E"
-        track-color="#00617E"
-        thumb-color="#153A4B"
-        hide-details
-      >
-      </v-slider>
-    </v-row>
 
-    <v-row>
-      <v-col>
-        <v-text-field
-          v-model.number="angle"
-          type="number"
-          label="Angle"
-          hint="Rotation angle in degrees clockwise"
-        ></v-text-field>
-      </v-col>
-    </v-row>
+    <div v-if="isChromium()">
+      <v-row>
+        <span style="line-height: 36px">Presets:</span>
+        <j-tooltip tooltipcontent="reset rotation and flip">
+          <v-btn icon @click="reset">
+            <v-icon>mdi-restore</v-icon>
+          </v-btn>
+        </j-tooltip>
+        <j-tooltip v-if="has_wcs" tooltipcontent="north up, east right">
+          <v-btn icon @click="set_north_up_east_right">
+            <img :src="icon_nuer" width="24" class="invert-if-dark" style="opacity: 0.65"/>
+          </v-btn>
+        </j-tooltip>
+        <j-tooltip v-if="has_wcs" tooltipcontent="north up, east left">
+          <v-btn icon @click="set_north_up_east_left">
+            <img :src="icon_nuel" width="24" class="invert-if-dark" style="opacity: 0.65"/>
+          </v-btn>
+        </j-tooltip>
+      </v-row>
+      
+      <v-row>
+        <v-slider
+          v-model="angle"
+          class="align-center"
+          max="180"
+          min="-180"
+          step="1"
+          color="#00617E"
+          track-color="#00617E"
+          thumb-color="#153A4B"
+          hide-details
+        >
+        </v-slider>
+      </v-row>
 
-    <v-row>
-      <v-switch v-model="flip_horizontal" label="Flip horizontally after rotation"></v-switch>
-    </v-row>
+      <v-row>
+        <v-col>
+          <v-text-field
+            v-model.number="angle"
+            type="number"
+            label="Angle"
+            hint="Rotation angle in degrees clockwise"
+          ></v-text-field>
+        </v-col>
+      </v-row>
 
+      <v-row>
+        <v-switch v-model="flip_horizontal" label="Flip horizontally after rotation"></v-switch>
+      </v-row>
+    </div>
+    <div v-else>Image rotation is not supported by your browser. Please see our docs for more information.</div>
   </j-tray-plugin>
 </template>
+
+<script>
+  methods: {
+    isChromium() {
+      try {
+        for (brand_version_pair of navigator.userAgentData.brands) {
+            if (brand_version_pair.brand == "Chromium"){
+                return true;
+            }
+        }
+        return false;
+      }
+      catch {
+        return false
+      }
+    }
+  }
+</script>


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

As requested after having issues with rotation in non Chrome browsers. this PR implements a JS script check to enter a `disabled_msg` if it detects a non-Chromium browser, which disables the plugin, referring the user to the documentation, where I included a new line that mentions only supporting Chrome browsers.

As you can see from the screenshot, this PR also, by suggestion from reviewers, displays the description and documentation field even when the plugin is disabled:

![image](https://github.com/spacetelescope/jdaviz/assets/25206008/650e2196-3de0-4b2c-b126-7d2894cecd85)

Of importance to note: This PR does NOT disable the plugin's API. After talking with @kecnry, this effort should be considered for followup work, though consideration should be made whether the effort should be undertaken depending on if we are planning on ditching this plugin entirely eventually anyways. We thought of some points to think about if we do end up tackling this effort:

Kyle's three-step plan:

> I think this is probably what would need to be done to edit the traitlet from the vue file:
> * move the JS logic into mounted (there are other examples of this, just not for editing traitlets)
> * in there, emit an event (something like this.$emit('update_disabled_msg', 'whatever');
> * add a def vue_update_disabled_msg in PluginTemplateMixin which actually sets the traitlet on the python side

On top of this, there is a ramification of having the `isChromium()` check in the plugin itself, that being it does not fire until the plugin is actually opened. As a result, the `isChromium()` check should probably be moved to `app.vue` and stored in the `app.state` so that the browser state can be known before the plugin tray is opened.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
