### PR TITLE
nested toolbar logic to hide inapplicable tools

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ New Features
 
 - Add first-pass launcher to select config and auto-identify data. [#2257]
 
+- Viewer toolbar items hide themselves when they are not applicable. [#2284]
+
 Cubeviz
 ^^^^^^^
 

--- a/docs/imviz/displayimages.rst
+++ b/docs/imviz/displayimages.rst
@@ -85,27 +85,27 @@ are saved when beginning a zoom selection or when activating a pan/zoom tool.
 Box Zoom and Linked Box Zoom
 ============================
 
-Linked Box Zoom is an Imviz-specific feature that allows the user to zoom
-images in multiple different viewers simultaneously, not unlike
+Linked Box Zoom is an Imviz-specific feature enabled only when there are multiple viewers that
+allows the user to zoom images in multiple different viewers simultaneously, not unlike
 :ref:`imviz_pan_zoom`.
 
 Single-viewer Box Zoom is also available and is used in a similar way as in
-other Jdaviz tools. To access this option, right-click on the Linked Box Zoom button
-and left-click on the second option down to select it.
+other Jdaviz tools. To access this option when there are multiple viewers, 
+right-click on the Linked Box Zoom button and left-click on the second option down to select it.
 
 .. _imviz_pan_zoom:
 
 Pan/Zoom and Linked Pan/Zoom
 ============================
 
-Linked Pan/Zoom is an Imviz-specific feature that allows the user to pan and zoom
-images in multiple different viewers simultaneously. This works by matching images
+Linked Pan/Zoom is an Imviz-specific feature enabled only when there are multiple viewers that
+allows the user to pan and zoom images in multiple different viewers simultaneously. This works by matching images
 based on the way they are linked together. Images are linked by pixels on load time,
 but you can re-link them via WCS using :ref:`imviz-link-control`.
 
 Single-viewer Pan/Zoom is also available and is used in a similar way as in
-other Jdaviz tools. To access this option, right-click on the Linked Pan/Zoom button
-and left-click on the second option down to select it.
+other Jdaviz tools. To access this option when there are multiple viewers, right-click on the
+Linked Pan/Zoom button and left-click on the second option down to select it.
 
 When in either of these modes, clicking on the image will recenter the image to the
 location under cursor.
@@ -219,8 +219,9 @@ Blinking
 
 Blinking is an Imviz-specific functionality that allows a user to quickly switch
 between viewing two or more images, as long as they are linked (see :ref:`imviz_pan_zoom` for
-more on linking behavior). This can be done by selecting the |icon-blink| icon and
-then left-clicking on the image to blink forward; right-clicking would blink backwards.
+more on linking behavior). This can be done by selecting the |icon-blink| icon (only available if
+there are more than one image loaded in the viewer) and then left-clicking on the image to blink
+forward; right-clicking would blink backwards.
 
 You can also blink forward by pressing the "b" key on your keyboard while moused over the image.
 If you press Shift + "b" ("B"), you may blink backwards.

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2287,7 +2287,7 @@ class Application(VuetifyTemplate, HubListener):
         cfg = get_configuration(path=path, section=section, config=config)
         return cfg
 
-    def get_tray_item_from_name(self, name):
+    def get_tray_item_from_name(self, name, return_none_if_not_found=False):
         """Return the instance of a tray item for a given name.
         This is useful for direct programmatic access to Jdaviz plugins
         registered under tray items.
@@ -2297,6 +2297,9 @@ class Application(VuetifyTemplate, HubListener):
         name : str
             The name used when the plugin was registered to
             an internal `~jdaviz.core.registries.TrayRegistry`.
+        return_none_if_not_found : bool`
+            Whether to return ``None`` (instead of raising an error)
+            if the entry does not exist.
 
         Returns
         -------
@@ -2317,7 +2320,7 @@ class Application(VuetifyTemplate, HubListener):
                 tray_item = widget_serialization['from_json'](ipy_model_id, None)
                 break
 
-        if tray_item is None:
+        if tray_item is None and not return_none_if_not_found:
             raise KeyError(f'{name} not found in app.state.tray_items')
 
         return tray_item

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2287,7 +2287,7 @@ class Application(VuetifyTemplate, HubListener):
         cfg = get_configuration(path=path, section=section, config=config)
         return cfg
 
-    def get_tray_item_from_name(self, name, return_none_if_not_found=False):
+    def get_tray_item_from_name(self, name):
         """Return the instance of a tray item for a given name.
         This is useful for direct programmatic access to Jdaviz plugins
         registered under tray items.
@@ -2297,9 +2297,6 @@ class Application(VuetifyTemplate, HubListener):
         name : str
             The name used when the plugin was registered to
             an internal `~jdaviz.core.registries.TrayRegistry`.
-        return_none_if_not_found : bool`
-            Whether to return ``None`` (instead of raising an error)
-            if the entry does not exist.
 
         Returns
         -------
@@ -2320,7 +2317,7 @@ class Application(VuetifyTemplate, HubListener):
                 tray_item = widget_serialization['from_json'](ipy_model_id, None)
                 break
 
-        if tray_item is None and not return_none_if_not_found:
+        if tray_item is None:
             raise KeyError(f'{name} not found in app.state.tray_items')
 
         return tray_item

--- a/jdaviz/components/toolbar_nested.py
+++ b/jdaviz/components/toolbar_nested.py
@@ -79,7 +79,7 @@ class NestedJupyterToolbar(BasicJupyterToolbar, HubListener):
         needs_deactivate_active = False
         for menu_ind in range(self._max_menu_ind):
             has_primary = False
-            nvisible = 0
+            n_visible = 0
             primary_id = None
             if self.active_tool_id:
                 current_primary_active = self.tools_data[self.active_tool_id]['menu_ind'] == menu_ind  # noqa
@@ -90,7 +90,7 @@ class NestedJupyterToolbar(BasicJupyterToolbar, HubListener):
                     continue
                 visible = self._is_visible(tool_id)
                 if visible:
-                    nvisible += 1
+                    n_visible += 1
 
                 if tool_id == self.active_tool_id:
                     # then the primary was already set by which tool is active
@@ -119,7 +119,7 @@ class NestedJupyterToolbar(BasicJupyterToolbar, HubListener):
                                             'visible': visible}
             if primary_id:
                 self.tools_data[primary_id] = {**self.tools_data[primary_id],
-                                               'has_suboptions': nvisible > 1}
+                                               'has_suboptions': n_visible > 1}
 
         # mutation to dictionary needs to be manually sent to update the UI
         self.send_state("tools_data")

--- a/jdaviz/components/toolbar_nested.py
+++ b/jdaviz/components/toolbar_nested.py
@@ -73,7 +73,9 @@ class NestedJupyterToolbar(BasicJupyterToolbar, HubListener):
     def _is_visible(self, tool_id):
         # tools can optionally implement self.is_visible(). If not NotImplementedError
         # the tool will always be visible
-        return getattr(self.tools[tool_id], 'is_visible', lambda: True)()
+        if hasattr(self.tools[tool_id], 'is_visible'):
+            return self.tools[tool_id].is_visible()
+        return True
 
     def _update_tool_visibilities(self):
         needs_deactivate_active = False

--- a/jdaviz/components/toolbar_nested.py
+++ b/jdaviz/components/toolbar_nested.py
@@ -2,14 +2,20 @@ import os
 import traitlets
 
 from glue.config import viewer_tool
+from glue.core import HubListener
 from glue.icons import icon_path
 from glue.viewers.common.tool import CheckableTool
 from glue_jupyter.common.toolbar_vuetify import BasicJupyterToolbar, read_icon
 
+from jdaviz.core.marks import SpectralLine
+from jdaviz.core.events import (AddDataMessage, RemoveDataMessage,
+                                ViewerAddedMessage, ViewerRemovedMessage,
+                                SpectralMarksChangedMessage)
+
 __all__ = ['NestedJupyterToolbar']
 
 
-class NestedJupyterToolbar(BasicJupyterToolbar):
+class NestedJupyterToolbar(BasicJupyterToolbar, HubListener):
     template_file = (__file__, 'toolbar_nested.vue')
 
     # defined in BasicJupyterToolbar:
@@ -28,6 +34,8 @@ class NestedJupyterToolbar(BasicJupyterToolbar):
 
     def __init__(self, viewer, tools_nested, default_tool_priority=[]):
         super().__init__(viewer)
+        self.viewer = viewer
+        self._max_menu_ind = len(tools_nested)
 
         # iterate through the nested list.  The first item in each entry
         # is treated as the default primary tool of that subcategory,
@@ -43,7 +51,12 @@ class NestedJupyterToolbar(BasicJupyterToolbar):
                 self.add_tool(tool,
                               menu_ind=menu_ind,
                               has_suboptions=len(subtools) > 1,
-                              primary=i == 0)
+                              primary=i == 0,
+                              visible=True)
+
+        # handle logic for tool visibilities (which will also handle setting the primary
+        # to something other than the first entry, if necessary)
+        self._update_tool_visibilities()
 
         # default_tool_priority allows falling back on an existing tool
         # if its the primary tool.  If no items in default_tool_priority
@@ -53,13 +66,80 @@ class NestedJupyterToolbar(BasicJupyterToolbar):
         self.default_tool_priority = default_tool_priority
         self._handle_default_tool()
 
+        for msg in (AddDataMessage, RemoveDataMessage, ViewerAddedMessage, ViewerRemovedMessage,
+                    SpectralMarksChangedMessage):
+            self.viewer.hub.subscribe(self, msg,
+                                      handler=lambda _: self._update_tool_visibilities())
+
+    def _is_visible(self, tool_id, nviewers, nlayers):
+        if tool_id == 'jdaviz:blinkonce':
+            return nlayers > 1
+        elif 'match' in tool_id:
+            return nviewers > 1
+        elif tool_id == 'jdaviz:selectline':
+            return len([m for m in self.viewer.figure.marks if isinstance(m, SpectralLine)]) > 0
+        return True
+
+    def _update_tool_visibilities(self, msg={}):
+        nviewers = len(self.viewer.jdaviz_app._viewer_store)
+        nlayers = len(self.viewer.state.layers)
+        needs_deactivate_active = False
+        for menu_ind in range(self._max_menu_ind):
+            has_primary = False
+            nvisible = 0
+            primary_id = None
+            if self.active_tool_id:
+                current_primary_active = self.tools_data[self.active_tool_id]['menu_ind'] == menu_ind  # noqa
+            else:
+                current_primary_active = False
+            for tool_id, info in self.tools_data.items():
+                if info['menu_ind'] != menu_ind:
+                    continue
+                visible = self._is_visible(tool_id, nviewers, nlayers)
+                if visible:
+                    nvisible += 1
+
+                if tool_id == self.active_tool_id:
+                    # then the primary was already set by which tool is active
+                    if visible:
+                        # then keep this as primary
+                        primary = True
+                    else:
+                        # then the currently active tool is being removed, so we need to deactivate
+                        # the tool and allow the default logic to be triggered
+                        primary = False
+                        needs_deactivate_active = True
+                elif current_primary_active and self._is_visible(self.active_tool_id, nviewers, nlayers):  # noqa
+                    # then we are keeping the previous primary
+                    primary = False
+                else:
+                    # then there is no primary already in this submenu, so the first visible
+                    # entry will be selected as primary
+                    primary = visible and not has_primary
+
+                if primary:
+                    primary_id = tool_id
+                    has_primary = True
+
+                self.tools_data[tool_id] = {**info,
+                                            'primary': primary,
+                                            'visible': visible}
+            if primary_id:
+                self.tools_data[primary_id] = {**self.tools_data[primary_id],
+                                               'has_suboptions': nvisible > 1}
+
+        # mutation to dictionary needs to be manually sent to update the UI
+        self.send_state("tools_data")
+        if needs_deactivate_active:
+            self.active_tool_id = None
+
     def _handle_default_tool(self):
         # default to the first item in the default_tool_priority list that is currently
         # already primary
         for tool_id in self.default_tool_priority:
             if tool_id not in self.tools_data:
                 continue
-            if self.tools_data[tool_id]['primary']:
+            if self.tools_data[tool_id]['primary'] and self.tools_data[tool_id]['visible']:
                 self.active_tool_id = tool_id
                 break
 
@@ -75,7 +155,7 @@ class NestedJupyterToolbar(BasicJupyterToolbar):
             if event['old'] is not None:
                 self.active_tool_id = event['old']
 
-    def add_tool(self, tool, menu_ind, has_suboptions=True, primary=False):
+    def add_tool(self, tool, menu_ind, has_suboptions=True, primary=False, visible=True):
         # NOTE: this method is essentially copied from glue-jupyter's BasicJupyterToolbar,
         # but we need extra values in the tools_data dictionary.  We could call super(),
         # but then that would create tools_data twice, which would then cause
@@ -92,7 +172,8 @@ class NestedJupyterToolbar(BasicJupyterToolbar):
                 'img': read_icon(path, 'svg+xml'),
                 'menu_ind': menu_ind,
                 'has_suboptions': has_suboptions,
-                'primary': primary
+                'primary': primary,
+                'visible': visible
             }
         }
 

--- a/jdaviz/components/toolbar_nested.vue
+++ b/jdaviz/components/toolbar_nested.vue
@@ -1,7 +1,7 @@
 <template>
   <div style="overflow: hidden">
     <v-btn-toggle v-model="active_tool_id" class="transparent">
-        <v-tooltip v-for="[id, {tooltip, img, menu_ind, has_suboptions, primary}] of Object.entries(tools_data)" v-if="primary" bottom>
+        <v-tooltip v-for="[id, {tooltip, img, menu_ind, has_suboptions, primary, visible}] of Object.entries(tools_data)" v-if="primary && visible" bottom>
             <template v-slot:activator="{ on }">
                 <v-btn v-on="on" icon :value="id" style="min-width: 40px !important" @contextmenu="(e) => show_submenu(e, has_suboptions, menu_ind)">
                     <img :src="img" width="20px" @click.ctrl.stop=""/>
@@ -22,8 +22,8 @@
     >
       <v-list>
         <v-tooltip
-          v-for="[id, {tooltip, img, menu_ind, has_suboptions, primary}] of Object.entries(tools_data)"
-          v-if="menu_ind==suboptions_ind"
+          v-for="[id, {tooltip, img, menu_ind, has_suboptions, primary, visible}] of Object.entries(tools_data)"
+          v-if="menu_ind==suboptions_ind && visible"
           :key="id"
           left
         >

--- a/jdaviz/configs/imviz/plugins/tools.py
+++ b/jdaviz/configs/imviz/plugins/tools.py
@@ -85,6 +85,9 @@ class BlinkOnce(CheckableTool):
     def on_click(self, data):
         self.viewer.blink_once(reversed=data['event']=='contextmenu')  # noqa: E225
 
+    def is_visible(self):
+        return len(self.viewer.state.layers) > 1
+
 
 @viewer_tool
 class MatchBoxZoom(_ImvizMatchedZoomMixin, BoxZoom):

--- a/jdaviz/configs/imviz/tests/test_tools.py
+++ b/jdaviz/configs/imviz/tests/test_tools.py
@@ -138,3 +138,23 @@ def test_compass_open_while_load(imviz_helper):
     # Should not crash even if Compass is open in tray.
     imviz_helper.load_data(np.ones((2, 2)))
     assert len(imviz_helper.app.data_collection) == 1
+
+
+def test_tool_visibility(imviz_helper):
+    tb = imviz_helper.default_viewer.toolbar
+
+    assert not tb.tools_data['jdaviz:boxzoommatch']['visible']
+
+    assert tb.tools_data['jdaviz:boxzoom']['primary']
+    # activate boxzoom to ensure it remains primary
+    tb.active_tool_id = 'jdaviz:boxzoom'
+
+    imviz_helper.create_image_viewer()
+
+    assert tb.tools_data['jdaviz:boxzoommatch']['visible']
+    assert tb.active_tool_id == 'jdaviz:boxzoom'
+    assert tb.tools_data['jdaviz:boxzoom']['primary']
+
+    # but the panzoom has updated primary since there was no active tool in that submenu
+    assert tb.tools_data['jdaviz:panzoommatch']['visible']
+    assert tb.tools_data['jdaviz:panzoommatch']['primary']

--- a/jdaviz/configs/imviz/tests/test_tools.py
+++ b/jdaviz/configs/imviz/tests/test_tools.py
@@ -141,6 +141,7 @@ def test_compass_open_while_load(imviz_helper):
 
 
 def test_tool_visibility(imviz_helper):
+    imviz_helper.load_data(np.ones((2, 2)))
     tb = imviz_helper.default_viewer.toolbar
 
     assert not tb.tools_data['jdaviz:boxzoommatch']['visible']
@@ -150,6 +151,7 @@ def test_tool_visibility(imviz_helper):
     tb.active_tool_id = 'jdaviz:boxzoom'
 
     imviz_helper.create_image_viewer()
+    imviz_helper.app.set_data_visibility('imviz-1', imviz_helper.app.data_collection[0].label, True)
 
     assert tb.tools_data['jdaviz:boxzoommatch']['visible']
     assert tb.active_tool_id == 'jdaviz:boxzoom'
@@ -158,3 +160,10 @@ def test_tool_visibility(imviz_helper):
     # but the panzoom has updated primary since there was no active tool in that submenu
     assert tb.tools_data['jdaviz:panzoommatch']['visible']
     assert tb.tools_data['jdaviz:panzoommatch']['primary']
+
+    # now set the tool to the matched box zoom to ensure it deactivates itself when removing
+    # a viewer
+    tb.active_tool_id = 'jdaviz:boxzoommatch'
+    imviz_helper.destroy_viewer('imviz-1')
+    assert not tb.tools_data['jdaviz:boxzoommatch']['visible']
+    assert tb.active_tool_id is None

--- a/jdaviz/core/tools.py
+++ b/jdaviz/core/tools.py
@@ -16,6 +16,7 @@ from glue_jupyter.bqplot.common.tools import (CheckableTool,
 from bqplot.interacts import BrushSelector, BrushIntervalSelector
 
 from jdaviz.core.events import LineIdentifyMessage, SpectralMarksChangedMessage
+from jdaviz.core.marks import SpectralLine
 
 __all__ = []
 
@@ -115,6 +116,9 @@ class _MatchedZoomMixin:
                         if not np.isnan(value) and (orig_value is None or
                                                     abs(value-orig_lims.get(k, np.inf)) > tol):
                             setattr(viewer.state, k, value)
+
+    def is_visible(self):
+        return len(self.viewer.jdaviz_app._viewer_store) > 1
 
 
 @viewer_tool
@@ -329,6 +333,9 @@ class SelectLine(CheckableTool, HubListener):
         # find line closest to mouse position and transmit event
         msg = LineIdentifyMessage(self.line_names[ind], sender=self)
         self.viewer.session.hub.broadcast(msg)
+
+    def is_visible(self):
+        return len([m for m in self.viewer.figure.marks if isinstance(m, SpectralLine)]) > 0
 
 
 class _BaseSidebarShortcut(Tool):


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request adds logic in jdaviz's custom nested toolbar to handle visibility, active, and "primary" status of tools based on whether they are currently applicable.

For Imviz, this is currently implemented for the blink and "matched zoom" tools, reacting to the number of active layers and viewers, respectively:


https://github.com/spacetelescope/jdaviz/assets/877591/a0fbf1ac-3239-4814-b8ee-36cf1baeded9


In specviz, this is implemented for the spectral line selection tool, reacting to the number of spectral lines plotted in the viewer:


https://github.com/spacetelescope/jdaviz/assets/877591/98d55fcd-c23e-4c33-8b8c-52e3b556e568



In the case where a tool is "removed" but was already active, the tool is deactivated and the default tool selection takes place (for cubeviz, the slice tool would be assigned as the active tool):


https://github.com/spacetelescope/jdaviz/assets/877591/02cabf02-ff90-4119-9849-3c83347a4a01


In the case where a tool becomes re-applicable, but a tool in that same menu is currently active, that active tool will remain active and retain its "primary" position in the menu:


https://github.com/spacetelescope/jdaviz/assets/877591/7ccaf23b-0e51-47a5-be20-ea01b4ada492



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
