### PR TITLE
TST: Increase Imviz rotation test coverage

### DIFF
--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -296,8 +296,10 @@ class Imviz(ImageConfigHelper):
                 break  # Might have duplicate, just grab first match
 
         if link_type is None:
+            avail_links = [f"({elink.data1.label}, {elink.data2.label})"
+                           for elink in self.app.data_collection.external_links]
             raise ValueError(f'{data_label_1} and {data_label_2} combo not found '
-                             'in data collection external links')
+                             f'in data collection external links: {avail_links}')
 
         return link_type
 

--- a/jdaviz/configs/imviz/tests/test_delete_data.py
+++ b/jdaviz/configs/imviz/tests/test_delete_data.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from astropy.coordinates import Angle
 from astropy.nddata import NDData
 from astropy.tests.helper import assert_quantity_allclose
@@ -75,6 +76,7 @@ class TestDeleteData(BaseImviz_WCS_WCS):
         assert_allclose(subset2.subset_state.roi.ymax, 2)
 
 
+@pytest.mark.xfail(reason="FIXME: JDAT-3958")
 class TestDeleteWCSLayerWithSubset(BaseImviz_WCS_GWCS):
     """Regression test for https://jira.stsci.edu/browse/JDAT-3958"""
     def test_delete_wcs_layer_with_subset(self):

--- a/jdaviz/configs/imviz/tests/test_delete_data.py
+++ b/jdaviz/configs/imviz/tests/test_delete_data.py
@@ -2,7 +2,6 @@ import numpy as np
 from astropy.coordinates import Angle
 from astropy.nddata import NDData
 from astropy.tests.helper import assert_quantity_allclose
-from glue.core.message import DataCollectionDeleteMessage
 from numpy.testing import assert_allclose
 from regions import PixCoord, CirclePixelRegion, RectanglePixelRegion, EllipsePixelRegion
 
@@ -93,10 +92,8 @@ class TestDeleteWCSLayerWithSubset(BaseImviz_WCS_GWCS):
         # Switch back to Default Orientation.
         self.imviz.app._change_reference_data("Default orientation")
 
-        # Delete N-up E-left reference data.
-        self.imviz.app._on_data_deleted(DataCollectionDeleteMessage(
-            data=self.imviz.app.data_collection["North-up, East-left"],
-            sender=self.imviz.app.data_collection))
+        # Delete N-up E-left reference data from GUI.
+        self.imviz.app.vue_data_item_remove({"item_name": "North-up, East-left"})
 
         # Make sure rotated ellipse is still the same as before.
         out_reg_d = self.imviz.app.get_subsets(include_sky_region=True)['Subset 1'][0]['sky_region']

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -131,10 +131,12 @@ class TestNonDefaultOrientation(BaseImviz_WCS_WCS):
         assert self.viewer.state.reference_data.label == "has_wcs_1[SCI,1]"
         assert viewer_2.state.reference_data.label == "has_wcs_1[SCI,1]"
 
-        # FIXME: https://github.com/spacetelescope/jdaviz/issues/2724
+        # FIXME: spacetelescope/jdaviz#2724 (remove AssertionError)
         lc_plugin.link_type = 'WCS'
-        assert self.viewer.state.reference_data.label == "has_wcs_1[SCI,1]"
-        assert viewer_2.state.reference_data.label == "has_wcs_1[SCI,1]"
+        with pytest.raises(AssertionError):
+            assert self.viewer.state.reference_data.label == "Default orientation"
+        with pytest.raises(AssertionError):
+            assert viewer_2.state.reference_data.label == "Default orientation"
 
     def test_custom_orientation(self):
         lc_plugin = self.imviz.plugins['Orientation']

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -1,31 +1,149 @@
 import pytest
-
 from astropy.table import Table
+from numpy.testing import assert_allclose
+
 from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_WCS
 
 
-class TestLinksControl(BaseImviz_WCS_WCS):
-    def test_plugin(self):
-        lc_plugin = self.imviz.app.get_tray_item_from_name('imviz-orientation')
+class TestDefaultOrientation(BaseImviz_WCS_WCS):
+    def test_affine_reset_and_linktype(self):
+        lc_plugin = self.imviz.plugins['Orientation']
 
-        lc_plugin.link_type.selected = 'WCS'
+        lc_plugin.link_type = 'WCS'
         lc_plugin.wcs_use_affine = False
