### PR TITLE
Imviz+Roman updates for latest example Roman data

### DIFF
--- a/notebooks/concepts/imviz_roman_asdf.ipynb
+++ b/notebooks/concepts/imviz_roman_asdf.ipynb
@@ -70,9 +70,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from astropy.utils.data import get_pkg_data_filename\n",
+    "from astropy.utils.data import download_file\n",
     "\n",
-    "image_model = get_pkg_data_filename('data/roman_wfi_image_model.asdf', package='jdaviz.configs.imviz.tests')"
+    "# # Each of these files is ~1 GB:\n",
+    "image_model1 = download_file('https://stsci.box.com/shared/static/be2nfy4jovdhw1cxru99kdwnfnqxxlgo.asdf', cache=True)\n",
+    "image_model2 = download_file('https://stsci.box.com/shared/static/ktpt4li627kq4mipi3er5yd4qw6hq7ll.asdf', cache=True)"
    ]
   },
   {
@@ -89,7 +91,8 @@
     "\n",
     "with warnings.catch_warnings():\n",
     "    warnings.simplefilter('ignore')  # ErfaWarning\n",
-    "    imviz.load_data(image_model, ext='data')"
+    "    imviz.load_data(image_model1, ext='data', data_label='exposure 1')\n",
+    "    imviz.load_data(image_model2, ext='data', data_label='exposure 2')"
    ]
   },
   {
@@ -107,7 +110,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imviz.show()"
+    "imviz.show('sidecar:split-right', height=1000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52adc3d4-7f44-43aa-af46-6acb390d56e2",
+   "metadata": {},
+   "source": [
+    "We have loaded two sequential exposures with the same pointing. Let's orient both images by their WCS:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8427d4f9-8ea3-4d60-a8b7-3f3f63e3f3e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "orientation = imviz.plugins['Orientation']\n",
+    "\n",
+    "orientation.link_type = 'WCS'"
    ]
   },
   {
@@ -129,16 +152,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "plot_options = imviz.plugins['Plot Options']\n",
+    "\n",
     "for viewer_name in imviz.app.get_viewer_reference_names():\n",
     "    viewer = imviz.app.get_viewer(viewer_name)\n",
-    "\n",
-    "    # set colormap and stretch:\n",
-    "    viewer.stretch = 'log'\n",
-    "    viewer.set_colormap('Viridis')\n",
-    "    viewer.cuts = [1, 1e4]\n",
+    "    plot_options.viewer = viewer_name\n",
     "    \n",
-    "    # set zoom level\n",
-    "    viewer.zoom(1.25)"
+    "    for data in viewer.data():\n",
+    "        plot_options.layer = data.label\n",
+    "        \n",
+    "        # set colormap and stretch for this layer:\n",
+    "        plot_options.stretch_function = 'arcsinh'\n",
+    "        plot_options.image_colormap = 'Viridis'\n",
+    "        plot_options.stretch_vmin = 0\n",
+    "        plot_options.stretch_vmax = 20"
    ]
   },
   {
@@ -192,7 +219,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mask = regions['Subset 1'].to_mask(mode='subpixels')"
+    "wcs = imviz.app.data_collection[-1].coords\n",
+    "mask = regions['Subset 1'].to_pixel(wcs).to_mask(mode='subpixels')"
    ]
   },
   {
@@ -221,6 +249,16 @@
    "metadata": {},
    "source": [
     "You can use Astrowidgets API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2ce00c9-093c-4bc0-8cb7-b7c8fe38ec64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer = imviz.default_viewer"
    ]
   },
   {
@@ -260,8 +298,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "center = regions['Subset 1'].center\n",
-    "data.wcs.pixel_to_world([center.x], [center.y]).to_string('hmsdms')"
+    "center = regions['Subset 1'].center"
    ]
   },
   {
@@ -272,7 +309,7 @@
    "outputs": [],
    "source": [
     "# Center the image on given sky coordinates.\n",
-    "sky = SkyCoord(ra=\"13h11m34.25069521s\", dec=\"-01d21m55.92127995s\")\n",
+    "sky = SkyCoord(ra=79.91038, dec=29.95529, unit=('deg', 'deg'))\n",
     "viewer.center_on(sky)"
    ]
   },
@@ -321,7 +358,7 @@
    "outputs": [],
    "source": [
     "# Set the zoom level directly.\n",
-    "viewer.zoom_level = 1"
+    "viewer.zoom_level = 100"
    ]
   },
   {
@@ -332,7 +369,7 @@
    "outputs": [],
    "source": [
     "# Set the relative zoom based on current zoom level.\n",
-    "viewer.zoom(2)"
+    "viewer.zoom(1.5)"
    ]
   },
   {
@@ -355,6 +392,7 @@
     "image_shape = data.data.shape\n",
     "t_xy = Table({'x': np.random.randint(0, image_shape[1], 20),\n",
     "              'y': np.random.randint(0, image_shape[0], 20)})\n",
+    "\n",
     "viewer.add_markers(t_xy)"
    ]
   },
@@ -364,16 +402,6 @@
    "metadata": {},
    "source": [
     "You could customize marker color, alpha, size, and fill with values that Glue supports."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7c8edb6f-c928-4aee-8e64-73a34ab020d0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "viewer.marker = {'color': 'green', 'alpha': 0.8, 'markersize': 10, 'fill': False}"
    ]
   },
   {
@@ -488,7 +516,7 @@
    "outputs": [],
    "source": [
     "# Show the first image in the second viewer.\n",
-    "imviz.app.add_data_to_viewer(viewer_2_name, \"roman_wfi_image_model[DATA]\")"
+    "imviz.app.add_data_to_viewer(viewer_2_name, \"exposure 1[DATA]\")"
    ]
   },
   {
@@ -518,7 +546,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer_2.center_on((5, 1))"
+    "viewer_2.center_on((1500, 1000))"
    ]
   },
   {
@@ -564,7 +592,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The work to support Roman L2 data products in https://github.com/spacetelescope/jdaviz/pull/1822 used some very simple package data with fake sources to demonstrate that it worked. Those data have been re/moved, and the concept notebook isn't useful without example data.

Since https://github.com/spacetelescope/jdaviz/pull/1822, Roman DMS now maintains "example data" for Roman L2 products on Box. This PR updates the concept notebook with links to the Box data, and updates the notebook to conform with best practices in the latest version of jdaviz.


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4185)
