### PR TITLE
subset plugin components to use filter instead of allowed_type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,7 +63,7 @@ Imviz
 - Simple Aperture Photometry plugin: Custom annulus background options are removed.
   Please draw/load annulus as you would with other region shapes, then select it
   in the plugin from Subset dropdown for the background. Using annulus region as
-  aperture is not supported. [#2276]
+  aperture is not supported. [#2276, #2287]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -132,7 +132,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
                                                'spatial_subset_items',
                                                'spatial_subset_selected',
                                                default_text='Entire Cube',
-                                               allowed_type='spatial')
+                                               filters=['is_spatial'])
         else:
             self.spatial_subset = None
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -62,7 +62,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin, TableMix
                                       'bg_subset_selected',
                                       default_text='Manual',
                                       manual_options=['Manual'],
-                                      filters=['is_spatial'])
+                                      filters=['is_spatial', 'is_not_composite'])
 
         headers = ['xcenter', 'ycenter', 'sky_center',
                    'sum', 'sum_aper_area',

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -55,14 +55,14 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin, TableMix
                                    'subset_items',
                                    'subset_selected',
                                    default_text=None,
-                                   allowed_type='spatial')
+                                   filters=['is_spatial', 'is_not_composite', 'is_not_annulus'])
 
         self.bg_subset = SubsetSelect(self,
                                       'bg_subset_items',
                                       'bg_subset_selected',
                                       default_text='Manual',
                                       manual_options=['Manual'],
-                                      allowed_type='spatial')
+                                      filters=['is_spatial'])
 
         headers = ['xcenter', 'ycenter', 'sky_center',
                    'sum', 'sum_aper_area',

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -18,7 +18,7 @@
         :selected.sync="subset_selected"
         :show_if_single_entry="true"
         label="Aperture"
-        hint="Select aperture region for photometry."
+        hint="Select aperture region for photometry (cannot be an annulus or composite subset)."
       />
 
       <div v-if="subset_selected">
@@ -27,7 +27,7 @@
           :selected.sync="bg_subset_selected"
           :show_if_single_entry="true"
           label="Background"
-          hint="Select subset region for background calculation."
+          hint="Select subset region for background calculation (cannot be a composite subset)."
         />
 
         <v-row v-if="subset_selected === bg_subset_selected">

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -224,6 +224,10 @@ def test_annulus_background(imviz_helper):
         PixCoord(x=20.5, y=37.5), inner_radius=20.5, outer_radius=30.5)
     imviz_helper.load_regions([annulus_2])
 
+    # Subset 4 (annulus) should be available for the background but not the aperture
+    assert 'Subset 4' not in phot_plugin.subset.choices
+    assert 'Subset 4' in phot_plugin.bg_subset.choices
+
     phot_plugin.subset_selected = 'Subset 3'
     phot_plugin.bg_subset_selected = 'Subset 4'
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -130,7 +130,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
                                       'continuum_subset_items',
                                       'continuum_subset_selected',
                                       default_text='Surrounding',
-                                      allowed_type='spectral')
+                                      filters=['is_spectral'])
 
         # when accessing the selected data, access the spectrum-viewer version
         self.dataset._viewers = [self._default_spectrum_viewer_reference_name]
@@ -142,7 +142,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
                                                'spatial_subset_items',
                                                'spatial_subset_selected',
                                                default_text=SPATIAL_DEFAULT_TEXT,
-                                               allowed_type='spatial')
+                                               filters=['is_spatial'])
         else:
             self.spatial_subset = None
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -975,10 +975,12 @@ class SubsetSelect(SelectPluginComponent):
         default_text : str or None
             the text to show for no selection.  If not provided or None, no entry will be provided
             in the dropdown for no selection.
-        manual_options: list
+        manual_options : list
             list of options to provide that are not automatically populated by subsets.  If
             ``default`` text is provided but not in ``manual_options`` it will still be included as
             the first item in the list.
