### PR TITLE
Reset angle to 0 for new subsets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,8 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Changing the angle of a subset no longer sometimes applies that angle to subsequent new subsets. [#2639]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
+++ b/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
@@ -96,8 +96,9 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
             # Reset theta to 0 if we're creating a new subset
             for viewer_id in self.app._viewer_store:
                 viewer = self.app.get_viewer(viewer_id)
-                if hasattr(viewer.toolbar.active_tool, "_roi") and hasattr(viewer.toolbar.active_tool._roi, "theta"):
-                    viewer.toolbar.active_tool._roi.theta = 0
+                if hasattr(viewer.toolbar.active_tool, "_roi"):
+                    if hasattr(viewer.toolbar.active_tool._roi, "theta"):
+                        viewer.toolbar.active_tool._roi.theta = 0
 
         else:
             new_label = self.session.edit_subset_mode.edit_subset[0].label

--- a/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
+++ b/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
@@ -93,6 +93,12 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
             if self.subset_selected != self.subset_select.default_text:
                 self.subset_selected = self.subset_select.default_text
                 self.show_region_info = False
+            # Reset theta to 0 if we're creating a new subset
+            for viewer_id in self.app._viewer_store:
+                viewer = self.app.get_viewer(viewer_id)
+                if hasattr(viewer.toolbar.active_tool, "_roi") and hasattr(viewer.toolbar.active_tool._roi, "theta"):
+                    viewer.toolbar.active_tool._roi.theta = 0
+
         else:
             new_label = self.session.edit_subset_mode.edit_subset[0].label
             if new_label != self.subset_selected:
@@ -103,7 +109,7 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
 
     def _on_subset_update(self, *args):
         self._sync_selected_from_state(*args)
-        if 'Create New' in self.subset_selected:
+        if 'create new' in self.subset_selected.lower():
             return
         self._get_subset_definition(*args)
         subset_to_update = self.session.edit_subset_mode.edit_subset[0]

--- a/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
+++ b/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
@@ -93,12 +93,11 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
             if self.subset_selected != self.subset_select.default_text:
                 self.subset_selected = self.subset_select.default_text
                 self.show_region_info = False
-            # Reset theta to 0 if we're creating a new subset
+            # Ditch the previous ROI if it was saved on the tool
             for viewer_id in self.app._viewer_store:
                 viewer = self.app.get_viewer(viewer_id)
                 if hasattr(viewer.toolbar.active_tool, "_roi"):
-                    if hasattr(viewer.toolbar.active_tool._roi, "theta"):
-                        viewer.toolbar.active_tool._roi.theta = 0
+                    viewer.toolbar.active_tool._roi = None
 
         else:
             new_label = self.session.edit_subset_mode.edit_subset[0].label


### PR DESCRIPTION
I don't see a Github issue for this, but it was reported by @cshanahan1:

"If an elliptical or rectangular subset is created, then rotated in the subset plugin, the next created subset of that type will preserve the old orientation rather than creating one with the expected default angle of 0."

Turns out this is because the ROI gets cached on the glue-jupyter toolbar tool itself if it was still active when the angle was changed. This PR checks the active tool for all viewers when "Create New" is selected to see if the active tools have an `_roi` with a `theta` attribute and if so, sets it to 0.