### PR TITLE
stretch histogram support multi-select

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ New Features
 
 - Plugin APIs now include a ``close_in_tray()`` method. [#2562]
 
-- Convert the layer select dropdown in Plot Options into a horizontal panel of buttons. [#2566, #2574]
+- Convert the layer select dropdown in Plot Options into a horizontal panel of buttons. [#2566, #2574, #2582]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -818,6 +818,7 @@ class PlotOptions(PluginTemplateMixin):
              'stretch_hist_nbins',
              'stretch_curve_visible',
              'stretch_function_value', 'stretch_vmin_value', 'stretch_vmax_value',
+             'layer_multiselect'
              )
     @skip_if_no_updates_since_last_active()
     def _update_stretch_curve(self, msg=None):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request generalizes and approves the stretch histogram's support for the new separate multiselect modes introduced in #2574 - the stretch curve and colorbar now works correctly regardless of whether the viewer and/or layer are in multiselect mode, supports multiple viewers selected (in which case vmin/vmax lines are currently shown based on the first entry - we could eventually somehow represent mixed state here somehow, but it isn't clear if that is necessary yet).  Note that the entire histogram is hidden if the select layer is a subset OR if multiple layers are chosen.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
