### PR TITLE
cubeviz spectral extraction live-previews

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ Cubeviz
 
 - New aperture photometry plugin that can perform aperture photometry on selected cube slice. [#2666]
 
+- Live previews in spectral extraction plugin. [#2733]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -127,6 +127,7 @@ custom_components = {'j-tooltip': 'components/tooltip.vue',
                      'j-plugin-section-header': 'components/plugin_section_header.vue',
                      'j-number-uncertainty': 'components/number_uncertainty.vue',
                      'j-plugin-popout': 'components/plugin_popout.vue',
+                     'plugin-previews-temp-disabled': 'components/plugin_previews_temp_disabled.vue',  # noqa
                      'plugin-table': 'components/plugin_table.vue',
                      'plugin-dataset-select': 'components/plugin_dataset_select.vue',
                      'plugin-subset-select': 'components/plugin_subset_select.vue',

--- a/jdaviz/components/plugin_previews_temp_disabled.vue
+++ b/jdaviz/components/plugin_previews_temp_disabled.vue
@@ -1,0 +1,25 @@
+<template>
+  <v-alert v-if="previews_temp_disabled && show_live_preview" type='warning' style="margin-left: -12px; margin-right: -12px">
+    Live-updating is temporarily disabled (last update took {{previews_last_time}}s)
+    <v-row justify='center'>
+      <j-tooltip tooltipcontent='hide live preview (can be re-enabled from the settings section in the plugin).' span_style="width: 100%">
+        <v-btn style='width: 100%' @click="() => {$emit('update:show_live_preview', false); $emit('disable_previews')}">
+          disable previews
+        </v-btn>
+      </j-tooltip>
+    </v-row>
+    <v-row justify='center'>
+      <j-tooltip tooltipcontent='manually update live-previews based on current plugin inputs.' span_style="width: 100%">
+        <v-btn style='width: 100%' @click="$emit('update:previews_temp_disabled', false)">
+          update preview
+        </v-btn>
+      </j-tooltip>
+    </v-row>
+  </v-alert>
+</template>
+
+<script>
+module.exports = {
+  props: ['previews_temp_disabled', 'show_live_preview', 'previews_last_time']
+};
+</script>

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -14,6 +14,7 @@ from specutils import Spectrum1D
 
 from jdaviz.core.custom_traitlets import FloatHandleEmpty
 from jdaviz.core.events import SnackbarMessage, SliceValueUpdatedMessage
+from jdaviz.core.marks import SpectralExtractionPreview
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         DatasetSelectMixin,
@@ -21,10 +22,12 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         ApertureSubsetSelectMixin,
                                         ApertureSubsetSelect,
                                         AddResultsMixin,
-                                        with_spinner)
+                                        skip_if_no_updates_since_last_active,
+                                        with_spinner, with_temp_disable)
 from jdaviz.core.user_api import PluginUserApi
 from jdaviz.core.region_translators import regions2aperture
 from jdaviz.configs.cubeviz.plugins.parsers import _return_spectrum_with_correct_units
+from jdaviz.configs.cubeviz.plugins.viewers import CubevizProfileView
 
 
 __all__ = ['SpectralExtraction']
