### PR TITLE
DEV: feature-flag implementation at app-level

### DIFF
--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -170,3 +170,11 @@ def test_viewer_renaming_imviz(imviz_helper):
             old_reference='non-existent',
             new_reference='this-is-forbidden'
         )
+
+
+def test_feature_flags(imviz_helper):
+    imviz_helper.app.feature_flags = {'example-feature': False}
+    assert not imviz_helper.app._ff_is_enabled('example-feature')
+    with imviz_helper.app._ff_temporarily_enabled('example-feature'):
+        assert imviz_helper.app._ff_is_enabled('example-feature')
+    assert not imviz_helper.app._ff_is_enabled('example-feature')


### PR DESCRIPTION
## NOT (YET) INTENDED FOR REVIEW/MERGE

**UP FOR DISCUSSION** 

This pull request implements one possible re-usable approach to feature-flags.  The idea here is that we can merge incremental PRs directly into main without making an incomplete feature user-facing, and then switch the feature to be enabled (or delete the applicable code blocks) down the road.  This is an alternate to the long-lived feature branches as we've seen with image rotation that can become difficult to manage.

https://github.com/spacetelescope/jdaviz/pull/2664 had implemented a single-use feature-flag, which inspired this more general approach.  https://github.com/kecnry/jdaviz/pull/7 then shows how that would be modified to use the implementation proposed here.

The general idea here is that anything that is not ready for use yet, can be disabled by default, but still exposed for developer testing with something like:

```
viz.app._ff_enable('my-feature')
```

or within test blocks temporarily with:

```
with viz.app._ff_temporarily_enabled('my-feature'):
    # in here the feature is enabled, outside it is not.
```

We then can also put `v-if` statements anywhere in vue to hide/alter the applicable sections of the UI, or `if app._ff_is_enabled('my-feature')` in python to raise NotImplementedErrors, etc.

**Milestones and changelogs**: if we go in this direction, how should the changelog and milestones be handled?  Can we milestone these into a separate section of the changelog entirely and then somehow just go move the necessary entries?  Should we have a milestone for each active feature we're working on so that a specific release version doesn't have to be targeted yet?
