### PR TITLE
Fix unit conversion for PluginMarks and y-limits

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -102,9 +102,15 @@ class UnitConverterWithSpectral:
         # as the original native units of the component in the data.
         if cid.label == "flux":
             spec = data.get_object(cls=Spectrum1D)
-            eqv = u.spectral_density(spec.spectral_axis)
+            if len(values) == 2:
+                # Need this for setting the y-limits
+                spec_limits = [spec.spectral_axis[0].value, spec.spectral_axis[-1].value]
+                eqv = u.spectral_density(spec_limits*spec.spectral_axis.unit)
+            else:
+                eqv = u.spectral_density(spec.spectral_axis)
         else:  # spectral axis
             eqv = u.spectral()
+
         return (values * u.Unit(original_units)).to_value(u.Unit(target_units), equivalencies=eqv)
 
 

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.py
@@ -173,7 +173,6 @@ class Slice(PluginTemplateMixin):
         if msg.axis != 'spectral':
             return
         prev_unit = self.wavelength_unit
-        self.wavelength_unit = msg.unit.to_string()
         # original unit during init can be blank or deg (before axis is set correctly)
         if self._x_all is None or prev_unit in ('deg', ''):
             return

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.py
@@ -145,6 +145,9 @@ class Slice(PluginTemplateMixin):
                 # leave in the pre-init state and don't update the wavelength/slice
                 return
 
+        # Also update unit when data is updated
+        self.wavelength_unit = x_all.unit.to_string()
+
         # force wavelength to update from the current slider value
         self._on_slider_updated({'new': self.slice})
 

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -106,11 +106,15 @@ class PluginMark():
         unit = u.Unit(unit)
 
         if self.yunit is not None:
-            spec = self.viewer.state.reference_data.get_object(cls=Spectrum1D)
-            eqv = u.spectral_density(spec.spectral_axis)
-            y = (self.y * self.yunit).to_value(unit, equivalencies=eqv)
+            if ("spec" in self.viewer.reference or "specviz" in self.viewer.reference_id):
+                spec = self.viewer.state.reference_data.get_object(cls=Spectrum1D)
+                eqv = u.spectral_density(spec.spectral_axis)
+                y = (self.y * self.yunit).to_value(unit, equivalencies=eqv)
+            else:
+                y = (self.y * self.yunit).to_value(unit)
             self.yunit = unit
             self.y = y
+
         self.yunit = unit
 
     def _on_global_display_unit_changed(self, msg):

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -104,8 +104,13 @@ class PluginMark():
                 return
             unit = self.viewer.state.y_display_unit
         unit = u.Unit(unit)
+
         if self.yunit is not None:
-            self.y = (self.y * self.yunit).to_value(unit)
+            spec = self.viewer.state.reference_data.get_object(cls=Spectrum1D)
+            eqv = u.spectral_density(spec.spectral_axis)
+            y = (self.y * self.yunit).to_value(unit, equivalencies=eqv)
+            self.yunit = unit
+            self.y = y
         self.yunit = unit
 
     def _on_global_display_unit_changed(self, msg):

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -106,7 +106,7 @@ class PluginMark():
         unit = u.Unit(unit)
 
         if self.yunit is not None:
-            if ("spec" in self.viewer.reference or "specviz" in self.viewer.reference_id):
+            if self.viewer.default_class is Spectrum1D:
                 spec = self.viewer.state.reference_data.get_object(cls=Spectrum1D)
                 eqv = u.spectral_density(spec.spectral_axis)
                 y = (self.y * self.yunit).to_value(unit, equivalencies=eqv)


### PR DESCRIPTION
Our custom unit converter needed to account for the case where the viewer y-limits are converted, and the PluginMark y-unit conversion needed to include the `spectral_density` equivalencies.

The tests that need dev glue will still fail, should be 37 of those I think.