### PR TITLE
Allow change in cmap_att on change in data components

### DIFF
--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2899,16 +2899,23 @@ class PlotOptionsSyncState(BasePluginComponent):
                 if glue_name in ['contour_visible', 'bitmap_visible']:
                     state.add_callback('visible', self._on_glue_layer_visible_changed)
 
-                if self.sync.get('choices') is None and \
-                        (hasattr(getattr(type(state), glue_name), 'get_display_func')
-                         or glue_name == 'cmap'):
-                    # then we can access and populate the choices.  We are assuming here
-                    # that each state-instance with this same name will have the same
-                    # choices and that those will not change.  If we ever hookup options
-                    # with changing choices, we'll need additional logic to sync to those
-                    # and handle mixed state in the choices...
+                if (
+                    # We are assuming here that each state-instance with this same name
+                    # will have the same choices and that those will not change. If we
+                    # ever hookup options with changing choices, we'll need additional
+                    # logic to sync to those and handle mixed state in the choices...
+                    self.sync.get('choices') is None and
+                    (
+                        hasattr(getattr(type(state), glue_name), 'get_display_func') or
+                        glue_name == 'cmap'
+                    )
+                ) or (
+                    # update choices in `sync` if glue state choices are updated
+                    # during glue Component add/rename/delete:
+                    glue_name == 'cmap_att'
+                ):
+                    # then we can access and populate/update the choices.
                     self.sync = {**self.sync, 'choices': self._get_glue_choices(state)}
-
         self.sync = {**self.sync,
                      'in_subscribed_states': in_subscribed_states,
                      'icons': icons,


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Glue scatter viewers plot 2D scatter points, with an option for custom sizes and colors, mapped onto any of the glue `Data`'s components. In order for this to work correctly, the [glue `ComponentIDComboHelper`s](https://github.com/glue-viz/glue/blob/47012410f0a60ef59a2bb00725e464e189609bbc/glue/core/data_combo_helper.py#L118) like the `cmap_att_helper`, which can be found at `viewer.layers[0].state.cmap_att_helper`, must have a list of `choices` which are in sync with all of that layer's `Data` components. If components can be added or renamed, the component choices within `PlotOptionsSyncState` _should_ be updated. I was using this feature in LCviz today, and I found that those component choices do not get updated (😱). 

I traced the problem back to one line, and implemented a fix in this PR. No one will see any difference in jdaviz (until we use more scatter viewers in the near[?] future!), but this PR enables features that are implemented but not working in LCviz.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
