### PR TITLE
 Resolving traceback bug in cubeviz spectral extraction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,8 @@ Bug Fixes
 
 Cubeviz
 ^^^^^^^
+- Fixes Spectral Extraction's assumptions of one data per viewer, and flux data only in
+  flux-viewer/uncertainty data only in uncert-viewer. [#2646]
 
 Imviz
 ^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,8 +58,6 @@ Bug Fixes
 
 Cubeviz
 ^^^^^^^
-- Fixes Spectral Extraction's assumptions of one data per viewer, and flux data only in
-  flux-viewer/uncertainty data only in uncert-viewer. [#2646]
 
 Imviz
 ^^^^^
@@ -86,6 +84,8 @@ Bug Fixes
 
 Cubeviz
 ^^^^^^^
+- Fixes Spectral Extraction's assumptions of one data per viewer, and flux data only in
+  flux-viewer/uncertainty data only in uncert-viewer. [#2646]
 
 Imviz
 ^^^^^

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -22,6 +22,9 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
     _default_flux_viewer_reference_name = "flux-viewer"
     _default_image_viewer_reference_name = "image-viewer"
 
+    _loaded_flux_cube = None
+    _loaded_uncert_cube = None
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.app.hub.subscribe(self, AddDataMessage,

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -243,10 +243,8 @@ def _parse_hdulist(app, hdulist, file_name=None,
         metadata['_orig_spatial_wcs'] = _get_celestial_wcs(wcs)
 
         # metadata needs to be added before data is added to data_collection
-        if data_type == 'flux':
-            metadata['_cubetype_flux'] = data_label
-        if data_type == 'uncert':
-            metadata['_cubetype_uncert'] = data_label
+        if data_type == 'flux' or data_type == 'uncert':
+            metadata['_cube_data_type'] = data_type
 
         app.add_data(sc, data_label)
         if data_type == 'flux':  # Forced wave unit conversion made it lose stuff, so re-add
@@ -305,10 +303,8 @@ def _parse_jwst_s3d(app, hdulist, data_label, ext='SCI',
     data = _return_spectrum_with_correct_units(flux, wcs, metadata, data_type, hdulist=hdulist)
 
     # metadata needs to be added before data is added to data_collection
-    if data_type == 'flux':
-        metadata['_cubetype_flux'] = data_label
-    if data_type == 'uncert':
-        metadata['_cubetype_uncert'] = data_label
+    if data_type == 'flux' or data_type == 'uncert':
+        metadata['_cube_data_type'] = data_type
 
     app.add_data(data, data_label)
 
@@ -360,10 +356,8 @@ def _parse_esa_s3d(app, hdulist, data_label, ext='DATA', flux_viewer_reference_n
     data = _return_spectrum_with_correct_units(flux, wcs, metadata, data_type, hdulist=hdulist)
 
     # metadata needs to be added before data is added to data_collection
-    if data_type == 'flux':
-        metadata['_cubetype_flux'] = data_label
-    if data_type == 'uncert':
-        metadata['_cubetype_uncert'] = data_label
+    if data_type == 'flux' or data_type == 'uncert':
+        metadata['_cube_data_type'] = data_type
 
     app.add_data(data, data_label)
 
@@ -417,10 +411,8 @@ def _parse_spectrum1d_3d(app, file_obj, data_label=None,
         cur_data_label = app.return_data_label(data_label, attr.upper())
 
         # metadata needs to be added before data is added to data_collection
-        if attr == 'flux':
-            meta['_cubetype_flux'] = cur_data_label
-        if attr == 'uncert':
-            meta['_cubetype_uncert'] = cur_data_label
+        if attr == 'flux' or attr == 'uncert':
+            meta['_cube_data_type'] = attr
 
         app.add_data(s1d, cur_data_label)
 
@@ -470,10 +462,8 @@ def _parse_ndarray(app, file_obj, data_label=None, data_type=None,
     s3d = Spectrum1D(flux=flux, meta=meta)
 
     # metadata needs to be added before data is added to data_collection
-    if data_type == 'flux':
-        meta['_cubetype_flux'] = data_label
-    if data_type == 'uncert':
-        meta['_cubetype_uncert'] = data_label
+    if data_type == 'flux' or data_type == 'uncert':
+        meta['_cube_data_type'] = data_type
 
     app.add_data(s3d, data_label)
 

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -242,9 +242,8 @@ def _parse_hdulist(app, hdulist, file_name=None,
         # to sky regions, where the parent data of the subset might have dropped spatial WCS info
         metadata['_orig_spatial_wcs'] = _get_celestial_wcs(wcs)
 
-        # metadata needs to be added before data is added to data_collection
-        if data_type == 'flux' or data_type == 'uncert':
-            metadata['_cube_data_type'] = data_type
+        # store cube data type in metadata for spectral extraction
+        metadata['_cube_data_type'] = data_type
 
         app.add_data(sc, data_label)
         if data_type == 'flux':  # Forced wave unit conversion made it lose stuff, so re-add
@@ -297,14 +296,13 @@ def _parse_jwst_s3d(app, hdulist, data_label, ext='SCI',
     # to sky regions, where the parent data of the subset might have dropped spatial WCS info
     metadata['_orig_spatial_wcs'] = _get_celestial_wcs(wcs)
 
+    # store cube data type in metadata for spectral extraction
+    metadata['_cube_data_type'] = data_type
+
     if hdu.name != 'PRIMARY' and 'PRIMARY' in hdulist:
         metadata[PRIHDR_KEY] = standardize_metadata(hdulist['PRIMARY'].header)
 
     data = _return_spectrum_with_correct_units(flux, wcs, metadata, data_type, hdulist=hdulist)
-
-    # metadata needs to be added before data is added to data_collection
-    if data_type == 'flux' or data_type == 'uncert':
-        metadata['_cube_data_type'] = data_type
 
     app.add_data(data, data_label)
 
@@ -353,11 +351,10 @@ def _parse_esa_s3d(app, hdulist, data_label, ext='DATA', flux_viewer_reference_n
     # to sky regions, where the parent data of the subset might have dropped spatial WCS info
     metadata['_orig_spatial_wcs'] = _get_celestial_wcs(wcs)
 
-    data = _return_spectrum_with_correct_units(flux, wcs, metadata, data_type, hdulist=hdulist)
+    # store cube data type in metadata for spectral extraction
+    metadata['_cube_data_type'] = data_type
 
-    # metadata needs to be added before data is added to data_collection
-    if data_type == 'flux' or data_type == 'uncert':
-        metadata['_cube_data_type'] = data_type
+    data = _return_spectrum_with_correct_units(flux, wcs, metadata, data_type, hdulist=hdulist)
 
     app.add_data(data, data_label)
 
@@ -409,9 +406,9 @@ def _parse_spectrum1d_3d(app, file_obj, data_label=None,
 
         cur_data_label = app.return_data_label(data_label, attr.upper())
 
-        # metadata needs to be added before data is added to data_collection
-        if attr == 'flux' or attr == 'uncertainty':
-            meta['_cube_data_type'] = attr
+        # store cube data type in metadata for spectral extraction
+        meta['_cube_data_type'] = attr
+
         app.add_data(s1d, cur_data_label)
 
         if attr == 'flux':
@@ -459,9 +456,8 @@ def _parse_ndarray(app, file_obj, data_label=None, data_type=None,
     meta = standardize_metadata({'_orig_spatial_wcs': None})
     s3d = Spectrum1D(flux=flux, meta=meta)
 
-    # metadata needs to be added before data is added to data_collection
-    if data_type == 'flux' or data_type == 'uncert':
-        meta['_cube_data_type'] = data_type
+    # store cube data type in metadata for spectral extraction
+    meta['_cube_data_type'] = data_type
 
     app.add_data(s3d, data_label)
 

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -372,7 +372,6 @@ def _parse_spectrum1d_3d(app, file_obj, data_label=None,
                          flux_viewer_reference_name=None, spectrum_viewer_reference_name=None,
                          uncert_viewer_reference_name=None):
     """Load spectrum1d as a cube."""
-
     if data_label is None:
         data_label = "Unknown spectrum object"
 
@@ -411,9 +410,8 @@ def _parse_spectrum1d_3d(app, file_obj, data_label=None,
         cur_data_label = app.return_data_label(data_label, attr.upper())
 
         # metadata needs to be added before data is added to data_collection
-        if attr == 'flux' or attr == 'uncert':
+        if attr == 'flux' or attr == 'uncertainty':
             meta['_cube_data_type'] = attr
-
         app.add_data(s1d, cur_data_label)
 
         if attr == 'flux':

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -13,6 +13,7 @@ from specutils import Spectrum1D
 from jdaviz.core.registries import data_parser_registry
 from jdaviz.utils import standardize_metadata, PRIHDR_KEY
 
+
 __all__ = ['parse_data']
 
 EXT_TYPES = dict(flux=['flux', 'sci', 'data'],
@@ -58,6 +59,7 @@ def parse_data(app, file_obj, data_type=None, data_label=None):
             spectrum_viewer_reference_name=spectrum_viewer_reference_name,
             uncert_viewer_reference_name=uncert_viewer_reference_name
         )
+        app.get_tray_item_from_name("Spectral Extraction").disabled_msg = ""
     elif isinstance(file_obj, str):
         if file_obj.lower().endswith('.gif'):  # pragma: no cover
             _parse_gif(app, file_obj, data_label,
@@ -104,6 +106,7 @@ def parse_data(app, file_obj, data_type=None, data_label=None):
                     spectrum_viewer_reference_name=spectrum_viewer_reference_name,
                     uncert_viewer_reference_name=uncert_viewer_reference_name
                 )
+        app.get_tray_item_from_name("Spectral Extraction").disabled_msg = ""
 
     # If the data types are custom data objects, use explicit parsers. Note
     #  that this relies on the glue-astronomy machinery to turn the data object
@@ -121,11 +124,14 @@ def parse_data(app, file_obj, data_type=None, data_label=None):
                 app, file_obj, data_label=data_label,
                 spectrum_viewer_reference_name=spectrum_viewer_reference_name
             )
+        app.get_tray_item_from_name("Spectral Extraction").disabled_msg = ""
+
     elif isinstance(file_obj, np.ndarray) and file_obj.ndim == 3:
         _parse_ndarray(app, file_obj, data_label=data_label, data_type=data_type,
                        flux_viewer_reference_name=flux_viewer_reference_name,
                        spectrum_viewer_reference_name=spectrum_viewer_reference_name,
                        uncert_viewer_reference_name=uncert_viewer_reference_name)
+        app.get_tray_item_from_name("Spectral Extraction").disabled_msg = ""
     else:
         raise NotImplementedError(f'Unsupported data format: {file_obj}')
 

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -242,6 +242,12 @@ def _parse_hdulist(app, hdulist, file_name=None,
         # to sky regions, where the parent data of the subset might have dropped spatial WCS info
         metadata['_orig_spatial_wcs'] = _get_celestial_wcs(wcs)
 
+        # metadata needs to be added before data is added to data_collection
+        if data_type == 'flux':
+            metadata['_cubetype_flux'] = data_label
+        if data_type == 'uncert':
+            metadata['_cubetype_uncert'] = data_label
+
         app.add_data(sc, data_label)
         if data_type == 'flux':  # Forced wave unit conversion made it lose stuff, so re-add
             app.data_collection[-1].get_component("flux").units = flux_unit
@@ -297,7 +303,15 @@ def _parse_jwst_s3d(app, hdulist, data_label, ext='SCI',
         metadata[PRIHDR_KEY] = standardize_metadata(hdulist['PRIMARY'].header)
 
     data = _return_spectrum_with_correct_units(flux, wcs, metadata, data_type, hdulist=hdulist)
+
+    # metadata needs to be added before data is added to data_collection
+    if data_type == 'flux':
+        metadata['_cubetype_flux'] = data_label
+    if data_type == 'uncert':
+        metadata['_cubetype_uncert'] = data_label
+
     app.add_data(data, data_label)
+
     if data_type == 'flux':  # Forced wave unit conversion made it lose stuff, so re-add
         app.data_collection[-1].get_component("flux").units = flux.unit
 
@@ -344,6 +358,12 @@ def _parse_esa_s3d(app, hdulist, data_label, ext='DATA', flux_viewer_reference_n
     metadata['_orig_spatial_wcs'] = _get_celestial_wcs(wcs)
 
     data = _return_spectrum_with_correct_units(flux, wcs, metadata, data_type, hdulist=hdulist)
+
+    # metadata needs to be added before data is added to data_collection
+    if data_type == 'flux':
+        metadata['_cubetype_flux'] = data_label
+    if data_type == 'uncert':
+        metadata['_cubetype_uncert'] = data_label
 
     app.add_data(data, data_label)
 
@@ -395,6 +415,13 @@ def _parse_spectrum1d_3d(app, file_obj, data_label=None,
             s1d = Spectrum1D(flux=flux, wcs=file_obj.wcs, meta=meta)
 
         cur_data_label = app.return_data_label(data_label, attr.upper())
+
+        # metadata needs to be added before data is added to data_collection
+        if attr == 'flux':
+            meta['_cubetype_flux'] = cur_data_label
+        if attr == 'uncert':
+            meta['_cubetype_uncert'] = cur_data_label
+
         app.add_data(s1d, cur_data_label)
 
         if attr == 'flux':
@@ -441,6 +468,13 @@ def _parse_ndarray(app, file_obj, data_label=None, data_type=None,
 
     meta = standardize_metadata({'_orig_spatial_wcs': None})
     s3d = Spectrum1D(flux=flux, meta=meta)
+
+    # metadata needs to be added before data is added to data_collection
+    if data_type == 'flux':
+        meta['_cubetype_flux'] = data_label
+    if data_type == 'uncert':
+        meta['_cubetype_uncert'] = data_label
+
     app.add_data(s3d, data_label)
 
     if data_type == 'flux':
@@ -455,6 +489,7 @@ def _parse_gif(app, file_obj, data_label=None, flux_viewer_reference_name=None,
     # NOTE: Parsing GIF needs imageio and Pillow, both are which undeclared
     # in setup.cfg but might or might not be installed by declared ones.
     import imageio
+    # This does not account for multiple cubes
 
     file_name = os.path.basename(file_obj)
 
@@ -484,4 +519,5 @@ def _get_data_type_by_hdu(hdu):
         data_type = 'flux'
     else:
         data_type = ''
+
     return data_type

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -87,7 +87,7 @@ class SpectralExtraction(PluginTemplateMixin, DatasetSelectMixin,
 
         self.disabled_msg = (
             "Spectral Extraction requires a single dataset to be loaded into Cubeviz, "
-            "please load data to enabl this plugin."
+            "please load data to enable this plugin."
         )
 
     @property

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -111,11 +111,14 @@ class SpectralExtraction(PluginTemplateMixin, DatasetSelectMixin,
         """
         spectral_cube, uncert_cube = None, None
         # get glue Data objects for the spectral cube and uncertainties
-        for index in range(len(self.app.data_collection)):
-            if self.app.data_collection[index].meta.get('_cube_data_type') == 'flux':
-                spectral_cube = self.app.data_collection[index]
-            if self.app.data_collection[index].meta.get('_cube_data_type') == 'uncert':
-                uncert_cube = self.app.data_collection[index]
+        for data in self.app.data_collection:
+            if data.meta.get('_cube_data_type'):
+                data_type = data.meta.get('_cube_data_type')
+
+                if data_type == 'flux':
+                    spectral_cube = data
+                elif data_type == 'uncert' or 'uncertainty':
+                    uncert_cube = data
 
         # verify there isn't N = 0 or N > 1 sets of cube data in data collection
         if (spectral_cube is None) or (uncert_cube is None):

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -109,27 +109,8 @@ class SpectralExtraction(PluginTemplateMixin, DatasetSelectMixin,
             Additional keyword arguments passed to the NDDataArray collapse operation.
             Examples include ``propagate_uncertainties`` and ``operation_ignores_mask``.
         """
-        spectral_cube, uncert_cube = None, None
-        # get glue Data objects for the spectral cube and uncertainties
-        for data in self.app.data_collection:
-            data_type = data.meta.get('_cube_data_type')
-
-            if data_type and data_type != 'mask':
-                if data_type == 'flux':
-                    spectral_cube = data
-                elif data_type in ['uncert', 'uncertainty']:
-                    uncert_cube = data
-
-        # verify there isn't N = 0 or N > 1 sets of cube data in data collection
-        if (spectral_cube is None) or (uncert_cube is None):
-            self.disabled_msg = "No data detected, please load data into data collection " \
-                    "and try again to compute spectral extraction."
-            return
-        elif (len([spectral_cube]) > 1) or (len([uncert_cube]) > 1):
-            self.disabled_msg = "Only one dataset is allowed in Cubeviz, please " \
-                    "remove a dataset and try again to compute spectral " \
-                    "extraction."
-            return
+        spectral_cube = self._app._jdaviz_helper._loaded_flux_cube
+        uncert_cube = self._app._jdaviz_helper._loaded_uncert_cube
 
         # This plugin collapses over the *spatial axes* (optionally over a spatial subset,
         # defaults to ``No Subset``). Since the Cubeviz parser puts the fluxes

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -112,12 +112,12 @@ class SpectralExtraction(PluginTemplateMixin, DatasetSelectMixin,
         spectral_cube, uncert_cube = None, None
         # get glue Data objects for the spectral cube and uncertainties
         for data in self.app.data_collection:
-            if data.meta.get('_cube_data_type'):
-                data_type = data.meta.get('_cube_data_type')
+            data_type = data.meta.get('_cube_data_type')
 
+            if data_type and data_type != 'mask':
                 if data_type == 'flux':
                     spectral_cube = data
-                elif data_type == 'uncert' or 'uncertainty':
+                elif data_type in ['uncert', 'uncertainty']:
                     uncert_cube = data
 
         # verify there isn't N = 0 or N > 1 sets of cube data in data collection

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -112,10 +112,10 @@ class SpectralExtraction(PluginTemplateMixin, DatasetSelectMixin,
         spectral_cube, uncert_cube = None, None
         # get glue Data objects for the spectral cube and uncertainties
         for index in range(len(self.app.data_collection)):
-            if self.app.data_collection[index].meta.get('_cubetype_flux'):
-                [spectral_cube] = [self.app.data_collection[index]]
-            if self.app.data_collection[index].meta.get('_cubetype_uncert'):
-                [uncert_cube] = [self.app.data_collection[index]]
+            if self.app.data_collection[index].meta.get('_cube_data_type') == 'flux':
+                spectral_cube = self.app.data_collection[index]
+            if self.app.data_collection[index].meta.get('_cube_data_type') == 'uncert':
+                uncert_cube = self.app.data_collection[index]
 
         # verify there isn't N = 0 or N > 1 sets of cube data in data collection
         if (spectral_cube is None) or (uncert_cube is None):

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -85,6 +85,11 @@ class SpectralExtraction(PluginTemplateMixin, DatasetSelectMixin,
             # on the user's machine, so export support in cubeviz should be disabled
             self.export_enabled = False
 
+        self.disabled_msg = (
+            "Spectral Extraction requires a single dataset to be loaded into Cubeviz, "
+            "please load data to enabl this plugin."
+        )
+
     @property
     def user_api(self):
         return PluginUserApi(

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -22,7 +22,7 @@ def test_version_before_nddata_update(cubeviz_helper, spectrum1d_cube_with_uncer
 def test_version_after_nddata_update(cubeviz_helper, spectrum1d_cube_with_uncerts):
     # Also test that plugin is disabled before data is loaded.
     plg = cubeviz_helper.plugins['Spectral Extraction']
-    assert plg._obj.disabled_msg == ''
+    assert plg._obj.disabled_msg != ''
 
     cubeviz_helper.load_data(spectrum1d_cube_with_uncerts)
 
@@ -37,6 +37,7 @@ def test_version_after_nddata_update(cubeviz_helper, spectrum1d_cube_with_uncert
     # Collapse the spectral cube using the methods in jdaviz:
     collapsed_cube_s1d = plg.collapse_to_spectrum(add_data=False)  # returns Spectrum1D
 
+    assert plg._obj.disabled_msg == ''
     assert isinstance(spectral_cube, NDDataArray)
     assert isinstance(collapsed_cube_s1d, Spectrum1D)
 

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -6,6 +6,7 @@ import astropy
 from astropy.nddata import NDDataArray, StdDevUncertainty
 from specutils import Spectrum1D
 from regions import CirclePixelRegion, PixCoord
+from astropy.utils.exceptions import AstropyUserWarning
 
 ASTROPY_LT_5_3_2 = Version(astropy.__version__) < Version('5.3.2')
 
@@ -43,6 +44,54 @@ def test_version_after_nddata_update(cubeviz_helper, spectrum1d_cube_with_uncert
         collapsed_cube_nddata.data,
         collapsed_cube_s1d.flux.to_value(collapsed_cube_nddata.unit)
     )
+
+
+@pytest.mark.skipif(ASTROPY_LT_5_3_2, reason='Needs astropy 5.3.2 or later')
+def test_gauss_smooth_before_spec_extract(cubeviz_helper, spectrum1d_cube_with_uncerts):
+    # Also test if gaussian smooth plugin is run before spec extract
+    # that spec extract yields results of correct cube data
+    gs_plugin = cubeviz_helper.plugins['Gaussian Smooth']._obj
+
+    # give uniform unit uncertainties for spec extract test:
+    spectrum1d_cube_with_uncerts.uncertainty = StdDevUncertainty(
+        np.ones_like(spectrum1d_cube_with_uncerts.data)
+    )
+
+    cubeviz_helper.load_data(spectrum1d_cube_with_uncerts)
+
+    gs_plugin.mode_selected = 'Spatial'
+    gs_plugin.stddev = 3
+
+    with pytest.warns(
+            AstropyUserWarning,
+            match='The following attributes were set on the data object, but will be ignored'):
+        gs_plugin.vue_apply()
+
+    # create a subset with a single pixel:
+    regions = [
+        # create a subset with a single pixel:
+        CirclePixelRegion(PixCoord(0, 1), radius=0.7),
+        # two-pixel region:
+        CirclePixelRegion(PixCoord(0.5, 0), radius=1.2)
+    ]
+    cubeviz_helper.load_regions(regions)
+
+    extract_plugin = cubeviz_helper.plugins['Spectral Extraction']
+    extract_plugin.function = "Sum"
+    expected_uncert = 2
+
+    extract_plugin.spatial_subset = 'Subset 1'
+    collapsed_spec = extract_plugin.collapse_to_spectrum()
+
+    # this single pixel has two wavelengths, and all uncertainties are unity
+    # irrespective of which collapse function is applied:
+    assert len(collapsed_spec.flux) == 2
+    assert np.all(np.equal(collapsed_spec.uncertainty.array, 1))
+
+    # this two-pixel region has four unmasked data points per wavelength:
+    extract_plugin.spatial_subset = 'Subset 2'
+    collapsed_spec_2 = extract_plugin.collapse_to_spectrum()
+    assert np.all(np.equal(collapsed_spec_2.uncertainty.array, expected_uncert))
 
 
 @pytest.mark.skipif(ASTROPY_LT_5_3_2, reason='Needs astropy 5.3.2 or later')

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -59,6 +59,7 @@ def test_gauss_smooth_before_spec_extract(cubeviz_helper, spectrum1d_cube_with_u
 
     cubeviz_helper.load_data(spectrum1d_cube_with_uncerts)
 
+    gs_plugin.dataset_selected = f'{cubeviz_helper.app.data_collection[0].label}'
     gs_plugin.mode_selected = 'Spatial'
     gs_plugin.stddev = 3
 
@@ -66,6 +67,9 @@ def test_gauss_smooth_before_spec_extract(cubeviz_helper, spectrum1d_cube_with_u
             AstropyUserWarning,
             match='The following attributes were set on the data object, but will be ignored'):
         gs_plugin.vue_apply()
+
+    gs_data_label = cubeviz_helper.app.data_collection[2].label
+    cubeviz_helper.app.add_data_to_viewer('flux-viewer', gs_data_label)
 
     # create a subset with a single pixel:
     regions = [


### PR DESCRIPTION

https://github.com/spacetelescope/jdaviz/assets/42986583/f160e86a-2813-4c14-8897-7caa97ab9c57


This PR resolves a traceback bug that arises when loading datasets with N = 0 or N > 1 in one or both Cubeviz image viewers. Previously, this issue disabled spectral extraction, as the extraction process assumed the presence of only one dataset in each viewer. The patch introduced in this PR tracks when the parser adds uncertainty and flux data to the data collection (via metadata) and selects the now labeled data for spectral extraction. 

Notes:
Cubeviz plugin tests pass including parsers tests, spectral extraction tests are not passing. 

GIF parser does not differentiate data type (flux,  uncert., mask, etc.) until after the add_data function, disabling the ability to add metadata. 
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
