### PR TITLE
Astrowidgets API: Markers to use Astropy regions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,10 @@ Imviz
 - Fixed wrong angle translations between sky regions in ``regions`` and ``photutils``.
   They were previously off by 90 degrees. [#2154]
 
+- Astrowidgets markers API is overhauled to work with Astropy regions instead of table.
+  As a result, the presence of those markers no longer blocks data re-linking and
+  ``MarkersChangedMessage`` is removed. This is not to be confused with the Markers plugin. [#2410]
+
 Mosviz
 ^^^^^^
 

--- a/docs/imviz/import_data.rst
+++ b/docs/imviz/import_data.rst
@@ -142,20 +142,22 @@ data entries into the viewer until after the parsing is complete::
 Importing catalogs via the API
 ==============================
 
-If you have a catalog file supported by `astropy.table.Table`, you
-can load the catalog into Imviz and add markers to Imviz viewers to show
-positions from the catalog. These markers are different than Imviz
+If you have a catalog file, you can load the catalog into Imviz and
+add markers to Imviz viewers to show positions from the catalog.
+These markers are different than Imviz
 :ref:`spatial regions <imviz_defining_spatial_regions>` as they are only meant to mark catalog positions.
-Loading markers can be done with the following commands:
+Loading markers can be done with the following commands
+(in this example, they are defined to be circles each with radius of 1 arcsec):
 
 .. code-block:: python
 
-    viewer.marker = {'color': 'green', 'alpha': 0.8, 'markersize': 10, 'fill': False}
-    my_markers = Table.read('my_catalog.ecsv')
-    coord_i2d = Table({'coord': [SkyCoord(ra=my_catalog['sky_centroid'].ra.degree,
-                                          dec=my_catalog['sky_centroid'].dec.degree,
-                                          unit="deg")]})
-    viewer.add_markers(coord_i2d, use_skycoord=True, marker_name='my_markers')
+    from astropy import units as u
+    from regions import CircleSkyRegion
+    viewer.marker = {'color': 'green', 'alpha': 0.8, 'fill': False}
+    my_catalog = Table.read('my_catalog.ecsv')
+    r = 1 * u.arcsec
+    regs = [CircleSkyRegion(c, r) for c in my_catalog['sky_centroid']]
+    viewer.add_markers(regs, marker_name='my_markers')
 
 If you have a large catalog, you might want to filter your table to the
 marks of interest before adding them to Imviz, in order to avoid performance

--- a/docs/known_bugs.rst
+++ b/docs/known_bugs.rst
@@ -135,13 +135,7 @@ in the Cubeviz cube viewer.
 Imviz
 -----
 
-add_markers may not show markers
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-In some OS/browser combinations, ``imviz.add_markers(...)`` might take a few tries
-to show the markers, or not at all. This is a known bug reported in
-https://github.com/glue-viz/glue-jupyter/issues/243 . If you encounter this,
-try a different OS/browser combo.
+N/A
 
 .. _known_issues_specviz:
 

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -387,13 +387,6 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
     """(Re)link loaded data in Imviz with the desired link type.
     All existing links will be replaced.
 
-    .. note::
-
-        Any markers added in Imviz will need to be removed manually before changing linking type.
-        You can add back the markers using
-        :meth:`~jdaviz.core.astrowidgets_api.AstrowidgetsImageViewerMixin.add_markers`
-        for the relevant viewer(s).
-
     Parameters
     ----------
     app : `~jdaviz.app.Application`
@@ -450,11 +443,6 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
     if link_type == app._link_type and wcs_use_affine == app._wcs_use_affine:
         data_already_linked = [link.data2 for link in app.data_collection.external_links]
     else:
-        for viewer in app._viewer_store.values():
-            if len(viewer._marktags):
-                raise ValueError(f"cannot change link_type (from '{app._link_type}' to "
-                                 f"'{link_type}') when markers are present. "
-                                 f" Clear markers with viewer.reset_markers() first")
         data_already_linked = []
 
     refdata, iref = get_reference_image_data(app)

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -66,7 +66,7 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
         self.dataset._manual_options = ['auto', 'none']
         self.dataset.filters = ['layer_in_viewers']
         if self.app.config == 'imviz':
-            # filter out scatter-plot entries (from add_markers API, for example)
+            # filter out scatter-plot entries, if any
             self.dataset.add_filter('is_image')
         # we also want to include auto-collapsed spectra (spatial subsets)
         self.dataset._cubeviz_include_spatial_subsets()

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -40,28 +40,6 @@
           </v-switch>
         </v-row>
       </div>
-      <div v-if="need_clear_markers"
-            class="text-center"
-            style="grid-area: 1/1; 
-                   z-index:2;
-                   margin-left: -24px;
-                   margin-right: -24px;
-                   padding-top: 60px;
-                   background-color: rgb(0 0 0 / 80%)">
-         <v-card color="transparent" elevation=0 >
-           <v-card-text width="100%">
-             <div class="white--text">
-               Markers must be cleared before re-linking
-             </div>
-           </v-card-text>
-
-           <v-card-actions>
-             <v-row justify="end">
-               <v-btn tile small color="accent" class="mr-4" @click="reset_markers" >Clear Markers</v-btn>
-             </v-row>
-           </v-card-actions>
-         </v-card>
-      </div>      
       <div v-if="linking_in_progress"
            class="text-center"
            style="grid-area: 1/1; 

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -10,6 +10,7 @@ from astropy.table import Table
 from astropy.utils.data import get_pkg_data_filename
 from astropy.visualization import AsinhStretch, LinearStretch, LogStretch, SqrtStretch
 from numpy.testing import assert_allclose
+from regions import PixCoord, CircleSkyRegion, CirclePixelRegion
 
 from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_NoWCS, BaseImviz_WCS_WCS
 
@@ -271,18 +272,19 @@ class TestMarkers(BaseImviz_WCS_NoWCS):
             self.viewer.marker = {'alpha': '1'}
         with pytest.raises(ValueError, match='Invalid alpha'):
             self.viewer.marker = {'alpha': 42}
-        with pytest.raises(ValueError, match='Invalid marker size'):
+        with pytest.raises(KeyError, match='Invalid attribute'):
             self.viewer.marker = {'markersize': '1'}
         with pytest.raises(ValueError, match='Invalid fill'):
             self.viewer.marker = {'fill': '1'}
 
     def test_mvp_markers(self):
-        x_pix = (0, 0)
-        y_pix = (0, 1)
-        sky = self.wcs.pixel_to_world(x_pix, y_pix)
-        tbl = Table({'x': x_pix, 'y': y_pix, 'coord': sky})
+        reg_pix = CirclePixelRegion(PixCoord(0, 1), 3)
+        reg_sky = reg_pix.to_sky(self.wcs)
 
-        self.viewer.add_markers(tbl)
+        self.viewer.add_markers([reg_pix, reg_sky])
+
+        # FIXME: Need to update all the tests from here on!
+
         data = self.imviz.app.data_collection[2]
         assert data.label == 'default-marker-name'
         assert data.style.color in ('red', '#ff0000')

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -173,12 +173,25 @@ def test_offline_ecsv_catalog(imviz_helper, image_2d_wcs, tmp_path):
     out_tbl = catalogs_plugin._obj.search()
     assert len(out_tbl) == n_entries
     assert catalogs_plugin._obj.number_of_results == n_entries
-    assert len(imviz_helper.app.data_collection) == 2  # image + markers
+    # image + markers
+    bqplot_marks = imviz_helper.default_viewer._get_marks("catalog_results")
+    for mrk in bqplot_marks:
+        assert mrk.visible
+        assert mrk.colors == ["red"]
+        assert mrk.opacities == [0.8]
+        assert mrk.fill_opacities == [0]
 
     catalogs_plugin._obj.clear()
     assert not catalogs_plugin._obj.results_available
-    assert len(imviz_helper.app.data_collection) == 2  # markers still there, just hidden
+    # markers still there, just hidden
+    bqplot_marks = imviz_helper.default_viewer._get_marks("catalog_results")
+    for mrk in bqplot_marks:
+        assert not mrk.visible
+        assert mrk.colors == ["red"]
+        assert mrk.opacities == [0.8]
+        assert mrk.fill_opacities == [0]
 
     catalogs_plugin._obj.clear(hide_only=False)
     assert not catalogs_plugin._obj.results_available
-    assert len(imviz_helper.app.data_collection) == 1  # markers gone for good
+    # markers gone for good
+    assert len(imviz_helper.default_viewer._get_marks("catalog_results")) == 0

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -1,5 +1,4 @@
 import pytest
-from astropy.table import Table
 from astropy.wcs import WCS
 from glue.core.link_helpers import LinkSame
 from glue.plugins.wcs_autolinking.wcs_autolinking import OffsetLink, WCSLink
@@ -118,15 +117,6 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
                                  PolygonPixelRegion(vertices=PixCoord(x=[1, 2, 2], y=[1, 1, 2])),
                                  PolygonPixelRegion(vertices=PixCoord(x=[2, 3, 3], y=[2, 2, 3]))])
 
-        # Add markers.
-        tbl = Table({'x': (0, 0), 'y': (0, 1)})
-        self.viewer.add_markers(tbl, marker_name='xy_markers')
-        assert 'xy_markers' in self.imviz.app.data_collection.labels
-
-        # Run linking again with the same options as before (otherwise would fail with an error
-        # since markers now exist)
-        self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None, error_on_fail=True)
-
         # Ensure display is still customized.
         assert self.viewer.state.layers[1].cmap.name == 'viridis'
         assert self.viewer.state.layers[1].stretch == 'sqrt'
@@ -138,11 +128,6 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
         assert sorted(self.imviz.get_interactive_regions()) == ['Subset 1', 'Subset 2']
         assert 'MaskedSubset 1' in all_labels
         assert 'MaskedSubset 2' in all_labels
-
-        # Markers should still exist since the type has not changed
-        # Zoom and pan will reset in this case, so we do not check those.
-        assert 'xy_markers' in self.imviz.app.data_collection.labels
-        assert len(self.viewer._marktags) == 1
 
         # Pan/zoom.
         self.viewer.center_on((5, 5))
@@ -177,14 +162,7 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
                                              'World 22h30m04.8674s -20d49m59.9990s (ICRS)',
                                              '337.5202808000 -20.8333330600 (deg)')
 
-        # Changing link type will raise an error
-        with pytest.raises(ValueError, match="cannot change link_type"):
-            self.imviz.link_data(link_type='pixels', wcs_fallback_scheme=None, error_on_fail=True)
-
-        self.viewer.reset_markers()
         self.imviz.link_data(link_type='pixels', wcs_fallback_scheme=None, error_on_fail=True)
-        assert 'xy_markers' not in self.imviz.app.data_collection.labels
-        assert len(self.viewer._marktags) == 0
 
     def test_wcslink_fullblown(self):
         self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None, wcs_use_affine=False,

--- a/jdaviz/configs/imviz/tests/test_links_control.py
+++ b/jdaviz/configs/imviz/tests/test_links_control.py
@@ -1,6 +1,5 @@
-import pytest
+from regions import PixCoord, CirclePixelRegion
 
-from astropy.table import Table
 from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_WCS
 
 
@@ -15,17 +14,7 @@ class TestLinksControl(BaseImviz_WCS_WCS):
         # wcs_use_affine should revert/default to True
         assert lc_plugin.wcs_use_affine is True
 
-        # adding markers should disable changing linking from both UI and API
-        assert lc_plugin.need_clear_markers is False
-        tbl = Table({'x': (0, 0), 'y': (0, 1)})
-        self.viewer.add_markers(tbl, marker_name='xy_markers')
-
-        assert lc_plugin.need_clear_markers is True
-        with pytest.raises(ValueError, match="cannot change linking"):
-            lc_plugin.link_type.selected = 'WCS'
-        assert lc_plugin.link_type.selected == 'Pixels'
-
-        lc_plugin.vue_reset_markers()
-
-        assert lc_plugin.need_clear_markers is False
+        # adding markers should not crash when linking is changed
+        reg = CirclePixelRegion(PixCoord(3, 3), 1)
+        self.viewer.add_markers([reg], marker_name='xy_markers')
         lc_plugin.link_type.selected = 'WCS'

--- a/jdaviz/configs/mosviz/plugins/viewers.py
+++ b/jdaviz/configs/mosviz/plugins/viewers.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from astropy.coordinates import SkyCoord
-from astropy.table import QTable
 from functools import cached_property
 from glue.core import BaseData
 from glue_jupyter.bqplot.image import BqplotImageView
@@ -49,18 +48,22 @@ class MosvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewe
                 isinstance(layer_state.layer, BaseData)]
 
     # NOTE: This is currently only for debugging. It is not used in app.
-    def _mark_targets(self):
+    def _mark_targets(self):  # pragma: no cover
         table_data = self.jdaviz_app.data_collection['MOS Table']
 
         if ("R.A." not in table_data.component_ids() or
                 "Dec." not in table_data.component_ids()):
             return
 
+        from astropy import units as u
+        from regions import CircleSkyRegion
+
         ra = table_data["R.A."]
         dec = table_data["Dec."]
         sky = SkyCoord(ra, dec, unit='deg')
-        t = QTable({'coord': sky})
-        self.add_markers(t, use_skycoord=True, marker_name='Targets')
+        sky_radius = 0.1 * u.arcsec
+        t = [CircleSkyRegion(c, sky_radius) for c in sky]
+        self.add_markers(t, marker_name='Targets')
 
 
 @viewer_registry("mosviz-profile-2d-viewer", label="Spectrum 2D (Mosviz)")

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -7,7 +7,7 @@ __all__ = ['NewViewerMessage', 'ViewerAddedMessage', 'ViewerRemovedMessage', 'Lo
            'SliceSelectSliceMessage',
            'SliceToolStateMessage',
            'TableClickMessage', 'LinkUpdatedMessage', 'ExitBatchLoadMessage',
-           'MarkersChangedMessage', 'CanvasRotationChangedMessage',
+           'CanvasRotationChangedMessage',
            'GlobalDisplayUnitChanged']
 
 
@@ -324,17 +324,6 @@ class ExitBatchLoadMessage(Message):
     '''Message generated when exiting the outermost batch_load context manager'''
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-
-class MarkersChangedMessage(Message):
-    '''Message generated when markers are added/removed from an image viewer'''
-    def __init__(self, has_markers, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._has_markers = has_markers
-
-    @property
-    def has_markers(self):
-        return self._has_markers
 
 
 class CanvasRotationChangedMessage(Message):

--- a/notebooks/ImvizDitheredExample.ipynb
+++ b/notebooks/ImvizDitheredExample.ipynb
@@ -35,7 +35,7 @@
     "from astropy.table import Table\n",
     "from astropy.utils.data import download_file\n",
     "from photutils.aperture import CircularAperture, SkyCircularAperture\n",
-    "from regions import PixCoord, CirclePixelRegion, CircleSkyRegion\n",
+    "from regions import PixCoord, CirclePixelRegion, CircleSkyRegion, RectanglePixelRegion\n",
     "\n",
     "from jdaviz import Imviz"
    ]
@@ -473,11 +473,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Default marker properties repeated here for reproducibility \n",
+    "# during out-of-order cell runs.\n",
+    "viewer.marker = {'color': 'red', 'alpha': 1.0, 'fill': False}\n",
+    "\n",
     "# Add 100 randomly generated X,Y (0-indexed) w.r.t. reference image\n",
-    "# using default marker properties.\n",
-    "t_xy = Table({'x': np.random.randint(0, 4096, 100),\n",
-    "              'y': np.random.randint(0, 2048, 100)})\n",
-    "viewer.add_markers(t_xy)"
+    "# as 10-pix diamonds using default marker properties.\n",
+    "rect_angle = 45 * u.deg\n",
+    "regs_xy = [RectanglePixelRegion(PixCoord(x, y), width=10, height=10, angle=rect_angle)\n",
+    "           for x, y in zip(np.random.randint(0, 4000, 100), np.random.randint(0, 2048, 100))]\n",
+    "viewer.add_markers(regs_xy)"
    ]
   },
   {
@@ -485,7 +490,7 @@
    "id": "f1c1aa0d-46b7-42f6-b6d7-395305c15f91",
    "metadata": {},
    "source": [
-    "You could customize marker color, alpha, size, and fill with values that Glue supports."
+    "You could customize marker color, alpha (for the edge), and fill (alpha is hardcoded) with values that Glue supports."
    ]
   },
   {
@@ -495,7 +500,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer.marker = {'color': 'green', 'alpha': 0.8, 'markersize': 10, 'fill': False}"
+    "viewer.marker = {'color': 'green', 'alpha': 0.5, 'fill': True}"
    ]
   },
   {
@@ -506,12 +511,30 @@
    "outputs": [],
    "source": [
     "# Mark some sky coordinates using updated marker properties.\n",
-    "t_sky = Table({'coord': [SkyCoord('00h24m07.33s -71d52m50.71s'),\n",
-    "                         SkyCoord('00h24m01.57s -71d53m17.77s'),\n",
-    "                         SkyCoord('00h24m11.70s -71d52m29.21s'),\n",
-    "                         SkyCoord('00h24m22.29s -71d53m28.04s')]})\n",
-    "viewer.add_markers(t_sky, use_skycoord=True, marker_name='my_sky')\n",
-    "t_sky"
+    "# This time, mark it as circles with a sky radius.\n",
+    "r_sky = 1.0 * u.arcsec\n",
+    "regs_sky = [CircleSkyRegion(SkyCoord(s), r_sky) for s in [\n",
+    "    '00h24m07.33s -71d52m50.71s', '00h24m01.57s -71d53m17.77s',\n",
+    "    '00h24m11.70s -71d52m29.21s', '00h24m22.29s -71d53m28.04s']]\n",
+    "viewer.add_markers(regs_sky, marker_name='my_sky')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66ae93fe",
+   "metadata": {},
+   "source": [
+    "You can get back all the added markers as `Regions`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b0bbe8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer.get_markers()"
    ]
   },
   {
@@ -573,7 +596,7 @@
    "id": "96fee8ea-66e3-489c-be27-b06223dd8809",
    "metadata": {},
    "source": [
-    "If you want to align the images by WCS instead of pixels, you can run this but it will remove all markers."
+    "If you want to align the images by WCS instead of pixels, you can run this."
    ]
   },
   {
@@ -697,7 +720,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -113,9 +113,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#data_dir = tempfile.gettempdir()\n",
+    "data_dir = tempfile.gettempdir()\n",
     "#data_dir = \"/Users/username/Data/\"\n",
-    "data_dir = \"/home/lim/test_data/mastDownloads/\"\n",
     "\n",
     "files = ['jw02727-o002_t062_nircam_clear-f090w_i2d.fits',\n",
     "         #'jw02727-o002_t062_nircam_clear-f150w_i2d.fits',\n",

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -36,7 +36,7 @@
     "from astropy.table import Table\n",
     "from astroquery.mast import Observations\n",
     "from photutils.aperture import CircularAperture, SkyCircularAperture\n",
-    "from regions import PixCoord, CirclePixelRegion, CircleSkyRegion\n",
+    "from regions import PixCoord, CirclePixelRegion, CircleSkyRegion, RectanglePixelRegion\n",
     "\n",
     "from jdaviz import Imviz"
    ]
@@ -113,8 +113,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_dir = tempfile.gettempdir()\n",
+    "#data_dir = tempfile.gettempdir()\n",
     "#data_dir = \"/Users/username/Data/\"\n",
+    "data_dir = \"/home/lim/test_data/mastDownloads/\"\n",
     "\n",
     "files = ['jw02727-o002_t062_nircam_clear-f090w_i2d.fits',\n",
     "         #'jw02727-o002_t062_nircam_clear-f150w_i2d.fits',\n",
@@ -522,11 +523,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Default marker properties repeated here for reproducibility \n",
+    "# during out-of-order cell runs.\n",
+    "viewer.marker = {'color': 'red', 'alpha': 1.0, 'fill': False}\n",
+    "\n",
     "# Add 20 randomly generated X,Y (0-indexed) w.r.t. reference image\n",
-    "# using default marker properties.\n",
-    "t_xy = Table({'x': np.random.randint(0, 4000, 20),\n",
-    "              'y': np.random.randint(0, 4000, 20)})\n",
-    "viewer.add_markers(t_xy)"
+    "# as 10-pix diamonds using default marker properties.\n",
+    "rect_angle = 45 * u.deg\n",
+    "regs_xy = [RectanglePixelRegion(PixCoord(x, y), width=10, height=10, angle=rect_angle)\n",
+    "           for x, y in np.random.randint(0, 4000, (20, 2))]\n",
+    "viewer.add_markers(regs_xy)"
    ]
   },
   {
@@ -534,7 +540,7 @@
    "id": "f1c1aa0d-46b7-42f6-b6d7-395305c15f91",
    "metadata": {},
    "source": [
-    "You could customize marker color, alpha, size, and fill with values that Glue supports."
+    "You could customize marker color, alpha (for the edge), and fill (alpha is hardcoded) with values that Glue supports."
    ]
   },
   {
@@ -544,7 +550,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer.marker = {'color': 'green', 'alpha': 0.8, 'markersize': 10, 'fill': False}"
+    "viewer.marker = {'color': 'green', 'alpha': 0.5, 'fill': True}"
    ]
   },
   {
@@ -555,12 +561,32 @@
    "outputs": [],
    "source": [
     "# Mark some sky coordinates using updated marker properties.\n",
-    "t_sky = Table({'coord': [SkyCoord('00h37m42.278s -33d42m00.271s'),\n",
-    "                         SkyCoord('00h37m40.111s -33d42m36.871s'),\n",
-    "                         SkyCoord('00h37m43.411s -33d42m55.64s'),\n",
-    "                         SkyCoord('00h37m41.611s -33d42m56.15s')]})\n",
-    "viewer.add_markers(t_sky, use_skycoord=True, marker_name='my_sky')\n",
-    "t_sky"
+    "# This time, mark it as circles with a sky radius.\n",
+    "r_sky = 1.0 * u.arcsec\n",
+    "regs_sky = [CircleSkyRegion(SkyCoord(ra, dec, unit=\"deg\"), r_sky) for ra, dec in [\n",
+    "    [9.4246103, -33.70580397],\n",
+    "    [9.42181872, -33.7023592],\n",
+    "    [9.41987542, -33.7005257],\n",
+    "    [9.41791984, -33.70269787]]]\n",
+    "viewer.add_markers(regs_sky, marker_name='my_sky')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74b92374",
+   "metadata": {},
+   "source": [
+    "You can get back all the added markers as `Regions`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da7096b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer.get_markers()"
    ]
   },
   {
@@ -728,7 +754,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/notebooks/concepts/imviz_line_profiles.ipynb
+++ b/notebooks/concepts/imviz_line_profiles.ipynb
@@ -18,8 +18,9 @@
     "import numpy as np\n",
     "from astropy import units as u\n",
     "from astropy.nddata import NDData\n",
-    "from astropy.table import Table, QTable\n",
+    "from astropy.table import QTable\n",
     "from photutils.datasets import make_4gaussians_image, make_gaussian_sources_image\n",
+    "from regions import PixCoord, CirclePixelRegion\n",
     "\n",
     "from jdaviz import Imviz"
    ]
@@ -98,8 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "t_xy = Table({'x': [5, 79.3, 24.7, 150],\n",
-    "              'y': [5, 90.2, 50, 25]})"
+    "regs_xy = [CirclePixelRegion(PixCoord(x, y), 3) for x, y in zip([5, 79.3, 24.7, 150], [5, 90.2, 50, 25])]"
    ]
   },
   {
@@ -109,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imviz.default_viewer.add_markers(t_xy)"
+    "imviz.default_viewer.add_markers(regs_xy)"
    ]
   },
   {
@@ -158,13 +158,77 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer_2.add_markers(t_xy)"
+    "viewer_2.add_markers(regs_xy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0222b93",
+   "metadata": {},
+   "source": [
+    "Hmmm..."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89fd4a25",
+   "id": "80e4db73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from regions import PolygonPixelRegion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a623f23f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer_2.reset_markers()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cbd3f22d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = [1.04728634, 1.0204958, 0.94012415, 1.95816496, 1.95816496,\n",
+    "     2.94941523, 2.92262468, 2.92262468, 3.8870844, 3.96745604,\n",
+    "     3.02978687, 3.96745604, 4.82475357, 4.74438192, 8.17357203,\n",
+    "     8.17357203, 8.92370736, 9.88816708, 9.03086955, 9.96853872,\n",
+    "     9.91495762, 11.04016063, 10.95978898, 10.93299844, 11.9242487,\n",
+    "     12.00462034, 11.95103925, 11.09374172, 9.96853872, 9.96853872,\n",
+    "     9.96853872, 9.0576601, 9.004079, 3.77992221, 3.8335033,\n",
+    "     2.92262468, 3.00299632, 1.77063113, 1.04728634]\n",
+    "y = [2.02814867, 3.12281621, 4.19011706, 4.13538369, 5.03848441,\n",
+    "     5.01111772, 6.10578526, 7.14571942, 7.2004528, 8.02145345,\n",
+    "     9.03402092, 9.11612099, 8.10355352, 7.2004528, 7.17308611,\n",
+    "     8.24038696, 9.00665424, 9.0887543, 7.14571942, 7.09098604,\n",
+    "     6.02368519, 6.10578526, 4.90165096, 4.13538369, 4.02591693,\n",
+    "     2.9038827, 1.89131523, 3.50594985, 3.53331654, 2.79441595,\n",
+    "     1.9734153, 2.11024874, 1.17978133, 1.23451471, 2.02814867,\n",
+    "     2.16498211, 3.47858316, 3.50594985, 2.02814867]\n",
+    "reg_si = PolygonPixelRegion(PixCoord(x=x, y=y))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07c2201d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer_2.add_markers(reg_si, marker_name=\"space_invader\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c05f300c",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -186,7 +250,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/notebooks/concepts/imviz_roman_asdf.ipynb
+++ b/notebooks/concepts/imviz_roman_asdf.ipynb
@@ -33,6 +33,7 @@
     "from astropy import units as u\n",
     "from astropy.coordinates import SkyCoord\n",
     "from astropy.table import Table\n",
+    "from regions import PixCoord, CirclePixelRegion, CircleSkyRegion\n",
     "\n",
     "from jdaviz import Imviz"
    ]
@@ -70,9 +71,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from astropy.utils.data import get_pkg_data_filename\n",
+    "from jdaviz.configs.imviz.tests.utils import create_wfi_image_model\n",
     "\n",
-    "image_model = get_pkg_data_filename('data/roman_wfi_image_model.asdf', package='jdaviz.configs.imviz.tests')"
+    "image_model = create_wfi_image_model((20, 10))"
    ]
   },
   {
@@ -353,9 +354,10 @@
     "# Add 20 randomly generated X,Y (0-indexed) w.r.t. reference image\n",
     "# using default marker properties.\n",
     "image_shape = data.data.shape\n",
-    "t_xy = Table({'x': np.random.randint(0, image_shape[1], 20),\n",
-    "              'y': np.random.randint(0, image_shape[0], 20)})\n",
-    "viewer.add_markers(t_xy)"
+    "regs_xy = [CirclePixelRegion(PixCoord(x, y), 3)\n",
+    "           for x, y in zip(np.random.randint(0, image_shape[1], 20),\n",
+    "                           np.random.randint(0, image_shape[0], 20))]\n",
+    "viewer.add_markers(regs_xy)"
    ]
   },
   {
@@ -373,7 +375,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer.marker = {'color': 'green', 'alpha': 0.8, 'markersize': 10, 'fill': False}"
+    "viewer.marker = {'color': 'green', 'alpha': 0.8, 'fill': False}"
    ]
   },
   {
@@ -384,11 +386,10 @@
    "outputs": [],
    "source": [
     "np.random.seed(42)\n",
+    "sky_radius = 0.1 * u.arcsec\n",
     "# Mark some sky coordinates using updated marker properties.\n",
-    "t_sky = Table({'coord': [sky.spherical_offsets_by(*np.random.normal(scale=0.1, size=2) * u.arcsec)\n",
-    "                         for i in range(5)]})\n",
-    "viewer.add_markers(t_sky, use_skycoord=True, marker_name='my_sky')\n",
-    "t_sky"
+    "regs_sky = [CircleSkyRegion(sky.spherical_offsets_by(*np.random.normal(scale=0.1, size=2) * u.arcsec), sky_radius) for _ in range(5)]\n",
+    "viewer.add_markers(regs_sky, marker_name='my_sky')"
    ]
   },
   {
@@ -564,7 +565,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to explore what if markers use Astropy regions instead of Astropy Table. There is no expectation for this to be merged until more backends are explored and then API is finalized upstream in https://github.com/astropy/astrowidgets

![Screenshot 2023-09-06 155420](https://github.com/spacetelescope/jdaviz/assets/2090236/91cff476-efb2-41c8-bd1c-cf0ee3fe1599)

Related issues:

* https://github.com/astropy/astrowidgets/issues/137
* https://github.com/astropy/astrowidgets/issues/51

Pros:

* Markers no longer cause data tables to be added to app data collection. They are now pure bqplot figure marks. This probably also improved performance.
* Linking can now change link type with or without markers. This also means we can now get rid of `MarkersChangedMessage`.
* When you zoom in now, marker gets larger. That is, marker now follows data size, not viewer.

Cons:

* You can add sky regions but it does not respect WCS linking because under the hood, everything gets turned into pixels for bqplot.
* We need to render all the shapes into polygons for bqplot so the shape follows data size, not viewer. This means we need to track the input regions separately to preserve API roundtrip.
* API changes are totally not backward compatible.
* Afraid to expose more customization (e.g., alpha for the fill color) in fear of causing Astrowidgets API to be unrealistic for other backends out there.
* Can be easily confused with Footprints and Markers *plugins*. (This is already a problem regardless of this change or not but might as well list it.)

[🐱](https://jira.stsci.edu/browse/JDAT-3723)

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
