### PR TITLE
fix dark-mode support for section header when used in data-menu

### DIFF
--- a/jdaviz/components/plugin_section_header.vue
+++ b/jdaviz/components/plugin_section_header.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="active ? 'strike strike-active text--secondary': 'strike text--secondary'">
+  <div :class="active ? 'strike strike-active': 'strike'">
      <span>
        <slot></slot>
      </span>
@@ -37,7 +37,7 @@ module.exports = {
     top: 50%;
     width: 9999px;
     height: 1px;
-    background: rgba(0, 0, 0, 0.15);
+    background: gray;
 }
 
 .strike-active > span:before,


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes dark-mode support for the plugin-section-header when used in the viewer's data menu (currently only used for "Orientation")

Before:

<img width="568" alt="Screen Shot 2024-02-23 at 9 25 45 AM" src="https://github.com/spacetelescope/jdaviz/assets/877591/c1f89b04-38c1-416d-bbc8-c2c5403a35b4">

After:
<img width="568" alt="Screen Shot 2024-02-23 at 9 25 34 AM" src="https://github.com/spacetelescope/jdaviz/assets/877591/dd431c07-fe70-4a24-8bbe-2248eb534680">



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
