### PR TITLE
Update roman WFI test file for latest rad/rdm

### DIFF
--- a/jdaviz/configs/imviz/tests/test_parser_roman.py
+++ b/jdaviz/configs/imviz/tests/test_parser_roman.py
@@ -4,7 +4,6 @@ import pytest
 roman_datamodels = pytest.importorskip("roman_datamodels")
 
 from astropy.utils.data import get_pkg_data_filename
-from erfa.core import ErfaWarning
 from gwcs import WCS as GWCS
 
 
@@ -15,8 +14,7 @@ from gwcs import WCS as GWCS
      (['data', 'var_rnoise'], 2)])
 def test_roman_wfi_ext_options(imviz_helper, ext_list, n_dc):
     filename = get_pkg_data_filename('data/roman_wfi_image_model.asdf')
-    with pytest.warns(ErfaWarning, match=r".*dubious year"):
-        imviz_helper.load_data(filename, ext=ext_list)
+    imviz_helper.load_data(filename, ext=ext_list)
     dc = imviz_helper.app.data_collection
     assert len(dc) == n_dc
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ docs = [
     "sphinx_design"
 ]
 roman = [
-    "roman_datamodels>=0.14.2",
+    "roman_datamodels>=0.16.1",
 ]
 
 [build-system]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
The latest releases of `roman_datamodels` (0.16.1) and `rad` (0.16.0) have updated schema. If we run tests with these latest releases, the Roman WFI package data can't be read, raising `jsonschema.exceptions.ValidationError: 'read_pattern' is a required property` (since https://github.com/spacetelescope/rad/pull/233 was released). 

This PR updates the ASDF package data file, and revises the test to remove a catch for a formerly expected warning that's been resolved upstream.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
