### PR TITLE
plugins: disable action button while computing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ New Features
 
 - Reorder viewer and layer settings in Plot Options. [#2543]
 
+- Plugin "action" buttons disable and show icon indicating that an action is in progress. [#2560]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/components/plugin_add_results.vue
+++ b/jdaviz/components/plugin_add_results.vue
@@ -59,8 +59,16 @@
           color="accent"
           @click="$emit('click:action')"
         >
-          <v-icon>{{action_spinner ? 'mdi-progress-check' : 'mdi-check'}}</v-icon>
-        {{action_label}}{{label_overwrite ? ' (Overwrite)' : ''}}
+          <v-progress-circular
+            v-if="action_spinner"
+            indeterminate
+            color="primary"
+            size="20"
+            width="3"
+            style="margin-right: 4px"
+          ></v-progress-circular>
+          <span v-else style="width: 24px"></span>
+          {{action_label}}{{label_overwrite ? ' (Overwrite)' : ''}}
         </v-btn>
       </j-tooltip>
     </v-row>

--- a/jdaviz/components/plugin_add_results.vue
+++ b/jdaviz/components/plugin_add_results.vue
@@ -54,11 +54,13 @@
 
     <v-row justify="end">
       <j-tooltip :tooltipcontent="label_overwrite ? action_tooltip+' and replace existing entry' : action_tooltip">
-        <v-btn :disabled="label_invalid_msg.length > 0 || action_disabled"
+        <v-btn :disabled="label_invalid_msg.length > 0 || action_disabled || action_spinner"
           text
           color="accent"
           @click="$emit('click:action')"
-        >{{action_label}}{{label_overwrite ? ' (Overwrite)' : ''}}
+        >
+          <v-icon>{{action_spinner ? 'mdi-progress-check' : 'mdi-check'}}</v-icon>
+        {{action_label}}{{label_overwrite ? ' (Overwrite)' : ''}}
         </v-btn>
       </j-tooltip>
     </v-row>
@@ -75,6 +77,6 @@
 module.exports = {
   props: ['label', 'label_default', 'label_auto', 'label_invalid_msg', 'label_overwrite', 'label_label', 'label_hint',
           'add_to_viewer_items', 'add_to_viewer_selected', 'add_to_viewer_hint',
-          'action_disabled', 'action_label', 'action_tooltip']
+          'action_disabled', 'action_spinner', 'action_label', 'action_tooltip']
 };
 </script>

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -13,7 +13,8 @@ from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         DatasetSelectMixin,
                                         SpectralSubsetSelectMixin,
-                                        AddResultsMixin)
+                                        AddResultsMixin,
+                                        with_spinner)
 from jdaviz.core.user_api import PluginUserApi
 
 __all__ = ['MomentMap']
@@ -91,6 +92,7 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
         label_comps += [f"moment {self.n_moment}"]
         self.results_label_default = " ".join(label_comps)
 
+    @with_spinner()
     def calculate_moment(self, add_data=True):
         """
         Calculate the moment map

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
@@ -46,6 +46,7 @@
       :add_to_viewer_selected.sync="add_to_viewer_selected"
       action_label="Calculate"
       action_tooltip="Calculate moment map"
+      :action_spinner="spinner"
       @click:action="calculate_moment"
     ></plugin-add-results>
     

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -12,7 +12,8 @@ from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         SelectPluginComponent,
                                         SpatialSubsetSelectMixin,
-                                        AddResultsMixin)
+                                        AddResultsMixin,
+                                        with_spinner)
 from jdaviz.core.user_api import PluginUserApi
 from jdaviz.configs.cubeviz.plugins.parsers import _return_spectrum_with_correct_units
 
@@ -72,6 +73,7 @@ class SpectralExtraction(PluginTemplateMixin, SpatialSubsetSelectMixin, AddResul
             )
         )
 
+    @with_spinner()
     def collapse_to_spectrum(self, add_data=True, **kwargs):
         """
         Collapse over the spectral axis.

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
@@ -36,6 +36,7 @@
       :add_to_viewer_selected.sync="add_to_viewer_selected"
       action_label="Extract"
       action_tooltip="Run spectral extraction with error and mask propagation"
+      :action_spinner="spinner"
       @click:action="spectral_extraction"
     ></plugin-add-results>
 

--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -11,7 +11,8 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         DatasetSelectMixin,
                                         SelectPluginComponent,
                                         SpectralSubsetSelectMixin,
-                                        AddResultsMixin)
+                                        AddResultsMixin,
+                                        with_spinner)
 from jdaviz.core.user_api import PluginUserApi
 
 __all__ = ['Collapse']
