### PR TITLE
fix: custom styles work in solara server

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -154,7 +154,7 @@ for name, path in custom_components.items():
 ipyvue.register_component_from_file('g-viewer-tab', "container.vue", __file__)
 
 
-style_registry.instance.add((__file__, 'main_styles.vue'))
+style_registry.add((__file__, 'main_styles.vue'))
 
 
 class ApplicationState(State):
@@ -263,7 +263,7 @@ class Application(VuetifyTemplate, HubListener):
         self._verbosity = 'warning'
         self._history_verbosity = 'info'
         self.popout_button = PopoutButton(self)
-        self.style_registry_instance = style_registry.instance
+        self.style_registry_instance = style_registry.get_style_registry()
 
         # Generate a state object for this application to maintain the state of
         #  the user interface.


### PR DESCRIPTION
In #2580 we fixed support for custom style in combination with ipypopout. However, this uses a global widget, which does not work with solara, since multiple virtual kernels would then share the same widget.

This is using a singleton decorator that makes sure each virtual kernel will create only 1 StyleRegistry widget.

