### PR TITLE
Hide Centroid Redshift when lines aren't loaded

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ New Features
 
 - Viewer toolbar items hide themselves when they are not applicable. [#2284]
 
+- Line Analysis "Redshift from Centroid" only visible when lines are loaded [#2294]
+
 Cubeviz
 ^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ New Features
 
 - Viewer toolbar items hide themselves when they are not applicable. [#2284]
 
-- Line Analysis "Redshift from Centroid" only visible when lines are loaded [#2294]
+- Line Analysis "Redshift from Centroid" only visible when lines are loaded. [#2294]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -115,7 +115,6 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
     identified_line = Unicode("").tag(sync=True)
     selected_line = Unicode("").tag(sync=True)
     selected_line_redshift = Float(0).tag(sync=True)
-    lines_loaded = Bool(False).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
 
@@ -287,7 +286,6 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         return self.results
 
     def _on_plotted_lines_changed(self, msg):
-        self.lines_loaded = True if len(msg.marks) > 0 else False
         self.line_marks = msg.marks
         self.line_items = msg.names_rest
         if self.selected_line not in self.line_items:

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -115,6 +115,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
     identified_line = Unicode("").tag(sync=True)
     selected_line = Unicode("").tag(sync=True)
     selected_line_redshift = Float(0).tag(sync=True)
+    lines_loaded = Bool(False).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
 
@@ -286,6 +287,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         return self.results
 
     def _on_plotted_lines_changed(self, msg):
+        self.lines_loaded = True if len(msg.marks) > 0 else False
         self.line_marks = msg.marks
         self.line_items = msg.names_rest
         if self.selected_line not in self.line_items:

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -133,55 +133,57 @@
         ></v-progress-circular>
       </div>
 
-      <j-plugin-section-header>Redshift from Centroid</j-plugin-section-header>
-      <v-row>
-        <j-docs-link>Assign the centroid reported above to the observed wavelength of a given line and set the resulting redshift.  Lines must be loaded and plotted through the Line Lists plugin first.</j-docs-link>
-      </v-row>
-      <v-row class="row-no-outside-padding">
-        <v-col cols=2>
-          <j-tooltip tipid='plugin-line-analysis-sync-identify'>
-            <v-btn icon @click="() => sync_identify = !sync_identify" style="margin-top: 14px">
-              <img :class="sync_identify ? 'color-to-accent' : 'invert-if-dark'" :src="sync_identify ? sync_identify_icon_enabled : sync_identify_icon_disabled" width="20"/>
+      <div v-if="lines_loaded">
+        <j-plugin-section-header>Redshift from Centroid</j-plugin-section-header>
+        <v-row>
+          <j-docs-link>Assign the centroid reported above to the observed wavelength of a given line and set the resulting redshift.  Lines must be loaded and plotted through the Line Lists plugin first.</j-docs-link>
+        </v-row>
+        <v-row class="row-no-outside-padding">
+          <v-col cols=2>
+            <j-tooltip tipid='plugin-line-analysis-sync-identify'>
+              <v-btn icon @click="() => sync_identify = !sync_identify" style="margin-top: 14px">
+                <img :class="sync_identify ? 'color-to-accent' : 'invert-if-dark'" :src="sync_identify ? sync_identify_icon_enabled : sync_identify_icon_disabled" width="20"/>
+              </v-btn>
+            </j-tooltip>
+          </v-col>
+          <v-col cols=10>
+            <v-select
+              :menu-props="{ left: true }"
+              attach
+              :items="line_items"
+              v-model="selected_line"
+              label="Line"
+              hint="Select reference line."
+              persistent-hint
+            ></v-select>
+          </v-col>
+        </v-row>
+
+        <v-row v-if="selected_line">
+          <v-text-field
+            :value='selected_line_redshift'
+            class="mt-0 pt-0"
+            type="number"
+            label="Redshift"
+            hint="Redshift that will be applied by assigning centroid to the selected line."
+            persistent-hint
+            disabled
+          ></v-text-field>
+        </v-row>
+
+        <v-row justify="end">
+          <j-tooltip tipid='plugin-line-analysis-assign'>
+            <v-btn 
+            color="accent"
+            style="padding-left: 8px; padding-right: 8px;"
+            text
+            :disabled="!selected_line"
+            @click="line_assign">
+              Assign
             </v-btn>
           </j-tooltip>
-        </v-col>
-        <v-col cols=10>
-          <v-select
-            :menu-props="{ left: true }"
-            attach
-            :items="line_items"
-            v-model="selected_line"
-            label="Line"
-            hint="Select reference line."
-            persistent-hint
-          ></v-select>
-        </v-col>
-      </v-row>
-
-      <v-row v-if="selected_line">
-        <v-text-field
-          :value='selected_line_redshift'
-          class="mt-0 pt-0"
-          type="number"
-          label="Redshift"
-          hint="Redshift that will be applied by assigning centroid to the selected line."
-          persistent-hint
-          disabled
-        ></v-text-field>
-      </v-row>
-
-      <v-row justify="end">
-        <j-tooltip tipid='plugin-line-analysis-assign'>
-          <v-btn 
-           color="accent"
-           style="padding-left: 8px; padding-right: 8px;"
-           text
-           :disabled="!selected_line"
-           @click="line_assign">
-            Assign
-          </v-btn>
-        </j-tooltip>
-      </v-row>
+        </v-row>
+      </div>
     </div>  
   </j-tray-plugin>
 </template>

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -133,7 +133,7 @@
         ></v-progress-circular>
       </div>
 
-      <div v-if="lines_loaded">
+      <div v-if="line_items.length > 0">
         <j-plugin-section-header>Redshift from Centroid</j-plugin-section-header>
         <v-row>
           <j-docs-link>Assign the centroid reported above to the observed wavelength of a given line and set the resulting redshift.  Lines must be loaded and plotted through the Line Lists plugin first.</j-docs-link>


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This PR incorporates user feedback that the Redshfit from Centroid section from the Line Analysis plugin should only be shown if lines are actually plotted.

Because this is a UI element, coverage is expected to decrease

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
