### PR TITLE
BUG: Moment map retains WCS on write

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,8 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Fixed moment map losing WCS when being written out to FITS file. [#2431]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -5,7 +5,7 @@ from astropy import units as u
 from astropy.nddata import CCDData
 
 from traitlets import Unicode, Bool, observe
-from specutils import Spectrum1D, manipulation, analysis
+from specutils import manipulation, analysis
 
 from jdaviz.core.custom_traitlets import IntHandleEmpty
 from jdaviz.core.events import SnackbarMessage
@@ -101,7 +101,11 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
             Whether to add the resulting data object to the app according to ``add_results``.
         """
         # Retrieve the data cube and slice out desired region, if specified
-        cube = self.dataset.get_object(cls=Spectrum1D, statistic=None)
+        if "_orig_spec" in self.dataset.selected_obj.meta:
+            cube = self.dataset.selected_obj.meta["_orig_spec"]
+        else:
+            cube = self.dataset.selected_obj
+
         spec_min, spec_max = self.spectral_subset.selected_min_max(cube)
         slab = manipulation.spectral_slab(cube, spec_min, spec_max)
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -154,3 +154,10 @@ def test_momentmap_nirspec_prism(cubeviz_helper, tmp_path):
     plugin = cubeviz_helper.plugins['Moment Maps']
     plugin.calculate_moment()
     assert isinstance(plugin._obj.moment.wcs, WCS)
+
+    # Because cube axes order is re-arranged by specutils on load, this gets confusing.
+    # There is a swapaxes within Moment Map WCS calculation.
+    sky_moment = plugin._obj.moment.wcs.pixel_to_world(50, 30)
+    sky_cube = cubeviz_helper.app.data_collection[0].meta["_orig_spec"].wcs.celestial.pixel_to_world(30, 50)  # noqa: E501
+    assert_allclose((sky_moment.ra.deg, sky_moment.dec.deg),
+                    (sky_cube.ra.deg, sky_cube.dec.deg))


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to hook the Moment Map logic into our existing hack for everything else in Cubeviz.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3766)
