### PR TITLE
API access (hidden) to disable moment map server-side saving

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -151,7 +151,7 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
         if not self.export_enabled:
             # this should never be triggered since this is intended for UI-disabling and the
             # UI section is hidden, but would prevent any JS-hacking
-            raise ValueError("_write_moment_to_fits is currently disabled")
+            raise ValueError("Writing out moment map to file is currently disabled")
 
         # Make sure file does not end up in weird places in standalone mode.
         path = os.path.dirname(self.filename)

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -50,6 +50,11 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
     moment_available = Bool(False).tag(sync=True)
     overwrite_warn = Bool(False).tag(sync=True)
 
+    # export_enabled controls whether saving the moment map to a file is enabled via the UI.  This
+    # is a temporary measure to allow server-installations to disable saving server-side until
+    # saving client-side is supported
+    export_enabled = Bool(True).tag(sync=True)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -57,6 +62,11 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
 
         self.dataset.add_filter('is_cube')
         self.add_results.viewer.filters = ['is_image_viewer']
+
+        if self.app.state.settings.get('server_is_remote', False):
+            # when the server is remote, saving the file in python would save on the server, not
+            # on the user's machine, so export support in cubeviz should be disabled
+            self.export_enabled = False
 
     @property
     def _default_image_viewer_reference_name(self):
@@ -138,6 +148,10 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
     def _write_moment_to_fits(self, overwrite=False, *args):
         if self.moment is None or not self.filename:  # pragma: no cover
             return
+        if not self.export_enabled:
+            # this should never be triggered since this is intended for UI-disabling and the
+            # UI section is hidden, but would prevent any JS-hacking
+            raise ValueError("_write_moment_to_fits is currently disabled")
 
         # Make sure file does not end up in weird places in standalone mode.
         path = os.path.dirname(self.filename)

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
@@ -49,11 +49,11 @@
       @click:action="calculate_moment"
     ></plugin-add-results>
     
-    <j-plugin-section-header>Results</j-plugin-section-header>
+    <j-plugin-section-header v-if="export_enabled">Results</j-plugin-section-header>
 
     <div style="display: grid; position: relative"> <!-- overlay container -->
       <div style="grid-area: 1/1">
-        <div v-if="moment_available">
+        <div v-if="moment_available && export_enabled">
           <v-row>
               <v-text-field
               v-model="filename"
@@ -77,7 +77,7 @@
       <v-overlay
         absolute
         opacity=1.0
-        :value="overwrite_warn"
+        :value="overwrite_warn && export_enabled"
         :zIndex=3
         style="grid-area: 1/1; 
                margin-left: -24px;

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
@@ -73,7 +73,7 @@ def test_valid_function(cubeviz_helper, spectrum1d_cube):
     assert cubeviz_helper.specviz.get_data(data_label="test[FLUX]").flux.ndim == 1
 
 
-def test_remote_server_disable_movie():
+def test_remote_server_disable_save_serverside():
     config = get_configuration('cubeviz')
     config['settings']['server_is_remote'] = True
 
@@ -81,6 +81,9 @@ def test_remote_server_disable_movie():
     cubeviz_helper = Cubeviz(cubeviz_app)
     ep = cubeviz_helper.plugins['Export Plot']
     assert ep._obj.movie_enabled is False
+
+    mm = cubeviz_helper.plugins['Moment Maps']
+    assert mm._obj.export_enabled is False
 
 
 def test_get_data_spatial_and_spectral(cubeviz_helper, spectrum1d_cube_larger):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Similar to #2440 (and using the same solution), this pull request allows disabling the support for saving a moment map to a fits file until we change that implementation to save through the browser client-side.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
