### PR TITLE
Aperture photometry: refactor, batch mode, enable user API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,6 @@ Imviz
 
 - Aperture photometry (previously "Imviz Simple Aperture Photometry") now supports batch mode. [#2465]
 
-- Enable user API for aperture photometry. [#2465]
-
 Mosviz
 ^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Enable user API for aperture photometry. [#2465]
+
 Mosviz
 ^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Aperture photometry (previously "Imviz Simple Aperture Photometry") now supports batch mode. [#2465]
+
 - Enable user API for aperture photometry. [#2465]
 
 Mosviz

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -161,8 +161,8 @@ This plugin only considers pixel locations, not sky coordinates.
 
 .. _aper-phot-simple:
 
-Simple Aperture Photometry
-==========================
+Aperture Photometry
+===================
 
 .. warning::
 

--- a/jdaviz/components/plugin_dataset_select.vue
+++ b/jdaviz/components/plugin_dataset_select.vue
@@ -10,33 +10,60 @@
       :label="label ? label : 'Data'"
       :hint="hint ? hint : 'Select data.'"
       :rules="rules ? rules : []"
+      :multiple="multiselect"
+      :chips="multiselect"
       item-text="label"
       item-value="label"
       persistent-hint
     >
-    <template slot="selection" slot-scope="data">
-      <div class="single-line">
-        <span>
-          <j-layer-viewer-icon v-if="data.item.icon" span_style="margin-right: 4px" :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
-          {{ data.item.label }}
-        </span>
-      </div>
-    </template>
-    <template slot="item" slot-scope="data">
-      <div class="single-line">
-        <span>
-          <j-layer-viewer-icon v-if="data.item.icon" span_style="margin-right: 4px" :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
-          {{ data.item.label }}
-        </span>
-      </div>
-    </template>
+      <template slot="selection" slot-scope="data">
+        <div class="single-line">
+          <v-chip v-if="multiselect" style="width: calc(100% - 20px)">
+            <span>
+              <j-layer-viewer-icon v-if="data.item.icon" span_style="margin-right: 4px" :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
+              {{ data.item.label }}
+            </span>
+          </v-chip>
+          <span v-else>
+            <j-layer-viewer-icon v-if="data.item.icon" span_style="margin-right: 4px" :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
+            {{ data.item.label }}
+          </span>
+        </div>
+      </template>
+      <template v-slot:prepend-item v-if="multiselect">
+        <v-list-item
+        ripple
+        @mousedown.prevent
+        @click="() => {if (selected.length < items.length) { $emit('update:selected', items.map((item) => item.label))} else {$emit('update:selected', [])}}"
+        >
+        <v-list-item-action>
+          <v-icon>
+            {{ selected.length == items.length ? 'mdi-close-box' : selected.length ? 'mdi-minus-box' : 'mdi-checkbox-blank-outline' }}
+          </v-icon>
+        </v-list-item-action>
+        <v-list-item-content>
+          <v-list-item-title>
+            {{ selected.length < items.length ? "Select All" : "Clear All" }}
+          </v-list-item-title>
+        </v-list-item-content>
+        </v-list-item>
+        <v-divider class="mt-2"></v-divider>
+      </template>
+      <template slot="item" slot-scope="data">
+        <div class="single-line">
+          <span>
+            <j-layer-viewer-icon v-if="data.item.icon" span_style="margin-right: 4px" :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
+            {{ data.item.label }}
+          </span>
+        </div>
+      </template>
    </v-select>
   </v-row>
  </div>
 </template>
 <script>
 module.exports = {
-  props: ['items', 'selected', 'label', 'hint', 'rules', 'show_if_single_entry']
+  props: ['items', 'selected', 'label', 'hint', 'rules', 'show_if_single_entry', 'multiselect']
 };
 </script>
 

--- a/jdaviz/components/plugin_dataset_select.vue
+++ b/jdaviz/components/plugin_dataset_select.vue
@@ -17,8 +17,8 @@
       persistent-hint
     >
       <template slot="selection" slot-scope="data">
-        <div class="single-line">
-          <v-chip v-if="multiselect" style="width: calc(100% - 20px)">
+        <div class="single-line" style="width: 100%">
+          <v-chip v-if="multiselect" style="width: calc(100% - 10px)">
             <span>
               <j-layer-viewer-icon v-if="data.item.icon" span_style="margin-right: 4px" :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
               {{ data.item.label }}
@@ -67,9 +67,11 @@ module.exports = {
 };
 </script>
 
-<style>
+<style scoped>
   .v-select__selections {
     flex-wrap: nowrap !important;
+    display: block !important;
+    margin-bottom: -32px;
   }
   .single-line {
       white-space: nowrap;

--- a/jdaviz/components/plugin_layer_select.vue
+++ b/jdaviz/components/plugin_layer_select.vue
@@ -18,7 +18,7 @@
     >
     <template slot="selection" slot-scope="data">
       <div class="single-line" style="width: 100%">
-        <v-chip v-if="multiselect" style="width: calc(100% - 20px)">
+        <v-chip v-if="multiselect" style="width: calc(100% - 10px)">
           <span>
             <j-layer-viewer-icon :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
             {{ data.item.label }}

--- a/jdaviz/components/plugin_subset_select.vue
+++ b/jdaviz/components/plugin_subset_select.vue
@@ -80,9 +80,9 @@ module.exports = {
 </script>
 
 <style>
-.v-select__selections {
-  flex-wrap: nowrap !important;
-}
+  .v-select__selections {
+    flex-wrap: nowrap !important;
+  }
   .single-line {
       white-space: nowrap;
       overflow: hidden;

--- a/jdaviz/components/plugin_subset_select.vue
+++ b/jdaviz/components/plugin_subset_select.vue
@@ -17,8 +17,8 @@
       persistent-hint
     >
       <template slot="selection" slot-scope="data">
-        <div class="single-line">
-          <v-chip v-if="multiselect" style="width: calc(100% - 20px)">
+        <div class="single-line" style="width: 100%">
+          <v-chip v-if="multiselect" style="width: calc(100% - 10px)">
             <span>
               <v-icon v-if="data.item.color" left :color="data.item.color">
                 {{ data.item.type=='spectral' ? 'mdi-chart-bell-curve' : 'mdi-chart-scatter-plot' }}
@@ -79,9 +79,11 @@ module.exports = {
 };
 </script>
 
-<style>
+<style scoped>
   .v-select__selections {
     flex-wrap: nowrap !important;
+    display: block !important;
+    margin-bottom: -32px;
   }
   .single-line {
       white-space: nowrap;

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -54,6 +54,10 @@ class MetadataViewer(PluginTemplateMixin, DatasetSelectMixin):
 
     @observe("dataset_selected")
     def show_metadata(self, event):
+        if not hasattr(self, 'dataset'):
+            # plugin not fully initialized
+            return
+
         data = self.dataset.selected_dc_item
         if (data is None or not hasattr(data, 'meta') or not isinstance(data.meta, dict)
                 or len(data.meta) < 1):

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -54,7 +54,7 @@ class MetadataViewer(PluginTemplateMixin, DatasetSelectMixin):
 
     @observe("dataset_selected")
     def show_metadata(self, event):
-        if not hasattr(self, 'dataset'):
+        if not hasattr(self, 'dataset'):  # pragma: no cover
             # plugin not fully initialized
             return
 

--- a/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
+++ b/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
@@ -49,7 +49,7 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
 
     subplugins_opened = Any().tag(sync=True)
 
-    multiselect = Bool(False).tag(sync=True)
+    multiselect = Bool(False).tag(sync=True)  # multiselect only for subset
     is_centerable = Bool(False).tag(sync=True)
     can_simplify = Bool(False).tag(sync=True)
     can_freeze = Bool(False).tag(sync=True)

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -267,7 +267,7 @@ class Imviz(ImageConfigHelper):
             Photometry results if available or `None` otherwise.
 
         """
-        return self.plugins['Imviz Simple Aperture Photometry']._obj.export_table()
+        return self.plugins['Aperture Photometry']._obj.export_table()
 
     def get_catalog_source_results(self):
         """Return table of sources given by querying from a catalog, if any.

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -24,7 +24,6 @@ from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin, DatasetMultiSelectMixin,
                                         SubsetSelect, TableMixin, PlotMixin)
 from jdaviz.core.tools import ICON_DIR
-from jdaviz.core.user_api import PluginUserApi
 from jdaviz.utils import PRIHDR_KEY
 
 __all__ = ['SimpleAperturePhotometry']
@@ -131,13 +130,14 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetMultiSelectMixin, Tab
         self.session.hub.subscribe(self, SubsetUpdateMessage, handler=self._on_subset_update)
         self.session.hub.subscribe(self, LinkUpdatedMessage, handler=self._on_link_update)
 
-    @property
-    def user_api(self):
-        return PluginUserApi(self, expose=('multiselect', 'dataset', 'aperture',
-                                           'background', 'background_value',
-                                           'pixel_area', 'counts_factor', 'flux_scaling',
-                                           'calculate_photometry',
-                                           'unpack_batch_options', 'calculate_batch_photometry'))
+# TODO: expose public API once finalized
+#    @property
+#    def user_api(self):
+#        return PluginUserApi(self, expose=('multiselect', 'dataset', 'aperture',
+#                                           'background', 'background_value',
+#                                           'pixel_area', 'counts_factor', 'flux_scaling',
+#                                           'calculate_photometry',
+#                                           'unpack_batch_options', 'calculate_batch_photometry'))
 
     def _get_defaults_from_metadata(self, dataset=None):
         defaults = {}
@@ -643,7 +643,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetMultiSelectMixin, Tab
                 raise ValueError("must either provide a dictionary or set plugin to multiselect mode")  # noqa
             options = {'dataset': self.dataset.selected, 'aperture': self.aperture.selected}
 
-        user_api = self.user_api
+        # TODO: use self.user_api once API is made public
+        user_api = self  # .user_api
         invalid_keys = [k for k in options.keys() if not hasattr(user_api, k)]
         if len(invalid_keys):
             raise ValueError(f"{invalid_keys} are not valid inputs for batch photometry")

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -320,11 +320,11 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetMultiSelectMixin, Tab
         -------
         * table row, fit results
         """
-        if self.multiselect and (dataset is None or aperture is None):
+        if self.multiselect and (dataset is None or aperture is None):  # pragma: no cover
             raise ValueError("for batch mode, use calculate_batch_photometry")
 
         if dataset is not None:
-            if dataset not in self.dataset.choices:
+            if dataset not in self.dataset.choices:  # pragma: no cover
                 raise ValueError(f"dataset must be one of {self.dataset.choices}")
             data = self.dataset._get_dc_item(dataset)
         else:
@@ -348,7 +348,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetMultiSelectMixin, Tab
 
         comp = data.get_component(data.main_components[0])
 
-        if background is not None and background not in self.background.choices:
+        if background is not None and background not in self.background.choices:  # pragma: no cover
             raise ValueError(f"background must be one of {self.background.choices}")
         if background_value is not None:
             if ((background not in (None, 'Manual'))
@@ -639,7 +639,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetMultiSelectMixin, Tab
         if not isinstance(options, dict):
             raise TypeError("options must be a dictionary")
         if not options:
-            if not self.multiselect:
+            if not self.multiselect:  # pragma: no cover
                 raise ValueError("must either provide a dictionary or set plugin to multiselect mode")  # noqa
             options = {'dataset': self.dataset.selected, 'aperture': self.aperture.selected}
 
@@ -710,7 +710,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetMultiSelectMixin, Tab
         if not np.all([isinstance(option, dict) for option in options]):
             raise TypeError("options must be a list of dictionaries")
         if not len(options):
-            if not self.multiselect:
+            if not self.multiselect:  # pragma: no cover
                 raise ValueError("must either provide manual options or put the plugin in multiselect mode")  # noqa
             # unpack the batch options as provided in the app
             options = self.unpack_batch_options()

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -664,6 +664,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin, TableMix
                 mult_values[k] = this_value
 
         def _unpack_dict_list(mult_values, single_values):
+            if not len(mult_values):
+                return [single_values]
             options_list = []
             # loop over the first item in mult_values
             # any remaining mult values will require recursion

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -238,7 +238,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetMultiSelectMixin, Tab
         if not self.dataset_selected or not self.aperture_selected:
             return
         if self.multiselect:
-            self._backgound_selected_changed()
+            self._background_selected_changed()
             return
 
         sbst = msg.subset

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -72,7 +72,6 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetMultiSelectMixin, Tab
     background_value = Any(0).tag(sync=True)
     pixel_area_multi_auto = Bool(True).tag(sync=True)
     pixel_area = FloatHandleEmpty(0).tag(sync=True)
-    counts_factor_multi_auto = Bool(True).tag(sync=True)
     counts_factor = FloatHandleEmpty(0).tag(sync=True)
     flux_scaling_multi_auto = Bool(True).tag(sync=True)
     flux_scaling = FloatHandleEmpty(0).tag(sync=True)
@@ -194,7 +193,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetMultiSelectMixin, Tab
 
         try:
             defaults = self._get_defaults_from_metadata()
-            self.counts_factor = defaults.get('counts_factor', 0)
+            self.counts_factor = 0
             self.pixel_area = defaults.get('pixel_area', 0)
             self.flux_scaling = defaults.get('flux_scaling', 0)
 
@@ -722,8 +721,6 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetMultiSelectMixin, Tab
             this_update_plots = i == len(options) and update_plots
             defaults = self._get_defaults_from_metadata(option.get('dataset',
                                                                    self.dataset.selected))
-            if self.counts_factor_multi_auto:
-                option.setdefault('counts_factor', defaults.get('counts_factor', 0))
             if self.pixel_area_multi_auto:
                 option.setdefault('pixel_area', defaults.get('pixel_area', 0))
             if self.flux_scaling_multi_auto:

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -258,6 +258,10 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetMultiSelectMixin, Tab
     def _aperture_selected_changed(self, event={}):
         if not self.dataset_selected or not self.aperture_selected:
             return
+        if self.multiselect is not isinstance(self.aperture_selected, list):
+            # then multiselect is in the process of changing but the traitlet for aperture_selected
+            # has not been updated internally yet
+            return
         if self.multiselect:
             self._background_selected_changed()
             return

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -298,27 +298,27 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetMultiSelectMixin, Tab
 
         Parameters
         ----------
-        * ``dataset`` : str, optional
+        dataset : str, optional
             Dataset to use for photometry.
-        * ``aperture`` : str, optional
+        aperture : str, optional
             Subset to use as the aperture.
-        * ``background`` : str, optional
+        background : str, optional
             Subset to use to calculate the background.
-        * ``background_value`` : float, optional
+        background_value : float, optional
             Background to subtract, same unit as data.  Automatically computed if ``background``
             is set to a subset.
-        * ``pixel_area`` : float, optional
+        pixel_area : float, optional
             Pixel area in arcsec squared, only used if sr in data unit.
-        * ``counts_factor`` : float, optional
+        counts_factor : float, optional
             Factor to convert data unit to counts, in unit of flux/counts.
-        * ``flux_scaling`` : float, optional
+        flux_scaling : float, optional
             Same unit as data, used in -2.5 * log(flux / flux_scaling).
-        * ``add_to_table`` : bool, optional
-        * ``update_plots`` : bool, optional
+        add_to_table : bool, optional
+        update_plots : bool, optional
 
         Returns
         -------
-        * table row, fit results
+        table row, fit results
         """
         if self.multiselect and (dataset is None or aperture is None):  # pragma: no cover
             raise ValueError("for batch mode, use calculate_batch_photometry")

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -42,24 +42,6 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetMultiSelectMixin, Tab
 
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.show`
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.open_in_tray`
-    * ``dataset`` (:class:`~jdaviz.core.template_mixin.DatasetSelect`):
-      Dataset to use for photometry.
-    * ``aperture`` (:class:`~jdaviz.core.template_mixin.SubsetSelect`):
-      Subset to use as the aperture.
-    * ``background`` (:class:`~jdaviz.core.template_mixin.SubsetSelect`):
-      Subset to use to calculate the background.
-    * ``background_value``:
-      Background to subtract, same unit as data.  Automatically computed if ``background``
-      is set to a subset.
-    * ``pixel_area``:
-      Pixel area in arcsec squared, only used if sr in data unit.
-    * ``counts_factor``:
-      Factor to convert data unit to counts, in unit of flux/counts.
-    * ``flux_scaling``:
-      Same unit as data, used in -2.5 * log(flux / flux_scaling).
-    * :meth:`calculate_photometry`
-    * :meth:`unpack_batch_options`
-    * :meth:`calculate_batch_photometry`
     """
     template_file = __file__, "aper_phot_simple.vue"
     multiselect = Bool(False).tag(sync=True)

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -206,7 +206,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin, TableMix
                 self.aperture_area = 0
         except Exception as e:
             self.hub.broadcast(SnackbarMessage(
-                f"Failed to extract {self.aperture_selected}: {repr(e)}", color='error', sender=self))
+                f"Failed to extract {self.aperture_selected}: {repr(e)}",
+                color='error', sender=self))
         else:
             self._background_selected_changed()
 
@@ -300,7 +301,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin, TableMix
             if ((background not in (None, 'Manual'))
                     or (background is None and self.background_selected != 'Manual')):
                 raise ValueError("cannot provide background_value with background!='Manual'")
-        elif background == 'Manual' or (background is None and self.background.selected == 'Manual'):
+        elif (background == 'Manual'
+                or (background is None and self.background.selected == 'Manual')):
             background_value = self.background_value
         elif background is None and dataset is None:
             # use the previously-computed value in the plugin

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -578,6 +578,9 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin, TableMix
 
         try:
             if self.multiselect:
+                # even though plots aren't show in the UI when in multiselect mode,
+                # we'll create the last entry so if multiselect is disabled, the last
+                # iteration will show and not result in confusing behavior
                 self.calculate_batch_photometry(add_to_table=True, update_plots=True)
             else:
                 self.calculate_photometry(add_to_table=True, update_plots=True)

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -21,7 +21,7 @@ from jdaviz.core.custom_traitlets import FloatHandleEmpty
 from jdaviz.core.events import SnackbarMessage, LinkUpdatedMessage
 from jdaviz.core.region_translators import regions2aperture, _get_region_from_spatial_subset
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import (PluginTemplateMixin, DatasetSelectMixin,
+from jdaviz.core.template_mixin import (PluginTemplateMixin, DatasetMultiSelectMixin,
                                         SubsetSelect, TableMixin, PlotMixin)
 from jdaviz.core.tools import ICON_DIR
 from jdaviz.core.user_api import PluginUserApi
@@ -33,7 +33,7 @@ ASTROPY_LT_5_2 = Version(astropy.__version__) < Version('5.2')
 
 
 @tray_registry('imviz-aper-phot-simple', label="Aperture Photometry")
-class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin, TableMixin, PlotMixin):
+class SimpleAperturePhotometry(PluginTemplateMixin, DatasetMultiSelectMixin, TableMixin, PlotMixin):
     """
     The Aperture Photometry plugin performs aperture photometry for drawn regions.
     See the :ref:`Aperture Photometry Plugin Documentation <aper-phot-simple>` for more details.

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -575,7 +575,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetSelectMixin, TableMix
         -------
         options : list
             List of all combinations of input parameters, which can then be used as input to
-            `batch_aper_phot`
+            `calculate_batch_photometry`.
         """
         if not isinstance(options, dict):
             raise TypeError("options must be a dictionary")

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -143,7 +143,7 @@
           </v-text-field>
         </v-row>
 
-        <v-row>
+        <v-row v-if="!multiselect">
           <v-select
             :menu-props="{ left: true }"
             attach
@@ -155,13 +155,13 @@
           ></v-select>
         </v-row>
 
-        <v-row v-if="current_plot_type==='Radial Profile (Raw)' && aperture_area > 5000">
+        <v-row v-if="!multiselect && current_plot_type==='Radial Profile (Raw)' && aperture_area > 5000">
           <span class="v-messages v-messages__message text--secondary">
               <b>WARNING</b>: Computing and displaying raw profile of an aperture containing ~{{aperture_area}} pixels may be slow or unresponsive.
           </span>
         </v-row>
 
-        <v-row v-if="current_plot_type.indexOf('Radial Profile') != -1">
+        <v-row v-if="!multiselect && current_plot_type.indexOf('Radial Profile') != -1">
 
           <v-switch
             label="Fit Gaussian"
@@ -183,11 +183,11 @@
       </span>
     </v-row>
 
-    <v-row v-if="plot_available">
+    <v-row v-if="!multiselect && plot_available">
       <jupyter-widget :widget="plot_widget"/> 
     </v-row>
 
-    <div v-if="plot_available && fit_radial_profile && current_plot_type != 'Curve of Growth'">
+    <div v-if="!multiselect && plot_available && fit_radial_profile && current_plot_type != 'Curve of Growth'">
       <j-plugin-section-header>Gaussian Fit Results</j-plugin-section-header>
       <v-row no-gutters>
         <v-col cols=6><U>Result</U></v-col>
@@ -204,7 +204,7 @@
       </v-row>
     </div>
 
-    <div v-if="result_available">
+    <div v-if="!multiselect && result_available">
       <j-plugin-section-header>Photometry Results</j-plugin-section-header>
 
       <v-row no-gutters>
@@ -220,7 +220,9 @@
         </v-col>
         <v-col cols=6>{{ item.result }}</v-col>
       </v-row>
+    </div>
 
+    <div v-if="result_available">
       <j-plugin-section-header>Results History</j-plugin-section-header>
       <jupyter-widget :widget="table_widget"></jupyter-widget> 
     </div>

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -1,6 +1,6 @@
 <template>
   <j-tray-plugin
-    description='Perform aperture photometry for a single region.'
+    description='Perform aperture photometry for drawn regions.'
     :link="docs_link || 'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#simple-aperture-photometry'"
     :popout_button="popout_button">
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -95,20 +95,7 @@
           </v-text-field>
         </v-row>
 
-        <v-row v-if="multiselect">
-          <v-switch
-            v-model="counts_factor_multi_auto"
-            label="Auto counts conversion factor"
-            hint="Calculate automatically for each input dataset."
-            persistent-hint
-          />
-        </v-row>
-        <v-row v-if="multiselect && counts_factor_multi_auto">
-          <span class="v-messages v-messages__message text--secondary">
-            <b>Batch mode:</b> counts conversion factor will be automatically computed for each selected data entry separately and exposed in the output table.
-          </span>
-        </v-row>
-        <v-row v-else>
+        <v-row>
           <v-text-field
             label="Counts conversion factor"
             v-model.number="counts_factor"

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -14,23 +14,23 @@
 
     <div v-if='dataset_selected'>
       <plugin-subset-select
-        :items="subset_items"
-        :selected.sync="subset_selected"
+        :items="aperture_items"
+        :selected.sync="aperture_selected"
         :show_if_single_entry="true"
         label="Aperture"
         hint="Select aperture region for photometry (cannot be an annulus or composite subset)."
       />
 
-      <div v-if="subset_selected">
+      <div v-if="aperture_selected">
         <plugin-subset-select
-          :items="bg_subset_items"
-          :selected.sync="bg_subset_selected"
+          :items="background_items"
+          :selected.sync="background_selected"
           :show_if_single_entry="true"
           label="Background"
           hint="Select subset region for background calculation (cannot be a composite subset)."
         />
 
-        <v-row v-if="subset_selected === bg_subset_selected">
+        <v-row v-if="aperture_selected === background_selected">
           <span class="v-messages v-messages__message text--secondary" style="color: red !important">
               Background and aperture cannot be set to the same subset
           </span>
@@ -42,7 +42,7 @@
             v-model.number="background_value"
             type="number"
             hint="Background to subtract, same unit as data"
-            :disabled="bg_subset_selected!='Manual'"
+            :disabled="background_selected!='Manual'"
             persistent-hint
           >
           </v-text-field>
@@ -93,9 +93,9 @@
           ></v-select>
         </v-row>
 
-        <v-row v-if="current_plot_type==='Radial Profile (Raw)' && subset_area > 5000">
+        <v-row v-if="current_plot_type==='Radial Profile (Raw)' && aperture_area > 5000">
           <span class="v-messages v-messages__message text--secondary">
-              <b>WARNING</b>: Computing and displaying raw profile of an aperture containing ~{{subset_area}} pixels may be slow or unresponsive.
+              <b>WARNING</b>: Computing and displaying raw profile of an aperture containing ~{{aperture_area}} pixels may be slow or unresponsive.
           </span>
         </v-row>
 
@@ -110,7 +110,7 @@
         </v-row>
 
         <v-row justify="end">
-          <v-btn color="primary" text @click="do_aper_phot" :disabled="subset_selected === bg_subset_selected">Calculate</v-btn>
+          <v-btn color="primary" text @click="do_aper_phot" :disabled="aperture_selected === background_selected">Calculate</v-btn>
         </v-row>
       </div>
     </div>

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -56,7 +56,7 @@
 
         <v-row v-if="multiselect && background_selected !== 'Manual'">
           <span class="v-messages v-messages__message text--secondary">
-            <b>Batch mode:</b> background value will be automatically computed for each selected data entry separately
+            <b>Batch mode:</b> background value will be automatically computed for each selected data entry separately and exposed in the output table.
           </span>
         </v-row>
         <v-row v-else>
@@ -71,7 +71,20 @@
           </v-text-field>
         </v-row>
 
-        <v-row>
+        <v-row v-if="multiselect">
+          <v-switch
+            v-model="pixel_area_multi_auto"
+            label="Auto pixel area"
+            hint="Calculate automatically for each input dataset."
+            persistent-hint
+          />
+        </v-row>
+        <v-row v-if="multiselect && pixel_area_multi_auto">
+          <span class="v-messages v-messages__message text--secondary">
+            <b>Batch mode:</b> pixel area will be automatically computed for each selected data entry separately and exposed in the output table.
+          </span>
+        </v-row>
+        <v-row v-else>
           <v-text-field
             label="Pixel area"
             v-model.number="pixel_area"
@@ -82,7 +95,20 @@
           </v-text-field>
         </v-row>
 
-        <v-row>
+        <v-row v-if="multiselect">
+          <v-switch
+            v-model="counts_factor_multi_auto"
+            label="Auto counts conversion factor"
+            hint="Calculate automatically for each input dataset."
+            persistent-hint
+          />
+        </v-row>
+        <v-row v-if="multiselect && counts_factor_multi_auto">
+          <span class="v-messages v-messages__message text--secondary">
+            <b>Batch mode:</b> counts conversion factor will be automatically computed for each selected data entry separately and exposed in the output table.
+          </span>
+        </v-row>
+        <v-row v-else>
           <v-text-field
             label="Counts conversion factor"
             v-model.number="counts_factor"
@@ -93,7 +119,20 @@
           </v-text-field>
         </v-row>
 
-        <v-row>
+        <v-row v-if="multiselect">
+          <v-switch
+            v-model="flux_scaling_multi_auto"
+            label="Auto flux scaling"
+            hint="Calculate automatically for each input dataset."
+            persistent-hint
+          />
+        </v-row>
+        <v-row v-if="multiselect && flux_scaling_multi_auto">
+          <span class="v-messages v-messages__message text--secondary">
+            <b>Batch mode:</b> flux scaling will be automatically computed for each selected data entry separately and exposed in the output table.
+          </span>
+        </v-row>
+        <v-row v-else>
           <v-text-field
             label="Flux scaling"
             v-model.number="flux_scaling"

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -54,7 +54,12 @@
           </span>
         </v-row>
 
-        <v-row>
+        <v-row v-if="multiselect && background_selected !== 'Manual'">
+          <span class="v-messages v-messages__message text--secondary">
+            <b>Batch mode:</b> background value will be automatically computed for each selected data entry separately
+          </span>
+        </v-row>
+        <v-row v-else>
           <v-text-field
             label="Background value"
             v-model.number="background_value"

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -119,6 +119,11 @@
           >
           </v-text-field>
         </v-row>
+        <v-row v-if="flux_scaling_warning.length > 0">
+          <span class="v-messages v-messages__message text--secondary" style="color: red !important">
+            {{flux_scaling_warning}}
+          </span>
+        </v-row>
 
         <v-row v-if="!multiselect">
           <v-select

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -4,24 +4,42 @@
     :link="docs_link || 'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#simple-aperture-photometry'"
     :popout_button="popout_button">
 
+    <v-row>
+      <div style="width: calc(100% - 32px)">
+      </div>
+      <div style="width: 32px">
+        <j-tooltip tooltipcontent="Toggle batch mode">
+          <v-btn
+            icon
+            style="opacity: 0.7"
+            @click="() => {multiselect = !multiselect}"
+          >
+            <img :src="multiselect ? icon_checktoradial : icon_radialtocheck" width="24" class="invert-if-dark"/>
+          </v-btn>
+        </j-tooltip>
+      </div>
+    </v-row>
+
     <plugin-dataset-select
       :items="dataset_items"
       :selected.sync="dataset_selected"
+      :multiselect="multiselect"
       :show_if_single_entry="false"
       label="Data"
       hint="Select the data for photometry."
     />
 
-    <div v-if='dataset_selected'>
+    <div v-if='dataset_selected.length > 0'>
       <plugin-subset-select
         :items="aperture_items"
         :selected.sync="aperture_selected"
+        :multiselect="multiselect"
         :show_if_single_entry="true"
         label="Aperture"
         hint="Select aperture region for photometry (cannot be an annulus or composite subset)."
       />
 
-      <div v-if="aperture_selected">
+      <div v-if="aperture_selected.length > 0">
         <plugin-subset-select
           :items="background_items"
           :selected.sync="background_selected"
@@ -30,7 +48,7 @@
           hint="Select subset region for background calculation (cannot be a composite subset)."
         />
 
-        <v-row v-if="aperture_selected === background_selected">
+        <v-row v-if="(multiselect && aperture_selected.includes(background_selected)) || aperture_selected === background_selected">
           <span class="v-messages v-messages__message text--secondary" style="color: red !important">
               Background and aperture cannot be set to the same subset
           </span>

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -75,16 +75,11 @@
           <v-switch
             v-model="pixel_area_multi_auto"
             label="Auto pixel area"
-            hint="Calculate automatically for each input dataset."
+            :hint="pixel_area_multi_auto ? 'Pixel area will be automatically computed for each selected data entry separately and exposed in the output table.' : 'Pixel area will be held fixed at the value below for each iteration.'"
             persistent-hint
           />
         </v-row>
-        <v-row v-if="multiselect && pixel_area_multi_auto">
-          <span class="v-messages v-messages__message text--secondary">
-            <b>Batch mode:</b> pixel area will be automatically computed for each selected data entry separately and exposed in the output table.
-          </span>
-        </v-row>
-        <v-row v-else>
+        <v-row v-if="!multiselect || !pixel_area_multi_auto">
           <v-text-field
             label="Pixel area"
             v-model.number="pixel_area"
@@ -110,16 +105,11 @@
           <v-switch
             v-model="flux_scaling_multi_auto"
             label="Auto flux scaling"
-            hint="Calculate automatically for each input dataset."
+            :hint="flux_scaling_multi_auto ? 'Flux scaling will be automatically computed for each selected data entry separately and exposed in the output table.' : 'Flux scaling will be held fixed at the value below for each iteration.'"
             persistent-hint
           />
         </v-row>
-        <v-row v-if="multiselect && flux_scaling_multi_auto">
-          <span class="v-messages v-messages__message text--secondary">
-            <b>Batch mode:</b> flux scaling will be automatically computed for each selected data entry separately and exposed in the output table.
-          </span>
-        </v-row>
-        <v-row v-else>
+        <v-row v-if="!multiselect || !flux_scaling_multi_auto">
           <v-text-field
             label="Flux scaling"
             v-model.number="flux_scaling"

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -265,7 +265,7 @@ class TestParseImage:
         # Test simple aperture photometry plugin.
         phot_plugin = imviz_helper.app.get_tray_item_from_name('imviz-aper-phot-simple')
         phot_plugin.data_selected = 'contents[DATA]'
-        phot_plugin.subset_selected = 'Subset 1'
+        phot_plugin.aperture_selected = 'Subset 1'
         assert_allclose(phot_plugin.background_value, 0)
         phot_plugin.background_selected = 'Subset 2'
         assert_allclose(phot_plugin.background_value, 0.1741226315498352)  # Subset 2 median
@@ -395,7 +395,7 @@ class TestParseImage:
                                                (1512, 2611))  # Galaxy
         phot_plugin = imviz_helper.app.get_tray_item_from_name('imviz-aper-phot-simple')
         phot_plugin.data_selected = 'contents[SCI,1]'
-        phot_plugin.subset_selected = 'Subset 1'
+        phot_plugin.aperture_selected = 'Subset 1'
         phot_plugin.background_value = 0.0014  # Manual entry: Median on whole array
         assert_allclose(phot_plugin.pixel_area, 0.0025)  # Not used but still auto-populated
         phot_plugin.vue_do_aper_phot()

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -267,7 +267,7 @@ class TestParseImage:
         phot_plugin.data_selected = 'contents[DATA]'
         phot_plugin.subset_selected = 'Subset 1'
         assert_allclose(phot_plugin.background_value, 0)
-        phot_plugin.bg_subset_selected = 'Subset 2'
+        phot_plugin.background_selected = 'Subset 2'
         assert_allclose(phot_plugin.background_value, 0.1741226315498352)  # Subset 2 median
         # NOTE: jwst.datamodels.find_fits_keyword("PHOTMJSR")
         phot_plugin.counts_factor = (data.meta['photometry']['conversion_megajanskys'] /

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -198,21 +198,22 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         self.imviz.link_data(link_type='wcs')  # They are dithered by 1 pixel on X
         self.imviz._apply_interactive_region('bqplot:truecircle', (0, 0), (9, 9))  # Draw a circle
 
-        phot_plugin = self.imviz.app.get_tray_item_from_name('imviz-aper-phot-simple')
+        phot_plugin = self.imviz.plugins['Aperture Photometry']
         assert phot_plugin.dataset.choices == ['has_wcs_1[SCI,1]', 'has_wcs_2[SCI,1]']
         assert phot_plugin.aperture.choices == ['Subset 1']
 
-        phot_plugin.calculate_batch_photometry([{'dataset': 'has_wcs_1[SCI,1]', 'aperture': 'Subset 1'},  # noqa
-                                                {'dataset': 'has_wcs_2[SCI,1]'}])
+        phot_plugin.aperture = 'Subset 1'
+        phot_plugin._obj.calculate_batch_photometry([{'dataset': 'has_wcs_1[SCI,1]', 'aperture': 'Subset 1'},  # noqa
+                                                     {'dataset': 'has_wcs_2[SCI,1]'}])
 
-        assert len(phot_plugin.table) == 2
+        assert len(phot_plugin._obj.table) == 2
 
         with pytest.raises(RuntimeError):
-            phot_plugin.calculate_batch_photometry([{'dataset': 'has_wcs_1[SCI,1]', 'aperture': 'DNE'},  # noqa
-                                                    {'dataset': 'has_wcs_2[SCI,1]', 'aperture': 'Subset 1'}])  # noqa
+            phot_plugin._obj.calculate_batch_photometry([{'dataset': 'has_wcs_1[SCI,1]', 'aperture': 'DNE'},  # noqa
+                                                         {'dataset': 'has_wcs_2[SCI,1]', 'aperture': 'Subset 1'}])  # noqa
 
         # second entry above should have been successful, resulting in one addition to the results
-        assert len(phot_plugin.table) == 3
+        assert len(phot_plugin._obj.table) == 3
 
 
 class TestSimpleAperPhot_NoWCS(BaseImviz_WCS_NoWCS):

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -202,14 +202,14 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         assert phot_plugin.dataset.choices == ['has_wcs_1[SCI,1]', 'has_wcs_2[SCI,1]']
         assert phot_plugin.aperture.choices == ['Subset 1']
 
-        phot_plugin.batch_aper_phot([{'dataset': 'has_wcs_1[SCI,1]', 'aperture': 'Subset 1'},
-                                     {'dataset': 'has_wcs_2[SCI,1]'}])
+        phot_plugin.calculate_batch_photometry([{'dataset': 'has_wcs_1[SCI,1]', 'aperture': 'Subset 1'},  # noqa
+                                                {'dataset': 'has_wcs_2[SCI,1]'}])
 
         assert len(phot_plugin.table) == 2
 
         with pytest.raises(RuntimeError):
-            phot_plugin.batch_aper_phot([{'dataset': 'has_wcs_1[SCI,1]', 'aperture': 'DNE'},
-                                         {'dataset': 'has_wcs_2[SCI,1]', 'aperture': 'Subset 1'}])
+            phot_plugin.calculate_batch_photometry([{'dataset': 'has_wcs_1[SCI,1]', 'aperture': 'DNE'},  # noqa
+                                                    {'dataset': 'has_wcs_2[SCI,1]', 'aperture': 'Subset 1'}])  # noqa
 
         # second entry above should have been successful, resulting in one addition to the results
         assert len(phot_plugin.table) == 3
@@ -265,7 +265,7 @@ class TestAdvancedAperPhot:
 
         self.imviz = imviz_helper
         self.viewer = imviz_helper.default_viewer
-        self.phot_plugin = imviz_helper.plugins["Imviz Simple Aperture Photometry"]._obj
+        self.phot_plugin = imviz_helper.plugins["Aperture Photometry"]._obj
 
     @pytest.mark.parametrize(('data_label', 'local_bkg'), [
         ('gauss100_fits_wcs[PRIMARY,1]', 5.0),

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -168,7 +168,8 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         assert phot_plugin.plot.figure.title == 'Curve of growth from aperture center'
 
     def test_batch_unpack(self):
-        phot_plugin = self.imviz.app.get_tray_item_from_name('imviz-aper-phot-simple')
+        # TODO: remove ._obj when API is made public
+        phot_plugin = self.imviz.plugins['Aperture Photometry']._obj
 
         # NOTE: these input values are not currently validated, so it does not matter that the
         # datasets and subsets do not exist with these names (if that changes, this test will
@@ -198,35 +199,36 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         self.imviz.link_data(link_type='wcs')  # They are dithered by 1 pixel on X
         self.imviz._apply_interactive_region('bqplot:truecircle', (0, 0), (9, 9))  # Draw a circle
 
-        phot_plugin = self.imviz.plugins['Aperture Photometry']
+        # TODO: remove ._obj when API is made public
+        phot_plugin = self.imviz.plugins['Aperture Photometry']._obj
         assert phot_plugin.dataset.choices == ['has_wcs_1[SCI,1]', 'has_wcs_2[SCI,1]']
         assert phot_plugin.aperture.choices == ['Subset 1']
 
-        phot_plugin.aperture = 'Subset 1'
-        phot_plugin._obj.calculate_batch_photometry([{'dataset': 'has_wcs_1[SCI,1]', 'aperture': 'Subset 1'},  # noqa
-                                                     {'dataset': 'has_wcs_2[SCI,1]'}])
+        phot_plugin.aperture.selected = 'Subset 1'
+        phot_plugin.calculate_batch_photometry([{'dataset': 'has_wcs_1[SCI,1]', 'aperture': 'Subset 1'},  # noqa
+                                                {'dataset': 'has_wcs_2[SCI,1]'}])
 
-        assert len(phot_plugin._obj.table) == 2
+        assert len(phot_plugin.table) == 2
 
         with pytest.raises(RuntimeError):
-            phot_plugin._obj.calculate_batch_photometry([{'dataset': 'has_wcs_1[SCI,1]', 'aperture': 'DNE'},  # noqa
-                                                         {'dataset': 'has_wcs_2[SCI,1]', 'aperture': 'Subset 1'}])  # noqa
+            phot_plugin.calculate_batch_photometry([{'dataset': 'has_wcs_1[SCI,1]', 'aperture': 'DNE'},  # noqa
+                                                    {'dataset': 'has_wcs_2[SCI,1]', 'aperture': 'Subset 1'}])  # noqa
 
         # second entry above should have been successful, resulting in one addition to the results
-        assert len(phot_plugin._obj.table) == 3
+        assert len(phot_plugin.table) == 3
 
         # now run through the UI directly
         phot_plugin.multiselect = True
         phot_plugin.dataset.select_all()
         phot_plugin.aperture.select_none()
         assert len(phot_plugin.unpack_batch_options()) == 0
-        phot_plugin._obj.vue_do_aper_phot()
+        phot_plugin.vue_do_aper_phot()
 
-        assert len(phot_plugin._obj.table) == 3
+        assert len(phot_plugin.table) == 3
         phot_plugin.aperture.select_all()
         assert len(phot_plugin.unpack_batch_options()) == 2
-        phot_plugin._obj.vue_do_aper_phot()
-        assert len(phot_plugin._obj.table) == 5
+        phot_plugin.vue_do_aper_phot()
+        assert len(phot_plugin.table) == 5
 
 
 class TestSimpleAperPhot_NoWCS(BaseImviz_WCS_NoWCS):

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -31,21 +31,21 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
             phot_plugin.dataset_selected = 'no_such_data'
         with pytest.raises(ValueError):
             # will raise an error and revert to first entry
-            phot_plugin.subset_selected = 'no_such_subset'
-        assert phot_plugin.subset_selected == ''
-        phot_plugin.subset_selected = phot_plugin.subset.labels[0]
+            phot_plugin.aperture_selected = 'no_such_subset'
+        assert phot_plugin.aperture_selected == ''
+        phot_plugin.aperture_selected = phot_plugin.aperture.labels[0]
         assert_allclose(phot_plugin.background_value, 0)
 
         phot_plugin.dataset_selected = 'has_wcs_1[SCI,1]'
-        phot_plugin.subset_selected = phot_plugin.subset.labels[0]
+        phot_plugin.aperture_selected = phot_plugin.aperture.labels[0]
         with pytest.raises(ValueError):
-            phot_plugin.bg_subset_selected = 'no_such_subset'
-        assert phot_plugin.bg_subset_selected == 'Manual'
+            phot_plugin.background_selected = 'no_such_subset'
+        assert phot_plugin.background_selected == 'Manual'
         assert_allclose(phot_plugin.background_value, 0)
 
         # Perform photometry on both images using same Subset.
         phot_plugin.dataset_selected = 'has_wcs_1[SCI,1]'
-        phot_plugin.subset_selected = 'Subset 1'
+        phot_plugin.aperture_selected = 'Subset 1'
         assert phot_plugin.dataset.selected_dc_item is not None
         phot_plugin.vue_do_aper_phot()
         tbl = self.imviz.get_aperture_photometry_results()
@@ -54,8 +54,8 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         phot_plugin.dataset_selected = 'has_wcs_2[SCI,1]'
         phot_plugin.current_plot_type = 'Radial Profile (Raw)'
         assert phot_plugin.dataset.selected_dc_item is not None
-        assert phot_plugin.subset.selected_spatial_region is not None
-        assert phot_plugin.bg_subset.labels == ['Manual', 'Subset 1']
+        assert phot_plugin.aperture.selected_spatial_region is not None
+        assert phot_plugin.background.labels == ['Manual', 'Subset 1']
         assert_allclose(phot_plugin.background_value, 0)
         assert_allclose(phot_plugin.counts_factor, 0)
         assert_allclose(phot_plugin.pixel_area, 0)
@@ -114,7 +114,7 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         # Make sure it also works on an ellipse subset.
         self.imviz._apply_interactive_region('bqplot:ellipse', (0, 0), (9, 4))
         phot_plugin.dataset_selected = 'has_wcs_1[SCI,1]'
-        phot_plugin.subset_selected = 'Subset 2'
+        phot_plugin.aperture_selected = 'Subset 2'
         phot_plugin.current_plot_type = 'Radial Profile'
         phot_plugin.vue_do_aper_phot()
         tbl = self.imviz.get_aperture_photometry_results()
@@ -135,8 +135,8 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         # We also subtract off background from itself here.
         self.imviz._apply_interactive_region('bqplot:rectangle', (0, 0), (9, 9))
         phot_plugin.dataset_selected = 'has_wcs_1[SCI,1]'
-        phot_plugin.subset_selected = 'Subset 3'
-        phot_plugin.bg_subset_selected = 'Subset 3'
+        phot_plugin.aperture_selected = 'Subset 3'
+        phot_plugin.background_selected = 'Subset 3'
         assert_allclose(phot_plugin.background_value, 1)
         phot_plugin.vue_do_aper_phot()
         tbl = self.imviz.get_aperture_photometry_results()
@@ -154,9 +154,9 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         assert tbl[-1]['subset_label'] == 'Subset 3'
 
         # Make sure background auto-updates.
-        phot_plugin.bg_subset_selected = 'Manual'
+        phot_plugin.background_selected = 'Manual'
         assert_allclose(phot_plugin.background_value, 1)  # Keeps last value
-        phot_plugin.bg_subset_selected = 'Subset 1'
+        phot_plugin.background_selected = 'Subset 1'
         assert_allclose(phot_plugin.background_value, 1)
         self.imviz.load_data(np.ones((10, 10)) + 1, data_label='twos')
         phot_plugin.dataset_selected = 'twos'
@@ -174,24 +174,24 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         # datasets and subsets do not exist with these names (if that changes, this test will
         # need to be udpated accordingly)
         unpacked = phot_plugin.unpack_batch_options(dataset=['image1', 'image2'],
-                                                    subset=['Subset 1', 'Subset 2'],
-                                                    bg_subset=['Subset 3'],
+                                                    aperture=['Subset 1', 'Subset 2'],
+                                                    background=['Subset 3'],
                                                     flux_scaling=3)
-        assert unpacked == [{'subset': 'Subset 1',
+        assert unpacked == [{'aperture': 'Subset 1',
                              'dataset': 'image1',
-                             'bg_subset': 'Subset 3',
+                             'background': 'Subset 3',
                              'flux_scaling': 3},
-                            {'subset': 'Subset 2',
+                            {'aperture': 'Subset 2',
                              'dataset': 'image1',
-                             'bg_subset': 'Subset 3',
+                             'background': 'Subset 3',
                              'flux_scaling': 3},
-                            {'subset': 'Subset 1',
+                            {'aperture': 'Subset 1',
                              'dataset': 'image2',
-                             'bg_subset': 'Subset 3',
+                             'background': 'Subset 3',
                              'flux_scaling': 3},
-                            {'subset': 'Subset 2',
+                            {'aperture': 'Subset 2',
                              'dataset': 'image2',
-                             'bg_subset': 'Subset 3',
+                             'background': 'Subset 3',
                              'flux_scaling': 3}]
 
     def test_batch_phot(self):
@@ -200,16 +200,16 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
 
         phot_plugin = self.imviz.app.get_tray_item_from_name('imviz-aper-phot-simple')
         assert phot_plugin.dataset.choices == ['has_wcs_1[SCI,1]', 'has_wcs_2[SCI,1]']
-        assert phot_plugin.subset.choices == ['Subset 1']
+        assert phot_plugin.aperture.choices == ['Subset 1']
 
-        phot_plugin.batch_aper_phot([{'dataset': 'has_wcs_1[SCI,1]', 'subset': 'Subset 1'},
+        phot_plugin.batch_aper_phot([{'dataset': 'has_wcs_1[SCI,1]', 'aperture': 'Subset 1'},
                                      {'dataset': 'has_wcs_2[SCI,1]'}])
 
         assert len(phot_plugin.table) == 2
 
         with pytest.raises(RuntimeError):
-            phot_plugin.batch_aper_phot([{'dataset': 'has_wcs_1[SCI,1]', 'subset': 'DNE'},
-                                         {'dataset': 'has_wcs_2[SCI,1]', 'subset': 'Subset 1'}])
+            phot_plugin.batch_aper_phot([{'dataset': 'has_wcs_1[SCI,1]', 'aperture': 'DNE'},
+                                         {'dataset': 'has_wcs_2[SCI,1]', 'aperture': 'Subset 1'}])
 
         # second entry above should have been successful, resulting in one addition to the results
         assert len(phot_plugin.table) == 3
@@ -222,7 +222,7 @@ class TestSimpleAperPhot_NoWCS(BaseImviz_WCS_NoWCS):
         phot_plugin = self.imviz.app.get_tray_item_from_name('imviz-aper-phot-simple')
 
         phot_plugin.dataset_selected = 'has_wcs[SCI,1]'
-        phot_plugin.subset_selected = 'Subset 1'
+        phot_plugin.aperture_selected = 'Subset 1'
         phot_plugin.vue_do_aper_phot()
         tbl = self.imviz.get_aperture_photometry_results()
         assert len(tbl) == 1
@@ -280,8 +280,8 @@ class TestAdvancedAperPhot:
     def test_aperphot(self, data_label, local_bkg, subset_label, expected_sum):
         """All data should give similar result for the same Subset."""
         self.phot_plugin.dataset_selected = data_label
-        self.phot_plugin.subset_selected = subset_label
-        self.phot_plugin.bg_subset_selected = 'Manual'
+        self.phot_plugin.aperture_selected = subset_label
+        self.phot_plugin.background_selected = 'Manual'
         self.phot_plugin.background_value = local_bkg
         self.phot_plugin.vue_do_aper_phot()
         tbl = self.imviz.get_aperture_photometry_results()
@@ -303,8 +303,8 @@ class TestAdvancedAperPhot:
         Down-sampled data has higher factor due to flux conservation.
         """
         self.phot_plugin.dataset_selected = data_label
-        self.phot_plugin.subset_selected = "Subset 1"  # Does not matter
-        self.phot_plugin.bg_subset_selected = bg_label
+        self.phot_plugin.aperture_selected = "Subset 1"  # Does not matter
+        self.phot_plugin.background_selected = bg_label
 
         # Imperfect down-sampling and abusing apertures, so 10% is good enough.
         assert_allclose(float(self.phot_plugin.background_value), expected_bg * fac, rtol=0.1)
@@ -331,8 +331,8 @@ def test_annulus_background(imviz_helper):
         PixCoord(x=150, y=25), inner_radius=7, outer_radius=17)
     imviz_helper.load_regions([annulus_1])
 
-    phot_plugin.subset_selected = 'Subset 1'
-    phot_plugin.bg_subset_selected = 'Subset 2'
+    phot_plugin.aperture_selected = 'Subset 1'
+    phot_plugin.background_selected = 'Subset 2'
 
     # Check annulus for ones
     assert_allclose(phot_plugin.background_value, 1)
@@ -351,25 +351,25 @@ def test_annulus_background(imviz_helper):
     imviz_helper.load_regions([annulus_2])
 
     # Subset 4 (annulus) should be available for the background but not the aperture
-    assert 'Subset 4' not in phot_plugin.subset.choices
-    assert 'Subset 4' in phot_plugin.bg_subset.choices
+    assert 'Subset 4' not in phot_plugin.aperture.choices
+    assert 'Subset 4' in phot_plugin.background.choices
 
-    phot_plugin.subset_selected = 'Subset 3'
-    phot_plugin.bg_subset_selected = 'Subset 4'
+    phot_plugin.aperture_selected = 'Subset 3'
+    phot_plugin.background_selected = 'Subset 4'
 
     # Check new annulus for four_gaussians
     assert_allclose(phot_plugin.background_value, 5.13918435824334)  # Changed
 
     # Switch to manual, should not change
-    phot_plugin.bg_subset_selected = 'Manual'
+    phot_plugin.background_selected = 'Manual'
     assert_allclose(phot_plugin.background_value, 5.13918435824334)
 
     # Switch to Subset, should change a lot because this is not background area
-    phot_plugin.bg_subset_selected = 'Subset 1'
+    phot_plugin.background_selected = 'Subset 1'
     assert_allclose(phot_plugin.background_value, 44.72559981461203)
 
     # Switch back to annulus, should be same as before in same mode
-    phot_plugin.bg_subset_selected = 'Subset 4'
+    phot_plugin.background_selected = 'Subset 4'
     assert_allclose(phot_plugin.background_value, 5.13918435824334)
 
     # Edit the annulus and make sure background updates

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -46,15 +46,15 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         # Perform photometry on both images using same Subset.
         phot_plugin.dataset_selected = 'has_wcs_1[SCI,1]'
         phot_plugin.subset_selected = 'Subset 1'
-        assert phot_plugin._selected_data is not None
+        assert phot_plugin.dataset.selected_dc_item is not None
         phot_plugin.vue_do_aper_phot()
         tbl = self.imviz.get_aperture_photometry_results()
         assert len(tbl) == 1
 
         phot_plugin.dataset_selected = 'has_wcs_2[SCI,1]'
         phot_plugin.current_plot_type = 'Radial Profile (Raw)'
-        assert phot_plugin._selected_data is not None
-        assert phot_plugin._selected_subset is not None
+        assert phot_plugin.dataset.selected_dc_item is not None
+        assert phot_plugin.subset.selected_spatial_region is not None
         assert phot_plugin.bg_subset.labels == ['Manual', 'Subset 1']
         assert_allclose(phot_plugin.background_value, 0)
         assert_allclose(phot_plugin.counts_factor, 0)

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -215,6 +215,19 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         # second entry above should have been successful, resulting in one addition to the results
         assert len(phot_plugin._obj.table) == 3
 
+        # now run through the UI directly
+        phot_plugin.multiselect = True
+        phot_plugin.dataset.select_all()
+        phot_plugin.aperture.select_none()
+        assert len(phot_plugin.unpack_batch_options()) == 0
+        phot_plugin._obj.vue_do_aper_phot()
+
+        assert len(phot_plugin._obj.table) == 3
+        phot_plugin.aperture.select_all()
+        assert len(phot_plugin.unpack_batch_options()) == 2
+        phot_plugin._obj.vue_do_aper_phot()
+        assert len(phot_plugin._obj.table) == 5
+
 
 class TestSimpleAperPhot_NoWCS(BaseImviz_WCS_NoWCS):
     def test_plugin_no_wcs(self):

--- a/jdaviz/core/region_translators.py
+++ b/jdaviz/core/region_translators.py
@@ -20,7 +20,7 @@ from regions import (CirclePixelRegion, CircleSkyRegion,
 __all__ = ['regions2roi', 'regions2aperture', 'aperture2regions']
 
 
-def _get_region_from_spatial_subset(plugin_obj, subset_state):
+def _get_region_from_spatial_subset(plugin_obj, subset_state, dataset=None):
     """Convert the given ``glue`` ROI subset state to ``regions`` shape.
 
     .. note:: This is for internal use only in Imviz plugins.
@@ -36,6 +36,9 @@ def _get_region_from_spatial_subset(plugin_obj, subset_state):
 
     subset_state : obj
         ROI subset state to translate.
+
+    dataset : string, optional
+        Name of the dataset.  If not provided, will look for ``plugin_obj.dataset_selected``.
 
     Returns
     -------
@@ -53,9 +56,12 @@ def _get_region_from_spatial_subset(plugin_obj, subset_state):
     # Subset is defined against its parent. This is not necessarily
     # the current viewer reference data, which can be changed.
 
+    if dataset is None:
+        dataset = plugin_obj.dataset_selected
+
     # See https://github.com/spacetelescope/jdaviz/issues/2230
     link_type = plugin_obj.app._jdaviz_helper.get_link_type(
-        subset_state.xatt.parent.label, plugin_obj.dataset_selected)
+        subset_state.xatt.parent.label, dataset)
 
     return roi_subset_state_to_region(subset_state, to_sky=(link_type == 'wcs'))
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -619,7 +619,7 @@ class SelectPluginComponent(BasePluginComponent, HasTraits):
             raise ValueError("currently in multiselect mode")
 
         cycle = self.choices
-        if not len(cycle):
+        if not len(cycle):  # pragma: no cover
             raise ValueError("no choices")
         if self.selected == '':
             curr_ind = -1
@@ -1554,7 +1554,7 @@ class SubsetSelect(SelectPluginComponent):
                         s.label == subset]
         if len(subset_group) == 0:
             return None
-        if len(subset_group) != 1:
+        if len(subset_group) != 1:  # pragma: no cover
             raise ValueError("found multiple matches for subset")
         return subset_group[0].subset_state
 
@@ -1568,7 +1568,7 @@ class SubsetSelect(SelectPluginComponent):
         if subset is None:
             subset = self.selected
         if dataset is None:
-            if getattr(self.plugin, 'dataset', None) is None:
+            if getattr(self.plugin, 'dataset', None) is None:  # pragma: no cover
                 raise ValueError("Retrieving subset mask requires associated dataset")
             dataset = self.plugin.dataset.selected
         get_data_kwargs = {'data_label': dataset}
@@ -1588,7 +1588,7 @@ class SubsetSelect(SelectPluginComponent):
 
     @cached_property
     def selected_subset_mask(self):
-        if self.is_multiselect:
+        if self.is_multiselect:  # pragma: no cover
             raise NotImplementedError("Retrieving subset mask is not"
                                       " supported in multiselect mode")
 
@@ -1608,9 +1608,9 @@ class SubsetSelect(SelectPluginComponent):
 
     @cached_property
     def selected_spatial_region(self):
-        if not getattr(self, 'dataset', None):
+        if not getattr(self, 'dataset', None):  # pragma: no cover
             raise ValueError("Retrieving subset mask requires associated dataset")
-        if self.is_multiselect and self.dataset.is_multiselect:
+        if self.is_multiselect and self.dataset.is_multiselect:  # pragma: no cover
             # technically this could work if either has length of one, but would require extra
             # logic
             raise NotImplementedError("cannot access selected_spatial_region for multiple subsets and multiple datasets")  # noqa
@@ -1625,9 +1625,9 @@ class SubsetSelect(SelectPluginComponent):
         """
         Get the min/max spectral range of ``dataset`` given the selected spectral subset
         """
-        if self.is_multiselect:
+        if self.is_multiselect:  # pragma: no cover
             raise TypeError("This action cannot be done when multiselect is active")
-        if not isinstance(dataset, Spectrum1D):
+        if not isinstance(dataset, Spectrum1D):  # pragma: no cover
             raise TypeError("dataset must be a Spectrum1D object")
 
         if self.selected_obj is None:

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -750,7 +750,7 @@ class SelectPluginComponent(BasePluginComponent, HasTraits):
     def _multiselect_changed(self, event):
         self._clear_cache()
         if self.is_multiselect:
-            self.selected = [self.selected]
+            self.selected = [self.selected] if self.selected != '' else []
         elif isinstance(self.selected, list) and len(self.selected):
             self.selected = self.selected[0]
         else:

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1520,7 +1520,8 @@ class SubsetSelect(SelectPluginComponent):
             ((self.is_multiselect and subset.label in self.selected)
              or (subset.label == self.selected))):
             # updated the currently selected subset
-            self._clear_cache("selected_obj", "selected_item")
+            self._clear_cache("selected_obj", "selected_item", "selected_subset_state",
+                              "selected_subset_mask", "selected_subset", "selected_spatial_region")
             self._update_has_subregions()
 
     def _update_has_subregions(self):

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -48,7 +48,7 @@ __all__ = ['show_widget', 'TemplateMixin', 'PluginTemplateMixin',
            'ViewerSelect', 'ViewerSelectMixin',
            'LayerSelect', 'LayerSelectMixin',
            'NonFiniteUncertaintyMismatchMixin',
-           'DatasetSelect', 'DatasetSelectMixin',
+           'DatasetSelect', 'DatasetSelectMixin', 'DatasetMultiSelectMixin',
            'FileImportSelectPluginComponent', 'HasFileImportSelect',
            'Table', 'TableMixin',
            'Plot', 'PlotMixin',
@@ -2269,13 +2269,48 @@ class DatasetSelectMixin(VuetifyTemplate, HubListener):
 
     """
     dataset_items = List().tag(sync=True)
-    dataset_selected = Any().tag(sync=True)
+    dataset_selected = Unicode().tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # NOTE: cannot be named self.data or will conflict with existing self.data traitlet!
         self.dataset = DatasetSelect(self, 'dataset_items', 'dataset_selected',
-                                     multiselect='multiselect' if hasattr(self, 'multiselect') else None)  # noqa
+                                     multiselect=None)
+
+
+class DatasetMultiSelectMixin(VuetifyTemplate, HubListener):
+    """
+    Applies the DatasetSelect component as a mixin in the base plugin with togglable multiselect.  
+    This automatically adds traitlets as well as new properties to the plugin with minimal
+    extra code.  For multiple instances or custom traitlet names/defaults, use the
+    component instead.
+
+    To use in a plugin:
+
+    * add ``DatasetMultiSelectMixin`` as a mixin to the class
+    * use the traitlets available from the plugin or properties/methods available from
+      ``plugin.dataset``.
+
+    Example template (label and hint are optional)::
+
+      <plugin-dataset-select
+        :items="dataset_items"
+        :selected.sync="dataset_selected"
+        :multiselect="multiselect"
+        label="Data"
+        hint="Select data."
+      />
+
+    """
+    dataset_items = List().tag(sync=True)
+    dataset_selected = Any().tag(sync=True)
+    multiselect = Bool(False).tag(sync=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # NOTE: cannot be named self.data or will conflict with existing self.data traitlet!
+        self.dataset = DatasetSelect(self, 'dataset_items', 'dataset_selected',
+                                     multiselect='multiselect')  # noqa
 
 
 class AutoTextField(BasePluginComponent):

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1,5 +1,5 @@
 from astropy.coordinates.sky_coordinate import SkyCoord
-from astropy.nddata.ccddata import CCDData
+from astropy.nddata import NDData
 from astropy.table import QTable
 from astropy.table.row import Row as QTableRow
 import astropy.units as u
@@ -2127,7 +2127,7 @@ class DatasetSelect(SelectPluginComponent):
     @property
     def default_data_cls(self):
         if self.app.config == 'imviz':
-            return CCDData
+            return NDData
         if 'is_trace' in self.filters:
             return None
         return Spectrum1D

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1617,8 +1617,8 @@ class SubsetSelect(SelectPluginComponent):
             # technically this could work if either has length of one, but would require extra
             # logic
             raise NotImplementedError("cannot access selected_spatial_region for multiple subsets and multiple datasets")
-        items = self.selected_item if self.multiselect else [self.selected_items]
-        if np.any([item.get('type') != 'spatial' for item in items]:
+        items = self.selected_item if self.multiselect else [self.selected_item]
+        if np.any([item.get('type') != 'spatial' for item in items]):
             raise TypeError("This action is only supported on spatial-type subsets")
         if self.multiselect:
             return [self._get_spatial_region(dataset=self.dataset.selected, subset=subset) for subset in self.selected]  # noqa

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -618,7 +618,12 @@ class SelectPluginComponent(BasePluginComponent, HasTraits):
             raise ValueError("currently in multiselect mode")
 
         cycle = self.choices
-        curr_ind = cycle.index(self.selected)
+        if not len(cycle):
+            raise ValueError("no choices")
+        if self.selected == '':
+            curr_ind = -1
+        else:
+            curr_ind = cycle.index(self.selected)
         self.selected = cycle[(curr_ind + 1) % len(cycle)]
         return self.selected
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1613,7 +1613,7 @@ class SubsetSelect(SelectPluginComponent):
         if self.is_multiselect and self.dataset.is_multiselect:
             # technically this could work if either has length of one, but would require extra
             # logic
-            raise NotImplementedError("cannot access selected_spatial_region for multiple subsets and multiple datasets")
+            raise NotImplementedError("cannot access selected_spatial_region for multiple subsets and multiple datasets")  # noqa
         items = self.selected_item if self.is_multiselect else [self.selected_item]
         if np.any([item.get('type') != 'spatial' for item in items]):
             raise TypeError("This action is only supported on spatial-type subsets")
@@ -2280,7 +2280,7 @@ class DatasetSelectMixin(VuetifyTemplate, HubListener):
 
 class DatasetMultiSelectMixin(VuetifyTemplate, HubListener):
     """
-    Applies the DatasetSelect component as a mixin in the base plugin with togglable multiselect.  
+    Applies the DatasetSelect component as a mixin in the base plugin with togglable multiselect.
     This automatically adds traitlets as well as new properties to the plugin with minimal
     extra code.  For multiple instances or custom traitlet names/defaults, use the
     component instead.

--- a/notebooks/concepts/imviz_advanced_aper_phot.ipynb
+++ b/notebooks/concepts/imviz_advanced_aper_phot.ipynb
@@ -255,10 +255,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "phot_plugin.subset_selected = \"Subset 1\"\n",
-    "#phot_plugin.subset_selected = \"Subset 2\"\n",
-    "#phot_plugin.subset_selected = \"Subset 3\"\n",
-    "#phot_plugin.subset_selected = \"Subset 4\""
+    "phot_plugin.aperture_selected = \"Subset 1\"\n",
+    "#phot_plugin.aperture_selected = \"Subset 2\"\n",
+    "#phot_plugin.aperture_selected = \"Subset 3\"\n",
+    "#phot_plugin.aperture_selected = \"Subset 4\""
    ]
   },
   {
@@ -278,7 +278,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "phot_plugin.bg_subset_selected = 'Manual'\n",
+    "phot_plugin.background_selected = 'Manual'\n",
     "phot_plugin.background_value = 5.0\n",
     "\n",
     "phot_plugin.dataset_selected = \"gauss100_fits_wcs[PRIMARY,1]\"\n",

--- a/notebooks/concepts/imviz_advanced_aper_phot.ipynb
+++ b/notebooks/concepts/imviz_advanced_aper_phot.ipynb
@@ -237,7 +237,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "phot_plugin = imviz.plugins[\"Imviz Simple Aperture Photometry\"]._obj"
+    "phot_plugin = imviz.plugins[\"Aperture Photometry\"]._obj"
    ]
   },
   {

--- a/notebooks/concepts/imviz_simple_aper_phot.ipynb
+++ b/notebooks/concepts/imviz_simple_aper_phot.ipynb
@@ -5,7 +5,7 @@
    "id": "65797402-e16b-4a78-8acc-02dd90ca5e7d",
    "metadata": {},
    "source": [
-    "# Imviz simple aperture photometry\n",
+    "# Aperture Photometry\n",
     "\n",
     "This is a proof-of-concept showing how to use Imviz to perform simple aperture photometry using hand-drawn aperture on a single object."
    ]
@@ -163,7 +163,7 @@
    "id": "9abeb637-dac2-4787-8087-3be5f54a5dd0",
    "metadata": {},
    "source": [
-    "Now, use the \"Imviz Simple Aperture Photometry\" plugin.\n",
+    "Now, use the \"Aperture Photometry\" plugin.\n",
     "\n",
     "Once photometry is done, we would do the following to extract the data from Imviz back to notebook for further processing."
    ]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

TODO before merge:
- [x] fix snackbar errors when traitlets updated out of order
- [x] fix subset choices not updating when in multiselect
- [x] avoid snackbar error when going from multi to single select
- [x] deprecate old plugin name?
- [x] revert defaulting to CCDData or using NDData instead (https://github.com/spacetelescope/jdaviz/pull/2465#discussion_r1343041167)
- [x] hide batch aper phot methods from user API (so that we can iterate before they become public)
- [x] postpone auto-switch decision (either hiding traitlets or disabling inputs and setting to no-scaling, etc)
- [x] fix selecting subset as background in multiselect (https://github.com/spacetelescope/jdaviz/pull/2465#discussion_r1355686159)
- [x] update API docs now that user API deferred

Follow-up efforts:
- [ ] improve error message in multi-select component (https://github.com/spacetelescope/jdaviz/pull/2465#issuecomment-1743849613)
- [ ] move radial profile (somewhere else) and results summary from plugin (#2493)
- [ ] try to consolidate method calls for batch and non-batch mode (https://github.com/spacetelescope/jdaviz/pull/2465#discussion_r1341752302)
- [ ] make API public (once happy with the API syntax, error handling, etc).
- [ ] multiple plugins: improve discoverability of multiselect mode in consulation with @Jenneh (https://github.com/spacetelescope/jdaviz/pull/2465#issuecomment-1750777595) 

This pull request updates the aperture photometry plugin to:
* allow overriding individual traitlet names as optional inputs to API methods (requiring significant moving of code),
* renames `subset` -> `aperture` and `bg_subset` to `background`,
* renames the plugin from "Imviz Simple Aperture Photometry" to "Aperture Photometry" since its no longer simple and that is easier to remember for accessing the user API, 
* generalizes some re-used logic and make use of caching when possible,
* exposing basic components/traitlets and methods through the user API (if we're not ready to commit to the exposed names, that can easily be disabled for this PR and re-introduced later),
* changes the [batch methods](https://github.com/spacetelescope/jdaviz/pull/2401) to use the new ability to override traitlet values so that overrides are always wrt the plugin/traitlet values rather than the previous iteration.  This also means that calling these methods from the API does not affect the state of the UI input widgets (but still does add to the table and expose the plot of the latest iteration),
* adds a multiselect/batch-mode toggle along with multiselect for dataset and aperture in the UI.  When multiselect mode is on, switches are exposed to control the behavior of values that default based on the selected dataset, and the results and plots are hidden (table is still shown),
* `plugin.unpack_batch_options()` (without arguments) will expose the batch options based on the selections in the UI/traitlets, which is useful for reproducing or for filtering that list to a subset in a notebook workflow.

~With the exception of small changes to text in the UI, since this plugin did not previously have exposed user-API, none of these changes should affect users directly.~

~This work was done to prepare for the upcoming batch mode support in the aperture photometry UI which will add support for multiselect for dataset and aperture.  `vue_do_aper_phot` can then handle passing off those lists through existing methods without needing to affect the state of other traits defined.~

NOTE: more work will need to be done if we want to support multiselect for `background`, as that will affect `background_value`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
