### PR TITLE
Bugfix: enable str arguments for app._reparent_subsets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ New Features
 
 - The Plot Options plugin now include a 'spline' stretch feature. [#2525]
   
-- User can now remove data from the app completely after removing it from viewers. [#2409]
+- User can now remove data from the app completely after removing it from viewers. [#2409, #2531]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1910,10 +1910,10 @@ class Application(VuetifyTemplate, HubListener):
         from astropy.wcs.utils import pixel_to_pixel
 
         if isinstance(old_parent, str):
-            old_parent = self.data_collection(old_parent)
+            old_parent = self.data_collection[old_parent]
 
         if isinstance(new_parent, str):
-            new_parent = self.data_collection(new_parent)
+            new_parent = self.data_collection[new_parent]
         elif new_parent is None:
             for data in self.data_collection:
                 if data is not old_parent:

--- a/jdaviz/configs/imviz/tests/test_delete_data.py
+++ b/jdaviz/configs/imviz/tests/test_delete_data.py
@@ -8,6 +8,13 @@ from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_WCS
 
 class TestDeleteData(BaseImviz_WCS_WCS):
 
+    def test_reparent_str(self):
+        for subset in self.imviz.app.data_collection.subset_groups:
+            self.imviz.app._reparent_subsets(
+                subset.subset_state.xatt.parent.label,
+                "has_wcs_1[SCI,1]"
+            )
+
     def test_delete_with_subset_wcs(self):
         # Add a third dataset to test relinking
         arr = np.ones((10, 10))


### PR DESCRIPTION
Docstring for `app._reparent_subsets` from #2409 suggests that the user can provide as arguments `Data` objects or their labels as strings. The logic for supplying strings wasn't covered by the tests, and fails when used. This PR fixes that bug and tests for it.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
