### PR TITLE
consolidate stretch histogram code

### DIFF
--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -772,7 +772,7 @@ class PlotOptions(PluginTemplateMixin):
 
         # create the new/updated stretch curve following the colormapping
         # procedure in glue's CompositeArray:
-        interval = ManualInterval(self.stretch_vmin.value, self.stretch_vmax.value)
+        interval = ManualInterval(self.stretch_vmin_value, self.stretch_vmax_value)
         contrast_bias = ContrastBiasStretch(self.image_contrast_value, self.image_bias_value)
         stretch = stretches.members[self.stretch_function_value]
         layer_cmap = layer.state.cmap
@@ -818,7 +818,8 @@ class PlotOptions(PluginTemplateMixin):
         # show "knot" locations if the stretch_function is a spline
         if isinstance(stretch, SplineStretch) and self.stretch_curve_visible:
             knot_mark = self.stretch_histogram.marks['stretch_knots']
-            knot_mark.x = self.stretch_vmin_value + stretch.x * ( self.stretch_vmax_value - self.stretch_vmin_value)
+            knot_mark.x = (self.stretch_vmin_value +
+                           stretch.x * (self.stretch_vmax_value - self.stretch_vmin_value))
             # scale to 0.9 so always falls below colorbar (same as for stretch_curve)
             # (may need to revisit this when supporting dragging)
             knot_mark.y = 0.9 * stretch.y

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -739,9 +739,10 @@ class PlotOptions(PluginTemplateMixin):
 
         # update the n_bins since this may be a new layer
         self._histogram_nbins_changed()
+        # update the curve/colorbar
+        self._update_stretch_curve(msg)
 
