### PR TITLE
Plugin user API: inapplicable attrs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ Specviz2d
 API Changes
 -----------
 
+- Plugin user APIs now hide attributes that are not applicable based on the values of other options
+  within the plugin. [#2347]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -31,7 +31,7 @@
           </v-switch>
         </v-row>
 
-        <v-row v-if="link_type_selected == 'WCS'">
+        <v-row v-if="!inapplicable_attrs.includes('wcs_use_affine')">
           <v-switch
             label="Fast approximation"
             hint="Use fast approximation for image alignment if possible (accurate to <1 pixel)."

--- a/jdaviz/configs/imviz/tests/test_links_control.py
+++ b/jdaviz/configs/imviz/tests/test_links_control.py
@@ -29,3 +29,13 @@ class TestLinksControl(BaseImviz_WCS_WCS):
 
         assert lc_plugin.need_clear_markers is False
         lc_plugin.link_type.selected = 'WCS'
+
+    def test_user_api(self):
+        lc_plugin = self.imviz.plugins['Links Control']
+        assert lc_plugin.link_type == 'Pixels'
+        # wcs_use_affine is inapplicable when link_type == 'Pixels'
+        with pytest.raises(AttributeError):
+            lc_plugin.wcs_use_affine
+
+        lc_plugin.link_type = 'WCS'
+        assert lc_plugin.wcs_use_affine is True


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements the concept of "inapplicable attributes" for a plugin which then disables access to that attribute (method, traitlet, etc) within the user API based on conditions defined in the plugin.  As a proof-of-concept, this is then implemented within the links control plugin to toggle the visibility of the "wcs_use_affine" traitlet based on the value of "link_type", but would be useful across many plugins used in jdaviz.

https://github.com/spacetelescope/jdaviz/assets/877591/03b12b8e-6290-4126-9e46-051a96de024c


This was originally implemented for #2341, but after generalizing the code so that all instruments accepted the same input arguments, was no longer necessary there, so I'm opening as its own PR in case we still would want something like this to use across other plugins.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