@@ -69,6 +70,7 @@ class Collapse(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMixi
         label_comps += ["collapsed"]
         self.results_label_default = " ".join(label_comps)
 
+    @with_spinner()
     def collapse(self, add_data=True):
         """
         Collapse over the spectral axis.

--- a/jdaviz/configs/default/plugins/collapse/collapse.vue
+++ b/jdaviz/configs/default/plugins/collapse/collapse.vue
@@ -45,6 +45,7 @@
       :add_to_viewer_selected.sync="add_to_viewer_selected"
       action_label="Collapse"
       action_tooltip="Collapse data"
+      :action_spinner="spinner"
       @click:action="collapse"
     ></plugin-add-results>
 

--- a/jdaviz/configs/default/plugins/export_plot/export_plot.py
+++ b/jdaviz/configs/default/plugins/export_plot/export_plot.py
@@ -7,7 +7,7 @@ from traitlets import Any, Bool, Unicode
 from jdaviz.core.custom_traitlets import FloatHandleEmpty, IntHandleEmpty
 from jdaviz.core.events import AddDataMessage, SnackbarMessage
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import PluginTemplateMixin, ViewerSelectMixin
+from jdaviz.core.template_mixin import PluginTemplateMixin, ViewerSelectMixin, with_spinner
 from jdaviz.core.user_api import PluginUserApi
 
 try:
@@ -146,6 +146,7 @@ class ExportViewer(PluginTemplateMixin, ViewerSelectMixin):
         """
         self.save_figure(filetype=filetype)
 
+    @with_spinner('movie_recording')
     def _save_movie(self, i_start, i_end, fps, filename, rm_temp_files):
         # NOTE: All the stuff here has to be in the same thread but
         #       separate from main app thread to work.
@@ -161,8 +162,6 @@ class ExportViewer(PluginTemplateMixin, ViewerSelectMixin):
         i_step = 1  # Need n_frames check if we allow tweaking
 
         try:
-            self.movie_recording = True
-
             while i <= i_end:
                 if self.movie_interrupt:
                     break
@@ -190,7 +189,6 @@ class ExportViewer(PluginTemplateMixin, ViewerSelectMixin):
             if video:
                 video.release()
             slice_plg._on_slider_updated({'new': orig_slice})
-            self.movie_recording = False
 
         if rm_temp_files or self.movie_interrupt:
             for cur_pngfile in temp_png_files:

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -10,7 +10,8 @@ from jdaviz.core.custom_traitlets import FloatHandleEmpty
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin, DatasetSelectMixin,
-                                        SelectPluginComponent, AddResultsMixin)
+                                        SelectPluginComponent, AddResultsMixin,
+                                        with_spinner)
 from jdaviz.core.user_api import PluginUserApi
 
 __all__ = ['GaussianSmooth']
@@ -176,6 +177,7 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
 
         return results
 
+    @with_spinner()
     def spectral_smooth(self):
         """
         Smooth the input spectrum along the spectral axis.  To add the resulting spectrum into
@@ -199,6 +201,7 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
 
         return spec_smoothed
 
+    @with_spinner('spinner')
     def spatial_smooth(self):
         """
         Use astropy convolution machinery to smooth the spatial dimensions of

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.vue
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.vue
@@ -50,6 +50,7 @@
         :add_to_viewer_selected.sync="add_to_viewer_selected"
         action_label="Smooth"
         action_tooltip="Smooth data"
+        :action_spinner="spinner"
         @click:action="apply"
       ></plugin-add-results>
     </j-tray-plugin>

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -19,7 +19,8 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         NonFiniteUncertaintyMismatchMixin,
                                         AutoTextField,
                                         AddResultsMixin,
-                                        TableMixin)
+                                        TableMixin,
+                                        with_spinner)
 from jdaviz.core.custom_traitlets import IntHandleEmpty
 from jdaviz.core.user_api import PluginUserApi
 from jdaviz.configs.default.plugins.model_fitting.fitting_backend import fit_model_to_spectrum
@@ -767,6 +768,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
             # only want spectral viewers in the options
             self.add_results.viewer.filters = ['is_spectrum_viewer']
 