-    @observe('is_active', 'layer_selected',
-             'image_color_mode_value', 'image_color_value', 'image_colormap_value',
+    @observe('image_color_mode_value', 'image_color_value', 'image_colormap_value',
              'image_contrast_value', 'image_bias_value',
              'stretch_hist_nbins',
              'stretch_curve_visible',
@@ -753,9 +754,6 @@ class PlotOptions(PluginTemplateMixin):
             # don't update histogram if selected viewer is not an image viewer,
             # or the stretch histogram hasn't been initialized:
             return
-
-        # TODO: make sure entire histogram is hidden in multiselect
-        # TODO: look at what is in msg and don't updating things that don't need updating
 
         if self.multiselect:
             self.stretch_histogram.clear_marks('stretch_curve', 'stretch_knots', 'colorbar')

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -812,7 +812,6 @@ class PlotOptions(PluginTemplateMixin):
         colorbar_mark = self.stretch_histogram.marks['colorbar']
         colorbar_mark.x = x
         colorbar_mark.y = y
-        # TODO: fix all white on load...
         colorbar_mark.colors = ipycolors
 
         # show "knot" locations if the stretch_function is a spline

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -266,7 +266,7 @@ class PlotOptions(PluginTemplateMixin):
     stretch_hist_nbins = IntHandleEmpty(25).tag(sync=True)
     stretch_histogram_widget = Unicode().tag(sync=True)
 
-    stretch_curve_visible = Bool().tag(sync=True)
+    stretch_curve_visible = Bool(True).tag(sync=True)
 
     subset_visible_value = Bool().tag(sync=True)
     subset_visible_sync = Dict().tag(sync=True)

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -345,7 +345,8 @@
       ></v-select>
     </glue-state-sync-wrapper>
 
-    <glue-state-sync-wrapper :sync="stretch_vmin_sync" :multiselect="multiselect" @unmix-state="unmix_state('stretch_vmin')">
+    <!-- for multiselect, show vmin/max here, otherwise they'll be in the "more stretch options" expandable section -->
+    <glue-state-sync-wrapper v-if="multiselect" :sync="stretch_vmin_sync" :multiselect="multiselect" @unmix-state="unmix_state('stretch_vmin')">
       <v-text-field
         ref="stretch_vmin"
         label="Stretch VMin"
@@ -355,7 +356,7 @@
       ></v-text-field>
     </glue-state-sync-wrapper>
 
-    <glue-state-sync-wrapper :sync="stretch_vmax_sync" :multiselect="multiselect" @unmix-state="unmix_state('stretch_vmax')">
+    <glue-state-sync-wrapper v-if="multiselect" :sync="stretch_vmax_sync" :multiselect="multiselect" @unmix-state="unmix_state('stretch_vmax')">
       <v-text-field
         ref="stretch_vmax"
         label="Stretch VMax"
@@ -365,40 +366,65 @@
       ></v-text-field>
     </glue-state-sync-wrapper>
 
-    <div v-if="stretch_function_sync.in_subscribed_states">
-      <v-row>
-        <v-text-field
-            ref="stretch_hist_nbins"
-            label="Number of Bins"
-            v-model.number="stretch_hist_nbins"
-            type="number"
-            hint="The amount of bins used in the histogram."
-            persistent-hint
-            :rules="[() => stretch_hist_nbins !== '' || 'This field is required',
-                     () => stretch_hist_nbins > 0 || 'Number of Bins must be greater than zero']"
-        ></v-text-field>
-      </v-row>
-      <v-row>
-        <!-- z-index to ensure on top of the jupyter widget with negative margin-top -->
-        <v-switch
-          v-model="stretch_hist_zoom_limits"
-          class="hide-input"
-          label="Limit histogram to current zoom limits"
-          style="z-index: 1"
-        ></v-switch>
-      </v-row>
-      <v-row>
-        <v-switch
-          v-model="stretch_curve_visible"
-          class="hide-input"
-          label="Show stretch function curve"
-          style="z-index: 1"
-        ></v-switch>
-        <!-- NOTE: height defined here should match that in the custom CSS rules
-             below for the bqplot class -->
-      </v-row>
+    <div v-if="stretch_function_sync.in_subscribed_states && !multiselect">
       <jupyter-widget :widget="stretch_histogram_widget"/>
-      </div>
+      <v-row>
+        <v-expansion-panels accordion>
+          <v-expansion-panel>
+            <v-expansion-panel-header v-slot="{ open }">
+              <span style="padding: 6px">More Stretch Options</span>
+            </v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <v-row>
+                <v-text-field
+                    ref="stretch_hist_nbins"
+                    label="Number of Bins"
+                    v-model.number="stretch_hist_nbins"
+                    type="number"
+                    hint="The amount of bins used in the histogram."
+                    persistent-hint
+                    :rules="[() => stretch_hist_nbins !== '' || 'This field is required',
+                             () => stretch_hist_nbins > 0 || 'Number of Bins must be greater than zero']"
+                ></v-text-field>
+              </v-row>
+              <v-row>
+                <v-switch
+                  v-model="stretch_hist_zoom_limits"
+                  class="hide-input"
+                  label="Limit histogram to current zoom limits"
+                ></v-switch>
+              </v-row>
+              <v-row>
+                <v-switch
+                  v-model="stretch_curve_visible"
+                  class="hide-input"
+                  label="Show stretch function curve"
+                ></v-switch>
+              </v-row>
+              <glue-state-sync-wrapper :sync="stretch_vmin_sync" :multiselect="multiselect" @unmix-state="unmix_state('stretch_vmin')">
+                <v-text-field
+                  ref="stretch_vmin"
+                  label="Stretch VMin"
+                  v-model.number="stretch_vmin_value"
+                  type="number"
+                  :step="stretch_vstep"
+                ></v-text-field>
+              </glue-state-sync-wrapper>
+              <glue-state-sync-wrapper :sync="stretch_vmax_sync" :multiselect="multiselect" @unmix-state="unmix_state('stretch_vmax')">
+                <v-text-field
+                  ref="stretch_vmax"
+                  label="Stretch VMax"
+                  v-model.number="stretch_vmax_value"
+                  type="number"
+                  :step="stretch_vstep"
+                ></v-text-field>
+              </glue-state-sync-wrapper>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </v-row>
+
+    </div>
 
     <!-- IMAGE:IMAGE -->
     <j-plugin-section-header v-if="image_visible_sync.in_subscribed_states">Image</j-plugin-section-header>

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from astropy import units as u
 from astropy.nddata import NDData
@@ -204,15 +205,16 @@ def test_stretch_spline(imviz_helper):
         po.stretch_function = "Spline"
 
     # Retrieve knots data from the generated histogram
-    scatter_obj = po._obj.stretch_histogram.marks["stretch_knots: NDData[DATA] (DATA)"]
+    scatter_obj = po._obj.stretch_histogram.marks["stretch_knots"]
     knots_x = scatter_obj.x
     knots_y = scatter_obj.y
 
     # Expected knots based on initial stretch settings
     expected_x = [10., 19., 28., 73., 100.]
-    expected_y = [0., 0.05, 0.3, 0.9, 1.]
+    expected_y = np.array([0., 0.05, 0.3, 0.9, 1.]) * 0.9  # rescaled to 0.9
 
     # Validate if the generated knots match the expected knots
