### PR TITLE
Fix direct links in remote tests

### DIFF
--- a/jdaviz/configs/mosviz/tests/test_parsers.py
+++ b/jdaviz/configs/mosviz/tests/test_parsers.py
@@ -180,7 +180,7 @@ def test_nircam_parser(mosviz_helper, tmp_path):
     Tests loading a NIRCam dataset
     '''
 
-    # Download data
+    # Download data (nircam_parser_test_data.zip)
     test_data = 'https://stsci.box.com/shared/static/g3tymg7c1yj67gy0hpfreo80inqdm1ps.zip'
     fn = download_file(test_data, cache=True, timeout=100)
 

--- a/jdaviz/configs/mosviz/tests/test_parsers.py
+++ b/jdaviz/configs/mosviz/tests/test_parsers.py
@@ -89,7 +89,8 @@ def test_nirspec_level2_parser(mosviz_helper, tmp_path):
     Also tests no instrument keyword fallback, and IntraRow linking
     '''
 
-    test_data = 'https://stsci.box.com/shared/static/mytqf082lpbfia7wlwjq6p1h5cggd9h6.zip'
+    # nirspec_level2_test_data.zip
+    test_data = 'https://stsci.box.com/shared/static/4hgfhul8el3ciu3p59aqb1m0dk3b0v8y.zip'
     fn = download_file(test_data, cache=True, timeout=100)
     with ZipFile(fn, 'r') as sample_data_zip:
         sample_data_zip.extractall(tmp_path)
@@ -180,7 +181,7 @@ def test_nircam_parser(mosviz_helper, tmp_path):
     '''
 
     # Download data
-    test_data = 'https://stsci.box.com/shared/static/itk7pav073nubwn58pig002m9796qzpw.zip'
+    test_data = 'https://stsci.box.com/shared/static/g3tymg7c1yj67gy0hpfreo80inqdm1ps.zip'
     fn = download_file(test_data, cache=True, timeout=100)
 
     # Extract to a known, temporary folder
@@ -214,8 +215,8 @@ def test_missing_srctype(mosviz_helper, tmp_path):
 
     '''
 
-    # Download data
-    test_data = 'https://stsci.box.com/shared/static/l2azhcqd3tvzhybdlpx2j2qlutkaro3z.zip'
+    # Download data (niriss_parser_test_data.zip)
+    test_data = 'https://stsci.box.com/shared/static/7ndets0vjjsa97la2hvjvm6xvnu5b594.zip'
     fn = download_file(test_data, cache=True, timeout=30)
 
     # Extract to a known, temporary folder

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -362,7 +362,8 @@ def test_app_links(specviz_helper, spectrum1d):
 
 @pytest.mark.remote_data
 def test_load_spectrum_list_directory(tmpdir, specviz_helper):
-    test_data = 'https://stsci.box.com/shared/static/l2azhcqd3tvzhybdlpx2j2qlutkaro3z.zip'
+    # niriss_parser_test_data.zip
+    test_data = 'https://stsci.box.com/shared/static/7ndets0vjjsa97la2hvjvm6xvnu5b594.zip'
     fn = download_file(test_data, cache=True, timeout=30)
     with ZipFile(fn, 'r') as sample_data_zip:
         sample_data_zip.extractall(tmpdir.strpath)
@@ -387,7 +388,8 @@ def test_load_spectrum_list_directory(tmpdir, specviz_helper):
 
 @pytest.mark.remote_data
 def test_load_spectrum_list_directory_concat(tmpdir, specviz_helper):
-    test_data = 'https://stsci.box.com/shared/static/l2azhcqd3tvzhybdlpx2j2qlutkaro3z.zip'
+    # niriss_parser_test_data.zip
+    test_data = 'https://stsci.box.com/shared/static/7ndets0vjjsa97la2hvjvm6xvnu5b594.zip'
     fn = download_file(test_data, cache=True, timeout=30)
     with ZipFile(fn, 'r') as sample_data_zip:
         sample_data_zip.extractall(tmpdir.strpath)

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -37,7 +37,8 @@ def test_2d_parser_jwst(specviz2d_helper):
 
 @pytest.mark.remote_data
 def test_2d_parser_ext_transpose_file(specviz2d_helper):
-    fn = download_file('https://stsci.box.com/shared/static/e3n30l8vr7hkpnuy7g0t8c5nbl70632b.fits', cache=True)  # noqa
+    # jw01538-o160_s00004_nirspec_f170lp-g235h-s1600a1-sub2048_s2d
+    fn = download_file('https://stsci.box.com/shared/static/l1dmioxuvtzyuq1p7o9wvjq8pph2yqkk.fits', cache=True)  # noqa
 
     specviz2d_helper.load_data(spectrum_2d=fn, ext=2, transpose=True)
 
@@ -47,7 +48,8 @@ def test_2d_parser_ext_transpose_file(specviz2d_helper):
 
 @pytest.mark.remote_data
 def test_2d_parser_ext_transpose_hdulist(specviz2d_helper):
-    fn = download_file('https://stsci.box.com/shared/static/e3n30l8vr7hkpnuy7g0t8c5nbl70632b.fits', cache=True)  # noqa
+    # jw01538-o160_s00004_nirspec_f170lp-g235h-s1600a1-sub2048_s2d
+    fn = download_file('https://stsci.box.com/shared/static/l1dmioxuvtzyuq1p7o9wvjq8pph2yqkk.fits', cache=True)  # noqa
     with fits.open(fn) as hdulist:
         specviz2d_helper.load_data(spectrum_2d=hdulist, ext=2, transpose=True)
     dc_0 = specviz2d_helper.app.data_collection[0]


### PR DESCRIPTION
The direct links for the files in mosviz_test_data got changed, updating them so the tests will stop failing. I also noted which files the links point to.