### PR TITLE
Fix for hanging plot options in cubeviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -137,6 +137,8 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Prevent Plot Options plugin from hanging when selecting a spectrum viewer in Cubeviz [#2305]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -482,6 +482,9 @@ class PlotOptions(PluginTemplateMixin):
     @observe('plugin_opened', 'layer_selected', 'viewer_selected',
              'stretch_hist_zoom_limits')
     def _update_stretch_histogram(self, msg={}):
+        from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
+        from jdaviz.configs.cubeviz.plugins.viewers import CubevizImageView
+
         if not self.stretch_function_sync.get('in_subscribed_states'):  # pragma: no cover
             # no (image) viewer with stretch function options
             return
@@ -507,11 +510,8 @@ class PlotOptions(PluginTemplateMixin):
             bqplot_clear_figure(self.stretch_histogram)
             return
 
-        spectrum_viewer_reference = getattr(
-            self.app._jdaviz_helper, '_default_spectrum_viewer_reference_name', None
-        )
-        if self.viewer.selected == spectrum_viewer_reference:
-            # don't update a histogram if the spectrum viewer is selected:
+        if not isinstance(self.viewer.selected_obj, (ImvizImageView, CubevizImageView)):
+            # don't update histogram if selected viewer is not an image viewer:
             return
 
         viewer = self.viewer.selected_obj[0] if self.multiselect else self.viewer.selected_obj

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -507,6 +507,13 @@ class PlotOptions(PluginTemplateMixin):
             bqplot_clear_figure(self.stretch_histogram)
             return
 
+        spectrum_viewer_reference = getattr(
+            self.app._jdaviz_helper, '_default_spectrum_viewer_reference_name', None
+        )
+        if self.viewer.selected == spectrum_viewer_reference:
+            # don't update a histogram if the spectrum viewer is selected:
+            return
+
         viewer = self.viewer.selected_obj[0] if self.multiselect else self.viewer.selected_obj
 
         # manage viewer zoom limit callbacks
@@ -522,7 +529,14 @@ class PlotOptions(PluginTemplateMixin):
                 for attr in ('x_min', 'x_max', 'y_min', 'y_max'):
                     vs_old.remove_callback(attr, self._update_stretch_histogram)
 
-        data = self.layer.selected_obj[0][0].layer if self.multiselect else self.layer.selected_obj[0].layer  # noqa
+        if self.multiselect:
+            data = self.layer.selected_obj[0][0].layer
+        elif len(self.layer.selected_obj):
+            data = self.layer.selected_obj[0].layer
+        else:
+            # skip further updates if no data are available:
+            return
+
         comp = data.get_component(data.main_components[0])
 
         if self.stretch_hist_zoom_limits:

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -494,7 +494,7 @@
             </glue-state-sync-wrapper>
           </div>
         </div>
-
+      </div>
       </div>
       <div v-if="contour_spinner"
            class="text-center"

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -495,7 +495,6 @@
           </div>
         </div>
       </div>
-      </div>
       <div v-if="contour_spinner"
            class="text-center"
            style="grid-area: 1/1; 
@@ -511,7 +510,7 @@
           width="6"
         ></v-progress-circular>
       </div>
-
+    </div>
     <!-- GENERAL:AXES -->
     <j-plugin-section-header v-if="axes_visible_sync.in_subscribed_states && config !== 'imviz'">Axes</j-plugin-section-header>
     <glue-state-sync-wrapper v-if="config !== 'imviz'":sync="axes_visible_sync" :multiselect="multiselect" @unmix-state="unmix_state('axes_visible')">


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description

In Cubeviz (including example notebook), if you open the Plot Options plugin and switch between flux-viewer (or uncert-viewer) and spectrum-viewer, you will likely get a traceback in your log. Plot Options creates a histogram figure for flux-viewer and uncert-viewer, and switching to spectrum-viewer currently also calls the `PlotOptions._update_stretch_histogram` method, which leads to a failure because no histogram should be shown or updated. 

It looks like this was introduced in #2153, but the bug is hard to notice unless you flip between image and spectrum viewers in this one plugin.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Dev tests are still expected to fail due to glue-jupyter.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3511) 