+        filters : list
+            list of strings (for built-in filters) or callables to filter to only valid options.
         """
         super().__init__(plugin,
                          items=items,
@@ -1471,6 +1473,8 @@ class DatasetSelect(SelectPluginComponent):
             the name of the items traitlet defined in ``plugin``
         selected : str
             the name of the selected traitlet defined in ``plugin``
+        filters : list
+            list of strings (for built-in filters) or callables to filter to only valid options.
         default_text : str or None
             the text to show for no selection.  If not provided or None, no entry will be provided
             in the dropdown for no selection.

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -14,6 +14,7 @@ from glue.core.message import (DataCollectionAddMessage,
                                SubsetCreateMessage,
                                SubsetDeleteMessage,
                                SubsetUpdateMessage)
+from glue.core.roi import CircularAnnulusROI
 from glue.core.subset import RoiSubsetState
 from glue_jupyter.bqplot.image import BqplotImageView
 from glue_jupyter.widgets.linked_dropdown import get_choices as _get_glue_choices
@@ -745,7 +746,7 @@ class LayerSelect(SelectPluginComponent):
     """
     def __init__(self, plugin, items, selected, viewer,
                  multiselect=None,
-                 default_text=None, manual_options=[], allowed_type=None,
+                 default_text=None, manual_options=[],
                  default_mode='first'):
         """
         Parameters
@@ -937,8 +938,7 @@ class SubsetSelect(SelectPluginComponent):
 
     * create (empty) traitlets in the plugin
     * register with all the automatic logic in the plugin's init by passing the string names
-      of the respective traitlets.  Pass ``allowed_type='spectral'`` or ``allowed_type='spatial'``
-      to only support spectral or spatial subsets, respectively.
+      of the respective traitlets.
     * use component in plugin template (see below)
     * refer to properties above based on the interally stored reference to the
       instantiated object of this component
@@ -956,7 +956,7 @@ class SubsetSelect(SelectPluginComponent):
 
     """
     def __init__(self, plugin, items, selected, selected_has_subregions=None,
-                 viewers=None, default_text=None, manual_options=[], allowed_type=None,
+                 viewers=None, default_text=None, manual_options=[], filters=[],
                  default_mode='default_text'):
         """
         Parameters
@@ -979,22 +979,16 @@ class SubsetSelect(SelectPluginComponent):
             list of options to provide that are not automatically populated by subsets.  If
             ``default`` text is provided but not in ``manual_options`` it will still be included as
             the first item in the list.
-        allowed_type : str or None
-            whether to filter to 'spatial' or 'spectral' types of subsets.  If not provided or None,
-            will include both entries.
         """
         super().__init__(plugin,
                          items=items,
                          selected=selected,
+                         filters=filters,
                          selected_has_subregions=selected_has_subregions,
                          viewers=viewers,
                          default_text=default_text,
                          manual_options=manual_options,
                          default_mode=default_mode)
-
-        if allowed_type not in [None, 'spatial', 'spectral']:
-            raise ValueError("allowed_type must be None, 'spatial', or 'spectral'")
-        self._allowed_type = allowed_type
 
         if selected_has_subregions is not None:
             self.selected_has_subregions = False
@@ -1029,14 +1023,29 @@ class SubsetSelect(SelectPluginComponent):
         if self.selected not in self.labels:
             self._apply_default_selection()
 
-    def _update_subset(self, subset, attribute=None):
-        if self._allowed_type is not None and _subset_type(subset) != self._allowed_type:
-            return
+    def _is_valid_item(self, subset):
+        def is_spectral(subset):
+            return _subset_type(subset) == 'spectral'
 
+        def is_spatial(subset):
+            return _subset_type(subset) == 'spatial'
+
+        def is_not_composite(subset):
+            return not hasattr(subset.subset_state, 'state1')
+
+        def is_not_annulus(subset):
+            # this will be considered "not an annulus" if it is composite, even
+            # if that composite subset contains an annulus
+            return (not is_not_composite(subset)
+                    or not isinstance(subset.subset_state.roi, CircularAnnulusROI))
+
+        return super()._is_valid_item(subset, locals())
+
+    def _update_subset(self, subset, attribute=None):
         if subset.label not in self.labels:
             # NOTE: this logic will need to be revisited if generic renaming of subsets is added
             # see https://github.com/spacetelescope/jdaviz/pull/1175#discussion_r829372470
-            if subset.label.startswith('Subset'):
+            if subset.label.startswith('Subset') and self._is_valid_item(subset):
                 # NOTE: += will not trigger traitlet update
                 self.items = self.items + [self._subset_to_dict(subset)]  # noqa
         else:
@@ -1084,10 +1093,12 @@ class SubsetSelect(SelectPluginComponent):
     @property
     def selected_subset_mask(self):
         get_data_kwargs = {'data_label': self.plugin.dataset.selected}
-        if self._allowed_type:
-            get_data_kwargs[f'{self._allowed_type}_subset'] = self.selected
+        if 'is_spectral' in self.filters:
+            get_data_kwargs['spectral_subset'] = self.selected
+        elif 'is_spatial' in self.filters:
+            get_data_kwargs['spatial_subset'] = self.selected
 
-        if self.app.config == 'cubeviz' and self._allowed_type == 'spectral':
+        if self.app.config == 'cubeviz' and 'is_spectral' in self.filters:
             viewer_ref = getattr(self.plugin,
                                  '_default_spectrum_viewer_reference_name',
                                  self.viewers[0].reference_id)
@@ -1143,7 +1154,7 @@ class SpectralSubsetSelectMixin(VuetifyTemplate, HubListener):
                                             'spectral_subset_selected_has_subregions',
                                             viewers=[spectrum_viewer],
                                             default_text='Entire Spectrum',
-                                            allowed_type='spectral')
+                                            filters=['is_spectral'])
 
 
 class SpatialSubsetSelectMixin(VuetifyTemplate, HubListener):
@@ -1180,7 +1191,7 @@ class SpatialSubsetSelectMixin(VuetifyTemplate, HubListener):
                                            'spatial_subset_selected',
                                            'spatial_subset_selected_has_subregions',
                                            default_text='No Subset',
-                                           allowed_type='spatial')
+                                           filters=['is_spatial'])
 
 
 class DatasetSpectralSubsetValidMixin(VuetifyTemplate, HubListener):


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is a follow-up to https://github.com/spacetelescope/jdaviz/pull/2276#discussion_r1248082434 and refactors the plugin `Subset` component to use the same `filters` infrastructure as other components instead of its own `allowed_type`.  In doing so, this also implements new `is_not_annulus` and `is_not_composite` filters which can then be used directly by the aperture photometry plugin for the aperture subset dropdown component.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #2280

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
