### PR TITLE
provide access to API from show_launcher

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 New Features
 ------------
 
-- Improved design of Launcher and pass filepath arg from cli when no config specified. [#2311, #2417, #2418]
+- Improved design of Launcher and pass filepath argument from CLI when no configuration is specified. [#2311, #2417, #2418]
 
 - Subset Tools plugin now displays the parent data of a spatial (ROI) subset. [#2154]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 New Features
 ------------
 
-- Improved design of Launcher and pass filepath arg from cli when no config specified. [#2311, #2417]
+- Improved design of Launcher and pass filepath arg from cli when no config specified. [#2311, #2417, #2418]
 
 - Subset Tools plugin now displays the parent data of a spatial (ROI) subset. [#2154]
 

--- a/jdaviz/core/launcher.py
+++ b/jdaviz/core/launcher.py
@@ -106,6 +106,7 @@ class Launcher(v.VuetifyTemplate):
     filepath = Unicode().tag(sync=True)
     compatible_configs = List().tag(sync=True)
     config_icons = Dict().tag(sync=True)
+    config_loaded = Bool(False).tag(sync=True)
     hint = Unicode().tag(sync=True)
     vdocs = Unicode("").tag(sync=True)  # App not available yet, so we need to recompute it here
     # File picker Traitlets
@@ -192,6 +193,14 @@ class Launcher(v.VuetifyTemplate):
             self.main.height = default_height
         self.main.color = 'transparent'
         self.main.children = [helper.app]
+        self.config_loaded = True
+
+    @property
+    def jdaviz_helper(self):
+        if not self.config_loaded:
+            raise ValueError("jdaviz instance has not yet been chosen/loaded")
+        # give access to the helper after it is selected
+        return self.main.children[0]
 
 
 def show_launcher(configs=ALL_JDAVIZ_CONFIGS, filepath='', height='450px'):
@@ -217,3 +226,4 @@ def show_launcher(configs=ALL_JDAVIZ_CONFIGS, filepath='', height='450px'):
     main.children = [Launcher(main, configs, filepath, height)]
 
     show_widget(main, loc='inline', title=None)
+    return main.children[0]

--- a/jdaviz/core/launcher.vue
+++ b/jdaviz/core/launcher.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="mx-12">
+  <div v-if="config_loaded">
+    <v-alert type="warning">
+      Jdaviz instance from this launcher has already loaded.  Create a new launcher instance or access launcher.jdaviz_helper.
+    </v-alert>
+  </div>
+  <div v-else class="mx-12">
     <span style="float: right; font-weight: 100; color: white">
         <a :href="'https://jdaviz.readthedocs.io/en/'+vdocs" target="__blank" style="color: white">
             <b>Learn More</b>


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request provides access to the launcher/helper APIs when calling `show_launcher()`.  While working on #2417, I noticed it was difficult to debug because `show_launcher` _only_ calls show but does not return the launcher itself.  But once the launcher is returned, we want a way to be able to access the resulting config-helper as well.  This implements the following:

* instantiated launcher object returned by `show_launcher()` (`launcher = show_launcher()`)
* `launcher.jdaviz_helper` is available after choosing config, and will raise error until a config is chosen
* calling `launcher` (as the last entry in a cell) will not re-show a broken launcher after config chosen, but rather a warning message suggesting accessing the chosen configuration via `launcher.jdaviz_helper`

Note: I do not necessarily suggest we publicize this too much on docs since it is still a bit clunky, but _definitely_ is useful for debugging internally.  Ultimately, most users using the launcher will not be calling from the notebook but rather from the standalone mode.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.
  
~Once #2417 is merged, this should be rebased and 2418 added to the same changelog entry (if we want this)~

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
