### PR TITLE
stretch hist: prevent vmin/vmax lines from clearing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ New Features
 - Plots in plugins now include basic zoom/pan tools for Plot Options,
   Imviz Line Profiles, and Imviz's aperture photometry. [#2498]
 
-- Histogram plot in Plot Options now includes tool to set stretch vmin and vmax. [#2513, #2556]
+- Histogram plot in Plot Options now includes tool to set stretch vmin and vmax. [#2513, #2556, #2573]
 
 - The Plot Options plugin now include a 'spline' stretch feature. [#2525]
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -893,11 +893,15 @@ class PlotOptions(PluginTemplateMixin):
 
     @observe('stretch_vmin_value')
     def _stretch_vmin_changed(self, msg=None):
-        self.stretch_histogram.marks['vmin'].x = [self.stretch_vmin_value, self.stretch_vmin_value]
+        mark = self.stretch_histogram.marks['vmin']
+        mark.x = [self.stretch_vmin_value, self.stretch_vmin_value]
+        mark.y = [0, 1]
 
     @observe('stretch_vmax_value')
     def _stretch_vmax_changed(self, msg=None):
-        self.stretch_histogram.marks['vmax'].x = [self.stretch_vmax_value, self.stretch_vmax_value]
+        mark = self.stretch_histogram.marks['vmax']
+        mark.x = [self.stretch_vmax_value, self.stretch_vmax_value]
+        mark.y = [0, 1]
 
     @observe("stretch_hist_nbins")
     def _histogram_nbins_changed(self, msg={}):


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This PR fixes an unreleased bug where toggling multiselect would clear the marks for vmin/vmax and they would not recover since y was never re-set.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
