### PR TITLE
Don't try to update viewer state if it was deleted

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -102,6 +102,9 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Plot options layer selection no longer gets stuck in some cases when deleting
+  the currently selected viewer. [#2541]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -659,12 +659,11 @@ class PlotOptions(PluginTemplateMixin):
             viewer_label_old = msg.get('old')
             if isinstance(viewer_label_old, list):
                 viewer_label_old = viewer_label_old[0]
-            if len(viewer_label_old):
-                # If the previously selected viewer was deleted, we don't need to do this.
-                if viewer_label_old in self.app._viewer_store:
-                    vs_old = self.app.get_viewer(viewer_label_old).state
-                    for attr in ('x_min', 'x_max', 'y_min', 'y_max'):
-                        vs_old.remove_callback(attr, self._update_stretch_histogram)
+            # If the previously selected viewer was deleted, we don't need to do this.
+            if viewer_label_old in self.app._viewer_store:
+                vs_old = self.app.get_viewer(viewer_label_old).state
+                for attr in ('x_min', 'x_max', 'y_min', 'y_max'):
+                    vs_old.remove_callback(attr, self._update_stretch_histogram)
 
         if self.multiselect:
             data = self.layer.selected_obj[0][0].layer

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -660,9 +660,11 @@ class PlotOptions(PluginTemplateMixin):
             if isinstance(viewer_label_old, list):
                 viewer_label_old = viewer_label_old[0]
             if len(viewer_label_old):
-                vs_old = self.app.get_viewer(viewer_label_old).state
-                for attr in ('x_min', 'x_max', 'y_min', 'y_max'):
-                    vs_old.remove_callback(attr, self._update_stretch_histogram)
+                # If the previously selected viewer was deleted, we don't need to do this.
+                if viewer_label_old in self.app._viewer_store:
+                    vs_old = self.app.get_viewer(viewer_label_old).state
+                    for attr in ('x_min', 'x_max', 'y_min', 'y_max'):
+                        vs_old.remove_callback(attr, self._update_stretch_histogram)
 
         if self.multiselect:
             data = self.layer.selected_obj[0][0].layer

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -6,6 +6,7 @@ from jdaviz.app import Application
 from jdaviz.core.config import get_configuration
 from jdaviz.configs.imviz.helper import Imviz
 from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
+from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_WCS
 
 
 @pytest.mark.parametrize(
@@ -53,24 +54,6 @@ def test_destroy_viewer_invalid(imviz_helper):
     assert imviz_helper.app.get_viewer_ids() == ['imviz-0']
 
 
-def test_plot_options_after_destroy(imviz_helper):
-    np.random.seed(42)
-    arr = np.random.sample((10, 10))
-    imviz_helper.load_data(arr, data_label='array_1')
-    arr = np.random.sample((10, 10))*5
-    imviz_helper.load_data(arr, data_label='array_2')
-
-    imviz_helper.create_image_viewer(viewer_name="imviz-1")
-    imviz_helper.app.add_data_to_viewer('imviz-1', 'array_2')
-
-    po = imviz_helper.plugins['Plot Options']
-    po.open_in_tray()
-    po.viewer = "imviz-1"
-    po.stretch_function = "Square Root"
-    imviz_helper.destroy_viewer("imviz-1")
-    assert len(po.layer.choices) == 2
-
-
 def test_destroy_viewer_with_subset(imviz_helper):
     """Regression test for https://github.com/spacetelescope/jdaviz/issues/1614"""
     arr = np.ones((10, 10))
@@ -112,3 +95,17 @@ def test_mastviz_config():
 
     assert im.app.get_viewer_ids() == ['mastviz-0']
     assert im.app.data_collection[0].shape == (2, 2)
+
+
+class TestDeleteData(BaseImviz_WCS_NoWCS):
+
+    def test_plot_options_after_destroy(self):
+        self.imviz.create_image_viewer(viewer_name="imviz-1")
+        self.imviz.app.add_data_to_viewer('imviz-1', 'has_wcs_2[SCI,1]')
+
+        po = self.imviz.plugins['Plot Options']
+        po.open_in_tray()
+        po.viewer = "imviz-1"
+        po.stretch_function = "Square Root"
+        self.imviz.destroy_viewer("imviz-1")
+        assert len(po.layer.choices) == 2

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -6,7 +6,7 @@ from jdaviz.app import Application
 from jdaviz.core.config import get_configuration
 from jdaviz.configs.imviz.helper import Imviz
 from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
-from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_WCS
+from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_NoWCS
 
 
 @pytest.mark.parametrize(
@@ -101,7 +101,7 @@ class TestDeleteData(BaseImviz_WCS_NoWCS):
 
     def test_plot_options_after_destroy(self):
         self.imviz.create_image_viewer(viewer_name="imviz-1")
-        self.imviz.app.add_data_to_viewer('imviz-1', 'has_wcs_2[SCI,1]')
+        self.imviz.app.add_data_to_viewer('imviz-1', 'no_wcs[SCI,1]')
 
         po = self.imviz.plugins['Plot Options']
         po.open_in_tray()

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -53,6 +53,24 @@ def test_destroy_viewer_invalid(imviz_helper):
     assert imviz_helper.app.get_viewer_ids() == ['imviz-0']
 
 
+def test_plot_options_after_destroy(imviz_helper):
+    np.random.seed(42)
+    arr = np.random.sample((10, 10))
+    imviz_helper.load_data(arr, data_label='array_1')
+    arr = np.random.sample((10, 10))*5
+    imviz_helper.load_data(arr, data_label='array_2')
+
+    imviz_helper.create_image_viewer(viewer_name="imviz-1")
+    imviz_helper.app.add_data_to_viewer('imviz-1', 'array_2')
+
+    po = imviz_helper.plugins['Plot Options']
+    po.open_in_tray()
+    po.viewer = "imviz-1"
+    po.stretch_function = "Square Root"
+    imviz_helper.destroy_viewer("imviz-1")
+    assert len(po.layer.choices) == 2
+
+
 def test_destroy_viewer_with_subset(imviz_helper):
     """Regression test for https://github.com/spacetelescope/jdaviz/issues/1614"""
     arr = np.ones((10, 10))


### PR DESCRIPTION
Closes #2521 , turned out to be very simple once I tracked it down. This was previously causing an error if the viewer was deleted, since `None` has no `state`.