### PR TITLE
expand "show data not in viewer" for empty new viewer

### DIFF
--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -115,7 +115,7 @@ module.exports = {
       // default to passed values, whenever value or uncertainty are changed
       // updateTruncatedValues will overwrite the displayed values
       multi_select: multi_select,
-      showExtraItems: false,
+      showExtraItems: Object.keys(this.$props.viewer.selected_data_items).length == 0,
       valueTrunc: this.value,
       uncertTrunc: this.uncertainty
     }


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request changes the default "collapse/expanded" state for the "show data not in viewer" section of the viewer's data menu to be opened when there is no data loaded in the viewer.  Note that this default only applies when the menu is _first_ opened, but saves an extra click and perhaps some confusion when first creating a new (empty) viewer.  We could potentially automatically re-open the section when all data is manually unloaded, but that would take more logic to catch those events, and arguably there is more feedback and the user isn't confused by an empty viewer when they were the ones who removed everything from it.

Before:
<img width="1463" alt="Screen Shot 2023-11-07 at 4 15 56 PM" src="https://github.com/spacetelescope/jdaviz/assets/877591/d4feb971-3fbd-4150-bf12-53a5474a441e">

After:
<img width="1463" alt="Screen Shot 2023-11-07 at 4 16 00 PM" src="https://github.com/spacetelescope/jdaviz/assets/877591/ecccacd6-ef11-4eea-a6cd-d50a95a2499d">



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
