### PR TITLE
Aperture photometry batch mode API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -102,6 +102,8 @@ Specviz2d
 Other Changes and Additions
 ---------------------------
 
+- API framework for batch aperture photometry. [#2401]
+
 3.6.3 (unreleased)
 ==================
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -524,6 +524,14 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin, TableMix
 
     def batch_aper_phot(self, options):
         """
+        Run aperture photometry over a list of options.  Values will be looped in order and any
+        unprovided options will remain at there previous values (either from a previous entry
+        in the list or from the plugin).  The plugin itself will update and will remain at the
+        final state from the last entry in the list.
+
+        To provide a list of values per-input, use `unpack_batch_options` to and pass that as input
+        here.
+
         Parameters
         ----------
         options : list
@@ -537,11 +545,18 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin, TableMix
             raise TypeError("options must be a list of dictionaries")
 
         for option in options:
-            # run aperture photometry with **option
-            # log result in table
-            pass
-
-        return
+            # NOTE: if we do not want the UI to update (and end up in the final state), then
+            # we would need to refactor the plugin so that all we can compute computed values
+            # from the selected dataset without necessarily observing and updating traitlets.
+            # We would still want to check any select component against the valid choices.
+            # We could then also skip creating/showing the plot and have a manual call to
+            # vue_do_aper_phot re-enable plotting
+            for attr, value in option.items():
+                # TODO: when enabling user_api, skip this and call setattr directly on self.user_api
+                if hasattr(self, f'{attr}_selected'):
+                    attr = f'{attr}_selected'
+                setattr(self, attr, value)
+            self.vue_do_aper_phot()
 
 
 # NOTE: These are hidden because the APIs are for internal use only

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2978,6 +2978,9 @@ class Table(PluginSubcomponent):
         # clean data to show in the UI
         self.items = self.items + [{k: json_safe(k, v) for k, v in item.items()}]
 
+    def __len__(self):
+        return len(self.items)
+
     def clear_table(self):
         """
         Clear all entries/markers from the current table.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements the (not-yet public*) plugin API for batch processing of aperture photometry.  The main method (`plugin.batch_aper_phot`) takes a list of dictionaries with traitlets names and values as inputs, loops over the list, sets the traitlets, and calls the existing internal method to compute aperture photometry.  The results are then available in the results table (from the plugin UI or API, once its public) and the state of the plugin, including the plot, is left based on the last iteration from that list.  Any value that is not provided in a dictionary will be adopted from the "current" state at the time (either the original plugin state or as it was left from the previous iteration).  *This is something we may want to reconsider - perhaps restoring to the original state after each iteration, so that an override in the first entry isn't then adopted in the second if not explicitly provided again.*

\* none of these methods are made public via this API since there is no exposed user API for aperture photometry yet and the UI implementation is scheduled for follow-up work.  When we do expose the user API, we will need to finalize some traitlet/attribute names to avoid confusion and add these two methods to the list of exposed methods.

For example:

```
ap = imviz.plugins['Imviz Simple Aperture Photometry']
ap._obj.batch_aper_phot([{'dataset': 'image 1', 'subset': 'Subset 1'},
                         {'dataset': 'image 2', 'subset': 'Subset 2'}])
```

This also implements a helper method (`plugin.unpack_batch_options`) which takes any number of keyword arguments, where each item can contain either a single value or a list.  This then unpacks to create the "matrix" of all combinations that can then be used as input to the method described above.  This will then become the hook-in point for the multi-select dropdowns to be implemented in the UI (which likely will only support this matrix mode for the input dataset and aperture subsets).

For example:

```
ap._obj.unpack_batch_options(dataset=['image1', 'image2'],
                             subset=['Subset 1', 'Subset 2'],
                             bg_subset=['Subset 3'],
                             flux_scaling=3)
```

returns:

```
[{'subset': 'Subset 1',
  'dataset': 'image1',
  'bg_subset': 'Subset 3',
  'flux_scaling': 3},
 {'subset': 'Subset 2',
  'dataset': 'image1',
  'bg_subset': 'Subset 3',
  'flux_scaling': 3},
 {'subset': 'Subset 1',
  'dataset': 'image2',
  'bg_subset': 'Subset 3',
  'flux_scaling': 3},
 {'subset': 'Subset 2',
  'dataset': 'image2',
  'bg_subset': 'Subset 3',
  'flux_scaling': 3}]
```

which could then be passed directly (or modified) as input to `batch_aper_phot`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
