### PR TITLE
improve stretch histogram performance (downsampling and decorator)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Imviz
 - Add a curve to stretch histograms in the Plot Options plugin representing the colormap
   stretch function. [#2390]
 
+- The stretch histogram is now downsampled for large images for improved performance. [#2408]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -205,7 +205,6 @@ class PlotOptions(PluginTemplateMixin):
 
     stretch_hist_zoom_limits = Bool().tag(sync=True)
     stretch_hist_nbins = IntHandleEmpty(25).tag(sync=True)
-    stretch_hist_downsampled = List([0, 0]).tag(sync=True)
     stretch_histogram_widget = Unicode().tag(sync=True)
 
     stretch_curve_visible = Bool().tag(sync=True)
@@ -601,9 +600,9 @@ class PlotOptions(PluginTemplateMixin):
                     xstep = max(1, round(arr.shape[1] / 400))
                     ystep = max(1, round(arr.shape[0] / 400))
                     arr = arr[::ystep, ::xstep]
-                    self.stretch_hist_downsampled = [size, arr.shape[0] * arr.shape[1]]
+                    stretch_hist_downsampled = [size, arr.shape[0] * arr.shape[1]]
                 else:
-                    self.stretch_hist_downsampled = [size, size]  # not downsampled
+                    stretch_hist_downsampled = size
 
                 sub_data = arr.ravel()
 
@@ -619,10 +618,11 @@ class PlotOptions(PluginTemplateMixin):
                                 (y_data >= viewer.state.y_min) &
                                 (y_data <= viewer.state.y_max))
 
-                # downsampling not currently implemented for 2d spectrum
-                self.stretch_hist_downsampled = [0, 0]
-
                 sub_data = comp.data[inds].ravel()
+
+                # downsampling not currently implemented for 2d spectrum
+                stretch_hist_downsampled = len(sub_data)
+
         else:
             # include all data, regardless of zoom limits
             arr = comp.data
@@ -631,9 +631,9 @@ class PlotOptions(PluginTemplateMixin):
                 xstep = max(1, round(arr.shape[1] / 400))
                 ystep = max(1, round(arr.shape[0] / 400))
                 arr = arr[::ystep, ::xstep]
-                self.stretch_hist_downsampled = [size, arr.shape[0] * arr.shape[1]]
+                stretch_hist_downsampled = [size, arr.shape[0] * arr.shape[1]]
             else:
-                self.stretch_hist_downsampled = [size, size]  # not downsampled
+                stretch_hist_downsampled = size
 
             sub_data = arr.ravel()
 
@@ -658,6 +658,11 @@ class PlotOptions(PluginTemplateMixin):
             # in case only the sample has changed but its length has not,
             # we'll force the traitlet to trigger a change
             hist_mark.send_state('sample')
+        if isinstance(stretch_hist_downsampled, list):
+            title = f"{stretch_hist_downsampled[1]} of {stretch_hist_downsampled[0]} pixels"
+        else:
+            title = f"{stretch_hist_downsampled} pixels"
+        self.stretch_histogram.figure.title = title
 
     @observe('is_active', 'stretch_vmin_value', 'stretch_vmax_value', 'layer_selected',
              'stretch_hist_nbins', 'image_contrast_value', 'image_bias_value',

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -659,11 +659,10 @@ class PlotOptions(PluginTemplateMixin):
             # we'll force the traitlet to trigger a change
             hist_mark.send_state('sample')
 
-        self._stretch_histogram_needs_update = False
-
-    @observe('stretch_vmin_value', 'stretch_vmax_value', 'layer_selected',
+    @observe('is_active', 'stretch_vmin_value', 'stretch_vmax_value', 'layer_selected',
              'stretch_hist_nbins', 'image_contrast_value', 'image_bias_value',
              'stretch_curve_visible')
+    @skip_if_no_updates_since_last_active()
     def _update_stretch_curve(self, msg=None):
         mark_label_prefix = "stretch_curve: "
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -80,7 +80,7 @@ class PlotOptions(PluginTemplateMixin):
       limits instead of all data within the layer; not exposed for Specviz.
     * ``stretch_hist_nbins`` : number of bins to use in creating the histogram; not exposed
       for Specviz.
-    * ``stretch_curve_visible`` : (:class:`~jdaviz.core.template_mixin.PlotOptionsSyncState`):
+    * ``stretch_curve_visible`` : bool
       whether the stretch histogram's colormap "curve" is visible; not exposed for Specviz.
     * ``image_visible`` (:class:`~jdaviz.core.template_mixin.PlotOptionsSyncState`):
       whether the image bitmap is visible; not exposed for Specviz.
@@ -208,8 +208,7 @@ class PlotOptions(PluginTemplateMixin):
     stretch_hist_downsampled = List([0, 0]).tag(sync=True)
     stretch_histogram_widget = Unicode().tag(sync=True)
 
-    stretch_curve_visible_value = Bool().tag(sync=True)
-    stretch_curve_visible_sync = Dict().tag(sync=True)
+    stretch_curve_visible = Bool().tag(sync=True)
 
     subset_visible_value = Bool().tag(sync=True)
     subset_visible_sync = Dict().tag(sync=True)
@@ -394,12 +393,6 @@ class PlotOptions(PluginTemplateMixin):
         self.stretch_vmax = PlotOptionsSyncState(self, self.viewer, self.layer, 'v_max',
                                                  'stretch_vmax_value', 'stretch_vmax_sync',
                                                  state_filter=is_image)
-
-        self.stretch_curve_visible = PlotOptionsSyncState(self, self.viewer, self.layer,
-                                                          'stretch_curve_visible',
-                                                          'stretch_curve_visible_value',
-                                                          'stretch_curve_visible_sync',
-                                                          state_filter=is_image)
 
         self.stretch_histogram = Plot(self)
         self.stretch_histogram.add_bins('histogram', color='gray')
@@ -670,7 +663,7 @@ class PlotOptions(PluginTemplateMixin):
 
     @observe('stretch_vmin_value', 'stretch_vmax_value', 'layer_selected',
              'stretch_hist_nbins', 'image_contrast_value', 'image_bias_value',
-             'stretch_curve_visible_value')
+             'stretch_curve_visible')
     def _update_stretch_curve(self, msg=None):
         mark_label_prefix = "stretch_curve: "
 
@@ -679,7 +672,7 @@ class PlotOptions(PluginTemplateMixin):
             # or the stretch histogram hasn't been initialized:
             return
 
-        if not self.stretch_curve_visible_value:
+        if not self.stretch_curve_visible:
             # clear marks if curve is not visible:
             for existing_mark_label, mark in self.stretch_histogram.marks.items():
                 if existing_mark_label.startswith(mark_label_prefix):

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -394,11 +394,6 @@
         <!-- NOTE: height defined here should match that in the custom CSS rules
              below for the bqplot class -->
       </v-row>
-      <v-row v-if="stretch_hist_downsampled[0] > stretch_hist_downsampled[1]">
-        <v-alert type='info'>
-          Histogram samples a subset of {{stretch_hist_downsampled[1]}} out of {{stretch_hist_downsampled[0]}} pixels.
-        </v-alert>
-      </v-row>
       <jupyter-widget :widget="stretch_histogram_widget"/>
       </div>
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -394,7 +394,12 @@
         <!-- NOTE: height defined here should match that in the custom CSS rules
              below for the bqplot class -->
       </v-row>
-        <jupyter-widget :widget="stretch_histogram_widget"/>
+      <v-row v-if="stretch_hist_downsampled[0] > stretch_hist_downsampled[1]">
+        <v-alert type='info'>
+          Histogram samples a subset of {{stretch_hist_downsampled[1]}} out of {{stretch_hist_downsampled[0]}} pixels.
+        </v-alert>
+      </v-row>
+      <jupyter-widget :widget="stretch_histogram_widget"/>
       </div>
 
     <!-- IMAGE:IMAGE -->

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -386,7 +386,7 @@
       </v-row>
       <v-row>
         <v-switch
-          v-model="stretch_curve_visible_value"
+          v-model="stretch_curve_visible"
           class="hide-input"
           label="Show stretch function curve"
           style="z-index: 1"


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request improves the performance of the stretch histogram and the stretch curve, especially for large images, by downsampling the data sent to the histogram and by making use of #2386 for the stretch curve introduced in #2390.


https://github.com/spacetelescope/jdaviz/assets/877591/3a99859d-2b85-4e33-a8a1-517aa837bbb6






<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
