### PR TITLE
live-preview marks based on mouseover

### DIFF
--- a/docs/dev/ui_style_guide.rst
+++ b/docs/dev/ui_style_guide.rst
@@ -8,7 +8,7 @@ Tray Plugins
 In order to be consistent with layout, styling, and spacing, UI development on plugins should
 try to adhere to the following principles:
 
-* Any tray plugin should utilize ``<j-tray-plugin :disabled_msg='disabled_msg'>`` as the
+* Any tray plugin should utilize ``<j-tray-plugin :has_previews="has_previews" :plugin_active.sync="plugin_active" :persistent_previews.sync="persistent_previews" :disabled_msg='disabled_msg' :popout_button="popout_button">`` as the
   outer-container (which provides consistent styling rules).  Any changes to style
   across all plugins should then take place in the
   ``j-tray-plugin`` stylesheet (``jdaviz/components/tray_plugin.vue``).

--- a/jdaviz/components/tray_plugin.vue
+++ b/jdaviz/components/tray_plugin.vue
@@ -1,26 +1,42 @@
 <template>
-  <v-container class="tray-plugin" style="padding-left: 24px; padding-right: 24px; padding-top: 12px">
-    <v-row>
-      <div style="width: calc(100% - 32px)">
-        <j-docs-link :link="link">{{ description }}</j-docs-link>
-      </div>
-      <div style="width: 32px">
-        <j-plugin-popout :popout_button="popout_button"></j-plugin-popout>
-      </div>
-    </v-row>
-    
-    <v-row v-if="isDisabled()">
-      <span> {{ getDisabledMsg() }}</span>
-    </v-row>
-    <div v-else>
-      <slot></slot>
+  <div
+    @mouseenter="if (!persistent_previews){$emit('update:plugin_active', true)}"
+    @mouseleave="if (!persistent_previews){$emit('update:plugin_active', false)}"
+    :style="(plugin_active || persistent_previews) ? 'border-left: 4px solid rgb(2 123 161 / 80%)' : 'margin-left: 4px'"
+    >
+      <v-container class="tray-plugin" style="padding-left: 24px; padding-right: 24px; padding-top: 12px">
+        <v-row>
+          <div style="width: calc(100% - 32px)">
+            <j-docs-link :link="link">{{ description }}</j-docs-link>
+          </div>
+          <div style="width: 32px">
+            <j-plugin-popout :popout_button="popout_button"></j-plugin-popout>
+          </div>
+        </v-row>
+        
+        <v-row v-if="isDisabled()">
+          <span> {{ getDisabledMsg() }}</span>
+        </v-row>
+        <div v-else>
+          <v-row v-if="has_previews">
+            <v-switch
+              v-model="persistent_previews"
+              @change="$emit('update:persistent_previews', $event)"
+              label="persistent live-preview"
+              hint="show live-preview even when mouse is not over plugin"
+              persistent-hint>
+            </v-switch>
+          </v-row>
+          <slot></slot>
+        </div>
+      </v-container>
     </div>
