### PR TITLE
fix removing cube data from cubeviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,11 +76,12 @@ Bug Fixes
 
 - Fix image layer visibility toggle in plot options. [#2595]
 
-
 - Fixes viewer toolbar items losing ability to bring up right-click menu. [#2605]
 
 Cubeviz
 ^^^^^^^
+
+- Fixes ability to remove cube data from the app. [#2608]
 
 Imviz
 ^^^^^

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -173,6 +173,11 @@ class LineListTool(PluginTemplateMixin):
         if msg is None or msg.viewer_id != self._viewer_id or msg.data is None:
             return
 
+        viewer = self.app.get_viewer(self._default_spectrum_viewer_reference_name)
+        viewer_data_labels = [layer.layer.label for layer in viewer.layers]
+        if msg.data.label not in viewer_data_labels:
+            return
+
         label = msg.data.label
         try:
             viewer_data = self.app._jdaviz_helper.get_data(data_label=label)

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -181,6 +181,10 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
             return
 
         viewer = self.app.get_viewer(self._default_spectrum_viewer_reference_name)
+        viewer_data_labels = [layer.layer.label for layer in viewer.layers]
+        if msg.data.label not in viewer_data_labels:
+            return
+
         get_data_kwargs = {'data_label': msg.data.label}
         if self.config == 'cubeviz':
             get_data_kwargs['function'] = getattr(viewer.state, 'function', None)


### PR DESCRIPTION


<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes the case where removing data from a cube viewer in cubeviz would raise a traceback from the plugins through the spectral viewer.  To reproduce: load cubeviz, open moment maps, calculate moment map (adding to viewer or not, does not matter), use the data-menu in the uncertainty viewer to remove the moment map.  Previously this resulted in a callback from either line lists or line analysis.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
