### PR TITLE
DOC: Update release instructions

### DIFF
--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -4,7 +4,7 @@ Package Release Instructions
 
 This document outlines the steps for releasing a versioned Jdaviz package to
 PyPI. Currently, these do not cover submitting package updates to other
-distribution outlets, such as ``astroconda`` or ``conda-forge``.
+distribution outlets, such as ``conda-forge``.
 
 This process currently requires you (the release manager) to have sufficient GitHub
 permissions to tag, push, and create a GitHub release on Jdaviz repository. These
@@ -89,8 +89,8 @@ You can do a release from your fork directly without a clean code check-out.
      git commit -m "Preparing release vX.Y.0"
 
 #. Push the ``vX.Y.x`` branch to upstream.
-   Make sure the CI passes. If any of the CI fails, especially the job that
-   says "Release", abandon this way. Stop here; do not continue! Otherwise,
+   Make sure the CI passes. If any of the CI fails,
+   abandon this way. Stop here; do not continue! Otherwise,
    go to the next step.
 
 #. Go to `Releases on GitHub <https://github.com/spacetelescope/jdaviz/releases>`_
@@ -295,8 +295,8 @@ instances of ``vX.Y.x`` with ``v3.5.x``.
      git commit -m "Preparing release vX.Y.Z"
 
 #. Push the ``vX.Y.x`` branch to upstream.
-   Make sure the CI passes. If any of the CI fails, especially the job that
-   says "Release", abandon this way. Stop here; do not continue! Otherwise,
+   Make sure the CI passes. If any of the CI fails,
+   abandon this way. Stop here; do not continue! Otherwise,
    go to the next step.
 
 #. Go to `Releases on GitHub <https://github.com/spacetelescope/jdaviz/releases>`_


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

I noticed outdated text while doing v3.8.1 release:

* `astroconda` is not a thing anymore.
* Looks like now we release via GitHub UI, not pushing a tag manually, so the "check Release" text makes no sense.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
