### PR TITLE
adding check for valid subset name

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1186,6 +1186,47 @@ class Application(VuetifyTemplate, HubListener):
                 f"Data '{data_label}' successfully added.", sender=self, color="success")
             self.hub.broadcast(snackbar_message)
 
+    def check_valid_subset_label(self, subset_name):
+        """Check that `subset_name` is a valid choice for a subset name. This
+        check is run when renaming subsets.
+
+        A valid subset name must not be the name of another subset in the data
+        collection (case insensitive? there cant be a subset 1 and a Subset 1.)
+        The name may match a subset in the data collection if it the current
+        active selection (i.e the renaming is not really a renaming, it is
+        just keeping the old name, which is valid).
+
+        Unlike dataset names, the attempted renaming of a subset to an existing
+        subset label will not append a number (e.g Subset 1 repeated because
+        Subset 1(1)). If the name exists, a warning will be raised and the
+        original subset name will be returned.
+
+        """
+
+        # get all existing subset labels
+        dc = self.data_collection
+        subsets = dc.subset_groups
+        existing_labels = [subset.label.lower() for subset in subsets]
+
+        # get active selection, if there is one
+        if self.session.edit_subset_mode.edit_subset == []:
+            subset_selected = None
+        else:
+            subset_selected = self.session.edit_subset_mode.edit_subset[0].label
+
+        # remove the current selection label from the set of labels, because its ok
+        # if the new subset shares the name of the current selection (renaming to current name)
+        if subset_selected.lower() in existing_labels:
+            existing_labels.remove(subset_selected.lower())
+
+        # now check `subset_name` against list of non-active current subset labels
+        # and warn and return if it is
+        if subset_name.lower() in existing_labels:
+            warnings.warn(f"Can not rename subset to name of another existing subset ({subset_name}).")
+            return subset_selected
+
+        return subset_name
+
     def return_data_label(self, loaded_object, ext=None, alt_name=None, check_unique=True):
         """
         Returns a unique data label that can be safely used to load data into data collection.

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -170,3 +170,22 @@ def test_viewer_renaming_imviz(imviz_helper):
             old_reference='non-existent',
             new_reference='this-is-forbidden'
         )
+
+def test_check_valid_subset_label(self, imviz_helper):
+
+    # imviz instance with some data
+    data = NDData(np.ones((50, 50)) * u.nJy)
+    imviz_helper.load_data(data)
+
+    # apply three subsets, with their default names of `Subset 1`, `Subset 2`, and `Subset 3`
+    imviz_helper.app.get_viewer('imviz-0').apply_roi(CircularROI(20, 20, 10))
+    imviz_helper.app.get_viewer('imviz-0').apply_roi(CircularROI(25, 25, 10))
+    imviz_helper.app.get_viewer('imviz-0').apply_roi(CircularROI(30, 30, 10))
+
+    # we should not be able to rename or add a subset named 'subset 1', since 'Subset 1'
+    # exists. make sure this warns and returns accordingly.
+
+    new_name = 'subset 1'
+
+    with pytest.raises(UserWarning, )
+


### PR DESCRIPTION
(Draft PR from hack day).

This adds a function to (eventually) check if a subset name provided when renaming is valid, and raises a warning if it's not (and returns the existing name to prevent renaming).