### PR TITLE
expose spatial subset opacity in plot options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ New Features
 
 - Spectrum viewer bounds can now be set through the Plot Options UI. [#2604]
 
+- Opacity for spatial subsets is now adjustable from within Plot Options. [#2663]
+
 Cubeviz
 ^^^^^^^
 - Calculated moments can now be output in velocity units. [#2584, #2588]

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -114,6 +114,8 @@ class PlotOptions(PluginTemplateMixin):
       whether a subset should be visible.
     * ``subset_color`` (:class:`~jdaviz.core.template_mixin.PlotOptionsSyncState`):
       not exposed for Specviz
+    * ``subset_opacity`` (:class:`~jdaviz.core.template_mixin.PlotOptionsSyncState`):
+      not exposed for Specviz
     * ``axes_visible`` (:class:`~jdaviz.core.template_mixin.PlotOptionsSyncState`):
       not exposed for Imviz
     * ``collapse_function`` (:class:`~jdaviz.core.template_mixin.PlotOptionsSyncState`):
@@ -302,6 +304,9 @@ class PlotOptions(PluginTemplateMixin):
 
     subset_color_value = Unicode().tag(sync=True)
     subset_color_sync = Dict().tag(sync=True)
+
+    subset_opacity_value = Float().tag(sync=True)
+    subset_opacity_sync = Dict().tag(sync=True)
 
     image_visible_value = Bool().tag(sync=True)
     image_visible_sync = Dict().tag(sync=True)
@@ -561,6 +566,9 @@ class PlotOptions(PluginTemplateMixin):
         self.subset_color = PlotOptionsSyncState(self, self.viewer, self.layer, 'color',
                                                  'subset_color_value', 'subset_color_sync',
                                                  state_filter=is_spatial_subset)
+        self.subset_opacity = PlotOptionsSyncState(self, self.viewer, self.layer, 'alpha',
+                                                   'subset_opacity_value', 'subset_opacity_sync',
+                                                   state_filter=is_spatial_subset)
         self.image_visible = PlotOptionsSyncState(self, self.viewer, self.layer, 'bitmap_visible',
                                                   'image_visible_value', 'image_visible_sync',
                                                   state_filter=is_image)
@@ -624,7 +632,7 @@ class PlotOptions(PluginTemplateMixin):
             expose += ['axes_visible', 'line_visible', 'line_color', 'line_width', 'line_opacity',
                        'line_as_steps', 'uncertainty_visible']
         if self.config != "specviz":
-            expose += ['subset_color',
+            expose += ['subset_color', 'subset_opacity',
                        'stretch_function', 'stretch_preset', 'stretch_vmin', 'stretch_vmax',
                        'stretch_hist_zoom_limits', 'stretch_hist_nbins',
                        'image_visible', 'image_color_mode',

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -205,6 +205,13 @@
         </div>
       </glue-state-sync-wrapper>
 
+      <glue-state-sync-wrapper :sync="subset_opacity_sync" :multiselect="layer_multiselect" @unmix-state="unmix_state('subset_opacity')">
+        <div>
+          <v-subheader class="pl-0 slider-label" style="height: 12px">Subset Opacity</v-subheader>
+          <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="subset_opacity_value" hide-details class="no-hint" />
+        </div>
+      </glue-state-sync-wrapper>
+
 
       <!-- PROFILE/LINE -->
       <j-plugin-section-header v-if="(line_visible_sync.in_subscribed_states && ((!marker_visible_sync.in_subscribed_states && line_visible_value) || (marker_visible_sync.in_subscribed_states && marker_visible_value))) || collapse_func_sync.in_subscribed_states">Line</j-plugin-section-header>


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request exposes the spatial subset opacity in the plot options (UI and API).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
