### PR TITLE
POC: stretch-per-slice

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/slice/slice.vue
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.vue
@@ -33,6 +33,15 @@
     </v-row>
 
     <v-row>
+      <v-switch
+        label="Stretch-per-slice"
+        hint="Whether the stretch percentile is applied per slice or across the entire cube."
+        v-model="stretch_per_slice"
+        persistent-hint>
+      </v-switch>
+    </v-row>
+
+    <v-row>
       <v-slider
         :value="slice"
         @input="throttledSetValue"


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements a proof-of-concept for stretch-per-slice support using https://github.com/glue-viz/glue/pull/2476.


https://github.com/spacetelescope/jdaviz/assets/877591/6e46a453-39d9-45c4-bfd9-cc861da1d39f




Future to-do items if we go in this direction:
- [ ] consider moving plugin-level toggle to a viewer-level choice in plot options (placed alongside stretch options)
- [ ] update stretch histogram to follow the same toggle (only show histogram of data in current slice when enabled)
- [ ] handle manually setting vmin/vmax vs setting percentile.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
