### PR TITLE
Adding colormap "curve" to Plot Options stretch histogram

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ Imviz
 
 - Footprints plugin for plotting overlays of instrument footprints in the image viewer. [#2341]
 
+- Add a curve to stretch histograms in the Plot Options plugin representing the colormap
+  stretch function. [#2390]
+
 Mosviz
 ^^^^^^
 

--- a/docs/imviz/displayimages.rst
+++ b/docs/imviz/displayimages.rst
@@ -353,6 +353,18 @@ can be accessed with ``plot_options.stretch_function.choices``:
     plot_options.select_all()
     plot_options.stretch_function = 'Square Root'
 
+
+A histogram is displayed showing the distribution of pixel values, with
+vertical lines representing the ``stretch_vmin`` and ``stretch_vmin``
+values. A stretch "curve" can be plotted under the histogram to represent
+how pixel values are mapped to the colorbar. This feature can be toggled
+on from the API with:
+
+.. code-block:: python
+
+    plot_options = imviz.plugins['Plot Options']
+    plot_options.stretch_curve_visible = True
+
 Percentile
 ----------
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -378,6 +378,8 @@ class PlotOptions(PluginTemplateMixin):
                                                      state_filter=is_image)
         # use add_observe to ensure that the glue state syncs with the traitlet choice:
         self.stretch_function.add_observe('stretch_function_value', self._update_stretch_curve)
+        # self.stretch_function.add_observe('image_contrast_value', self._update_stretch_curve)
+        # self.stretch_function.add_observe('image_bias_value', self._update_stretch_curve)
 
         self.stretch_preset = PlotOptionsSyncState(self, self.viewer, self.layer, 'percentile',
                                                    'stretch_preset_value', 'stretch_preset_sync',
@@ -636,7 +638,8 @@ class PlotOptions(PluginTemplateMixin):
         self._stretch_histogram_needs_update = False
 
     @observe('stretch_vmin_value', 'stretch_vmax_value', 'layer_selected',
-             'stretch_function_value', 'stretch_hist_nbins')
+             'stretch_function_value', 'stretch_hist_nbins',
+             'image_contrast_value', 'image_bias_value')
     def _update_stretch_curve(self, msg=None):
         if not hasattr(self, 'stretch_histogram'):
             return

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -641,7 +641,17 @@ class PlotOptions(PluginTemplateMixin):
              'stretch_function_value', 'stretch_hist_nbins',
              'image_contrast_value', 'image_bias_value')
     def _update_stretch_curve(self, msg=None):
-        if not hasattr(self, 'stretch_histogram'):
+        # Import here to prevent circular import (and not at the top of the method so the import
+        # check is avoided, whenever possible).
+        from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
+        from jdaviz.configs.cubeviz.plugins.viewers import CubevizImageView
+
+        if (
+            not isinstance(self.viewer.selected_obj, (ImvizImageView, CubevizImageView)) or
+            not hasattr(self, 'stretch_histogram')
+        ):
+            # don't update histogram if selected viewer is not an image viewer,
+            # or the stretch histogram hasn't been initialized:
             return
 
         mark_label_prefix = "stretch_curve: "

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -376,6 +376,9 @@ class PlotOptions(PluginTemplateMixin):
         self.stretch_function = PlotOptionsSyncState(self, self.viewer, self.layer, 'stretch',
                                                      'stretch_function_value', 'stretch_function_sync',  # noqa
                                                      state_filter=is_image)
+        # use add_observe to ensure that the glue state syncs with the traitlet choice:
+        self.stretch_function.add_observe('stretch_function_value', self._update_stretch_curve)
+
         self.stretch_preset = PlotOptionsSyncState(self, self.viewer, self.layer, 'percentile',
                                                    'stretch_preset_value', 'stretch_preset_sync',
                                                    state_filter=is_image)
@@ -632,20 +635,17 @@ class PlotOptions(PluginTemplateMixin):
 
         self._stretch_histogram_needs_update = False
 
-    @observe('stretch_vmin_value', 'stretch_vmax_value', 'layer_selected'
+    @observe('stretch_vmin_value', 'stretch_vmax_value', 'layer_selected',
              'stretch_function_value', 'stretch_hist_nbins')
     def _update_stretch_curve(self, msg=None):
         if not hasattr(self, 'stretch_histogram'):
             return
 
-        layers = self.layer.selected_obj
         mark_label_prefix = "stretch_curve: "
-        for layer in layers:
+        for layer in self.layer.selected_obj:
             # clear old mark, if it exists:
             mark_label = f'{mark_label_prefix}{layer.label}'
             mark_exists = mark_label in self.stretch_histogram.marks
-            if mark_exists:
-                self.stretch_histogram.clear_marks(mark_label)
 
             # create the new/updated mark following the colormapping
             # procedure in glue's CompositeArray:
@@ -668,8 +668,8 @@ class PlotOptions(PluginTemplateMixin):
                     x=curve_x,
                     y=curve_y,
                     ynorm=True,
-                    color='#000000',
-                    opacities=[0.3],
+                    color='#c75d2c',
+                    opacities=[0.5],
                 )
 
             for existing_mark_label, mark in self.stretch_histogram.marks.items():

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -80,6 +80,8 @@ class PlotOptions(PluginTemplateMixin):
       limits instead of all data within the layer; not exposed for Specviz.
     * ``stretch_hist_nbins`` : number of bins to use in creating the histogram; not exposed
       for Specviz.
