### PR TITLE
Add option to get_data to apply spectral subset to collapse spatial

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ Cubeviz
 - ``get_data`` now supports ``function=True`` to adopt the collapse-function from the spectrum viewer.
   [#2117]
 
+- ``get_data`` now supports applying a spectral mask to a collapse spatial subset. [#2199]
+
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -149,9 +149,12 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
             Data is returned as type cls with subsets applied.
 
         """
-        if function or (spectral_subset and spatial_subset):
+        if function and spectral_subset and spatial_subset:
             return self.specviz.get_data(data_label=data_label, spectral_subset=spectral_subset,
                                          cls=cls, spatial_subset=spatial_subset, function=function)
+        elif function is False and (spectral_subset and spatial_subset):
+            raise ValueError("function cannot be False if spectral_subset"
+                             " and spatial_subset have values")
         elif function is False:
             function = None
         return self._get_data(data_label=data_label, spatial_subset=spatial_subset,

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -120,7 +120,8 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
             self._specviz = Specviz(app=self.app)
         return self._specviz
 
-    def get_data(self, data_label=None, cls=None, subset_to_apply=None, function=None):
+    def get_data(self, data_label=None, cls=None, subset_to_apply=None, function=None,
+                 spectral_to_spatial=None):
         """
         Returns data with name equal to data_label of type cls with subsets applied from
         subset_to_apply.
@@ -138,6 +139,9 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
             If True, will collapse according to the current collapse function defined in the
             spectrum viewer.  If provided as a string, the cube will be collapsed with the provided
             function.  If False, None, or not passed, the entire cube will be returned.
+        spectral_to_spatial : str, optional
+            Spectral subset to be applied to spatial subset. Only possible if function is
+            set to True.
 
         Returns
         -------
@@ -147,7 +151,8 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
         """
         if function is True:
             return self.specviz.get_data(data_label=data_label, cls=cls,
-                                         subset_to_apply=subset_to_apply)
+                                         subset_to_apply=subset_to_apply,
+                                         spectral_to_spatial=spectral_to_spatial)
         elif function is False:
             function = None
         return self._get_data(data_label=data_label, cls=cls, subset_to_apply=subset_to_apply,

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -149,11 +149,9 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
             Data is returned as type cls with subsets applied.
 
         """
-        if function:
+        if function or (spectral_subset and spatial_subset):
             return self.specviz.get_data(data_label=data_label, spectral_subset=spectral_subset,
                                          cls=cls, spatial_subset=spatial_subset, function=function)
-        elif function is None and spectral_subset and spatial_subset:
-            function = True
         elif function is False:
             function = None
         return self._get_data(data_label=data_label, spatial_subset=spatial_subset,

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -120,8 +120,8 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
             self._specviz = Specviz(app=self.app)
         return self._specviz
 
-    def get_data(self, data_label=None, cls=None, subset_to_apply=None, function=None,
-                 spectral_to_spatial=None):
+    def get_data(self, data_label=None, spatial_subset=None, spectral_subset=None, function=None,
+                 cls=None):
         """
         Returns data with name equal to data_label of type cls with subsets applied from
         subset_to_apply.
@@ -149,14 +149,15 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
             Data is returned as type cls with subsets applied.
 
         """
-        if function is True:
-            return self.specviz.get_data(data_label=data_label, cls=cls,
-                                         subset_to_apply=subset_to_apply,
-                                         spectral_to_spatial=spectral_to_spatial)
+        if function:
+            return self.specviz.get_data(data_label=data_label, spectral_subset=spectral_subset,
+                                         cls=cls, spatial_subset=spatial_subset, function=function)
+        elif function is None and spectral_subset and spatial_subset:
+            function = True
         elif function is False:
             function = None
-        return self._get_data(data_label=data_label, cls=cls, subset_to_apply=subset_to_apply,
-                              function=function)
+        return self._get_data(data_label=data_label, spatial_subset=spatial_subset,
+                              spectral_subset=spectral_subset, function=function, cls=cls)
 
 
 def layer_is_cube_image_data(layer):

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -149,15 +149,16 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
             Data is returned as type cls with subsets applied.
 
         """
-        if function is not False and spectral_subset and spatial_subset:
+        # If function is a value ('sum' or 'minimum') or True and spatial and spectral
+        # are set, then we collapse the cube along the spatial subset using the function, then
+        # we apply the mask from the spectral subset.
+        # If function is any value other than False, we use specviz
+        if (function is not False and spectral_subset and spatial_subset) or function:
             return self.specviz.get_data(data_label=data_label, spectral_subset=spectral_subset,
                                          cls=cls, spatial_subset=spatial_subset, function=function)
-        elif function and spatial_subset:
-            return self.specviz.get_data(data_label=data_label, spectral_subset=spectral_subset,
-                                         cls=cls, spatial_subset=spatial_subset, function=function)
-        elif function is False and (spectral_subset and spatial_subset):
+        elif function is False and spectral_subset:
             raise ValueError("function cannot be False if spectral_subset"
-                             " and spatial_subset have values")
+                             " is set")
         elif function is False:
             function = None
         return self._get_data(data_label=data_label, spatial_subset=spatial_subset,

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -149,7 +149,10 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
             Data is returned as type cls with subsets applied.
 
         """
-        if (function or function is None) and spectral_subset and spatial_subset:
+        if function is not False and spectral_subset and spatial_subset:
+            return self.specviz.get_data(data_label=data_label, spectral_subset=spectral_subset,
+                                         cls=cls, spatial_subset=spatial_subset, function=function)
+        elif function and spatial_subset:
             return self.specviz.get_data(data_label=data_label, spectral_subset=spectral_subset,
                                          cls=cls, spatial_subset=spatial_subset, function=function)
         elif function is False and (spectral_subset and spatial_subset):

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -130,18 +130,18 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
         ----------
         data_label : str, optional
             Provide a label to retrieve a specific data set from data_collection.
-        cls : `~specutils.Spectrum1D`, `~astropy.nddata.CCDData`, optional
-            The type that data will be returned as.
-        subset_to_apply : str, optional
-            Subset that is to be applied to data before it is returned.
+        spatial_subset : str, optional
+            Spatial subset applied to data.
+        spectral_subset : str, optional
+            Spectral subset applied to data.
         function : {True, False, 'minimum', 'maximum', 'mean', 'median', 'sum'}, optional
             Ignored if ``data_label`` does not point to cube-like data.
             If True, will collapse according to the current collapse function defined in the
             spectrum viewer.  If provided as a string, the cube will be collapsed with the provided
-            function.  If False, None, or not passed, the entire cube will be returned.
-        spectral_to_spatial : str, optional
-            Spectral subset to be applied to spatial subset. Only possible if function is
-            set to True.
+            function.  If False, None, or not passed, the entire cube will be returned (unless there
+            are values for ``spatial_subset`` and ``spectral_subset``).
+        cls : `~specutils.Spectrum1D`, `~astropy.nddata.CCDData`, optional
+            The type that data will be returned as.
 
         Returns
         -------

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -149,7 +149,7 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
             Data is returned as type cls with subsets applied.
 
         """
-        if function and spectral_subset and spatial_subset:
+        if (function or function is None) and spectral_subset and spatial_subset:
             return self.specviz.get_data(data_label=data_label, spectral_subset=spectral_subset,
                                          cls=cls, spatial_subset=spatial_subset, function=function)
         elif function is False and (spectral_subset and spatial_subset):

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
@@ -74,7 +74,7 @@ def test_get_data_spatial_and_spectral(cubeviz_helper, spectrum1d_cube_larger):
     cubeviz_helper.load_data(spectrum1d_cube_larger, data_label)
     cubeviz_helper._apply_interactive_region('bqplot:ellipse', (0, 0), (9, 8))
 
-    spec_viewer = cubeviz_helper.app.get_viewer(cubeviz_helper._default_spectrum_viewer_reference_name)
+    spec_viewer = cubeviz_helper.app.get_viewer(cubeviz_helper._default_spectrum_viewer_reference_name) # noqa
     spec_viewer.apply_roi(XRangeROI(4.62440061e-07, 4.62520112e-07))
 
     data_label = data_label + "[FLUX]"
@@ -94,4 +94,3 @@ def test_get_data_spatial_and_spectral(cubeviz_helper, spectrum1d_cube_larger):
                                                 function='minimum')
     assert max(list(spatial_with_spec.flux.value)) == 78.
     assert min(list(spatial_with_spec.flux.value)) == 6.
-

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
@@ -29,7 +29,7 @@ def test_invalid_function(cubeviz_helper, spectrum1d_cube):
     cubeviz_helper._apply_interactive_region('bqplot:ellipse', (0, 0), (9, 8))
 
     with pytest.raises(ValueError, match='function 42 not in list of valid '):
-        cubeviz_helper.get_data(data_label="test[FLUX]", subset_to_apply='Subset 1', function=42)
+        cubeviz_helper.get_data(data_label="test[FLUX]", spatial_subset='Subset 1', function=42)
 
     # Also make sure specviz redshift slider warning does not show up.
     # https://github.com/spacetelescope/jdaviz/issues/2029
@@ -41,20 +41,20 @@ def test_valid_function(cubeviz_helper, spectrum1d_cube):
     cubeviz_helper._apply_interactive_region('bqplot:ellipse', (0, 0), (9, 8))
 
     results_cube = cubeviz_helper.get_data(data_label="test[FLUX]",
-                                           subset_to_apply='Subset 1')
+                                           spatial_subset='Subset 1')
     assert results_cube.flux.ndim == 3
     results_false = cubeviz_helper.get_data(data_label="test[FLUX]",
-                                            subset_to_apply='Subset 1', function=False)
+                                            spatial_subset='Subset 1', function=False)
     assert results_false.flux.ndim == 3
 
     results_def = cubeviz_helper.get_data(data_label="test[FLUX]",
-                                          subset_to_apply='Subset 1', function=True)
+                                          spatial_subset='Subset 1', function=True)
     assert results_def.flux.ndim == 1
 
     results_min = cubeviz_helper.get_data(data_label="test[FLUX]",
-                                          subset_to_apply='Subset 1', function="minimum")
+                                          spatial_subset='Subset 1', function="minimum")
     results_max = cubeviz_helper.get_data(data_label="test[FLUX]",
-                                          subset_to_apply='Subset 1', function="maximum")
+                                          spatial_subset='Subset 1', function="maximum")
     assert isinstance(results_min, Spectrum1D)
     assert_quantity_allclose(results_min.flux,
                              [6., 14.] * u.Jy, atol=1e-5 * u.Jy)

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
@@ -102,11 +102,14 @@ def test_get_data_spatial_and_spectral(cubeviz_helper, spectrum1d_cube_larger):
                                                      function=True)
 
     with pytest.raises(ValueError, match=f'{spectral_subset} is not a spatial subset.'):
-        cubeviz_helper.get_data(data_label=data_label, spatial_subset=spectral_subset, function=True)
+        cubeviz_helper.get_data(data_label=data_label, spatial_subset=spectral_subset,
+                                function=True)
     with pytest.raises(ValueError, match=f'{spatial_subset} is not a spectral subset.'):
-        cubeviz_helper.get_data(data_label=data_label, spectral_subset=spatial_subset, function=True)
+        cubeviz_helper.get_data(data_label=data_label, spectral_subset=spatial_subset,
+                                function=True)
     with pytest.raises(ValueError, match='function cannot be False if spectral_subset'):
-        cubeviz_helper.get_data(data_label=data_label, spectral_subset=spectral_subset, function=False)
+        cubeviz_helper.get_data(data_label=data_label, spectral_subset=spectral_subset,
+                                function=False)
 
     collapse_with_spectral2 = cubeviz_helper.get_data(data_label=data_label,
                                                       function=True)

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
@@ -100,6 +100,10 @@ def test_get_data_spatial_and_spectral(cubeviz_helper, spectrum1d_cube_larger):
     collapse_with_spectral = cubeviz_helper.get_data(data_label=data_label,
                                                      spectral_subset=spectral_subset,
                                                      function=True)
+    collapse_with_spectral2 = cubeviz_helper.get_data(data_label=data_label,
+                                                      function=True)
+
+    assert list(collapse_with_spectral.flux) == list(collapse_with_spectral2.flux)
 
     with pytest.raises(ValueError, match=f'{spectral_subset} is not a spatial subset.'):
         cubeviz_helper.get_data(data_label=data_label, spatial_subset=spectral_subset,
@@ -110,8 +114,3 @@ def test_get_data_spatial_and_spectral(cubeviz_helper, spectrum1d_cube_larger):
     with pytest.raises(ValueError, match='function cannot be False if spectral_subset'):
         cubeviz_helper.get_data(data_label=data_label, spectral_subset=spectral_subset,
                                 function=False)
-
-    collapse_with_spectral2 = cubeviz_helper.get_data(data_label=data_label,
-                                                      function=True)
-
-    assert list(collapse_with_spectral.flux) == list(collapse_with_spectral2.flux)

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
@@ -85,8 +85,8 @@ def test_get_data_spatial_and_spectral(cubeviz_helper, spectrum1d_cube_larger):
                                                 spatial_subset=spatial_subset,
                                                 spectral_subset=spectral_subset)
     assert spatial_with_spec.flux.ndim == 1
-    assert list(spatial_with_spec.mask) == [False, False, True, True, False,
-                                            False, False, False, False, False]
+    assert list(spatial_with_spec.mask) == [True, True, False, False, True,
+                                            True, True, True, True, True]
     assert max(list(spatial_with_spec.flux.value)) == 157.
     assert min(list(spatial_with_spec.flux.value)) == 13.
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
@@ -71,6 +71,8 @@ def test_valid_function(cubeviz_helper, spectrum1d_cube):
 
 def test_get_data_spatial_and_spectral(cubeviz_helper, spectrum1d_cube_larger):
     data_label = "test"
+    spatial_subset = "Subset 1"
+    spectral_subset = "Subset 2"
     cubeviz_helper.load_data(spectrum1d_cube_larger, data_label)
     cubeviz_helper._apply_interactive_region('bqplot:ellipse', (0, 0), (9, 8))
 
@@ -80,8 +82,8 @@ def test_get_data_spatial_and_spectral(cubeviz_helper, spectrum1d_cube_larger):
     data_label = data_label + "[FLUX]"
     # This will be the same if function is None or True
     spatial_with_spec = cubeviz_helper.get_data(data_label=data_label,
-                                                spatial_subset="Subset 1",
-                                                spectral_subset="Subset 2")
+                                                spatial_subset=spatial_subset,
+                                                spectral_subset=spectral_subset)
     assert spatial_with_spec.flux.ndim == 1
     assert list(spatial_with_spec.mask) == [False, False, True, True, False,
                                             False, False, False, False, False]
@@ -89,8 +91,24 @@ def test_get_data_spatial_and_spectral(cubeviz_helper, spectrum1d_cube_larger):
     assert min(list(spatial_with_spec.flux.value)) == 13.
 
     spatial_with_spec = cubeviz_helper.get_data(data_label=data_label,
-                                                spatial_subset="Subset 1",
-                                                spectral_subset="Subset 2",
+                                                spatial_subset=spatial_subset,
+                                                spectral_subset=spectral_subset,
                                                 function='minimum')
     assert max(list(spatial_with_spec.flux.value)) == 78.
     assert min(list(spatial_with_spec.flux.value)) == 6.
+
+    collapse_with_spectral = cubeviz_helper.get_data(data_label=data_label,
+                                                     spectral_subset=spectral_subset,
+                                                     function=True)
+
+    with pytest.raises(ValueError, match=f'{spectral_subset} is not a spatial subset.'):
+        cubeviz_helper.get_data(data_label=data_label, spatial_subset=spectral_subset, function=True)
+    with pytest.raises(ValueError, match=f'{spatial_subset} is not a spectral subset.'):
+        cubeviz_helper.get_data(data_label=data_label, spectral_subset=spatial_subset, function=True)
+    with pytest.raises(ValueError, match='function cannot be False if spectral_subset'):
+        cubeviz_helper.get_data(data_label=data_label, spectral_subset=spectral_subset, function=False)
+
+    collapse_with_spectral2 = cubeviz_helper.get_data(data_label=data_label,
+                                                      function=True)
+
+    assert list(collapse_with_spectral.flux) == list(collapse_with_spectral2.flux)

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -239,6 +239,28 @@ class Imviz(ImageConfigHelper):
         """
         return getattr(self.app, '_catalog_source_table', None)
 
+    def get_data(self, data_label=None, spatial_subset=None, cls=None):
+        """
+        Returns data with name equal to data_label of type cls with subsets applied from
+        spatial_subset.
+
+        Parameters
+        ----------
+        data_label : str, optional
+            Provide a label to retrieve a specific data set from data_collection.
+        spatial_subset : str, optional
+            Spatial subset applied to data.
+        cls : `~specutils.Spectrum1D`, `~astropy.nddata.CCDData`, optional
+            The type that data will be returned as.
+
+        Returns
+        -------
+        data : cls
+            Data is returned as type cls with subsets applied.
+
+        """
+        return self._get_data(data_label=data_label, spatial_subset=spatial_subset, cls=cls)
+
 
 def split_filename_with_fits_ext(filename):
     """Split a ``filename[ext]`` input into filename and FITS extension.

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -1076,3 +1076,25 @@ class Mosviz(ConfigHelper, LineListMixin):
         `~specutils.Spectrum1D`
         """
         return self._get_spectrum('2D Spectra', row, apply_slider_redshift)
+
+    def get_data(self, data_label=None, spectral_subset=None, cls=None):
+        """
+        Returns data with name equal to data_label of type cls with subsets applied from
+        spectral_subset.
+
+        Parameters
+        ----------
+        data_label : str, optional
+            Provide a label to retrieve a specific data set from data_collection.
+        spectral_subset : str, optional
+            Spectral subset applied to data.
+        cls : `~specutils.Spectrum1D`, `~astropy.nddata.CCDData`, optional
+            The type that data will be returned as.
+
+        Returns
+        -------
+        data : cls
+            Data is returned as type cls with subsets applied.
+
+        """
+        return self._get_data(data_label=data_label, spectral_subset=spectral_subset, cls=cls)

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -308,6 +308,7 @@ class Specviz(ConfigHelper, LineListMixin):
         elif spatial_subset or function:
             raise ValueError('kwargs spatial subset and function are not valid in specviz')
         else:
+            spatial_subset = None
             function = None
 
         return self._get_data(data_label=data_label, spatial_subset=spatial_subset,

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -305,6 +305,8 @@ class Specviz(ConfigHelper, LineListMixin):
 
             if cls is None:
                 cls = Spectrum1D
+        elif spatial_subset or function:
+            raise ValueError('kwargs spatial subset and function are not valid in specviz')
         else:
             function = None
 

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -85,6 +85,7 @@ class Specviz(ConfigHelper, LineListMixin):
         else:
             for layer_state in viewer.state.layers:
                 lyr = layer_state.layer
+                print(lyr.label, type(lyr))
                 if subset_to_apply is not None:
                     if lyr.label == subset_to_apply:
                         spectrum = get_data_method(data_label=lyr.data.label,
@@ -97,7 +98,7 @@ class Specviz(ConfigHelper, LineListMixin):
                 else:
                     if isinstance(lyr, GroupedSubset):
                         spectrum = get_data_method(data_label=lyr.data.label,
-                                                   spectral_subset=lyr.label,
+                                                   spatial_subset=lyr.label,
                                                    cls=Spectrum1D,
                                                    **function_kwargs)
                         spectra[f'{lyr.data.label} ({lyr.label})'] = spectrum

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -79,7 +79,7 @@ class Specviz(ConfigHelper, LineListMixin):
 
         if data_label is not None:
             spectrum = get_data_method(data_label=data_label,
-                                       subset_to_apply=subset_to_apply,
+                                       spectral_subset=subset_to_apply,
                                        cls=Spectrum1D)
             spectra[data_label] = spectrum
         else:
@@ -88,7 +88,7 @@ class Specviz(ConfigHelper, LineListMixin):
                 if subset_to_apply is not None:
                     if lyr.label == subset_to_apply:
                         spectrum = get_data_method(data_label=lyr.data.label,
-                                                   subset_to_apply=subset_to_apply,
+                                                   spectral_subset=subset_to_apply,
                                                    cls=Spectrum1D,
                                                    **function_kwargs)
                         spectra[lyr.data.label] = spectrum
@@ -97,7 +97,7 @@ class Specviz(ConfigHelper, LineListMixin):
                 else:
                     if isinstance(lyr, GroupedSubset):
                         spectrum = get_data_method(data_label=lyr.data.label,
-                                                   subset_to_apply=lyr.label,
+                                                   spectral_subset=lyr.label,
                                                    cls=Spectrum1D,
                                                    **function_kwargs)
                         spectra[f'{lyr.data.label} ({lyr.label})'] = spectrum
@@ -271,7 +271,7 @@ class Specviz(ConfigHelper, LineListMixin):
             self._default_spectrum_viewer_reference_name
         ).figure.axes[axis].tick_format = fmt
 
-    def get_data(self, data_label=None, cls=None, subset_to_apply=None, spectral_to_spatial=None):
+    def get_data(self, data_label=None, spectral_subset=None, cls=None, **kwargs):
         """
         Returns data with name equal to data_label of type cls with subsets applied from
         subset_to_apply.
@@ -294,15 +294,22 @@ class Specviz(ConfigHelper, LineListMixin):
             Data is returned as type cls with subsets applied.
 
         """
+        spatial_subset = kwargs.pop("spatial_subset", None)
+        function = kwargs.pop("function", None)
         if self.app.config == 'cubeviz':
             # then this is a specviz instance inside cubeviz and we want to default to the
             # viewer's collapse function
             default_sp_viewer = self.app.get_viewer(self._default_spectrum_viewer_reference_name)
-            function = getattr(default_sp_viewer.state, 'function', None)
+            if function is True or function is None:
+                function = getattr(default_sp_viewer.state, 'function', None)
+
             if cls is None:
                 cls = Spectrum1D
         else:
             function = None
 
-        return self._get_data(data_label=data_label, cls=cls, subset_to_apply=subset_to_apply,
-                              function=function, spectral_to_spatial=spectral_to_spatial)
+        # return self._get_data(data_label=data_label, cls=cls, subset_to_apply=subset_to_apply,
+        #                       function=function, spectral_to_spatial=spectral_to_spatial)
+        # print(function)
+        return self._get_data(data_label=data_label, spatial_subset=spatial_subset,
+                              spectral_subset=spectral_subset, function=function, cls=cls)

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -271,7 +271,7 @@ class Specviz(ConfigHelper, LineListMixin):
             self._default_spectrum_viewer_reference_name
         ).figure.axes[axis].tick_format = fmt
 
-    def get_data(self, data_label=None, cls=None, subset_to_apply=None):
+    def get_data(self, data_label=None, cls=None, subset_to_apply=None, spectral_to_spatial=None):
         """
         Returns data with name equal to data_label of type cls with subsets applied from
         subset_to_apply.
@@ -284,6 +284,9 @@ class Specviz(ConfigHelper, LineListMixin):
             The type that data will be returned as.
         subset_to_apply : str, optional
             Subset that is to be applied to data before it is returned.
+        spectral_to_spatial : str, optional
+            Spectral subset to be applied to spatial subset. Only possible if this is
+            a specviz instance inside cubeviz.
 
         Returns
         -------
@@ -302,4 +305,4 @@ class Specviz(ConfigHelper, LineListMixin):
             function = None
 
         return self._get_data(data_label=data_label, cls=cls, subset_to_apply=subset_to_apply,
-                              function=function)
+                              function=function, spectral_to_spatial=spectral_to_spatial)

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -296,6 +296,9 @@ class Specviz(ConfigHelper, LineListMixin):
         """
         spatial_subset = kwargs.pop("spatial_subset", None)
         function = kwargs.pop("function", None)
+        if len(kwargs) > 0:
+            raise ValueError(f'kwargs {[x for x in kwargs.keys()]} are not valid')
+
         if self.app.config == 'cubeviz':
             # then this is a specviz instance inside cubeviz and we want to default to the
             # viewer's collapse function
@@ -308,8 +311,5 @@ class Specviz(ConfigHelper, LineListMixin):
         else:
             function = None
 
-        # return self._get_data(data_label=data_label, cls=cls, subset_to_apply=subset_to_apply,
-        #                       function=function, spectral_to_spatial=spectral_to_spatial)
-        # print(function)
         return self._get_data(data_label=data_label, spatial_subset=spatial_subset,
                               spectral_subset=spectral_subset, function=function, cls=cls)

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -280,13 +280,10 @@ class Specviz(ConfigHelper, LineListMixin):
         ----------
         data_label : str, optional
             Provide a label to retrieve a specific data set from data_collection.
+        spectral_subset : str, optional
+            Spectral subset applied to data.
         cls : `~specutils.Spectrum1D`, optional
             The type that data will be returned as.
-        subset_to_apply : str, optional
-            Subset that is to be applied to data before it is returned.
-        spectral_to_spatial : str, optional
-            Spectral subset to be applied to spatial subset. Only possible if this is
-            a specviz instance inside cubeviz.
 
         Returns
         -------

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -383,7 +383,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
             # cube, but still apply that to the spatially-collapsed spectrum.
             continuum_mask = ~self._specviz_helper.get_data(
                 self.dataset.selected,
-                subset_to_apply=self.continuum_subset_selected).mask
+                spectral_subset=self.continuum_subset_selected).mask
             spectral_axis_nanmasked = spectral_axis.value.copy()
             spectral_axis_nanmasked[~continuum_mask] = np.nan
             if self.spectral_subset_selected == "Entire Spectrum":

--- a/jdaviz/configs/specviz2d/helper.py
+++ b/jdaviz/configs/specviz2d/helper.py
@@ -238,3 +238,25 @@ class Specviz2d(ConfigHelper, LineListMixin):
             self.app.add_data_to_viewer(
                 self._default_spectrum_2d_viewer_reference_name, data_label
             )
+
+    def get_data(self, data_label=None, spectral_subset=None, cls=None):
+        """
+        Returns data with name equal to data_label of type cls with subsets applied from
+        spectral_subset.
+
+        Parameters
+        ----------
+        data_label : str, optional
+            Provide a label to retrieve a specific data set from data_collection.
+        spectral_subset : str, optional
+            Spectral subset applied to data.
+        cls : `~specutils.Spectrum1D`, `~astropy.nddata.CCDData`, optional
+            The type that data will be returned as.
+
+        Returns
+        -------
+        data : cls
+            Data is returned as type cls with subsets applied.
+
+        """
+        return self._get_data(data_label=data_label, spectral_subset=spectral_subset, cls=cls)

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -511,30 +511,25 @@ class ConfigHelper(HubListener):
 
         return data
 
-    def get_data(self, data_label=None, spatial_subset=None, spectral_subset=None, cls=None):
+    def get_data(self, data_label=None, cls=None):
         """
-        Returns data with name equal to data_label of type cls with subsets applied from
-        spatial_subsets and/or spectral_subsets.
+        Returns data with name equal to data_label of type cls.
 
         Parameters
         ----------
         data_label : str, optional
             Provide a label to retrieve a specific data set from data_collection.
-        spatial_subset : str, optional
-            Spatial subset applied to data.
-        spectral_subset : str, optional
-            Spectral subset applied to data.
         cls : `~specutils.Spectrum1D`, `~astropy.nddata.CCDData`, optional
             The type that data will be returned as.
 
         Returns
         -------
         data : cls
-            Data is returned as type cls with subsets applied.
+            Data is returned as type cls.
 
         """
-        return self._get_data(data_label=data_label, spatial_subset=spatial_subset,
-                              spectral_subset=spectral_subset, function=None, cls=None)
+        return self._get_data(data_label=data_label, spatial_subset=None,
+                              spectral_subset=None, function=None, cls=None)
 
 
 class ImageConfigHelper(ConfigHelper):

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -504,7 +504,7 @@ class ConfigHelper(HubListener):
                 spec_subset = handler.to_object(spec_sub, **object_kwargs)
             except Exception as e:
                 warnings.warn(f"Not able to get {data_label} returned with"
-                              f" subset {subsets.label} applied of type {cls}."
+                              f" subset {spectral_subset} applied of type {cls}."
                               f" Exception: {e}")
             # Return collapsed Spectrum1D object with spectral subset mask applied
             data.mask = ~spec_subset.mask

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -22,6 +22,7 @@ from glue.core.subset import Subset, MaskSubsetState
 from glue.config import data_translator
 from ipywidgets.widgets import widget_serialization
 from specutils import Spectrum1D
+from specutils.manipulation import extract_region
 
 
 from jdaviz.app import Application
@@ -410,7 +411,8 @@ class ConfigHelper(HubListener):
                       DeprecationWarning)
         return self.show(loc="sidecar:tab-after", title=title)
 
-    def _get_data(self, data_label=None, cls=None, subset_to_apply=None, function=None):
+    def _get_data(self, data_label=None, cls=None, subset_to_apply=None, function=None,
+                  spectral_to_spatial=None):
         list_of_valid_function_values = ('minimum', 'maximum', 'mean',
                                          'median', 'sum')
         if function and function not in list_of_valid_function_values:
@@ -480,9 +482,15 @@ class ConfigHelper(HubListener):
                             warnings.warn(f"Not able to get {data_label} returned with"
                                           f" subset {subsets.label} applied of type {cls}."
                                           f" Exception: {e}")
+        # Apply spectral subset to spatial subset if applicable
+        if spectral_to_spatial:
+            sr = self.app.get_subsets(spectral_to_spatial)
+            if sr:
+                data = extract_region(data, sr, return_single_spectrum=True)
+
         return data
 
-    def get_data(self, data_label=None, cls=None, subset_to_apply=None):
+    def get_data(self, data_label=None, cls=None, subset_to_apply=None, spectral_to_spatial=None):
         """
         Returns data with name equal to data_label of type cls with subsets applied from
         subset_to_apply.
@@ -495,6 +503,8 @@ class ConfigHelper(HubListener):
             The type that data will be returned as.
         subset_to_apply : str, optional
             Subset that is to be applied to data before it is returned.
+        spectral_to_spatial : str, optional
+            Spectral subset to be applied to spatial subset.
 
         Returns
         -------
@@ -502,7 +512,8 @@ class ConfigHelper(HubListener):
             Data is returned as type cls with subsets applied.
 
         """
-        return self._get_data(data_label=data_label, cls=cls, subset_to_apply=subset_to_apply)
+        return self._get_data(data_label=data_label, cls=cls, subset_to_apply=subset_to_apply,
+                              spectral_to_spatial=spectral_to_spatial)
 
 
 class ImageConfigHelper(ConfigHelper):

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -517,7 +517,7 @@ class ConfigHelper(HubListener):
                               f" Exception: {e}")
             if spatial_subset or function:
                 # Return collapsed Spectrum1D object with spectral subset mask applied
