### PR TITLE
Colorbar on histogram

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ New Features
   
 - User can now remove data from the app completely after removing it from viewers. [#2409, #2531]
 
+- Colorbar now shown on top of the histogram in Plot Options for image viewers. [#2517]
+
 Cubeviz
 ^^^^^^^
 
@@ -24,7 +26,6 @@ Imviz
 ^^^^^
 
 - Aperture photometry (previously "Imviz Simple Aperture Photometry") now supports batch mode. [#2465]
-
 
 - Expose sky regions in get_subsets. If 'include_sky_region' is True, a sky Region will be returned (in addition to a pixel Region) for spatial subsets with parent data that was a WCS. [#2496]
 

--- a/docs/imviz/displayimages.rst
+++ b/docs/imviz/displayimages.rst
@@ -372,7 +372,7 @@ can be accessed with ``plot_options.stretch_function.choices``:
 
 A histogram is displayed showing the distribution of pixel values, with
 vertical lines representing the ``stretch_vmin`` and ``stretch_vmax``
-values. A stretch "curve" can be plotted under the histogram to represent
+values, and a colorbar on top. A stretch "curve" can be plotted under the histogram to represent
 how pixel values are mapped to the colorbar. This feature can be toggled
 on from the API with:
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -762,6 +762,7 @@ class PlotOptions(PluginTemplateMixin):
             contrast_bias = ContrastBiasStretch(self.image_contrast_value, self.image_bias_value)
             stretch = stretches.members[self.stretch_function_value]
 
+            # NOTE: Index 0 in marks is assumed to be the bin centers.
             x = self.stretch_histogram.figure.marks[0].x
             y = np.ones_like(x)
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -476,8 +476,8 @@ class PlotOptions(PluginTemplateMixin):
         self.stretch_histogram._add_data('histogram', x=[0, 1])
 
         self.stretch_histogram.add_line('vmin', x=[0, 0], y=[0, 1], ynorm=True, color='#c75d2c')
-        self.stretch_histogram.add_line('vmax', x=[0, 0], y=[0, 1], ynorm=True, color='#c75d2c')
-        self.stretch_histogram.add_scatter('colorbar', x=[0, 0], y=[0, 1], marker='square', stroke_width=33)  # noqa: E501
+        self.stretch_histogram.add_line('vmax', x=[0, 0], y=[0, 1], ynorm='vmin', color='#c75d2c')
+        self.stretch_histogram.add_scatter('colorbar', x=[], y=[], ynorm='vmin', marker='square', stroke_width=33)  # noqa: E501
         with self.stretch_histogram.figure.hold_sync():
             self.stretch_histogram.figure.axes[0].label = 'pixel value'
             self.stretch_histogram.figure.axes[0].num_ticks = 3
@@ -763,7 +763,7 @@ class PlotOptions(PluginTemplateMixin):
             stretch = stretches.members[self.stretch_function_value]
 
             x = self.stretch_histogram.figure.marks[0].x
-            y = np.full(x.shape, self.stretch_histogram.figure.axes[1].scale.max)
+            y = np.ones_like(x)
 
             # Copied from the __call__ internals of glue/viewers/image/composite_array.py
             data = interval(x)

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -821,7 +821,7 @@ class PlotOptions(PluginTemplateMixin):
         for layer in self.layer.selected_obj:
             if isinstance(layer.layer, GroupedSubset):
                 # don't update histogram for subsets:
-                return
+                continue
 
             # clear old mark, if it exists:
             mark_label = f'{mark_label_prefix}{layer.label}'

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -1,4 +1,5 @@
 import os
+import matplotlib
 import numpy as np
 
 from astropy.visualization import (
@@ -8,11 +9,12 @@ from echo import delay_callback
 from traitlets import Any, Dict, Float, Bool, Int, List, Unicode, observe
 
 from glue.core.subset_group import GroupedSubset
-from glue.config import stretches
+from glue.config import colormaps, stretches
 from glue.viewers.scatter.state import ScatterViewerState
 from glue.viewers.profile.state import ProfileViewerState, ProfileLayerState
 from glue.viewers.image.state import ImageSubsetLayerState
 from glue.viewers.scatter.state import ScatterLayerState as BqplotScatterLayerState
+from glue.viewers.image.composite_array import COLOR_CONVERTER
 from glue_jupyter.bqplot.image.state import BqplotImageLayerState
 from glue_jupyter.common.toolbar_vuetify import read_icon
 
@@ -475,6 +477,7 @@ class PlotOptions(PluginTemplateMixin):
 
         self.stretch_histogram.add_line('vmin', x=[0, 0], y=[0, 1], ynorm=True, color='#c75d2c')
         self.stretch_histogram.add_line('vmax', x=[0, 0], y=[0, 1], ynorm=True, color='#c75d2c')
+        self.stretch_histogram.add_scatter('colorbar', x=[0, 0], y=[0, 1], marker='square', stroke_width=33)  # noqa: E501
         with self.stretch_histogram.figure.hold_sync():
             self.stretch_histogram.figure.axes[0].label = 'pixel value'
             self.stretch_histogram.figure.axes[0].num_ticks = 3
@@ -724,6 +727,73 @@ class PlotOptions(PluginTemplateMixin):
         # update the n_bins since this may be a new layer
         self._histogram_nbins_changed()
 
+    @observe('is_active', 'image_color_mode_value', 'image_color_value', 'image_colormap_value',
+             'image_contrast_value', 'image_bias_value',
+             'stretch_function_value', 'stretch_vmin_value', 'stretch_vmax_value',
+             'stretch_hist_nbins', 'stretch_hist_zoom_limits')
+    @skip_if_no_updates_since_last_active()
+    def _update_stretch_histogram_colorbar(self, msg={}):
+        """Renders a colorbar on top of the histogram."""
+        if not self._viewer_is_image_viewer() or not hasattr(self, 'stretch_histogram'):
+            # don't update histogram if selected viewer is not an image viewer,
+            # or the stretch histogram hasn't been initialized:
+            return
+
+        if self.multiselect:
+            with self.stretch_histogram.hold_sync():
+                self.stretch_histogram._marks["colorbar"].x = []
+                self.stretch_histogram._marks["colorbar"].y = []
+            return
+
+        if len(self.layer.selected_obj):
+            layer = self.layer.selected_obj[0]
+        else:
+            # skip further updates if no data are available:
+            return
+
+        if isinstance(layer.layer, GroupedSubset):
+            # don't update histogram for subsets:
+            return
+
+        # Cannot use layer.state because it can be out-of-sync
+        with self.stretch_histogram.hold_sync():
+            color_mode = self.image_color_mode_value
+            interval = ManualInterval(self.stretch_vmin.value, self.stretch_vmax.value)
+            contrast_bias = ContrastBiasStretch(self.image_contrast_value, self.image_bias_value)
+            stretch = stretches.members[self.stretch_function_value]
+
+            x = self.stretch_histogram.figure.marks[0].x
+            y = np.full(x.shape, self.stretch_histogram.figure.axes[1].scale.max)
+
+            # Copied from the __call__ internals of glue/viewers/image/composite_array.py
+            data = interval(x)
+            data = contrast_bias(data, out=data)
+            data = stretch(data, out=data)
+
+            if color_mode == 'Colormaps':
+                cmap = colormaps[self.image_colormap.text]
+                if hasattr(cmap, "get_bad"):
+                    bad_color = cmap.get_bad().tolist()[:3]
+                    layer_cmap = cmap.with_extremes(bad=bad_color + [self.image_opacity_value])
+                else:
+                    layer_cmap = cmap
+
+                # Compute colormapped image
+                plane = layer_cmap(data)
+
+            else:  # Monochromatic
+                # Get color
+                color = COLOR_CONVERTER.to_rgba_array(self.image_color_value)[0]
+                plane = data[:, np.newaxis] * color
+                plane[:, 3] = 1
+
+            plane = np.clip(plane, 0, 1, out=plane)
+            ipycolors = [matplotlib.colors.rgb2hex(p, keep_alpha=False) for p in plane]
+
+            self.stretch_histogram._marks["colorbar"].x = x
+            self.stretch_histogram._marks["colorbar"].y = y
+            self.stretch_histogram._marks["colorbar"].colors = ipycolors
+
     @observe('is_active', 'stretch_vmin_value', 'stretch_vmax_value', 'layer_selected',
              'stretch_hist_nbins', 'image_contrast_value', 'image_bias_value',
              'stretch_curve_visible')
@@ -748,6 +818,10 @@ class PlotOptions(PluginTemplateMixin):
             return
 
         for layer in self.layer.selected_obj:
+            if isinstance(layer.layer, GroupedSubset):
+                # don't update histogram for subsets:
+                return
+
             # clear old mark, if it exists:
             mark_label = f'{mark_label_prefix}{layer.label}'
             mark_exists = mark_label in self.stretch_histogram.marks

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -76,6 +76,7 @@ def test_stretch_histogram(cubeviz_helper, spectrum1d_cube_with_uncerts):
     po.plugin_opened = True
 
     assert po.stretch_histogram is not None
+    assert "colorbar" in po.stretch_histogram._marks
 
     hist_lyr = po.stretch_histogram.layers['histogram']
     flux_cube_sample = hist_lyr.layer.data['x']

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -1,10 +1,9 @@
 import pytest
-import numpy as np
-from numpy import allclose
+from astropy import units as u
+from astropy.nddata import NDData
 from numpy.testing import assert_allclose
 from photutils.datasets import make_4gaussians_image
-from astropy.nddata import NDData
-from astropy import units as u
+
 from jdaviz.configs.default.plugins.plot_options.plot_options import SplineStretch
 
 
@@ -76,14 +75,25 @@ def test_stretch_histogram(cubeviz_helper, spectrum1d_cube_with_uncerts):
     po.plugin_opened = True
 
     assert po.stretch_histogram is not None
-    assert "colorbar" in po.stretch_histogram._marks
+
+    # check the colorbar
+    cb = po.stretch_histogram._marks["colorbar"]
+    assert_allclose(cb.x, po.stretch_histogram.figure.marks[0].x)
+    assert_allclose(cb.y, 1)
+    assert cb.colors == [  # Gray scale, linear
+        '#050505', '#0f0f0f', '#191919', '#232323', '#2e2e2e',
+        '#383838', '#424242', '#4c4c4c', '#575757', '#616161',
+        '#6b6b6b', '#757575', '#808080', '#8a8a8a', '#949494',
+        '#9e9e9e', '#a8a8a8', '#b3b3b3', '#bdbdbd', '#c7c7c7',
+        '#d1d1d1', '#dcdcdc', '#e6e6e6', '#f0f0f0', '#fafafa']
 
     hist_lyr = po.stretch_histogram.layers['histogram']
     flux_cube_sample = hist_lyr.layer.data['x']
 
     # changing viewer should change results
     po.viewer.selected = 'uncert-viewer'
-    assert not allclose(hist_lyr.layer.data['x'], flux_cube_sample)
+    with pytest.raises(AssertionError):
+        assert_allclose(hist_lyr.layer.data['x'], flux_cube_sample)
 
     po.viewer.selected = 'flux-viewer'
     assert_allclose(hist_lyr.layer.data['x'], flux_cube_sample)
@@ -203,8 +213,8 @@ def test_stretch_spline(imviz_helper):
     expected_y = [0., 0.05, 0.3, 0.9, 1.]
 
     # Validate if the generated knots match the expected knots
-    np.testing.assert_allclose(knots_x, expected_x)
-    np.testing.assert_allclose(knots_y, expected_y)
+    assert_allclose(knots_x, expected_x)
+    assert_allclose(knots_y, expected_y)
 
     # Update the stretch options to new values and verify the knots update correctly
     with po.as_active():
@@ -220,8 +230,8 @@ def test_stretch_spline(imviz_helper):
     expected_y = [0., 0.05, 0.3, 0.9, 1.]
 
     # Validate if the generated knots for updated settings match the expected values
-    np.testing.assert_allclose(knots_x, expected_x)
-    np.testing.assert_allclose(knots_y, expected_y)
+    assert_allclose(knots_x, expected_x)
+    assert_allclose(knots_y, expected_y)
 
     # Disable the stretch curve and ensure no knots or stretches are visible
     with po.as_active():

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3420,6 +3420,16 @@ class Plot(PluginSubcomponent):
         self.clear_marks(*self.marks.keys())
 
     def _add_mark(self, cls, label, xnorm=False, ynorm=False, **kwargs):
+        """
+        Parameters
+        ----------
+        xnorm : bool or str
+            If True, axes will be normalized.  If a string of an existing mark, this mark will
+            share that same x-axis scale.
+        ynorm : bool or str
+            If True, axes will be normalized.  If a string of an existing mark, this mark will
+            share that same y-axis scale.
+        """
         if label in self._marks:
             raise ValueError(f"mark with label '{label}' already exists")
         mark = cls(scales={'x': bqplot.LinearScale() if xnorm else self.figure.axes[0].scale,

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3432,8 +3432,16 @@ class Plot(PluginSubcomponent):
         """
         if label in self._marks:
             raise ValueError(f"mark with label '{label}' already exists")
-        mark = cls(scales={'x': bqplot.LinearScale() if xnorm else self.figure.axes[0].scale,
-                           'y': bqplot.LinearScale() if ynorm else self.figure.axes[1].scale},
+        scales = {}
+        for dim, norm in zip(('x', 'y'), (xnorm, ynorm)):
+            if isinstance(norm, str) and norm in self._marks.keys():
+                # point to an existing marks scales
+                scales[dim] = self._marks[norm].scales[dim]
+            elif norm:
+                scales[dim] = bqplot.LinearScale()
+            else:
+                scales[dim] = self.figure.axes[0].scale
+        mark = cls(scales=scales,
                    labels=[label],
                    **kwargs)
         self.figure.marks = self.figure.marks + [mark]

--- a/notebooks/concepts/imviz_colorbar_mpl.ipynb
+++ b/notebooks/concepts/imviz_colorbar_mpl.ipynb
@@ -19,6 +19,9 @@
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
+    "from regions import CirclePixelRegion, PixCoord\n",
+    "\n",
+    "from jdaviz import Imviz\n",
     "\n",
     "%matplotlib inline"
    ]
@@ -63,16 +66,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b04c9b4-ddf4-4025-aea2-77d5920e53dd",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from jdaviz import Imviz"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "e9349094-620b-40c4-8ae2-d424b5983119",
    "metadata": {},
    "outputs": [],
@@ -105,11 +98,32 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "83167260-2cc8-4e33-9fd0-9105db23d521",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz.default_viewer.zoom_level = \"fit\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3f7d496-1447-4e0a-851b-baee27dcb2e5",
+   "metadata": {},
+   "source": [
+    "At this point, it is good to pop the histogram out and put it side by side with this notebook to see any changes.\n",
+    "\n",
+    "Now these changes in the plugin should change the colorbar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "ed2c2107-1803-4481-81b9-e6ab162e7425",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Colormap (to compare with Matplotlib above)\n",
+    "plg.image_color_mode = \"Colormaps\"\n",
     "plg.image_colormap = \"Viridis\""
    ]
   },
@@ -121,8 +135,20 @@
    "outputs": [],
    "source": [
     "# Monochromatic\n",
-    "plg.image_color_mode = \"Monochromatic\"\n",
-    "plg.image_color = \"red\""
+    "#plg.image_color_mode = \"Monochromatic\"\n",
+    "#plg.image_color = \"red\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef143d48-e7f6-4fb7-8a96-2a04ffa04785",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Does not change colorbar but just want to see this\n",
+    "# together with changing stretch function below.\n",
+    "plg.stretch_curve_visible = True"
    ]
   },
   {
@@ -132,95 +158,94 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plg.stretch_function = \"Square Root\""
+    "plg.stretch_function = \"Logarithmic\"\n",
+    "#plg.stretch_function = \"Square Root\"\n",
+    "#plg.stretch_function = \"Linear\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83167260-2cc8-4e33-9fd0-9105db23d521",
+   "id": "5e8fb2ea-c973-4315-97db-3e23277aca89",
    "metadata": {},
    "outputs": [],
    "source": [
-    "imviz.default_viewer.zoom_level = \"fit\""
+    "plg.stretch_preset = \"95%\"\n",
+    "#plg.stretch_preset = \"Min/Max\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e2e02e3-7a25-47c1-a6db-b5ccafcc823d",
+   "id": "7c72d225-520f-42e1-bda6-c84fc91bb131",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from astropy.visualization import ManualInterval, ContrastBiasStretch\n",
-    "from glue.config import colormaps, stretches\n",
-    "from glue.viewers.image.composite_array import COLOR_CONVERTER\n",
-    "\n",
-    "# Copied from glue/viewers/image/composite_array.py\n",
-    "\n",
-    "color_mode = plg._obj.image_color_mode_value\n",
-    "interval = ManualInterval(vmin=plg._obj.stretch_vmin_value, vmax=plg._obj.stretch_vmax_value)\n",
-    "contrast_bias = ContrastBiasStretch(plg._obj.image_contrast_value, plg._obj.image_bias_value)\n",
-    "stretch = stretches.members[plg._obj.stretch_function_value]\n",
-    "array = plg._obj.stretch_histogram.figure.marks[0].x\n",
-    "\n",
-    "data = interval(array)\n",
-    "data = contrast_bias(data, out=data)\n",
-    "data = stretch(data, out=data)\n",
-    "\n",
-    "if color_mode == 'Colormaps':\n",
-    "    cmap = colormaps[plg._obj.image_colormap.text]\n",
-    "    if hasattr(cmap, \"get_bad\"):\n",
-    "        bad_color = cmap.get_bad().tolist()[:3]\n",
-    "        layer_cmap = cmap.with_extremes(bad=bad_color + [plg._obj.image_opacity_value])\n",
-    "    else:\n",
-    "        layer_cmap = cmap\n",
-    "\n",
-    "    # Compute colormapped image\n",
-    "    plane = layer_cmap(data)\n",
-    "\n",
-    "else:  # Monochromatic\n",
-    "    # Get color\n",
-    "    color = COLOR_CONVERTER.to_rgba_array(plg._obj.image_color_value)[0]\n",
-    "    plane = data[:, np.newaxis] * color\n",
-    "    plane[:, 3] = 1\n",
-    "\n",
-    "plane = np.clip(plane, 0, 1, out=plane)"
+    "plg.stretch_vmin = 3000"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25389f05-caf9-4975-b83b-ed4881f4b307",
+   "id": "0c34b4ca-6729-47f5-a97c-dde3a80b3488",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import matplotlib\n",
-    "\n",
-    "ipycolors = [matplotlib.colors.rgb2hex(p, keep_alpha=False) for p in plane]"
+    "plg.stretch_vmax = 35000"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ef6b087-04af-4f91-8bc5-bd0c50f2601a",
+   "id": "82ada867-05c7-4a76-b52b-41f890b56e76",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This draws dots across the histogram. Drawing line does not work. ynorm=True does not put it on top.\n",
-    "#x = plg._obj.stretch_histogram.figure.marks[0].x\n",
-    "#plg._obj.stretch_histogram.add_scatter('colorbar', x=x, y=np.ones(x.size), ynorm=True, color=ipycolors)"
+    "plg.stretch_hist_nbins = 50"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "637b0051-b1d1-4018-9bb6-e502dc9ebcb5",
+   "id": "d9685500-9f4f-4ad4-997f-0a8e1d4b661f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This encodes colorbar inside histogram bars\n",
-    "plg._obj.stretch_histogram.figure.marks[1].colors = ipycolors"
+    "# Zoom in before limiting histogram to zoom limits below.\n",
+    "imviz.default_viewer.zoom(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88f8f4e5-82ed-4184-ad11-36d7c244367a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plg.stretch_hist_zoom_limits = True\n",
+    "#plg.stretch_hist_zoom_limits = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ae7aad4-e2a9-4bb2-9bdf-1b65187a6ca5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plg.image_contrast = 4\n",
+    "#plg.image_contrast = 1.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d32cdbeb-21c9-4c01-8d1c-c0ca26c025f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plg.image_bias = 1\n",
+    "#plg.image_bias = 0.5"
    ]
   },
   {
@@ -231,25 +256,122 @@
    "outputs": [],
    "source": [
     "# Re-displays the histogram\n",
-    "plg._obj.stretch_histogram"
+    "#plg._obj.stretch_histogram"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54164d4e-d1ec-4744-9d38-0003b4a79106",
+   "metadata": {},
+   "source": [
+    "What about another data? With Subset?"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "09810929-c901-45c4-9595-34b322a8de50",
+   "id": "91b34c6c-cba2-4d20-97bf-d6f5dcbcd675",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Matplotlib rendering of the same colors, as reassurance\n",
-    "x = plg._obj.stretch_histogram.figure.marks[0].x\n",
-    "plt.scatter(x, np.ones(x.size), color=ipycolors)"
+    "reg = CirclePixelRegion(PixCoord(100, 100), 10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3b63137-fc41-4836-b440-6cca3f7b9560",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz.load_regions(reg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8431cabb-35c5-49c7-add4-e380fcf4bfb3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image2 = np.random.random(image.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9af2028b-0f6b-42db-ac0a-57e3e277a700",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz.load_data(image2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7118a1f3-bf8f-4d1f-ac7e-f4b7fcc473fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plg.layer = \"Array\"\n",
+    "#plg.layer = \"Subset 1\"  # Buggy!\n",
+    "#plg.layer = \"test image\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a74b677-b572-4702-b2f6-4fbf30261983",
+   "metadata": {},
+   "source": [
+    "What about multi-viewer?"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "b6fc89f6-801c-4944-945e-73c475b5fd72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v2 = imviz.create_image_viewer(\"v2\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1666c1c3-ee3c-49c0-9426-ecbc8228873c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v2.add_data(\"test image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "961bc5c7-ebfd-4b6e-adf6-78103990dcc0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plg.viewer = \"v2\"\n",
+    "#plg.viewer = \"imviz-0\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ed3219e-9e05-46fd-96fe-3a78e5a43c26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#imviz.destroy_viewer(\"v2\")  # Buggy!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36c96416-4981-4d05-a423-51f74e8e66fa",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/concepts/imviz_colorbar_mpl.ipynb
+++ b/notebooks/concepts/imviz_colorbar_mpl.ipynb
@@ -1,0 +1,279 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7b9bf568-7416-46ad-9108-0d1d97c9af32",
+   "metadata": {},
+   "source": [
+    "Concept notebook to explore colorbar implementation in bqplot vs Matplotlib.\n",
+    "\n",
+    "Matplotlib example is from https://docs.astropy.org/en/latest/visualization/normalization.html ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6374a84-beaa-4e98-ae25-75ece45cc54b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f4c35a6-ba8f-4f63-b68a-607de30c08f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate a test image\n",
+    "image = np.arange(65536).reshape((256, 256))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c6f2384-b70b-4106-973d-b62623d67e5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.visualization import simple_norm\n",
+    "\n",
+    "# Create an ImageNormalize object\n",
+    "norm = simple_norm(image, 'sqrt')\n",
+    "\n",
+    "# Display the image\n",
+    "fig, ax = plt.subplots()\n",
+    "im = ax.imshow(image, origin='lower', norm=norm)\n",
+    "fig.colorbar(im, location=\"bottom\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ab7bbf6-372b-4aa0-9f02-a5dacace164e",
+   "metadata": {},
+   "source": [
+    "How, how does Imviz fare?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b04c9b4-ddf4-4025-aea2-77d5920e53dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jdaviz import Imviz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9349094-620b-40c4-8ae2-d424b5983119",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz = Imviz()\n",
+    "imviz.load_data(image, data_label=\"test image\")\n",
+    "imviz.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27a06c70-b7af-4055-9b50-2d1269ba38d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plg = imviz.plugins[\"Plot Options\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e261197-8db5-4051-9f9f-07e7245cc53d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plg.open_in_tray()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed2c2107-1803-4481-81b9-e6ab162e7425",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Colormap (to compare with Matplotlib above)\n",
+    "plg.image_colormap = \"Viridis\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc2331cf-e8e4-4ad9-ac80-3dac338c298a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Monochromatic\n",
+    "plg.image_color_mode = \"Monochromatic\"\n",
+    "plg.image_color = \"red\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52dd988b-a763-4caa-acee-3d39682bdcce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plg.stretch_function = \"Square Root\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83167260-2cc8-4e33-9fd0-9105db23d521",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz.default_viewer.zoom_level = \"fit\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e2e02e3-7a25-47c1-a6db-b5ccafcc823d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.visualization import ManualInterval, ContrastBiasStretch\n",
+    "from glue.config import colormaps, stretches\n",
+    "from glue.viewers.image.composite_array import COLOR_CONVERTER\n",
+    "\n",
+    "# Copied from glue/viewers/image/composite_array.py\n",
+    "\n",
+    "color_mode = plg._obj.image_color_mode_value\n",
+    "interval = ManualInterval(vmin=plg._obj.stretch_vmin_value, vmax=plg._obj.stretch_vmax_value)\n",
+    "contrast_bias = ContrastBiasStretch(plg._obj.image_contrast_value, plg._obj.image_bias_value)\n",
+    "stretch = stretches.members[plg._obj.stretch_function_value]\n",
+    "array = plg._obj.stretch_histogram.figure.marks[0].x\n",
+    "\n",
+    "data = interval(array)\n",
+    "data = contrast_bias(data, out=data)\n",
+    "data = stretch(data, out=data)\n",
+    "\n",
+    "if color_mode == 'Colormaps':\n",
+    "    cmap = colormaps[plg._obj.image_colormap.text]\n",
+    "    if hasattr(cmap, \"get_bad\"):\n",
+    "        bad_color = cmap.get_bad().tolist()[:3]\n",
+    "        layer_cmap = cmap.with_extremes(bad=bad_color + [plg._obj.image_opacity_value])\n",
+    "    else:\n",
+    "        layer_cmap = cmap\n",
+    "\n",
+    "    # Compute colormapped image\n",
+    "    plane = layer_cmap(data)\n",
+    "\n",
+    "else:  # Monochromatic\n",
+    "    # Get color\n",
+    "    color = COLOR_CONVERTER.to_rgba_array(plg._obj.image_color_value)[0]\n",
+    "    plane = data[:, np.newaxis] * color\n",
+    "    plane[:, 3] = 1\n",
+    "\n",
+    "plane = np.clip(plane, 0, 1, out=plane)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25389f05-caf9-4975-b83b-ed4881f4b307",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib\n",
+    "\n",
+    "ipycolors = [matplotlib.colors.rgb2hex(p, keep_alpha=False) for p in plane]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ef6b087-04af-4f91-8bc5-bd0c50f2601a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This draws dots across the histogram. Drawing line does not work. ynorm=True does not put it on top.\n",
+    "#x = plg._obj.stretch_histogram.figure.marks[0].x\n",
+    "#plg._obj.stretch_histogram.add_scatter('colorbar', x=x, y=np.ones(x.size), ynorm=True, color=ipycolors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "637b0051-b1d1-4018-9bb6-e502dc9ebcb5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This encodes colorbar inside histogram bars\n",
+    "plg._obj.stretch_histogram.figure.marks[1].colors = ipycolors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6b38132-8241-4c7e-876c-9e02cc97cfc6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Re-displays the histogram\n",
+    "plg._obj.stretch_histogram"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09810929-c901-45c4-9595-34b322a8de50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Matplotlib rendering of the same colors, as reassurance\n",
+    "x = plg._obj.stretch_histogram.figure.marks[0].x\n",
+    "plt.scatter(x, np.ones(x.size), color=ipycolors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6fc89f6-801c-4944-945e-73c475b5fd72",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is a different approach to encode colorbar information on the Plot Options histogram. Previous attempt to use pure bqplot (#2514) failed. This one lifts code from glue-core to compute the colors using matplotlib and then throw them on the bqplot histogram directly.

- [x] Once we decided on the look we want (see below), I will transfer the code from the concept notebook added in this PR to the actual app code. Right now, this only works if you run the concept notebook. (I went with hacked Scatter plot on top of histogram.)

Known issues due to it listening to too many things at once, I think. Not sure how to make it cleaner:

* Wonky after toggling multiselect on/off.
* Wonky after selecting/deselecting subset.
* Wonky after zooming in/out too fast while having it follow zoom.
* Possibly unrelated bug of it crashing when destroying viewer. https://github.com/spacetelescope/jdaviz/issues/2521

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3725)
