### PR TITLE
API access (hidden) to disable cubeviz movie UI

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -194,6 +194,7 @@ class ApplicationState(State):
         },
         'viewer_labels': True,
         'dense_toolbar': True,
+        'server_is_remote': False,  # sets some defaults, should be set before loading the config
         'context': {
             'notebook': {
                 'max_height': '600px'

--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -9,6 +9,7 @@ settings:
     tray: true
     tab_headers: true
   dense_toolbar: false
+  server_is_remote: false
   context:
     notebook:
       max_height: 750px

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
@@ -6,6 +6,10 @@ from specutils import Spectrum1D
 
 from glue.core.roi import XRangeROI
 
+from jdaviz import Cubeviz
+from jdaviz.app import Application
+from jdaviz.core.config import get_configuration
+
 
 def test_nested_helper(cubeviz_helper):
     '''Ensures the Cubeviz helper is always returned, even after the Specviz helper is called'''
@@ -67,6 +71,16 @@ def test_valid_function(cubeviz_helper, spectrum1d_cube):
     assert cubeviz_helper.get_data(data_label="test[FLUX]").flux.ndim == 3
     # but calling through specviz automatically collapses
     assert cubeviz_helper.specviz.get_data(data_label="test[FLUX]").flux.ndim == 1
+
+
+def test_remote_server_disable_movie():
+    config = get_configuration('cubeviz')
+    config['settings']['server_is_remote'] = True
+
+    cubeviz_app = Application(config)
+    cubeviz_helper = Cubeviz(cubeviz_app)
+    ep = cubeviz_helper.plugins['Export Plot']
+    assert ep._obj.movie_enabled is False
 
 
 def test_get_data_spatial_and_spectral(cubeviz_helper, spectrum1d_cube_larger):

--- a/jdaviz/configs/default/default.yaml
+++ b/jdaviz/configs/default/default.yaml
@@ -4,6 +4,7 @@ settings:
     toolbar: true
     tray: true
     tab_headers: true
+  server_is_remote: false
   context:
     notebook:
       max_height: 600px

--- a/jdaviz/configs/default/plugins/export_plot/export_plot.py
+++ b/jdaviz/configs/default/plugins/export_plot/export_plot.py
@@ -46,6 +46,12 @@ class ExportViewer(PluginTemplateMixin, ViewerSelectMixin):
     # For Cubeviz movie.
     i_start = IntHandleEmpty(0).tag(sync=True)
     i_end = IntHandleEmpty(0).tag(sync=True)
+
+    # movie_enabled controls whether movie support is enabled via the UI.  This is a temporary
+    # measure to allow server-installations to disable support for saving movies but setting this
+    # traitlet until movie-support is refactored to be sent through the browser instead of saved
+    # server-side in python.
+    movie_enabled = Bool(True).tag(sync=True)
     movie_fps = FloatHandleEmpty(5.0).tag(sync=True)
     movie_filename = Any("mymovie.mp4").tag(sync=True)
     movie_msg = Unicode("").tag(sync=True)
@@ -233,6 +239,11 @@ class ExportViewer(PluginTemplateMixin, ViewerSelectMixin):
         """
         if self.config != "cubeviz":
             raise NotImplementedError(f"save_movie is not available for config={self.config}")
+
+        if not self.movie_enabled:
+            # this should never be triggered since this is intended for UI-disabling and the
+            # UI section is hidden, but would prevent any JS-hacking
+            raise ValueError("save_movie is currently disabled")
 
         if not HAS_OPENCV:
             raise ImportError("Please install opencv-python to save cube as movie.")

--- a/jdaviz/configs/default/plugins/export_plot/export_plot.py
+++ b/jdaviz/configs/default/plugins/export_plot/export_plot.py
@@ -75,6 +75,11 @@ class ExportViewer(PluginTemplateMixin, ViewerSelectMixin):
                 # NOTE: HTML tags do not work here.
                 self.movie_msg = 'Please install opencv-python to use this feature.'
 
+        if self.app.state.settings.get('server_is_remote', False):
+            # when the server is remote, saving thet movie in python would save on the server, not
+            # on the user's machine, so movie support in cubeviz should be disabled
+            self.movie_enabled = False
+
     def _on_cubeviz_data_added(self, msg):
         # NOTE: This needs revising if we allow loading more than one cube.
         if isinstance(msg.viewer, BqplotImageView):

--- a/jdaviz/configs/default/plugins/export_plot/export_plot.vue
+++ b/jdaviz/configs/default/plugins/export_plot/export_plot.vue
@@ -33,7 +33,7 @@
         </v-btn>
       </v-row>
 
-      <v-row v-if="config==='cubeviz' && viewer_selected!=='spectrum-viewer'">
+      <v-row v-if="config==='cubeviz' && viewer_selected!=='spectrum-viewer' && movie_enabled">
         <v-expansion-panels accordion>
           <v-expansion-panel>
             <v-expansion-panel-header v-slot="{ open }">

--- a/jdaviz/configs/imviz/imviz.yaml
+++ b/jdaviz/configs/imviz/imviz.yaml
@@ -9,6 +9,7 @@ settings:
     tray: true
     tab_headers: true
   dense_toolbar: false
+  server_is_remote: false
   context:
     notebook:
       max_height: 600px

--- a/jdaviz/configs/mosviz/mosviz.yaml
+++ b/jdaviz/configs/mosviz/mosviz.yaml
@@ -6,6 +6,7 @@ settings:
     tray: true
     tab_headers: false
   dense_toolbar: false
+  server_is_remote: false
   context:
     notebook:
       max_height: 860px

--- a/jdaviz/configs/specviz/specviz.yaml
+++ b/jdaviz/configs/specviz/specviz.yaml
@@ -8,6 +8,7 @@ settings:
     tray: true
     tab_headers: false
   dense_toolbar: false
+  server_is_remote: false
   context:
     notebook:
       max_height: 600px

--- a/jdaviz/configs/specviz2d/specviz2d.yaml
+++ b/jdaviz/configs/specviz2d/specviz2d.yaml
@@ -6,6 +6,7 @@ settings:
     tray: true
     tab_headers: false
   dense_toolbar: false
+  server_is_remote: false
   context:
     notebook:
       max_height: 600px


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request creates a traitlet in the "Export Plot" plugin so that notebooks running a standalone UI can disable the capability for cubeviz movies (#2264).  The movie implementation saves the movie on the python/server-side, so would for cases where the python/server and browser/client are on different machines, it may make sense to disable (at least until we re-implement to send the movie _through_ the browser's save file dialog).

This can be done in the launching notebook via: `cubeviz.plugins['Export Plot']._obj.movie_enabled = False`.

Alternatively, this will _default_ to `True` if the configuration sets `server_is_remote: true`, _before_ the plugin is first initialized.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
