### PR TITLE
Backport PR #2479: bugfix for viewer rename when viewer ID is differe…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,27 @@
+3.7.1 (unreleased)
+==================
+
+Bug Fixes
+---------
+
+- Fixed bug which did not update all references to a viewer's ID when
+  updating a viewer's reference name. [#2479]
+
+Cubeviz
+^^^^^^^
+
+Imviz
+^^^^^
+
+Mosviz
+^^^^^^
+
+Specviz
+^^^^^^^
+
+Specviz2d
+^^^^^^^^^
+
 3.7 (2023-09-21)
 ================
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1655,11 +1655,11 @@ class Application(VuetifyTemplate, HubListener):
             viewer_item['name'] = new_reference
 
         # optionally update the viewer IDs:
-        if update_id and viewer_item['id'] == old_reference:
-            # update the id as well
+        if update_id:
             old_id = viewer_item['id']
             viewer_item['id'] = new_reference
             self._viewer_store[new_reference] = self._viewer_store.pop(old_id)
+            self._viewer_store[new_reference]._reference_id = new_reference
             self.state.viewer_icons[new_reference] = self.state.viewer_icons.pop(old_id)
 
         # update the viewer name attributes on the helper:


### PR DESCRIPTION
Manual backport of #2479.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