+    @with_spinner()
     def calculate_fit(self, add_data=True):
         """
         Calculate the fit.

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -261,6 +261,7 @@
         action_label="Fit Model"
         action_tooltip="Fit the model to the data"
         :action_disabled="model_equation_invalid_msg.length > 0 || !spectral_subset_valid"
+        :action_spinner="spinner"
         @click:action="apply"
       >
         <div v-if="config!=='cubeviz' || !cube_fit">

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -22,7 +22,7 @@ from jdaviz.core.events import SnackbarMessage, LinkUpdatedMessage
 from jdaviz.core.region_translators import regions2aperture, _get_region_from_spatial_subset
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin, DatasetMultiSelectMixin,
-                                        SubsetSelect, TableMixin, PlotMixin)
+                                        SubsetSelect, TableMixin, PlotMixin, with_spinner)
 from jdaviz.core.tools import ICON_DIR
 from jdaviz.utils import PRIHDR_KEY
 
@@ -305,6 +305,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetMultiSelectMixin, Tab
             self.hub.broadcast(SnackbarMessage(
                 f"Failed to extract {background_selected}: {repr(e)}", color='error', sender=self))
 
+    @with_spinner()
     def calculate_photometry(self, dataset=None, aperture=None, background=None,
                              background_value=None, pixel_area=None, counts_factor=None,
                              flux_scaling=None, add_to_table=True, update_plots=True):
@@ -726,6 +727,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, DatasetMultiSelectMixin, Tab
 
         return _unpack_dict_list(mult_values, single_values)
 
+    @with_spinner()
     def calculate_batch_photometry(self, options=[], add_to_table=True, update_plots=True,
                                    full_exceptions=False):
         """

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -154,7 +154,7 @@
         </v-row>
 
         <v-row justify="end">
-          <v-btn color="primary" text @click="do_aper_phot" :disabled="aperture_selected === background_selected">Calculate</v-btn>
+          <v-btn color="primary" text @click="do_aper_phot" :disabled="aperture_selected === background_selected || spinner">Calculate</v-btn>
         </v-row>
       </div>
     </div>

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -8,7 +8,8 @@ from traitlets import List, Unicode, Bool, Int
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin, ViewerSelectMixin,
-                                        FileImportSelectPluginComponent, HasFileImportSelect)
+                                        FileImportSelectPluginComponent, HasFileImportSelect,
+                                        with_spinner)
 
 __all__ = ['Catalogs']
 
@@ -55,6 +56,7 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
 
         return '', {path: table}
 
+    @with_spinner()
     def search(self):
         """
         Search the catalog, display markers on the viewer, and return a table of results (or None

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
@@ -32,7 +32,7 @@
          <v-btn color="primary" text @click="do_clear">Clear</v-btn>
        </v-col>
        <v-col>
-         <v-btn color="primary" text @click="do_search">Search</v-btn>
+         <v-btn color="primary" text @click="do_search" :disabled="spinner">Search</v-btn>
        </v-col>
     </v-row>
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -9,7 +9,8 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         SelectPluginComponent,
                                         DatasetSelect,
                                         AddResults,
-                                        skip_if_no_updates_since_last_active)
+                                        skip_if_no_updates_since_last_active,
+                                        with_spinner)
 from jdaviz.core.user_api import PluginUserApi
 from jdaviz.core.custom_traitlets import IntHandleEmpty, FloatHandleEmpty
 from jdaviz.core.marks import PluginLine
@@ -130,6 +131,7 @@ class SpectralExtraction(PluginTemplateMixin):
     trace_results_label_overwrite = Bool().tag(sync=True)
     trace_add_to_viewer_items = List().tag(sync=True)
     trace_add_to_viewer_selected = Unicode().tag(sync=True)
+    trace_spinner = Bool(False).tag(sync=True)
 
     # BACKGROUND
     bg_dataset_items = List().tag(sync=True)
@@ -156,6 +158,7 @@ class SpectralExtraction(PluginTemplateMixin):
     bg_results_label_overwrite = Bool().tag(sync=True)
     bg_add_to_viewer_items = List().tag(sync=True)
     bg_add_to_viewer_selected = Unicode().tag(sync=True)
+    bg_img_spinner = Bool(False).tag(sync=True)
 
     bg_spec_results_label = Unicode().tag(sync=True)
     bg_spec_results_label_default = Unicode().tag(sync=True)
@@ -164,6 +167,7 @@ class SpectralExtraction(PluginTemplateMixin):
     bg_spec_results_label_overwrite = Bool().tag(sync=True)
     bg_spec_add_to_viewer_items = List().tag(sync=True)
     bg_spec_add_to_viewer_selected = Unicode().tag(sync=True)
+    bg_spec_spinner = Bool(False).tag(sync=True)
 
     bg_sub_results_label = Unicode().tag(sync=True)
     bg_sub_results_label_default = Unicode().tag(sync=True)
@@ -172,6 +176,7 @@ class SpectralExtraction(PluginTemplateMixin):
     bg_sub_results_label_overwrite = Bool().tag(sync=True)
     bg_sub_add_to_viewer_items = List().tag(sync=True)
     bg_sub_add_to_viewer_selected = Unicode().tag(sync=True)
+    bg_sub_spinner = Bool(False).tag(sync=True)
 
     # EXTRACT
     ext_dataset_items = List().tag(sync=True)
@@ -195,6 +200,7 @@ class SpectralExtraction(PluginTemplateMixin):
     ext_results_label_overwrite = Bool().tag(sync=True)
     ext_add_to_viewer_items = List().tag(sync=True)
     ext_add_to_viewer_selected = Unicode().tag(sync=True)
+    # uses default "spinner"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -682,6 +688,7 @@ class SpectralExtraction(PluginTemplateMixin):
         else:  # pragma: no cover
             raise NotImplementedError(f"trace of type {trace.__class__.__name__} not supported")
 
+    @with_spinner('trace_spinner')
     def export_trace(self, add_data=False, **kwargs):
         """
         Create a specreduce Trace object from the input parameters
