### PR TITLE
Improve Imviz parser for Roman-like ASDF files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Improved ASDF parsing support for non-standard Roman-like data products [#2351]
+
 Mosviz
 ^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,7 +83,7 @@ Cubeviz
 Imviz
 ^^^^^
 
-- Improved ASDF parsing support for non-standard Roman-like data products [#2351]
+- Improved ASDF parsing support for non-standard Roman-like data products. [#2351]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -157,7 +157,7 @@ def get_image_data_iterator(app, file_obj, data_label, ext=None):
 
     # load ASDF files that may not validate as Roman datamodels:
     elif isinstance(file_obj, asdf.AsdfFile):
-        data_iter = _asdf_2d_to_glue_data(file_obj, data_label, ext=ext)
+        data_iter = _roman_asdf_2d_to_glue_data(file_obj, data_label, ext=ext)
 
     else:
         raise NotImplementedError(f'Imviz does not support {file_obj}')

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -342,7 +342,7 @@ def _roman_2d_to_glue_data(file_obj, data_label, ext=None):
         yield data, new_data_label
 
 
-def _asdf_2d_to_glue_data(file_obj, data_label, ext=None):
+def _roman_asdf_2d_to_glue_data(file_obj, data_label, ext=None):
     if ext == '*' or ext is None:
         # NOTE: Update as needed. Should cover all the image extensions available.
         ext_list = ('data', 'dq', 'err', 'var_poisson', 'var_rnoise')

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -1,5 +1,6 @@
 import os
 
+import asdf
 import numpy as np
 from astropy import units as u
 from astropy.io import fits
@@ -76,12 +77,14 @@ def parse_data(app, file_obj, ext=None, data_label=None):
             _parse_image(app, pf, data_label, ext=ext)
 
         elif file_obj_lower.endswith('.asdf'):
-            if not HAS_ROMAN_DATAMODELS:
-                raise ImportError(
-                    "ASDF detected but roman-datamodels is not installed."
-                )
-            with rdd.open(file_obj) as pf:
-                _parse_image(app, pf, data_label, ext=ext)
+            try:
+                if HAS_ROMAN_DATAMODELS:
+                    with rdd.open(file_obj) as pf:
+                        _parse_image(app, pf, data_label, ext=ext)
+            except TypeError:
+                # if roman_datamodels cannot parse the file, load it with asdf:
+                with asdf.open(file_obj) as af:
+                    _parse_image(app, af, data_label, ext=ext)
 
         elif file_obj_lower.endswith('.reg'):
             # This will load DS9 regions as Subset but only if there is already data.
@@ -148,9 +151,13 @@ def get_image_data_iterator(app, file_obj, data_label, ext=None):
     elif isinstance(file_obj, np.ndarray):
         data_iter = _ndarray_to_glue_data(file_obj, data_label)
 
-    # Roman 2D datamodels
+    # load Roman 2D datamodels:
     elif HAS_ROMAN_DATAMODELS and isinstance(file_obj, rdd.DataModel):
         data_iter = _roman_2d_to_glue_data(file_obj, data_label, ext=ext)
+
+    # load ASDF files that may not validate as Roman datamodels:
+    elif isinstance(file_obj, asdf.AsdfFile):
+        data_iter = _asdf_2d_to_glue_data(file_obj, data_label, ext=ext)
 
     else:
         raise NotImplementedError(f'Imviz does not support {file_obj}')
@@ -333,6 +340,35 @@ def _roman_2d_to_glue_data(file_obj, data_label, ext=None):
         data.meta.update(standardize_metadata(dict(meta)))
 
         yield data, new_data_label
+
+
+def _asdf_2d_to_glue_data(file_obj, data_label, ext=None):
+    if ext == '*' or ext is None:
+        # NOTE: Update as needed. Should cover all the image extensions available.
+        ext_list = ('data', 'dq', 'err', 'var_poisson', 'var_rnoise')
+    elif isinstance(ext, (list, tuple)):
+        ext_list = ext
+    else:
+        ext_list = (ext, )
+
+    roman = file_obj.tree.get('roman')
+    meta = roman.get('meta', {})
+    coords = meta.get('wcs', None)
+
+    for cur_ext in ext_list:
+        if cur_ext in roman:
+            comp_label = cur_ext.upper()
+            new_data_label = f'{data_label}[{comp_label}]'
+            data = Data(coords=coords, label=new_data_label)
+
+            # This could be a quantity or a ndarray:
+            ext_values = roman.get(cur_ext)
+            bunit = getattr(ext_values, 'unit', '')
+            component = Component(np.array(ext_values), units=bunit)
+            data.add_component(component=component, label=comp_label)
+            data.meta.update(standardize_metadata(dict(meta)))
+
+            yield data, new_data_label
 
 
 # ---- Functions that handle input from non-JWST, non-Roman FITS files -----

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -4,7 +4,7 @@ from astropy import units as u
 from astropy.io import fits
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.tests.helper import assert_quantity_allclose
-from astropy.utils.data import download_file, get_pkg_data_filename
+from astropy.utils.data import download_file
 from astropy.wcs import WCS
 from gwcs import WCS as GWCS
 from numpy.testing import assert_allclose, assert_array_equal
@@ -506,7 +506,6 @@ def test_load_valid_not_valid(imviz_helper):
 
 
 @pytest.mark.skipif(not HAS_ROMAN_DATAMODELS, reason="roman_datamodels is not installed")
-def test_roman_parser(imviz_helper):
-    filename = get_pkg_data_filename('data/roman_wfi_image_model.asdf')
-    imviz_helper.load_data(filename)
+def test_roman_parser(imviz_helper, roman_imagemodel):
+    imviz_helper.load_data(roman_imagemodel, data_label='roman_wfi_image_model', ext='data')
     assert len(imviz_helper.app.data_collection) == 1

--- a/jdaviz/configs/imviz/tests/test_parser_asdf.py
+++ b/jdaviz/configs/imviz/tests/test_parser_asdf.py
@@ -1,0 +1,26 @@
+import asdf
+import numpy as np
+import astropy.units as u
+
+from jdaviz.configs.imviz.tests.utils import create_example_gwcs
+
+
+def test_asdf_not_rdm(imviz_helper):
+    # test support for ASDF files that look like Roman files
+    # for users with or without roman_datamodels:
+    in_unit = u.Jy
+    in_data = np.arange(16, dtype=np.float32).reshape((4, 4)) * in_unit
+    tree = {
+        'roman': {
+            'data': in_data,
+            'meta': {
+                'wcs': create_example_gwcs((4, 4))
+            },
+        },
+    }
+
+    af = asdf.AsdfFile(tree=tree)
+    imviz_helper.load_data(af)
+    out_component = imviz_helper.app.data_collection[0].get_component('DATA')
+    np.testing.assert_array_equal(in_data.value, out_component.data)
+    assert str(in_unit) == out_component.units

--- a/jdaviz/configs/imviz/tests/test_parser_roman.py
+++ b/jdaviz/configs/imviz/tests/test_parser_roman.py
@@ -3,7 +3,6 @@ import pytest
 # NOTE: Since this is optional dependency, codecov coverage does not include this test module.
 roman_datamodels = pytest.importorskip("roman_datamodels")
 
-from astropy.utils.data import get_pkg_data_filename
 from gwcs import WCS as GWCS
 
 
@@ -12,9 +11,8 @@ from gwcs import WCS as GWCS
     [(None, 5),
      ('data', 1),
      (['data', 'var_rnoise'], 2)])
-def test_roman_wfi_ext_options(imviz_helper, ext_list, n_dc):
-    filename = get_pkg_data_filename('data/roman_wfi_image_model.asdf')
-    imviz_helper.load_data(filename, ext=ext_list)
+def test_roman_wfi_ext_options(imviz_helper, roman_imagemodel, ext_list, n_dc):
+    imviz_helper.load_data(roman_imagemodel, data_label='roman_wfi_image_model', ext=ext_list)
     dc = imviz_helper.app.data_collection
     assert len(dc) == n_dc
 

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -14,6 +14,8 @@ from astropy.wcs import WCS
 from specutils import Spectrum1D, SpectrumCollection, SpectrumList
 
 from jdaviz import __version__, Cubeviz, Imviz, Mosviz, Specviz, Specviz2d
+from jdaviz.configs.imviz.tests.utils import create_wfi_image_model
+from jdaviz.configs.imviz.plugins.parsers import HAS_ROMAN_DATAMODELS
 
 SPECTRUM_SIZE = 10  # length of spectrum
 
@@ -288,6 +290,12 @@ def mos_image():
     np.random.seed(42)
     data = np.random.sample((55, 55))
     return CCDData(data, wcs=wcs, unit='Jy', meta=header)
+
+
+@pytest.fixture
+@pytest.mark.skipif(not HAS_ROMAN_DATAMODELS, reason="roman_datamodels is not installed")
+def roman_imagemodel():
+    return create_wfi_image_model((20, 10))
 
 
 try:

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -293,9 +293,9 @@ def mos_image():
 
 
 @pytest.fixture
-@pytest.mark.skipif(not HAS_ROMAN_DATAMODELS, reason="roman_datamodels is not installed")
 def roman_imagemodel():
-    return create_wfi_image_model((20, 10))
+    if HAS_ROMAN_DATAMODELS:
+        return create_wfi_image_model((20, 10))
 
 
 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ docs = [
     "sphinx_design"
 ]
 roman = [
-    "roman_datamodels>=0.16.1",
+    "roman_datamodels>=0.17.1",
 ]
 
 [build-system]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

There are lots of "Roman-like" ASDF files that do not pass validation by `roman_datamodels`, but currently on `main`, attempting to parse a file that cannot be fully parsed by `roman_datamodels` raises an error. 

A minimal "Roman-like" image in an ASDF file could be constructed with:
```python
import asdf
import numpy as np

tree = {
    'roman': {
        'data': np.arange(16).reshape((4, 4)),
    },
}

af = asdf.AsdfFile(tree=tree)
```
If the above ASDF file is passed to `roman_datamodels`, an error is raised, even though it's pretty clear that we could parse the `data` node as an image:
```python
>>> import roman_datamodels.datamodels as rdd
>>> rdd.open(af)
TypeError: Unknown datamodel type: <class 'dict'>
```

This PR allows the parser to use `asdf` to look for the usual Roman tree structure in files ending in `".asdf"`, even when `roman_datamodels` can't parse the file. This allows non-standard Roman-like data products to be loaded.

I say "Roman-like" because this parser is still looking for a top-level node called `"roman"`, which is standard in Roman data products. If that node isn't there, this parser will raise an error. If we need in the future, we can revise this parser logic to accept the preferred top-level node as a kwarg.

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3694)
