### PR TITLE
plugin active status based on pings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,9 @@ API Changes
 - ``viz.get_data()`` now takes optional ``**kwargs``; e.g., you could pass in
   ``function="sum"`` to collapse a cube in Cubeviz. [#2242]
 
+- Live-previews and keypress events that depend on the plugin being opened now work for inline
+  and popout windows. [#2295]
+
 Cubeviz
 ^^^^^^^
 
@@ -91,8 +94,8 @@ Bug Fixes
 
 - Fixed ``cls`` input being ignored in ``viz.get_data()``. [#2242]
 
-- Live-previews and keypress events that depend on the plugin being opened now work for inline
-  and popout windows. [#2295]
+- Line analysis plugin's ``show_continuum_marks`` is deprecated, use ``plugin.as_active()`` 
+  instead. [#2295]
 
 Cubeviz
 ^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,9 @@ Bug Fixes
 
 - Fixed ``cls`` input being ignored in ``viz.get_data()``. [#2242]
 
+- Live-previews and keypress events that depend on the plugin being opened now work for inline
+  and popout windows. [#2295]
+
 Cubeviz
 ^^^^^^^
 

--- a/docs/dev/ui_style_guide.rst
+++ b/docs/dev/ui_style_guide.rst
@@ -8,9 +8,11 @@ Tray Plugins
 In order to be consistent with layout, styling, and spacing, UI development on plugins should
 try to adhere to the following principles:
 
-* Any tray plugin should utilize ``<j-tray-plugin :uses_active_status="uses_active_status" @plugin-ping="plugin_ping($event)" :keep_active.sync="keep_active" :disabled_msg='disabled_msg' :popout_button="popout_button">`` as the
-  outer-container (which provides consistent styling rules).  Any changes to style
-  across all plugins should then take place in the
+* Any tray plugin should utilize ``<j-tray-plugin :disabled_msg='disabled_msg' :popout_button="popout_button">`` as the
+  outer-container (which provides consistent styling rules).  If the plugin makes use of active status
+  (live-preview marks or viewer callbacks), then also pass `` :uses_active_status="uses_active_status" @plugin-ping="plugin_ping($event)"``.
+  To enable the "keep active" check, pass `` :uses_active_status="uses_active_status" @plugin-ping="plugin_ping($event)" :keep_active.sync="keep_active" ``.
+  Any changes to style across all plugins should then take place in the
   ``j-tray-plugin`` stylesheet (``jdaviz/components/tray_plugin.vue``).
 * Each item should be wrapped in a ``v-row``, but avoid any unnecessary additional wrapping-components
   (``v-card-*``, ``v-container``, etc).

--- a/docs/dev/ui_style_guide.rst
+++ b/docs/dev/ui_style_guide.rst
@@ -8,7 +8,7 @@ Tray Plugins
 In order to be consistent with layout, styling, and spacing, UI development on plugins should
 try to adhere to the following principles:
 
-* Any tray plugin should utilize ``<j-tray-plugin :has_previews="has_previews" :plugin_ping.sync="plugin_ping" :persistent_previews.sync="persistent_previews" :disabled_msg='disabled_msg' :popout_button="popout_button">`` as the
+* Any tray plugin should utilize ``<j-tray-plugin :uses_active_status="uses_active_status" :plugin_ping.sync="plugin_ping" :keep_active.sync="keep_active" :disabled_msg='disabled_msg' :popout_button="popout_button">`` as the
   outer-container (which provides consistent styling rules).  Any changes to style
   across all plugins should then take place in the
   ``j-tray-plugin`` stylesheet (``jdaviz/components/tray_plugin.vue``).

--- a/docs/dev/ui_style_guide.rst
+++ b/docs/dev/ui_style_guide.rst
@@ -8,7 +8,7 @@ Tray Plugins
 In order to be consistent with layout, styling, and spacing, UI development on plugins should
 try to adhere to the following principles:
 
-* Any tray plugin should utilize ``<j-tray-plugin :disabled_msg='disabled_msg'>`` as the
+* Any tray plugin should utilize ``<j-tray-plugin :has_previews="has_previews" :plugin_ping.sync="plugin_ping" :persistent_previews.sync="persistent_previews" :disabled_msg='disabled_msg' :popout_button="popout_button">`` as the
   outer-container (which provides consistent styling rules).  Any changes to style
   across all plugins should then take place in the
   ``j-tray-plugin`` stylesheet (``jdaviz/components/tray_plugin.vue``).

--- a/docs/dev/ui_style_guide.rst
+++ b/docs/dev/ui_style_guide.rst
@@ -8,7 +8,7 @@ Tray Plugins
 In order to be consistent with layout, styling, and spacing, UI development on plugins should
 try to adhere to the following principles:
 
-* Any tray plugin should utilize ``<j-tray-plugin :uses_active_status="uses_active_status" :plugin_ping.sync="plugin_ping" :keep_active.sync="keep_active" :disabled_msg='disabled_msg' :popout_button="popout_button">`` as the
+* Any tray plugin should utilize ``<j-tray-plugin :uses_active_status="uses_active_status" @plugin-ping="plugin_ping($event)" :keep_active.sync="keep_active" :disabled_msg='disabled_msg' :popout_button="popout_button">`` as the
   outer-container (which provides consistent styling rules).  Any changes to style
   across all plugins should then take place in the
   ``j-tray-plugin`` stylesheet (``jdaviz/components/tray_plugin.vue``).

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -120,7 +120,7 @@
                       </j-tooltip>
                     </v-expansion-panel-header>
                     <v-expansion-panel-content style="margin-left: -12px; margin-right: -12px;">
-                      <jupyter-widget :widget="trayItem.widget"></jupyter-widget>
+                      <jupyter-widget :widget="trayItem.widget" v-if="state.tray_items_open.includes(index)"></jupyter-widget>
                     </v-expansion-panel-content>
                   </div>
                 </v-expansion-panel>

--- a/jdaviz/components/tray_plugin.vue
+++ b/jdaviz/components/tray_plugin.vue
@@ -30,7 +30,7 @@
 <script>
 module.exports = {
   props: ['disabled_msg', 'description', 'link', 'popout_button',
-          'uses_active_status', 'plugin_ping', 'keep_active'],
+          'uses_active_status', 'keep_active'],
   methods: {
     isDisabled() {
       return this.getDisabledMsg().length > 0
@@ -43,7 +43,7 @@ module.exports = {
         return
       }
       if (!document.hidden) {
-        this.$emit('update:plugin_ping', Date.now())
+        this.$emit('plugin-ping', Date.now())
       }
       if (!recursive) {
         return

--- a/jdaviz/components/tray_plugin.vue
+++ b/jdaviz/components/tray_plugin.vue
@@ -13,12 +13,12 @@
       <span> {{ getDisabledMsg() }}</span>
     </v-row>
     <div v-else>
-      <v-row v-if="has_previews">
+      <v-row v-if="uses_active_status">
         <v-switch
-          v-model="persistent_previews"
-          @change="$emit('update:persistent_previews', $event)"
-          label="persistent live-preview"
-          hint="show live-preview even when plugin is not opened"
+          v-model="keep_active"
+          @change="$emit('update:keep_active', $event)"
+          label="keep active"
+          hint="consider plugin active (showing any previews and enabling all keypress events) even when not opened"
           persistent-hint>
         </v-switch>
       </v-row>
@@ -30,7 +30,7 @@
 <script>
 module.exports = {
   props: ['disabled_msg', 'description', 'link', 'popout_button',
-          'has_previews', 'plugin_ping', 'persistent_previews'],
+          'uses_active_status', 'plugin_ping', 'keep_active'],
   methods: {
     isDisabled() {
       return this.getDisabledMsg().length > 0
@@ -45,7 +45,7 @@ module.exports = {
       this.$emit('update:plugin_ping', Date.now())
       setTimeout(() => {
         this.sendPing()
-      }, 100)  // ms
+      }, 200)  // ms
     }
   },
   mounted() {

--- a/jdaviz/components/tray_plugin.vue
+++ b/jdaviz/components/tray_plugin.vue
@@ -13,6 +13,15 @@
       <span> {{ getDisabledMsg() }}</span>
     </v-row>
     <div v-else>
+      <v-row v-if="has_previews">
+        <v-switch
+          v-model="persistent_previews"
+          @change="$emit('update:persistent_previews', $event)"
+          label="persistent live-preview"
+          hint="show live-preview even when plugin is not opened"
+          persistent-hint>
+        </v-switch>
+      </v-row>
       <slot></slot>
     </div>
   </v-container>
@@ -20,7 +29,8 @@
 
 <script>
 module.exports = {
-  props: ['disabled_msg', 'description', 'link', 'popout_button'],
+  props: ['disabled_msg', 'description', 'link', 'popout_button',
+          'has_previews', 'plugin_ping', 'persistent_previews'],
   methods: {
     isDisabled() {
       return this.getDisabledMsg().length > 0
@@ -28,7 +38,19 @@ module.exports = {
     getDisabledMsg() {
       return this.disabled_msg || ''
     },
-  }
+    sendPing() {
+      if (!this.$el.isConnected) {
+        return
+      }
+      this.$emit('update:plugin_ping', Date.now())
+      setTimeout(() => {
+        this.sendPing()
+      }, 100)  // ms
+    }
+  },
+  mounted() {
+    this.sendPing();
+  },
 };
 </script>
 

--- a/jdaviz/components/tray_plugin.vue
+++ b/jdaviz/components/tray_plugin.vue
@@ -13,7 +13,7 @@
       <span> {{ getDisabledMsg() }}</span>
     </v-row>
     <div v-else>
-      <v-row v-if="uses_active_status">
+      <v-row v-if="uses_active_status && keep_active !== undefined">
         <v-switch
           v-model="keep_active"
           @change="$emit('update:keep_active', $event)"

--- a/jdaviz/components/tray_plugin.vue
+++ b/jdaviz/components/tray_plugin.vue
@@ -38,18 +38,28 @@ module.exports = {
     getDisabledMsg() {
       return this.disabled_msg || ''
     },
-    sendPing() {
+    sendPing(recursive) {
       if (!this.$el.isConnected) {
         return
       }
-      this.$emit('update:plugin_ping', Date.now())
+      if (!document.hidden) {
+        this.$emit('update:plugin_ping', Date.now())
+      }
+      if (!recursive) {
+        return
+      }
       setTimeout(() => {
-        this.sendPing()
+        this.sendPing(true)          
       }, 200)  // ms
     }
   },
   mounted() {
-    this.sendPing();
+    this.sendPing(true);
+    document.addEventListener("visibilitychange", () => {
+      if (!document.hidden) {
+        this.sendPing(false)
+      }
+    });
   },
 };
 </script>

--- a/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
@@ -15,13 +15,13 @@ def test_spectrum_at_spaxel(cubeviz_helper, spectrum1d_cube):
     flux_viewer.toolbar.active_tool = flux_viewer.toolbar.tools['jdaviz:spectrumperspaxel']
     x = 1
     y = 1
-    assert len(flux_viewer.figure.marks) == 2
+    assert len(flux_viewer.native_marks) == 2
     assert len(spectrum_viewer.data()) == 1
 
     # Click on spaxel location
     flux_viewer.toolbar.active_tool.on_mouse_event(
         {'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
-    assert len(flux_viewer.figure.marks) == 3
+    assert len(flux_viewer.native_marks) == 3
     assert len(spectrum_viewer.data()) == 2
 
     # Check that a new subset was created
@@ -32,7 +32,7 @@ def test_spectrum_at_spaxel(cubeviz_helper, spectrum1d_cube):
 
     # Deselect tool
     flux_viewer.toolbar.active_tool = None
-    assert len(flux_viewer.figure.marks) == 3
+    assert len(flux_viewer.native_marks) == 3
 
 
 def test_spectrum_at_spaxel_altkey_true(cubeviz_helper, spectrum1d_cube):
@@ -46,7 +46,7 @@ def test_spectrum_at_spaxel_altkey_true(cubeviz_helper, spectrum1d_cube):
     flux_viewer.toolbar.active_tool = flux_viewer.toolbar.tools['jdaviz:spectrumperspaxel']
     x = 1
     y = 1
-    assert len(flux_viewer.figure.marks) == 2
+    assert len(flux_viewer.native_marks) == 2
     assert len(spectrum_viewer.data()) == 1
 
     # Check coordinate info panel
@@ -60,7 +60,7 @@ def test_spectrum_at_spaxel_altkey_true(cubeviz_helper, spectrum1d_cube):
     # Click on spaxel location
     flux_viewer.toolbar.active_tool.on_mouse_event(
         {'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
-    assert len(flux_viewer.figure.marks) == 3
+    assert len(flux_viewer.native_marks) == 3
     assert len(spectrum_viewer.data()) == 2
 
     # Check that subset was created
@@ -74,7 +74,7 @@ def test_spectrum_at_spaxel_altkey_true(cubeviz_helper, spectrum1d_cube):
     y = 2
     flux_viewer.toolbar.active_tool.on_mouse_event(
         {'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': True})
-    assert len(flux_viewer.figure.marks) == 4
+    assert len(flux_viewer.native_marks) == 4
     assert len(spectrum_viewer.data()) == 3
 
     subsets = cubeviz_helper.app.get_subsets()
@@ -118,15 +118,15 @@ def test_spectrum_at_spaxel_with_2d(cubeviz_helper):
     flux_viewer.toolbar.active_tool = flux_viewer.toolbar.tools['jdaviz:spectrumperspaxel']
     x = 1
     y = 1
-    assert len(flux_viewer.figure.marks) == 2
+    assert len(flux_viewer.native_marks) == 2
     assert len(spectrum_viewer.data()) == 0
 
     # Click on spaxel location
     flux_viewer.toolbar.active_tool.on_mouse_event(
         {'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
-    assert len(flux_viewer.figure.marks) == 3
+    assert len(flux_viewer.native_marks) == 3
     assert len(spectrum_viewer.data()) == 0
 
     # Deselect tool
     flux_viewer.toolbar.active_tool = None
-    assert len(flux_viewer.figure.marks) == 3
+    assert len(flux_viewer.native_marks) == 3

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -322,9 +322,9 @@ class LineListTool(PluginTemplateMixin):
             msg = RedshiftMessage("redshift", value, sender=self)
             self.app.hub.broadcast(msg)
 
-    @observe('plugin_active')
+    @observe('plugin_opened')
     def _update_line_list_obs(self, *args):
-        if not self.plugin_active:
+        if not self.plugin_opened:
             return
 
         for list_name, line_list in self.list_contents.items():

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -322,11 +322,7 @@ class LineListTool(PluginTemplateMixin):
             msg = RedshiftMessage("redshift", value, sender=self)
             self.app.hub.broadcast(msg)
 
-    @observe('plugin_opened')
     def _update_line_list_obs(self, *args):
-        if not self.plugin_opened:
-            return
-
         for list_name, line_list in self.list_contents.items():
             for i, line in enumerate(line_list['lines']):
                 if self._rs_line_obs_change[0] == list_name and self._rs_line_obs_change[1] == i:  # noqa

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -322,12 +322,11 @@ class LineListTool(PluginTemplateMixin):
             msg = RedshiftMessage("redshift", value, sender=self)
             self.app.hub.broadcast(msg)
 
-    @observe('plugin_opened')
+    @observe('plugin_active')
     def _update_line_list_obs(self, *args):
-        if not self.plugin_opened:
+        if not self.plugin_active:
             return
 
-        new_list_contents = {}
         for list_name, line_list in self.list_contents.items():
             for i, line in enumerate(line_list['lines']):
                 if self._rs_line_obs_change[0] == list_name and self._rs_line_obs_change[1] == i:  # noqa
@@ -339,10 +338,9 @@ class LineListTool(PluginTemplateMixin):
                 else:
                     line_list['lines'][i]['obs'] = self._rest_to_obs(float(line['rest']))
 
-            new_list_contents[list_name] = line_list
+            self.list_contents[list_name] = line_list
 
-        self.list_contents = {}
-        self.list_contents = new_list_contents
+        self.send_state('list_contents')
 
     def vue_change_line_obs(self, kwargs):
         # NOTE: we can only pass one argument from vue (it seems), so we'll pass as

--- a/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
@@ -64,8 +64,8 @@ def test_redshift(specviz_helper, spectrum1d):
         specviz_helper.load_line_list(lt)
 
     ll_plugin = specviz_helper.app.get_tray_item_from_name('g-line-list')
-    # fake the plugin to be opened so that all updates run
-    ll_plugin.plugin_opened = True
+    # open the plugin so that all updates run
+    ll_plugin.open_in_tray()
     line = ll_plugin.list_contents['Test List']['lines'][0]
     assert_allclose(line['obs'], line['rest'])
     # test API access

--- a/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
@@ -47,13 +47,13 @@ def test_line_lists(specviz_helper):
 
 def test_redshift(specviz_helper, spectrum1d):
     # Also test that plugin is disabled before data is loaded.
-    plg = specviz_helper.plugins['Line Lists']
-    assert plg._obj.disabled_msg
+    ll_plugin = specviz_helper.plugins['Line Lists']._obj
+    assert ll_plugin.disabled_msg
 
     label = "Test 1D Spectrum"
     specviz_helper.load_data(spectrum1d, data_label=label)
 
-    assert not plg._obj.disabled_msg
+    assert not ll_plugin.disabled_msg
 
     lt = QTable()
     lt['linename'] = ['O III', 'Halpha']
@@ -63,9 +63,9 @@ def test_redshift(specviz_helper, spectrum1d):
     with pytest.warns(UserWarning, match='per line/list redshifts not supported, use viz.set_redshift'):  # noqa
         specviz_helper.load_line_list(lt)
 
-    ll_plugin = specviz_helper.app.get_tray_item_from_name('g-line-list')
     # open the plugin so that all updates run
     ll_plugin.open_in_tray()
+    print("*** 1", ll_plugin.plugin_opened)
     line = ll_plugin.list_contents['Test List']['lines'][0]
     assert_allclose(line['obs'], line['rest'])
     # test API access
@@ -89,6 +89,7 @@ def test_redshift(specviz_helper, spectrum1d):
     ll_plugin.vue_change_line_obs({'list_name': 'Test List',
                                    'line_ind': 0,
                                    'obs_new': 5508})
+    print("***", ll_plugin.plugin_opened)
     assert_allclose(line['obs'], 5508)
     assert ll_plugin.rs_redshift == 0.10005991611743559
 

--- a/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
@@ -64,8 +64,7 @@ def test_redshift(specviz_helper, spectrum1d):
         specviz_helper.load_line_list(lt)
 
     # open the plugin so that all updates run
-    ll_plugin.open_in_tray()
-    print("*** 1", ll_plugin.plugin_opened)
+    ll_plugin.plugin_opened = True
     line = ll_plugin.list_contents['Test List']['lines'][0]
     assert_allclose(line['obs'], line['rest'])
     # test API access
@@ -89,7 +88,6 @@ def test_redshift(specviz_helper, spectrum1d):
     ll_plugin.vue_change_line_obs({'list_name': 'Test List',
                                    'line_ind': 0,
                                    'obs_new': 5508})
-    print("***", ll_plugin.plugin_opened)
     assert_allclose(line['obs'], 5508)
     assert ll_plugin.rs_redshift == 0.10005991611743559
 

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -1,5 +1,5 @@
 import numpy as np
-from traitlets import observe
+from traitlets import Bool, observe
 
 from jdaviz.core.events import ViewerAddedMessage
 from jdaviz.core.marks import MarkersMark
@@ -24,6 +24,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
     * :meth:`~jdaviz.core.template_mixin.TableMixin.export_table`
     """
     template_file = __file__, "markers.vue"
+    has_previews = Bool(True).tag(sync=True)
 
     _default_table_values = {'spectral_axis': np.nan,
                              'spectral_axis:unit': '',
@@ -79,7 +80,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
         self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewer_added)
 
     def _create_viewer_callbacks(self, viewer):
-        if not self.plugin_opened:
+        if not self.show_previews:
             return
 
         callback = self._viewer_callback(viewer, self._on_viewer_key_event)
@@ -106,14 +107,14 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
     def coords_info(self):
         return self.app.session.application._tools['g-coords-info']
 
-    @observe('plugin_opened')
-    def _on_plugin_opened_changed(self, *args):
+    @observe('show_previews')
+    def _on_show_previews_changed(self, *args):
         if self.disabled_msg:
             return
 
         # toggle visibility of markers
         for mark in self.marks.values():
-            mark.visible = self.plugin_opened
+            mark.visible = self.show_previews
 
         # subscribe/unsubscribe to keypress events across all viewers
         for viewer in self.app._viewer_store.values():
@@ -122,7 +123,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
                 continue
             callback = self._viewer_callback(viewer, self._on_viewer_key_event)
 
-            if self.plugin_opened:
+            if self.show_previews:
                 viewer.add_event_callback(callback, events=['keydown'])
             else:
                 viewer.remove_event_callback(callback)

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -24,7 +24,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
     * :meth:`~jdaviz.core.template_mixin.TableMixin.export_table`
     """
     template_file = __file__, "markers.vue"
-    has_previews = Bool(True).tag(sync=True)
+    uses_active_status = Bool(True).tag(sync=True)
 
     _default_table_values = {'spectral_axis': np.nan,
                              'spectral_axis:unit': '',
@@ -80,7 +80,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
         self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewer_added)
 
     def _create_viewer_callbacks(self, viewer):
-        if not self.show_previews:
+        if not self.is_active:
             return
 
         callback = self._viewer_callback(viewer, self._on_viewer_key_event)
@@ -107,14 +107,14 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
     def coords_info(self):
         return self.app.session.application._tools['g-coords-info']
 
-    @observe('show_previews')
-    def _on_show_previews_changed(self, *args):
+    @observe('is_active')
+    def _on_is_active_changed(self, *args):
         if self.disabled_msg:
             return
 
         # toggle visibility of markers
         for mark in self.marks.values():
-            mark.visible = self.show_previews
+            mark.visible = self.is_active
 
         # subscribe/unsubscribe to keypress events across all viewers
         for viewer in self.app._viewer_store.values():
@@ -123,7 +123,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
                 continue
             callback = self._viewer_callback(viewer, self._on_viewer_key_event)
 
-            if self.show_previews:
+            if self.is_active:
                 viewer.add_event_callback(callback, events=['keydown'])
             else:
                 viewer.remove_event_callback(callback)

--- a/jdaviz/configs/default/plugins/markers/markers.vue
+++ b/jdaviz/configs/default/plugins/markers/markers.vue
@@ -3,7 +3,7 @@
     description='Create and export markers.  Press "m" with the cursor over a viewer to log the mouseover information.  To change the selected layer, click the layer cycler in the mouseover information section of the app-level toolbar.'
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#markers'"
     :uses_active_status="uses_active_status"
-    :plugin_ping.sync="plugin_ping"
+    @plugin-ping="plugin_ping($event)"
     :keep_active.sync="keep_active"
     :popout_button="popout_button">
 

--- a/jdaviz/configs/default/plugins/markers/markers.vue
+++ b/jdaviz/configs/default/plugins/markers/markers.vue
@@ -2,6 +2,9 @@
   <j-tray-plugin
     description='Create and export markers.  Press "m" with the cursor over a viewer to log the mouseover information.  To change the selected layer, click the layer cycler in the mouseover information section of the app-level toolbar.'
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#markers'"
+    :has_previews="has_previews"
+    :plugin_ping.sync="plugin_ping"
+    :persistent_previews.sync="persistent_previews"
     :popout_button="popout_button">
 
     <jupyter-widget :widget="table_widget"></jupyter-widget> 

--- a/jdaviz/configs/default/plugins/markers/markers.vue
+++ b/jdaviz/configs/default/plugins/markers/markers.vue
@@ -2,9 +2,9 @@
   <j-tray-plugin
     description='Create and export markers.  Press "m" with the cursor over a viewer to log the mouseover information.  To change the selected layer, click the layer cycler in the mouseover information section of the app-level toolbar.'
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#markers'"
-    :has_previews="has_previews"
+    :uses_active_status="uses_active_status"
     :plugin_ping.sync="plugin_ping"
-    :persistent_previews.sync="persistent_previews"
+    :keep_active.sync="keep_active"
     :popout_button="popout_button">
 
     <jupyter-widget :widget="table_widget"></jupyter-widget> 

--- a/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
+++ b/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
@@ -28,7 +28,7 @@ def test_markers_cubeviz(cubeviz_helper, spectrum1d_cube):
     label_mouseover = cubeviz_helper.app.session.application._tools['g-coords-info']
 
     mp = cubeviz_helper.plugins['Markers']
-    mp.open_in_tray()
+    mp.keep_active = True
 
     # test event in flux viewer
     label_mouseover._viewer_mouse_event(fv,
@@ -112,8 +112,8 @@ def test_markers_cubeviz(cubeviz_helper, spectrum1d_cube):
     assert len(_get_markers_from_viewer(fv).x) == 1
     assert len(_get_markers_from_viewer(sv).x) == 2
 
-    # markers hide when plugin closed (since persistent_previews == False)
-    cubeviz_helper.app.state.drawer = False
+    # markers hide when plugin closed and keep_active = False
+    mp.keep_active = False
     assert _get_markers_from_viewer(fv).visible is False
     assert _get_markers_from_viewer(sv).visible is False
 

--- a/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
+++ b/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
@@ -118,7 +118,7 @@ def test_markers_cubeviz(cubeviz_helper, spectrum1d_cube):
     assert _get_markers_from_viewer(sv).visible is False
 
     # markers re-appear when plugin re-opened
-    mp.open_in_tray()
+    mp._obj.plugin_opened = True
     assert _get_markers_from_viewer(fv).visible is True
     assert _get_markers_from_viewer(sv).visible is True
     assert len(_get_markers_from_viewer(fv).x) == 1

--- a/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
+++ b/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
@@ -136,7 +136,7 @@ class TestImvizMultiLayer(BaseImviz_WCS_NoWCS):
         label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
 
         mp = self.imviz.plugins['Markers']
-        mp.open_in_tray()
+        mp.plugin_opened = True
 
         # cycle through dataset options (used for both coords info and markers)
         assert label_mouseover.dataset.choices == ['auto', 'none',
@@ -217,7 +217,7 @@ class TestImvizMultiLayer(BaseImviz_WCS_NoWCS):
         label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
 
         mp = self.imviz.plugins['Markers']
-        mp.open_in_tray()
+        mp.plugin_opened = True
 
         nv = self.imviz.create_image_viewer()
         self.imviz.app.add_data_to_viewer('imviz-1', 'has_wcs[SCI,1]')

--- a/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
+++ b/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
@@ -112,7 +112,7 @@ def test_markers_cubeviz(cubeviz_helper, spectrum1d_cube):
     assert len(_get_markers_from_viewer(fv).x) == 1
     assert len(_get_markers_from_viewer(sv).x) == 2
 
-    # markers hide when plugin closed
+    # markers hide when plugin closed (since persistent_previews == False)
     cubeviz_helper.app.state.drawer = False
     assert _get_markers_from_viewer(fv).visible is False
     assert _get_markers_from_viewer(sv).visible is False

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -445,10 +445,6 @@ class PlotOptions(PluginTemplateMixin):
 
         return PluginUserApi(self, expose)
 
-    def show(self, *args, **kwargs):
-        super().show(*args, **kwargs)
-        self._update_stretch_histogram()
-
     @observe('show_viewer_labels')
     def _on_show_viewer_labels_changed(self, event):
         self.app.state.settings['viewer_labels'] = event['new']
@@ -483,7 +479,8 @@ class PlotOptions(PluginTemplateMixin):
         value = data.get('value')
         setattr(self, attr_name, value)
 
-    @observe('plugin_opened_in_tray', 'layer_selected', 'viewer_selected', 'stretch_hist_zoom_limits')
+    @observe('plugin_opened', 'layer_selected', 'viewer_selected',
+             'stretch_hist_zoom_limits')
     def _update_stretch_histogram(self, msg={}):
         if not self.stretch_function_sync.get('in_subscribed_states'):  # pragma: no cover
             # no (image) viewer with stretch function options
@@ -491,7 +488,9 @@ class PlotOptions(PluginTemplateMixin):
         if not hasattr(self, 'viewer'):  # pragma: no cover
             # plugin hasn't been fully initialized yet
             return
-        if (not self.viewer.selected or not self.layer.selected):  # pragma: no cover
+        if (not self.plugin_opened
+                or not self.viewer.selected
+                or not self.layer.selected):  # pragma: no cover
             # no need to make updates, updates will be redrawn when plugin is opened
             # NOTE: this won't update when the plugin is shown but not open in the tray
             return
@@ -505,8 +504,7 @@ class PlotOptions(PluginTemplateMixin):
                                  or len(self.layer.selected) > 1):  # pragma: no cover
             # currently only support single-layer/viewer.  For now we'll just clear and return.
             # TODO: add support for multi-layer/viewer
-            if self.stretch_histogram is not None:
-                bqplot_clear_figure(self.stretch_histogram)
+            bqplot_clear_figure(self.stretch_histogram)
             return
 
         viewer = self.viewer.selected_obj[0] if self.multiselect else self.viewer.selected_obj

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -97,6 +97,7 @@ class PlotOptions(PluginTemplateMixin):
       not exposed for Specviz. This only applies when ``contour_mode`` is "Custom".
     """
     template_file = __file__, "plot_options.vue"
+    uses_active_status = Bool(True).tag(sync=True)
 
     # multiselect is shared between viewer and layer
     multiselect = Bool(False).tag(sync=True)
@@ -479,7 +480,7 @@ class PlotOptions(PluginTemplateMixin):
         value = data.get('value')
         setattr(self, attr_name, value)
 
-    @observe('plugin_opened', 'layer_selected', 'viewer_selected',
+    @observe('is_active', 'layer_selected', 'viewer_selected',
              'stretch_hist_zoom_limits')
     def _update_stretch_histogram(self, msg={}):
         if not self.stretch_function_sync.get('in_subscribed_states'):  # pragma: no cover
@@ -488,7 +489,7 @@ class PlotOptions(PluginTemplateMixin):
         if not hasattr(self, 'viewer'):  # pragma: no cover
             # plugin hasn't been fully initialized yet
             return
-        if (not self.plugin_opened
+        if (not self.is_active
                 or not self.viewer.selected
                 or not self.layer.selected):  # pragma: no cover
             # no need to make updates, updates will be redrawn when plugin is opened

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -2,6 +2,8 @@
   <j-tray-plugin
     description='Viewer and data/layer options.'
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#plot-options'"
+    :uses_active_status="uses_active_status"
+    @plugin-ping="plugin_ping($event)"
     :popout_button="popout_button">
 
     <v-row>

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -63,7 +63,7 @@ def test_multiselect(cubeviz_helper, spectrum1d_cube):
 def test_stretch_histogram(cubeviz_helper, spectrum1d_cube_with_uncerts):
     cubeviz_helper.load_data(spectrum1d_cube_with_uncerts)
     po = cubeviz_helper.app.get_tray_item_from_name('g-plot-options')
-    po.open_in_tray()
+    po.plugin_opened = True
 
     assert po.stretch_histogram is not None
 

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -63,7 +63,6 @@ def test_multiselect(cubeviz_helper, spectrum1d_cube):
 def test_stretch_histogram(cubeviz_helper, spectrum1d_cube_with_uncerts):
     cubeviz_helper.load_data(spectrum1d_cube_with_uncerts)
     po = cubeviz_helper.app.get_tray_item_from_name('g-plot-options')
-    po.open_in_tray()  # forces histogram to draw
 
     assert po.stretch_histogram is not None
 

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -63,6 +63,7 @@ def test_multiselect(cubeviz_helper, spectrum1d_cube):
 def test_stretch_histogram(cubeviz_helper, spectrum1d_cube_with_uncerts):
     cubeviz_helper.load_data(spectrum1d_cube_with_uncerts)
     po = cubeviz_helper.app.get_tray_item_from_name('g-plot-options')
+    po.open_in_tray()
 
     assert po.stretch_histogram is not None
 

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -21,7 +21,7 @@ class JdavizViewerMixin:
     toolbar = None
     tools_nested = []
     _prev_limits = None
-    _native_mark_classnames = ('Lines', 'LinesGL')
+    _native_mark_classnames = ('Lines', 'LinesGL', 'FRBImage', 'Contour')
 
     def __init__(self, *args, **kwargs):
         # NOTE: anything here most likely won't be called by viewers because of inheritance order

--- a/jdaviz/configs/imviz/plugins/compass/compass.py
+++ b/jdaviz/configs/imviz/plugins/compass/compass.py
@@ -23,6 +23,8 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
     * ``data_label``: label of the top-layer shown in the compass (read-only)
     """
     template_file = __file__, "compass.vue"
+    uses_active_status = Bool(True).tag(sync=True)
+
     icon = Unicode("").tag(sync=True)
     data_label = Unicode("").tag(sync=True)
     img_data = Unicode("").tag(sync=True)
@@ -57,7 +59,7 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
         self.canvas_angle = viewer_item.get('canvas_angle', 0)  # noqa
         self.canvas_flip_horizontal = viewer_item.get('canvas_flip_horizontal', False)
 
-    @observe("viewer_selected", "plugin_opened")
+    @observe("viewer_selected", "is_active")
     def _compass_with_new_viewer(self, *args, **kwargs):
         if not hasattr(self, 'viewer'):
             # mixin object not yet initialized

--- a/jdaviz/configs/imviz/plugins/compass/compass.py
+++ b/jdaviz/configs/imviz/plugins/compass/compass.py
@@ -61,7 +61,7 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
         self.canvas_angle = viewer_item.get('canvas_angle', 0)  # noqa
         self.canvas_flip_horizontal = viewer_item.get('canvas_flip_horizontal', False)
 
-    @observe("viewer_selected", "plugin_opened")
+    @observe("viewer_selected", "plugin_opened_in_tray")
     def _compass_with_new_viewer(self, *args, **kwargs):
         if not hasattr(self, 'viewer'):
             # mixin object not yet initialized
@@ -69,7 +69,7 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
 
         # There can be only one!
         for vid, viewer in self.app._viewer_store.items():
-            if vid == self.viewer.selected_id and (self.plugin_opened or kwargs.get('from_show')):
+            if vid == self.viewer.selected_id and (self.plugin_opened_in_tray or kwargs.get('from_show')):  # noqa
                 viewer.compass = self
                 viewer.on_limits_change()  # Force redraw
 

--- a/jdaviz/configs/imviz/plugins/compass/compass.py
+++ b/jdaviz/configs/imviz/plugins/compass/compass.py
@@ -40,10 +40,6 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
     def user_api(self):
         return PluginUserApi(self, expose=('viewer',), readonly=('data_label',))
 
-    def show(self, *args, **kwargs):
-        super().show(*args, **kwargs)
-        self._compass_with_new_viewer(from_show=True)
-
     def _on_viewer_data_changed(self, msg=None):
         if self.viewer_selected:
             viewer = self.viewer.selected_obj
@@ -61,7 +57,7 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
         self.canvas_angle = viewer_item.get('canvas_angle', 0)  # noqa
         self.canvas_flip_horizontal = viewer_item.get('canvas_flip_horizontal', False)
 
-    @observe("viewer_selected", "plugin_opened_in_tray")
+    @observe("viewer_selected", "plugin_opened")
     def _compass_with_new_viewer(self, *args, **kwargs):
         if not hasattr(self, 'viewer'):
             # mixin object not yet initialized
@@ -69,7 +65,7 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
 
         # There can be only one!
         for vid, viewer in self.app._viewer_store.items():
-            if vid == self.viewer.selected_id and (self.plugin_opened_in_tray or kwargs.get('from_show')):  # noqa
+            if vid == self.viewer.selected_id and self.plugin_opened:
                 viewer.compass = self
                 viewer.on_limits_change()  # Force redraw
 

--- a/jdaviz/configs/imviz/plugins/compass/compass.vue
+++ b/jdaviz/configs/imviz/plugins/compass/compass.vue
@@ -2,6 +2,8 @@
   <j-tray-plugin
     description='Show active data label, compass, and zoom box.'
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#compass'"
+    :uses_active_status="uses_active_status"
+    @plugin-ping="plugin_ping($event)"
     :popout_button="popout_button">
 
     <plugin-viewer-select

--- a/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
+++ b/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
@@ -52,10 +52,10 @@ class LineProfileXY(PluginTemplateMixin):
         self.plot_across_y.clear_all_marks()
 
     # This is also triggered from viewer code.
-    @observe("selected_viewer")
+    @observe("plugin_opened", "selected_viewer")
     def vue_draw_plot(self, *args, **kwargs):
         """Draw line profile plots for given Data across given X and Y indices (0-indexed)."""
-        if not self.selected_x or not self.selected_y:
+        if not self.selected_x or not self.selected_y or not self.plugin_opened:
             return
 
         viewer = self.app.get_viewer_by_id(self.selected_viewer)

--- a/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
+++ b/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
@@ -55,7 +55,7 @@ class LineProfileXY(PluginTemplateMixin):
     @observe("selected_viewer")
     def vue_draw_plot(self, *args, **kwargs):
         """Draw line profile plots for given Data across given X and Y indices (0-indexed)."""
-        if not self.selected_x or not self.selected_y or not self.plugin_opened:
+        if not self.selected_x or not self.selected_y:
             return
 
         viewer = self.app.get_viewer_by_id(self.selected_viewer)

--- a/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
+++ b/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
@@ -1,18 +1,18 @@
-from traitlets import Any, Bool, List, Unicode, observe
+from traitlets import Any, Bool, Unicode, observe
 
 from jdaviz.configs.imviz.helper import get_top_layer_index
-from jdaviz.core.events import ViewerAddedMessage, ViewerRemovedMessage
+from jdaviz.core.events import ViewerAddedMessage
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import PluginTemplateMixin, Plot
+from jdaviz.core.template_mixin import PluginTemplateMixin, ViewerSelectMixin, Plot
 
 __all__ = ['LineProfileXY']
 
 
 @tray_registry('imviz-line-profile-xy', label="Imviz Line Profiles (XY)")
-class LineProfileXY(PluginTemplateMixin):
+class LineProfileXY(PluginTemplateMixin, ViewerSelectMixin):
     template_file = __file__, "line_profile_xy.vue"
-    viewer_items = List([]).tag(sync=True)
-    selected_viewer = Unicode("").tag(sync=True)
+    uses_active_status = Bool(True).tag(sync=True)
+
     plot_available = Bool(False).tag(sync=True)
     selected_x = Any('').tag(sync=True)
     selected_y = Any('').tag(sync=True)
@@ -22,7 +22,6 @@ class LineProfileXY(PluginTemplateMixin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._default_viewer = f'{self.app.config}-0'
 
         self.plot_across_x = Plot(self)
         self.plot_across_x.add_line('line', color='gray')
@@ -34,31 +33,62 @@ class LineProfileXY(PluginTemplateMixin):
         self.plot_across_y.figure.axes[0].label = 'X (pix)'
         self.plot_across_y_widget = 'IPY_MODEL_'+self.plot_across_y.model_id
 
-        self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewers_changed)
-        self.hub.subscribe(self, ViewerRemovedMessage, handler=self._on_viewers_changed)
-
-        self._on_viewers_changed()  # Populate it on start-up
-
-    def _on_viewers_changed(self, msg=None):
-        self.viewer_items = self.app.get_viewer_ids()
-
-        # Selected viewer was removed but Imviz always has a default viewer to fall back on.
-        if self.selected_viewer not in self.viewer_items:
-            self.selected_viewer = self._default_viewer
+        self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewer_added)
 
     def reset_results(self):
         self.plot_available = False
         self.plot_across_x.clear_all_marks()
         self.plot_across_y.clear_all_marks()
 
-    # This is also triggered from viewer code.
-    @observe("plugin_opened", "selected_viewer")
-    def vue_draw_plot(self, *args, **kwargs):
-        """Draw line profile plots for given Data across given X and Y indices (0-indexed)."""
-        if not self.selected_x or not self.selected_y or not self.plugin_opened:
+    def _create_viewer_callbacks(self, viewer):
+        if not self.is_active:
             return
 
-        viewer = self.app.get_viewer_by_id(self.selected_viewer)
+        callback = self._viewer_callback(viewer, self._on_viewer_key_event)
+        viewer.add_event_callback(callback, events=['keydown'])
+
+    def _on_viewer_added(self, msg):
+        self._create_viewer_callbacks(self.app.get_viewer_by_id(msg.viewer_id))
+
+    @observe('is_active')
+    def on_is_active_changed(self, *args):
+        # subscribe/unsubscribe to keypress events across all viewers
+        for viewer in self.app._viewer_store.values():
+            if not hasattr(viewer, 'figure'):
+                # table viewer, etc
+                continue
+            callback = self._viewer_callback(viewer, self._on_viewer_key_event)
+
+            if self.is_active:
+                viewer.add_event_callback(callback, events=['keydown'])
+            else:
+                viewer.remove_event_callback(callback)
+
+        if self.is_active:
+            self.vue_draw_plot()
+
+    def _on_viewer_key_event(self, viewer, data):
+        if data['key'] == 'l':
+            image = viewer.active_image_layer.layer
+            x = data['domain']['x']
+            y = data['domain']['y']
+            if x is None or y is None:  # Out of bounds
+                return
+            x, y, _, _ = viewer._get_real_xy(image, x, y)
+            self.selected_x = x
+            self.selected_y = y
+            self.viewer_selected = viewer.reference_id
+            # TODO: remove manual calls to vue_draw_plot and trigger
+            # by changes to selected_x/selected_y as well as viewer_selected
+            self.vue_draw_plot()
+
+    @observe("viewer_selected")
+    def vue_draw_plot(self, *args, **kwargs):
+        """Draw line profile plots for given Data across given X and Y indices (0-indexed)."""
+        if not self.selected_x or not self.selected_y or not self.is_active:
+            return
+
+        viewer = self.viewer.selected_obj
         i = get_top_layer_index(viewer)
         data = viewer.state.layers[i].layer
 

--- a/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.vue
+++ b/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.vue
@@ -2,40 +2,35 @@
   <j-tray-plugin
     description='Press l to plot line profiles across X and Y under cursor. You can also manually enter X, Y and then click PLOT.'
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#line-profiles'"
+    :uses_active_status="uses_active_status"
+    @plugin-ping="plugin_ping($event)"
     :popout_button="popout_button">
 
+    <plugin-viewer-select
+      :items="viewer_items"
+      :selected.sync="viewer_selected"
+      label="Viewer"
+      :show_if_single_entry="false"
+      hint="Select a viewer to plot."
+      persistent-hint
+    />
+
     <v-row>
-      <v-select
-        attach
-        :menu-props="{ left: true }"
-        :items="viewer_items"
-        v-model="selected_viewer"
-        label="Viewer"
-        hint="Select a viewer to plot."
-        persistent-hint
-      ></v-select>
+      <v-text-field
+        v-model='selected_x'
+        type="number"
+        label="X"
+        hint="Value of X"
+      ></v-text-field>
     </v-row>
 
-    <v-row no-gutters>
-      <v-col>
-        <v-text-field
-          v-model='selected_x'
-          type="number"
-          label="X"
-          hint="Value of X"
-        ></v-text-field>
-      </v-col>
-    </v-row>
-
-    <v-row no-gutters>
-      <v-col>
-        <v-text-field
-          v-model='selected_y'
-          type="number"
-          label="Y"
-          hint="Value of Y"
-        ></v-text-field>
-      </v-col>
+    <v-row>
+      <v-text-field
+        v-model='selected_y'
+        type="number"
+        label="Y"
+        hint="Value of Y"
+      ></v-text-field>
     </v-row>
 
     <v-row justify="end">

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -79,7 +79,8 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
             if key_pressed in ('b', 'B'):
                 self.blink_once(reversed=key_pressed=='B')  # noqa: E225
 
-            elif key_pressed == 'l' and self.line_profile_xy.plugin_opened:
+            # TODO: move into plugin callback?
+            elif key_pressed == 'l':
                 # Same data as mousemove above.
                 image = self.active_image_layer.layer
                 x = data['domain']['x']

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -79,20 +79,6 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
             if key_pressed in ('b', 'B'):
                 self.blink_once(reversed=key_pressed=='B')  # noqa: E225
 
-            # TODO: move into plugin callback?
-            elif key_pressed == 'l' and self.line_profile_xy.plugin_opened:
-                # Same data as mousemove above.
-                image = self.active_image_layer.layer
-                x = data['domain']['x']
-                y = data['domain']['y']
-                if x is None or y is None:  # Out of bounds
-                    return
-                x, y, _, _ = self._get_real_xy(image, x, y)
-                self.line_profile_xy.selected_x = x
-                self.line_profile_xy.selected_y = y
-                self.line_profile_xy.selected_viewer = self.reference_id
-                self.line_profile_xy.vue_draw_plot()
-
     def blink_once(self, reversed=False):
         # Simple blinking of images - this will make it so that only one
         # layer is visible at a time and cycles through the layers.
@@ -140,7 +126,7 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
                             'imviz-line-profile-xy')
                     except KeyError:  # pragma: no cover
                         return
-                self.line_profile_xy.selected_viewer = self.reference_id
+                self.line_profile_xy.viewer_selected = self.reference_id
                 self.line_profile_xy.vue_draw_plot()
 
     def on_limits_change(self, *args):

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -80,7 +80,7 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
                 self.blink_once(reversed=key_pressed=='B')  # noqa: E225
 
             # TODO: move into plugin callback?
-            elif key_pressed == 'l':
+            elif key_pressed == 'l' and self.line_profile_xy.plugin_opened:
                 # Same data as mousemove above.
                 image = self.active_image_layer.layer
                 x = data['domain']['x']

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -38,7 +38,7 @@ class TestCatalogs:
         self.imviz = imviz_helper
 
         catalogs_plugin = self.imviz.app.get_tray_item_from_name('imviz-catalogs')
-        catalogs_plugin.plugin_active = True
+        catalogs_plugin.open_in_tray()
         # running the search without any data loaded into Imviz
         catalogs_plugin.vue_do_search()
 
@@ -54,7 +54,7 @@ class TestCatalogs:
         self.imviz = imviz_helper
 
         catalogs_plugin = self.imviz.app.get_tray_item_from_name('imviz-catalogs')
-        catalogs_plugin.plugin_active = True
+        catalogs_plugin.open_in_tray()
         catalogs_plugin.vue_do_search()
 
         # number of results should be 0
@@ -91,7 +91,7 @@ class TestCatalogs:
         self.imviz = imviz_helper
 
         catalogs_plugin = self.imviz.app.get_tray_item_from_name('imviz-catalogs')
-        catalogs_plugin.plugin_active = True
+        catalogs_plugin.open_in_tray()
         # This basically calls the following under the hood:
         #   skycoord_center = SkyCoord(6.62754354, 1.54466139, unit="deg")
         #   zoom_radius = r_max = 3 * u.arcmin

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -38,7 +38,7 @@ class TestCatalogs:
         self.imviz = imviz_helper
 
         catalogs_plugin = self.imviz.app.get_tray_item_from_name('imviz-catalogs')
-        catalogs_plugin.open_in_tray()
+        catalogs_plugin.plugin_opened = True
         # running the search without any data loaded into Imviz
         catalogs_plugin.vue_do_search()
 
@@ -54,7 +54,7 @@ class TestCatalogs:
         self.imviz = imviz_helper
 
         catalogs_plugin = self.imviz.app.get_tray_item_from_name('imviz-catalogs')
-        catalogs_plugin.open_in_tray()
+        catalogs_plugin.plugin_opened = True
         catalogs_plugin.vue_do_search()
 
         # number of results should be 0
@@ -91,7 +91,7 @@ class TestCatalogs:
         self.imviz = imviz_helper
 
         catalogs_plugin = self.imviz.app.get_tray_item_from_name('imviz-catalogs')
-        catalogs_plugin.open_in_tray()
+        catalogs_plugin.plugin_opened = True
         # This basically calls the following under the hood:
         #   skycoord_center = SkyCoord(6.62754354, 1.54466139, unit="deg")
         #   zoom_radius = r_max = 3 * u.arcmin

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -38,7 +38,7 @@ class TestCatalogs:
         self.imviz = imviz_helper
 
         catalogs_plugin = self.imviz.app.get_tray_item_from_name('imviz-catalogs')
-        catalogs_plugin.plugin_opened = True
+        catalogs_plugin.plugin_active = True
         # running the search without any data loaded into Imviz
         catalogs_plugin.vue_do_search()
 
@@ -54,7 +54,7 @@ class TestCatalogs:
         self.imviz = imviz_helper
 
         catalogs_plugin = self.imviz.app.get_tray_item_from_name('imviz-catalogs')
-        catalogs_plugin.plugin_opened = True
+        catalogs_plugin.plugin_active = True
         catalogs_plugin.vue_do_search()
 
         # number of results should be 0
@@ -91,7 +91,7 @@ class TestCatalogs:
         self.imviz = imviz_helper
 
         catalogs_plugin = self.imviz.app.get_tray_item_from_name('imviz-catalogs')
-        catalogs_plugin.plugin_opened = True
+        catalogs_plugin.plugin_active = True
         # This basically calls the following under the hood:
         #   skycoord_center = SkyCoord(6.62754354, 1.54466139, unit="deg")
         #   zoom_radius = r_max = 3 * u.arcmin

--- a/jdaviz/configs/imviz/tests/test_line_profile_xy.py
+++ b/jdaviz/configs/imviz/tests/test_line_profile_xy.py
@@ -10,7 +10,7 @@ class TestLineProfileXY(BaseImviz_WCS_NoWCS):
     def test_plugin_linked_by_pixel(self):
         """Go through plugin logic but does not check plot contents."""
         lp_plugin = self.imviz.app.get_tray_item_from_name('imviz-line-profile-xy')
-        lp_plugin.plugin_active = True
+        lp_plugin.open_in_tray()
 
         lp_plugin._on_viewers_changed()  # Populate plugin menu items.
         assert lp_plugin.viewer_items == ['imviz-0']
@@ -66,7 +66,7 @@ class TestLineProfileXY(BaseImviz_WCS_NoWCS):
         assert lp_plugin.plot_available
 
         # Nothing should update on "l" when plugin closed.
-        lp_plugin.plugin_active = False
+        lp_plugin.plugin_opened = False
         self.viewer.on_mouse_or_key_event(
             {'event': 'keydown', 'key': 'l', 'domain': {'x': 5.1, 'y': 5}})
         lp_plugin.selected_x = '1.1'

--- a/jdaviz/configs/imviz/tests/test_line_profile_xy.py
+++ b/jdaviz/configs/imviz/tests/test_line_profile_xy.py
@@ -10,7 +10,7 @@ class TestLineProfileXY(BaseImviz_WCS_NoWCS):
     def test_plugin_linked_by_pixel(self):
         """Go through plugin logic but does not check plot contents."""
         lp_plugin = self.imviz.app.get_tray_item_from_name('imviz-line-profile-xy')
-        lp_plugin.open_in_tray()
+        lp_plugin.plugin_opened = True
 
         lp_plugin._on_viewers_changed()  # Populate plugin menu items.
         assert lp_plugin.viewer_items == ['imviz-0']

--- a/jdaviz/configs/imviz/tests/test_line_profile_xy.py
+++ b/jdaviz/configs/imviz/tests/test_line_profile_xy.py
@@ -12,9 +12,8 @@ class TestLineProfileXY(BaseImviz_WCS_NoWCS):
         lp_plugin = self.imviz.app.get_tray_item_from_name('imviz-line-profile-xy')
         lp_plugin.plugin_opened = True
 
-        lp_plugin._on_viewers_changed()  # Populate plugin menu items.
-        assert lp_plugin.viewer_items == ['imviz-0']
-        assert lp_plugin.selected_viewer == 'imviz-0'
+        assert lp_plugin.viewer.labels == ['imviz-0']
+        assert lp_plugin.viewer_selected == 'imviz-0'
 
         # Plot attempt with null X/Y should not crash but also no-op.
         assert len(lp_plugin.plot_across_x.marks['line'].x) == 0
@@ -23,8 +22,9 @@ class TestLineProfileXY(BaseImviz_WCS_NoWCS):
         assert not lp_plugin.plot_available
 
         # Mimic "l" key pressed.
-        self.viewer.on_mouse_or_key_event(
-            {'event': 'keydown', 'key': 'l', 'domain': {'x': 5.1, 'y': 5}})
+        lp_plugin._on_viewer_key_event(self.viewer,
+                                       {'event': 'keydown', 'key': 'l',
+                                        'domain': {'x': 5.1, 'y': 5}})
         assert_allclose(lp_plugin.selected_x, 5.1)
         assert_allclose(lp_plugin.selected_y, 5)
         assert len(lp_plugin.plot_across_x.marks['line'].x) > 0
@@ -42,8 +42,8 @@ class TestLineProfileXY(BaseImviz_WCS_NoWCS):
         # Blink also triggers viewer takeover and line profile redraw,
         # similar to the "l" key but without touching X and Y.
         viewer_2.blink_once()
-        assert lp_plugin.viewer_items == ['imviz-0', 'imviz-1']
-        assert lp_plugin.selected_viewer == 'imviz-1'
+        assert lp_plugin.viewer.labels == ['imviz-0', 'imviz-1']
+        assert lp_plugin.viewer_selected == 'imviz-1'
         assert_allclose(lp_plugin.selected_x, 5.1)
         assert_allclose(lp_plugin.selected_y, 5)
         assert len(lp_plugin.plot_across_x.marks['line'].x) > 0
@@ -60,14 +60,15 @@ class TestLineProfileXY(BaseImviz_WCS_NoWCS):
         # Mimic manual GUI inputs.
         lp_plugin.selected_x = '1.1'
         lp_plugin.selected_y = '9'
-        lp_plugin.selected_viewer = 'imviz-0'
+        lp_plugin.viewer_selected = 'imviz-0'
         assert len(lp_plugin.plot_across_x.marks['line'].x) > 0
         assert len(lp_plugin.plot_across_y.marks['line'].x) > 0
         assert lp_plugin.plot_available
 
         # Nothing should update on "l" when plugin closed.
         lp_plugin.plugin_opened = False
-        self.viewer.on_mouse_or_key_event(
-            {'event': 'keydown', 'key': 'l', 'domain': {'x': 5.1, 'y': 5}})
+        lp_plugin._on_viewer_key_event(self.viewer,
+                                       {'event': 'keydown', 'key': 'l',
+                                        'domain': {'x': 5.1, 'y': 5}})
         lp_plugin.selected_x = '1.1'
         lp_plugin.selected_y = '9'

--- a/jdaviz/configs/imviz/tests/test_line_profile_xy.py
+++ b/jdaviz/configs/imviz/tests/test_line_profile_xy.py
@@ -10,7 +10,7 @@ class TestLineProfileXY(BaseImviz_WCS_NoWCS):
     def test_plugin_linked_by_pixel(self):
         """Go through plugin logic but does not check plot contents."""
         lp_plugin = self.imviz.app.get_tray_item_from_name('imviz-line-profile-xy')
-        lp_plugin.plugin_opened = True
+        lp_plugin.plugin_active = True
 
         lp_plugin._on_viewers_changed()  # Populate plugin menu items.
         assert lp_plugin.viewer_items == ['imviz-0']
@@ -66,7 +66,7 @@ class TestLineProfileXY(BaseImviz_WCS_NoWCS):
         assert lp_plugin.plot_available
 
         # Nothing should update on "l" when plugin closed.
-        lp_plugin.plugin_opened = False
+        lp_plugin.plugin_active = False
         self.viewer.on_mouse_or_key_event(
             {'event': 'keydown', 'key': 'l', 'domain': {'x': 5.1, 'y': 5}})
         lp_plugin.selected_x = '1.1'

--- a/jdaviz/configs/imviz/tests/test_tools.py
+++ b/jdaviz/configs/imviz/tests/test_tools.py
@@ -133,7 +133,7 @@ def test_blink(imviz_helper):
 
 def test_compass_open_while_load(imviz_helper):
     plg = imviz_helper.plugins['Compass']
-    plg.open_in_tray()
+    plg.plugin_opened = True
 
     # Should not crash even if Compass is open in tray.
     imviz_helper.load_data(np.ones((2, 2)))

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -22,8 +22,7 @@ def test_create_destroy_viewer(imviz_helper, desired_name, actual_name):
     assert viewer is imviz_helper.app._viewer_store.get(actual_name), list(imviz_helper.app._viewer_store.keys())  # noqa
     assert imviz_helper.app.get_viewer_ids() == viewer_names
 
-    # Make sure plugins that store viewer_items differently are consistent.
-    assert imviz_helper.plugins['Imviz Line Profiles (XY)']._obj.viewer_items == viewer_names
+    # Make sure plugins that store viewer_items are updated.
     assert sorted(imviz_helper.plugins['Compass'].viewer.labels) == viewer_names
 
     imviz_helper.destroy_viewer(actual_name)

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -97,7 +97,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
     """
     dialog = Bool(False).tag(sync=True)
     template_file = __file__, "line_analysis.vue"
-    has_previews = Bool(True).tag(sync=True)
+    uses_active_status = Bool(True).tag(sync=True)
 
     spatial_subset_items = List().tag(sync=True)
     spatial_subset_selected = Unicode().tag(sync=True)
@@ -206,26 +206,26 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         if (msg.subset.label in [self.spectral_subset_selected,
                                  self.spatial_subset_selected,
                                  self.continuum_subset_selected]
-                and (self.show_previews or self.plugin_opened_in_tray)):
+                and self.is_active):
             self._calculate_statistics()
 
     def _on_global_display_unit_changed(self, msg):
-        if self.show_previews:
+        if self.is_active:
             self._calculate_statistics()
 
-    @observe('show_previews')
-    def _show_previews_changed(self, *args):
+    @observe('is_active')
+    def _is_active_changed(self, msg):
         if self.disabled_msg:
             return
 
         for pos, mark in self.marks.items():
-            mark.visible = self.show_previews
-        if self.show_previews:
+            mark.visible = self.is_active
+        if self.is_active:
             self._calculate_statistics()
 
-    @deprecated(since="3.6", alternative="persistent_previews")
+    @deprecated(since="3.6", alternative="keep_active")
     def show_continuum_marks(self):
-        self.persistent_previews = True
+        self.keep_active = True
 
     @property
     def marks(self):
@@ -247,9 +247,9 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
                 return {}
             # then haven't been initialized yet, so initialize with empty
             # marks that will be populated once the first analysis is done.
-            marks = {'left': LineAnalysisContinuumLeft(viewer, visible=self.show_previews),
-                     'center': LineAnalysisContinuumCenter(viewer, visible=self.show_previews),
-                     'right': LineAnalysisContinuumRight(viewer, visible=self.show_previews)}
+            marks = {'left': LineAnalysisContinuumLeft(viewer, visible=self.is_active),
+                     'center': LineAnalysisContinuumCenter(viewer, visible=self.is_active),
+                     'right': LineAnalysisContinuumRight(viewer, visible=self.is_active)}
             shadows = [ShadowLine(mark, shadow_width=2) for mark in marks.values()]
             # NOTE: += won't trigger the figure to notice new marks
             viewer.figure.marks = viewer.figure.marks + shadows + list(marks.values())

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -3,7 +3,7 @@
     description="Return statistics for a single spectral line."
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#line-analysis'"
     :uses_active_status="uses_active_status"
-    :plugin_ping.sync="plugin_ping"
+    @plugin-ping="plugin_ping($event)"
     :keep_active.sync="keep_active"
     :disabled_msg="disabled_msg"
     :popout_button="popout_button">

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -2,6 +2,9 @@
   <j-tray-plugin
     description="Return statistics for a single spectral line."
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#line-analysis'"
+    :has_previews="has_previews"
+    :plugin_ping.sync="plugin_ping"
+    :persistent_previews.sync="persistent_previews"
     :disabled_msg="disabled_msg"
     :popout_button="popout_button">
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -2,9 +2,9 @@
   <j-tray-plugin
     description="Return statistics for a single spectral line."
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#line-analysis'"
-    :has_previews="has_previews"
+    :uses_active_status="uses_active_status"
     :plugin_ping.sync="plugin_ping"
-    :persistent_previews.sync="persistent_previews"
+    :keep_active.sync="keep_active"
     :disabled_msg="disabled_msg"
     :popout_button="popout_button">
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_allclose
 import pytest
 from astropy import units as u
 from astropy.table import QTable
@@ -162,7 +163,7 @@ def test_line_identify(specviz_helper, spectrum1d):
 
     # manually update redshift
     la_plugin.vue_line_assign()
-    assert la_plugin.selected_line_redshift == -1.0
+    assert_allclose(la_plugin.selected_line_redshift, 0.4594414354783614)
 
 
 def test_coerce_unit():

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -120,6 +120,7 @@ def test_line_identify(specviz_helper, spectrum1d):
 
     ll_plugin = specviz_helper.app.get_tray_item_from_name('g-line-list')
     la_plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
+    la_plugin.plugin_opened = True
     rest_names = [line['name_rest'] for line in ll_plugin.list_contents['Test List']['lines']]
 
     # will default to no selection
@@ -131,7 +132,7 @@ def test_line_identify(specviz_helper, spectrum1d):
     # but selecting a line from line-list (or clicking) should change the dropdown value
     # since sync is enabled by default
     assert la_plugin.sync_identify is True
-    # think this is the problem and we need to send the rest name here!
+
     msg = LineIdentifyMessage(rest_names[1],
                               sender=specviz_helper)
     specviz_helper.app.session.hub.broadcast(msg)
@@ -163,7 +164,12 @@ def test_line_identify(specviz_helper, spectrum1d):
 
     # manually update redshift
     la_plugin.vue_line_assign()
-    assert_allclose(la_plugin.selected_line_redshift, 0.4594414354783614)
+    assert_allclose(la_plugin.results_centroid, 7307.4232674401555)
+    line_mark = la_plugin.line_marks[la_plugin.line_items.index(la_plugin.selected_line)]
+    assert_allclose(line_mark.rest_value, 5007)
+    z = la_plugin._compute_redshift_for_selected_line()
+    assert_allclose(z, (la_plugin.results_centroid - line_mark.rest_value)/line_mark.rest_value)
+    assert_allclose(la_plugin.selected_line_redshift, z)
 
 
 def test_coerce_unit():

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -17,7 +17,7 @@ def test_plugin(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.persistent_previews = True
+    plugin.keep_active = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -25,8 +25,8 @@ def test_plugin(specviz_helper, spectrum1d):
     assert len(continuum_marks) == 3
     assert np.all([cm.visible for cm in continuum_marks])
 
-    # disabling persistent_previews should hide the continuum
-    plugin.persistent_previews = False
+    # disabling keep_active should hide the continuum
+    plugin.keep_active = False
     assert np.all([cm.visible is False for cm in continuum_marks])
 
     # add a region and rerun stats for that region
@@ -63,7 +63,7 @@ def test_spatial_subset(cubeviz_helper, image_cube_hdu_obj):
     cubeviz_helper.app.state.drawer = True
 
     plugin = cubeviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.persistent_previews = True
+    plugin.keep_active = True
 
     plugin.spatial_subset_selected = 'Subset 1'
     plugin.spectral_subset_selected = 'Subset 2'
@@ -85,7 +85,7 @@ def test_user_api(specviz_helper, spectrum1d):
     sv.apply_roi(XRangeROI(6500, 7400))
 
     la = specviz_helper.plugins['Line Analysis']
-    la.persistent_previews = True
+    la.keep_active = True
 
     # spectral subset does not support multiselect
     assert "multiselect" not in la.spectral_subset.__repr__()
@@ -183,7 +183,7 @@ def test_continuum_surrounding_spectral_subset(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.persistent_previews = True
+    plugin.keep_active = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -210,7 +210,7 @@ def test_continuum_spectral_same_value(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.persistent_previews = True
+    plugin.keep_active = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -237,7 +237,7 @@ def test_continuum_surrounding_invalid_width(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.persistent_previews = True
+    plugin.keep_active = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -262,7 +262,7 @@ def test_continuum_subset_spectral_entire(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.persistent_previews = True
+    plugin.keep_active = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -289,7 +289,7 @@ def test_continuum_subset_spectral_subset2(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.persistent_previews = True
+    plugin.keep_active = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -322,7 +322,7 @@ def test_continuum_surrounding_no_right(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.persistent_previews = True
+    plugin.keep_active = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -350,7 +350,7 @@ def test_continuum_surrounding_no_left(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.persistent_previews = True
+    plugin.keep_active = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -378,7 +378,7 @@ def test_subset_changed(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.persistent_previews = True
+    plugin.keep_active = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -17,7 +17,7 @@ def test_plugin(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -25,8 +25,8 @@ def test_plugin(specviz_helper, spectrum1d):
     assert len(continuum_marks) == 3
     assert np.all([cm.visible for cm in continuum_marks])
 
-    # closing tray/plugin should hide the continuum
-    specviz_helper.app.state.drawer = False
+    # disabling persistent_previews should hide the continuum
+    plugin.persistent_previews = False
     assert np.all([cm.visible is False for cm in continuum_marks])
 
     # add a region and rerun stats for that region
@@ -63,7 +63,7 @@ def test_spatial_subset(cubeviz_helper, image_cube_hdu_obj):
     cubeviz_helper.app.state.drawer = True
 
     plugin = cubeviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     plugin.spatial_subset_selected = 'Subset 1'
     plugin.spectral_subset_selected = 'Subset 2'
@@ -85,7 +85,7 @@ def test_user_api(specviz_helper, spectrum1d):
     sv.apply_roi(XRangeROI(6500, 7400))
 
     la = specviz_helper.plugins['Line Analysis']
-    la.open_in_tray()
+    la.persistent_previews = True
 
     # spectral subset does not support multiselect
     assert "multiselect" not in la.spectral_subset.__repr__()
@@ -183,7 +183,7 @@ def test_continuum_surrounding_spectral_subset(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -210,7 +210,7 @@ def test_continuum_spectral_same_value(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -237,7 +237,7 @@ def test_continuum_surrounding_invalid_width(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -262,7 +262,7 @@ def test_continuum_subset_spectral_entire(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -289,7 +289,7 @@ def test_continuum_subset_spectral_subset2(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -322,7 +322,7 @@ def test_continuum_surrounding_no_right(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -350,7 +350,7 @@ def test_continuum_surrounding_no_left(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')
@@ -378,7 +378,7 @@ def test_subset_changed(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d, data_label=label)
 
     plugin = specviz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    plugin.open_in_tray()
+    plugin.persistent_previews = True
 
     # continuum should be created, plotted, and visible
     sv = specviz_helper.app.get_viewer('spectrum-viewer')

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_lineflux.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_lineflux.py
@@ -62,7 +62,7 @@ def _calculate_line_flux(viz_helper):
     # Open the plugin and force the calculation
     viz_helper.app.state.drawer = True
     line_analysis_plugin = viz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    line_analysis_plugin.persistent_previews = True
+    line_analysis_plugin.keep_active = True
 
     # Retrieve Results
     for result in line_analysis_plugin.results:

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_lineflux.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_lineflux.py
@@ -62,7 +62,8 @@ def _calculate_line_flux(viz_helper):
     # Open the plugin and force the calculation
     viz_helper.app.state.drawer = True
     line_analysis_plugin = viz_helper.app.get_tray_item_from_name('specviz-line-analysis')
-    line_analysis_plugin.open_in_tray()
+    line_analysis_plugin.persistent_previews = True
+
     # Retrieve Results
     for result in line_analysis_plugin.results:
         if result['function'] == 'Line Flux':

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -95,7 +95,7 @@ class SpectralExtraction(PluginTemplateMixin):
     """
     dialog = Bool(False).tag(sync=True)
     template_file = __file__, "spectral_extraction.vue"
-    has_previews = Bool(True).tag(sync=True)
+    uses_active_status = Bool(True).tag(sync=True)
 
     active_step = Unicode().tag(sync=True)
     interactive_extract = Bool(True).tag(sync=True)
@@ -406,12 +406,12 @@ class SpectralExtraction(PluginTemplateMixin):
             else:
                 raise ValueError("step must be one of: trace, bg, ext")
 
-    @observe('show_previews', 'interactive_extract')
+    @observe('is_active', 'interactive_extract')
     def _update_plugin_marks(self, *args):
         if not self._do_marks:
             return
 
-        if not (self.show_previews):
+        if not (self.is_active):
             for step, mark in self.marks.items():
                 mark.visible = False
             return
@@ -469,22 +469,22 @@ class SpectralExtraction(PluginTemplateMixin):
 
         # the marks haven't been initialized yet, so initialize with empty
         # marks that will be populated once the first analysis is done.
-        self._marks = {'trace': PluginLine(viewer2d, visible=self.show_previews),
-                       'ext_lower': PluginLine(viewer2d, visible=self.show_previews),
-                       'ext_upper': PluginLine(viewer2d, visible=self.show_previews),
-                       'bg1_center': PluginLine(viewer2d, visible=self.show_previews,
+        self._marks = {'trace': PluginLine(viewer2d, visible=self.is_active),
+                       'ext_lower': PluginLine(viewer2d, visible=self.is_active),
+                       'ext_upper': PluginLine(viewer2d, visible=self.is_active),
+                       'bg1_center': PluginLine(viewer2d, visible=self.is_active,
                                                 line_style='dotted'),
-                       'bg1_lower': PluginLine(viewer2d, visible=self.show_previews),
-                       'bg1_upper': PluginLine(viewer2d, visible=self.show_previews),
-                       'bg2_center': PluginLine(viewer2d, visible=self.show_previews,
+                       'bg1_lower': PluginLine(viewer2d, visible=self.is_active),
+                       'bg1_upper': PluginLine(viewer2d, visible=self.is_active),
+                       'bg2_center': PluginLine(viewer2d, visible=self.is_active,
                                                 line_style='dotted'),
-                       'bg2_lower': PluginLine(viewer2d, visible=self.show_previews),
-                       'bg2_upper': PluginLine(viewer2d, visible=self.show_previews)}
+                       'bg2_lower': PluginLine(viewer2d, visible=self.is_active),
+                       'bg2_upper': PluginLine(viewer2d, visible=self.is_active)}
         # NOTE: += won't trigger the figure to notice new marks
         viewer2d.figure.marks = viewer2d.figure.marks + list(self._marks.values())
 
-        self._marks['extract'] = PluginLine(viewer1d, visible=self.show_previews)
-        self._marks['bg_spec'] = PluginLine(viewer1d, visible=self.show_previews, stroke_width=1)  # noqa
+        self._marks['extract'] = PluginLine(viewer1d, visible=self.is_active)
+        self._marks['bg_spec'] = PluginLine(viewer1d, visible=self.is_active, stroke_width=1)  # noqa
 
         # NOTE: += won't trigger the figure to notice new marks
         viewer1d.figure.marks = viewer1d.figure.marks + [self._marks['extract'],
@@ -497,7 +497,7 @@ class SpectralExtraction(PluginTemplateMixin):
              'trace_pixel', 'trace_peak_method_selected',
              'trace_do_binning', 'trace_bins', 'trace_window', 'active_step')
     def _interaction_in_trace_step(self, event={}):
-        if not self.show_previews or not self._do_marks:
+        if not self.is_active or not self._do_marks:
             return
         if event.get('name', '') == 'active_step' and event.get('new') != 'trace':
             return
@@ -518,7 +518,7 @@ class SpectralExtraction(PluginTemplateMixin):
              'bg_trace_selected', 'bg_trace_pixel',
              'bg_separation', 'bg_width', 'bg_statistic_selected', 'active_step')
     def _interaction_in_bg_step(self, event={}):
-        if not self.show_previews or not self._do_marks:
+        if not self.is_active or not self._do_marks:
             return
         if event.get('name', '') == 'active_step' and event.get('new') != 'bg':
             return
@@ -574,7 +574,7 @@ class SpectralExtraction(PluginTemplateMixin):
     @observe('ext_dataset_selected', 'ext_trace_selected',
              'ext_type_selected', 'ext_width', 'active_step')
     def _interaction_in_ext_step(self, event={}):
-        if not self.show_previews or not self._do_marks:
+        if not self.is_active or not self._do_marks:
             return
         if event.get('name', '') == 'active_step' and event.get('new') != 'ext':
             return

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -95,6 +95,7 @@ class SpectralExtraction(PluginTemplateMixin):
     """
     dialog = Bool(False).tag(sync=True)
     template_file = __file__, "spectral_extraction.vue"
+    has_previews = Bool(True).tag(sync=True)
 
     active_step = Unicode().tag(sync=True)
     interactive_extract = Bool(True).tag(sync=True)
@@ -396,7 +397,6 @@ class SpectralExtraction(PluginTemplateMixin):
             Step in the extraction process to visualize.  Must be one of: 'trace', 'bg', 'ext'.
         """
         if step is not None:
-            self.plugin_opened = True
             if step == 'trace':
                 self._interaction_in_trace_step()
             elif step == 'bg':
@@ -406,18 +406,12 @@ class SpectralExtraction(PluginTemplateMixin):
             else:
                 raise ValueError("step must be one of: trace, bg, ext")
 
-    def clear_marks(self):
-        """
-        Manually clear the live-preview marks.
-        """
-        self.plugin_opened = False
-
-    @observe('plugin_opened', 'interactive_extract')
+    @observe('show_previews', 'interactive_extract')
     def _update_plugin_marks(self, *args):
         if not self._do_marks:
             return
 
-        if not self.plugin_opened:
+        if not (self.show_previews):
             for step, mark in self.marks.items():
                 mark.visible = False
             return
@@ -475,22 +469,22 @@ class SpectralExtraction(PluginTemplateMixin):
 
         # the marks haven't been initialized yet, so initialize with empty
         # marks that will be populated once the first analysis is done.
-        self._marks = {'trace': PluginLine(viewer2d, visible=self.plugin_opened),
-                       'ext_lower': PluginLine(viewer2d, visible=self.plugin_opened),
-                       'ext_upper': PluginLine(viewer2d, visible=self.plugin_opened),
-                       'bg1_center': PluginLine(viewer2d, visible=self.plugin_opened,
+        self._marks = {'trace': PluginLine(viewer2d, visible=self.show_previews),
+                       'ext_lower': PluginLine(viewer2d, visible=self.show_previews),
+                       'ext_upper': PluginLine(viewer2d, visible=self.show_previews),
+                       'bg1_center': PluginLine(viewer2d, visible=self.show_previews,
                                                 line_style='dotted'),
-                       'bg1_lower': PluginLine(viewer2d, visible=self.plugin_opened),
-                       'bg1_upper': PluginLine(viewer2d, visible=self.plugin_opened),
-                       'bg2_center': PluginLine(viewer2d, visible=self.plugin_opened,
+                       'bg1_lower': PluginLine(viewer2d, visible=self.show_previews),
+                       'bg1_upper': PluginLine(viewer2d, visible=self.show_previews),
+                       'bg2_center': PluginLine(viewer2d, visible=self.show_previews,
                                                 line_style='dotted'),
-                       'bg2_lower': PluginLine(viewer2d, visible=self.plugin_opened),
-                       'bg2_upper': PluginLine(viewer2d, visible=self.plugin_opened)}
+                       'bg2_lower': PluginLine(viewer2d, visible=self.show_previews),
+                       'bg2_upper': PluginLine(viewer2d, visible=self.show_previews)}
         # NOTE: += won't trigger the figure to notice new marks
         viewer2d.figure.marks = viewer2d.figure.marks + list(self._marks.values())
 
-        self._marks['extract'] = PluginLine(viewer1d, visible=self.plugin_opened)
-        self._marks['bg_spec'] = PluginLine(viewer1d, visible=self.plugin_opened, stroke_width=1)  # noqa
+        self._marks['extract'] = PluginLine(viewer1d, visible=self.show_previews)
+        self._marks['bg_spec'] = PluginLine(viewer1d, visible=self.show_previews, stroke_width=1)  # noqa
 
         # NOTE: += won't trigger the figure to notice new marks
         viewer1d.figure.marks = viewer1d.figure.marks + [self._marks['extract'],
@@ -503,7 +497,7 @@ class SpectralExtraction(PluginTemplateMixin):
              'trace_pixel', 'trace_peak_method_selected',
              'trace_do_binning', 'trace_bins', 'trace_window', 'active_step')
     def _interaction_in_trace_step(self, event={}):
-        if not self.plugin_opened or not self._do_marks:
+        if not self.show_previews or not self._do_marks:
             return
         if event.get('name', '') == 'active_step' and event.get('new') != 'trace':
             return
@@ -524,7 +518,7 @@ class SpectralExtraction(PluginTemplateMixin):
              'bg_trace_selected', 'bg_trace_pixel',
              'bg_separation', 'bg_width', 'bg_statistic_selected', 'active_step')
     def _interaction_in_bg_step(self, event={}):
-        if not self.plugin_opened or not self._do_marks:
+        if not self.show_previews or not self._do_marks:
             return
         if event.get('name', '') == 'active_step' and event.get('new') != 'bg':
             return
@@ -580,7 +574,7 @@ class SpectralExtraction(PluginTemplateMixin):
     @observe('ext_dataset_selected', 'ext_trace_selected',
              'ext_type_selected', 'ext_width', 'active_step')
     def _interaction_in_ext_step(self, event={}):
-        if not self.plugin_opened or not self._do_marks:
+        if not self.show_previews or not self._do_marks:
             return
         if event.get('name', '') == 'active_step' and event.get('new') != 'ext':
             return

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -3,7 +3,7 @@
     description="2D to 1D spectral extraction."
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#spectral-extraction'"
     :uses_active_status="uses_active_status"
-    :plugin_ping.sync="plugin_ping"
+    @plugin-ping="plugin_ping($event)"
     :keep_active.sync="keep_active"
     :popout_button="popout_button">
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -2,6 +2,9 @@
   <j-tray-plugin
     description="2D to 1D spectral extraction."
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#spectral-extraction'"
+    :has_previews="has_previews"
+    :plugin_ping.sync="plugin_ping"
+    :persistent_previews.sync="persistent_previews"
     :popout_button="popout_button">
 
     <v-row>
@@ -25,7 +28,8 @@
     </v-row>
 
 
-    <div @mouseover="() => active_step='trace'">
+    <div @mouseover="() => active_step='trace'"
+      :style="plugin_active && active_step==='trace' ? 'box-shadow: rgb(2 123 161 / 20%) -20px 0px 0px 0px' : ''">
       <j-plugin-section-header>Trace</j-plugin-section-header>
       <v-row>
         <j-docs-link>
@@ -184,7 +188,8 @@
       </v-row>
     </div>
 
-    <div @mouseover="() => active_step='bg'">
+    <div @mouseover="() => active_step='bg'"
+      :style="plugin_active && active_step==='bg' ? 'box-shadow: rgb(2 123 161 / 20%) -20px 0px 0px 0px' : ''">
       <j-plugin-section-header>Background</j-plugin-section-header>
       <v-row>
         <j-docs-link>Create a background and/or background-subtracted image.</j-docs-link>
@@ -346,7 +351,8 @@
       </v-row>
     </div>
 
-    <div @mouseover="() => active_step='ext'">
+    <div @mouseover="() => active_step='ext'"
+      :style="plugin_active && active_step==='ext' ? 'box-shadow: rgb(2 123 161 / 20%) -20px 0px 0px 0px' : ''">
       <j-plugin-section-header>Extraction</j-plugin-section-header>
       <v-row>
         <j-docs-link>

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -2,9 +2,9 @@
   <j-tray-plugin
     description="2D to 1D spectral extraction."
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#spectral-extraction'"
-    :has_previews="has_previews"
+    :uses_active_status="uses_active_status"
     :plugin_ping.sync="plugin_ping"
-    :persistent_previews.sync="persistent_previews"
+    :keep_active.sync="keep_active"
     :popout_button="popout_button">
 
     <v-row>
@@ -28,8 +28,7 @@
     </v-row>
 
 
-    <div @mouseover="() => active_step='trace'"
-      :style="plugin_active && active_step==='trace' ? 'box-shadow: rgb(2 123 161 / 20%) -20px 0px 0px 0px' : ''">
+    <div @mouseover="() => active_step='trace'">
       <j-plugin-section-header>Trace</j-plugin-section-header>
       <v-row>
         <j-docs-link>
@@ -188,8 +187,7 @@
       </v-row>
     </div>
 
-    <div @mouseover="() => active_step='bg'"
-      :style="plugin_active && active_step==='bg' ? 'box-shadow: rgb(2 123 161 / 20%) -20px 0px 0px 0px' : ''">
+    <div @mouseover="() => active_step='bg'">
       <j-plugin-section-header>Background</j-plugin-section-header>
       <v-row>
         <j-docs-link>Create a background and/or background-subtracted image.</j-docs-link>
@@ -351,8 +349,7 @@
       </v-row>
     </div>
 
-    <div @mouseover="() => active_step='ext'"
-      :style="plugin_active && active_step==='ext' ? 'box-shadow: rgb(2 123 161 / 20%) -20px 0px 0px 0px' : ''">
+    <div @mouseover="() => active_step='ext'">
       <j-plugin-section-header>Extraction</j-plugin-section-header>
       <v-row>
         <j-docs-link>

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -24,7 +24,7 @@ def test_plugin(specviz2d_helper):
     sp2dv = specviz2d_helper.app.get_viewer('spectrum-2d-viewer')
     assert len(sp2dv.figure.marks) == 2
 
-    pext.persistent_previews = True
+    pext.keep_active = True
     assert len(sp2dv.figure.marks) == 11
     assert pext.marks['trace'].visible is True
     assert len(pext.marks['trace'].x) > 0
@@ -156,7 +156,7 @@ def test_user_api(specviz2d_helper):
     specviz2d_helper.load_data(spectrum_2d=fn)
 
     pext = specviz2d_helper.plugins['Spectral Extraction']
-    pext.persistent_previews = True
+    pext.keep_active = True
 
     # test that setting a string to an AddResults object redirects to the label
     pext.bg_sub_add_results = 'override label'

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -24,7 +24,7 @@ def test_plugin(specviz2d_helper):
     sp2dv = specviz2d_helper.app.get_viewer('spectrum-2d-viewer')
     assert len(sp2dv.figure.marks) == 2
 
-    pext.open_in_tray()
+    pext.persistent_previews = True
     assert len(sp2dv.figure.marks) == 11
     assert pext.marks['trace'].visible is True
     assert len(pext.marks['trace'].x) > 0
@@ -156,7 +156,7 @@ def test_user_api(specviz2d_helper):
     specviz2d_helper.load_data(spectrum_2d=fn)
 
     pext = specviz2d_helper.plugins['Spectral Extraction']
-    pext.open_in_tray()
+    pext.persistent_previews = True
 
     # test that setting a string to an AddResults object redirects to the label
     pext.bg_sub_add_results = 'override label'

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -263,7 +263,7 @@ class PluginTemplateMixin(TemplateMixin):
         self._inactive_thread.start()
 
     def _watch_active(self):
-        # expected_delay_ms hould match value in setTimeout in tray_plugin.vue
+        # expected_delay_ms should match value in setTimeout in tray_plugin.vue
         # NOTE: could control with a traitlet, but then would need to pass through each
         # <j-tray-plugin> component
         expected_delay_ms = 200

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -228,19 +228,16 @@ class PluginTemplateMixin(TemplateMixin):
     This base class can be inherited by all sidebar/tray plugins to expose common functionality.
     """
     disabled_msg = Unicode("").tag(sync=True)
-    plugin_opened_in_tray = Bool(False).tag(sync=True)  # plugin is opened in the tray
     plugin_ping = Integer(0).tag(sync=True)
-    plugin_active = Bool(False).tag(sync=True)  # any instance of the plugin has recently pinged
-    has_previews = Bool(False).tag(sync=True)  # whether the plugin has live-preview marks, set in plugins
-    persistent_previews = Bool(False).tag(sync=True)  # noqa whether the live-preview marks show regardless of active state
-    show_previews = Bool(False).tag(sync=True)  # noqa read-only: whether the previews should be shown according to settings above
+    plugin_opened = Bool(False).tag(sync=True)  # noqa any instance of the plugin is open (recently sent an "alive" ping)
+    uses_active_status = Bool(False).tag(sync=True)  # noqa whether the plugin has live-preview marks, set to True in plugins to expose keep_active switch
+    keep_active = Bool(False).tag(sync=True)  # noqa whether the live-preview marks show regardless of active state, inapplicable unless uses_active_status is True
+    is_active = Bool(False).tag(sync=True)  # noqa read-only: whether the previews should be shown according to plugin_opened and keep_active
 
     def __init__(self, **kwargs):
         self._viewer_callbacks = {}
-        self._inactive_thread = None
+        self._inactive_thread = None  # thread checking for alive pings to control plugin_opened
         super().__init__(**kwargs)
-        self.app.state.add_callback('tray_items_open', self._mxn_update_plugin_opened)
-        self.app.state.add_callback('drawer', self._mxn_update_plugin_opened)
 
     @property
     def user_api(self):
@@ -251,25 +248,37 @@ class PluginTemplateMixin(TemplateMixin):
     @observe('plugin_ping')
     def _plugin_ping_changed(self, *args):
         if self.plugin_ping == 0:
+            # initial traitlet state
             return
-        self.plugin_active = True
+        # we've received a ping, so immediately set plugin_opened state to True
+        if not self.plugin_opened:
+            self.plugin_opened = True
 
         if self._inactive_thread is not None and self._inactive_thread.is_alive():
+            # a thread already exists to check for pings, the latest ping will allow
+            # the existing while-loop to continue
             return
 
+        # create a thread to monitor for pings.  If a ping hasn't been received in the
+        # expected time, then plugin_opened will be set to False.
         self._inactive_thread = threading.Thread(target=self._watch_active)
         self._inactive_thread.start()
 
     def _watch_active(self):
-        expected_delay_ms = 100
-        plugin_ping = self.plugin_ping  # ms
-        now = time.time() * 1000  # s -> ms
-        while now - plugin_ping < 1.5 * expected_delay_ms:
-            time.sleep(expected_delay_ms / 1000)
-            now = time.time() * 1000 # s -> ms
-            plugin_ping = self.plugin_ping
+        # expected_delay_ms hould match value in setTimeout in tray_plugin.vue
+        # NOTE: could control with a traitlet, but then would need to pass through each
+        # <j-tray-plugin> component
+        expected_delay_ms = 200
+        # plugin_ping (ms) set by setTimeout in tray_plugin.vue
+        # time.time() is in s, so need to convert to ms
+        while time.time()*1000 - self.plugin_ping < 2 * expected_delay_ms:
+            # at least one plugin has sent an "alive" ping within twice of the expected
+            # interval, wait a full (double) interval and then check again
+            time.sleep(2 * expected_delay_ms / 1000)
 
-        self.plugin_active = False
+        # "alive" ping has not been received within the expected time, consider all instances
+        # of the plugin to be closed
+        self.plugin_opened = False
 
     def _viewer_callback(self, viewer, plugin_method):
         """
@@ -293,11 +302,6 @@ class PluginTemplateMixin(TemplateMixin):
             self._viewer_callbacks[key] = plugin_viewer_callback(viewer, plugin_method)
         return self._viewer_callbacks.get(key)
 
-    def _mxn_update_plugin_opened(self, new_value):
-        app_state = self.app.state
-        tray_names_open = [app_state.tray_items[i]['name'] for i in app_state.tray_items_open]
-        self.plugin_opened_in_tray = app_state.drawer and self._registry_name in tray_names_open
-
     def open_in_tray(self):
         """
         Open the plugin in the sidebar/tray (and open the sidebar if it is not already).
@@ -308,19 +312,20 @@ class PluginTemplateMixin(TemplateMixin):
         if index not in app_state.tray_items_open:
             app_state.tray_items_open = app_state.tray_items_open + [index]
 
-    @observe('plugin_active', 'persistent_previews')
-    def _update_show_previews(self, *args):
-        self.show_previews = self.persistent_previews or self.plugin_active
+    @observe('plugin_opened', 'keep_active')
+    def _update_is_active(self, *args):
+        self.is_active = self.keep_active or self.plugin_opened
 
     @contextmanager
-    def temporarily_show_previews(self):
+    def as_active(self):
         """
-        Context manager to temporarily enable persistent live-previews
+        Context manager to temporarily enable keep_active and enable live-previews and keypress
+        events, even if the plugin UI is not opened.
         """
-        _persistent_previews = self.persistent_previews
-        self.persistent_previews = True
+        _keep_active = self.keep_active
+        self.keep_active = True
         yield
-        self.persistent_previews = _persistent_previews
+        self.keep_active = _keep_active
 
     def show(self, loc="inline", title=None):  # pragma: no cover
         """Display the plugin UI.

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -86,6 +86,8 @@ class PluginUserApi(UserApiWrapper):
     """
     def __init__(self, plugin, expose=[], readonly=[]):
         expose = list(set(list(expose) + ['open_in_tray', 'show']))
+        if plugin.has_previews:
+            expose += ['persistent_previews', 'temporarily_show_previews']
         super().__init__(plugin, expose, readonly)
 
     def __repr__(self):

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -86,8 +86,8 @@ class PluginUserApi(UserApiWrapper):
     """
     def __init__(self, plugin, expose=[], readonly=[]):
         expose = list(set(list(expose) + ['open_in_tray', 'show']))
-        if plugin.has_previews:
-            expose += ['persistent_previews', 'temporarily_show_previews']
+        if plugin.uses_active_status:
+            expose += ['keep_active', 'as_active']
         super().__init__(plugin, expose, readonly)
 
     def __repr__(self):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is an alternative to #2293 and controls the live-previews (as well as keypress events and any other optimizations) based on determining whether _any_ instance of a particular plugin is opened by having the individual instances send "I'm alive" pings back to python at a regular interval.  Once these pings are no longer received, the plugin (on the python side) is determined to be inactive.

**NOTE**: this can result in flickering if the intervals are not tuned correctly, so it would be useful to have multiple devs/machines/data to test and make sure the interval and interval-factor are robustly set here.


https://github.com/spacetelescope/jdaviz/assets/877591/9722a273-23d1-4577-925f-800852e4d1ae



Lastly, for any plugin for which `plugin.uses_active_status == True`, this exposes the `keep_active` traitlet (and switch in the UI if it is passed to the template) as well as an `as_active` context manager that can be used for workflows in the API:


https://github.com/spacetelescope/jdaviz/assets/877591/e6d5bfe4-ac19-41ae-87aa-ebd1bbb05107



This PR affects the following plugins:

* line lists: redshift information updates regardless of plugin active state, this section of the code is now also optimized to use send_state (see https://github.com/spacetelescope/jdaviz/pull/2285) to avoid any unnecessary lag.
* markers: the visibility of markers and the "m" keypress event are controlled by the active state of the plugin.
* plot options: stretch histogram is first created whenever the plugin is first opened in the tray or via plugin.show(), and is only updated when the plugin is active.
* compass: the compass image is first created whenever the plugin is first opened in the tray or via plugin.show(), and is only updated when the plugin is opened (in the tray, popup, or in-line).
* line profile XY: the "l" keypress event is only enabled when the plugin is active.
* line analysis: continuum preview marks are visible based on the plugin's "active" status, but the results table continues to update regardless. plugin.show_continuum_marks() which used to allow showing these marks from the API is now deprecated, in favor of using plugin.persistent_previews = True or with plugin.temporarily_show_previews():
* spectral extraction: preview marks are visible based on the plugin's "active" status. Previous behavior with respect to different active sections in the plugin remains, with new visual cues.

Development considerations:

* when a plugin implements preview marks or keypress events that depend on a plugin's active status, it should set `self.uses_active_status = True` and pass `:uses_active_status="uses_active_status" @plugin-ping="plugin_ping($event)" :keep_active.sync="keep_active"` to `j-tray-plugin` (as indicated in the developer docs). It should then observe the `is_active` traitlet to control the visibility of any marks.
* tests should use `plugin.keep_active = True` or `plugin.plugin_opened = True` rather than `plugin.open_in_tray()` as the traitlet is no longer required to be _immediately_ set.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->



### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