+    * ``stretch_curve_visible`` : (:class:`~jdaviz.core.template_mixin.PlotOptionsSyncState`):
+      whether the stretch histogram's colormap "curve" is visible; not exposed for Specviz.
     * ``image_visible`` (:class:`~jdaviz.core.template_mixin.PlotOptionsSyncState`):
       whether the image bitmap is visible; not exposed for Specviz.
     * ``image_color_mode`` (:class:`~jdaviz.core.template_mixin.PlotOptionsSyncState`):
@@ -204,6 +206,9 @@ class PlotOptions(PluginTemplateMixin):
     stretch_hist_zoom_limits = Bool().tag(sync=True)
     stretch_hist_nbins = IntHandleEmpty(25).tag(sync=True)
     stretch_histogram_widget = Unicode().tag(sync=True)
+
+    stretch_curve_visible_value = Bool().tag(sync=True)
+    stretch_curve_visible_sync = Dict().tag(sync=True)
 
     subset_visible_value = Bool().tag(sync=True)
     subset_visible_sync = Dict().tag(sync=True)
@@ -378,8 +383,6 @@ class PlotOptions(PluginTemplateMixin):
                                                      state_filter=is_image)
         # use add_observe to ensure that the glue state syncs with the traitlet choice:
         self.stretch_function.add_observe('stretch_function_value', self._update_stretch_curve)
-        # self.stretch_function.add_observe('image_contrast_value', self._update_stretch_curve)
-        # self.stretch_function.add_observe('image_bias_value', self._update_stretch_curve)
 
         self.stretch_preset = PlotOptionsSyncState(self, self.viewer, self.layer, 'percentile',
                                                    'stretch_preset_value', 'stretch_preset_sync',
@@ -390,6 +393,13 @@ class PlotOptions(PluginTemplateMixin):
         self.stretch_vmax = PlotOptionsSyncState(self, self.viewer, self.layer, 'v_max',
                                                  'stretch_vmax_value', 'stretch_vmax_sync',
                                                  state_filter=is_image)
+
+        self.stretch_curve_visible = PlotOptionsSyncState(self, self.viewer, self.layer,
+                                                          'stretch_curve_visible',
+                                                          'stretch_curve_visible_value',
+                                                          'stretch_curve_visible_sync',
+                                                          state_filter=is_image)
+
         self.stretch_histogram = Plot(self)
         self.stretch_histogram.add_bins('histogram', color='gray')
         self.stretch_histogram.add_line('vmin', x=[0, 0], y=[0, 1], ynorm=True, color='#c75d2c')
@@ -471,7 +481,8 @@ class PlotOptions(PluginTemplateMixin):
                        'image_color', 'image_colormap', 'image_opacity',
                        'image_contrast', 'image_bias',
                        'contour_visible', 'contour_mode',
-                       'contour_min', 'contour_max', 'contour_nlevels', 'contour_custom_levels']
+                       'contour_min', 'contour_max', 'contour_nlevels', 'contour_custom_levels',
+                       'stretch_curve_visible']
 
         return PluginUserApi(self, expose)
 
@@ -544,12 +555,7 @@ class PlotOptions(PluginTemplateMixin):
             self.stretch_histogram.clear_all_marks()
             return
 
-        # Import here to prevent circular import (and not at the top of the method so the import
-        # check is avoided, whenever possible).
-        from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
-        from jdaviz.configs.cubeviz.plugins.viewers import CubevizImageView
-
-        if not isinstance(self.viewer.selected_obj, (ImvizImageView, CubevizImageView)):
+        if not self._viewer_is_image_viewer():
             # don't update histogram if selected viewer is not an image viewer:
             return
 
@@ -638,23 +644,25 @@ class PlotOptions(PluginTemplateMixin):
         self._stretch_histogram_needs_update = False
 
     @observe('stretch_vmin_value', 'stretch_vmax_value', 'layer_selected',
-             'stretch_function_value', 'stretch_hist_nbins',
-             'image_contrast_value', 'image_bias_value')
+             'stretch_hist_nbins', 'image_contrast_value', 'image_bias_value',
+             'stretch_curve_visible_value')
     def _update_stretch_curve(self, msg=None):
-        # Import here to prevent circular import (and not at the top of the method so the import
-        # check is avoided, whenever possible).
-        from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
-        from jdaviz.configs.cubeviz.plugins.viewers import CubevizImageView
+        mark_label_prefix = "stretch_curve: "
 
