### PR TITLE
BUG: Fix Line Profile when there is NaN

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Line Profile (XY) plugin no longer malfunctions when image contains NaN values. [#2594]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
+++ b/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
@@ -127,12 +127,11 @@ class LineProfileXY(PluginTemplateMixin, ViewerSelectMixin):
         self.plot_across_x._update_data('line', x=range(comp.data.shape[0]), y=comp.data[:, x],
                                         reset_lims=False)
         zoomed_data_x = comp.data[y_min:y_max, x]
-        zoomed_data_x_finite = zoomed_data_x[np.isfinite(zoomed_data_x)]
         if zoomed_data_x.size > 0:
             self.plot_across_x.set_limits(x_min=y_min,
                                           x_max=y_max,
-                                          y_min=zoomed_data_x_finite.min() * 0.95,
-                                          y_max=zoomed_data_x_finite.max() * 1.05)
+                                          y_min=np.nanmin(zoomed_data_x) * 0.95,
+                                          y_max=np.nanmax(zoomed_data_x) * 1.05)
         self.plot_across_x.update_style('line', line_visible=True,
                                         markers_visible=False, color='gray', size=10)
         self.plot_across_x.viewer.axis_x.label = 'Y (pix)'
@@ -142,12 +141,11 @@ class LineProfileXY(PluginTemplateMixin, ViewerSelectMixin):
         self.plot_across_y._update_data('line', x=range(comp.data.shape[1]), y=comp.data[y, :],
                                         reset_lims=False)
         zoomed_data_y = comp.data[y, x_min:x_max]
-        zoomed_data_y_finite = zoomed_data_y[np.isfinite(zoomed_data_y)]
         if zoomed_data_y.size > 0:
             self.plot_across_y.set_limits(x_min=x_min,
                                           x_max=x_max,
-                                          y_min=zoomed_data_y_finite.min() * 0.95,
-                                          y_max=zoomed_data_y_finite.max() * 1.05)
+                                          y_min=np.nanmin(zoomed_data_y) * 0.95,
+                                          y_max=np.nanmax(zoomed_data_y) * 1.05)
         self.plot_across_y.update_style('line', line_visible=True,
                                         markers_visible=False, color='gray', size=10)
         self.plot_across_y.viewer.axis_x.label = 'X (pix)'

--- a/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
+++ b/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
@@ -1,3 +1,4 @@
+import numpy as np
 from traitlets import Bool, Unicode, observe
 
 from jdaviz.configs.imviz.helper import get_top_layer_index
@@ -126,11 +127,12 @@ class LineProfileXY(PluginTemplateMixin, ViewerSelectMixin):
         self.plot_across_x._update_data('line', x=range(comp.data.shape[0]), y=comp.data[:, x],
                                         reset_lims=False)
         zoomed_data_x = comp.data[y_min:y_max, x]
+        zoomed_data_x_finite = zoomed_data_x[np.isfinite(zoomed_data_x)]
         if zoomed_data_x.size > 0:
             self.plot_across_x.set_limits(x_min=y_min,
                                           x_max=y_max,
-                                          y_min=zoomed_data_x.min() * 0.95,
-                                          y_max=zoomed_data_x.max() * 1.05)
+                                          y_min=zoomed_data_x_finite.min() * 0.95,
+                                          y_max=zoomed_data_x_finite.max() * 1.05)
         self.plot_across_x.update_style('line', line_visible=True,
                                         markers_visible=False, color='gray', size=10)
         self.plot_across_x.viewer.axis_x.label = 'Y (pix)'
@@ -140,11 +142,12 @@ class LineProfileXY(PluginTemplateMixin, ViewerSelectMixin):
         self.plot_across_y._update_data('line', x=range(comp.data.shape[1]), y=comp.data[y, :],
                                         reset_lims=False)
         zoomed_data_y = comp.data[y, x_min:x_max]
+        zoomed_data_y_finite = zoomed_data_y[np.isfinite(zoomed_data_y)]
         if zoomed_data_y.size > 0:
             self.plot_across_y.set_limits(x_min=x_min,
                                           x_max=x_max,
-                                          y_min=zoomed_data_y.min() * 0.95,
-                                          y_max=zoomed_data_y.max() * 1.05)
+                                          y_min=zoomed_data_y_finite.min() * 0.95,
+                                          y_max=zoomed_data_y_finite.max() * 1.05)
         self.plot_across_y.update_style('line', line_visible=True,
                                         markers_visible=False, color='gray', size=10)
         self.plot_across_y.viewer.axis_x.label = 'X (pix)'

--- a/jdaviz/configs/imviz/tests/test_line_profile_xy.py
+++ b/jdaviz/configs/imviz/tests/test_line_profile_xy.py
@@ -1,7 +1,7 @@
 import numpy as np
 from astropy import units as u
 from astropy.nddata import NDData
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 
 from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_NoWCS
 
@@ -9,7 +9,7 @@ from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_NoWCS
 class TestLineProfileXY(BaseImviz_WCS_NoWCS):
     def test_plugin_linked_by_pixel(self):
         """Go through plugin logic but does not check plot contents."""
-        lp_plugin = self.imviz.app.get_tray_item_from_name('imviz-line-profile-xy')
+        lp_plugin = self.imviz.plugins['Imviz Line Profiles (XY)']._obj
         lp_plugin.plugin_opened = True
 
         assert lp_plugin.viewer.labels == ['imviz-0']
@@ -72,3 +72,28 @@ class TestLineProfileXY(BaseImviz_WCS_NoWCS):
                                         'domain': {'x': 5.1, 'y': 5}})
         lp_plugin.selected_x = 1.1
         lp_plugin.selected_y = 9
+
+
+def test_line_profile_with_nan(imviz_helper):
+    arr = np.ones((10, 10))
+    arr[5, 5] = np.nan
+    imviz_helper.load_data(arr)
+
+    lp_plugin = imviz_helper.plugins['Imviz Line Profiles (XY)']._obj
+    lp_plugin.plugin_opened = True
+    lp_plugin.selected_x = 5
+    lp_plugin.selected_y = 5
+    lp_plugin.vue_draw_plot()
+    assert lp_plugin.plot_available
+
+    # NaN still in data but rendered properly as gap.
+    # Cannot check the gap stuff in CI but can make sure X-axis is populated properly etc.
+    for lp_plot in (lp_plugin.plot_across_x, lp_plugin.plot_across_y):
+        assert lp_plot.layers['line'].state.line_visible
+        assert not np.all(np.isfinite(lp_plot.layers['line'].layer.data['y']))
+        assert_array_equal(lp_plot.layers['line'].layer.data['x'], range(10))
+        assert_allclose([lp_plot.layers['line'].state.viewer_state.x_min,
+                         lp_plot.layers['line'].state.viewer_state.x_max,
+                         lp_plot.layers['line'].state.viewer_state.y_min,
+                         lp_plot.layers['line'].state.viewer_state.y_max],
+                        [0, 9, 0.95, 1.05])


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address plotting line profiles when NaN is present. With this patch, the plot should now look like this instead of a blank plot:

![Screenshot 2023-12-06 121646](https://github.com/spacetelescope/jdaviz/assets/2090236/b140cb02-7fbe-45fb-a21c-d737411433eb)

I still see this in the browser dev console but does not seem to break Imviz:

![Screenshot 2023-12-06 121622](https://github.com/spacetelescope/jdaviz/assets/2090236/fcac40e3-ce17-4e67-b461-7993a2cfb60f)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-2961)
