### PR TITLE
View spectrum from single spaxel on hover

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Cubeviz
 
 - Moment map plugin now supports linear per-spaxel continuum subtraction. [#2587]
 
+- Single-pixel subset tool now shows spectrum-at-spaxel on hover. [#2647]
+
 Imviz
 ^^^^^
 

--- a/docs/cubeviz/displaycubes.rst
+++ b/docs/cubeviz/displaycubes.rst
@@ -111,6 +111,11 @@ You can also use the subset modes that are explained in the
 :ref:`Spatial Regions <imviz_defining_spatial_regions>`
 section above in the same way you would with the other subset selection tools.
 
+Note that moving the cursor outside of the image viewer or deactivating the spectrum-at-spaxel tool
+will revert the spectrum viewer zoom limits from the zoomed-in preview view to the limits set prior
+to using the tool. Thus it may be necessary to reset the zoom to see any single-spaxel subset spectra
+created using the tool.
+
 .. _cubeviz-display-settings:
 
 Display Settings

--- a/docs/cubeviz/displaycubes.rst
+++ b/docs/cubeviz/displaycubes.rst
@@ -99,9 +99,10 @@ the bottom of the UI.
 Spectrum At Spaxel
 ==================
 
-This tool allows the user to create a one spaxel subset in an image viewer. This subset will then be
+This tool allows the user to create a single-spaxel subset in an image viewer. This subset will then be
 visualized in the spectrum viewer by showing the spectrum at that spaxel.
-Activate this tool and then left-click to create the new region.
+While this tool is active, hovering over a pixel in the image viewer will show a preview of the spectrum
+at that spaxel in the spectrum viewer, and left-clicking will create a new subset at that spaxel.
 Click again to move the region to a new location under the cursor. Holding down the
 alt key (Alt key on Windows, Option key on Mac) while clicking on a spaxel creates a new subset at
 that point instead of moving the previously created region.

--- a/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
@@ -18,6 +18,12 @@ def test_spectrum_at_spaxel(cubeviz_helper, spectrum1d_cube):
     assert len(flux_viewer.native_marks) == 2
     assert len(spectrum_viewer.data()) == 1
 
+    # Move to spaxel location
+    flux_viewer.toolbar.active_tool.on_mouse_move(
+        {'event': 'mousemove', 'domain': {'x': x, 'y': y}, 'altKey': False})
+    assert flux_viewer.toolbar.active_tool._mark in spectrum_viewer.figure.marks
+    assert flux_viewer.toolbar.active_tool._mark.visible is True
+
     # Click on spaxel location
     flux_viewer.toolbar.active_tool.on_mouse_event(
         {'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
@@ -29,6 +35,11 @@ def test_spectrum_at_spaxel(cubeviz_helper, spectrum1d_cube):
     reg = subsets.get('Subset 1')[0]['region']
     assert len(subsets) == 1
     assert isinstance(reg, RectanglePixelRegion)
+
+    # Mouse leave event
+    flux_viewer.toolbar.active_tool.on_mouse_move(
+        {'event': 'mouseleave', 'domain': {'x': x, 'y': y}, 'altKey': False})
+    assert flux_viewer.toolbar.active_tool._mark.visible is False
 
     # Deselect tool
     flux_viewer.toolbar.active_tool = None

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -127,17 +127,21 @@ class SpectrumPerSpaxel(SinglePixelRegion):
         y = int(np.round(data['domain']['y']))
 
         # Use first visible layer for now
-        cube_data = [layer.layer for layer in self.viewer.layers if layer.state.visible][0]
+        cube_data = [layer.layer for layer in self.viewer.layers if layer.state.visible]
+        if len(cube_data) == 0:
+            return
+        cube_data = cube_data[0]
         spectrum = cube_data.get_object(statistic=None)
 
         if x >= spectrum.flux.shape[0] or x < 0 or y >= spectrum.flux.shape[1] or y < 0:
+            self._reset_spectrum_viewer_bounds()
             self._mark.visible = False
         else:
-            self._mark.visible = True
             y_values = spectrum.flux[x, y, :]
             if np.all(np.isnan(y_values)):
                 self._mark.visible = False
                 return
             self._mark.update_xy(spectrum.spectral_axis.value, y_values)
+            self._mark.visible = True
             self._spectrum_viewer.state.y_max = np.nanmax(y_values.value) * 1.2
             self._spectrum_viewer.state.y_min = np.nanmin(y_values.value) * 0.8

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -137,7 +137,10 @@ class SpectrumPerSpaxel(SinglePixelRegion):
         if coords_dataset == 'auto':
             cube_data = self.viewer.active_image_layer.layer
         elif coords_dataset == 'none':
-            cube_data = self.viewer.layers[0].layer
+            if len(self.viewer.layers):
+                cube_data = self.viewer.layers[0].layer
+            else:
+                return
         else:
             cube_data = self.viewer.session.application._tools['g-coords-info'].dataset.selected_obj
 

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -121,9 +121,9 @@ class SpectrumPerSpaxel(SinglePixelRegion):
             self._mark.visible = False
         else:
             self._mark.visible = True
-            y_values = spectrum.flux[x,y,:]
+            y_values = spectrum.flux[x, y, :]
             if np.all(np.isnan(y_values)):
-                self._mark.visible=False
+                self._mark.visible = False
                 return
             self._mark.update_xy(spectrum.spectral_axis.value, y_values)
             self._spectrum_viewer.state.y_max = np.nanmax(y_values.value) * 1.2

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -5,6 +5,7 @@ from glue.config import viewer_tool
 from glue_jupyter.bqplot.image import BqplotImageView
 from glue.viewers.common.tool import CheckableTool
 import numpy as np
+from specutils import Spectrum1D
 
 from jdaviz.configs.imviz.plugins.tools import _MatchedZoomMixin
 from jdaviz.core.events import SliceToolStateMessage
@@ -133,6 +134,10 @@ class SpectrumPerSpaxel(SinglePixelRegion):
             return
         cube_data = cube_data[0]
         spectrum = cube_data.get_object(statistic=None)
+        # Note: change this when Spectrum1D.with_spectral_axis is fixed.
+        if spectrum.spectral_axis.unit != self._spectrum_viewer.state.x_display_unit:
+            new_spectral_axis = spectrum.spectral_axis.to(self._spectrum_viewer.state.x_display_unit)
+            spectrum = Spectrum1D(spectrum.flux, new_spectral_axis)
 
         if x >= spectrum.flux.shape[0] or x < 0 or y >= spectrum.flux.shape[1] or y < 0:
             self._reset_spectrum_viewer_bounds()

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -127,7 +127,8 @@ class SpectrumPerSpaxel(SinglePixelRegion):
         y = int(np.round(data['domain']['y']))
 
         # Use first visible layer for now
-        cube_data = [layer.layer for layer in self.viewer.layers if layer.state.visible]
+        cube_data = [layer.layer for layer in self.viewer.layers if layer.state.visible
+                     and len(layer.layer.shape) == 3]
         if len(cube_data) == 0:
             return
         cube_data = cube_data[0]

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -122,6 +122,9 @@ class SpectrumPerSpaxel(SinglePixelRegion):
         else:
             self._mark.visible = True
             y_values = spectrum.flux[x,y,:]
+            if np.all(np.isnan(y_values)):
+                self._mark.visible=False
+                return
             self._mark.update_xy(spectrum.spectral_axis.value, y_values)
-            self._spectrum_viewer.state.y_max = y_values.max().value * 1.2
-            self._spectrum_viewer.state.y_min = y_values.min().value * 0.8
+            self._spectrum_viewer.state.y_max = np.nanmax(y_values.value) * 1.2
+            self._spectrum_viewer.state.y_min = np.nanmin(y_values.value) * 0.8

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -4,7 +4,6 @@ import os
 from glue.config import viewer_tool
 from glue_jupyter.bqplot.image import BqplotImageView
 from glue_jupyter.bqplot.profile import BqplotProfileView
-from glue_jupyter.bqplot.image.layer_artist import BqplotImageSubsetLayerArtist
 from glue.viewers.common.tool import CheckableTool
 import numpy as np
 from specutils import Spectrum1D

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -129,14 +129,14 @@ class SpectrumPerSpaxel(SinglePixelRegion):
         y = int(np.round(data['domain']['y']))
 
         # Use the selected layer from coords_info as long as it's 3D
-        coords_info_dataset = self.viewer.session.application._tools['g-coords-info'].dataset.selected
-        if coords_info_dataset == 'auto':
+        coords_dataset = self.viewer.session.application._tools['g-coords-info'].dataset.selected
+        if coords_dataset == 'auto':
             cube_data = self.viewer.active_image_layer.layer
-        elif coords_info_dataset == 'none':
+        elif coords_dataset == 'none':
             cube_data = self.viewer.layers[0].layer
         else:
             for layer in self.viewer.layers:
-                if layer.layer.label == coords_info_dataset and layer.visible:
+                if layer.layer.label == coords_dataset and layer.visible:
                     if isinstance(layer, BqplotImageSubsetLayerArtist):
                         # cannot expose info for spatial subset layers
                         continue
@@ -147,15 +147,16 @@ class SpectrumPerSpaxel(SinglePixelRegion):
 
         if cube_data.ndim != 3:
             cube_data = [layer.layer for layer in self.viewer.layers if layer.state.visible
-                        and layer.layer.ndim == 3]
+                         and layer.layer.ndim == 3]
             if len(cube_data) == 0:
                 return
             cube_data = cube_data[0]
 
         spectrum = cube_data.get_object(statistic=None)
         # Note: change this when Spectrum1D.with_spectral_axis is fixed.
-        if spectrum.spectral_axis.unit != self._spectrum_viewer.state.x_display_unit:
-            new_spectral_axis = spectrum.spectral_axis.to(self._spectrum_viewer.state.x_display_unit)
+        x_unit = self._spectrum_viewer.state.x_display_unit
+        if spectrum.spectral_axis.unit != x_unit:
+            new_spectral_axis = spectrum.spectral_axis.to(x_unit)
             spectrum = Spectrum1D(spectrum.flux, new_spectral_axis)
 
         if x >= spectrum.flux.shape[0] or x < 0 or y >= spectrum.flux.shape[1] or y < 0:


### PR DESCRIPTION
Now shows spectrum and auto-scales spectrum viewer when hovering with the single-spaxel subset tool activated, see demo:

https://github.com/spacetelescope/jdaviz/assets/39831871/98b989f0-d798-4a25-b529-30d74e3db1a0

Opened as draft since I still need to add tests and update docs. Outstanding question: do we want to reset the spectrum viewer limits to the default when deactivating the tool/leaving the viewer area?