-        lc_plugin.link_type.selected = 'Pixels'
+        assert self.imviz.get_link_type("Default orientation", "has_wcs_2[SCI,1]") == "wcs"
 
-        # wcs_use_affine should revert/default to True
+        # wcs_use_affine should revert/default to True when change back to Pixels.
+        lc_plugin.link_type = 'Pixels'
         assert lc_plugin.wcs_use_affine is True
+        assert self.imviz.get_link_type("has_wcs_1[SCI,1]", "has_wcs_2[SCI,1]") == "pixels"
 
-        # adding markers should disable changing linking from both UI and API
-        assert lc_plugin.need_clear_astrowidget_markers is False
+        assert self.imviz.get_link_type("has_wcs_1[SCI,1]", "has_wcs_1[SCI,1]") == "self"
+
+        with pytest.raises(ValueError, match=".*combo not found"):
+            self.imviz.get_link_type("has_wcs_1[SCI,1]", "foo")
+
+    def test_astrowidgets_markers_disable_relinking(self):
+        lc_plugin = self.imviz.plugins['Orientation']
+        lc_plugin.link_type = 'Pixels'
+
+        # Adding markers should disable changing linking from both UI and API.
+        assert lc_plugin._obj.need_clear_astrowidget_markers is False
         tbl = Table({'x': (0, 0), 'y': (0, 1)})
         self.viewer.add_markers(tbl, marker_name='xy_markers')
 
-        assert lc_plugin.need_clear_astrowidget_markers is True
+        assert lc_plugin._obj.need_clear_astrowidget_markers is True
         with pytest.raises(ValueError, match="cannot change linking"):
-            lc_plugin.link_type.selected = 'WCS'
-        assert lc_plugin.link_type.selected == 'Pixels'
+            lc_plugin.link_type = 'WCS'
+        assert lc_plugin.link_type == 'Pixels'
 
-        lc_plugin.vue_reset_astrowidget_markers()
+        lc_plugin._obj.vue_reset_astrowidget_markers()
 
