### PR TITLE
Revert "Bump actions/upload-artifact from 3 to 4 in /.github/workflows"

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -122,14 +122,14 @@ jobs:
 
     - name: Upload Test artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: test-results-${{ matrix.os }}
         path: standalone/test-results
 
     - name: Upload jdaviz standalone (non-OSX)
       if: ${{ always() && (matrix.os != 'macos') }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: jdaviz-standlone-${{ matrix.os }}
         path: |
@@ -137,7 +137,7 @@ jobs:
 
     - name: Upload jdaviz standalone (OSX)
       if: ${{ always() && (matrix.os == 'macos') }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: jdaviz-standlone-${{ matrix.os }}
         path: standalone/dist/jdaviz.dmg


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Turns out this isn't a drop-in replacement. Now I see weird standalone build failure for Windows, so reverting.

xref https://github.com/actions/upload-artifact/issues/472