### PR TITLE
enable stretch histogram in 2d spectrum viewers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@ Imviz
 Mosviz
 ^^^^^^
 
+- Plot options now includes the stretch histogram previously implemented for Imviz/Cubeviz. [#2407]
+
 Specviz
 ^^^^^^^
 
@@ -40,6 +42,8 @@ Specviz
 
 Specviz2d
 ^^^^^^^^^
+
+- Plot options now includes the stretch histogram previously implemented for Imviz/Cubeviz. [#2407]
 
 API Changes
 -----------

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -613,8 +613,11 @@ class PlotOptions(PluginTemplateMixin):
                 x_data = data.get_component(data.components[1]).data
                 y_data = data.get_component(data.components[0]).data
 
-                inds = np.where((x_data >= viewer.state.x_min) &
-                                (x_data <= viewer.state.x_max) &
+                inverted_x = getattr(viewer, 'inverted_x_axis', False)
+                x_min = viewer.state.x_min if not inverted_x else viewer.state.x_max
+                x_max = viewer.state.x_max if not inverted_x else viewer.state.x_min
+                inds = np.where((x_data >= x_min) &
+                                (x_data <= x_max) &
                                 (y_data >= viewer.state.y_min) &
                                 (y_data <= viewer.state.y_max))
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -759,5 +759,7 @@ class PlotOptions(PluginTemplateMixin):
         # check is avoided, whenever possible).
         from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
         from jdaviz.configs.cubeviz.plugins.viewers import CubevizImageView
+        from jdaviz.configs.mosviz.plugins.viewers import MosvizImageView, MosvizProfile2DView
 
-        return isinstance(self.viewer.selected_obj, (ImvizImageView, CubevizImageView))
+        return isinstance(self.viewer.selected_obj, (ImvizImageView, CubevizImageView,
+                                                     MosvizImageView, MosvizProfile2DView))


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request includes the stretch histogram (in plot options) in 2d spectrum viewers in specviz2d and mosviz, and fixes a bug related to handling zoom-limits when the x-axis is inverted (caused by linking between pixels and the spectral axis in the 1d spectrum viewer).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
