### PR TITLE
Manual backport of PR 2404: fix case of a multiselect dropdown becoming single when no selection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,28 @@
+3.6.3 (unreleased)
+==================
+
+Bug Fixes
+---------
+
+- Fixes turning off multiselect mode for a dropdown when no selections are currently made. 
+  Previously this resulted in a traceback, but now applies the default selection for 
+  single-select mode. [#2404]
+
+Cubeviz
+^^^^^^^
+
+Imviz
+^^^^^
+
+Mosviz
+^^^^^^
+
+Specviz
+^^^^^^^
+
+Specviz2d
+^^^^^^^^^
+
 3.6.2 (2023-08-25)
 ==================
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -682,7 +682,7 @@ class SelectPluginComponent(BasePluginComponent, HasTraits):
         self._clear_cache()
         if self.is_multiselect:
             self.selected = [self.selected]
-        elif isinstance(self.selected, list):
+        elif isinstance(self.selected, list) and len(self.selected):
             self.selected = self.selected[0]
         else:
             self._apply_default_selection()


### PR DESCRIPTION
This is a manual backport (change log conflict) of #2404.