### PR TITLE
Bugfix: correction to Plot Options stretch function curve

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,8 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Fix Plot Options stretch histogram's curve for non-gray colormaps. [#2537]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -827,11 +827,10 @@ class PlotOptions(PluginTemplateMixin):
 
         if self.stretch_curve_visible:
             # create a photoshop style "curve" for the stretch function
-            curve_x = np.linspace(self.stretch_vmin.value, self.stretch_vmax.value, 50)
-            curve_y = interval(curve_x, clip=False)
-            curve_y = contrast_bias(curve_y, out=curve_y, clip=False)
-            curve_y = stretch(curve_y, out=curve_y, clip=False)
-            curve_y = layer_cmap(curve_y)[:, 0]
+            curve_x = np.linspace(self.stretch_vmin_value, self.stretch_vmax_value, 50)
+            curve_y = interval(curve_x)
+            curve_y = contrast_bias(curve_y)
+            curve_y = stretch(curve_y)
 
             curve_mark = self.stretch_histogram.marks['stretch_curve']
             curve_mark.x = curve_x


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description

The Plot Options stretch histogram curve from #2390 looks fine in Gray colormap, but does not look fine in other colormaps. Here's an image with a linear stretch showing a nonlinear curve in the stretch histogram:

![Screen Shot 2023-10-26 at 13 09 47 (1)](https://github.com/spacetelescope/jdaviz/assets/3497584/326eff69-1885-40eb-aaea-a6b1765bb59a)

In reproducing the logic in [glue's CompositeArray module](https://github.com/glue-viz/glue/blob/4de2cfd31670acb9aae60d198be4a5f83ebd8c0e/glue/viewers/image/composite_array.py#L137-L139), I apply the stretch, contrast, and bias correctly, but then I went one line too far and also applied the _colormap_ to the values that should represent the curve. That's not what we want! In the gray colormap case, the colormap is linear+monotonic so you don't notice the problem. 

This PR corrects the implementation to work with any colormap:

<img width="1641" alt="Screen Shot 2023-10-26 at 13 56 50" src="https://github.com/spacetelescope/jdaviz/assets/3497584/33844dfb-1f7a-49fd-856c-cc9ab1f33c70">


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3921)