### PR TITLE
Reverse gist_rainbow colors to match order of manual presets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -124,6 +124,8 @@ Bug Fixes
 
 - Fix redshifted line lists that were displaying at rest wavelengths, by assuming a global redshift. [#2726]
 
+- Order of RGB preset colors now matches for less than and greater than 5 layers. [#2731]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -808,6 +808,7 @@ class PlotOptions(PluginTemplateMixin):
             cmap = matplotlib.colormaps['gist_rainbow'].resampled(n_visible)
             preset_colors = [matplotlib.colors.to_hex(cmap(i), keep_alpha=True) for
                              i in range(n_visible)]
+            preset_colors.reverse()
         elif n_visible >= 2 and n_visible < len(preset_colors):
             preset_colors = [preset_colors[i] for i in preset_inds[n_visible]]
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -806,6 +806,8 @@ class PlotOptions(PluginTemplateMixin):
         # Sample along a colormap if we have too many layers
         if n_visible > len(preset_colors):
             cmap = matplotlib.colormaps['gist_rainbow'].resampled(n_visible)
+            # Have to reverse the order of the cmap to make physical sense with
+            # assumed wavelength order of layers.
             preset_colors = [matplotlib.colors.to_hex(cmap(i), keep_alpha=True) for
                              i in range(n_visible - 1, -1, -1)]
         elif n_visible >= 2 and n_visible < len(preset_colors):

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -807,8 +807,7 @@ class PlotOptions(PluginTemplateMixin):
         if n_visible > len(preset_colors):
             cmap = matplotlib.colormaps['gist_rainbow'].resampled(n_visible)
             preset_colors = [matplotlib.colors.to_hex(cmap(i), keep_alpha=True) for
-                             i in range(n_visible)]
-            preset_colors.reverse()
+                             i in range(n_visible - 1, -1, -1)]
         elif n_visible >= 2 and n_visible < len(preset_colors):
             preset_colors = [preset_colors[i] for i in preset_inds[n_visible]]
 

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -288,8 +288,16 @@ def test_apply_presets(imviz_helper):
     po.apply_RGB_presets()
 
     assert po.layer.selected == "array_3"
+    assert po.stretch_function.value == "arcsinh"
+    po.layer = "array_5"
+    # Make sure this one didn't change
+    assert po.stretch_function.value == "linear"
 
-    colorbar_colors = matplotlib.colormaps['gist_rainbow'].resampled(7)
+    # Turn layer 5 back on
+    po.image_visible = True
+    po.apply_RGB_presets()
+
+    colorbar_colors = matplotlib.colormaps['gist_rainbow'].resampled(8)
     color_ind = 0
 
     def _rgb_to_hex(rgb):
@@ -298,15 +306,11 @@ def test_apply_presets(imviz_helper):
 
     for i in range(8):
         po.layer = f"array_{i}"
-        if i == 5:
-            # Make sure this one didn't change
-            assert po.stretch_function.value == "linear"
-        else:
-            assert po.stretch_function.value == "arcsinh"
-            assert po.stretch_preset.value == 99
-            assert po.image_color.value == matplotlib.colors.to_hex(colorbar_colors(color_ind),
-                                                                    keep_alpha=True)
-            color_ind += 1
+        assert po.stretch_function.value == "arcsinh"
+        assert po.stretch_preset.value == 99
+        assert po.image_color.value == matplotlib.colors.to_hex(colorbar_colors(7-color_ind),
+                                                                keep_alpha=True)
+        color_ind += 1
 
 
 def test_track_mixed_states(imviz_helper):


### PR DESCRIPTION
@camipacifici noticed that the RGB colors at n>5 were reversed compared to at n<=5. This fixes the problem.

Before:

![image](https://github.com/spacetelescope/jdaviz/assets/39831871/b94fe043-226d-474e-a53c-9928df7e5ec4)

After:

<img width="443" alt="Screenshot 2024-02-27 at 11 28 31 AM" src="https://github.com/spacetelescope/jdaviz/assets/39831871/42e495b2-811b-44ac-a084-e1781aa8db61">
