### PR TITLE
Allow data entries to be deleted

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ New Features
 
 - Allow Subset Plugin to edit composite subsets. [#2182]
 
+- Allow secondary data products to be removed from the app (except for Mosviz) [#2194]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -121,14 +121,15 @@ module.exports = {
         // forbid unloading the original reference cube
         // this logic might need to be generalized if supporting custom data labels
         // per-cube or renaming data labels
+        const extension = this.itemNameExtension
         if (this.$props.viewer.reference === 'flux-viewer') {
-          return this.$props.item.name.indexOf('[FLUX]') === -1
+          return ['SCI', 'FLUX'].indexOf(extension) !== -1
         } else if (this.$props.viewer.reference === 'uncert-viewer') {
-          return this.$props.item.name.indexOf('[IVAR]') === -1
+          return ['IVAR', 'ERR'].indexOf(extension) !== -1
         } else if (this.$props.viewer.reference === 'mask-viewer') {
-          return this.$props.item.name.indexOf('[MASK]') === -1
+          return ['MASK', 'DQ'].indexOf(extension) !== -1
         } else if (this.$props.viewer.reference === 'spectrum-viewer') {
-          return this.$props.item.name.indexOf('[FLUX]') === -1          
+          return ['SCI', 'FLUX'].indexOf(extension) !== -1
         }
       } else if (this.$props.viewer.config === 'specviz2d') {
         if (this.$props.viewer.reference === 'spectrum-2d-viewer') {

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -144,7 +144,11 @@ module.exports = {
       // only allow deleting products from plugins.  We might want to allow some non-plugin
       // data to also be deleted in the future, but would probably need more advanced logic
       // to ensure essential data isn't removed that would break the app.
-      return !this.isSelected && (this.$props.viewer.config === 'mosviz' ? false : true)
+      notSelected = !this.isSelected
+      isMosviz = this.$props.viewer.config === 'mosviz'
+      isCubeviz = this.$props.viewer.config === 'cubeviz'
+      isPluginData = !(this.$props.item.meta.Plugin === undefined)
+      return notSelected && !isMosviz && !(isCubeviz && !isPluginData)
     },
     selectTipId() {
       if (this.multi_select) {

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -1,59 +1,68 @@
 <template>
   <div style="display: contents">
-    <div v-if="isSelected">
-      <j-tooltip :tipid="multi_select ? 'viewer-data-select' : 'viewer-data-radio'">
-        <v-btn 
-          icon
-          :color="visibleState==='visible' ? 'accent' : 'default'"
-          @click="selectClicked">
-            <v-icon v-if="multi_select || item.type==='trace'">{{visibleState!=='hidden' ? "mdi-checkbox-marked" : "mdi-checkbox-blank-outline"}}</v-icon>
-            <v-icon v-else>{{visibleState!=='hidden' ? "mdi-radiobox-marked" : "mdi-radiobox-blank"}}</v-icon>
-        </v-btn>
-      </j-tooltip>
-    </div>
-    <div v-else>
-      <j-tooltip tipid="viewer-data-enable">
-        <v-btn 
-          icon
-          color="default"
-          @click="selectClicked">
-            <v-icon>mdi-plus</v-icon>
-        </v-btn>
-      </j-tooltip>
-    </div>
 
-    <j-tooltip :tooltipcontent="'data label: '+item.name" span_style="font-size: 12pt; padding-top: 6px; padding-left: 6px; width: calc(100% - 80px); white-space: nowrap; cursor: default;">
-      <j-layer-viewer-icon span_style="margin-left: 4px; margin-right: 2px" :icon="icon" color="#000000DE"></j-layer-viewer-icon>      
-      <div class="text-ellipsis-middle" style="font-weight: 500">
-        <span>
-          {{itemNamePrefix}}
-        </span>
-        <span>
-          {{itemNameExtension}}
-        </span>
+    <v-col cols=1 style="padding: 0" align-self="center">
+      <div v-if="isSelected">
+        <j-tooltip :tipid="multi_select ? 'viewer-data-select' : 'viewer-data-radio'">
+          <v-btn 
+            icon
+            :color="visibleState==='visible' ? 'accent' : 'default'"
+            @click="selectClicked">
+              <v-icon v-if="multi_select || item.type==='trace'">{{visibleState!=='hidden' ? "mdi-checkbox-marked" : "mdi-checkbox-blank-outline"}}</v-icon>
+              <v-icon v-else>{{visibleState!=='hidden' ? "mdi-radiobox-marked" : "mdi-radiobox-blank"}}</v-icon>
+          </v-btn>
+        </j-tooltip>
       </div>
-    </j-tooltip>
+      <div v-else>
+        <j-tooltip tipid="viewer-data-enable">
+          <v-btn 
+            icon
+            color="default"
+            @click="selectClicked">
+              <v-icon>mdi-plus</v-icon>
+          </v-btn>
+        </j-tooltip>
+      </div>
+    </v-col>
 
-    <div v-if="isSelected && isUnloadable" style="right: 2px">
-      <j-tooltip tipid='viewer-data-disable'>
-        <v-btn
-          icon
-          @click="$emit('data-item-unload', {
-            id: viewer.id,
-            item_id: item.id
-          })"
-        ><v-icon>mdi-close</v-icon></v-btn>
+    <v-col cols=9 style="padding: 0" align-self="center">
+      <j-tooltip :tooltipcontent="'data label: '+item.name" span_style="font-size: 12pt; padding-top: 6px; padding-left: 6px; width: calc(100% - 80px); white-space: nowrap; cursor: default;">
+        <j-layer-viewer-icon span_style="margin-left: 4px; margin-right: 2px" :icon="icon" color="#000000DE"></j-layer-viewer-icon>      
+        <div class="text-ellipsis-middle" style="font-weight: 500">
+          <span>
+            {{itemNamePrefix}}
+          </span>
+          <span>
+            {{itemNameExtension}}
+          </span>
+        </div>
       </j-tooltip>
-    </div>
+    </v-col>
 
-    <div v-if="isDeletable" style="right: 2px">
-      <j-tooltip tipid='viewer-data-delete'>
-        <v-btn
-          icon
-          @click="$emit('data-item-remove', {item_name: item.name})"
-        ><v-icon>mdi-delete</v-icon></v-btn>
-      </j-tooltip>
-    </div>
+    <v-col cols=1 style="padding: 0" align-self="center">
+      <div v-if="isSelected && isUnloadable">
+        <j-tooltip tipid='viewer-data-disable'>
+          <v-btn
+            icon
+            @click="$emit('data-item-unload', {
+              id: viewer.id,
+              item_id: item.id
+            })"
+          ><v-icon>mdi-close</v-icon></v-btn>
+        </j-tooltip>
+      </div>
+    </v-col>
+    <v-col cols=1 style="padding: 0" align-self="center">
+      <div v-if="isDeletable">
+        <j-tooltip tipid='viewer-data-delete'>
+          <v-btn
+            icon
+            @click="$emit('data-item-remove', {item_name: item.name})"
+          ><v-icon>mdi-delete</v-icon></v-btn>
+        </j-tooltip>
+      </div>
+    </v-col>
+
   </div>
 </template>
 

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -136,6 +136,7 @@ module.exports = {
       // only allow deleting products from plugins.  We might want to allow some non-plugin
       // data to also be deleted in the future, but would probably need more advanced logic
       // to ensure essential data isn't removed that would break the app.
+      return true
       if (this.$props.item.meta.Plugin === undefined) {
         return false
       }

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -25,7 +25,7 @@
       </div>
     </v-col>
 
-    <v-col cols=9 style="padding: 0" align-self="center">
+    <v-col cols=10 style="padding: 0" align-self="center">
       <j-tooltip :tooltipcontent="'data label: '+item.name" span_style="font-size: 12pt; padding-top: 6px; padding-left: 6px; width: calc(100% - 80px); white-space: nowrap; cursor: default;">
         <j-layer-viewer-icon span_style="margin-left: 4px; margin-right: 2px" :icon="icon" color="#000000DE"></j-layer-viewer-icon>      
         <div class="text-ellipsis-middle" style="font-weight: 500">
@@ -51,8 +51,6 @@
           ><v-icon>mdi-close</v-icon></v-btn>
         </j-tooltip>
       </div>
-    </v-col>
-    <v-col cols=1 style="padding: 0" align-self="center">
       <div v-if="isDeletable">
         <j-tooltip tipid='viewer-data-delete'>
           <v-btn
@@ -145,7 +143,7 @@ module.exports = {
       // only allow deleting products from plugins.  We might want to allow some non-plugin
       // data to also be deleted in the future, but would probably need more advanced logic
       // to ensure essential data isn't removed that would break the app.
-      return (this.$props.viewer.config === 'mosviz' ? false : true)
+      return !this.isSelected && (this.$props.viewer.config === 'mosviz' ? false : true)
     },
     selectTipId() {
       if (this.multi_select) {

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -145,12 +145,7 @@ module.exports = {
       // only allow deleting products from plugins.  We might want to allow some non-plugin
       // data to also be deleted in the future, but would probably need more advanced logic
       // to ensure essential data isn't removed that would break the app.
-      return true
-      if (this.$props.item.meta.Plugin === undefined) {
-        return false
-      }
-      // for any exceptions not above, enable deleting
-      return !this.isSelected
+      return (this.$props.viewer.config === 'mosviz' ? false : true)
     },
     selectTipId() {
       if (this.multi_select) {

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -345,8 +345,9 @@ class SpectralExtraction(PluginTemplateMixin):
 
     @observe('trace_dataset_selected')
     def _trace_dataset_selected(self, msg=None):
-        if not hasattr(self, 'trace_dataset'):
+        if not hasattr(self, 'trace_dataset') or (hasattr(msg, 'new') and msg.new == ''):
             # happens when first initializing plugin outside of tray
+            # or when all data is deleted from 2D viewer
             return
 
         width = self.trace_dataset.selected_obj.shape[0]

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -2,6 +2,7 @@ import pytest
 
 from jdaviz import Application, Specviz
 from jdaviz.configs.default.plugins.gaussian_smooth.gaussian_smooth import GaussianSmooth
+from glue.core.roi import XRangeROI
 
 
 # This applies to all viz but testing with Imviz should be enough.
@@ -140,3 +141,14 @@ def test_case_that_used_to_break_return_label(specviz_helper, spectrum1d):
     dc = specviz_helper.app.data_collection
     assert dc[0].label == "this used to break (1)"
     assert dc[1].label == "this used to break (2)"
+
+
+def test_vue_remove_data(specviz_helper, spectrum1d):
+    specviz_helper.load_spectrum(spectrum1d, data_label="data1")
+    specviz_helper.load_spectrum(spectrum1d, data_label="data2")
+    specviz_helper.app.vue_data_item_remove({'item_name': 'data1'})
+    specviz_helper.app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(7000, 7100))
+    with pytest.raises(RuntimeError, match="Cannot remove all base data"):
+        specviz_helper.app.vue_data_item_remove({'item_name': 'data2'})
+    specviz_helper.load_spectrum(spectrum1d, data_label="data3")
+    specviz_helper.app.vue_data_item_remove({'item_name': 'data2'})


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

~DO NOT MERGE THIS PR IN THIS STATE. This PR is kept in draft to allow for experimentation and discussion.~

In enabling data to be deleted, I found a few bugs and a few pieces of discussion we should have:

1. ~BUG: When I load 2 datasets and try to delete entries from Imviz, the first removal generally works. Though attempting to clear the second entry, Glue complains it cannot find the first entry that I already removed. I think there may be a key-lookup mismatch error occurring~ Worked around
2. ~BUG: When I delete an entry from Mosviz, the tool functions properly, but then gets confused when I try to switch rows, as it tries to delete the entry again, though it no longer exists. Have we given thought to how we want to "delete entries" in mosviz? Does it make sense to remove a single element from the row, rather than the row itself?~ Out of Scope
3. ~BUG: Specviz2D spectral extraction plugin does not respond well to the main 2D data getting removed~ Fixed in https://github.com/spacetelescope/jdaviz/pull/2194/commits/84c3804a6696be671687711c9aec1c82c802bbde
4. FWIW, Specviz and Cubeviz behave nicely! Of note, Cubeviz only allows you to reload data after ALL cube extensions are removed

After some additional testing, a critical bug surrounding subsets and plugin-generated data products emerged. These products are handed off nicely between data products when the original is deleted, but once the entire app is emptied of user-loaded data, the subsets and plugin-data graphically disappear. They still exist, but do not show on the plot. Unfortunately, requesting the subsets to redraw themselves didn't work, a suggestion made by Jesse in: https://github.com/spacetelescope/jdaviz/pull/2182/files#diff-efc390db5e069fce31d7fbdb264bccc290af500c8017bcdab575ca87da1656adR220-R222. 

This PR attempts to accommodate this issue by checking each viewer for a "survivor" dataset (that being, a non-subset and non-plugin dataset) for the other artifacts to transfer to, before allowing the data from being deleted.

Screen Recordings:

<details>
<summary>Bug showing in Cubeviz</summary>

https://github.com/spacetelescope/jdaviz/assets/25206008/bd898c09-a892-4953-b29e-40f207b733d4

</details>

<details>
<summary>Correct behavior in Specviz</summary>

https://github.com/spacetelescope/jdaviz/assets/25206008/381aa272-b8f2-4201-bb49-fd1616bac6c5

</details>

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
