### PR TITLE
Max pin Notebook, update/fix markdown in SpecvizExample notebook

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,9 @@ Specviz2d
 Other Changes and Additions
 ---------------------------
 
+- Pinned Jupyter Notebook version to less than 7 to avoid buggy behavior due
+  to incompatibility. [#2415]
+
 3.6.3 (unreleased)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,9 +91,6 @@ Specviz2d
 Other Changes and Additions
 ---------------------------
 
-- Pinned Jupyter Notebook version to less than 7 to avoid buggy behavior due
-  to incompatibility. [#2415]
-
 3.6.3 (unreleased)
 ==================
 
@@ -103,6 +100,9 @@ Bug Fixes
 - Fixes turning off multiselect mode for a dropdown when no selections are currently made. 
   Previously this resulted in a traceback, but now applies the default selection for 
   single-select mode. [#2404]
+
+- Pinned Jupyter Notebook version to less than 7 to avoid buggy behavior due
+  to incompatibility. [#2415]
 
 Cubeviz
 ^^^^^^^

--- a/notebooks/SpecvizExample.ipynb
+++ b/notebooks/SpecvizExample.ipynb
@@ -54,14 +54,7 @@
    "source": [
     "## Display Specviz\n",
     "\n",
-    "Note: you probably want to pick one of the three options below depending on preference. Also not the latter two will only work in JupyterLab, not the \"classic\" notebook interface."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This will show Specviz inline in the notebook"
+    "This will show Specviz inline in the notebook. You can pass an integer to the `height` keyword to change the displayed height of the app (the default is 600). You can also pass `loc=\"popout:window\"` to immediately pop out the Jdaviz app into a separate window."
    ]
   },
   {
@@ -300,7 +293,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "ipysplitpanes>=0.1.0",
     "ipygoldenlayout>=0.3.0",
     "ipywidgets>=8.0.6",
+    "notebook<7",
     "voila>=0.4,<0.5",
     "pyyaml>=5.4.1",
     "specutils>=1.9",


### PR DESCRIPTION
Max pin `notebook` to avoid buggy behavior due to incompatibility with Notebook 7. Also fixed some bad text I noticed in a notebook.