-        if (
-            not isinstance(self.viewer.selected_obj, (ImvizImageView, CubevizImageView)) or
-            not hasattr(self, 'stretch_histogram')
-        ):
+        if not self._viewer_is_image_viewer() or not hasattr(self, 'stretch_histogram'):
             # don't update histogram if selected viewer is not an image viewer,
             # or the stretch histogram hasn't been initialized:
             return
 
-        mark_label_prefix = "stretch_curve: "
+        if not self.stretch_curve_visible_value:
+            # clear marks if curve is not visible:
+            for existing_mark_label, mark in self.stretch_histogram.marks.items():
+                if existing_mark_label.startswith(mark_label_prefix):
+                    # clear this mark
+                    mark.x = []
+                    mark.y = []
+            return
+
         for layer in self.layer.selected_obj:
             # clear old mark, if it exists:
             mark_label = f'{mark_label_prefix}{layer.label}'
@@ -662,11 +670,10 @@ class PlotOptions(PluginTemplateMixin):
 
             # create the new/updated mark following the colormapping
             # procedure in glue's CompositeArray:
-            layer_state = layer.state.as_dict()
             interval = ManualInterval(self.stretch_vmin.value, self.stretch_vmax.value)
-            contrast_bias = ContrastBiasStretch(layer_state['contrast'], layer_state['bias'])
-            stretch = stretches.members[layer_state['stretch']]
-            layer_cmap = layer_state['cmap']
+            contrast_bias = ContrastBiasStretch(layer.state.contrast, layer.state.bias)
+            stretch = stretches.members[layer.state.stretch]
+            layer_cmap = layer.state.cmap
 
             # create a photoshop style "curve" for the stretch function
             curve_x = np.linspace(self.stretch_vmin.value, self.stretch_vmax.value, 50)
@@ -674,16 +681,6 @@ class PlotOptions(PluginTemplateMixin):
             curve_y = contrast_bias(curve_y, out=curve_y, clip=False)
             curve_y = stretch(curve_y, out=curve_y, clip=False)
             curve_y = layer_cmap(curve_y)[:, 0]
-
-            if not mark_exists:
-                self.stretch_histogram.add_line(
-                    mark_label,
-                    x=curve_x,
-                    y=curve_y,
-                    ynorm=True,
-                    color='#c75d2c',
-                    opacities=[0.5],
-                )
 
             for existing_mark_label, mark in self.stretch_histogram.marks.items():
                 if mark_label == existing_mark_label:
@@ -695,6 +692,16 @@ class PlotOptions(PluginTemplateMixin):
                     mark.x = []
                     mark.y = []
 
+            if not mark_exists:
+                self.stretch_histogram.add_line(
+                    mark_label,
+                    x=curve_x,
+                    y=curve_y,
+                    ynorm=True,
+                    color='#c75d2c',
+                    opacities=[0.5],
+                )
+
             # reorder marks so histogram is on top:
             figure_marks = self.stretch_histogram.figure.marks
             for i, fig_mark in enumerate(figure_marks):
@@ -702,7 +709,6 @@ class PlotOptions(PluginTemplateMixin):
                     hist_mark = figure_marks.pop(i)
                     break
             self.stretch_histogram.figure.marks = figure_marks + [hist_mark]
->>>>>>> acf31432 (adding photoshop-style 'curves' feature to plot options hist)
 
     @observe('stretch_vmin_value')
     def _stretch_vmin_changed(self, msg=None):
@@ -725,3 +731,11 @@ class PlotOptions(PluginTemplateMixin):
     def set_histogram_y_limits(self, y_min, y_max):
         # NOTE: leaving this out of user API until API is finalized with interactive setting
         self.stretch_histogram.set_ylims(y_min, y_max)
+
+    def _viewer_is_image_viewer(self):
+        # Import here to prevent circular import (and not at the top of the method so the import
+        # check is avoided, whenever possible).
+        from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
+        from jdaviz.configs.cubeviz.plugins.viewers import CubevizImageView
+
+        return isinstance(self.viewer.selected_obj, (ImvizImageView, CubevizImageView))

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -383,6 +383,14 @@
           label="Limit histogram to current zoom limits"
           style="z-index: 1"
         ></v-switch>
+      </v-row>
+      <v-row>
+        <v-switch
+          v-model="stretch_curve_visible_value"
+          class="hide-input"
+          label="Show stretch function curve"
+          style="z-index: 1"
+        ></v-switch>
         <!-- NOTE: height defined here should match that in the custom CSS rules
              below for the bqplot class -->
       </v-row>


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description

This PR is the first towards @PatrickOgle's feature request for Photoshop's "curves" tool.  Curves shows a histogram of the pixel counts overlaid on a normalized representation of the colormap scaling. I've added a similar curve to the Plot Options histogram for image layers in Imviz or Cubeviz:

https://github.com/spacetelescope/jdaviz/assets/3497584/7e8b7667-40b7-4b59-88c8-c4c8aca66d1e

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3592)
