### PR TITLE
Revert "TST: Ignore ASDF warning about gwcs-1.0.0 schema"

### DIFF
--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -1,10 +1,8 @@
 import os
-import warnings
 
 import asdf
 import numpy as np
 import pytest
-from asdf.exceptions import AsdfWarning
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.nddata import NDData
@@ -355,11 +353,8 @@ class TestMarkers(BaseImviz_WCS_NoWCS):
 def test_markers_gwcs_lonlat(imviz_helper):
     """GWCS uses Lon/Lat for ICRS."""
     gw_file = get_pkg_data_filename('data/miri_i2d_lonlat_gwcs.asdf')
-    with warnings.catch_warnings():
-        # https://github.com/spacetelescope/jdaviz/issues/2446
-        warnings.filterwarnings("ignore", category=AsdfWarning)
-        with asdf.open(gw_file) as af:
-            gw = af.tree['wcs']
+    with asdf.open(gw_file) as af:
+        gw = af.tree['wcs']
     ndd = NDData(np.ones((10, 10), dtype=np.float32), wcs=gw, unit='MJy/sr')
     imviz_helper.load_data(ndd, data_label='MIRI_i2d')
     assert imviz_helper.app.data_collection[0].label == 'MIRI_i2d[DATA]'

--- a/jdaviz/configs/mosviz/tests/test_parsers.py
+++ b/jdaviz/configs/mosviz/tests/test_parsers.py
@@ -1,9 +1,7 @@
-import warnings
 from zipfile import ZipFile
 
 import pytest
 from numpy.testing import assert_allclose
-from asdf.exceptions import AsdfWarning
 from astropy.utils.data import download_file
 
 from jdaviz.utils import PRIHDR_KEY, COMMENTCARD_KEY
@@ -99,10 +97,7 @@ def test_nirspec_level2_parser(mosviz_helper, tmp_path):
     level3_path = tmp_path / 'jw02756001001_03103_00003_nrs1'
 
     data_dir = level3_path
-    with warnings.catch_warnings():
-        # https://github.com/spacetelescope/jdaviz/issues/2446
-        warnings.filterwarnings("ignore", category=AsdfWarning)
-        mosviz_helper.load_data(directory=data_dir, instrument='nirspec')
+    mosviz_helper.load_data(directory=data_dir, instrument='nirspec')
 
     assert len(mosviz_helper.app.data_collection) == 75
 
@@ -130,10 +125,7 @@ def test_niriss_parser(mosviz_helper, tmp_path):
     with ZipFile(fn, 'r') as sample_data_zip:
         sample_data_zip.extractall(tmp_path)
 
-    with warnings.catch_warnings():
-        # https://github.com/spacetelescope/jdaviz/issues/2446
-        warnings.filterwarnings("ignore", category=AsdfWarning)
-        mosviz_helper.load_data(directory=tmp_path, instrument="niriss")
+    mosviz_helper.load_data(directory=tmp_path, instrument="niriss")
     assert len(mosviz_helper.app.data_collection) == 10
 
     # The MOS Table should be first in the data collection


### PR DESCRIPTION
Reverts spacetelescope/jdaviz#2451 now that https://github.com/spacetelescope/gwcs/pull/475 is merged upstream. 🤞

xref https://github.com/spacetelescope/jdaviz/issues/2446 