### PR TITLE
BUG: Fix mouseover behavior in Cubeviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,8 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Fixed mouseover not behaving properly in spectrum viewer when spatial subset is present. [#2258]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -464,7 +464,7 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                     sp = self.app._get_object_cache[cache_key]
                 else:
                     sp = self._specviz_helper.get_data(data_label=data_label,
-                                                       spectral_subset=subset_label)
+                                                       spatial_subset=subset_label)
                     self.app._get_object_cache[cache_key] = sp
 
                 # Calculations have to happen in the frame of viewer display units.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to fix mouseover behavior in Cubeviz spectrum viewer when spatial subset is present. This was originally part of #2242 by @duytnguyendtn but we need to backport this. If this works, you should see two fixes:

1. Mouseover now does not ignore collapsed spectrum from spatial subset when you mouseover collapsed spectrum in spectrum viewer in Cubeviz.
2. You no longer see mouseover lag on Windows when you have spatial subset drawn and you are mousing over in spectrum viewer.

@javerbukh should review this.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