+    assert scatter_obj.visible
     assert_allclose(knots_x, expected_x)
     assert_allclose(knots_y, expected_y)
 
@@ -220,23 +222,24 @@ def test_stretch_spline(imviz_helper):
     with po.as_active():
         po.stretch_vmin.value = 10
         po.stretch_vmax.value = 80
-        po.stretch_curve_visible = True
         po.stretch_function = "Spline"
 
     knots_x = scatter_obj.x
+    knots_y = scatter_obj.y
 
     # Expected knots based on updated stretch settings
     expected_x = [10., 17., 24., 59., 80.]
-    expected_y = [0., 0.05, 0.3, 0.9, 1.]
+    expected_y = np.array([0., 0.05, 0.3, 0.9, 1.]) * 0.9  # rescaled to 0.9
 
     # Validate if the generated knots for updated settings match the expected values
+    assert scatter_obj.visible
     assert_allclose(knots_x, expected_x)
     assert_allclose(knots_y, expected_y)
 
     # Disable the stretch curve and ensure no knots or stretches are visible
     with po.as_active():
         po.stretch_curve_visible = False
-    stretch_curve = po._obj.stretch_histogram.marks['stretch_curve: NDData[DATA] (DATA)']
+    stretch_curve = po._obj.stretch_histogram.marks['stretch_curve']
     assert len(stretch_curve.y) == 0
     assert len(stretch_curve.x) == 0
     assert len(scatter_obj.x) == 0

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -67,8 +67,9 @@ SPATIAL_DEFAULT_TEXT = "Entire Cube"
 GLUE_STATES_WITH_HELPERS = ('size_att', 'cmap_att')
 
 # this histogram viewer (along with other viewers) are not in the glue viewer-registry by default
-# but may be added in the future.  If it is not in the registry, we'll add it now.  If/once the
-# min-pin of glue-jupyter includes this in the registry, we can safely remove this block.
+# but may be added in the future.  If it is not in the registry, we'll add it now.
+# Once glue-jupyter with https://github.com/glue-viz/glue-jupyter/pull/402 is pinned,
+# we can safely remove this block.
 if 'histogram' not in viewer_registry.members.keys():
     @viewer_registry('histogram')
     class RegisteredHistogramViewer(BqplotHistogramView):

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3406,15 +3406,16 @@ class Plot(PluginSubcomponent):
         return self._marks
 
     def clear_marks(self, *mark_labels):
-        for mark_label, mark in self.marks.items():
-            if mark_label in mark_labels:
-                if isinstance(mark, bqplot.Bins):
-                    # NOTE: cannot completely empty samples
-                    # may want to also set mark.visible=False manually if clearing
-                    # (but this will still at least clear any internal arrays)
-                    mark.samples = [0]
-                else:
-                    mark.x, mark.y = [], []
+        with self.hold_sync():
+            for mark_label, mark in self.marks.items():
+                if mark_label in mark_labels:
+                    if isinstance(mark, bqplot.Bins):
+                        # NOTE: cannot completely empty samples
+                        # may want to also set mark.visible=False manually if clearing
+                        # (but this will still at least clear any internal arrays)
+                        mark.samples = [0]
+                    else:
+                        mark.x, mark.y = [], []
 
     def clear_all_marks(self):
         self.clear_marks(*self.marks.keys())


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request:
* consolidates code introduced in #2525, #2517, #2513, and #2390 to be in a single loop and avoid code duplication.
* consolidates the UI itself by moving redundant input options (vmin, vmax, etc - now that these are editable interactively in the plugin plot) into an expandable menu.
* removes infrastructure code added in #2390 to support multiple layers in the stretch histogram as that is no longer planned, and if we do ever want to introduce it, would require more general code and design with these new capabilities built on top.
* scales the curve to 0.9 to avoid overlapping the colorbar
* shows the stretch curve by default

No changelog entry needed as none of these changes have seen a release yet.

Note: this is expected to have a merge conflict with #2537, but should be fairly simple to address.

<img width="250" alt="Screen Shot 2023-10-27 at 12 29 37 PM" src="https://github.com/spacetelescope/jdaviz/assets/877591/77308928-89db-4e09-b264-e4fdecfd82ab">

<img width="250" alt="Screen Shot 2023-10-27 at 12 29 46 PM" src="https://github.com/spacetelescope/jdaviz/assets/877591/558f7264-3bb6-4935-bd73-2b7367de2568">


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
