### PR TITLE
Revert "Bump actions/upload-artifact from 3 to 4 in /.github/workflows"

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -122,14 +122,14 @@ jobs:
 
     - name: Upload Test artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: test-results-${{ matrix.os }}
         path: standalone/test-results
 
     - name: Upload jdaviz standalone (non-OSX)
       if: ${{ always() && (matrix.os != 'macos') }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: jdaviz-standlone-${{ matrix.os }}
         path: |
@@ -137,7 +137,7 @@ jobs:
 
     - name: Upload jdaviz standalone (OSX)
       if: ${{ always() && (matrix.os == 'macos') }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: jdaviz-standlone-${{ matrix.os }}
         path: standalone/dist/jdaviz.dmg


### PR DESCRIPTION
Reverts spacetelescope/jdaviz#2637

Because of https://github.com/actions/upload-artifact/issues/485