### PR TITLE
Replace load_spectrum with load_data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ New Features
 
 - Plots within plugins can now be popped-out into their own windows. [#2254]
 
-- Replace specviz.load_spectrum with specviz.load_data. [#2273]
+- The ``specviz.load_spectrum`` method is deprecated; use ``specviz.load_data`` instead. [#2273]
 
 Cubeviz
 ^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ New Features
 
 - Plots within plugins can now be popped-out into their own windows. [#2254]
 
+- Replace specviz.load_spectrum with specviz.load_data. [#2273]
+
 Cubeviz
 ^^^^^^^
 

--- a/docs/cubeviz/import_data.rst
+++ b/docs/cubeviz/import_data.rst
@@ -74,7 +74,7 @@ Importing data via the API
 
 Alternatively, users who work in a coding environment like a Jupyter
 notebook can access the Cubeviz helper class API. Using this API, users can
-load data into the application through code with the :py:meth:`~jdaviz.configs.specviz.helper.Specviz.load_spectrum`
+load data into the application through code with the :py:meth:`~jdaviz.configs.specviz.helper.Specviz.load_data`
 method, which takes as input a :class:`~specutils.Spectrum1D` object.
 
 FITS Files
@@ -162,7 +162,7 @@ object, you can load it into Cubeviz as follows:
     # Create your spectrum1
     spec3d = Spectrum1D(data, wcs=my_wcs)
     cubeviz = Cubeviz()
-    cubeviz.load_spectrum(spec3d, data_label='My Cube')
+    cubeviz.load_data(spec3d, data_label='My Cube')
     cubeviz.show()
 
 There is no plan to natively load such objects until ``datamodels``

--- a/docs/specviz/export_data.rst
+++ b/docs/specviz/export_data.rst
@@ -45,7 +45,7 @@ spectrum containing only your subset by running:
     spec = specviz.get_data(spectral_subset='Subset 1')
     subset_spec = Spectrum1D(flux=spec.flux[~spec.mask],
                              spectral_axis=spec.spectral_axis[~spec.mask])
-    specviz.load_spectrum(subset_spec)
+    specviz.load_data(subset_spec)
 
 .. seealso::
 

--- a/docs/specviz/import_data.rst
+++ b/docs/specviz/import_data.rst
@@ -51,7 +51,7 @@ Importing data via the API
 Alternatively, users who work in a coding environment like a Jupyter
 notebook can access the Specviz helper class API. Using this API, users can
 load data into the application through code with the
-:py:meth:`~jdaviz.configs.specviz.helper.Specviz.load_spectrum`
+:py:meth:`~jdaviz.configs.specviz.helper.Specviz.load_data`
 method, which takes as input a :class:`~specutils.Spectrum1D` object.
 
 FITS Files
@@ -64,15 +64,15 @@ The example below loads a FITS file into Specviz:
     from specutils import Spectrum1D
     spec1d = Spectrum1D.read("/path/to/data/file")
     specviz = Specviz()
-    specviz.load_spectrum(spec1d, data_label="my_spec")
+    specviz.load_data(spec1d, data_label="my_spec")
     specviz.show()
 
 You can also pass the path to a file that `~specutils.Spectrum1D` understands directly to the
-:py:meth:`~jdaviz.configs.specviz.helper.Specviz.load_spectrum` method:
+:py:meth:`~jdaviz.configs.specviz.helper.Specviz.load_data` method:
 
 .. code-block:: python
 
-    specviz.load_spectrum("path/to/data/file")
+    specviz.load_data("path/to/data/file")
 
 Creating Your Own Array
 -----------------------
@@ -90,7 +90,7 @@ You can create your own array to load into Specviz:
     wavelength = np.arange(5100, 5300) * u.AA
     spec1d = Spectrum1D(spectral_axis=wavelength, flux=flux)
     specviz = Specviz()
-    specviz.load_spectrum(spec1d, data_label="my_spec")
+    specviz.load_data(spec1d, data_label="my_spec")
     specviz.show()
 
 JWST datamodels
@@ -111,7 +111,7 @@ object, you can load it into Specviz as follows:
 
     spec1d = Spectrum1D(flux=flux, spectral_axis=wave)
     specviz = Specviz()
-    specviz.load_spectrum(spec1d, data_label="MultiSpecModel")
+    specviz.load_data(spec1d, data_label="MultiSpecModel")
     specviz.show()
 
 There is no plan to natively load such objects until ``datamodels``
@@ -122,7 +122,7 @@ is separated from the ``jwst`` pipeline package.
 Importing a SpectrumList
 ------------------------
 
-The :py:meth:`~jdaviz.configs.specviz.helper.Specviz.load_spectrum` also accepts
+The :py:meth:`~jdaviz.configs.specviz.helper.Specviz.load_data` also accepts
 a `~specutils.SpectrumList` object, in which case it will both load the
 individual `~specutils.Spectrum1D` objects in the list and additionally attempt
 to stitch together the spectra into a single data object so that
@@ -132,7 +132,7 @@ they can be manipulated and analyzed in the application as a single entity:
 
     from specutils import SpectrumList
     spec_list = SpectrumList([spec1d_1, spec1d_2])
-    specviz.load_spectrum(spec_list)
+    specviz.load_data(spec_list)
     specviz.show()
 
 In the screenshot below, the combined spectrum is plotted in gray, and one of
@@ -145,13 +145,13 @@ end of the red region in the screenshot below:
 .. image:: img/spectrumlist_combined.png
 
 This functionality is also available in limited instances by providing a directory path
-to the :py:meth:`~jdaviz.configs.specviz.helper.Specviz.load_spectrum` method. Note
+to the :py:meth:`~jdaviz.configs.specviz.helper.Specviz.load_data` method. Note
 that the ``read`` method of :class:`~specutils.SpectrumList` is only set up to handle
 directory input in limited cases, for example JWST MIRI MRS data, and will throw an error
 in other cases. In cases that it does work, only files in the directory level specified
 will be read, with no recursion into deeper folders.
 
-The :py:meth:`~jdaviz.configs.specviz.helper.Specviz.load_spectrum` method also takes
+The :py:meth:`~jdaviz.configs.specviz.helper.Specviz.load_data` method also takes
 an optional keyword argument ``concat_by_file``. When set to ``True``, the spectra
 loaded in the :class:`~specutils.SpectrumList` will be concatenated together into one
 combined spectrum per loaded file, which may be useful for MIRI observations, for example.

--- a/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
@@ -12,7 +12,7 @@ from jdaviz.core.linelists import get_available_linelists
 def test_line_lists(specviz_helper):
     spec = Spectrum1D(flux=np.random.rand(100)*u.Jy,
                       spectral_axis=np.arange(6000, 7000, 10)*u.AA)
-    specviz_helper.load_spectrum(spec)
+    specviz_helper.load_data(spec)
 
     lt = QTable()
     lt['linename'] = ['O III', 'Halpha']
@@ -51,7 +51,7 @@ def test_redshift(specviz_helper, spectrum1d):
     assert plg._obj.disabled_msg
 
     label = "Test 1D Spectrum"
-    specviz_helper.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_data(spectrum1d, data_label=label)
 
     assert not plg._obj.disabled_msg
 
@@ -102,7 +102,7 @@ def test_redshift(specviz_helper, spectrum1d):
 def test_load_available_preset_lists(specviz_helper, spectrum1d):
     """ Loads all available line lists and checks the medium requirement """
     label = "Test 1D Spectrum"
-    specviz_helper.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_data(spectrum1d, data_label=label)
 
     # Check to make sure we got our line lists
     available_linelists = get_available_linelists()
@@ -125,7 +125,7 @@ def test_load_available_preset_lists(specviz_helper, spectrum1d):
 
 def test_line_identify(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_data(spectrum1d, data_label=label)
 
     lt = QTable()
     lt['linename'] = ['O III', 'Halpha']

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -20,7 +20,7 @@ from jdaviz.configs.default.plugins.model_fitting.initializers import MODELS
 
 
 def test_default_model_labels(specviz_helper, spectrum1d):
-    specviz_helper.load_spectrum(spectrum1d)
+    specviz_helper.load_data(spectrum1d)
     modelfit_plugin = specviz_helper.plugins['Model Fitting']
     # By default, the spectral region should be the entire spectrum
     assert modelfit_plugin._obj.spectral_subset_selected == "Entire Spectrum"
@@ -46,7 +46,7 @@ def test_default_model_labels(specviz_helper, spectrum1d):
 
 
 def test_custom_model_labels(specviz_helper, spectrum1d):
-    specviz_helper.load_spectrum(spectrum1d)
+    specviz_helper.load_data(spectrum1d)
     modelfit_plugin = specviz_helper.plugins['Model Fitting']
 
     for i, model in enumerate(MODELS):
@@ -68,7 +68,7 @@ def test_register_model_with_uncertainty_weighting(specviz_helper, spectrum1d):
     spectrum1d.uncertainty = StdDevUncertainty(spectrum1d.flux * 0.1)
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        specviz_helper.load_spectrum(spectrum1d)
+        specviz_helper.load_data(spectrum1d)
     modelfit_plugin = specviz_helper.plugins['Model Fitting']
 
     # Test registering a simple linear fit
@@ -105,7 +105,7 @@ def test_register_model_uncertainty_is_none(specviz_helper, spectrum1d):
     spectrum1d.uncertainty = None
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        specviz_helper.load_spectrum(spectrum1d)
+        specviz_helper.load_data(spectrum1d)
     modelfit_plugin = specviz_helper.plugins['Model Fitting']
 
     # Test registering a simple linear fit
@@ -157,7 +157,7 @@ def test_register_cube_model(cubeviz_helper, spectrum1d_cube):
 def test_user_api(specviz_helper, spectrum1d):
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        specviz_helper.load_spectrum(spectrum1d)
+        specviz_helper.load_data(spectrum1d)
     p = specviz_helper.plugins['Model Fitting']
 
     # even though the default label is set to C, adding Linear1D should default to its automatic
@@ -195,7 +195,7 @@ def test_user_api(specviz_helper, spectrum1d):
 def test_fit_gaussian_with_fixed_mean(specviz_helper, spectrum1d):
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        specviz_helper.load_spectrum(spectrum1d)
+        specviz_helper.load_data(spectrum1d)
     modelfit_plugin = specviz_helper.plugins['Model Fitting']
 
     modelfit_plugin.create_model_component('Gaussian1D', 'G')
@@ -217,7 +217,7 @@ def test_fit_gaussian_with_fixed_mean(specviz_helper, spectrum1d):
 def test_reestimate_parameters(specviz_helper, spectrum1d):
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        specviz_helper.load_spectrum(spectrum1d)
+        specviz_helper.load_data(spectrum1d)
     mf = specviz_helper.plugins['Model Fitting']
 
     mf.create_model_component('Gaussian1D', 'G')
@@ -327,12 +327,12 @@ def test_subset_masks(cubeviz_helper, spectrum1d_cube_larger):
 
 def test_invalid_subset(specviz_helper, spectrum1d):
     # 6000-8000
-    specviz_helper.load_spectrum(spectrum1d, data_label="right_spectrum")
+    specviz_helper.load_data(spectrum1d, data_label="right_spectrum")
 
     # 5000-7000
     sp2 = Spectrum1D(spectral_axis=spectrum1d.spectral_axis - 1000*spectrum1d.spectral_axis.unit,
                      flux=spectrum1d.flux * 1.25)
-    specviz_helper.load_spectrum(sp2, data_label="left_spectrum")
+    specviz_helper.load_data(sp2, data_label="left_spectrum")
 
     # apply subset that overlaps on left_spectrum, but not right_spectrum
     # NOTE: using a subset that overlaps the right_spectrum (reference) results in errors when

--- a/jdaviz/configs/default/plugins/subset_plugin/tests/test_subset_plugin.py
+++ b/jdaviz/configs/default/plugins/subset_plugin/tests/test_subset_plugin.py
@@ -6,7 +6,7 @@ from glue.core.roi import XRangeROI
 
 @pytest.mark.filterwarnings('ignore')
 def test_plugin(specviz_helper, spectrum1d):
-    specviz_helper.load_spectrum(spectrum1d)
+    specviz_helper.load_data(spectrum1d)
     p = specviz_helper.plugins['Subset Tools']
 
     # regression test for https://github.com/spacetelescope/jdaviz/issues/1693

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -66,7 +66,7 @@ class Specviz(ConfigHelper, LineListMixin):
         self.load_data(data, data_label, format, show_in_viewer, concat_by_file)
 
     def load_data(self, data, data_label=None, format=None, show_in_viewer=True,
-                      concat_by_file=False):
+                  concat_by_file=False):
         """
         Loads a data file or `~specutils.Spectrum1D` object into Specviz.
 

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -1,7 +1,7 @@
 import warnings
 
 from astropy import units as u
-from astropy.utils.decorators import deprecated_renamed_argument
+from astropy.utils.decorators import deprecated_renamed_argument, deprecated
 from regions.core.core import Region
 from glue.core.subset_group import GroupedSubset
 from specutils import SpectralRegion, Spectrum1D
@@ -41,7 +41,31 @@ class Specviz(ConfigHelper, LineListMixin):
         self.app.hub.subscribe(self, RedshiftMessage,
                                handler=self._redshift_listener)
 
+    @deprecated(since="3.6", alternative="specviz.load_data")
     def load_spectrum(self, data, data_label=None, format=None, show_in_viewer=True,
+                      concat_by_file=False):
+        """
+        Loads a data file or `~specutils.Spectrum1D` object into Specviz.
+
+        Parameters
+        ----------
+        data : str, `~specutils.Spectrum1D`, or `~specutils.SpectrumList`
+            Spectrum1D, SpectrumList, or path to compatible data file.
+        data_label : str
+            The Glue data label found in the ``DataCollection``.
+        format : str
+            Loader format specification used to indicate data format in
+            `~specutils.Spectrum1D.read` io method.
+        show_in_viewer : bool
+            Show data in viewer(s).
+        concat_by_file : bool
+            If True and there is more than one available extension, concatenate
+            the extensions within each spectrum file passed to the parser and
+            add a concatenated spectrum to the data collection.
+        """
+        self.load_data(data, data_label, format, show_in_viewer, concat_by_file)
+
+    def load_data(self, data, data_label=None, format=None, show_in_viewer=True,
                       concat_by_file=False):
         """
         Loads a data file or `~specutils.Spectrum1D` object into Specviz.

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -41,7 +41,7 @@ class Specviz(ConfigHelper, LineListMixin):
         self.app.hub.subscribe(self, RedshiftMessage,
                                handler=self._redshift_listener)
 
-    @deprecated(since="3.6", alternative="specviz.load_data")
+    @deprecated(since="3.6", alternative="load_data")
     def load_spectrum(self, data, data_label=None, format=None, show_in_viewer=True,
                       concat_by_file=False):
         """
@@ -68,7 +68,7 @@ class Specviz(ConfigHelper, LineListMixin):
     def load_data(self, data, data_label=None, format=None, show_in_viewer=True,
                   concat_by_file=False):
         """
-        Loads a data file or `~specutils.Spectrum1D` object into Specviz.
+        Load data into Specviz.
 
         Parameters
         ----------

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -14,7 +14,7 @@ from jdaviz.core.marks import LineAnalysisContinuum
 
 def test_plugin(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
     plugin.open_in_tray()
@@ -79,7 +79,7 @@ def test_spatial_subset(cubeviz_helper, image_cube_hdu_obj):
 
 def test_user_api(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_data(spectrum1d, data_label=label)
 
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
     sv.apply_roi(XRangeROI(6500, 7400))
@@ -109,7 +109,7 @@ def test_user_api(specviz_helper, spectrum1d):
 
 def test_line_identify(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_data(spectrum1d, data_label=label)
 
     lt = QTable()
     lt['linename'] = ['O III', 'Halpha']
@@ -180,7 +180,7 @@ def test_coerce_unit():
 
 def test_continuum_surrounding_spectral_subset(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
     plugin.open_in_tray()
@@ -207,7 +207,7 @@ def test_continuum_surrounding_spectral_subset(specviz_helper, spectrum1d):
 
 def test_continuum_spectral_same_value(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
     plugin.open_in_tray()
@@ -234,7 +234,7 @@ def test_continuum_spectral_same_value(specviz_helper, spectrum1d):
 
 def test_continuum_surrounding_invalid_width(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
     plugin.open_in_tray()
@@ -259,7 +259,7 @@ def test_continuum_surrounding_invalid_width(specviz_helper, spectrum1d):
 
 def test_continuum_subset_spectral_entire(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
     plugin.open_in_tray()
@@ -286,7 +286,7 @@ def test_continuum_subset_spectral_entire(specviz_helper, spectrum1d):
 
 def test_continuum_subset_spectral_subset2(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
     plugin.open_in_tray()
@@ -319,7 +319,7 @@ def test_continuum_subset_spectral_subset2(specviz_helper, spectrum1d):
 
 def test_continuum_surrounding_no_right(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
     plugin.open_in_tray()
@@ -347,7 +347,7 @@ def test_continuum_surrounding_no_right(specviz_helper, spectrum1d):
 
 def test_continuum_surrounding_no_left(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
     plugin.open_in_tray()
@@ -375,7 +375,7 @@ def test_continuum_surrounding_no_left(specviz_helper, spectrum1d):
 
 def test_subset_changed(specviz_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_spectrum(spectrum1d, data_label=label)
+    specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
     plugin.open_in_tray()
@@ -406,12 +406,12 @@ def test_subset_changed(specviz_helper, spectrum1d):
 
 def test_invalid_subset(specviz_helper, spectrum1d):
     # 6000-8000
-    specviz_helper.load_spectrum(spectrum1d, data_label="right_spectrum")
+    specviz_helper.load_data(spectrum1d, data_label="right_spectrum")
 
     # 5000-7000
     sp2 = Spectrum1D(spectral_axis=spectrum1d.spectral_axis - 1000*spectrum1d.spectral_axis.unit,
                      flux=spectrum1d.flux * 1.25)
-    specviz_helper.load_spectrum(sp2, data_label="left_spectrum")
+    specviz_helper.load_data(sp2, data_label="left_spectrum")
 
     # apply subset that overlaps on left_spectrum, but not right_spectrum
     # NOTE: using a subset that overlaps the right_spectrum (reference) results in errors when

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_lineflux.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_lineflux.py
@@ -99,7 +99,7 @@ def test_unit_gaussian(specviz_helper, test_case):
     Test an Area 1 Gaussian and ensure the result returns in W/m2
     Test provided by Patrick Ogle
     '''
-    specviz_helper.load_spectrum(test_case)
+    specviz_helper.load_data(test_case)
 
     lineflux_result = _calculate_line_flux(specviz_helper)
     assert_quantity_allclose(float(lineflux_result['result']) * u.Unit(lineflux_result['unit']),
@@ -117,7 +117,7 @@ def test_unit_gaussian_mixed_units_per_steradian(specviz_helper):
     flx_wave = _gauss_with_unity_area(lam_a.value, mn, sig)*1E3*u.erg/u.s/u.cm**2/u.Angstrom/u.sr
     fl_wave = Spectrum1D(spectral_axis=lam_a, flux=flx_wave)
 
-    specviz_helper.load_spectrum(fl_wave)
+    specviz_helper.load_data(fl_wave)
     lineflux_result = _calculate_line_flux(specviz_helper)
     assert_quantity_allclose(float(lineflux_result['result']) * u.Unit(lineflux_result['unit']),
                              1*u.Unit('W/(m2sr)'))

--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -10,7 +10,7 @@ from astropy import units as u
      ("micron", "fail", "micron", "Jy")])
 def test_value_error_exception(specviz_helper, spectrum1d, new_spectral_axis, new_flux,
                                expected_spectral_axis, expected_flux):
-    specviz_helper.load_spectrum(spectrum1d, data_label="Test 1D Spectrum")
+    specviz_helper.load_data(spectrum1d, data_label="Test 1D Spectrum")
     viewer = specviz_helper.app.get_viewer("spectrum-viewer")
     plg = specviz_helper.plugins["Unit Conversion"]
 
@@ -34,7 +34,7 @@ def test_value_error_exception(specviz_helper, spectrum1d, new_spectral_axis, ne
 def test_conv_wave_only(specviz_helper, spectrum1d, uncert):
     if uncert is False:
         spectrum1d.uncertainty = None
-    specviz_helper.load_spectrum(spectrum1d, data_label="Test 1D Spectrum")
+    specviz_helper.load_data(spectrum1d, data_label="Test 1D Spectrum")
 
     viewer = specviz_helper.app.get_viewer("spectrum-viewer")
     plg = specviz_helper.plugins["Unit Conversion"]
@@ -50,7 +50,7 @@ def test_conv_wave_only(specviz_helper, spectrum1d, uncert):
 def test_conv_flux_only(specviz_helper, spectrum1d, uncert):
     if uncert is False:
         spectrum1d.uncertainty = None
-    specviz_helper.load_spectrum(spectrum1d, data_label="Test 1D Spectrum")
+    specviz_helper.load_data(spectrum1d, data_label="Test 1D Spectrum")
 
     viewer = specviz_helper.app.get_viewer("spectrum-viewer")
     plg = specviz_helper.plugins["Unit Conversion"]
@@ -66,7 +66,7 @@ def test_conv_flux_only(specviz_helper, spectrum1d, uncert):
 def test_conv_wave_flux(specviz_helper, spectrum1d, uncert):
     if uncert is False:
         spectrum1d.uncertainty = None
-    specviz_helper.load_spectrum(spectrum1d, data_label="Test 1D Spectrum")
+    specviz_helper.load_data(spectrum1d, data_label="Test 1D Spectrum")
 
     viewer = specviz_helper.app.get_viewer("spectrum-viewer")
     plg = specviz_helper.plugins["Unit Conversion"]

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -23,7 +23,7 @@ class TestSpecvizHelper:
         self.multi_order_spectrum_list = multi_order_spectrum_list
 
         self.label = "Test 1D Spectrum"
-        self.spec_app.load_spectrum(spectrum1d, data_label=self.label)
+        self.spec_app.load_data(spectrum1d, data_label=self.label)
 
     def test_load_spectrum1d(self):
         # starts with a single loaded spectrum1d object:
@@ -38,7 +38,7 @@ class TestSpecvizHelper:
 
     def test_load_spectrum_list_no_labels(self):
         # now load three more spectra from a SpectrumList, without labels
-        self.spec_app.load_spectrum(self.spec_list)
+        self.spec_app.load_data(self.spec_list)
         assert len(self.spec_app.app.data_collection) == 4
         for i in (1, 2, 3):
             assert "specviz_data" in self.spec_app.app.data_collection[i].label
@@ -46,24 +46,24 @@ class TestSpecvizHelper:
     def test_load_spectrum_list_with_labels(self):
         # now load three more spectra from a SpectrumList, with labels:
         labels = ["List test 1", "List test 2", "List test 3"]
-        self.spec_app.load_spectrum(self.spec_list, data_label=labels)
+        self.spec_app.load_data(self.spec_list, data_label=labels)
         assert len(self.spec_app.app.data_collection) == 4
 
     def test_load_multi_order_spectrum_list(self):
         assert len(self.spec_app.app.data_collection) == 1
         # now load ten spectral orders from a SpectrumList:
-        self.spec_app.load_spectrum(self.multi_order_spectrum_list)
+        self.spec_app.load_data(self.multi_order_spectrum_list)
         assert len(self.spec_app.app.data_collection) == 11
 
     def test_mismatched_label_length(self):
         with pytest.raises(ValueError, match='Length'):
             labels = ["List test 1", "List test 2"]
-            self.spec_app.load_spectrum(self.spec_list, data_label=labels)
+            self.spec_app.load_data(self.spec_list, data_label=labels)
 
     def test_load_spectrum_collection(self):
         with pytest.raises(TypeError):
             collection = SpectrumCollection([1]*u.AA)
-            self.spec_app.load_spectrum(collection)
+            self.spec_app.load_data(collection)
 
     def test_get_spectra(self):
         with pytest.warns(UserWarning, match='Applying the value from the redshift slider'):
@@ -245,15 +245,15 @@ def test_get_spectra_no_spectra_label_redshift_error(specviz_helper, spectrum1d)
 
 
 def test_add_spectrum_after_subset(specviz_helper, spectrum1d):
-    specviz_helper.load_spectrum(spectrum1d, data_label="test")
+    specviz_helper.load_data(spectrum1d, data_label="test")
     specviz_helper.app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(6200, 7000))
     new_spec = specviz_helper.get_spectra(apply_slider_redshift=True)["test"]*0.9
-    specviz_helper.load_spectrum(new_spec, data_label="test2")
+    specviz_helper.load_data(new_spec, data_label="test2")
 
 
 def test_get_spectral_regions_unit(specviz_helper, spectrum1d):
     # Ensure units we put in are the same as the units we get out
-    specviz_helper.load_spectrum(spectrum1d)
+    specviz_helper.load_data(spectrum1d)
     specviz_helper.app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(6200, 7000))
 
     subsets = specviz_helper.get_spectral_regions()
@@ -275,7 +275,7 @@ def test_get_spectral_regions_unit_conversion(specviz_helper, spectrum1d):
 
     # If the reference (visible) data changes via unit conversion,
     # check that the region's units convert too
-    specviz_helper.load_spectrum(spectrum1d)  # Originally Angstrom
+    specviz_helper.load_data(spectrum1d)  # Originally Angstrom
 
     # Also check coordinates info panel.
     # x=0 -> 6000 A, x=1 -> 6222.222 A
@@ -322,7 +322,7 @@ def test_get_spectral_regions_unit_conversion(specviz_helper, spectrum1d):
 
 
 def test_subset_default_thickness(specviz_helper, spectrum1d):
-    specviz_helper.load_spectrum(spectrum1d)
+    specviz_helper.load_data(spectrum1d)
 
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
     sv.toolbar.active_tool = sv.toolbar.tools['bqplot:xrange']
@@ -350,7 +350,7 @@ def test_load_spectrum_list_directory(tmpdir, specviz_helper):
     # Load two NIRISS x1d files from FITS. They have 19 and 20 EXTRACT1D
     # extensions per file, for a total of 39 spectra to load:
     with pytest.warns(UserWarning, match='SRCTYPE is missing or UNKNOWN in JWST x1d loader'):
-        specviz_helper.load_spectrum(data_path)
+        specviz_helper.load_data(data_path)
 
     # NOTE: the length was 3 before specutils 1.9 (https://github.com/astropy/specutils/pull/982)
     expected_len = 39
@@ -377,12 +377,12 @@ def test_load_spectrum_list_directory_concat(tmpdir, specviz_helper):
     # spectra common to each file into one "Combined" spectrum to load per file.
     # Now the total is (19 EXTRACT 1D + 1 Combined) + (20 EXTRACT 1D + 1 Combined) = 41.
     with pytest.warns(UserWarning, match='SRCTYPE is missing or UNKNOWN in JWST x1d loader'):
-        specviz_helper.load_spectrum(data_path, concat_by_file=True)
+        specviz_helper.load_data(data_path, concat_by_file=True)
     assert len(specviz_helper.app.data_collection) == 41
 
 
 def test_plot_uncertainties(specviz_helper, spectrum1d):
-    specviz_helper.load_spectrum(spectrum1d)
+    specviz_helper.load_data(spectrum1d)
 
     specviz_viewer = specviz_helper.app.get_viewer("spectrum-viewer")
 
@@ -416,7 +416,7 @@ def test_plugin_user_apis(specviz_helper):
 
 def test_data_label_as_posarg(specviz_helper, spectrum1d):
     # Passing in data_label keyword as posarg.
-    specviz_helper.load_spectrum(spectrum1d, 'my_spec')
+    specviz_helper.load_data(spectrum1d, 'my_spec')
     assert specviz_helper.app.data_collection[0].label == 'my_spec'
 
 
@@ -431,8 +431,8 @@ def test_spectra_partial_overlap(specviz_helper):
     flux_2 = ([60] * wave_2.size) * u.nJy
     sp_2 = Spectrum1D(flux=flux_2, spectral_axis=wave_2)
 
-    specviz_helper.load_spectrum(sp_1, data_label='left')
-    specviz_helper.load_spectrum(sp_2, data_label='right')
+    specviz_helper.load_data(sp_1, data_label='left')
+    specviz_helper.load_data(sp_2, data_label='right')
 
     # Test mouseover outside of left but in range for right.
     # Should show right spectrum even when mouse is near left flux.

--- a/jdaviz/core/data_formats.py
+++ b/jdaviz/core/data_formats.py
@@ -293,7 +293,7 @@ def open(filename, show=True, **kwargs):
     show : bool
         Determines whether to immediately show the application
 
-    All other arguments are interpreted as load_data/load_spectrum arguments for
+    All other arguments are interpreted as load_data arguments for
     the autoidentified configuration class
 
     Returns
@@ -312,10 +312,7 @@ def open(filename, show=True, **kwargs):
 
     # Load data
     data = hdul if (hdul is not None) else filename
-    if helper_str == "specviz":
-        viz_helper.load_spectrum(data, **kwargs)
-    else:
-        viz_helper.load_data(data, **kwargs)
+    viz_helper.load_data(data, **kwargs)
 
     # Display app
     if show:

--- a/jdaviz/core/tests/test_data_menu.py
+++ b/jdaviz/core/tests/test_data_menu.py
@@ -29,11 +29,11 @@ example_uri_helper = [
 
 def test_data_menu_toggles(specviz_helper, spectrum1d):
     # load 2 data entries
-    specviz_helper.load_spectrum(spectrum1d, data_label="test")
+    specviz_helper.load_data(spectrum1d, data_label="test")
     app = specviz_helper.app
     sv = app.get_viewer('spectrum-viewer')
     new_spec = specviz_helper.get_spectra(apply_slider_redshift=True)["test"]*0.9
-    specviz_helper.load_spectrum(new_spec, data_label="test2")
+    specviz_helper.load_data(new_spec, data_label="test2")
 
     # check that both are enabled in the data menu
     selected_data_items = app._viewer_item_by_id('specviz-0')['selected_data_items']

--- a/jdaviz/core/tests/test_helpers.py
+++ b/jdaviz/core/tests/test_helpers.py
@@ -37,8 +37,8 @@ class TestConfigHelper:
 
         self.spec2 = spectrum1d._copy(spectral_axis=spectrum1d.spectral_axis+1000*u.AA)
         self.label2 = "Test 1D Spectrum 2"
-        self.spec_app.load_spectrum(spectrum1d, data_label=self.label)
-        self.spec_app.load_spectrum(self.spec2, data_label=self.label2)
+        self.spec_app.load_data(spectrum1d, data_label=self.label)
+        self.spec_app.load_data(self.spec2, data_label=self.label2)
 
         # Add 3 subsets to cover different parts of spec and spec2
         self.spec_app.app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(6000, 6500))

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -11,7 +11,7 @@ def test_spectralsubsetselect(specviz_helper, spectrum1d):
     mask = spectrum1d.flux < spectrum1d.flux.mean()
     spectrum1d.mask = mask
 
-    specviz_helper.load_spectrum(spectrum1d)
+    specviz_helper.load_data(spectrum1d)
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
     # create a "Subset 1" entry
     sv.apply_roi(XRangeROI(6500, 7400))

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -53,26 +53,26 @@ def test_nonstandard_specviz_viewer_name(spectrum1d):
     viz = Customviz()
     assert viz.app.get_viewer_reference_names() == ['h', 'k']
 
-    viz.load_spectrum(spectrum1d, data_label='example label')
+    viz.load_data(spectrum1d, data_label='example label')
     with pytest.raises(ValueError):
         viz.get_data("non-existent label")
 
 
 def test_duplicate_data_labels(specviz_helper, spectrum1d):
-    specviz_helper.load_spectrum(spectrum1d, data_label="test")
-    specviz_helper.load_spectrum(spectrum1d, data_label="test")
+    specviz_helper.load_data(spectrum1d, data_label="test")
+    specviz_helper.load_data(spectrum1d, data_label="test")
     dc = specviz_helper.app.data_collection
     assert dc[0].label == "test"
     assert dc[1].label == "test (1)"
-    specviz_helper.load_spectrum(spectrum1d, data_label="test_1")
-    specviz_helper.load_spectrum(spectrum1d, data_label="test")
+    specviz_helper.load_data(spectrum1d, data_label="test_1")
+    specviz_helper.load_data(spectrum1d, data_label="test")
     assert dc[2].label == "test_1"
     assert dc[3].label == "test (2)"
 
 
 def test_duplicate_data_labels_with_brackets(specviz_helper, spectrum1d):
-    specviz_helper.load_spectrum(spectrum1d, data_label="test[test]")
-    specviz_helper.load_spectrum(spectrum1d, data_label="test[test]")
+    specviz_helper.load_data(spectrum1d, data_label="test[test]")
+    specviz_helper.load_data(spectrum1d, data_label="test[test]")
     dc = specviz_helper.app.data_collection
     assert len(dc) == 2
     assert dc[0].label == "test[test]"
@@ -106,7 +106,7 @@ def test_unique_name_variations(specviz_helper, spectrum1d):
     data_label = specviz_helper.app.return_unique_name(None)
     assert data_label == "Unknown"
 
-    specviz_helper.load_spectrum(spectrum1d, data_label="test[flux]")
+    specviz_helper.load_data(spectrum1d, data_label="test[flux]")
     data_label = specviz_helper.app.return_data_label("test[flux]", ext="flux")
     assert data_label == "test[flux][flux]"
 
@@ -115,8 +115,8 @@ def test_unique_name_variations(specviz_helper, spectrum1d):
 
 
 def test_substring_in_label(specviz_helper, spectrum1d):
-    specviz_helper.load_spectrum(spectrum1d, data_label="M31")
-    specviz_helper.load_spectrum(spectrum1d, data_label="M32")
+    specviz_helper.load_data(spectrum1d, data_label="M31")
+    specviz_helper.load_data(spectrum1d, data_label="M32")
     data_label = specviz_helper.app.return_data_label("M")
     assert data_label == "M"
 
@@ -127,17 +127,17 @@ def test_substring_in_label(specviz_helper, spectrum1d):
 def test_edge_cases(specviz_helper, spectrum1d, data_label):
     dc = specviz_helper.app.data_collection
 
-    specviz_helper.load_spectrum(spectrum1d, data_label=data_label)
-    specviz_helper.load_spectrum(spectrum1d, data_label=data_label)
+    specviz_helper.load_data(spectrum1d, data_label=data_label)
+    specviz_helper.load_data(spectrum1d, data_label=data_label)
     assert dc[1].label == f"{data_label} (1)"
 
-    specviz_helper.load_spectrum(spectrum1d, data_label=data_label)
+    specviz_helper.load_data(spectrum1d, data_label=data_label)
     assert dc[2].label == f"{data_label} (2)"
 
 
 def test_case_that_used_to_break_return_label(specviz_helper, spectrum1d):
-    specviz_helper.load_spectrum(spectrum1d, data_label="this used to break (1)")
-    specviz_helper.load_spectrum(spectrum1d, data_label="this used to break")
+    specviz_helper.load_data(spectrum1d, data_label="this used to break (1)")
+    specviz_helper.load_data(spectrum1d, data_label="this used to break")
     dc = specviz_helper.app.data_collection
     assert dc[0].label == "this used to break (1)"
     assert dc[1].label == "this used to break (2)"

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -459,7 +459,7 @@ def test_with_invalid_subset_name(cubeviz_helper):
 
 
 def test_composite_region_from_subset_2d(specviz_helper, spectrum1d):
-    specviz_helper.load_spectrum(spectrum1d)
+    specviz_helper.load_data(spectrum1d)
     viewer = specviz_helper.app.get_viewer(specviz_helper._default_spectrum_viewer_reference_name)
     viewer.apply_roi(XRangeROI(6000, 7000))
     reg = specviz_helper.app.get_subsets("Subset 1", simplify_spectral=False)
@@ -505,7 +505,7 @@ def test_composite_region_from_subset_2d(specviz_helper, spectrum1d):
 
 
 def test_edit_composite_spectral_subset(specviz_helper, spectrum1d):
-    specviz_helper.load_spectrum(spectrum1d)
+    specviz_helper.load_data(spectrum1d)
     viewer = specviz_helper.app.get_viewer(specviz_helper._default_spectrum_viewer_reference_name)
 
     viewer.apply_roi(XRangeROI(6200, 6800))
@@ -554,7 +554,7 @@ def test_edit_composite_spectral_subset(specviz_helper, spectrum1d):
 
 
 def test_edit_composite_spectral_with_xor(specviz_helper, spectrum1d):
-    specviz_helper.load_spectrum(spectrum1d)
+    specviz_helper.load_data(spectrum1d)
     viewer = specviz_helper.app.get_viewer(specviz_helper._default_spectrum_viewer_reference_name)
 
     viewer.apply_roi(XRangeROI(6400, 6600))
@@ -574,7 +574,7 @@ def test_edit_composite_spectral_with_xor(specviz_helper, spectrum1d):
 
 
 def test_overlapping_spectral_regions(specviz_helper, spectrum1d):
-    specviz_helper.load_spectrum(spectrum1d)
+    specviz_helper.load_data(spectrum1d)
     viewer = specviz_helper.app.get_viewer(specviz_helper._default_spectrum_viewer_reference_name)
 
     viewer.apply_roi(XRangeROI(6400, 7400))
@@ -593,7 +593,7 @@ def test_overlapping_spectral_regions(specviz_helper, spectrum1d):
 
 
 def test_only_overlapping_spectral_regions(specviz_helper, spectrum1d):
-    specviz_helper.load_spectrum(spectrum1d)
+    specviz_helper.load_data(spectrum1d)
     viewer = specviz_helper.app.get_viewer(specviz_helper._default_spectrum_viewer_reference_name)
 
     viewer.apply_roi(XRangeROI(6400, 6600))


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request brings specviz in line with the other viz tools by deprecating `specviz.load_data` and replacing it with `specviz.load_data`. I think I got all the documentation changes as well here. Should be pretty uncontroversial, as we've been asking for this for a long time

The decreased coverage is due to the deprecated method

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