-                data.mask = ~spec_subset.mask
+                data.mask = spec_subset.mask
             else:
                 data = spec_subset
 

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -514,7 +514,7 @@ class ConfigHelper(HubListener):
     def get_data(self, data_label=None, spatial_subset=None, spectral_subset=None, cls=None):
         """
         Returns data with name equal to data_label of type cls with subsets applied from
-        subset_to_apply.
+        spatial_subsets and/or spectral_subsets.
 
         Parameters
         ----------

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -22,7 +22,6 @@ from glue.core.subset import Subset, MaskSubsetState
 from glue.config import data_translator
 from ipywidgets.widgets import widget_serialization
 from specutils import Spectrum1D
-from specutils.manipulation import extract_region
 
 
 from jdaviz.app import Application
@@ -521,12 +520,12 @@ class ConfigHelper(HubListener):
         ----------
         data_label : str, optional
             Provide a label to retrieve a specific data set from data_collection.
+        spatial_subset : str, optional
+            Spatial subset applied to data.
+        spectral_subset : str, optional
+            Spectral subset applied to data.
         cls : `~specutils.Spectrum1D`, `~astropy.nddata.CCDData`, optional
             The type that data will be returned as.
-        subset_to_apply : str, optional
-            Subset that is to be applied to data before it is returned.
-        spectral_to_spatial : str, optional
-            Spectral subset to be applied to spatial subset.
 
         Returns
         -------
@@ -534,8 +533,6 @@ class ConfigHelper(HubListener):
             Data is returned as type cls with subsets applied.
 
         """
