### PR TITLE
Fix ci again

### DIFF
--- a/docs/cubeviz/export_data.rst
+++ b/docs/cubeviz/export_data.rst
@@ -29,7 +29,7 @@ An example without accessing Specviz:
 .. code-block:: python
 
     subset1_spec1d = cubeviz.get_data(data_label=flux_data_label, 
-                                      subset_to_apply="Subset 1",
+                                      spatial_subset="Subset 1",
                                       function="mean")
 
 Note that in the above example, the ``function`` keyword is used to tell Cubeviz

--- a/docs/specviz/export_data.rst
+++ b/docs/specviz/export_data.rst
@@ -33,7 +33,7 @@ To extract a spectrum with a spectral subset applied:
 
 .. code-block:: python
 
-    specviz.get_data(subset_to_apply='Subset 1')
+    specviz.get_data(spectral_subset='Subset 1')
 
 In this case, the returned `specutils.Spectrum1D` object will have a ``mask``
 attribute, where ``True`` corresponds to the region outside the selected subset
@@ -42,7 +42,7 @@ spectrum containing only your subset by running:
 
 .. code-block:: python
 
-    spec = specviz.get_data(subset_to_apply='Subset 1')
+    spec = specviz.get_data(spectral_subset='Subset 1')
     subset_spec = Spectrum1D(flux=spec.flux[~spec.mask],
                              spectral_axis=spec.spectral_axis[~spec.mask])
     specviz.load_spectrum(subset_spec)

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -123,8 +123,8 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
     def get_data(self, data_label=None, spatial_subset=None, spectral_subset=None, function=None,
                  cls=None, use_display_units=False):
         """
-        Returns data with name equal to data_label of type cls with subsets applied from
-        subset_to_apply.
+        Returns data with name equal to ``data_label`` of type ``cls`` with subsets applied from
+        ``spatial_subset`` and/or ``spectral_subset`` using ``function`` if applicable.
 
         Parameters
         ----------

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -92,7 +92,8 @@ class PluginMark():
                 return
             unit = self.viewer.state.x_display_unit
         unit = u.Unit(unit)
-        if self.xunit is not None:
+
+        if self.xunit is not None and not np.all([s == 0 for s in self.x.shape]):
             x = (self.x * self.xunit).to_value(unit, u.spectral())
             self.xunit = unit
             self.x = x
@@ -105,7 +106,7 @@ class PluginMark():
             unit = self.viewer.state.y_display_unit
         unit = u.Unit(unit)
 
-        if self.yunit is not None:
+        if self.yunit is not None and not np.all([s == 0 for s in self.y.shape]):
             if self.viewer.default_class is Spectrum1D:
                 spec = self.viewer.state.reference_data.get_object(cls=Spectrum1D)
                 eqv = u.spectral_density(spec.spectral_axis)

--- a/notebooks/SpecvizExample.ipynb
+++ b/notebooks/SpecvizExample.ipynb
@@ -13,7 +13,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -37,7 +39,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from jdaviz import Specviz\n",
@@ -63,7 +67,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "specviz.show()"
@@ -91,7 +97,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "data_dir = tempfile.gettempdir()\n",
@@ -116,11 +124,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Returns a version of the whole spectra, with a mask applied\n",
-    "specviz.get_spectra(data_label='myfile', subset_to_apply='Subset 1')"
+    "specviz.get_data(data_label='myfile', spectral_subset='Subset 1')"
    ]
   },
   {
@@ -133,10 +143,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "specviz.app.get_subsets_from_viewer('spectrum-viewer')"
+    "specviz.get_spectra()"
    ]
   },
   {
@@ -281,7 +293,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The dang marks plugin keeps flubbing unit conversion. This time it was trying to convert an empty flux array, so the shape of the spectral axis didn't match.