### PR TITLE
Context-aware plugin relevancy

### DIFF
--- a/docs/dev/ui_style_guide.rst
+++ b/docs/dev/ui_style_guide.rst
@@ -69,8 +69,13 @@ try to adhere to the following principles:
 
     <template>
       <j-tray-plugin
-        :description="docs_description || 'Plugin description.'"
-        :link="docs_link || 'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#plugin-name'"
+        description='Plugin description.'
+        :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#plugin-name'"
+        :irrelevant_msg="irrelevant_msg"
+        :disabled_msg="disabled_msg"
+        :uses_active_status="uses_active_status"
+        @plugin-ping="plugin_ping($event)"
+        :keep_active.sync="keep_active"
         :popout_button="popout_button">
 
         <v-row>

--- a/docs/dev/ui_style_guide.rst
+++ b/docs/dev/ui_style_guide.rst
@@ -16,6 +16,9 @@ try to adhere to the following principles:
   To enable the "Keep active" check, pass `` :uses_active_status="uses_active_status" @plugin-ping="plugin_ping($event)" :keep_active.sync="keep_active" ``.
   Any changes to style across all plugins should then take place in the
   ``j-tray-plugin`` stylesheet (``jdaviz/components/tray_plugin.vue``).
+* ``disabled_msg`` should be set to replace the UI with a message explaining why the plugin is disabled.
+  ``irrelevant_msg`` should be set to skip the plugin in the UI entirely where the user would not need an explanation (slice plugin not
+  relevant because cube data is not present, for example).
 * Each item should be wrapped in a ``v-row``, but avoid any unnecessary additional wrapping-components
   (``v-card-*``, ``v-container``, etc).
 * Only use ``v-col`` components (within a ``<v-row class="row-no-outside-padding">``) if multiple
@@ -69,8 +72,8 @@ try to adhere to the following principles:
 
     <template>
       <j-tray-plugin
-        description='Plugin description.'
-        :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#plugin-name'"
+        :description="docs_description || 'Plugin description.'"
+        :link="docs_link || 'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#plugin-name'"
         :irrelevant_msg="irrelevant_msg"
         :disabled_msg="disabled_msg"
         :uses_active_status="uses_active_status"

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2523,9 +2523,11 @@ class Application(VuetifyTemplate, HubListener):
                 app=self, plugin_name=tray_item_label, **optional_tray_kwargs
             )
 
+            # NOTE: is_relevant is later updated by observing irrelevant_msg traitlet
             self.state.tray_items.append({
                 'name': name,
                 'label': tray_item_label,
+                'is_relevant': len(tray_item_instance.irrelevant_msg) == 0,
                 'widget': "IPY_MODEL_" + tray_item_instance.model_id
             })
 

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -111,7 +111,7 @@
               ></v-text-field>
               <v-expansion-panels accordion multiple focusable flat tile v-model="state.tray_items_open">
                 <v-expansion-panel v-for="(trayItem, index) in state.tray_items" :key="index">
-                  <div v-if="trayItemVisible(trayItem, state.tray_items_filter)">
+                  <div v-if="trayItem.is_relevant && trayItemVisible(trayItem, state.tray_items_filter)">
                     <v-expansion-panel-header >
                       <j-tooltip :tipid="trayItem.name">
                         {{ trayItem.label == 'Orientation' ? 'Orientation (prev. Links Control)' : trayItem.label }}

--- a/jdaviz/components/tray_plugin.vue
+++ b/jdaviz/components/tray_plugin.vue
@@ -29,14 +29,14 @@
 
 <script>
 module.exports = {
-  props: ['disabled_msg', 'description', 'link', 'popout_button',
+  props: ['irrelevant_msg', 'disabled_msg', 'description', 'link', 'popout_button',
           'uses_active_status', 'keep_active'],
   methods: {
     isDisabled() {
       return this.getDisabledMsg().length > 0
     },
     getDisabledMsg() {
-      return this.disabled_msg || ''
+      return this.irrelevant_msg || this.disabled_msg || ''
     },
     sendPing(recursive) {
       if (!this.$el.isConnected) {

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.vue
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.vue
@@ -1,6 +1,7 @@
 <template>
   <j-tray-plugin
     :description="docs_description || 'Select slice of the cube to show in the image viewers.  The slice can also be changed interactively in the spectrum viewer by activating the slice tool.'"
+    :irrelevant_msg="irrelevant_msg"
     :link="docs_link || 'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#slice'"
     :popout_button="popout_button">
 

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -132,7 +132,7 @@ class ConfigHelper(HubListener):
             dict of plugin objects
         """
         plugins = {item['label']: widget_serialization['from_json'](item['widget'], None).user_api
-                   for item in self.app.state.tray_items}
+                   for item in self.app.state.tray_items if item['is_relevant']}
 
         # handle renamed plugins during deprecation
         if 'Orientation' in plugins:


### PR DESCRIPTION


<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements infrastructure for plugins to determine when they are relevant/irrelevant based on the state of the application as a whole (data, viewers, units, etc).  When a plugin determines itself to be irrelevant, then:
* the plugin itself will _not_ appear in the tray, or will be removed if it already existed
* the plugin user API will no longer be listed in `viz.plugins`
* any existing UI instances (non-tray) of the plugin are replaced with the specified message (in the same way as the disabled message)
* TBD: any existing user API instances currently will continue to function.  Should these instead raise an error or have the message in the repr?
* the plugin will be considered not "active" meaning any live preview and auto-updating logic should be paused, even if UI instances remain open

This is distinct from the existing "disabled" capabilities which only replaces the content with a message, but leaves the plugin in the list of options.  There are cases where that might be less intrusive (change in units, etc), whereas this is designed more for the use-case of a more freeform configuration.  For example: lcviz should only show the slice plugin if there is cube-like data (and this could then allow us to consider merging cubeviz, specviz2d, and specviz down the road).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
