### PR TITLE
FEAT: Export RGB FITS in Imviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,8 +23,9 @@ Imviz
 
 - Aperture photometry (previously "Imviz Simple Aperture Photometry") now supports batch mode. [#2465]
 
-
 - Expose sky regions in get_subsets. If 'include_sky_region' is True, a sky Region will be returned (in addition to a pixel Region) for spatial subsets with parent data that was a WCS. [#2496]
+
+- Export Plot plugin now has option to save composite image to RGB FITS format, in addition to PNG and SVG. [#2528]
 
 Mosviz
 ^^^^^^

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -369,3 +369,6 @@ Export Plot
 ===========
 
 This plugin allows exporting the plot in a given viewer to a PNG or SVG file.
+
+In Imviz, there is also an option to export to RGB FITS cube, with three slices,
+each representing the red, green, and blue channel.

--- a/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import pytest
 from astropy.io import fits
@@ -151,6 +152,10 @@ class TestExportPlotImvizRGBFITS(BaseImviz_WCS_GWCS):
             assert arr.shape == (100, 100, 3)  # ny, nx, RGB
 
         # Silent overwrite.
+        # NOTE: This is not tested on Windows because it throws WinError 32.
+        if sys.platform.startswith("win"):
+            return
+
         self.viewer.shape = (50, 50)
         self.viewer.state._set_axes_aspect_ratio(1)
         self.viewer.zoom_level = "fit"

--- a/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
@@ -1,8 +1,10 @@
 import os
 
 import pytest
+from astropy.io import fits
 
 from jdaviz.configs.default.plugins.export_plot.export_plot import HAS_OPENCV
+from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_GWCS
 
 
 # TODO: Remove skip when https://github.com/bqplot/bqplot/pull/1397/files#r726500097 is resolved.
@@ -101,3 +103,61 @@ def test_export_plot_exceptions(cubeviz_helper):
 
     with pytest.raises(ValueError, match="Invalid path"):
         plugin.save_figure(filename="/fake/path/image.png")
+
+    with pytest.raises(NotImplementedError, match="save_rgbfits is not available"):
+        plugin._obj.save_rgbfits()
+
+
+# TODO: This will make more sense when we re-organize where plugins go,
+# which would also affect their tests.
+# See https://jira.stsci.edu/browse/JDAT-3200
+
+def test_export_plot_imviz_rgbfits_exceptions(imviz_helper):
+    plugin = imviz_helper.plugins["Export Plot"]
+
+    plugin._obj.movie_enabled = False
+    with pytest.raises(ValueError, match="save_rgbfits is currently disabled"):
+        plugin.save_rgbfits()
+    plugin._obj.movie_enabled = True
+
+    with pytest.raises(ValueError, match="Selected viewer has no display shape"):
+        plugin.save_rgbfits()
+
+    imviz_helper.default_viewer.shape = (100, 100)
+    plugin.rgbfits_filename = ""
+    with pytest.raises(ValueError, match="Invalid filename"):
+        plugin.save_rgbfits()
+
+    plugin.rgbfits_filename = "/fake/path/image.fits"
+    with pytest.raises(ValueError, match="Invalid path"):
+        plugin.save_rgbfits()
+
+
+class TestExportPlotImvizRGBFITS(BaseImviz_WCS_GWCS):
+
+    def test_export_wcs_linked(self, tmp_path):
+        self.imviz.link_data(link_type='wcs', error_on_fail=True)
+        self.viewer.zoom(2)
+
+        outfn = str(tmp_path / "myrgb.fits")
+
+        plugin = self.imviz.plugins["Export Plot"]
+        plugin.rgbfits_filename = outfn
+        out1 = plugin.save_rgbfits()
+
+        # Note: Content itself is not checked, just the shape.
+        with fits.open(outfn) as pf:
+            arr = pf[0].data
+            assert arr.shape == (100, 100, 3)  # ny, nx, RGB
+
+        # Silent overwrite.
+        self.viewer.shape = (50, 50)
+        self.viewer.state._set_axes_aspect_ratio(1)
+        self.viewer.zoom_level = "fit"
+        out2 = plugin.save_rgbfits()
+        assert out2 == out1
+
+        # Note: Content itself is not checked, just the shape.
+        with fits.open(outfn) as pf:
+            arr = pf[0].data
+            assert arr.shape == (50, 50, 3)  # ny, nx, RGB

--- a/jdaviz/configs/default/plugins/export_plot/export_plot.vue
+++ b/jdaviz/configs/default/plugins/export_plot/export_plot.vue
@@ -17,7 +17,7 @@
          text
          color="primary"
          @click="() => save_figure('png')"
-         :disabled="movie_recording"
+         :disabled="movie_recording || rgbfits_saving"
         >
          Export to PNG
         </v-btn>
@@ -27,7 +27,7 @@
          text
          color="primary"
          @click="() => save_figure('svg')"
-         :disabled="movie_recording"
+         :disabled="movie_recording || rgbfits_saving"
         >
          Export to SVG
         </v-btn>
@@ -124,6 +124,47 @@
                     </v-btn>
                   </template>
                   <span>Start movie recording</span>
+                </v-tooltip>
+              </v-row>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </v-row>
+
+      <v-row v-if="config==='imviz' && movie_enabled">
+        <v-expansion-panels accordion>
+          <v-expansion-panel>
+            <v-expansion-panel-header v-slot="{ open }">
+              <span style="padding: 6px">Export to RGB FITS</span>
+            </v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <v-row class="row-no-outside-padding row-min-bottom-padding">
+                <v-col>
+                  <v-text-field
+                    v-model="rgbfits_filename"
+                    class="mt-0 pt-0"
+                    :rules="[() => rgbfits_filename!=='' || 'Must provide filename.']"
+                    label="Filename"
+                    hint="RGB FITS filename"
+                     persistent-hint
+                  ></v-text-field>
+                </v-col>
+              </v-row>
+              <v-row justify='end'>
+                <v-tooltip top>
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-btn
+                     text
+                     color="primary"
+                     @click="() => save_rgbfits()"
+                     v-bind="attrs"
+                     v-on="on"
+                     :disabled="rgbfits_saving"
+                    >
+                     Export to RGB FITS
+                    </v-btn>
+                  </template>
+                  <span>Save image to RGB FITS cube</span>
                 </v-tooltip>
               </v-row>
             </v-expansion-panel-content>


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to implement new Imviz feature to allow export to RGB FITS cube as defined in https://ds9.si.edu/doc/ref/file.html#FITSRGB . This is an example using `concepts/imviz_dithered_gwcs.ipynb`.

![Screenshot 2023-10-23 201112 BIG MOSAIC GUI](https://github.com/spacetelescope/jdaviz/assets/2090236/ced53535-ac72-49f3-a84c-33e667053eae)

You can read it back it as NumPy array and Matplotlib magically knows how to interpret it:

![Screenshot 2023-10-23 201112 BIG MOSAIC MPL](https://github.com/spacetelescope/jdaviz/assets/2090236/fe1e8681-255c-4988-934c-508ec7ea43b3)

I have decided to just mirror whatever downsampled composite image that is sent to Imviz viewer. This is to avoid adding even more performance issues with big data, and also the "raw composite" does not do well when dithered images are linked by WCS and then rendered (more below).

Let's say, this is what you are seeing in `concepts/imviz_compass_mpl.fits` (the last example with 2 dithered data + 1 data without WCS, all linked by WCS when possible):

![Screenshot 2023-10-23 200554 ACTUAL VIEWER](https://github.com/spacetelescope/jdaviz/assets/2090236/f32ec5f3-efe3-4ff3-8dee-b9a5ddd09c1b)

I think the "raw composite" (the one that would match the original input data dimension) only stack them by pixels because I do not see the "red stripe" on the left, which is what I would expect if dithered images are offset by 1-pixel properly as above. Also, "raw composite" quickly eats up all the resources as I easily crashed my notebook kernel trying to extract it for the `imviz_dithered_gwcs.ipynb` above (two images, each with `(4471, 9970)` dimension):

![Screenshot 2023-10-23 200626 RAW COMPOSITE](https://github.com/spacetelescope/jdaviz/assets/2090236/dbbc31ad-872a-480a-9181-eb98f3946cb5)

Meanwhile, rendered composite is WYSIWYG, which I find more intuitive. And it avoids the performance problem mentioned above:

![Screenshot 2023-10-23 200710 RENDERED COMPOSITE](https://github.com/spacetelescope/jdaviz/assets/2090236/09b585d0-a8fb-4b07-b4a9-dbdc0f1c8fff)

Other related links:

* https://github.com/glue-viz/glue/blob/25c8df4edf9fcc4b3449a2a90610d021afc2b841/glue/viewers/image/composite_array.py#L91
* https://github.com/glue-viz/glue-jupyter/blob/09c882d4bb5c03a6b033950ab7f66ac1dfbbeeaa/glue_jupyter/bqplot/image/viewer.py#L42-L43

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3595)
