### PR TITLE
Better axis fonts for spectrum viewers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ Specviz2d
 API Changes
 -----------
 
+- Adjusted axis ticks and labels for spectrum viewers to be more readable.
+  Axes on image viewers no longer show by default. [#2372]
+
 Cubeviz
 ^^^^^^^
 

--- a/docs/cubeviz/plugins.rst
+++ b/docs/cubeviz/plugins.rst
@@ -34,6 +34,7 @@ Plot Options
 ============
 
 This plugin gives access to per-viewer and per-layer plotting options.
+To show axes on image viewers, toggle on the "Show Axes" option at the bottom of the plugin.
 
 .. seealso::
 

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -438,4 +438,16 @@ a:active {
    * appearing */
   overflow: hidden;
 }
+
+.cubeviz .jupyter-widgets.bqplot.figure .axislabel {
+    font-size: 12pt !important;
+}
+
+.specviz .jupyter-widgets.bqplot.figure .axislabel {
+    font-size: 14pt !important;
+}
+
+.specviz2d .jupyter-widgets.bqplot.figure .axislabel {
+    font-size: 12pt !important;
+}
 </style>

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -439,15 +439,11 @@ a:active {
   overflow: hidden;
 }
 
-.cubeviz .jupyter-widgets.bqplot.figure .axislabel {
-    font-size: 12pt !important;
+.jupyter-widgets.bqplot.figure .axislabel {
+    /* consistent with other labels (legend, buttons, plugin expansion menu labels, etc)*/
+    font-size: 15px !important;
+    font-family: Roboto, sans-serif !important;
+    font-weight: 500 !important;
 }
 
-.specviz .jupyter-widgets.bqplot.figure .axislabel {
-    font-size: 14pt !important;
-}
-
-.specviz2d .jupyter-widgets.bqplot.figure .axislabel {
-    font-size: 12pt !important;
-}
 </style>

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -36,6 +36,9 @@ class CubevizImageView(JdavizViewerMixin, BqplotImageView):
         self._subscribe_to_layers_update()
         self.state.add_callback('reference_data', self._initial_x_axis)
 
+        # Hide axes by default
+        self.state.show_axes = False
+
     @property
     def _default_spectrum_viewer_reference_name(self):
         return self.jdaviz_helper._default_spectrum_viewer_reference_name

--- a/jdaviz/configs/mosviz/plugins/viewers.py
+++ b/jdaviz/configs/mosviz/plugins/viewers.py
@@ -213,17 +213,21 @@ class MosvizProfile2DView(JdavizViewerMixin, BqplotImageView):
         self.figure.axes[1].label = "y: pixels"
         self.figure.axes[1].tick_format = None
         self.figure.axes[1].label_location = "middle"
-        self.figure.axes[1].num_ticks = 5
 
         # Sync with Spectrum1D viewer (that is also used by other viz).
         # Make it so y axis label is not covering tick numbers.
-        self.figure.fig_margin["left"] = 80
+        self.figure.fig_margin["left"] = 95
+        self.figure.fig_margin["bottom"] = 60
         self.figure.send_state('fig_margin')  # Force update
         self.figure.axes[0].label_offset = "40"
-        self.figure.axes[1].label_offset = "-65"
+        self.figure.axes[1].label_offset = "-70"
+        # NOTE: with tick_style changed below, the default responsive ticks in bqplot result
+        # in overlapping tick labels.  For now we'll hardcode at 8, but this could be removed
+        # (default to None) if/when bqplot auto ticks react to styling options.
+        self.figure.axes[1].num_ticks = 8
 
         for i in (0, 1):
-            self.figure.axes[i].tick_style = {'font-size': 16, 'font-weight': 'bold'}
+            self.figure.axes[i].tick_style = {'font-size': 15, 'font-weight': 600}
 
 
 @viewer_registry("mosviz-profile-viewer", label="Profile 1D")

--- a/jdaviz/configs/mosviz/plugins/viewers.py
+++ b/jdaviz/configs/mosviz/plugins/viewers.py
@@ -212,10 +212,18 @@ class MosvizProfile2DView(JdavizViewerMixin, BqplotImageView):
 
         self.figure.axes[1].label = "y: pixels"
         self.figure.axes[1].tick_format = None
-        self.figure.axes[1].label_location = "start"
+        self.figure.axes[1].label_location = "middle"
+        self.figure.axes[1].num_ticks = 5
 
+        # Sync with Spectrum1D viewer (that is also used by other viz).
         # Make it so y axis label is not covering tick numbers.
-        self.figure.axes[1].label_offset = "-50"
+        self.figure.fig_margin["left"] = 80
+        self.figure.send_state('fig_margin')  # Force update
+        self.figure.axes[0].label_offset = "40"
+        self.figure.axes[1].label_offset = "-65"
+
+        for i in (0, 1):
+            self.figure.axes[i].tick_style = {'font-size': 16, 'font-weight': 'bold'}
 
 
 @viewer_registry("mosviz-profile-viewer", label="Profile 1D")
@@ -229,6 +237,10 @@ class MosvizProfileView(SpecvizProfileView):
                     ['jdaviz:selectline'],
                     ['jdaviz:sidebar_plot', 'jdaviz:sidebar_export']
                 ]
+
+    def set_plot_axes(self):
+        super().set_plot_axes()
+        self.figure.axes[1].num_ticks = 5
 
 
 @viewer_registry("mosviz-table-viewer", label="Table (Mosviz)")

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -545,13 +545,18 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
         self.figure.axes[1].label = f"{flux_unit_type} [{self.state.y_display_unit}]"
 
         # Make it so axis labels are not covering tick numbers.
-        self.figure.fig_margin["left"] = 80
+        self.figure.fig_margin["left"] = 95
+        self.figure.fig_margin["bottom"] = 60
         self.figure.send_state('fig_margin')  # Force update
         self.figure.axes[0].label_offset = "40"
-        self.figure.axes[1].label_offset = "-65"
+        self.figure.axes[1].label_offset = "-70"
+        # NOTE: with tick_style changed below, the default responsive ticks in bqplot result
+        # in overlapping tick labels.  For now we'll hardcode at 8, but this could be removed
+        # (default to None) if/when bqplot auto ticks react to styling options.
+        self.figure.axes[1].num_ticks = 8
 
         # Set Y-axis to scientific notation
         self.figure.axes[1].tick_format = '0.1e'
 
         for i in (0, 1):
-            self.figure.axes[i].tick_style = {'font-size': 16, 'font-weight': 'bold'}
+            self.figure.axes[i].tick_style = {'font-size': 15, 'font-weight': 600}

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -544,8 +544,14 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
         self.figure.axes[0].label = f"{spectral_axis_unit_type} [{self.state.x_display_unit}]"
         self.figure.axes[1].label = f"{flux_unit_type} [{self.state.y_display_unit}]"
 
-        # Make it so y axis label is not covering tick numbers.
-        self.figure.axes[1].label_offset = "-50"
+        # Make it so axis labels are not covering tick numbers.
+        self.figure.fig_margin["left"] = 80
+        self.figure.send_state('fig_margin')  # Force update
+        self.figure.axes[0].label_offset = "40"
+        self.figure.axes[1].label_offset = "-65"
 
         # Set Y-axis to scientific notation
         self.figure.axes[1].tick_format = '0.1e'
+
+        for i in (0, 1):
+            self.figure.axes[i].tick_style = {'font-size': 16, 'font-weight': 'bold'}


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to make spectrum viewer axes more readable.

Right now:

* Axis label font stuff is hardcoded in `app.vue`.
* Tick label font stuff is not applied until data is loaded.

### Cubeviz

⬇️ Lab + Dark mode + 27" monitor

![cubeviz_darkmode_27in_monitor](https://github.com/spacetelescope/jdaviz/assets/2090236/84195f50-732f-49c1-9d0e-6eb19a556e44)

⬇️ Notebook + Light mode + 13" monitor (the viewer didn't fit on the whole screen)

<img width="756" alt="cubeviz_lightmode_13in_monitor" src="https://github.com/spacetelescope/jdaviz/assets/2090236/a1d8363a-823d-439e-b108-470d23193e5a">

⬇️ Standalone (voila) + Dark mode + 13" monitor (Y-axis label cut off on spectrum viewer)

<img width="960" alt="cubeviz_voila_darkmode_13in_monitor" src="https://github.com/spacetelescope/jdaviz/assets/2090236/4a0ed40f-166a-4a06-bb3e-7f31d34228e2">

### Mosviz

⬇️ Lab + Dark mode + 27" monitor

![specviz2d_darkmode_27in_monitor](https://github.com/spacetelescope/jdaviz/assets/2090236/0ad90e43-04aa-441a-9355-8f8c4aca7c19)

⬇️ Notebook + Light mode + 13" monitor (the viewer didn't fit on the whole screen, Y-axis label got cut off a little)

<img width="741" alt="mosviz_lightmode_13in_monitor" src="https://github.com/spacetelescope/jdaviz/assets/2090236/611f08e3-6a9b-4988-9e6a-2056c747e61b">

⬇️ Standalone (voila) + Light mode (cannot get dark mode to work and it is out of scope anyway and Mosviz parser is not really that robust in standalone mode) + 13" monitor (Y-axis label cut off on spectrum viewer, both spectrum viewers really not useful)

<img width="960" alt="mosviz_voila_lightmode_13in_monitor" src="https://github.com/spacetelescope/jdaviz/assets/2090236/78867002-a22f-48bb-b800-70690a86cd77">

### Specviz

⬇️ Lab + Dark mode + 27" monitor

![specviz_darkmode_27in_monitor](https://github.com/spacetelescope/jdaviz/assets/2090236/7877538d-d3b4-400a-9032-4d47a0f8d29c)

⬇️ Notebook + Light mode + 13" monitor (the viewer didn't fit on the whole screen)

<img width="744" alt="specviz_lightmode_13in_monitor" src="https://github.com/spacetelescope/jdaviz/assets/2090236/d9f08e76-cc80-487c-afab-67e191cae3b2">

⬇️ Standalone (voila) + Dark mode + 13" monitor

<img width="959" alt="specviz_voila_darkmode_13in_monitor" src="https://github.com/spacetelescope/jdaviz/assets/2090236/4cd9d57d-4c51-483e-8439-21fe8c66ce75">

### Specviz2d

⬇️ Lab + Dark mode + 27" monitor

![mosviz_darkmode_27in_monitor](https://github.com/spacetelescope/jdaviz/assets/2090236/437888b5-2e5d-47e2-81e3-d1967b2e36d9)

⬇️ Notebook + Light mode + 13" monitor (the viewer didn't fit on the whole screen)

<img width="738" alt="specviz2d_lightmode_13in_monitor" src="https://github.com/spacetelescope/jdaviz/assets/2090236/eb7b807c-4e77-49fb-b256-1f86717236ea">

⬇️ Standalone (voila) + Dark mode + 13" monitor (Y-axis label is going to cut off for longer flux units)

<img width="960" alt="specviz2d_voila_darkmode_13in_monitor" src="https://github.com/spacetelescope/jdaviz/assets/2090236/3b7c0a63-4eeb-41d8-9b29-dc01c3340230">

### TODO

- [x] "bigger and darker fonts"
- [x] Update screenshots
- [x] What about small screen?
- [x] What about dark mode?

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3707)
