### PR TITLE
bugfix for viewer rename when viewer ID is different from reference name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,9 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Fixed bug which did not update all references to a viewer's ID when
+  updating a viewer's reference name. [#2479]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1655,11 +1655,11 @@ class Application(VuetifyTemplate, HubListener):
             viewer_item['name'] = new_reference
 
         # optionally update the viewer IDs:
-        if update_id and viewer_item['id'] == old_reference:
-            # update the id as well
+        if update_id:
             old_id = viewer_item['id']
             viewer_item['id'] = new_reference
             self._viewer_store[new_reference] = self._viewer_store.pop(old_id)
+            self._viewer_store[new_reference]._reference_id = new_reference
             self.state.viewer_icons[new_reference] = self.state.viewer_icons.pop(old_id)
 
         # update the viewer name attributes on the helper:


### PR DESCRIPTION
https://github.com/spacetelescope/jdaviz/pull/2338 implemented viewer reference name updates, with an option to update viewer IDs as well. That feature is intended for internal use in lcviz. 

Subsequent development in lcviz exposed a bug in the jdaviz method when `update_id=True` (https://github.com/spacetelescope/lcviz/pull/35). Each viewer's entry in the viewer store has a hidden attr `_reference_id` which should match `viewer_item['id']`, but #2338 did not update that attr.

Also, the ID is only updated if `update_id=True` _and_ `viewer_item['id'] == old_reference`, but the latter condition is satisfied if the ID matches the reference name (which is not required elsewhere).

This PR adds the missing update to the hidden reference_id attr, and removes the unnecessary second condition for updating the ID.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
