### PR TITLE
BUG: Cube fit should work even without valid 3D WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -119,6 +119,9 @@ Cubeviz
 - Fixes Spectral Extraction's assumptions of one data per viewer, and flux data only in
   flux-viewer/uncertainty data only in uncert-viewer. [#2646]
 
+- Fixed a bug where cube model fitting could fail (endless spinner) if input cube
+  has invalid 3D WCS. [#2685]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -6,7 +6,6 @@ import astropy.units as u
 from specutils import Spectrum1D
 from specutils.utils import QuantityModel
 from traitlets import Bool, List, Unicode, observe
-from glue.core.data import Data
 
 from jdaviz.core.events import SnackbarMessage, GlobalDisplayUnitChanged
 from jdaviz.core.registries import tray_registry
@@ -947,17 +946,9 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
                 temp_label = "{} ({}, {})".format(self.results_label, m["x"], m["y"])
                 self.app.fitted_models[temp_label] = m["model"]
 
-        count = max(map(lambda s: int(next(iter(re.findall(r"\d$", s)), 0)),
-                        self.data_collection.labels)) + 1
+        output_cube = Spectrum1D(flux=fitted_spectrum.flux, wcs=fitted_spectrum.wcs)
 
-        label = self.app.return_data_label(f"{self.results_label}[Cube]", ext=count)
-
-        # Create new glue data object
-        output_cube = Data(label=label,
-                           coords=fitted_spectrum.wcs,
-                           flux=fitted_spectrum.flux.value)
-        output_cube.get_component('flux').units = fitted_spectrum.flux.unit.to_string()
-
+        # Create new data entry for glue
         if add_data:
             self.add_results.add_results_from_plugin(output_cube)
             self._set_default_results_label()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to fix how output cube gets loaded back into the app to prevent error when input cube has invalid 3D WCS (e.g., just the spectral WCS without spatial info).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4176)
