### PR TITLE
Hide spectral subsets in cubeviz

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -251,6 +251,9 @@ class CubevizProfileView(SpecvizProfileView):
                     )
 
         elif subset_type == 'spectral':
+            spectral_layers = self._get_spectral_subset_layers(layer_state.layer.data.label)
+            for layer in spectral_layers:
+                layer.visible = False
             # need to add marks for every intersection between THIS spectral subset and ALL spatial
             # subset marks corresponding to this data
             spatial_layers = [sub_layer for sub_layer in

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -251,9 +251,6 @@ class CubevizProfileView(SpecvizProfileView):
                     )
 
         elif subset_type == 'spectral':
-            spectral_layers = self._get_spectral_subset_layers(layer_state.layer.data.label)
-            for layer in spectral_layers:
-                layer.visible = False
             # need to add marks for every intersection between THIS spectral subset and ALL spatial
             # subset marks corresponding to this data
             spatial_layers = [sub_layer for sub_layer in

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -129,23 +129,28 @@ class JdavizViewerMixin:
             layer_state.add_callback('as_steps', self._show_uncertainty_changed)
 
     def _expected_subset_layer_default(self, layer_state):
-        if self.__class__.__name__ == 'CubevizImageView':
-            # Do not override default for subsets as for some reason
-            # this isn't getting called when they're first added, but rather when
-            # the next state change is made (for example: manually changing the visibility)
-            subset_type = self.get_subset_type(layer_state.layer)
-            if subset_type == 'spatial':
-                return
-            elif subset_type == 'spectral':
-                spectral_layers = self._get_spectral_subset_layers(layer_state.layer.data.label)
-                for layer in spectral_layers:
-                    layer.visible = False
-            else:
-                return
-        '''
-        default visibility based on the visibility of the "parent" data layer
-        layer_state.visible = self._get_layer(layer_state.layer.data.label).visible
-        '''
+        # Do not override default for subsets as for some reason
+        # this isn't getting called when they're first added, but rather when
+        # the next state change is made (for example: manually changing the visibility)
+        #layer_state = self._get_layer(msg.subset.label)
+        subset_type = get_subset_type(layer_state.layer)
+        
+        if subset_type == 'spectral':
+            if self.__class__.__name__ == 'CubevizImageView':
+                # don't display images layers in flux/uncert-viewers if they're spectral
+                layer_state.visible = False
+            elif self.__class__.__name__ == 'CubevizProfileView':
+                # default visibility of spectrum-viewer layers
+                layer_state.visible = self._get_layer(layer_state.layer.data.label).visible
+        elif subset_type == 'spatial':
+            # display spatial layers
+            if (self.__class__.__name__ == 'CubevizImageView' or
+                    self.__class__.__name__ == 'CubevizProfileView'):
+                layer_state.visible = self._get_layer(layer_state.layer.data.label).visible
+        else:
+            # Other configs, and for Cubeviz
+            # Want to plot spatial or None type subsets, in both Viewers
+            layer_state.visible = self._get_layer(layer_state.layer.data.label).visible
 
     def _update_layer_icons(self):
         # update visible_layers (TODO: move this somewhere that can update on color change, etc)

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -132,9 +132,8 @@ class JdavizViewerMixin:
         # Do not override default for subsets as for some reason
         # this isn't getting called when they're first added, but rather when
         # the next state change is made (for example: manually changing the visibility)
-        #layer_state = self._get_layer(msg.subset.label)
         subset_type = get_subset_type(layer_state.layer)
-        
+
         if subset_type == 'spectral':
             if self.__class__.__name__ == 'CubevizImageView':
                 # don't display images layers in flux/uncert-viewers if they're spectral

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -133,10 +133,19 @@ class JdavizViewerMixin:
             # Do not override default for subsets as for some reason
             # this isn't getting called when they're first added, but rather when
             # the next state change is made (for example: manually changing the visibility)
-            return
-
-        # default visibility based on the visibility of the "parent" data layer
+            subset_type = self.get_subset_type(layer_state.layer)
+            if subset_type == 'spatial':
+                return
+            elif subset_type == 'spectral':
+                spectral_layers = self._get_spectral_subset_layers(layer_state.layer.data.label)
+                for layer in spectral_layers:
+                    layer.visible = False
+            else:
+                return
+        '''
+        default visibility based on the visibility of the "parent" data layer
         layer_state.visible = self._get_layer(layer_state.layer.data.label).visible
+        '''
 
     def _update_layer_icons(self):
         # update visible_layers (TODO: move this somewhere that can update on color change, etc)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https

://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
https://github.com/spacetelescope/jdaviz/assets/42986583/201e5f33-0592-40ff-8000-b8585bceb946
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

Behavior in the video displays that the initial overlay when a slice is viewed is still visible in flux/uncert viewers. After a state change, overlays become hidden. 

When _expected_subset_layer_default() is called in on_layers_update(), the subset is either created and but the data is inaccessible, or the glue message is stating that the subset is in the process of being create, in either case, resulting in type None for data contained within the subset. 

Looking into the message created from _on_subset_create(), yields the same subset data of type None. Tracing through the remaining default viewer class methods yields the same conclusion. 

Note:
- By inferring the subset type is possible for the uncert-viewer, this can be done by accessing the data label, and using the string ending to turn off this overlay at the beginning, while still enabling spatial subsets to be shown on the viewer.
- The same assumption may be possible with the flux-viewer, although, the SCI data is used for both flux & spectrum-viewers, and so the share the same label. If there was a separate differentiation, then this may also be possible. 

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
