### PR TITLE
fix footprint defaults when changing traitlets before plugin active

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ Imviz
   image. [#2388]
 
 - Footprints plugin for plotting overlays of instrument footprints or custom regions in the image
-  viewer. [#2341, #2377]
+  viewer. [#2341, #2377, #2413]
 
 - Add a curve to stretch histograms in the Plot Options plugin representing the colormap
   stretch function. [#2390]

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -323,7 +323,11 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
         if self.overlay_selected not in self._overlays:
             # create new entry with defaults (any defaults not provided here will be carried over
             # from the previous selection based on current traitlet values)
-            self._overlays[self.overlay_selected] = {'color': '#c75109'}
+            # if this is the first overlay, there is a chance the traitlet for color was already set
+            # to something other than the default, so we want to use that, otherwise for successive
+            # new overlays, we want to ignore the traitlet and default back to "active" orange.
+            default_color = '#c75109' if len(self._overlays) else self.color
+            self._overlays[self.overlay_selected] = {'color': default_color}
             if self.preset_selected == 'From File...':
                 # don't carry over the imported file/region to the next selection
                 self._overlays[self.overlay_selected]['from_file'] = ''

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -323,17 +323,23 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
         if self.overlay_selected not in self._overlays:
             # create new entry with defaults (any defaults not provided here will be carried over
             # from the previous selection based on current traitlet values)
+
             # if this is the first overlay, there is a chance the traitlet for color was already set
             # to something other than the default, so we want to use that, otherwise for successive
             # new overlays, we want to ignore the traitlet and default back to "active" orange.
             default_color = '#c75109' if len(self._overlays) else self.color
             self._overlays[self.overlay_selected] = {'color': default_color}
-            if self.preset_selected == 'From File...':
-                # don't carry over the imported file/region to the next selection
+
+            # similarly, if the user called any import APIs before opening the plugin, we want to
+            # respect that, but when creating successive overlays, any selection from file/region
+            # should be cleared for the next selection
+            if self.preset_selected == 'From File...' and len(self._overlays) > 1:
                 self._overlays[self.overlay_selected]['from_file'] = ''
                 self._overlays[self.overlay_selected]['preset'] = self.preset.choices[0]
+
+            # for the first overlay only, default the position to be centered on the current
+            # zoom limits of the first selected viewer
             if len(self._overlays) == 1 and len(self.viewer.selected):
-                # default to the center of the current zoom limits of the first selected viewer
                 self.center_on_viewer(self.viewer.selected[0])
 
         fp = self._overlays[self.overlay_selected]
@@ -381,11 +387,12 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
         if self.overlay_selected not in self._overlays:
             # default dictionary has not been created yet
             return
-        if not self.is_active:
-            return
+        self._ensure_first_overlay()
         name = msg.get('name', '').split('_selected')[0]
         if len(name):
             self._overlays[self.overlay_selected][name] = msg.get('new')
+        if not self.is_active:
+            return
 
         # update existing mark (or add/remove from viewers)
         for viewer_id, viewer in self.app._viewer_store.items():

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -441,8 +441,14 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
             # we need to cache these locally in order to support multiple files/regions between
             # different overlay entries all selecting From File...
             overlay = self._overlays.get(self.overlay_selected, {})
-            if 'regions' not in overlay and isinstance(self.preset.selected_obj, regions.Regions):
-                overlay['regions'] = self.preset.selected_obj
+            if ('regions' not in overlay
+                    and isinstance(self.preset.selected_obj, (regions.Region, regions.Regions))):
+                regs = self.preset.selected_obj
+                if not isinstance(regs, regions.Regions):
+                    # then this is a single region, but to be compatible with looping logic,
+                    # let's just put as a single entry in a list
+                    regs = [regs]
+                overlay['regions'] = regs
             regs = overlay.get('regions', [])
         elif self.has_pysiaf and self.preset_selected in preset_regions._instruments:
             regs = preset_regions.jwst_footprint(self.preset_selected, **callable_kwargs)

--- a/jdaviz/configs/imviz/tests/test_footprints.py
+++ b/jdaviz/configs/imviz/tests/test_footprints.py
@@ -94,7 +94,13 @@ def test_user_api(imviz_helper, image_2d_wcs, tmp_path):
         reg = plugin.overlay_regions
         plugin.import_region(reg)
         assert plugin.preset.selected == 'From File...'
+        viewer_marks = _get_markers_from_viewer(imviz_helper.default_viewer)
         assert len(viewer_marks) == len(reg)
+        # test that importing a different region updates the marks and also that
+        # a single region is supported
+        plugin.import_region(reg[0])
+        viewer_marks = _get_markers_from_viewer(imviz_helper.default_viewer)
+        assert len(viewer_marks) == 1
         # clearing the file should default to the PREVIOUS preset (last from the for-loop above)
         plugin._obj.vue_file_import_cancel()
         assert plugin.preset.selected == preset
@@ -115,8 +121,9 @@ def test_user_api(imviz_helper, image_2d_wcs, tmp_path):
                                               height=3 * u.deg, width=2 * u.deg)
         plugin.import_region(valid_region_sky)
 
+        tmp_invalid_path = str(tmp_path / 'invalid_path.reg')
         with pytest.raises(ValueError):
-            plugin.import_region('./invalid_path.reg')
+            plugin.import_region(tmp_invalid_path)
         with pytest.raises(TypeError):
             plugin.import_region(5)
 

--- a/jdaviz/configs/imviz/tests/test_footprints.py
+++ b/jdaviz/configs/imviz/tests/test_footprints.py
@@ -23,6 +23,9 @@ def test_user_api(imviz_helper, image_2d_wcs, tmp_path):
     imviz_helper.load_data(ndd)
 
     plugin = imviz_helper.plugins['Footprints']
+    default_color = plugin.color
+    default_opacity = plugin.fill_opacity
+    plugin.color = '#333333'
     with plugin.as_active():
         assert plugin._obj.is_pixel_linked is True
         plugin._obj.vue_link_by_wcs()
@@ -35,9 +38,12 @@ def test_user_api(imviz_helper, image_2d_wcs, tmp_path):
             viewer_marks = _get_markers_from_viewer(imviz_helper.default_viewer)
             assert len(viewer_marks) == len(_all_apertures.get(preset))
 
+        # regression test for user-set traitlets (specifically color) being reset
+        # when the plugin is opened
+        assert plugin.color == '#333333'
+        assert viewer_marks[0].colors == ['#333333']
+
         # change the color/opacity of the first/default overlay
-        default_color = plugin.color
-        default_opacity = plugin.fill_opacity
         plugin.color = '#ffffff'
         plugin.fill_opacity = 0.5
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes respecting user-changed traitlets (specifically color, but also applies to the preset selection) when those traitlets were set in the API before the overlay objects are fully initialized when the plugin is first opened.

See the included regression test or the following example:

```
fp = imviz.plugins['Footprints']
fp._obj.vue_link_by_wcs()
fp.color = '#ff33ff'
fp.open_in_tray()
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
