### PR TITLE
Hover spectrum with extra axis

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Cubeviz
 
 - Moment map plugin now supports linear per-spaxel continuum subtraction. [#2587]
 
+- Single-pixel subset tool now shows spectrum-at-spaxel on hover. [#2647]
+
 Imviz
 ^^^^^
 

--- a/docs/cubeviz/displaycubes.rst
+++ b/docs/cubeviz/displaycubes.rst
@@ -111,6 +111,11 @@ You can also use the subset modes that are explained in the
 :ref:`Spatial Regions <imviz_defining_spatial_regions>`
 section above in the same way you would with the other subset selection tools.
 
+Note that moving the cursor outside of the image viewer or deactivating the spectrum-at-spaxel tool
+will revert the spectrum viewer zoom limits from the zoomed-in preview view to the limits set prior
+to using the tool. Thus it may be necessary to reset the zoom to see any single-spaxel subset spectra
+created using the tool.
+
 .. _cubeviz-display-settings:
 
 Display Settings

--- a/docs/cubeviz/displaycubes.rst
+++ b/docs/cubeviz/displaycubes.rst
@@ -99,9 +99,10 @@ the bottom of the UI.
 Spectrum At Spaxel
 ==================
 
-This tool allows the user to create a one spaxel subset in an image viewer. This subset will then be
+This tool allows the user to create a single-spaxel subset in an image viewer. This subset will then be
 visualized in the spectrum viewer by showing the spectrum at that spaxel.
-Activate this tool and then left-click to create the new region.
+While this tool is active, hovering over a pixel in the image viewer will show a preview of the spectrum
+at that spaxel in the spectrum viewer, and left-clicking will create a new subset at that spaxel.
 Click again to move the region to a new location under the cursor. Holding down the
 alt key (Alt key on Windows, Option key on Mac) while clicking on a spaxel creates a new subset at
 that point instead of moving the previously created region.

--- a/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
@@ -18,6 +18,12 @@ def test_spectrum_at_spaxel(cubeviz_helper, spectrum1d_cube):
     assert len(flux_viewer.native_marks) == 2
     assert len(spectrum_viewer.data()) == 1
 
+    # Move to spaxel location
+    flux_viewer.toolbar.active_tool.on_mouse_move(
+        {'event': 'mousemove', 'domain': {'x': x, 'y': y}, 'altKey': False})
+    assert flux_viewer.toolbar.active_tool._mark in spectrum_viewer.figure.marks
+    assert flux_viewer.toolbar.active_tool._mark.visible is True
+
     # Click on spaxel location
     flux_viewer.toolbar.active_tool.on_mouse_event(
         {'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
@@ -29,6 +35,11 @@ def test_spectrum_at_spaxel(cubeviz_helper, spectrum1d_cube):
     reg = subsets.get('Subset 1')[0]['region']
     assert len(subsets) == 1
     assert isinstance(reg, RectanglePixelRegion)
+
+    # Mouse leave event
+    flux_viewer.toolbar.active_tool.on_mouse_move(
+        {'event': 'mouseleave', 'domain': {'x': x, 'y': y}, 'altKey': False})
+    assert flux_viewer.toolbar.active_tool._mark.visible is False
 
     # Deselect tool
     flux_viewer.toolbar.active_tool = None

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -121,9 +121,9 @@ class SpectrumPerSpaxel(SinglePixelRegion):
             self._mark.visible = False
         else:
             self._mark.visible = True
-            y_values = spectrum.flux[x,y,:]
+            y_values = spectrum.flux[x, y, :]
             if np.all(np.isnan(y_values)):
-                self._mark.visible=False
+                self._mark.visible = False
                 return
             self._mark.update_xy(spectrum.spectral_axis.value, y_values)
             self._spectrum_viewer.state.y_max = np.nanmax(y_values.value) * 1.2

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -122,6 +122,9 @@ class SpectrumPerSpaxel(SinglePixelRegion):
         else:
             self._mark.visible = True
             y_values = spectrum.flux[x,y,:]
+            if np.all(np.isnan(y_values)):
+                self._mark.visible=False
+                return
             self._mark.update_xy(spectrum.spectral_axis.value, y_values)
-            self._spectrum_viewer.state.y_max = y_values.max().value * 1.2
-            self._spectrum_viewer.state.y_min = y_values.min().value * 0.8
+            self._spectrum_viewer.state.y_max = np.nanmax(y_values.value) * 1.2
+            self._spectrum_viewer.state.y_min = np.nanmin(y_values.value) * 0.8

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -115,14 +115,13 @@ class SpectrumPerSpaxel(SinglePixelRegion):
         # Add extra y-axis to show on right hand side of spectrum viewer
         if self._extra_axis not in self._spectrum_viewer.figure.axes:
             self._spectrum_viewer.figure.axes.append(self._extra_axis)
-            #self._spectrum_viewer.figure.send_state()
         # Create the mark for the preview spectrum
         if self._mark is None:
             scales = {}
             scales['x'] = self._spectrum_viewer.native_marks[0].scales['x']
             scales['y'] = bqplot.LinearScale()
             self._mark = PluginLine(self._spectrum_viewer, visible=False, scales=scales)
-            self._spectrum_viewer.figure.marks = self._spectrum_viewer.figure.marks + [self._mark,]
+            self._spectrum_viewer.figure.marks = self._spectrum_viewer.figure.marks + [self._mark]
         # Store these so we can revert to previous user-set zoom after preview view
         sv_state = self._spectrum_viewer.state
         self._previous_bounds = [sv_state.x_min, sv_state.x_max, sv_state.y_min, sv_state.y_max]
@@ -143,15 +142,15 @@ class SpectrumPerSpaxel(SinglePixelRegion):
         if data['event'] == 'mouseleave':
             self._mark.visible = False
             self._extra_axis.visible=False
-            self._extra_axis.send_state()
+            self._extra_axis.send_state("visible")
             self._spectrum_viewer.figure.fig_margin['right'] = 10
-            self._spectrum_viewer.figure.send_state()
+            self._spectrum_viewer.figure.send_state("fig_margin")
             #self._reset_spectrum_viewer_bounds()
             return
 
         elif data['event'] == 'mouseenter':
             # Make room for the extra axis
-            self._spectrum_viewer.figure.fig_margin['right'] = 50
+            self._spectrum_viewer.figure.fig_margin['right'] = 80
             self._extra_axis.visible = True
 
         x = int(np.round(data['domain']['x']))
@@ -178,13 +177,6 @@ class SpectrumPerSpaxel(SinglePixelRegion):
             float_y_max = float(np.nanmax(y_values.value))
             self._extra_axis.scale.min = float_y_min
             self._extra_axis.scale.max = float_y_max
-            #self._extra_axis.scale = bqplot.LinearScale(min=float_y_min, max=float_y_max)
-            #self._extra_axis.tick_values = np.linspace(float_y_min, float_y_max, 8)
-            #tick_vals = np.linspace(float_y_min, float_y_max, 8)
-            #self._extra_axis.tick_labels = {i: str(tick_vals[i]) for i in range(len(tick_vals))}
 
-            #self._spectrum_viewer.state.y_max = np.nanmax(y_values.value) * 1.2
-            #self._spectrum_viewer.state.y_min = np.nanmin(y_values.value) * 0.8
-
-        self._extra_axis.send_state()
-        self._spectrum_viewer.figure.send_state()
+        self._extra_axis.send_state(["scale", "visible"])
+        self._spectrum_viewer.figure.send_state(["fig_margin", "axes"])


### PR DESCRIPTION
This is a follow up to #2647 that would overlay the preview spectrum on whatever the current zoom is, with an additional y-axis on the right to show the flux of the preview spectrum. Currently blocked by a potential bqplot bug, where the axis tick values are not updating when the axis scale updates. 