### PR TITLE
fix case of a multiselect dropdown becoming single when no selection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -97,6 +97,10 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Fixes turning off multiselect mode for a dropdown when no selections are currently made. 
+  Previously this resulted in a traceback, but now applies the default selection for 
+  single-select mode. [#2404]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -736,7 +736,7 @@ class SelectPluginComponent(BasePluginComponent, HasTraits):
         self._clear_cache()
         if self.is_multiselect:
             self.selected = [self.selected]
-        elif isinstance(self.selected, list):
+        elif isinstance(self.selected, list) and len(self.selected):
             self.selected = self.selected[0]
         else:
             self._apply_default_selection()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes turning off multiselect mode for a dropdown when no selections are currently made.  Previously this resulted in a traceback, but now applies the default selection for single-select mode (which may either be empty or the first entry, etc, depending on the options for that dropdown).

To reproduce:

* load any viz tool with multiple layers and/or viewers
* open plot options
* select advanced multiselect mode in top right
* in either viewer or layer, clear the selection
* click the button again in the top right to enter single-select mode
* on main, this crashes, but is handled gracefully in this PR (for plot options, the dropdown remains empty)

Note: further improvements to these edge cases could be made (to hide all other plot options information when either viewer or layer is empty, rather than showing empty widgets with "NULL", etc), but those are a larger effort and at least don't result in tracebacks right now.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
