### PR TITLE
Debug standalone binary build

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -7,6 +7,7 @@ on:
     - 'v*'
     tags:
     - 'v*'
+  pull_request:
 
 defaults:
   run:
@@ -113,7 +114,7 @@ jobs:
       uses: ifaxity/wait-on-action@v1
       with:
         resource: tcp:8866
-        timeout: 60000
+        timeout: 180000
 
     - name: Test standalone
       run: (cd standalone; touch pytest.ini; JUPYTER_PLATFORM_DIRS=1 pytest test.py --video=on)

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -10,8 +10,6 @@ on:
   pull_request_target:
     branches:
       - 'debug-standalone-build'
-    paths:
-      - 'standalone.yml'
 
 defaults:
   run:

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -7,7 +7,11 @@ on:
     - 'v*'
     tags:
     - 'v*'
-  pull_request:
+  pull_request_target:
+    branches:
+      - 'debug-standalone-build'
+    paths:
+      - 'standalone.yml'
 
 defaults:
   run:


### PR DESCRIPTION
Does what it says on the tin. This build was passing in https://github.com/spacetelescope/jdaviz/pull/1960, trying to figure out what changed. Note that I temporarily enabled the stand alone build for PRs so I can see test it here, this will be dropped before merge.