### PR TITLE
Colorbar under histogram

### DIFF
--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -1,6 +1,7 @@
 import os
-import numpy as np
 
+import bqplot
+import numpy as np
 from astropy.visualization import (
     ManualInterval, ContrastBiasStretch, PercentileInterval
 )
@@ -639,6 +640,12 @@ class PlotOptions(PluginTemplateMixin):
             sub_data = sub_data[~np.isnan(sub_data)]
 
         self.stretch_histogram._update_data('histogram', x=sub_data)
+        self.stretch_histogram.figure.axes[2] = bqplot.ColorAxis(scale=bqplot.ColorScale(
+            scheme="Greys", #self.image_colormap_value, # FIXME: How to map from glue to Colorbrewer?
+            reverse=True,
+            scale_type=self.stretch_function_value,  # FIXME: bqscales only knows "linear"
+            min=self.stretch_vmin_value,
+            max=self.stretch_vmax_value))
 
         if len(sub_data) > 0:
             interval = PercentileInterval(95)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1,18 +1,20 @@
+import os
+import threading
+import time
+from contextlib import contextmanager
+from functools import cached_property
+
+import bqplot
+import numpy as np
+from astropy import units as u
 from astropy.coordinates.sky_coordinate import SkyCoord
 from astropy.nddata import NDData
 from astropy.table import QTable
 from astropy.table.row import Row as QTableRow
-import astropy.units as u
-import bqplot
-from contextlib import contextmanager
-import numpy as np
-import os
-import threading
-import time
-
 from echo import delay_callback
-from functools import cached_property
+from ipypopout import PopoutButton
 from ipyvuetify import VuetifyTemplate
+from ipywidgets import widget_serialization
 from glue.config import colormaps
 from glue.core import Data, HubListener
 from glue.core.link_helpers import LinkSame
@@ -29,9 +31,6 @@ from glue_jupyter.registries import viewer_registry
 from glue_jupyter.widgets.linked_dropdown import get_choices as _get_glue_choices
 from specutils import Spectrum1D
 from traitlets import Any, Bool, HasTraits, List, Unicode, observe
-
-from ipywidgets import widget_serialization
-from ipypopout import PopoutButton
 
 from jdaviz import __version__
 from jdaviz.components.toolbar_nested import NestedJupyterToolbar
@@ -3284,13 +3283,15 @@ class Plot(PluginSubcomponent):
         self._viewer_type = viewer_type
         if viewer_type == 'histogram':
             self._viewer_components = ('x',)
+            axis_c = bqplot.ColorAxis(scale=bqplot.ColorScale())
+            self.viewer.figure.axes.append(axis_c)
         else:
             self._viewer_components = ('x', 'y')
         self.figure = self.viewer.figure
         self._marks = {}
 
         self.figure.title_style = {'font-size': '12px'}
-        self.figure.fig_margin = {'top': 60, 'bottom': 60, 'left': 60, 'right': 10}
+        self.figure.fig_margin = {'top': 60, 'bottom': 100, 'left': 60, 'right': 10}
 
         self.toolbar = NestedJupyterToolbar(self.viewer, self.tools_nested, [])
 