-        # return self._get_data(data_label=data_label, cls=cls, subset_to_apply=subset_to_apply,
-        #                       spectral_to_spatial=spectral_to_spatial)
         return self._get_data(data_label=data_label, spatial_subset=spatial_subset,
                               spectral_subset=spectral_subset, function=None, cls=None)
 

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -411,8 +411,6 @@ class ConfigHelper(HubListener):
                       DeprecationWarning)
         return self.show(loc="sidecar:tab-after", title=title)
 
-    # def _get_data(self, data_label=None, cls=None, subset_to_apply=None, function=None,
-    #               spectral_to_spatial=None):
     def _get_data(self, data_label=None, spatial_subset=None, spectral_subset=None,
                   function=None, cls=None):
         list_of_valid_function_values = ('minimum', 'maximum', 'mean',
@@ -476,7 +474,8 @@ class ConfigHelper(HubListener):
             raise AttributeError(f"A valid cls must be provided to"
                                  f" apply subset {spectral_subset} to data. "
                                  f"Instead, {cls} was given.")
-        subset_to_apply = spatial_subset if spatial_subset else spectral_subset if spectral_subset else None
+        subset_to_apply = (spatial_subset if spatial_subset
+                           else spectral_subset if spectral_subset else None)
         # Loop through each subset
         for subsets in self.app.data_collection.subset_groups:
             # If name matches the name in subsets_to_apply, continue
@@ -501,7 +500,6 @@ class ConfigHelper(HubListener):
 
         return data
 
-    # def get_data(self, data_label=None, cls=None, subset_to_apply=None, spectral_to_spatial=None):
     def get_data(self, data_label=None, spatial_subset=None, spectral_subset=None, cls=None):
         """
         Returns data with name equal to data_label of type cls with subsets applied from

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1031,8 +1031,12 @@ class SubsetSelect(SelectPluginComponent):
 
     @property
     def selected_subset_mask(self):
-        get_data_kwargs = {'data_label': self.plugin.dataset.selected,
-                           'subset_to_apply': self.selected}
+        if self._allowed_type == 'spatial':
+            get_data_kwargs = {'data_label': self.plugin.dataset.selected,
+                               'spatial_subset': self.selected}
+        elif self._allowed_type == 'spectral':
+            get_data_kwargs = {'data_label': self.plugin.dataset.selected,
+                               'spectral_subset': self.selected}
 
         if self.app.config == 'cubeviz' and self._allowed_type == 'spectral':
             viewer_ref = getattr(self.plugin,
@@ -1487,7 +1491,7 @@ class DatasetSelect(SelectPluginComponent):
         if spatial_subset == SPATIAL_DEFAULT_TEXT:
             spatial_subset = None
         return self.plugin._specviz_helper.get_data(data_label=self.selected,
-                                                    subset_to_apply=spatial_subset)
+                                                    spatial_subset=spatial_subset)
 
     def _is_valid_item(self, data):
         def not_from_plugin(data):

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1031,12 +1031,9 @@ class SubsetSelect(SelectPluginComponent):
 
     @property
     def selected_subset_mask(self):
-        if self._allowed_type == 'spatial':
-            get_data_kwargs = {'data_label': self.plugin.dataset.selected,
-                               'spatial_subset': self.selected}
-        elif self._allowed_type == 'spectral':
-            get_data_kwargs = {'data_label': self.plugin.dataset.selected,
-                               'spectral_subset': self.selected}
+        get_data_kwargs = {'data_label': self.plugin.dataset.selected}
+        if self._allowed_type:
+            get_data_kwargs[f'{self._allowed_type}_subset'] = self.selected
 
         if self.app.config == 'cubeviz' and self._allowed_type == 'spectral':
             viewer_ref = getattr(self.plugin,

--- a/jdaviz/core/tests/test_helpers.py
+++ b/jdaviz/core/tests/test_helpers.py
@@ -64,7 +64,7 @@ class TestConfigHelper:
     def test_get_data_with_one_subset_per_data(self, specviz_helper, label, subset_name, answer):
 
         results = specviz_helper.get_data(data_label=label,
-                                          subset_to_apply=subset_name)
+                                          spectral_subset=subset_name)
         assert list(results.mask) == answer
 
     def test_get_data_no_label_multiple_in_dc(self, specviz_helper):
@@ -88,4 +88,4 @@ class TestConfigHelper:
 
     def test_get_data_invald_subset_name(self, specviz_helper):
         with pytest.raises(ValueError, match="not in list of valid subset names"):
-            specviz_helper.get_data('Test 1D Spectrum', subset_to_apply="Fail")
+            specviz_helper.get_data('Test 1D Spectrum', spectral_subset="Fail")


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to add API to retrieve a data cube with a spatial subset applied to it, with a spectral subset then applied to that. The way to do that (using the CubevizExample notebook) is:
```
data_label = "jw02732-o004_t004_miri_ch1-shortmediumlong_s3d.fits[SCI]"
spatial_subset = "Subset 1"
spectral_subset = "Subset 2"
cubeviz.get_data(data_label, spatial_subset=spatial_subset, spectral_subset=spectral_subset, function=True)
```

There are also now `get_data` methods in Imviz and Specviz2D since the core `get_data` method no longer allows a subset to be applied.

Todo:
- [x] Add tests
- [x] Update docstrings
- [x] Use in Line analysis
- [ ] Follow-up? Update documentation

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1354 
Fixes #1490 

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
