### PR TITLE
Fix explanation in markdown cell of SpecvizExample notebook

### DIFF
--- a/notebooks/SpecvizExample.ipynb
+++ b/notebooks/SpecvizExample.ipynb
@@ -54,14 +54,7 @@
    "source": [
     "## Display Specviz\n",
     "\n",
-    "Note: you probably want to pick one of the three options below depending on preference. Also not the latter two will only work in JupyterLab, not the \"classic\" notebook interface."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This will show Specviz inline in the notebook"
+    "This will show Specviz inline in the notebook. You can pass an integer to the `height` keyword to change the displayed height of the app (the default is 600). You can also pass `loc=\\\"popout:window\\\"` to immediately pop out the Jdaviz app into a separate window."
    ]
   },
   {
@@ -300,7 +293,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Some of the text here seems orphaned from when the code cell had different contents, I think this is better.