--- a/notebooks/concepts/imviz_colorbar_mpl.ipynb
+++ b/notebooks/concepts/imviz_colorbar_mpl.ipynb
@@ -1,0 +1,149 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7b9bf568-7416-46ad-9108-0d1d97c9af32",
+   "metadata": {},
+   "source": [
+    "Concept notebook to explore colorbar implementation in bqplot vs Matplotlib.\n",
+    "\n",
+    "Matplotlib example is from https://docs.astropy.org/en/latest/visualization/normalization.html ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c6f2384-b70b-4106-973d-b62623d67e5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from astropy.visualization import simple_norm\n",
+    "\n",
+    "# Generate a test image\n",
+    "image = np.arange(65536).reshape((256, 256))\n",
+    "\n",
+    "# Create an ImageNormalize object\n",
+    "norm = simple_norm(image, 'sqrt')\n",
+    "\n",
+    "# Display the image\n",
+    "fig = plt.figure()\n",
+    "ax = fig.add_subplot(1, 1, 1)\n",
+    "im = ax.imshow(image, origin='lower', norm=norm)\n",
+    "fig.colorbar(im)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ab7bbf6-372b-4aa0-9f02-a5dacace164e",
+   "metadata": {},
+   "source": [
+    "How, how does Imviz fare?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b04c9b4-ddf4-4025-aea2-77d5920e53dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jdaviz import Imviz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9349094-620b-40c4-8ae2-d424b5983119",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz = Imviz()\n",
+    "imviz.load_data(image, data_label=\"test image\")\n",
+    "imviz.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83167260-2cc8-4e33-9fd0-9105db23d521",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz.default_viewer.zoom_level = \"fit\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27a06c70-b7af-4055-9b50-2d1269ba38d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plg = imviz.plugins[\"Plot Options\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed2c2107-1803-4481-81b9-e6ab162e7425",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plg.image_colormap = \"Viridis\"\n",
+    "plg.stretch_function = \"Square Root\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ca8ca87-c8aa-4ff3-b4d8-b4c07e22db90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import bqplot\n",
+    "\n",
+    "plg._obj.stretch_histogram.figure.axes[2].scale = bqplot.ColorScale(\n",
+    "            scheme=\"YlGnBu\", #self.image_colormap_value, # FIXME: How to map from glue to Colorbrewer?\n",
+    "            reverse=True,\n",
+    "            scale_type=\"linear\", #plg._obj.stretch_function_value,  # FIXME: bqscales only knows \"linear\"\n",
+    "            min=plg._obj.stretch_vmin_value,\n",
+    "            max=plg._obj.stretch_vmax_value)\n",
+    "\n",
+    "# FIXME: Have to pop out the histogram to see the colorbar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ef6b087-04af-4f91-8bc5-bd0c50f2601a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to add a colorbar to build on #2498. Alas, it is not as easy as when using matplotlib. Problems:

* Visually, added the colorbar object in `figure.axes` shows it in pop-up but I cannot figure out how to make it appear in Plot Options without popping things out. Not sure which figure axis number to adjust here.
* Visually, not sure how to make the `ColorAxis` span entire plot width. `bqplot` examples do not dive so deeply and not obvious from API doc.
* Would be nice if I can just use `plugin.viewer.selected_obj._composite_image.scale_image` as the `ColorScale` for `ColorAxis` but it does not seem to faithfully represent what `glue` is rendering in the image viewer.
* In `ColorScale` (that is actually from yet another package called `bqscales`), `scheme` follows Colorbrewer names, not `glue` names. So, `"gray"` in `glue` does nothing. I have to use `"Greys"` as understood by Colorbrewer. Where is the mapping between `glue` and Colorbrewer for this?
* In `ColorScale`, `scale_type` only allows `"linear"` (according to `bqscales`), so the colorbar refuses to update when non-linear function is given. Forcefully setting `plugin.stretch_histogram.figure.axes[2].scale.scale_type = "sqrt"` would throw `TraitError: The 'scale_type' trait of a ColorScale instance expected any of ['linear'], not the str 'sqrt'.`

![Screenshot 2023-10-16 143041](https://github.com/spacetelescope/jdaviz/assets/2090236/a2300432-dd02-4c6f-a3da-736b66881171)

As it currently stands, I am actually not sure if we can use this without upstream fix(es).

Refs:

* https://bqplot.readthedocs.io/en/stable/_generate/bqplot.axes.ColorAxis.html
* https://bqplot.readthedocs.io/en/stable/_generate/bqplot.scales.ColorScale.html
* https://github.com/bqplot/bqscales/blob/master/bqscales/scales.py

Somewhat related PR(s):

* https://github.com/glue-viz/glue-jupyter/pull/403

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3725)
