### PR TITLE
BUG: Throw error on invalid path in save_figure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,9 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Explot Plot now throws exception if its "save_figure" method is called
+  with a path that contains invalid directory. [#2339]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
@@ -91,3 +91,13 @@ def test_export_movie_cubeviz_empty(cubeviz_helper):
 
     with pytest.raises(ValueError, match="Selected viewer has no display shape"):
         plugin.save_movie(i_start=0, i_end=1)
+
+
+def test_export_plot_exceptions(cubeviz_helper):
+    plugin = cubeviz_helper.plugins["Export Plot"]
+
+    with pytest.raises(NotImplementedError, match="filetype.*not supported"):
+        plugin.save_figure(filetype="gif")
+
+    with pytest.raises(ValueError, match="Invalid path"):
+        plugin.save_figure(filename="/fake/path/image.png")

--- a/jdaviz/configs/default/plugins/export_plot/export_plot.py
+++ b/jdaviz/configs/default/plugins/export_plot/export_plot.py
@@ -91,7 +91,7 @@ class ExportViewer(PluginTemplateMixin, ViewerSelectMixin):
 
         """
         if filename is not None:
-            filename = Path(filename)
+            filename = Path(filename).expanduser()
 
         if filetype is None:
             if filename is not None and filename.suffix:
@@ -235,11 +235,11 @@ class ExportViewer(PluginTemplateMixin, ViewerSelectMixin):
 
         if filename is None:
             if self.movie_filename:
-                filename = Path(self.movie_filename)
+                filename = self.movie_filename
             else:
                 raise ValueError("Invalid filename.")
-        else:
-            filename = Path(filename)
+
+        filename = Path(filename).expanduser()
 
         if filetype is None:
             if filename.suffix:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to accomplish 2 things:

* Throw explicit exception when a given path to save_figure in Export Plot plugin contains directory that does not exist (instead of failing silently).
* Also refactor the plugin to use `pathlib.Path` as @duytnguyendtn wanted.

I added tests for the exceptions but I cannot test the actual file saving functionality because CI will hang when the saving is farmed out to JS by bqplot (https://github.com/bqplot/bqplot/pull/1397/files#r726500097).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3655)
