### PR TITLE
Moment units redux

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ New Features
 
 Cubeviz
 ^^^^^^^
-- Calculated moments can now be output in velocity units. [#2584]
+- Calculated moments can now be output in velocity units. [#2584, #2588]
 
 - Added functionality to Collapse and Spectral Extraction plugins to save results to FITS file. [#2586]
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -141,6 +141,14 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
 
     @observe("dataset_selected", "n_moment")
     def _set_data_units(self, event={}):
+
+        if self.n_moment == 0:
+            self.output_unit_selected = "Flux"
+        elif ((self.n_moment == 1 and self.output_unit_selected in ("Flux", "Velocity^N")) or
+              (self.n_moment > 1 and self.output_unit_selected in ("Flux", "Wavelength"))):
+            self.output_unit_selected = "Velocity"
+        self.send_state("output_unit_selected")
+
         unit_dict = {"Flux": "",
                      "Wavelength": "",
                      "Velocity": "km/s",

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -145,7 +145,8 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
 
     @observe("dataset_selected", "n_moment")
     def _set_data_units(self, event={}):
-
+        if isinstance(self.n_moment, str): 
+            return
         unit_options_index = 2 if self.n_moment > 2 else self.n_moment
         if self.output_unit_selected not in moment_unit_options[unit_options_index]:
             self.output_unit_selected = moment_unit_options[unit_options_index][0]

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -236,10 +236,6 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
         spec_min, spec_max = self.spectral_subset.selected_min_max(cube)
         slab = manipulation.spectral_slab(cube, spec_min, spec_max)
 
-        # Retrieve the data cube and slice out desired region, if specified
-        if "_orig_spec" in self.dataset.selected_obj.meta:
-            cube = self.dataset.selected_obj.meta["_orig_spec"]
-
         # Calculate the moment and convert to CCDData to add to the viewers
         # Need transpose to align JWST mirror shape: This is because specutils
         # arrange the array shape to be (nx, ny, nz) but 2D visualization

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -95,10 +95,6 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
                                                  manual_options=['Flux', 'Spectral Unit',
                                                                  'Velocity', 'Velocity^N'])
 
-        # Initialize extra key in items dictionary
-        for item in self.output_unit_items:
-            item["unit_str"] = ""
-
         self.dataset.add_filter('is_cube')
         self.add_results.viewer.filters = ['is_image_viewer']
 
@@ -145,7 +141,7 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
 
     @observe("dataset_selected", "n_moment")
     def _set_data_units(self, event={}):
-        if isinstance(self.n_moment, str): 
+        if isinstance(self.n_moment, str):
             return
         unit_options_index = 2 if self.n_moment > 2 else self.n_moment
         if self.output_unit_selected not in moment_unit_options[unit_options_index]:
@@ -221,7 +217,7 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
         unit_options_index = 2 if n_moment > 2 else n_moment
         if self.output_unit_selected not in moment_unit_options[unit_options_index]:
             raise ValueError("Selected output units must be in "
-                             f"{moment_unit_options[unit_options_index]} for"
+                             f"{moment_unit_options[unit_options_index]} for "
                              f"moment {self.n_moment}")
 
         if self.continuum.selected == 'None':

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -141,7 +141,7 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
 
     @observe("dataset_selected", "n_moment")
     def _set_data_units(self, event={}):
-        if isinstance(self.n_moment, str):
+        if isinstance(self.n_moment, str) or self.n_moment < 0:
             return
         unit_options_index = 2 if self.n_moment > 2 else self.n_moment
         if self.output_unit_selected not in moment_unit_options[unit_options_index]:

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -88,7 +88,7 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
         self.output_unit = SelectPluginComponent(self,
                                                  items='output_unit_items',
                                                  selected='output_unit_selected',
-                                                 manual_options=['Flux', 'Wavelength',
+                                                 manual_options=['Flux', 'Spectral Unit',
                                                                  'Velocity', 'Velocity^N'])
 
         # Initialize extra key in items dictionary
@@ -145,12 +145,12 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
         if self.n_moment == 0:
             self.output_unit_selected = "Flux"
         elif ((self.n_moment == 1 and self.output_unit_selected in ("Flux", "Velocity^N")) or
-              (self.n_moment > 1 and self.output_unit_selected in ("Flux", "Wavelength"))):
+              (self.n_moment > 1 and self.output_unit_selected in ("Flux", "Spectral Unit"))):
             self.output_unit_selected = "Velocity"
         self.send_state("output_unit_selected")
 
         unit_dict = {"Flux": "",
-                     "Wavelength": "",
+                     "Spectral Unit": "",
                      "Velocity": "km/s",
                      "Velocity^N": f"km{self.n_moment}/s{self.n_moment}"}
 
@@ -160,7 +160,7 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
             if self.app.data_collection[self.dataset_selected].coords is not None:
                 sunit = data.coords.world_axis_units[0]
                 self.dataset_spectral_unit = sunit
-                unit_dict["Wavelength"] = sunit
+                unit_dict["Spectral Unit"] = sunit
             else:
                 self.dataset_spectral_unit = ""
             unit_dict["Flux"] = data.get_component('flux').units

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -88,7 +88,8 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
         self.output_unit = SelectPluginComponent(self,
                                                  items='output_unit_items',
                                                  selected='output_unit_selected',
-                                                 manual_options=['Flux', 'Wavelength', 'Velocity', 'Velocity^N'])
+                                                 manual_options=['Flux', 'Wavelength',
+                                                                 'Velocity', 'Velocity^N'])
 
         # Initialize extra key in items dictionary
         for item in self.output_unit_items:
@@ -171,7 +172,6 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
         # Force Traitlets to update
         self.send_state("output_unit_items")
         self.send_state("output_radio_items")
-
 
     @observe("dataset_selected", "spectral_subset_selected",
              "continuum_subset_selected", "continuum_width")

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
@@ -134,7 +134,13 @@
       @click:action="calculate_moment"
     ></plugin-add-results>
 
-    <v-row v-if="n_moment > 0 && output_unit_selected !== 'Spectral Unit' && reference_wavelength === 0">
+    <v-row v-if="n_moment > 0 && output_unit_selected === 'Flux'">
+      <span class="v-messages v-messages__message text--secondary" style="color: red !important">
+          Cannot calculate moment: Output unit set to invalid value from API.
+      </span>
+    </v-row>
+
+    <v-row v-else-if="n_moment > 0 && output_unit_selected !== 'Spectral Unit' && reference_wavelength === 0">
       <span class="v-messages v-messages__message text--secondary" style="color: red !important">
           Cannot calculate moment: Must set reference wavelength for output in velocity units.
       </span>

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
@@ -91,12 +91,13 @@
       <v-row>
         <v-radio-group
           label="Output Units"
-          hint="Choose whether calculated moment is in units of wavelength or velocity."
+          hint="Choose the output units for calculated moment."
           v-model="output_unit_selected"
           column
           class="no-hint">
           <v-radio
             v-for="item in output_radio_items"
+            :key="item.label"
             :label="item.label + ' (' + item.unit_str + ')'"
             :value="item.label"
           ></v-radio>

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
@@ -130,11 +130,11 @@
       action_label="Calculate"
       action_tooltip="Calculate moment map"
       :action_spinner="spinner"
-      :action_disabled="n_moment > 0 && output_unit_selected !== 'Spectral Unit' && output_unit_selected !== 'Flux' && reference_wavelength === 0"
+      :action_disabled="n_moment > 0 && output_unit_selected !== 'Spectral Unit' && reference_wavelength === 0"
       @click:action="calculate_moment"
     ></plugin-add-results>
 
-    <v-row v-if="n_moment > 0 && output_unit_selected !== 'Spectral Unit' && output_unit_selected !== 'Flux' && reference_wavelength === 0">
+    <v-row v-if="n_moment > 0 && output_unit_selected !== 'Spectral Unit' && reference_wavelength === 0">
       <span class="v-messages v-messages__message text--secondary" style="color: red !important">
           Cannot calculate moment: Must set reference wavelength for output in velocity units.
       </span>

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
@@ -103,7 +103,7 @@
           ></v-radio>
         </v-radio-group>
       </v-row>
-      <v-row v-if="output_unit_selected !== 'Wavelength' && output_unit_selected !== 'Flux'">
+      <v-row v-if="output_unit_selected !== 'Spectral Unit' && output_unit_selected !== 'Flux'">
         <v-text-field
         ref="reference_wavelength"
         type="number"
@@ -130,11 +130,11 @@
       action_label="Calculate"
       action_tooltip="Calculate moment map"
       :action_spinner="spinner"
-      :action_disabled="n_moment > 0 && output_unit_selected !== 'Wavelength' && output_unit_selected !== 'Flux' && reference_wavelength === 0"
+      :action_disabled="n_moment > 0 && output_unit_selected !== 'Spectral Unit' && output_unit_selected !== 'Flux' && reference_wavelength === 0"
       @click:action="calculate_moment"
     ></plugin-add-results>
 
-    <v-row v-if="n_moment > 0 && output_unit_selected !== 'Wavelength' && output_unit_selected !== 'Flux' && reference_wavelength === 0">
+    <v-row v-if="n_moment > 0 && output_unit_selected !== 'Spectral Unit' && output_unit_selected !== 'Flux' && reference_wavelength === 0">
       <span class="v-messages v-messages__message text--secondary" style="color: red !important">
           Cannot calculate moment: Must set reference wavelength for output in velocity units.
       </span>

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
@@ -97,8 +97,7 @@
           class="no-hint">
           <v-radio
             v-for="item in output_unit_items"
-            :key="item.label"
-            :label="item.label"
+            :label="item.label + ' (' + item.unit_str + ')'"
             :value="item.label"
           ></v-radio>
         </v-radio-group>

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
@@ -87,7 +87,7 @@
       ></v-text-field>
     </v-row>
 
-    <div v-if="n_moment > 0 && dataset_spectral_unit !== ''">
+    <div v-if="dataset_spectral_unit !== ''">
       <v-row>
         <v-radio-group
           label="Output Units"
@@ -96,13 +96,13 @@
           column
           class="no-hint">
           <v-radio
-            v-for="item in output_unit_items"
+            v-for="item in output_radio_items"
             :label="item.label + ' (' + item.unit_str + ')'"
             :value="item.label"
           ></v-radio>
         </v-radio-group>
       </v-row>
-      <v-row v-if="output_unit_selected === 'Velocity'">
+      <v-row v-if="output_unit_selected !== 'Wavelength' && output_unit_selected !== 'Flux'">
         <v-text-field
         ref="reference_wavelength"
         type="number"
@@ -129,11 +129,11 @@
       action_label="Calculate"
       action_tooltip="Calculate moment map"
       :action_spinner="spinner"
-      :action_disabled="n_moment > 0 && output_unit_selected === 'Velocity' && reference_wavelength === 0"
+      :action_disabled="n_moment > 0 && output_unit_selected !== 'Wavelength' && output_unit_selected !== 'Flux' && reference_wavelength === 0"
       @click:action="calculate_moment"
     ></plugin-add-results>
 
-    <v-row v-if="n_moment > 0 && output_unit_selected === 'Velocity' && reference_wavelength === 0">
+    <v-row v-if="n_moment > 0 && output_unit_selected !== 'Wavelength' && output_unit_selected !== 'Flux' && reference_wavelength === 0">
       <span class="v-messages v-messages__message text--secondary" style="color: red !important">
           Cannot calculate moment: Must set reference wavelength for output in velocity units.
       </span>

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -33,6 +33,17 @@ def test_user_api(cubeviz_helper, spectrum1d_cube):
 
         assert mom != mom_sub
 
+        mm.n_moment = -1
+        with pytest.raises(ValueError, match="Moment must be a positive integer"):
+            mm.calculate_moment()
+
+        mm.n_moment = 1
+        with pytest.raises(ValueError, match="not one of"):
+            mm._obj.output_unit_selected = "Bad Unit"
+        mm._obj.output_unit_selected = "Flux"
+        with pytest.raises(ValueError, match="units must be in"):
+            mm.calculate_moment()
+
 
 def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     dc = cubeviz_helper.app.data_collection

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -104,7 +104,7 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     assert os.path.isfile(mm._obj.filename)
 
     mm._obj.n_moment = 1
-    mm._obj.output_unit_selected = "Wavelength"
+    mm._obj.output_unit_selected = "Spectral Unit"
     assert mm._obj.results_label == 'moment 1'
     assert mm._obj.results_label_overwrite is False
     mm._obj.vue_calculate_moment()

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -47,17 +47,17 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     flux_viewer.shape = (100, 100)
     flux_viewer.state._set_axes_aspect_ratio(1)
 
-    mm = MomentMap(app=cubeviz_helper.app)
-    mm.dataset_selected = 'test[FLUX]'
+    mm = cubeviz_helper.plugins["Moment Maps"]
+    mm.dataset = 'test[FLUX]'
 
     mm.n_moment = 0  # Collapsed sum, will get back 2D spatial image
-    assert mm.results_label == 'moment 0'
-    assert mm.output_unit == "Wavelength"
+    assert mm._obj.results_label == 'moment 0'
+    assert mm.output_unit == "Flux"
 
-    mm.add_results.viewer.selected = cubeviz_helper._default_uncert_viewer_reference_name
-    mm.vue_calculate_moment()
+    mm._obj.add_results.viewer.selected = cubeviz_helper._default_uncert_viewer_reference_name
+    mm._obj.vue_calculate_moment()
 
-    assert mm.moment_available
+    assert mm._obj.moment_available
     assert dc[1].label == 'moment 0'
     mv_data = cubeviz_helper.app.get_viewer(
         cubeviz_helper._default_uncert_viewer_reference_name
@@ -69,8 +69,8 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
     assert len(dc.links) == 14
 
     # label should remain unchanged but raise overwrite warnings
-    assert mm.results_label == 'moment 0'
-    assert mm.results_label_overwrite is True
+    assert mm._obj.results_label == 'moment 0'
+    assert mm._obj.results_label_overwrite is True
 
     # Make sure coordinate display works
     label_mouseover = cubeviz_helper.app.session.application._tools['g-coords-info']
@@ -100,15 +100,16 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
                                          "World 13h39m59.9731s +27d00m00.3600s (ICRS)",
                                          "204.9998877673 27.0001000000 (deg)")
 
-    assert mm.filename == 'moment0_test_FLUX.fits'  # Auto-populated on calculate.
-    mm.filename = str(tmpdir.join(mm.filename))  # But we want it in tmpdir for testing.
-    mm.vue_save_as_fits()
-    assert os.path.isfile(mm.filename)
+    assert mm._obj.filename == 'moment0_test_FLUX.fits'  # Auto-populated on calculate.
+    mm._obj.filename = str(tmpdir.join(mm._obj.filename))  # But we want it in tmpdir for testing.
+    mm._obj.vue_save_as_fits()
+    assert os.path.isfile(mm._obj.filename)
 
-    mm.n_moment = 1
-    assert mm.results_label == 'moment 1'
-    assert mm.results_label_overwrite is False
-    mm.vue_calculate_moment()
+    mm._obj.n_moment = 1
+    mm._obj.output_unit_selected = "Wavelength"
+    assert mm._obj.results_label == 'moment 1'
+    assert mm._obj.results_label_overwrite is False
+    mm._obj.vue_calculate_moment()
 
     assert dc[2].label == 'moment 1'
 
@@ -165,7 +166,7 @@ def test_moment_velocity_calculation(cubeviz_helper, spectrum1d_cube, tmpdir):
 
     label_mouseover._viewer_mouse_event(uncert_viewer, {'event': 'mousemove',
                                                         'domain': {'x': 0, 'y': 0}})
-    assert label_mouseover.as_text() == ("Pixel x=00.0 y=00.0 Value +8.98755e+16 m2 / s2",
+    assert label_mouseover.as_text() == ("Pixel x=00.0 y=00.0 Value -2.99792e+08 m / s",
                                          "World 13h39m59.9731s +27d00m00.3600s (ICRS)",
                                          "204.9998877673 27.0001000000 (deg)")
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -9,8 +9,6 @@ from astropy.wcs import WCS
 from astroquery.mast import Observations
 from numpy.testing import assert_allclose
 
-from jdaviz.configs.cubeviz.plugins.moment_maps.moment_maps import MomentMap
-
 
 def test_user_api(cubeviz_helper, spectrum1d_cube):
     with warnings.catch_warnings():


### PR DESCRIPTION
Updates the recent Moment Maps unit work to better align with PO specs by displaying the actual physical units (including flux units for moment 0), and giving the option to reduce all higher moments to velocity rather than velocity^N.