-  </v-container>
 </template>
 
 <script>
 module.exports = {
-  props: ['disabled_msg', 'description', 'link', 'popout_button'],
+  props: ['disabled_msg', 'description', 'link', 'popout_button',
+          'has_previews', 'plugin_active', 'persistent_previews'],
   methods: {
     isDisabled() {
       return this.getDisabledMsg().length > 0

--- a/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
@@ -15,13 +15,13 @@ def test_spectrum_at_spaxel(cubeviz_helper, spectrum1d_cube):
     flux_viewer.toolbar.active_tool = flux_viewer.toolbar.tools['jdaviz:spectrumperspaxel']
     x = 1
     y = 1
-    assert len(flux_viewer.figure.marks) == 2
+    assert len(flux_viewer.native_marks) == 2
     assert len(spectrum_viewer.data()) == 1
 
     # Click on spaxel location
     flux_viewer.toolbar.active_tool.on_mouse_event(
         {'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
-    assert len(flux_viewer.figure.marks) == 3
+    assert len(flux_viewer.native_marks) == 3
     assert len(spectrum_viewer.data()) == 2
 
     # Check that a new subset was created
@@ -32,7 +32,7 @@ def test_spectrum_at_spaxel(cubeviz_helper, spectrum1d_cube):
 
     # Deselect tool
     flux_viewer.toolbar.active_tool = None
-    assert len(flux_viewer.figure.marks) == 3
+    assert len(flux_viewer.native_marks) == 3
 
 
 def test_spectrum_at_spaxel_altkey_true(cubeviz_helper, spectrum1d_cube):
@@ -46,7 +46,7 @@ def test_spectrum_at_spaxel_altkey_true(cubeviz_helper, spectrum1d_cube):
     flux_viewer.toolbar.active_tool = flux_viewer.toolbar.tools['jdaviz:spectrumperspaxel']
     x = 1
     y = 1
-    assert len(flux_viewer.figure.marks) == 2
+    assert len(flux_viewer.native_marks) == 2
     assert len(spectrum_viewer.data()) == 1
 
     # Check coordinate info panel
@@ -60,7 +60,7 @@ def test_spectrum_at_spaxel_altkey_true(cubeviz_helper, spectrum1d_cube):
     # Click on spaxel location
     flux_viewer.toolbar.active_tool.on_mouse_event(
         {'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
-    assert len(flux_viewer.figure.marks) == 3
+    assert len(flux_viewer.native_marks) == 3
     assert len(spectrum_viewer.data()) == 2
 
     # Check that subset was created
@@ -74,7 +74,7 @@ def test_spectrum_at_spaxel_altkey_true(cubeviz_helper, spectrum1d_cube):
     y = 2
     flux_viewer.toolbar.active_tool.on_mouse_event(
         {'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': True})
-    assert len(flux_viewer.figure.marks) == 4
+    assert len(flux_viewer.native_marks) == 4
     assert len(spectrum_viewer.data()) == 3
 
     subsets = cubeviz_helper.app.get_subsets()
@@ -118,15 +118,15 @@ def test_spectrum_at_spaxel_with_2d(cubeviz_helper):
     flux_viewer.toolbar.active_tool = flux_viewer.toolbar.tools['jdaviz:spectrumperspaxel']
     x = 1
     y = 1
-    assert len(flux_viewer.figure.marks) == 2
+    assert len(flux_viewer.native_marks) == 2
     assert len(spectrum_viewer.data()) == 0
 
     # Click on spaxel location
     flux_viewer.toolbar.active_tool.on_mouse_event(
         {'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
-    assert len(flux_viewer.figure.marks) == 3
+    assert len(flux_viewer.native_marks) == 3
     assert len(spectrum_viewer.data()) == 0
 
     # Deselect tool
     flux_viewer.toolbar.active_tool = None
-    assert len(flux_viewer.figure.marks) == 3
+    assert len(flux_viewer.native_marks) == 3

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -322,12 +322,7 @@ class LineListTool(PluginTemplateMixin):
             msg = RedshiftMessage("redshift", value, sender=self)
             self.app.hub.broadcast(msg)
 
-    @observe('plugin_opened')
     def _update_line_list_obs(self, *args):
-        if not self.plugin_opened:
-            return
-
-        new_list_contents = {}
         for list_name, line_list in self.list_contents.items():
             for i, line in enumerate(line_list['lines']):
                 if self._rs_line_obs_change[0] == list_name and self._rs_line_obs_change[1] == i:  # noqa
@@ -339,10 +334,9 @@ class LineListTool(PluginTemplateMixin):
                 else:
                     line_list['lines'][i]['obs'] = self._rest_to_obs(float(line['rest']))
 
-            new_list_contents[list_name] = line_list
+            self.list_contents[list_name] = line_list
 
-        self.list_contents = {}
-        self.list_contents = new_list_contents
+        self.send_state('list_contents')
 
     def vue_change_line_obs(self, kwargs):
         # NOTE: we can only pass one argument from vue (it seems), so we'll pass as

--- a/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
@@ -65,7 +65,7 @@ def test_redshift(specviz_helper, spectrum1d):
 
     ll_plugin = specviz_helper.app.get_tray_item_from_name('g-line-list')
     # fake the plugin to be opened so that all updates run
-    ll_plugin.plugin_opened = True
+    ll_plugin.plugin_active = True
     line = ll_plugin.list_contents['Test List']['lines'][0]
     assert_allclose(line['obs'], line['rest'])
     # test API access

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -1,5 +1,5 @@
 import numpy as np
-from traitlets import observe
+from traitlets import Bool, observe
 
 from jdaviz.core.events import ViewerAddedMessage
 from jdaviz.core.marks import MarkersMark
@@ -24,6 +24,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
     * :meth:`~jdaviz.core.template_mixin.TableMixin.export_table`
     """
     template_file = __file__, "markers.vue"
+    has_previews = Bool(True).tag(sync=True)
 
     _default_table_values = {'spectral_axis': np.nan,
                              'spectral_axis:unit': '',
@@ -78,8 +79,11 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
         # subscribe to mouse events on any new viewers
         self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewer_added)
 
+        # need to keep preview marks when mouse is not over plugin (by default)
+        self.persistent_previews = True
+
     def _create_viewer_callbacks(self, viewer):
-        if not self.plugin_opened:
+        if not self.show_previews:
             return
 
         callback = self._viewer_callback(viewer, self._on_viewer_key_event)
@@ -106,14 +110,14 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
     def coords_info(self):
         return self.app.session.application._tools['g-coords-info']
 
-    @observe('plugin_opened')
-    def _on_plugin_opened_changed(self, *args):
+    @observe('show_previews')
+    def _on_show_previews_changed(self, *args):
         if self.disabled_msg:
             return
 
         # toggle visibility of markers
         for mark in self.marks.values():
-            mark.visible = self.plugin_opened
+            mark.visible = self.show_previews
 
         # subscribe/unsubscribe to keypress events across all viewers
         for viewer in self.app._viewer_store.values():
@@ -122,7 +126,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
                 continue
             callback = self._viewer_callback(viewer, self._on_viewer_key_event)
 
-            if self.plugin_opened:
+            if self.show_previews:
                 viewer.add_event_callback(callback, events=['keydown'])
             else:
                 viewer.remove_event_callback(callback)

--- a/jdaviz/configs/default/plugins/markers/markers.vue
+++ b/jdaviz/configs/default/plugins/markers/markers.vue
@@ -2,7 +2,14 @@
   <j-tray-plugin
     description='Create and export markers.  Press "m" with the cursor over a viewer to log the mouseover information.  To change the selected layer, click the layer cycler in the mouseover information section of the app-level toolbar.'
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#markers'"
+    :has_previews="has_previews"
+    :plugin_active.sync="plugin_active"
+    :persistent_previews.sync="persistent_previews"
     :popout_button="popout_button">
+
+    <v-row v-if="!persistent_previews">
+      <v-alert color="warning">Persistent live-preview must be enabled for logging via keypress to be active</v-alert>
+    </v-row>
 
     <jupyter-widget :widget="table_widget"></jupyter-widget> 
 

--- a/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
+++ b/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
@@ -28,7 +28,6 @@ def test_markers_cubeviz(cubeviz_helper, spectrum1d_cube):
     label_mouseover = cubeviz_helper.app.session.application._tools['g-coords-info']
 
     mp = cubeviz_helper.plugins['Markers']
-    mp.open_in_tray()
 
     # test event in flux viewer
     label_mouseover._viewer_mouse_event(fv,
@@ -112,13 +111,13 @@ def test_markers_cubeviz(cubeviz_helper, spectrum1d_cube):
     assert len(_get_markers_from_viewer(fv).x) == 1
     assert len(_get_markers_from_viewer(sv).x) == 2
 
-    # markers hide when plugin closed
-    cubeviz_helper.app.state.drawer = False
+    # markers hide when persistent_previews disabled (and not active)
+    mp.persistent_previews = False
     assert _get_markers_from_viewer(fv).visible is False
     assert _get_markers_from_viewer(sv).visible is False
 
     # markers re-appear when plugin re-opened
-    mp.open_in_tray()
+    mp.persistent_previews = True
     assert _get_markers_from_viewer(fv).visible is True
     assert _get_markers_from_viewer(sv).visible is True
     assert len(_get_markers_from_viewer(fv).x) == 1
@@ -136,7 +135,6 @@ class TestImvizMultiLayer(BaseImviz_WCS_NoWCS):
         label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
 
         mp = self.imviz.plugins['Markers']
-        mp.open_in_tray()
 
         # cycle through dataset options (used for both coords info and markers)
         assert label_mouseover.dataset.choices == ['auto', 'none',
@@ -215,9 +213,6 @@ class TestImvizMultiLayer(BaseImviz_WCS_NoWCS):
 
     def test_markers_custom_viewer(self):
         label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
-
-        mp = self.imviz.plugins['Markers']
-        mp.open_in_tray()
 
         nv = self.imviz.create_image_viewer()
         self.imviz.app.add_data_to_viewer('imviz-1', 'has_wcs[SCI,1]')

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -63,7 +63,6 @@ def test_multiselect(cubeviz_helper, spectrum1d_cube):
 def test_stretch_histogram(cubeviz_helper, spectrum1d_cube_with_uncerts):
     cubeviz_helper.load_data(spectrum1d_cube_with_uncerts)
     po = cubeviz_helper.app.get_tray_item_from_name('g-plot-options')
-    po.open_in_tray()  # forces histogram to draw
 
     assert po.stretch_histogram is not None
 

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -22,7 +22,7 @@ class JdavizViewerMixin:
     toolbar = None
     tools_nested = []
     _prev_limits = None
-    _native_mark_classnames = ('Lines', 'LinesGL')
+    _native_mark_classnames = ('Lines', 'LinesGL', 'FRBImage', 'Contour')
 
     def __init__(self, *args, **kwargs):
         # NOTE: anything here most likely won't be called by viewers because of inheritance order

--- a/jdaviz/configs/imviz/plugins/compass/compass.py
+++ b/jdaviz/configs/imviz/plugins/compass/compass.py
@@ -61,7 +61,7 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
         self.canvas_angle = viewer_item.get('canvas_angle', 0)  # noqa
         self.canvas_flip_horizontal = viewer_item.get('canvas_flip_horizontal', False)
 
-    @observe("viewer_selected", "plugin_opened")
+    @observe("viewer_selected", "plugin_opened_in_tray")
     def _compass_with_new_viewer(self, *args, **kwargs):
         if not hasattr(self, 'viewer'):
             # mixin object not yet initialized
@@ -69,7 +69,7 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
 
         # There can be only one!
         for vid, viewer in self.app._viewer_store.items():
-            if vid == self.viewer.selected_id and (self.plugin_opened or kwargs.get('from_show')):
+            if vid == self.viewer.selected_id and (self.plugin_opened_in_tray or kwargs.get('from_show')):  # noqa
                 viewer.compass = self
                 viewer.on_limits_change()  # Force redraw
 

--- a/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
+++ b/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
@@ -55,7 +55,7 @@ class LineProfileXY(PluginTemplateMixin):
     @observe("selected_viewer")
     def vue_draw_plot(self, *args, **kwargs):
         """Draw line profile plots for given Data across given X and Y indices (0-indexed)."""
-        if not self.selected_x or not self.selected_y or not self.plugin_opened:
+        if not self.selected_x or not self.selected_y:
             return
 
         viewer = self.app.get_viewer_by_id(self.selected_viewer)

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -79,7 +79,8 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
             if key_pressed in ('b', 'B'):
                 self.blink_once(reversed=key_pressed=='B')  # noqa: E225
 
-            elif key_pressed == 'l' and self.line_profile_xy.plugin_opened:
+            # TODO: move into plugin callback?
+            elif key_pressed == 'l':
                 # Same data as mousemove above.
                 image = self.active_image_layer.layer
                 x = data['domain']['x']

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -38,7 +38,7 @@ class TestCatalogs:
         self.imviz = imviz_helper
 
         catalogs_plugin = self.imviz.app.get_tray_item_from_name('imviz-catalogs')
-        catalogs_plugin.plugin_opened = True
+        catalogs_plugin.plugin_active = True
         # running the search without any data loaded into Imviz
         catalogs_plugin.vue_do_search()
 
@@ -54,7 +54,7 @@ class TestCatalogs:
         self.imviz = imviz_helper
 
         catalogs_plugin = self.imviz.app.get_tray_item_from_name('imviz-catalogs')
-        catalogs_plugin.plugin_opened = True
+        catalogs_plugin.plugin_active = True
         catalogs_plugin.vue_do_search()
 
         # number of results should be 0
@@ -91,7 +91,7 @@ class TestCatalogs:
         self.imviz = imviz_helper
 
         catalogs_plugin = self.imviz.app.get_tray_item_from_name('imviz-catalogs')
-        catalogs_plugin.plugin_opened = True
+        catalogs_plugin.plugin_active = True
         # This basically calls the following under the hood:
         #   skycoord_center = SkyCoord(6.62754354, 1.54466139, unit="deg")
         #   zoom_radius = r_max = 3 * u.arcmin

--- a/jdaviz/configs/imviz/tests/test_line_profile_xy.py
+++ b/jdaviz/configs/imviz/tests/test_line_profile_xy.py
@@ -10,7 +10,7 @@ class TestLineProfileXY(BaseImviz_WCS_NoWCS):
     def test_plugin_linked_by_pixel(self):
         """Go through plugin logic but does not check plot contents."""
         lp_plugin = self.imviz.app.get_tray_item_from_name('imviz-line-profile-xy')
-        lp_plugin.plugin_opened = True
+        lp_plugin.plugin_active = True
 
         lp_plugin._on_viewers_changed()  # Populate plugin menu items.
         assert lp_plugin.viewer_items == ['imviz-0']
@@ -66,7 +66,7 @@ class TestLineProfileXY(BaseImviz_WCS_NoWCS):
         assert lp_plugin.plot_available
 
         # Nothing should update on "l" when plugin closed.
-        lp_plugin.plugin_opened = False
+        lp_plugin.plugin_active = False
         self.viewer.on_mouse_or_key_event(
             {'event': 'keydown', 'key': 'l', 'domain': {'x': 5.1, 'y': 5}})
         lp_plugin.selected_x = '1.1'

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -2,6 +2,9 @@
   <j-tray-plugin
     description="Return statistics for a single spectral line."
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#line-analysis'"
+    :has_previews="has_previews"
+    :plugin_active.sync="plugin_active"
+    :persistent_previews.sync="persistent_previews"
     :disabled_msg="disabled_msg"
     :popout_button="popout_button">
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -17,7 +17,7 @@ def test_plugin(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -25,8 +25,8 @@ def test_plugin(specviz_helper, spectrum1d):
     assert len(continuum_marks) == 3
     assert np.all([cm.visible for cm in continuum_marks])
 
-    # closing tray/plugin should hide the continuum
-    specviz_helper.app.state.drawer = False
+    # disabling persistent_previews should hide the continuum
+    plugin.persistent_previews = False
     assert np.all([cm.visible is False for cm in continuum_marks])
 
     # add a region and rerun stats for that region
@@ -63,7 +63,7 @@ def test_spatial_subset(cubeviz_helper, image_cube_hdu_obj):
     cubeviz_helper.app.state.drawer = True
 
     plugin = cubeviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     plugin.spatial_subset_selected = 'Subset 1'
     plugin.spectral_subset_selected = 'Subset 2'
@@ -85,7 +85,7 @@ def test_user_api(specviz_helper, spectrum1d):
     sv.apply_roi(XRangeROI(6500, 7400))
 
     la = specviz_helper.plugins['Line Analysis']
-    la.open_in_tray()
+    la.persistent_previews = True
 
     # spectral subset does not support multiselect
     assert "multiselect" not in la.spectral_subset.__repr__()
@@ -183,7 +183,7 @@ def test_continuum_surrounding_spectral_subset(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -210,7 +210,7 @@ def test_continuum_spectral_same_value(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -237,7 +237,7 @@ def test_continuum_surrounding_invalid_width(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -262,7 +262,7 @@ def test_continuum_subset_spectral_entire(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -289,7 +289,7 @@ def test_continuum_subset_spectral_subset2(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -322,7 +322,7 @@ def test_continuum_surrounding_no_right(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -350,7 +350,7 @@ def test_continuum_surrounding_no_left(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -378,7 +378,7 @@ def test_subset_changed(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_lineflux.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_lineflux.py
@@ -62,7 +62,8 @@ def _calculate_line_flux(viz_helper):
     # Open the plugin and force the calculation
     viz_helper.app.state.drawer = True
     line_analysis_plugin = viz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    line_analysis_plugin.open_in_tray()
+    line_analysis_plugin.persistent_previews = True
+
     # Retrieve Results
     for result in line_analysis_plugin.results:
         if result['function'] == 'Line Flux':

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -95,6 +95,7 @@ class SpectralExtraction(PluginTemplateMixin):
     """
     dialog = Bool(False).tag(sync=True)
     template_file = __file__, "spectral_extraction.vue"
+    has_previews = Bool(True).tag(sync=True)
 
     active_step = Unicode().tag(sync=True)
     interactive_extract = Bool(True).tag(sync=True)
@@ -396,7 +397,6 @@ class SpectralExtraction(PluginTemplateMixin):
             Step in the extraction process to visualize.  Must be one of: 'trace', 'bg', 'ext'.
         """
         if step is not None:
-            self.plugin_opened = True
             if step == 'trace':
                 self._interaction_in_trace_step()
             elif step == 'bg':
@@ -406,18 +406,12 @@ class SpectralExtraction(PluginTemplateMixin):
             else:
                 raise ValueError("step must be one of: trace, bg, ext")
 
-    def clear_marks(self):
-        """
-        Manually clear the live-preview marks.
-        """
-        self.plugin_opened = False
-
-    @observe('plugin_opened', 'interactive_extract')
+    @observe('show_previews', 'interactive_extract')
     def _update_plugin_marks(self, *args):
         if not self._do_marks:
             return
 
-        if not self.plugin_opened:
+        if not (self.show_previews):
             for step, mark in self.marks.items():
                 mark.visible = False
             return
@@ -475,22 +469,22 @@ class SpectralExtraction(PluginTemplateMixin):
 
         # the marks haven't been initialized yet, so initialize with empty
         # marks that will be populated once the first analysis is done.
-        self._marks = {'trace': PluginLine(viewer2d, visible=self.plugin_opened),
-                       'ext_lower': PluginLine(viewer2d, visible=self.plugin_opened),
-                       'ext_upper': PluginLine(viewer2d, visible=self.plugin_opened),
-                       'bg1_center': PluginLine(viewer2d, visible=self.plugin_opened,
+        self._marks = {'trace': PluginLine(viewer2d, visible=self.show_previews),
+                       'ext_lower': PluginLine(viewer2d, visible=self.show_previews),
+                       'ext_upper': PluginLine(viewer2d, visible=self.show_previews),
+                       'bg1_center': PluginLine(viewer2d, visible=self.show_previews,
                                                 line_style='dotted'),
-                       'bg1_lower': PluginLine(viewer2d, visible=self.plugin_opened),
-                       'bg1_upper': PluginLine(viewer2d, visible=self.plugin_opened),
-                       'bg2_center': PluginLine(viewer2d, visible=self.plugin_opened,
+                       'bg1_lower': PluginLine(viewer2d, visible=self.show_previews),
+                       'bg1_upper': PluginLine(viewer2d, visible=self.show_previews),
+                       'bg2_center': PluginLine(viewer2d, visible=self.show_previews,
                                                 line_style='dotted'),
-                       'bg2_lower': PluginLine(viewer2d, visible=self.plugin_opened),
-                       'bg2_upper': PluginLine(viewer2d, visible=self.plugin_opened)}
+                       'bg2_lower': PluginLine(viewer2d, visible=self.show_previews),
+                       'bg2_upper': PluginLine(viewer2d, visible=self.show_previews)}
         # NOTE: += won't trigger the figure to notice new marks
         viewer2d.figure.marks = viewer2d.figure.marks + list(self._marks.values())
 
-        self._marks['extract'] = PluginLine(viewer1d, visible=self.plugin_opened)
-        self._marks['bg_spec'] = PluginLine(viewer1d, visible=self.plugin_opened, stroke_width=1)  # noqa
+        self._marks['extract'] = PluginLine(viewer1d, visible=self.show_previews)
+        self._marks['bg_spec'] = PluginLine(viewer1d, visible=self.show_previews, stroke_width=1)  # noqa
 
         # NOTE: += won't trigger the figure to notice new marks
         viewer1d.figure.marks = viewer1d.figure.marks + [self._marks['extract'],
@@ -503,7 +497,7 @@ class SpectralExtraction(PluginTemplateMixin):
              'trace_pixel', 'trace_peak_method_selected',
              'trace_do_binning', 'trace_bins', 'trace_window', 'active_step')
     def _interaction_in_trace_step(self, event={}):
-        if not self.plugin_opened or not self._do_marks:
+        if not self.show_previews or not self._do_marks:
             return
         if event.get('name', '') == 'active_step' and event.get('new') != 'trace':
             return
@@ -524,7 +518,7 @@ class SpectralExtraction(PluginTemplateMixin):
              'bg_trace_selected', 'bg_trace_pixel',
              'bg_separation', 'bg_width', 'bg_statistic_selected', 'active_step')
     def _interaction_in_bg_step(self, event={}):
-        if not self.plugin_opened or not self._do_marks:
+        if not self.show_previews or not self._do_marks:
             return
         if event.get('name', '') == 'active_step' and event.get('new') != 'bg':
             return
@@ -580,7 +574,7 @@ class SpectralExtraction(PluginTemplateMixin):
     @observe('ext_dataset_selected', 'ext_trace_selected',
              'ext_type_selected', 'ext_width', 'active_step')
     def _interaction_in_ext_step(self, event={}):
-        if not self.plugin_opened or not self._do_marks:
+        if not self.show_previews or not self._do_marks:
             return
         if event.get('name', '') == 'active_step' and event.get('new') != 'ext':
             return

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -2,6 +2,9 @@
   <j-tray-plugin
     description="2D to 1D spectral extraction."
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#spectral-extraction'"
+    :has_previews="has_previews"
+    :plugin_active.sync="plugin_active"
+    :persistent_previews.sync="persistent_previews"
     :popout_button="popout_button">
 
     <v-row>
@@ -25,7 +28,8 @@
     </v-row>
 
 
-    <div @mouseover="() => active_step='trace'">
+    <div @mouseover="() => active_step='trace'"
+      :style="plugin_active && active_step==='trace' ? 'box-shadow: rgb(2 123 161 / 20%) -20px 0px 0px 0px' : ''">
       <j-plugin-section-header>Trace</j-plugin-section-header>
       <v-row>
         <j-docs-link>
@@ -184,7 +188,8 @@
       </v-row>
     </div>
 
-    <div @mouseover="() => active_step='bg'">
+    <div @mouseover="() => active_step='bg'"
+      :style="plugin_active && active_step==='bg' ? 'box-shadow: rgb(2 123 161 / 20%) -20px 0px 0px 0px' : ''">
       <j-plugin-section-header>Background</j-plugin-section-header>
       <v-row>
         <j-docs-link>Create a background and/or background-subtracted image.</j-docs-link>
@@ -346,7 +351,8 @@
       </v-row>
     </div>
 
-    <div @mouseover="() => active_step='ext'">
+    <div @mouseover="() => active_step='ext'"
+      :style="plugin_active && active_step==='ext' ? 'box-shadow: rgb(2 123 161 / 20%) -20px 0px 0px 0px' : ''">
       <j-plugin-section-header>Extraction</j-plugin-section-header>
       <v-row>
         <j-docs-link>

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -24,7 +24,7 @@ def test_plugin(specviz2d_helper):
     sp2dv = specviz2d_helper.app.get_viewer('spectrum-2d-viewer')
     assert len(sp2dv.figure.marks) == 2
 
-    pext.open_in_tray()
+    pext.persistent_previews = True
     assert len(sp2dv.figure.marks) == 11
     assert pext.marks['trace'].visible is True
     assert len(pext.marks['trace'].x) > 0
@@ -156,7 +156,7 @@ def test_user_api(specviz2d_helper):
     specviz2d_helper.load_data(spectrum_2d=fn)
 
     pext = specviz2d_helper.plugins['Spectral Extraction']
-    pext.open_in_tray()
+    pext.persistent_previews = True
 
     # test that setting a string to an AddResults object redirects to the label
     pext.bg_sub_add_results = 'override label'

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -86,6 +86,8 @@ class PluginUserApi(UserApiWrapper):
     """
     def __init__(self, plugin, expose=[], readonly=[]):
         expose = list(set(list(expose) + ['open_in_tray', 'show']))
+        if plugin.has_previews:
+            expose += ['persistent_previews', 'temporarily_show_previews']
         super().__init__(plugin, expose, readonly)
 
     def __repr__(self):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request modifies the previous `plugin_opened` logic (which only triggered when a plugin was opened _in the tray_) that controlled the visibilities of "live-preview marks" from plugins to instead be triggered based on whether the mouse is actively over the plugin.  A switch (which defaults to false in _most_ cases) can then be toggled to make the live-preview marks persistent and remain visible when the mouse leaves the plugin.  Internally, the plugin is considered "active" (and live-preview marks shown) whenever the mouse is over the plugin OR `persistent_previews == True`.


This includes a visual cue when the plugin is considered "active" matching the color of the live-preview marks (if/when we support customizing the color of the marks, this highlighting should also adjust to match). 


https://github.com/spacetelescope/jdaviz/assets/877591/0a07a7d0-1758-4cbd-a950-3400b7a02bb4

For spectral extraction, which already used mouseover location to determine which _section_ is active, additional visual cues are added:


https://github.com/spacetelescope/jdaviz/assets/877591/dfc23ed4-4132-4346-b592-591455f37aec



Lastly, for any plugin for which `plugin.has_previews == True`, this exposes a `temporarily_show_previews` context manager that can be used for workflows in the API:


https://github.com/spacetelescope/jdaviz/assets/877591/888ad6ec-4a95-407a-ac1e-248166b48f75


This PR affects the following plugins:
* line lists: redshift information updates whether the plugin is opened or not (regardless of mouseover location).  This section of the code is now also optimized to use `send_state` (see #2285) to avoid any unnecessary lag.
* markers: the visibility of markers and the "m" keypress event are controlled by the active state of the plugin, this plugin therefore sets "persistent_previews" to true by default, and includes a warning that they keypress is disabled if the user sets to false.
* plot options: stretch histogram is first created whenever the plugin is first opened in the tray or via `plugin.show()`, but is then updated regardless of the plugin's active status.
* compass: the compass image is first created whenever the plugin is first opened in the tray or via `plugin.show()`, but is then updated regardless of the plugin's active status
* line profile XY: the "l" keypress event is now _always_ enabled, regardless of whether the plugin is opened in the tray.  (Previously it was only active when opened in the tray, meaning it would not work for popups/inline plugins if closed in the tray).
* line analysis: continuum preview marks are visible based on the plugin's "active" status, but the results table continues to update regardless.  `plugin.show_continuum_marks()` which used to allow showing these marks from the API is now deprecated, in favor of using `plugin.persistent_previews = True` or `with plugin.temporarily_show_previews():`
* spectral extraction: preview marks are visible based on the plugin's "active" status.  Previous behavior with respect to different active sections in the plugin remains, with new visual cues.


Development considerations:
* when a plugin implements preview marks, it should set `self.has_previews = True` and pass `:has_previews="has_previews" :plugin_active.sync="plugin_active" :persistent_previews.sync="persistent_previews"` to `j-tray-plugin` (as indicated in the developer docs).  It should then observe the `show_previews` traitlet to control the visibility of any marks.
* when a plugin wants to defer initializing a component for efficiency purposes, it can observe the `plugin_opened_in_tray` traitlet but will also need to override `plugin.show` to handle the case where the plugin is first opened from the API (as is done here for plot options and compass).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