-        assert lc_plugin.need_clear_astrowidget_markers is False
-        lc_plugin.link_type.selected = 'WCS'
+        assert lc_plugin._obj.need_clear_astrowidget_markers is False
+        lc_plugin.link_type = 'WCS'
+
+    def test_markers_plugin_recompute_positions_pixels_to_wcs(self):
+        lc_plugin = self.imviz.plugins['Orientation']
+        lc_plugin.link_type = 'Pixels'
+
+        # Blink to second image, if we have to.
+        if self.viewer.top_visible_data_label != "has_wcs_2[SCI,1]":
+            self.viewer.blink_once()
+
+        label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
+        mp = self.imviz.plugins['Markers']
+        mp._obj.plugin_opened = True
+
+        # (0, 0) on second image.
+        label_mouseover._viewer_mouse_event(
+            self.viewer, {'event': 'mousemove', 'domain': {'x': 1, 'y': 0}})
+        mp._obj._on_viewer_key_event(self.viewer, {'event': 'keydown', 'key': 'm'})
+
+        # (0, 0) on first image.
+        self.viewer.blink_once()
+        label_mouseover._viewer_mouse_event(
+            self.viewer, {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+        mp._obj._on_viewer_key_event(self.viewer, {'event': 'keydown', 'key': 'm'})
+
+        lc_plugin.link_type = 'WCS'
+
+        # Both marks stay the same in sky, so this means X and Y w.r.t. reference
+        # same on both entries.
+        # 0.25 offset probably introduced by fake WCS layer.
+        assert_allclose(mp._obj.marks["imviz-0"].x, -0.25)
+        assert_allclose(mp._obj.marks["imviz-0"].y, -0.25)
+
+        mp.clear_table()
+        mp._obj.plugin_opened = False
+
+    def test_markers_plugin_recompute_positions_wcs_to_pixels(self):
+        lc_plugin = self.imviz.plugins['Orientation']
+        lc_plugin.link_type = 'WCS'
+
+        # Blink to second image, if we have to.
+        if self.viewer.top_visible_data_label != "has_wcs_2[SCI,1]":
+            self.viewer.blink_once()
+
+        label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
+        mp = self.imviz.plugins['Markers']
+        mp._obj.plugin_opened = True
+
+        # (0, 0) on second image, but linked by WCS.
+        label_mouseover._viewer_mouse_event(
+            self.viewer, {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+        mp._obj._on_viewer_key_event(self.viewer, {'event': 'keydown', 'key': 'm'})
+
+        # (0, 0) on first image.
+        self.viewer.blink_once()
+        label_mouseover._viewer_mouse_event(
+            self.viewer, {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+        mp._obj._on_viewer_key_event(self.viewer, {'event': 'keydown', 'key': 'm'})
+
+        lc_plugin.link_type = 'Pixels'
+
+        # Both marks now get separated, so this means X and Y w.r.t. reference
+        # are different on both entries.
+        # 0.25 offset probably introduced by fake WCS layer.
+        assert_allclose(mp._obj.marks["imviz-0"].x, [1.25, 0.25])
+        assert_allclose(mp._obj.marks["imviz-0"].y, 0.25)
+
+        mp.clear_table()
+        mp._obj.plugin_opened = False
+
+
+class TestNonDefaultOrientation(BaseImviz_WCS_WCS):
+    def test_N_up_multi_viewer(self):
+        lc_plugin = self.imviz.plugins['Orientation']
+        lc_plugin.link_type = 'WCS'
+
+        # Should automatically be applied as reference to first viewer.
+        lc_plugin._obj.create_north_up_east_left(set_on_create=True)
+
+        # This would set a different reference to second viewer.
+        viewer_2 = self.imviz.create_image_viewer()
+        self.imviz.app.add_data_to_viewer("imviz-1", "has_wcs_1[SCI,1]")
+        lc_plugin.viewer = "imviz-1"
+        lc_plugin._obj.create_north_up_east_right(set_on_create=True)
+
+        assert self.viewer.state.reference_data.label == "North-up, East-left"
+        assert viewer_2.state.reference_data.label == "North-up, East-right"
+
+        # Both viewers should revert back to same reference when pixel-linked.
+        lc_plugin.link_type = 'Pixels'
+        assert self.viewer.state.reference_data.label == "has_wcs_1[SCI,1]"
+        assert viewer_2.state.reference_data.label == "has_wcs_1[SCI,1]"
+
+        # FIXME: Brett, this seems wrong. I thought it would go back either
+        # to previous fake WCS layers or Default Orientation, but it is neither.
+        lc_plugin.link_type = 'WCS'
+        assert self.viewer.state.reference_data.label == "has_wcs_1[SCI,1]"
+        assert viewer_2.state.reference_data.label == "has_wcs_1[SCI,1]"
+
+    def test_custom_orientation(self):
+        lc_plugin = self.imviz.plugins['Orientation']
+        lc_plugin.link_type = 'WCS'
+        lc_plugin.viewer = "imviz-0"
+        lc_plugin.rotation_angle = 42  # Triggers auto-label
+        lc_plugin._obj.add_orientation(rotation_angle=None, east_left=True, label=None,
+                                       set_on_create=True, wrt_data=None)
+        assert self.viewer.state.reference_data.label == "CCW 42.00 deg (E-left)"

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -131,8 +131,7 @@ class TestNonDefaultOrientation(BaseImviz_WCS_WCS):
         assert self.viewer.state.reference_data.label == "has_wcs_1[SCI,1]"
         assert viewer_2.state.reference_data.label == "has_wcs_1[SCI,1]"
 
-        # FIXME: Brett, this seems wrong. I thought it would go back either
-        # to previous fake WCS layers or Default Orientation, but it is neither.
+        # FIXME: https://github.com/spacetelescope/jdaviz/issues/2724
         lc_plugin.link_type = 'WCS'
         assert self.viewer.state.reference_data.label == "has_wcs_1[SCI,1]"
         assert viewer_2.state.reference_data.label == "has_wcs_1[SCI,1]"

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -69,9 +69,12 @@ class TestDefaultOrientation(BaseImviz_WCS_WCS):
 
             # Both marks stay the same in sky, so this means X and Y w.r.t. reference
             # same on both entries.
-            # 0.25 offset probably introduced by fake WCS layer.
-            assert_allclose(mp._obj.marks["imviz-0"].x, -0.25)
-            assert_allclose(mp._obj.marks["imviz-0"].y, -0.25)
+            # FIXME: 0.25 offset introduced by fake WCS layer (remove AssertionError).
+            #        https://jira.stsci.edu/browse/JDAT-4256
+            with pytest.raises(AssertionError):
+                assert_allclose(mp._obj.marks["imviz-0"].x, 0)
+            with pytest.raises(AssertionError):
+                assert_allclose(mp._obj.marks["imviz-0"].y, 0)
 
             mp.clear_table()
 
@@ -102,9 +105,12 @@ class TestDefaultOrientation(BaseImviz_WCS_WCS):
 
             # Both marks now get separated, so this means X and Y w.r.t. reference
             # are different on both entries.
-            # 0.25 offset probably introduced by fake WCS layer.
-            assert_allclose(mp._obj.marks["imviz-0"].x, [1.25, 0.25])
-            assert_allclose(mp._obj.marks["imviz-0"].y, 0.25)
+            # FIXME: 0.25 offset introduced by fake WCS layer (remove AssertionError).
+            #        https://jira.stsci.edu/browse/JDAT-4256
+            with pytest.raises(AssertionError):
+                assert_allclose(mp._obj.marks["imviz-0"].x, [1, 0])
+            with pytest.raises(AssertionError):
+                assert_allclose(mp._obj.marks["imviz-0"].y, 0)
 
             mp.clear_table()
 

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -54,7 +54,7 @@ class TestDefaultOrientation(BaseImviz_WCS_WCS):
         mp = self.imviz.plugins['Markers']
 
         with mp.as_active():
-            # (0, 0) on second image.
+            # (1, 0) on second image but same sky coordinates as (0, 0) on first.
             label_mouseover._viewer_mouse_event(
                 self.viewer, {'event': 'mousemove', 'domain': {'x': 1, 'y': 0}})
             mp._obj._on_viewer_key_event(self.viewer, {'event': 'keydown', 'key': 'm'})

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -52,29 +52,28 @@ class TestDefaultOrientation(BaseImviz_WCS_WCS):
 
         label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
         mp = self.imviz.plugins['Markers']
-        mp._obj.plugin_opened = True
 
-        # (0, 0) on second image.
-        label_mouseover._viewer_mouse_event(
-            self.viewer, {'event': 'mousemove', 'domain': {'x': 1, 'y': 0}})
-        mp._obj._on_viewer_key_event(self.viewer, {'event': 'keydown', 'key': 'm'})
+        with mp.as_active():
+            # (0, 0) on second image.
+            label_mouseover._viewer_mouse_event(
+                self.viewer, {'event': 'mousemove', 'domain': {'x': 1, 'y': 0}})
+            mp._obj._on_viewer_key_event(self.viewer, {'event': 'keydown', 'key': 'm'})
 
-        # (0, 0) on first image.
-        self.viewer.blink_once()
-        label_mouseover._viewer_mouse_event(
-            self.viewer, {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
-        mp._obj._on_viewer_key_event(self.viewer, {'event': 'keydown', 'key': 'm'})
+            # (0, 0) on first image.
+            self.viewer.blink_once()
+            label_mouseover._viewer_mouse_event(
+                self.viewer, {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+            mp._obj._on_viewer_key_event(self.viewer, {'event': 'keydown', 'key': 'm'})
 
-        lc_plugin.link_type = 'WCS'
+            lc_plugin.link_type = 'WCS'
 
-        # Both marks stay the same in sky, so this means X and Y w.r.t. reference
-        # same on both entries.
-        # 0.25 offset probably introduced by fake WCS layer.
-        assert_allclose(mp._obj.marks["imviz-0"].x, -0.25)
-        assert_allclose(mp._obj.marks["imviz-0"].y, -0.25)
+            # Both marks stay the same in sky, so this means X and Y w.r.t. reference
+            # same on both entries.
+            # 0.25 offset probably introduced by fake WCS layer.
+            assert_allclose(mp._obj.marks["imviz-0"].x, -0.25)
+            assert_allclose(mp._obj.marks["imviz-0"].y, -0.25)
 
-        mp.clear_table()
-        mp._obj.plugin_opened = False
+            mp.clear_table()
 
     def test_markers_plugin_recompute_positions_wcs_to_pixels(self):
         lc_plugin = self.imviz.plugins['Orientation']
@@ -86,29 +85,28 @@ class TestDefaultOrientation(BaseImviz_WCS_WCS):
 
         label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
         mp = self.imviz.plugins['Markers']
-        mp._obj.plugin_opened = True
 
-        # (0, 0) on second image, but linked by WCS.
-        label_mouseover._viewer_mouse_event(
-            self.viewer, {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
-        mp._obj._on_viewer_key_event(self.viewer, {'event': 'keydown', 'key': 'm'})
+        with mp.as_active():
+            # (0, 0) on second image, but linked by WCS.
+            label_mouseover._viewer_mouse_event(
+                self.viewer, {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+            mp._obj._on_viewer_key_event(self.viewer, {'event': 'keydown', 'key': 'm'})
 
-        # (0, 0) on first image.
-        self.viewer.blink_once()
-        label_mouseover._viewer_mouse_event(
-            self.viewer, {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
-        mp._obj._on_viewer_key_event(self.viewer, {'event': 'keydown', 'key': 'm'})
+            # (0, 0) on first image.
+            self.viewer.blink_once()
+            label_mouseover._viewer_mouse_event(
+                self.viewer, {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
+            mp._obj._on_viewer_key_event(self.viewer, {'event': 'keydown', 'key': 'm'})
 
-        lc_plugin.link_type = 'Pixels'
+            lc_plugin.link_type = 'Pixels'
 
-        # Both marks now get separated, so this means X and Y w.r.t. reference
-        # are different on both entries.
-        # 0.25 offset probably introduced by fake WCS layer.
-        assert_allclose(mp._obj.marks["imviz-0"].x, [1.25, 0.25])
-        assert_allclose(mp._obj.marks["imviz-0"].y, 0.25)
+            # Both marks now get separated, so this means X and Y w.r.t. reference
+            # are different on both entries.
+            # 0.25 offset probably introduced by fake WCS layer.
+            assert_allclose(mp._obj.marks["imviz-0"].x, [1.25, 0.25])
+            assert_allclose(mp._obj.marks["imviz-0"].y, 0.25)
 
-        mp.clear_table()
-        mp._obj.plugin_opened = False
+            mp.clear_table()
 
 
 class TestNonDefaultOrientation(BaseImviz_WCS_WCS):

--- a/jdaviz/configs/imviz/tests/test_wcs_utils.py
+++ b/jdaviz/configs/imviz/tests/test_wcs_utils.py
@@ -10,7 +10,7 @@ from numpy.testing import assert_allclose
 
 from jdaviz.configs.imviz import wcs_utils
 from jdaviz.configs.imviz.helper import base_wcs_layer_label
-from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_GWCS
+from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_GWCS, create_example_gwcs
 
 
 def test_simple_fits_wcs():
@@ -161,3 +161,15 @@ def test_get_rotated_nddata_from_label_no_wcs(imviz_helper):
     imviz_helper.load_data(a, data_label="no_wcs")
     with pytest.raises(ValueError, match=r".*has no WCS for rotation"):
         wcs_utils._get_rotated_nddata_from_label(imviz_helper.app, "no_wcs", 0 * u.deg)
+
+
+def test_compute_scale():
+    # NOTE: compute_scale does not work with FITS WCS.
+    image_gwcs = create_example_gwcs((10, 10))
+    fiducial = [197.8925, -1.36555556] * u.deg
+
+    pixscale = wcs_utils.compute_scale(image_gwcs, fiducial, None)
+    assert_allclose(pixscale, 3.0555555555555554e-05)
+
+    pixscale = wcs_utils.compute_scale(image_gwcs, fiducial, None, pscale_ratio=1e+5)
+    assert_allclose(pixscale, 3.0555555555555554)

--- a/jdaviz/configs/imviz/wcs_utils.py
+++ b/jdaviz/configs/imviz/wcs_utils.py
@@ -564,7 +564,7 @@ def compute_scale(wcs, fiducial, disp_axis, pscale_ratio=1):
     """
     spectral = 'SPECTRAL' in wcs.output_frame.axes_type
 
-    if spectral and disp_axis is None:
+    if spectral and disp_axis is None:  # pragma: no cover
         raise ValueError('If input WCS is spectral, a disp_axis must be given')
 
     crpix = np.array(wcs.invert(*fiducial))
@@ -588,7 +588,7 @@ def compute_scale(wcs, fiducial, disp_axis, pscale_ratio=1):
         xscale *= pscale_ratio
         yscale *= pscale_ratio
 
-    if spectral:
+    if spectral:  # pragma: no cover
         # Assuming scale doesn't change with wavelength
         # Assuming disp_axis is consistent with DataModel.meta.wcsinfo.dispersion.direction
         return yscale if disp_axis == 1 else xscale

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ astropy_header = true
 doctest_plus = "enabled"
 text_file_format = "rst"
 addopts = "--doctest-rst --import-mode=append"
+xfail_strict = true
 filterwarnings = [
     "error",
     "ignore:numpy\\.ufunc size changed:RuntimeWarning",


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is a follow-up of #2179 to increase test coverage and prevent future regressions (within reason).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4084)
