### PR TITLE
fix subset histogram bug in plot options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,6 +95,9 @@ Bug Fixes
   the selection when the choices change if any of the previous entries are still
   valid. [#2344]
 
+- Fixed Plot Options stretch histogram bug that raised an error when a spatial subset
+  was selected in Imviz and Cubeviz. [#2393]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -4,6 +4,7 @@ import numpy as np
 from astropy.visualization import PercentileInterval
 from traitlets import Any, Dict, Float, Bool, Int, List, Unicode, observe
 
+from glue.core.subset_group import GroupedSubset
 from glue.viewers.scatter.state import ScatterViewerState
 from glue.viewers.profile.state import ProfileViewerState, ProfileLayerState
 from glue.viewers.image.state import ImageSubsetLayerState
@@ -577,6 +578,10 @@ class PlotOptions(PluginTemplateMixin):
             data = self.layer.selected_obj[0].layer
         else:
             # skip further updates if no data are available:
+            return
+
+        if isinstance(data, GroupedSubset):
+            # don't update histogram for subsets:
             return
 
         comp = data.get_component(data.main_components[0])


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description

When subsets are selected in Plot Options in Imviz/Cubeviz, the stretch histogram update raises an error. This PR adds a `return` to drop out of the stretch histogram update method when the selected layer is a subset, avoiding the error.

This bug was discovered in #2387, splitting it out so it can be merged before 3.6.2.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
