### PR TITLE
hacky metadata solution to address RA/Dec flipping due to cube reinge…

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -267,6 +267,8 @@ def _parse_hdulist(app, hdulist, file_name=None,
             app.add_data_to_viewer(spectrum_viewer_reference_name, data_label)
             app._jdaviz_helper._loaded_flux_cube = app.data_collection[data_label]
 
+        metadata['_parsed_before'] = True
+
 
 def _parse_jwst_s3d(app, hdulist, data_label, ext='SCI',
                     viewer_name=None, flux_viewer_reference_name=None,
@@ -315,10 +317,7 @@ def _parse_jwst_s3d(app, hdulist, data_label, ext='SCI',
     if viewer_name == flux_viewer_reference_name:
         app.add_data_to_viewer(spectrum_viewer_reference_name, data_label)
 
-    if data_type == 'flux':
-        app._jdaviz_helper._loaded_flux_cube = app.data_collection[data_label]
-    elif data_type == 'uncert':
-        app._jdaviz_helper._loaded_uncert_cube = app.data_collection[data_label]
+    metadata['_parsed_before'] = True
 
 
 def _parse_esa_s3d(app, hdulist, data_label, ext='DATA', flux_viewer_reference_name=None,
@@ -366,10 +365,7 @@ def _parse_esa_s3d(app, hdulist, data_label, ext='DATA', flux_viewer_reference_n
     app.add_data_to_viewer(flux_viewer_reference_name, data_label)
     app.add_data_to_viewer(spectrum_viewer_reference_name, data_label)
 
-    if data_type == 'flux':
-        app._jdaviz_helper._loaded_flux_cube = app.data_collection[data_label]
-    if data_type == 'uncert':
-        app._jdaviz_helper._loaded_uncert_cube = app.data_collection[data_label]
+    metadata['_parsed_before'] = True
 
 
 def _parse_spectrum1d_3d(app, file_obj, data_label=None,
@@ -395,13 +391,14 @@ def _parse_spectrum1d_3d(app, file_obj, data_label=None,
         else:
             flux = val
 
-        flux = np.moveaxis(flux, 1, 0)
-
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 'ignore', message='Input WCS indicates that the spectral axis is not last',
                 category=UserWarning)
             meta = standardize_metadata(file_obj.meta)
+
+            if '_parsed_before' in meta and meta['_parsed_before']:
+                flux = np.moveaxis(flux, 1, 0)
 
             # store original WCS in metadata. this is a hacky workaround for
             # converting subsets to sky regions, where the parent data of the
@@ -423,6 +420,8 @@ def _parse_spectrum1d_3d(app, file_obj, data_label=None,
             app.add_data_to_viewer(uncert_viewer_reference_name, cur_data_label)
             app._jdaviz_helper._loaded_uncert_cube = app.data_collection[cur_data_label]
         # We no longer auto-populate the mask cube into a viewer
+
+        meta['_parsed_before'] = True
 
 
 def _parse_spectrum1d(app, file_obj, data_label=None, spectrum_viewer_reference_name=None):
@@ -470,6 +469,8 @@ def _parse_ndarray(app, file_obj, data_label=None, data_type=None,
     elif data_type == 'uncert':
         app.add_data_to_viewer(uncert_viewer_reference_name, data_label)
         app._jdaviz_helper._loaded_uncert_cube = app.data_collection[data_label]
+
+    meta['_parsed_before'] = True
 
 
 def _parse_gif(app, file_obj, data_label=None, flux_viewer_reference_name=None,


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address when a cube extracted with get_data has RA and Dec flipped when reingested into cubeviz. The solution utilizes metadata stored within the extracted cube, so that a cube can pass information to the parser whether or not it is necessary to rotate/move axis.

Bug:
<img width="805" alt="Screenshot 2024-02-02 at 1 04 25 PM" src="https://github.com/spacetelescope/jdaviz/assets/42986583/d45d433b-43cc-495a-8333-d988bfa76214">
With fix:
<img width="810" alt="Screenshot 2024-02-02 at 1 05 15 PM" src="https://github.com/spacetelescope/jdaviz/assets/42986583/b87e5f2a-a75f-4bf0-a6e1-185b3275513a">


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
