### PR TITLE
Add keyboard shortcuts to see previous and next layer in plot options

### DIFF
--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -78,6 +78,23 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
 
             if key_pressed in ('b', 'B'):
                 self.blink_once(reversed=key_pressed=='B')  # noqa: E225
+            elif key_pressed in ('d', 'D', 'f', 'F'):
+                self.select_next_layer(reversed=key_pressed in ('d', 'D'))  # noqa: E225
+
+    def select_next_layer(self, reversed=False):
+        # Select next layer in Plot Options plugin. If reversed,
+        # select previous layer.
+        plot_options_plugin = self.jdaviz_app.get_tray_item_from_name('g-plot-options')
+        items = plot_options_plugin.layer_items
+        selected = plot_options_plugin.layer_selected
+        labels = [x['label'] for x in items]
+        label_index = labels.index(selected)
+        if reversed:
+            plot_options_plugin.layer_selected = labels[label_index - 1]
+        elif label_index + 1 == len(labels):
+            plot_options_plugin.layer_selected = labels[0]
+        else:
+            plot_options_plugin.layer_selected = labels[label_index + 1]
 
     def blink_once(self, reversed=False):
         # Simple blinking of images - this will make it so that only one


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to add keyboard shortcuts 'd' and 'f' to select the previous and next viewer layer, respectively.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
