### PR TITLE
only include stretch tool in stretch histogram

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ New Features
 - Plots in plugins now include basic zoom/pan tools for Plot Options,
   Imviz Line Profiles, and Imviz's aperture photometry. [#2498]
 
-- Histogram plot in Plot Options now includes tool to set stretch vmin and vmax. [#2513]
+- Histogram plot in Plot Options now includes tool to set stretch vmin and vmax. [#2513, #2556]
 
 - The Plot Options plugin now include a 'spline' stretch feature. [#2525]
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -18,7 +18,6 @@ from glue.viewers.image.composite_array import COLOR_CONVERTER
 from glue_jupyter.bqplot.image.state import BqplotImageLayerState
 from glue_jupyter.common.toolbar_vuetify import read_icon
 
-from jdaviz.components.toolbar_nested import NestedJupyterToolbar
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin, ViewerSelect, LayerSelect,
                                         PlotOptionsSyncState, Plot,
@@ -465,9 +464,7 @@ class PlotOptions(PluginTemplateMixin):
         self.stretch_histogram = Plot(self, viewer_type='histogram')
         # Add the stretch bounds tool to the default Plot viewer.
         self.stretch_histogram.tools_nested.append(["jdaviz:stretch_bounds"])
-        self.stretch_histogram.toolbar = NestedJupyterToolbar(self.stretch_histogram.viewer,
-                                                              self.stretch_histogram.tools_nested,
-                                                              ["jdaviz:stretch_bounds"])
+        self.stretch_histogram._initialize_toolbar(["jdaviz:stretch_bounds"])
 
         # NOTE: this is a current workaround so the histogram viewer doesn't crash when replacing
         # data.  Note also that passing x=[0] fails on SOME machines, so we'll pass [0, 1] instead

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3273,11 +3273,6 @@ class Plot(PluginSubcomponent):
 
     figure = Any().tag(sync=True, **widget_serialization)
     toolbar = Any().tag(sync=True, **widget_serialization)
-    tools_nested = [
-                    ['jdaviz:homezoom', 'jdaviz:prevzoom'],
-                    ['jdaviz:boxzoom', 'jdaviz:xrangezoom', 'jdaviz:yrangezoom'],
-                    ['jdaviz:panzoom', 'jdaviz:panzoom_x', 'jdaviz:panzoom_y'],
-                ]
 
     def __init__(self, plugin, viewer_type='scatter', app=None, *args, **kwargs):
         super().__init__(plugin, 'Plot', *args, **kwargs)
@@ -3299,7 +3294,15 @@ class Plot(PluginSubcomponent):
         self.figure.title_style = {'font-size': '12px'}
         self.figure.fig_margin = {'top': 60, 'bottom': 60, 'left': 60, 'right': 10}
 
-        self.toolbar = NestedJupyterToolbar(self.viewer, self.tools_nested, [])
+        self.tools_nested = [
+                        ['jdaviz:homezoom', 'jdaviz:prevzoom'],
+                        ['jdaviz:boxzoom', 'jdaviz:xrangezoom', 'jdaviz:yrangezoom'],
+                        ['jdaviz:panzoom', 'jdaviz:panzoom_x', 'jdaviz:panzoom_y'],
+                    ]
+        self._initialize_toolbar()
+
+    def _initialize_toolbar(self, default_tool_priority=[]):
+        self.toolbar = NestedJupyterToolbar(self.viewer, self.tools_nested, default_tool_priority)
 
     @property
     def app(self):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request removes the stretch bounds tool, introduced in #2513 (milestoned to 3.8, so no need for a bugfix here), from all viewers except the stretch histogram.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
