### PR TITLE
Support for viewer reference name updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,8 @@ Specviz2d
 Other Changes and Additions
 ---------------------------
 
+- Add support for changing viewer reference names [#2338]
+
 3.6.2 (unreleased)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,8 +60,6 @@ Specviz2d
 Other Changes and Additions
 ---------------------------
 
-- Add support for changing viewer reference names [#2338]
-
 3.6.2 (unreleased)
 ==================
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1579,6 +1579,18 @@ class Application(VuetifyTemplate, HubListener):
         Update viewer reference names.
 
         Viewer IDs will not be changed unless `update_id` is True.
+
+        Parameters
+        ----------
+        old_reference : str
+            The viewer reference name to be changed
+        new_reference : str
+            The viewer reference name to use instead of ``old_reference``
+        old_reference_helper_attr : str, optional
+            If one exists, update the helper's attribute `old_reference_helper_attr`
+            with the new viewer reference name. Default is None.
+        update_id : bool, optional
+            If True, update the viewer IDs as well as the viewer reference names.
         """
         if new_reference in self.get_viewer_reference_names():
             raise ValueError(f"viewer with reference='{new_reference}' already exists")

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1478,7 +1478,9 @@ class Application(VuetifyTemplate, HubListener):
             defined data set.
         """
         if ('mosviz_row' in self.state.settings and
-            not (self.get_viewer("table-viewer").row_selection_in_progress) and
+            not (self.get_viewer(
+                self._jdaviz_helper._default_table_viewer_reference_name
+            ).row_selection_in_progress) and
             self.data_collection[data_label].meta['mosviz_row'] !=
                 self.state.settings['mosviz_row']):
             raise NotImplementedError("Intra-row plotting not supported. "

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1572,8 +1572,7 @@ class Application(VuetifyTemplate, HubListener):
         return [self._viewer_item_by_id(vid).get('reference') for vid in self._viewer_store]
 
     def update_viewer_reference_name(
-        self, old_reference, new_reference,
-        old_reference_helper_attr=None, update_id=False
+        self, old_reference, new_reference, update_id=False
     ):
         """
         Update viewer reference names.
@@ -1586,9 +1585,6 @@ class Application(VuetifyTemplate, HubListener):
             The viewer reference name to be changed
         new_reference : str
             The viewer reference name to use instead of ``old_reference``
-        old_reference_helper_attr : str, optional
-            If one exists, update the helper's attribute `old_reference_helper_attr`
-            with the new viewer reference name. Default is None.
         update_id : bool, optional
             If True, update the viewer IDs as well as the viewer reference names.
         """
@@ -1610,19 +1606,15 @@ class Application(VuetifyTemplate, HubListener):
             self._viewer_store[new_reference] = self._viewer_store.pop(old_id)
             self.state.viewer_icons[new_reference] = self.state.viewer_icons.pop(old_id)
 
-        # Update the viewer name attributes on the helper. First check if
-        # an attr for this viewer reference name is stored on the helper:
-        if old_reference_helper_attr is None:
-            old_viewer_ref_attrs = [
-                attr for attr in dir(self._jdaviz_helper)
-                if old_reference.replace('-', '_') in attr
-            ]
-            if old_viewer_ref_attrs:
-                old_reference_helper_attr = old_viewer_ref_attrs[0]
-
-        # if there is a detectable attr to update, update it:
-        if old_reference_helper_attr:
-            setattr(self._jdaviz_helper, old_reference_helper_attr, new_reference)
+        # update the viewer name attributes on the helper:
+        old_viewer_ref_attrs = [
+            attr for attr in dir(self._jdaviz_helper)
+            if attr.startswith('_default_') and
+            getattr(self._jdaviz_helper, attr) == old_reference
+        ]
+        if old_viewer_ref_attrs:
+            # if there is an attr to update, update it:
+            setattr(self._jdaviz_helper, old_viewer_ref_attrs[0], new_reference)
 
         self.hub.broadcast(ViewerRenamedMessage(old_reference, new_reference, sender=self))
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1593,12 +1593,20 @@ class Application(VuetifyTemplate, HubListener):
         if old_reference == new_reference:  # no-op
             return
 
-        if new_reference in self.get_viewer_reference_names():
+        # ensure new reference is a string:
+        new_reference = str(new_reference)
+
+        viewer_reference_names = self.get_viewer_reference_names()
+
+        if new_reference in viewer_reference_names:
             raise ValueError(f"Viewer with reference='{new_reference}' already exists.")
 
         if old_reference == 'imviz-0':
             raise ValueError(f"The default Imviz viewer reference "
                              f"'{old_reference}' cannot be changed.")
+
+        if old_reference not in viewer_reference_names:
+            raise ValueError(f"Viewer with reference='{old_reference}' does not exist.")
 
         # update the viewer item's reference name
         viewer_item = self._get_viewer_item(old_reference)

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1573,7 +1573,7 @@ class Application(VuetifyTemplate, HubListener):
         # Cannot sort because of None
         return [self._viewer_item_by_id(vid).get('reference') for vid in self._viewer_store]
 
-    def update_viewer_reference_name(
+    def _update_viewer_reference_name(
         self, old_reference, new_reference, update_id=False
     ):
         """
@@ -1591,7 +1591,11 @@ class Application(VuetifyTemplate, HubListener):
             If True, update the viewer IDs as well as the viewer reference names.
         """
         if new_reference in self.get_viewer_reference_names():
-            raise ValueError(f"viewer with reference='{new_reference}' already exists")
+            raise ValueError(f"Viewer with reference='{new_reference}' already exists.")
+
+        if old_reference == 'imviz-0':
+            raise ValueError(f"The default Imviz viewer reference "
+                             f"'{old_reference}' cannot be changed.")
 
         # update the viewer item's reference name
         viewer_item = self._get_viewer_item(old_reference)

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1590,6 +1590,9 @@ class Application(VuetifyTemplate, HubListener):
         update_id : bool, optional
             If True, update the viewer IDs as well as the viewer reference names.
         """
+        if old_reference == new_reference:  # no-op
+            return
+
         if new_reference in self.get_viewer_reference_names():
             raise ValueError(f"Viewer with reference='{new_reference}' already exists.")
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1577,7 +1577,7 @@ class Application(VuetifyTemplate, HubListener):
         """
         Update viewer reference names.
 
-        Viewer IDs will not be changed unless `update_id` is True.
+        Viewer IDs will not be changed unless ``update_id`` is True.
 
         Parameters
         ----------

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -60,15 +60,11 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
 
     @property
     def _default_image_viewer_reference_name(self):
-        return getattr(
-            self.jdaviz_helper, '_default_image_viewer_reference_name', 'image-viewer'
-        )
+        return self.jdaviz_helper._default_image_viewer_reference_name
 
     @property
     def _default_spectrum_viewer_reference_name(self):
-        return getattr(
-            self.jdaviz_helper, '_default_spectrum_viewer_reference_name', 'spectrum-viewer'
-        )
+        return self.jdaviz_helper._default_spectrum_viewer_reference_name
 
     @property
     def user_api(self):

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -51,18 +51,24 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
     overwrite_warn = Bool(False).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
-        self._default_spectrum_viewer_reference_name = kwargs.get(
-            "spectrum_viewer_reference_name", "spectrum-viewer"
-        )
-        self._default_image_viewer_reference_name = kwargs.get(
-            "image_viewer_reference_name", "image-viewer"
-        )
         super().__init__(*args, **kwargs)
 
         self.moment = None
 
         self.dataset.add_filter('is_cube')
         self.add_results.viewer.filters = ['is_image_viewer']
+
+    @property
+    def _default_image_viewer_reference_name(self):
+        return getattr(
+            self.jdaviz_helper, '_default_image_viewer_reference_name', 'image-viewer'
+        )
+
+    @property
+    def _default_spectrum_viewer_reference_name(self):
+        return getattr(
+            self.jdaviz_helper, '_default_spectrum_viewer_reference_name', 'spectrum-viewer'
+        )
 
     @property
     def user_api(self):

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -289,10 +289,10 @@ def _parse_jwst_s3d(app, hdulist, data_label, ext='SCI',
         app.add_data_to_viewer(spectrum_viewer_reference_name, data_label)
 
 
-def _parse_esa_s3d(app, hdulist, data_label, ext='DATA', spectrum_viewer_reference_name=None):
+def _parse_esa_s3d(app, hdulist, data_label, ext='DATA', flux_viewer_reference_name=None,
+                   spectrum_viewer_reference_name=None):
     hdu = hdulist[ext]
     data_type = _get_data_type_by_hdu(hdu)
-    flux_viewer_reference_name = viewer_name = app._default_flux_viewer_reference_name
 
     if ext == 'QUALITY':  # QUALITY flags have no unit
         flux = hdu.data << u.dimensionless_unscaled
@@ -327,9 +327,8 @@ def _parse_esa_s3d(app, hdulist, data_label, ext='DATA', spectrum_viewer_referen
     if data_type == 'flux':  # Forced wave unit conversion made it lose stuff, so re-add
         app.data_collection[-1].get_component("flux").units = flux.unit
 
-    app.add_data_to_viewer(viewer_name, data_label)
-    if viewer_name == flux_viewer_reference_name:
-        app.add_data_to_viewer(spectrum_viewer_reference_name, data_label)
+    app.add_data_to_viewer(flux_viewer_reference_name, data_label)
+    app.add_data_to_viewer(spectrum_viewer_reference_name, data_label)
 
 
 def _parse_spectrum1d_3d(app, file_obj, data_label=None,

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -289,10 +289,10 @@ def _parse_jwst_s3d(app, hdulist, data_label, ext='SCI',
         app.add_data_to_viewer(spectrum_viewer_reference_name, data_label)
 
 
-def _parse_esa_s3d(app, hdulist, data_label, ext='DATA', viewer_name='flux-viewer',
-                   flux_viewer_reference_name=None, spectrum_viewer_reference_name=None):
+def _parse_esa_s3d(app, hdulist, data_label, ext='DATA', spectrum_viewer_reference_name=None):
     hdu = hdulist[ext]
     data_type = _get_data_type_by_hdu(hdu)
+    flux_viewer_reference_name = viewer_name = app._default_flux_viewer_reference_name
 
     if ext == 'QUALITY':  # QUALITY flags have no unit
         flux = hdu.data << u.dimensionless_unscaled

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.py
@@ -54,12 +54,6 @@ class Slice(PluginTemplateMixin):
     play_interval = Int(200).tag(sync=True)  # milliseconds
 
     def __init__(self, *args, **kwargs):
-        self._default_spectrum_viewer_reference_name = kwargs.get(
-            "spectrum_viewer_reference_name", "spectrum-viewer"
-        )
-        self._default_image_viewer_reference_name = kwargs.get(
-            "image_viewer_reference_name", "image-viewer"
-        )
         super().__init__(*args, **kwargs)
 
         self._watched_viewers = []
@@ -88,6 +82,18 @@ class Slice(PluginTemplateMixin):
         # update internal wavelength when x display unit is changed (preserving slice)
         self.session.hub.subscribe(self, GlobalDisplayUnitChanged,
                                    handler=self._on_global_display_unit_changed)
+
+    @property
+    def _default_spectrum_viewer_reference_name(self):
+        return getattr(
+            self.app._jdaviz_helper, '_default_spectrum_viewer_reference_name', 'spectrum-viewer'
+        )
+
+    @property
+    def _default_image_viewer_reference_name(self):
+        return getattr(
+            self.app._jdaviz_helper, '_default_image_viewer_reference_name', 'image-viewer'
+        )
 
     @property
     def user_api(self):

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.py
@@ -85,15 +85,11 @@ class Slice(PluginTemplateMixin):
 
     @property
     def _default_spectrum_viewer_reference_name(self):
-        return getattr(
-            self.app._jdaviz_helper, '_default_spectrum_viewer_reference_name', 'spectrum-viewer'
-        )
+        return self.app._jdaviz_helper_default_spectrum_viewer_reference_name
 
     @property
     def _default_image_viewer_reference_name(self):
-        return getattr(
-            self.app._jdaviz_helper, '_default_image_viewer_reference_name', 'image-viewer'
-        )
+        return self.app._jdaviz_helper._default_image_viewer_reference_name
 
     @property
     def user_api(self):

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -33,18 +33,26 @@ class CubevizImageView(JdavizViewerMixin, BqplotImageView):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._default_flux_viewer_reference_name = kwargs.get(
-            "flux_viewer_reference_name", "flux-viewer"
-        )
-        self._default_uncert_viewer_reference_name = kwargs.get(
-            "uncert_viewer_reference_name", "uncert-viewer"
-        )
-        self._default_spectrum_viewer_reference_name = kwargs.get(
-            "spectrum_viewer_reference_name", "spectrum-viewer"
-        )
-
         self._subscribe_to_layers_update()
         self.state.add_callback('reference_data', self._initial_x_axis)
+
+    @property
+    def _default_spectrum_viewer_reference_name(self):
+        return getattr(
+            self.jdaviz_helper, '_default_spectrum_viewer_reference_name', 'spectrum-viewer'
+        )
+
+    @property
+    def _default_flux_viewer_reference_name(self):
+        return getattr(
+            self.jdaviz_helper, '_default_flux_viewer_reference_name', 'flux-viewer'
+        )
+
+    @property
+    def _default_uncert_viewer_reference_name(self):
+        return getattr(
+            self.jdaviz_helper, '_default_uncert_viewer_reference_name', 'uncert-viewer'
+        )
 
     @property
     def active_image_layer(self):
@@ -104,9 +112,6 @@ class CubevizProfileView(SpecvizProfileView):
         kwargs.setdefault('default_tool_priority', ['jdaviz:selectslice'])
         super().__init__(*args, **kwargs)
 
-        self._default_flux_viewer_reference_name = kwargs.get(
-            "flux_viewer_reference_name", "flux-viewer"
-        )
         self.hub.subscribe(self, RemoveDataMessage,
                            handler=self._check_if_data_removed)
 
@@ -116,6 +121,12 @@ class CubevizProfileView(SpecvizProfileView):
 
         self.hub.subscribe(self, AddDataMessage,
                            handler=self._check_if_data_added)
+
+    @property
+    def _default_flux_viewer_reference_name(self):
+        return getattr(
+            self.jdaviz_helper, '_default_flux_viewer_reference_name', 'flux-viewer'
+        )
 
     def _check_if_data_removed(self, msg):
         # isinstance and the data uuid check will be true for the data

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -38,21 +38,15 @@ class CubevizImageView(JdavizViewerMixin, BqplotImageView):
 
     @property
     def _default_spectrum_viewer_reference_name(self):
-        return getattr(
-            self.jdaviz_helper, '_default_spectrum_viewer_reference_name', 'spectrum-viewer'
-        )
+        return self.jdaviz_helper_default_spectrum_viewer_reference_name
 
     @property
     def _default_flux_viewer_reference_name(self):
-        return getattr(
-            self.jdaviz_helper, '_default_flux_viewer_reference_name', 'flux-viewer'
-        )
+        return self.jdaviz_helper._default_flux_viewer_reference_name
 
     @property
     def _default_uncert_viewer_reference_name(self):
-        return getattr(
-            self.jdaviz_helper, '_default_uncert_viewer_reference_name', 'uncert-viewer'
-        )
+        return self.jdaviz_helper._default_uncert_viewer_reference_name
 
     @property
     def active_image_layer(self):
@@ -124,9 +118,7 @@ class CubevizProfileView(SpecvizProfileView):
 
     @property
     def _default_flux_viewer_reference_name(self):
-        return getattr(
-            self.jdaviz_helper, '_default_flux_viewer_reference_name', 'flux-viewer'
-        )
+        return self.jdaviz_helper._default_flux_viewer_reference_name
 
     def _check_if_data_removed(self, msg):
         # isinstance and the data uuid check will be true for the data

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -38,7 +38,7 @@ class CubevizImageView(JdavizViewerMixin, BqplotImageView):
 
     @property
     def _default_spectrum_viewer_reference_name(self):
-        return self.jdaviz_helper_default_spectrum_viewer_reference_name
+        return self.jdaviz_helper._default_spectrum_viewer_reference_name
 
     @property
     def _default_flux_viewer_reference_name(self):

--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -40,10 +40,6 @@ class Collapse(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMixi
 
     def __init__(self, *args, **kwargs):
 
-        self._default_spectrum_viewer_reference_name = kwargs.get(
-            "spectrum_viewer_reference_name", "spectrum-viewer"
-        )
-
         super().__init__(*args, **kwargs)
 
         self._label_counter = 0
@@ -55,6 +51,10 @@ class Collapse(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMixi
 
         self.dataset.add_filter('is_cube')
         self.add_results.viewer.filters = ['is_image_viewer']
+
+    @property
+    def _default_spectrum_viewer_reference_name(self):
+        return self.jdaviz_helper._default_spectrum_viewer_reference_name
 
     @property
     def user_api(self):

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -50,13 +50,6 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._default_spectrum_viewer_reference_name = kwargs.get(
-            "spectrum_viewer_reference_name", "spectrum-viewer"
-        )
-        self._default_flux_viewer_reference_name = kwargs.get(
-            "flux_viewer_reference_name", "flux-viewer"
-        )
-
         if self.config == "cubeviz":
             self.show_modes = True
             # retrieve the data from the cube, not the collapsed 1d spectrum
@@ -80,6 +73,18 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
 
         # set the filter on the viewer options
         self._update_viewer_filters()
+
+    @property
+    def _default_spectrum_viewer_reference_name(self):
+        return getattr(
+            self.app._jdaviz_helper, '_default_spectrum_viewer_reference_name', 'spectrum-viewer'
+        )
+
+    @property
+    def _default_flux_viewer_reference_name(self):
+        return getattr(
+            self.app._jdaviz_helper, '_default_flux_viewer_reference_name', 'flux-viewer'
+        )
 
     @property
     def user_api(self):

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -69,15 +69,10 @@ class LineListTool(PluginTemplateMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._default_spectrum_viewer_reference_name = kwargs.get(
-            "spectrum_viewer_reference_name", "spectrum-viewer"
-        )
-        self._default_flux_viewer_reference_name = kwargs.get(
-            "flux_viewer_reference_name", "flux-viewer"
-        )
         self._viewer = self.app.get_viewer(self._default_spectrum_viewer_reference_name)
         self._spectrum1d = None
-        self.available_lists = self._viewer.available_linelists()
+        if self._viewer:
+            self.available_lists = self._viewer.available_linelists()
         self.list_to_load = None
         self.loaded_lists = ["Custom"]
         self.list_contents = {"Custom": {"lines": [],
@@ -122,12 +117,25 @@ class LineListTool(PluginTemplateMixin):
                            handler=lambda x: self.update_line_mark_dict())
 
         # if set to auto (default), update the slider range when zooming on the spectrum viewer
-        self._viewer.state.add_callback("x_min",
-                                        lambda x_min: self._on_spectrum_viewer_limits_changed())
-        self._viewer.state.add_callback("x_max",
-                                        lambda x_max: self._on_spectrum_viewer_limits_changed())
+        if self._viewer:
+            self._viewer.state.add_callback("x_min",
+                                            lambda x_min: self._on_spectrum_viewer_limits_changed())
+            self._viewer.state.add_callback("x_max",
+                                            lambda x_max: self._on_spectrum_viewer_limits_changed())
 
         self._disable_if_no_data()
+
+    @property
+    def _default_spectrum_viewer_reference_name(self):
+        return getattr(
+            self.app._jdaviz_helper, '_default_spectrum_viewer_reference_name', 'spectrum-viewer'
+        )
+
+    @property
+    def _default_flux_viewer_reference_name(self):
+        return getattr(
+            self.app._jdaviz_helper, '_default_flux_viewer_reference_name', 'flux-viewer'
+        )
 
     def _disable_if_no_data(self):
         if len(self.app.data_collection) == 0:

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -127,15 +127,11 @@ class LineListTool(PluginTemplateMixin):
 
     @property
     def _default_spectrum_viewer_reference_name(self):
-        return getattr(
-            self.app._jdaviz_helper, '_default_spectrum_viewer_reference_name', 'spectrum-viewer'
-        )
+        return self.app._jdaviz_helper._default_spectrum_viewer_reference_name
 
     @property
     def _default_flux_viewer_reference_name(self):
-        return getattr(
-            self.app._jdaviz_helper, '_default_flux_viewer_reference_name', 'flux-viewer'
-        )
+        return self.app._jdaviz_helper._default_flux_viewer_reference_name
 
     def _disable_if_no_data(self):
         if len(self.app.data_collection) == 0:

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -127,11 +127,15 @@ class LineListTool(PluginTemplateMixin):
 
     @property
     def _default_spectrum_viewer_reference_name(self):
-        return self.app._jdaviz_helper._default_spectrum_viewer_reference_name
+        return getattr(
+            self.app._jdaviz_helper, '_default_spectrum_viewer_reference_name', 'spectrum-viewer'
+        )
 
     @property
     def _default_flux_viewer_reference_name(self):
-        return self.app._jdaviz_helper._default_flux_viewer_reference_name
+        return getattr(
+            self.app._jdaviz_helper, '_default_flux_viewer_reference_name', 'flux-viewer'
+        )
 
     def _disable_if_no_data(self):
         if len(self.app.data_collection) == 0:

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -115,12 +115,6 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._default_spectrum_viewer_reference_name = kwargs.get(
-            "spectrum_viewer_reference_name", "spectrum-viewer"
-        )
-        self._default_flux_viewer_reference_name = kwargs.get(
-            "flux_viewer_reference_name", "flux-viewer"
-        )
         self._units = {}
         self._fitted_model = None
         self._fitted_spectrum = None
@@ -172,6 +166,18 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
         self.hub.subscribe(self, GlobalDisplayUnitChanged,
                            handler=self._on_global_display_unit_changed)
+
+    @property
+    def _default_spectrum_viewer_reference_name(self):
+        return getattr(
+            self.app._jdaviz_helper, '_default_spectrum_viewer_reference_name', 'spectrum-viewer'
+        )
+
+    @property
+    def _default_flux_viewer_reference_name(self):
+        return getattr(
+            self.app._jdaviz_helper, '_default_flux_viewer_reference_name', 'flux-viewer'
+        )
 
     @property
     def user_api(self):

--- a/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
@@ -51,22 +51,36 @@ class SlitOverlay(PluginTemplateMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._default_table_viewer_reference_name = kwargs.get(
-            "table_viewer_reference_name", "table-viewer"
-        )
-        self._default_image_viewer_reference_name = kwargs.get(
-            "image_viewer_reference_name", "image-viewer"
-        )
-        self._default_spectrum_2d_viewer_reference_name = kwargs.get(
-            "spectrum_2d_viewer_reference_name", "spectrum-2d-viewer"
-        )
-        self._default_spectrum_viewer_reference_name = kwargs.get(
-            "spectrum_viewer_reference_name", "spectrum-viewer"
-        )
         table = self.app.get_viewer(self._default_table_viewer_reference_name)
         table.figure_widget.observe(self.place_slit_overlay, names=['highlighted'])
 
         self._slit_overlay_mark = None
+
+    @property
+    def _default_table_viewer_reference_name(self):
+        return getattr(
+            self.app._jdaviz_helper, '_default_table_viewer_reference_name', 'table-viewer'
+        )
+
+    @property
+    def _default_image_viewer_reference_name(self):
+        return getattr(
+            self.app._jdaviz_helper, '_default_image_viewer_reference_name', 'image-viewer'
+        )
+
+    @property
+    def _default_spectrum_viewer_reference_name(self):
+        return getattr(
+            self.app._jdaviz_helper, '_default_spectrum_viewer_reference_name', 'spectrum-viewer'
+        )
+
+    @property
+    def _default_spectrum_2d_viewer_reference_name(self):
+        return getattr(
+            self.app._jdaviz_helper,
+            '_default_spectrum_2d_viewer_reference_name',
+            'spectrum-2d-viewer'
+        )
 
     def vue_change_visible(self, *args, **kwargs):
         if self.visible:

--- a/jdaviz/configs/mosviz/plugins/viewers.py
+++ b/jdaviz/configs/mosviz/plugins/viewers.py
@@ -86,13 +86,6 @@ class MosvizProfile2DView(JdavizViewerMixin, BqplotImageView):
         # Setup viewer option defaults
         self.state.aspect = 'auto'
 
-        self._default_spectrum_viewer_reference_name = kwargs.get(
-            "spectrum_viewer_reference_name", "spectrum-viewer"
-        )
-        self._default_spectrum_viewer_reference_name = kwargs.get(
-            "spectrum_2d_viewer_reference_name", "spectrum-2d-viewer"
-        )
-
         self.session.hub.subscribe(self, AddDataToViewerMessage,
                                    handler=self._on_viewer_data_changed)
         self.session.hub.subscribe(self, RemoveDataFromViewerMessage,
@@ -254,18 +247,21 @@ class MosvizTableViewer(TableViewer, JdavizViewerMixin):
         self._on_row_selected_begin = None
         self._on_row_selected_end = None
 
-        self._default_table_viewer_reference_name = kwargs.get(
-            "table_viewer_reference_name", "table-viewer"
-        )
-        self._default_spectrum_viewer_reference_name = kwargs.get(
-            "spectrum_viewer_reference_name", "spectrum-viewer"
-        )
-        self._default_spectrum_2d_viewer_reference_name = kwargs.get(
-            "spectrum_2d_viewer_reference_name", "spectrum-2d-viewer"
-        )
-        self._default_image_viewer_reference_name = kwargs.get(
-            "image_viewer_reference_name", "image-viewer"
-        )
+    @property
+    def _default_table_viewer_reference_name(self):
+        return self.jdaviz_helper._default_table_viewer_reference_name
+
+    @property
+    def _default_spectrum_viewer_reference_name(self):
+        return self.jdaviz_helper._default_spectrum_viewer_reference_name
+
+    @property
+    def _default_spectrum_2d_viewer_reference_name(self):
+        return self.jdaviz_helper._default_spectrum_2d_viewer_reference_name
+
+    @property
+    def _default_image_viewer_reference_name(self):
+        return self.jdaviz_helper._default_image_viewer_reference_name
 
     def redraw(self):
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -120,10 +120,6 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
 
     def __init__(self, *args, **kwargs):
 
-        self._default_spectrum_viewer_reference_name = kwargs.get(
-            "spectrum_viewer_reference_name", "spectrum-viewer"
-        )
-
         super().__init__(**kwargs)
 
         self.update_results(None)
@@ -163,6 +159,12 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
                            handler=self._on_identified_line_changed)
         self.hub.subscribe(self, GlobalDisplayUnitChanged,
                            handler=self._on_global_display_unit_changed)
+
+    @property
+    def _default_spectrum_viewer_reference_name(self):
+        return getattr(
+            self.app._jdaviz_helper, '_default_spectrum_viewer_reference_name', 'spectrum-viewer'
+        )
 
     @property
     def user_api(self):
@@ -233,6 +235,8 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
     def marks(self):
         marks = {}
         viewer = self.app.get_viewer(self._default_spectrum_viewer_reference_name)
+        if viewer is None:
+            return {}
         for mark in viewer.figure.marks:
             if isinstance(mark, LineAnalysisContinuum):
                 # NOTE: we don't use isinstance anymore because of nested inheritance

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -162,9 +162,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
 
     @property
     def _default_spectrum_viewer_reference_name(self):
-        return getattr(
-            self.app._jdaviz_helper, '_default_spectrum_viewer_reference_name', 'spectrum-viewer'
-        )
+        return self.app._jdaviz_helper._default_spectrum_viewer_reference_name
 
     @property
     def user_api(self):

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -162,7 +162,9 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
 
     @property
     def _default_spectrum_viewer_reference_name(self):
-        return self.app._jdaviz_helper._default_spectrum_viewer_reference_name
+        return getattr(
+            self.app._jdaviz_helper, '_default_spectrum_viewer_reference_name', 'spectrum-viewer'
+        )
 
     @property
     def user_api(self):

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -197,12 +197,6 @@ class SpectralExtraction(PluginTemplateMixin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._default_spectrum_viewer_reference_name = kwargs.get(
-            "spectrum_viewer_reference_name", "spectrum-viewer"
-        )
-        self._default_spectrum_2d_viewer_reference_name = kwargs.get(
-            "spectrum_2d_viewer_reference_name", "spectrum-2d-viewer"
-        )
 
         self._marks = {}
         self._do_marks = kwargs.get('interactive', True)
@@ -322,6 +316,14 @@ class SpectralExtraction(PluginTemplateMixin):
         # NOTE: defaults to overwriting original spectrum
         self.ext_add_results.label_whitelist_overwrite = ['Spectrum 1D']
         self.ext_results_label_default = 'Spectrum 1D'
+
+    @property
+    def _default_spectrum_viewer_reference_name(self):
+        return self.jdaviz_helper._default_spectrum_viewer_reference_name
+
+    @property
+    def _default_spectrum_2d_viewer_reference_name(self):
+        return self.jdaviz_helper._default_spectrum_2d_viewer_reference_name
 
     @property
     def user_api(self):

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -319,11 +319,11 @@ class SpectralExtraction(PluginTemplateMixin):
 
     @property
     def _default_spectrum_viewer_reference_name(self):
-        return self.jdaviz_helper._default_spectrum_viewer_reference_name
+        return self.app._jdaviz_helper._default_spectrum_viewer_reference_name
 
     @property
     def _default_spectrum_2d_viewer_reference_name(self):
-        return self.jdaviz_helper._default_spectrum_2d_viewer_reference_name
+        return self.app._jdaviz_helper._default_spectrum_2d_viewer_reference_name
 
     @property
     def user_api(self):

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -59,6 +59,23 @@ class ViewerRemovedMessage(Message):
         return self._viewer_id
 
 
+class ViewerRenamedMessage(Message):
+    """Message emitted after a viewer is destroyed by the application."""
+    def __init__(self, old_viewer_ref, new_viewer_ref, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._old_viewer_ref = old_viewer_ref
+        self._new_viewer_ref = new_viewer_ref
+
+    @property
+    def old_viewer_ref(self):
+        return self._old_viewer_ref
+
+    @property
+    def new_viewer_ref(self):
+        return self._new_viewer_ref
+
+
 class LoadDataMessage(Message):
     def __init__(self, path, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -27,8 +27,10 @@ from ipywidgets import widget_serialization
 from ipypopout import PopoutButton
 
 from jdaviz import __version__
-from jdaviz.core.events import (AddDataMessage, RemoveDataMessage,
-                                ViewerAddedMessage, ViewerRemovedMessage)
+from jdaviz.core.events import (
+    AddDataMessage, RemoveDataMessage, ViewerAddedMessage, ViewerRemovedMessage,
+    ViewerRenamedMessage
+)
 from jdaviz.core.user_api import UserApiWrapper, PluginUserApi
 from jdaviz.utils import get_subset_type
 
@@ -1324,6 +1326,7 @@ class ViewerSelect(SelectPluginComponent):
 
         self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewers_changed)
         self.hub.subscribe(self, ViewerRemovedMessage, handler=self._on_viewers_changed)
+        self.hub.subscribe(self, ViewerRenamedMessage, handler=self._on_viewers_changed)
 
         # initialize viewer_items from original viewers
         self._on_viewers_changed()

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1115,15 +1115,13 @@ class SubsetSelect(SelectPluginComponent):
 
     @cached_property
     def selected_obj(self):
-        if self.selected in self.manual_options or self.selected not in self.labels:
+        if (
+            self.selected in self.manual_options or
+            self.selected not in self.labels or
+            self.selected is None
+        ):
             return None
-        # NOTE: we use reference names here instead of IDs since get_subsets requires
-        # that.  For imviz, this will mean we won't be able to loop through each of the viewers,
-        # but the original viewer should have access to all the subsets.
-        for viewer_ref in self.viewer_refs:
-            match = self.app.get_subsets(self.selected)
-            if match is not None:
-                return match
+        return self.app.get_subsets(self.selected)
 
     @property
     def selected_subset_state(self):

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -141,3 +141,20 @@ def test_case_that_used_to_break_return_label(specviz_helper, spectrum1d):
     dc = specviz_helper.app.data_collection
     assert dc[0].label == "this used to break (1)"
     assert dc[1].label == "this used to break (2)"
+
+
+def test_viewer_renaming():
+    viewer_names = [
+        'spectrum-viewer',
+        'second-viewer-name',
+        'third-viewer-name'
+    ]
+
+    specviz = Specviz()
+
+    for i in range(len(viewer_names) - 1):
+        specviz.app.update_viewer_reference_name(
+            old_reference=viewer_names[i],
+            new_reference=viewer_names[i + 1]
+        )
+        assert specviz.app.get_viewer(viewer_names[i+1]) is not None

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -143,7 +143,7 @@ def test_case_that_used_to_break_return_label(specviz_helper, spectrum1d):
     assert dc[1].label == "this used to break (2)"
 
 
-def test_viewer_renaming(specviz_helper, imviz_helper):
+def test_viewer_renaming_specviz(specviz_helper):
     viewer_names = [
         'spectrum-viewer',
         'second-viewer-name',
@@ -157,7 +157,9 @@ def test_viewer_renaming(specviz_helper, imviz_helper):
         )
         assert specviz_helper.app.get_viewer(viewer_names[i+1]) is not None
 
-    with pytest.raises(ValueError):
+
+def test_viewer_renaming_imviz(imviz_helper):
+    with pytest.raises(ValueError, match='already exists'):
         imviz_helper.app._update_viewer_reference_name(
             old_reference='imviz-0',
             new_reference='this-is-forbidden'

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -143,18 +143,16 @@ def test_case_that_used_to_break_return_label(specviz_helper, spectrum1d):
     assert dc[1].label == "this used to break (2)"
 
 
-def test_viewer_renaming():
+def test_viewer_renaming(specviz_helper):
     viewer_names = [
         'spectrum-viewer',
         'second-viewer-name',
         'third-viewer-name'
     ]
 
-    specviz = Specviz()
-
     for i in range(len(viewer_names) - 1):
-        specviz.app.update_viewer_reference_name(
+        specviz_helper.app.update_viewer_reference_name(
             old_reference=viewer_names[i],
             new_reference=viewer_names[i + 1]
         )
-        assert specviz.app.get_viewer(viewer_names[i+1]) is not None
+        assert specviz_helper.app.get_viewer(viewer_names[i+1]) is not None

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -143,7 +143,7 @@ def test_case_that_used_to_break_return_label(specviz_helper, spectrum1d):
     assert dc[1].label == "this used to break (2)"
 
 
-def test_viewer_renaming(specviz_helper):
+def test_viewer_renaming(specviz_helper, imviz_helper):
     viewer_names = [
         'spectrum-viewer',
         'second-viewer-name',
@@ -151,8 +151,14 @@ def test_viewer_renaming(specviz_helper):
     ]
 
     for i in range(len(viewer_names) - 1):
-        specviz_helper.app.update_viewer_reference_name(
+        specviz_helper.app._update_viewer_reference_name(
             old_reference=viewer_names[i],
             new_reference=viewer_names[i + 1]
         )
         assert specviz_helper.app.get_viewer(viewer_names[i+1]) is not None
+
+    with pytest.raises(ValueError):
+        imviz_helper.app._update_viewer_reference_name(
+            old_reference='imviz-0',
+            new_reference='this-is-forbidden'
+        )

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -159,8 +159,14 @@ def test_viewer_renaming_specviz(specviz_helper):
 
 
 def test_viewer_renaming_imviz(imviz_helper):
-    with pytest.raises(ValueError, match='already exists'):
+    with pytest.raises(ValueError, match="'imviz-0' cannot be changed"):
         imviz_helper.app._update_viewer_reference_name(
             old_reference='imviz-0',
+            new_reference='this-is-forbidden'
+        )
+
+    with pytest.raises(ValueError, match="does not exist"):
+        imviz_helper.app._update_viewer_reference_name(
+            old_reference='non-existent',
             new_reference='this-is-forbidden'
         )


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description

This PR adds a public method to `Application` for updating viewer reference names. A lot of generalization was done in https://github.com/spacetelescope/jdaviz/pull/1681 to remove many hard-coded references to viewer reference names like `flux-viewer` and `spectrum-viewer` in favor of attributes on each helper, though no public methods were added for self-consistently changing viewer reference names. This is functionality has been implemented downstream in https://github.com/spacetelescope/lcviz/pull/19, where it is useful for dynamically generating new viewers with custom names. 

This PR moves that functionality into jdaviz, with a few generalizations to make it compatible with both jdaviz and LCviz. I've also found a bunch of places in plugins where we can use a `property` tag to dynamically provide the up-to-date viewer reference names at runtime, rather than only one time at initialization, so that name updates don't break plugins.

There's a corresponding LCviz PR to use the new, superseding jdaviz methods: https://github.com/spacetelescope/lcviz/pull/35

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3680)
