### PR TITLE
fix nested toolbar losing suboptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,8 @@ Bug Fixes
 - Fix image layer visibility toggle in plot options. [#2595]
 
 
+- Fixes viewer toolbar items losing ability to bring up right-click menu. [#2605]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/components/toolbar_nested.py
+++ b/jdaviz/components/toolbar_nested.py
@@ -85,7 +85,6 @@ class NestedJupyterToolbar(BasicJupyterToolbar, HubListener):
         for menu_ind in range(self._max_menu_ind):
             has_primary = False
             n_visible = 0
-            primary_id = None
             if self.active_tool_id:
                 current_primary_active = self.tools_data[self.active_tool_id]['menu_ind'] == menu_ind  # noqa
             else:
@@ -116,15 +115,18 @@ class NestedJupyterToolbar(BasicJupyterToolbar, HubListener):
                     primary = visible and not has_primary
 
                 if primary:
-                    primary_id = tool_id
                     has_primary = True
 
                 self.tools_data[tool_id] = {**info,
                                             'primary': primary,
                                             'visible': visible}
-            if primary_id:
-                self.tools_data[primary_id] = {**self.tools_data[primary_id],
-                                               'has_suboptions': n_visible > 1}
+
+            # update has_suboptions for all entries in this menu
+            for tool_id, info in self.tools_data.items():
+                if info['menu_ind'] != menu_ind:
+                    continue
+                self.tools_data[tool_id] = {**self.tools_data[tool_id],
+                                            'has_suboptions': n_visible > 1}
 
         # mutation to dictionary needs to be manually sent to update the UI
         self.send_state("tools_data")


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes the case where clicking a tool in the toolbar dropdown menu could lose the ability to select other suboptions.  This was happening because the "has_suboptions" on the tool was originally set to False and not updated later when it then became the "primary" tool in the sub-menu.  This fix is perhaps overly conservative, but ensures that the "has_suboptions" will always be kept up-to-date in advance of choosing a new tool.

This could be reproduced in specviz2d by selecting the non-synced zoom tool in either viewer.

<img width="200" alt="image" src="https://github.com/spacetelescope/jdaviz/assets/877591/84222e74-89bc-443f-b214-508db16299ad">


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