@@ -780,6 +787,7 @@ class SpectralExtraction(PluginTemplateMixin):
 
         self.bg_width = bg.width
 
+    @with_spinner('bg_spinner')
     def export_bg(self, **kwargs):
         """
         Create a specreduce Background object from the input parameters defined in the plugin.
@@ -817,6 +825,7 @@ class SpectralExtraction(PluginTemplateMixin):
 
         return bg
 
+    @with_spinner('bg_img_spinner')
     def export_bg_img(self, add_data=False, **kwargs):
         """
         Create a background 2D spectrum from the input parameters defined in the plugin.
@@ -843,6 +852,7 @@ class SpectralExtraction(PluginTemplateMixin):
                                 color='error', sender=self)
             )
 
+    @with_spinner('bg_spec_spinner')
     def export_bg_spectrum(self, add_data=False, **kwargs):
         """
         Create a background 1D spectrum from the input parameters defined in the plugin.
@@ -863,6 +873,7 @@ class SpectralExtraction(PluginTemplateMixin):
     def vue_create_bg_spec(self, *args):
         self.export_bg_spectrum(add_data=True)
 
+    @with_spinner('bg_sub_spinner')
     def export_bg_sub(self, add_data=False, **kwargs):
         """
         Create a background-subtracted 2D spectrum from the input parameters defined in the plugin.
@@ -936,6 +947,7 @@ class SpectralExtraction(PluginTemplateMixin):
 
         return ext
 
+    @with_spinner('spinner')
     def export_extract_spectrum(self, add_data=False, **kwargs):
         """
         Create an extracted 1D spectrum from the input parameters defined in the plugin.

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.vue
@@ -179,6 +179,7 @@
                 :add_to_viewer_selected.sync="trace_add_to_viewer_selected"
                 action_label="Create"
                 action_tooltip="Create Trace"
+                :action_spinner="trace_spinner"
                 @click:action="create_trace"
               ></plugin-add-results>
             </v-expansion-panel-content>
@@ -293,6 +294,7 @@
                 :add_to_viewer_selected.sync="bg_add_to_viewer_selected"
                 action_label="Export"
                 action_tooltip="Create Background Image"
+                :action_spinner="bg_img_spinner"
                 @click:action="create_bg_img"
               ></plugin-add-results>
             </v-expansion-panel-content>
@@ -415,6 +417,7 @@
         action_label="Extract"
         action_tooltip="Extract 1D Spectrum"
         :action_disabled="ext_specreduce_err.length > 0"
+        :action_spinner="spinner"
         @click:action="extract_spectrum"
       ></plugin-add-results>
     </div>


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements re-usable infrastructure via a `@with_spinner()` method, which sets the `spinner` traitlet to True at the beginning of a method, and resets to False when it completes (successfully or not).  This traitlet can then be used to disable and change the icon on the action button by passing it to `<plugin-add-results :action_spinner='spinner'>`.  For expensive operations, this provides immediate feedback that something is happening and avoids the user clicking the button again before the action completes.

For more advanced cases, individual boolean traitlets can be added to the plugin and controlled separately by passing the name of the traitlet to the decorator.  For example `@with_spinner('spinner_custom')`.

All the logic lives in `template_mixin.py` and `plugin_add_results.vue`... everything else is just using that within all the various applicable plugins.

Example for model fitting a cube (but this PR applies the logic to _all_ existing `plugin-add-results` buttons and a few others):




https://github.com/spacetelescope/jdaviz/assets/877591/30bdb4ce-cfa3-400b-90b4-d00c512cdf1b





<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