@@ -59,6 +62,7 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
     """
     template_file = __file__, "spectral_extraction.vue"
     uses_active_status = Bool(True).tag(sync=True)
+    show_live_preview = Bool(True).tag(sync=True)
 
     # feature flag for background cone support
     dev_bg_support = Bool(False).tag(sync=True)  # when enabling: add entries to docstring
@@ -455,3 +459,60 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         ):
             label += f' ({self.aperture_selected})'
         self.results_label_default = label
+
+    @property
+    def marks(self):
+        marks = {}
+        for id, viewer in self.app._viewer_store.items():
+            if not isinstance(viewer, CubevizProfileView):
+                continue
+            for mark in viewer.figure.marks:
+                if isinstance(mark, SpectralExtractionPreview):
+                    marks[id] = mark
+                    break
+            else:
+                mark = SpectralExtractionPreview(viewer, visible=self.is_active)
+                viewer.figure.marks = viewer.figure.marks + [mark]
+                marks[id] = mark
+        return marks
+
+    def _clear_marks(self):
+        for mark in self.marks.values():
+            if mark.visible:
+                mark.clear()
+                mark.visible = False
+
+    @observe('is_active', 'show_live_preview')
+    def _toggle_marks(self, event={}):
+        visible = self.show_live_preview and self.is_active
+
+        if not visible:
+            self._clear_marks()
+        elif event.get('name', '') in ('is_active', 'show_live_preview'):
+            # then the marks themselves need to be updated
+            self._live_update(event)
+
+    @observe('aperture_selected', 'function_selected',
+             'wavelength_dependent', 'reference_wavelength',
+             'aperture_method_selected',
+             'previews_temp_disabled')
+    @skip_if_no_updates_since_last_active()
+    @with_temp_disable(timeout=0.3)
+    def _live_update(self, event={}):
+        if not self.show_live_preview or not self.is_active:
+            self._clear_marks()
+            return
+
+        if event.get('name', '') not in ('is_active', 'show_live_preview'):
+            # mark visibility hasn't been handled yet
+            self._toggle_marks()
+
+        try:
+            sp = self.collapse_to_spectrum(add_data=False)
+        except Exception:
+            self._clear_marks()
+            return
+
+        for mark in self.marks.values():
+            mark.update_xy(sp.spectral_axis.value, sp.flux.value)
+            mark.visible = True

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
@@ -8,6 +8,26 @@
     :popout_button="popout_button"
     :disabled_msg="disabled_msg">
 
+    <v-row>
+      <v-expansion-panels popout>
+        <v-expansion-panel>
+          <v-expansion-panel-header v-slot="{ open }">
+            <span style="padding: 6px">Settings</span>
+          </v-expansion-panel-header>
+          <v-expansion-panel-content class="plugin-expansion-panel-content">
+            <v-row>
+              <v-switch
+                v-model="show_live_preview"
+                label="Show live-extraction"
+                hint="Whether to compute/show extraction when making changes to input parameters.  Disable if live-preview becomes laggy."
+                persistent-hint
+              ></v-switch>
+            </v-row>
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </v-row>
+
     <div @mouseover="() => active_step='ap'">
       <j-plugin-section-header :active="active_step==='ap'">Aperture</j-plugin-section-header>
 
@@ -166,7 +186,11 @@
         </span>
       </v-row>
 
-
+      <plugin-previews-temp-disabled
+        :previews_temp_disabled.sync="previews_temp_disabled"
+        :previews_last_time="previews_last_time"
+        :show_live_preview.sync="show_live_preview"
+      />
 
       <plugin-add-results
         :label.sync="results_label"

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -18,7 +18,7 @@ __all__ = ['OffscreenLinesMarks', 'BaseSpectrumVerticalLine', 'SpectralLine',
            'LineAnalysisContinuum', 'LineAnalysisContinuumCenter',
            'LineAnalysisContinuumLeft', 'LineAnalysisContinuumRight',
            'LineUncertainties', 'ScatterMask', 'SelectedSpaxel', 'MarkersMark', 'FootprintOverlay',
-           'ApertureMark']
+           'ApertureMark', 'SpectralExtractionPreview']
 
 accent_color = "#c75d2c"
 
@@ -660,6 +660,11 @@ class FootprintOverlay(PluginLine):
 class ApertureMark(PluginLine):
     def __init__(self, viewer, id, **kwargs):
         self._id = id
+        super().__init__(viewer, **kwargs)
+
+
+class SpectralExtractionPreview(PluginLine):
+    def __init__(self, viewer, **kwargs):
         super().__init__(viewer, **kwargs)
 
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements live-previews for spectral extraction in cubeviz.  Since this may become expensive and to mitigate potential lag, this also migrates the functionality to time expensive live-previews and temporarily disable them from lcviz to here as a decorator which is then used in the implementation of live-previews in cubeviz's spectral extraction.

lcviz can then remove its own implementation to make use of this PR in https://github.com/kecnry/lcviz/pull/3

NOTE: this screen recording was done with the timeout lowered to 0.1 seconds to show how the pausing works.  In the PR, this value is set to 0.3 and usually does not trigger for the default cube.  The "entire cube" does not display any preview because of a known bug where nans in the cube are resulting in a spectrum of entire nans (addressed by #2737).


https://github.com/spacetelescope/jdaviz/assets/877591/3336212b-c317-42dd-a879-45392ca54481




### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
