### PR TITLE
PoC: Cubeviz parser for Roman L1 (ramp) products

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -680,6 +680,8 @@ Cubeviz
 - Add Spectral Extraction plugin for Cubeviz, which converts spectral cubes
   to 1D spectra with propagated uncertainties [#2039]
 
+- Support for loading Roman WFI Level 1 (ramp) files [#2376]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -104,10 +104,13 @@ class UnitConverterWithSpectral:
         # should return the converted values. Note that original_units
         # gives the units of the values array, which might not be the same
         # as the original native units of the component in the data.
-        if cid.label == "flux":
+        if cid.label == 'Pixel Axis 0 [z]' and target_units == '':
+            # handle ramps loaded into Cubeviz by avoiding conversion
+            # of the groups axis:
+            return values
+        elif cid.label == "flux":
             try:
                 spec = data.get_object(cls=Spectrum1D)
-
             except RuntimeError:
                 data = data.get_object(cls=NDDataArray)
                 spec = Spectrum1D(flux=data.data * u.Unit(original_units))
@@ -1255,6 +1258,9 @@ class Application(VuetifyTemplate, HubListener):
             elif axis == 'flux':
                 sv = self.get_viewer(self._jdaviz_helper._default_spectrum_viewer_reference_name)
                 return sv.data()[0].flux.unit
+            elif axis == 'data':
+                sv = self.get_viewer(self._jdaviz_helper._default_spectrum_viewer_reference_name)
+                return sv.data()[0].unit
             else:
                 raise ValueError(f"could not find units for axis='{axis}'")
         try:

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -506,7 +506,7 @@ def _parse_spectrum1d(app, file_obj, data_label=None, spectrum_viewer_reference_
 def _parse_ndarray(app, file_obj, data_label=None, data_type=None,
                    flux_viewer_reference_name=None,
                    uncert_viewer_reference_name=None,
-                   meta=None):
+                   meta={}):
     if data_label is None:
         data_label = app.return_data_label(file_obj)
 

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.py
@@ -172,7 +172,7 @@ class Slice(PluginTemplateMixin):
                     # conversion can be done efficiently
                     self._update_data(viewer_data[0].spectral_axis)
                 else:
-                    sample_index = np.arange(1, 1 + viewer_data[0].shape[-1]) * u.one
+                    sample_index = np.arange(viewer_data[0].shape[-1]) * u.one
                     self._update_data(sample_index)
 
             if viewer not in self._indicator_viewers:
@@ -196,7 +196,7 @@ class Slice(PluginTemplateMixin):
             return  # pragma: no cover
 
         if reference_data.meta.get(cubeviz_ramp_meta_flag, False):
-            sample_index = np.arange(1, 1 + reference_data['flux'].shape[-1]) * u.one
+            sample_index = np.arange(reference_data['flux'].shape[-1]) * u.one
             self._update_data(sample_index)
         else:
             self._update_data(reference_data.get_object(cls=Spectrum1D).spectral_axis)

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -167,7 +167,9 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
             self.disabled_msg = 'Line Analysis unavailable without spectral data'
             return
 
-        if viewer_data.spectral_axis.unit == u.pix:
+        if not hasattr(viewer_data, 'spectral_axis'):
+            self.disabled_msg = 'Line Analysis plugin unavailable when viewing ramps'
+        elif viewer_data.spectral_axis.unit == u.pix:
             # disable the plugin until we can address this properly (either using the wavelength
             # solution to support pixels in line-lists, or properly displaying the extracted
             # 1d spectrum in wavelength-space)

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -602,33 +602,29 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
             # default to Flux Density for flux density or uncaught types
             flux_unit_type = "Flux density"
 
-        # Set x axes labels for the spectrum viewer
-        x_disp_unit = self.state.x_display_unit
-
         is_ramp = (
             self.state.reference_data and
             self.state.reference_data.meta.get(cubeviz_ramp_meta_flag, False)
         )
 
-        if not is_ramp:
-            flux_unit_type = "Flux density"
-            x_unit = u.Unit(x_disp_unit) if x_disp_unit else u.dimensionless_unscaled
-            if x_unit.is_equivalent(u.m):
-                spectral_axis_unit_type = "Wavelength"
-            elif x_unit.is_equivalent(u.Hz):
-                spectral_axis_unit_type = "Frequency"
-            elif x_unit.is_equivalent(u.pixel):
-                spectral_axis_unit_type = "Pixel"
-            else:
-                spectral_axis_unit_type = str(x_unit.physical_type).title()
-            x_disp_unit = f'[{self.state.x_display_unit}]'
-        else:
-            flux_unit_type = "Counts"
+        # Set x axes labels for the spectrum viewer
+        x_disp_unit = self.state.x_display_unit
+        x_unit = u.Unit(x_disp_unit) if x_disp_unit else u.dimensionless_unscaled
+
+        if is_ramp:
             spectral_axis_unit_type = "Sample"
-            x_disp_unit = self.state.x_display_unit = ''
+            self.state.x_display_unit = ''
+        elif x_unit.is_equivalent(u.m):
+            spectral_axis_unit_type = "Wavelength"
+        elif x_unit.is_equivalent(u.Hz):
+            spectral_axis_unit_type = "Frequency"
+        elif x_unit.is_equivalent(u.pixel):
+            spectral_axis_unit_type = "Pixel"
+        else:
+            spectral_axis_unit_type = str(x_unit.physical_type).title()
 
         with self.figure.hold_sync():
-            self.figure.axes[0].label = f"{spectral_axis_unit_type} {x_disp_unit}"
+            self.figure.axes[0].label = f"{spectral_axis_unit_type} [{self.state.x_display_unit}]"
             self.figure.axes[1].label = f"{flux_unit_type} [{self.state.y_display_unit}]"
 
             # Make it so axis labels are not covering tick numbers.

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -625,7 +625,7 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
         else:
             flux_unit_type = "Counts"
             spectral_axis_unit_type = "Sample"
-            x_disp_unit = ''
+            x_disp_unit = self.state.x_display_unit = ''
 
         with self.figure.hold_sync():
             self.figure.axes[0].label = f"{spectral_axis_unit_type} {x_disp_unit}"

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3448,6 +3448,17 @@ class DatasetSelect(SelectPluginComponent):
         return self.plugin._specviz_helper.get_data(data_label=self.selected,
                                                     use_display_units=use_display_units)
 
+    def selected_spectrum_for_spatial_subset(self,
+                                             spatial_subset=SPATIAL_DEFAULT_TEXT,
+                                             use_display_units=True,
+                                             cls=None):
+        if spatial_subset == SPATIAL_DEFAULT_TEXT:
+            spatial_subset = None
+        return self.plugin._specviz_helper.get_data(data_label=self.selected,
+                                                    spatial_subset=spatial_subset,
+                                                    use_display_units=use_display_units,
+                                                    cls=cls)
+
     @cached_property
     def selected_spectrum(self):
         return self.get_selected_spectrum(use_display_units=True)

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -69,7 +69,8 @@ class UserApiWrapper:
             return
         elif isinstance(exp_obj, PlotOptionsSyncState):
             if not len(exp_obj.linked_states):
-                raise ValueError("there are currently no synced glue states to set")
+                raise ValueError("There are currently no synced glue states to set. "
+                                 "Check the selected viewer and/or layer.")
 
             # this allows setting the value immediately, and unmixing state, if appropriate,
             # even if the value matches the current value

--- a/notebooks/concepts/cubeviz-roman-ramp.ipynb
+++ b/notebooks/concepts/cubeviz-roman-ramp.ipynb
@@ -1,0 +1,90 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b3e22694-d8ee-4c14-8931-8f8db1d7485d",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## PoC: Visualize a Roman L1 ramp file in Cubeviz\n",
+    "\n",
+    "First download a synthetic Roman L1 file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e80524dd-bcc5-4312-879a-33780e297006",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from urllib.request import urlretrieve\n",
+    "\n",
+    "from jdaviz import Cubeviz\n",
+    "\n",
+    "force_download = False\n",
+    "\n",
+    "url_L1 = \"https://stsci.box.com/shared/static/80vahj27t3y02itfohc22p999snkcocw.asdf\"\n",
+    "local_path = \"L1.asdf\"\n",
+    "\n",
+    "if not os.path.exists(local_path) or force_download:\n",
+    "    urlretrieve(url_L1, local_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f94fbf1-6f4c-4118-917d-de824af57fe6",
+   "metadata": {},
+   "source": [
+    "Open the ramp in Cubeviz:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "863ce611-bf38-4a97-bd1d-c0ff79d36073",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cubeviz = Cubeviz()\n",
+    "cubeviz.load_data(local_path, data_label='Roman L1')\n",
+    "cubeviz.show(height=1000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4312b177-e0d5-45da-95ba-81c910ffff4f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/concepts/cubeviz_wfc3ir_ramp.ipynb
+++ b/notebooks/concepts/cubeviz_wfc3ir_ramp.ipynb
@@ -172,7 +172,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Description

Several folks on the Roman team have requested help visualizing WFI Level 1 (image ramp) products. These data are flux cubes with two spatial dimensions and one "sample"/"group"/"resultant" dimension (these three names sometimes have context-dependent meanings, and sometimes are used interchangeably). Typical ramp cubes for each of the 18 detectors have 4086^2 pixels and ~6 samples per pixel.

This PR implements a proof of concept that allows the user to load the ramps into Cubeviz. A dedicated Roman 3D data parser is introduced for Cubeviz, which updates each Cubeviz viewer name by taking advantage of the viewer reference name update support implemented in #2338.

The repurposed Cubeviz viewers for this use case are: 
* "group-viewer": shows the cumulative flux in each pixel at a specific sample-up-the-ramp or one "group"
* "group-diff-viewer": when group `i` is selected, this viewer shows the flux integrated between groups `i-1` and `i`. This viewer shows an all-zero slice when `i==0`.
* "integration-viewer": by default, shows the median flux of all pixels as a function of group number

Here's what the helper looks like with an L1 file loaded:

https://github.com/spacetelescope/jdaviz/assets/3497584/4801ce11-30f6-4676-8f8e-d25e8d4d392a

Interactive subsets are supported, showing the median flux in the subset for each sample in the integration-viewer:

https://github.com/spacetelescope/jdaviz/assets/3497584/f9619eac-f5a6-4891-8476-ed6b188ded37

The single-pixel subset option allows you to interactively view the ramp for single pixels of interest in the integration viewer. This may be helpful e.g. for finding where/when the core of a PSF saturates, or cosmic ray hits:

https://github.com/spacetelescope/jdaviz/assets/3497584/c27eea48-e49b-4c61-bf03-9576c7d0f54d


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3514)
