### PR TITLE
Remove single-pixel tool from Imviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,8 @@ Imviz
 
 - ``imviz.link_data()`` inputs and behaviors are now consistent with the Orientation plugin. [#2179]
 
+- Single-pixel tool is no longer available. To mark a single-pixel area, use Markers plugin. [#2710]
+
 Mosviz
 ^^^^^^
 

--- a/docs/imviz/displayimages.rst
+++ b/docs/imviz/displayimages.rst
@@ -204,31 +204,7 @@ to make subsets visible or invisible, to change their color, and to change their
 Single-Pixel Selection
 ----------------------
 
-This tool allows the user to create a single-pixel spatial region
-in an image viewer. Activate this tool and then left-click to create
-the new region. Click again to move the region to a new location under
-the cursor. Holding down the alt key (Alt key on Windows, Option key
-on Mac) while clicking pixels creates a new region at each point instead
-of moving the previously created region. You can also use the subset
-modes that are explained in the
-:ref:`Spatial Regions <imviz_defining_spatial_regions>`
-section above in the same way you would with the other subset selection
-tools.
-
-When you have multiple images loaded and linked by WCS
-(see :ref:`imviz-orientation`), the region defined is with respect to
-the reference image, which might not be the image you are viewing.
-
-.. warning::
-
-    Region created might not accurately represent area you think you are
-    clicking under the mouse if you click on an image that is zoomed out
-    too much. It is recommended that you zoom in sufficiently to see the
-    individual pixels to use this feature.
-
-.. note::
-
-    Creating too many single-pixel regions may affect performance.
+This tool is no longer available as of Jdaviz v3.9; use :ref:`markers-plugin` plugin instead.
 
 Blinking
 ========

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -26,7 +26,7 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
                     ['jdaviz:boxzoommatch', 'jdaviz:boxzoom'],
                     ['jdaviz:panzoommatch', 'jdaviz:imagepanzoom'],
                     ['bqplot:truecircle', 'bqplot:rectangle', 'bqplot:ellipse',
-                     'bqplot:circannulus', 'jdaviz:singlepixelregion'],
+                     'bqplot:circannulus'],
                     ['jdaviz:blinkonce', 'jdaviz:contrastbias'],
                     ['jdaviz:sidebar_plot', 'jdaviz:sidebar_export', 'jdaviz:sidebar_compass']
                 ]

--- a/jdaviz/configs/imviz/tests/test_tools.py
+++ b/jdaviz/configs/imviz/tests/test_tools.py
@@ -65,43 +65,6 @@ class TestPanZoomTools(BaseImviz_WCS_WCS):
         t_linkedpan.deactivate()
 
 
-# We use a new test class to avoid a dirty state from previous test.
-class TestSinglePixelRegion(BaseImviz_WCS_WCS):
-    def test_singlepixelregion(self):
-        # NOTE: This only works in pixel linking now, not WCS linking.
-
-        t = self.imviz.default_viewer._obj.toolbar.tools['jdaviz:singlepixelregion']
-        t.activate()
-
-        # Create a region while viewing reference data.
-        t.on_mouse_event({'event': 'click', 'altKey': False, 'domain': {'x': 1, 'y': 2}})
-        regions = self.imviz.get_interactive_regions()
-        assert len(regions) == 1
-        reg = regions['Subset 1']
-        assert (isinstance(reg, RectanglePixelRegion) and reg.center.x == 1 and reg.center.y == 2
-                and reg.width == 1 and reg.height == 1)
-
-        # Clicking again will move the region, not creating a new one.
-        t.on_mouse_event({'event': 'click', 'altKey': False, 'domain': {'x': 2, 'y': 3}})
-        regions = self.imviz.get_interactive_regions()
-        assert len(regions) == 1
-        reg = regions['Subset 1']
-        assert (isinstance(reg, RectanglePixelRegion) and reg.center.x == 2 and reg.center.y == 3
-                and reg.width == 1 and reg.height == 1)
-
-        # Create a new region while viewing dithered data.
-        # Region will still be w.r.t. reference data, that is, x and y from domain stay the same.
-        self.imviz.default_viewer.blink_once()
-        t.on_mouse_event({'event': 'click', 'altKey': True, 'domain': {'x': 3, 'y': 4}})
-        regions = self.imviz.get_interactive_regions()
-        assert len(regions) == 2
-        reg = regions['Subset 2']
-        assert (isinstance(reg, RectanglePixelRegion) and reg.center.x == 3 and reg.center.y == 4
-                and reg.width == 1 and reg.height == 1)
-
-        t.deactivate()
-
-
 def test_blink(imviz_helper):
     viewer = imviz_helper.default_viewer._obj
 

--- a/jdaviz/configs/imviz/tests/test_tools.py
+++ b/jdaviz/configs/imviz/tests/test_tools.py
@@ -1,6 +1,5 @@
 import numpy as np
 from numpy.testing import assert_allclose
-from regions import RectanglePixelRegion
 
 from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_WCS
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to remove single-pixel tool from Imviz but it is still available in Cubeviz. Because Cubeviz inherits from the class that Imviz used, I could not remove the class, but should not matter for end-users.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3994)
