### PR TITLE
reset fully non-finite uncertainties to None in specviz parser

### DIFF
--- a/jdaviz/configs/specviz/plugins/parsers.py
+++ b/jdaviz/configs/specviz/plugins/parsers.py
@@ -6,8 +6,10 @@ from astropy.io.registry import IORegistryError
 from astropy.nddata import StdDevUncertainty
 from specutils import Spectrum1D, SpectrumList, SpectrumCollection
 
+from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import data_parser_registry
 from jdaviz.utils import standardize_metadata
+
 
 __all__ = ["specviz_spectrum1d_parser"]
 
@@ -32,6 +34,7 @@ def specviz_spectrum1d_parser(app, data, data_label=None, format=None, show_in_v
         the extensions within each spectrum file passed to the parser and
         add a concatenated spectrum to the data collection.
     """
+
     spectrum_viewer_reference_name = app._jdaviz_helper._default_spectrum_viewer_reference_name
     # If no data label is assigned, give it a unique name
     if not data_label:
@@ -41,8 +44,9 @@ def specviz_spectrum1d_parser(app, data, data_label=None, format=None, show_in_v
         raise TypeError("SpectrumCollection detected."
                         " Please provide a Spectrum1D or SpectrumList")
     elif isinstance(data, Spectrum1D):
-        data = [data]
+        # should we make a copy if Spectrum1D is passed in to avoid modifying it when uncerts are reset to None?
         data_label = [app.return_data_label(data_label, alt_name="specviz_data")]
+        data = [data]
     # No special processing is needed in this case, but we include it for completeness
     elif isinstance(data, SpectrumList):
         pass
@@ -55,6 +59,7 @@ def specviz_spectrum1d_parser(app, data, data_label=None, format=None, show_in_v
             try:
                 data = [Spectrum1D.read(str(path), format=format)]
                 data_label = [app.return_data_label(data_label, alt_name="specviz_data")]
+
             except IORegistryError:
                 # Multi-extension files may throw a registry error
                 data = SpectrumList.read(str(path), format=format)
@@ -76,17 +81,78 @@ def specviz_spectrum1d_parser(app, data, data_label=None, format=None, show_in_v
             raise ValueError(f"Length of data labels list ({len(data_label)}) is different"
                              f" than length of list of data ({len(data)})")
 
-    with app.data_collection.delay_link_manager_update():
         # these are used to build a combined spectrum with all
         # input spectra included (taken from https://github.com/spacetelescope/
         # dat_pyinthesky/blob/main/jdat_notebooks/MRS_Mstar_analysis/
         # JWST_Mstar_dataAnalysis_analysis.ipynb)
-        wlallorig = []
-        fnuallorig = []
-        dfnuallorig = []
+        wlallorig = []  # to collect wavelengths
+        fnuallorig = []  # fluxes
+        dfnuallorig = []  # and uncertanties (if present)
 
+        for wlind in range(len(spec.spectral_axis)):
+            wlallorig.append(spec.spectral_axis[wlind].value)
+            fnuallorig.append(spec.flux[wlind].value)
+
+            # because some spec in the list might have uncertainties and
+            # others may not, if uncert is None, set to list of NaN. later,
+            # if the concatenated list of uncertanties is all nan (meaning
+            # they were all nan to begin with, or all None), it will be set
+            # to None on the final Spectrum1D
+            if spec.uncertainty[wlind] is not None:
+                dfnuallorig.append(spec.uncertainty[wlind].array)
+            else:
+                dfnuallorig.append(np.nan)
+
+    # if the entire uncert. array is Nan and the data is not, model fitting won't
+    # work (more generally, if uncert[i] is nan/inf and flux[i] is not, fitting will
+    # fail, but just deal with the all nan case here since it is straightforward).
+    # set uncerts. to None if they are all nan/inf, and display a warning message.
+    set_nans_to_none = False
+    if isinstance(data, SpectrumList):
+        uncerts = dfnuallorig  # alias these for clarity later on
+        flux = fnuallorig
+        if uncerts is not None:
+            if not np.all(np.isfinite(uncerts)):
+                uncerts = None
+                set_nans_to_none = Treu
+    else:
+        uncerts = np.isfinite(data[0].uncertainty.array)  # alias these for clarity later on
+        flux = data[0].flux.value
+        # i think it is safe to just check [0], this should just be [Spectrum1D]
+        if not np.all(uncerts):
+            data[0].uncertainty = None
+            set_nans_to_none = True
+
+    if set_nans_to_none:
+        pass  # not sure what the syntax is to do this in a function
+        # snackbar_message = SnackbarMessage('All uncertanties are nonfinite, setting to None.', sender=self)
+
+    # final part of data cleanup - if uncertainties are present, we need to make
+    # sure that if uncertainty[i]==nan/inf, that the corresponding data[i] is also nan/inf.
+    # if not, model fitting will fail. raise a warning if this ever happens.
+    mismatch_flux_uncert = False
+    if uncerts is not None:
+        for i, val in enumerate(uncerts):
+            if not np.isfinite(uncerts[i]) and np.isfinite(flux[i]):
+                mismatch_flux_uncert = True
+                break  # we only need to catch this once then can stop looking
+
+    if mismatch_flux_uncert:
+        pass  # again, not sure what the syntax is to do this in a function
+        msg = 'Data has non-finite uncertainties corresponding to finite ' +
+               'data values. his can cause plugins like `model_fitting` to ' +
+               'produce incorrect results. Consider masking these values in ' + 
+               'the data array.'
+        # snackbar_message = SnackbarMessage(msg, sender=self)
+
+
+
+    with app.data_collection.delay_link_manager_update():
         for i, spec in enumerate(data):
 
+            # note: if SpectrumList, this is just going to be the last unit when
+            # combined in the next block. should put a check here to make sure
+            # units are all the same or collect them in a list?
             wave_units = spec.spectral_axis.unit
             flux_units = spec.flux.unit
 
@@ -96,17 +162,8 @@ def specviz_spectrum1d_parser(app, data, data_label=None, format=None, show_in_v
             app.add_data(spec, data_label[i])
 
             # handle display, with the SpectrumList special case in mind.
-            if show_in_viewer:
-                if isinstance(data, SpectrumList):
-
-                    # add spectrum to combined result
-                    for wlind in range(len(spec.spectral_axis)):
-                        wlallorig.append(spec.spectral_axis[wlind].value)
-                        fnuallorig.append(spec.flux[wlind].value)
-                        dfnuallorig.append(spec.uncertainty[wlind].array)
-
-                elif i == 0:
-                    app.add_data_to_viewer(spectrum_viewer_reference_name, data_label[i])
+            if i == 0 and show_in_viewer:
+                app.add_data_to_viewer(spectrum_viewer_reference_name, data_label[i])
 
         if concat_by_file and isinstance(data, SpectrumList):
             # If >1 spectra in the list were opened from the same FITS file,
@@ -115,8 +172,9 @@ def specviz_spectrum1d_parser(app, data, data_label=None, format=None, show_in_v
             unique_files = group_spectra_by_filename(app.data_collection)
             for filename, datasets in unique_files.items():
                 if len(datasets) > 1:
-                    spec = combine_lists_to_1d_spectrum(wlallorig, fnuallorig, dfnuallorig,
-                                                        wave_units, flux_units)
+                    spec = combine_lists_to_1d_spectrum(wlallorig, fnuallorig,
+                                                        dfnuallorig, wave_units,
+                                                        flux_units)
 
                     # Make metadata layout conform with other viz.
                     spec.meta = standardize_metadata(spec.meta)
@@ -162,7 +220,7 @@ def combine_lists_to_1d_spectrum(wl, fnu, dfnu, wave_units, flux_units):
         Wavelength in each spectral channel
     fnu : list of `~astropy.units.Quantity`s
         Flux in each spectral channel
-    dfnu : list of `~astropy.units.Quantity`s
+    dfnu : list of `~astropy.units.Quantity`s or None
         Uncertainty on each flux
 
     Returns
@@ -172,14 +230,19 @@ def combine_lists_to_1d_spectrum(wl, fnu, dfnu, wave_units, flux_units):
     """
     wlallarr = np.array(wl)
     fnuallarr = np.array(fnu)
-    dfnuallarr = np.array(dfnu)
+    if dfnu is not None:
+        dfnuallarr = np.array(dfnu)
     srtind = np.argsort(wlallarr)
     wlall = wlallarr[srtind]
     fnuall = fnuallarr[srtind]
     fnuallerr = dfnuallarr[srtind]
 
     # units are not being handled properly yet.
-    unc = StdDevUncertainty(fnuallerr * flux_units)
+    if dfnu is not None:
+        unc = StdDevUncertainty(fnuallerr * flux_units)
+    else:
+        unc = None
+
     spec = Spectrum1D(flux=fnuall * flux_units, spectral_axis=wlall * wave_units,
                       uncertainty=unc)
     return spec


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
(see PR <insert link here> for an alternative fix for this issue. This PR makes changes in the parser, while the other approach
deals with this case in model fitting).

The model fitting plugin uses astropy models/fitting, is able to handle data that contains nans/infs and still perform the fit (using the filter_nonfinite flag). However, when uncertainties are provided and there is a mismatch between the indicies of nan/inf values in the data array and nan/inf values in the uncertainty array, fitting fails with an error. If data[i]==nan and uncertainty[i] != nan, that is fine. However, if data[i]!=nan and uncertainty[i]==nan, fitting will fail. 

This PR fixes the most straightforward case where this may happen (and the case that revealed this issue) - when the entire uncertainty array is nan but the data array is fully finite. In the specviz parser, the uncertainty array is reset to None (either on an individual input Spectrum1D, or a concatenated Spectrum1D from a SpectrumList) when this case occurs. Additionally, when a case arises where there are mismatches between data and uncertainty, but the arrays arent fully non-finite, a warning message is displayed prompting users to fix their data to avoid potential issues in model fitting.

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
