### PR TITLE
temporary subset plugin patch to handle non-spectral range subsets

### DIFF
--- a/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
+++ b/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
@@ -2,6 +2,7 @@ import os
 
 import numpy as np
 
+from astropy.time import Time
 import astropy.units as u
 from glue.core.message import EditSubsetMessage, SubsetUpdateMessage
 from glue.core.edit_subset_mode import (AndMode, AndNotMode, OrMode,
@@ -192,12 +193,21 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
                 subset_type = subset_state.roi.__class__.__name__
 
             elif isinstance(subset_state, RangeSubsetState):
-                lo = spec['region'].lower
-                hi = spec['region'].upper
-                subset_definition = [{"name": "Lower bound", "att": "lo", "value": lo.value,
-                                      "orig": lo.value, "unit": str(lo.unit)},
-                                     {"name": "Upper bound", "att": "hi", "value": hi.value,
-                                      "orig": hi.value, "unit": str(hi.unit)}]
+                region = spec['region']
+                if isinstance(region, Time):
+                    lo = region.min()
+                    hi = region.max()
+                    subset_definition = [{"name": "Lower bound", "att": "lo", "value": lo.value,
+                                          "orig": lo.value},
+                                         {"name": "Upper bound", "att": "hi", "value": hi.value,
+                                          "orig": hi.value}]
+                else:
+                    lo = region.lower
+                    hi = region.upper
+                    subset_definition = [{"name": "Lower bound", "att": "lo", "value": lo.value,
+                                          "orig": lo.value, "unit": str(lo.unit)},
+                                         {"name": "Upper bound", "att": "hi", "value": hi.value,
+                                          "orig": hi.value, "unit": str(hi.unit)}]
                 subset_type = "Range"
             if len(subset_definition) > 0:
                 # Note: .append() does not work for List traitlet.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements a patch so that temporal subsets (as currently [used in lcviz](https://github.com/spacetelescope/lcviz/pull/29)) do not crash the subset plugin.  Note that there are still bugs with the way that simplifying and updating these subsets are handled for the temporal case, but those will require more in-depth generalization [:cat:](https://jira.stsci.edu/browse/JDAT-3475).

This bug was introduced since the latest release, so does not need a change log entry as a bug fix.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
