### PR TITLE
Fix reparenting subsets between rotation orientations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,7 @@ Imviz
 ^^^^^
 
 - There is now option for image rotation in Orientation (was Links Control) plugin.
-  This feature requires WCS linking. [#2179, #2673, #2699]
+  This feature requires WCS linking. [#2179, #2673, #2699, #2734]
 
 - Add "Random" colormap for visualizing image segmentation maps. [#2671]
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1802,6 +1802,8 @@ class Application(VuetifyTemplate, HubListener):
                         old_angle, _, old_flip = get_compass_info(old_parent.coords, (10, 10))[-3:]
                         new_angle, _, new_flip = get_compass_info(new_parent.coords, (10, 10))[-3:]
                         if old_flip != new_flip:
+                            # Note that this won't work for an irregular/assymetric region if we
+                            # ever implement those.
                             relative_angle = 180 - new_angle - old_angle
                         else:
                             relative_angle = new_angle - old_angle

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1831,9 +1831,9 @@ class Application(VuetifyTemplate, HubListener):
                                     new_radius = np.sqrt((x2 - x)**2 + (y2 - y)**2)
                                     setattr(roi, att, new_radius)
 
-                            if hasattr(roi, "angle"):
-                                angle = getattr(roi, "angle")
-                                setattr(roi, "angle", angle + relative_angle)
+                            if hasattr(roi, "theta"):
+                                angle = getattr(roi, "theta")
+                                setattr(roi, "theta", angle - np.deg2rad(relative_angle))
 
                         elif type(roi) is RectangularROI:
                             x_min, y_min = pixel_to_pixel(old_parent.coords, new_parent.coords,

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1798,6 +1798,8 @@ class Application(VuetifyTemplate, HubListener):
                     if (self.config == "imviz" and
                             self._jdaviz_helper.plugins["Orientation"].link_type == "WCS"):
 
+                        # Default shape for WCS-only layers is 10x10, but it doesn't really matter
+                        # since we only need the angles.
                         old_angle, _, old_flip = get_compass_info(old_parent.coords, (10, 10))[-3:]
                         new_angle, _, new_flip = get_compass_info(new_parent.coords, (10, 10))[-3:]
                         if old_flip != new_flip:
@@ -1859,7 +1861,7 @@ class Application(VuetifyTemplate, HubListener):
                                 new_angle = (np.deg2rad(relative_angle) - angle) % 360
                             else:
                                 new_angle = (angle - np.deg2rad(relative_angle)) % 360
-                            setattr(roi, "theta", new_angle)
+                            roi.theta = new_angle
 
                     elif type(subset_group.subset_state) is RangeSubsetState:
                         range_state = subset_group.subset_state

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1,4 +1,3 @@
-import math
 import operator
 import os
 import pathlib
@@ -1799,7 +1798,7 @@ class Application(VuetifyTemplate, HubListener):
                     if (self.config == "imviz" and
                             self._jdaviz_helper.plugins["Orientation"].link_type == "WCS"):
 
-                        old_angle, _,  old_flip = get_compass_info(old_parent.coords, (10, 10))[-3:]
+                        old_angle, _, old_flip = get_compass_info(old_parent.coords, (10, 10))[-3:]
                         new_angle, _, new_flip = get_compass_info(new_parent.coords, (10, 10))[-3:]
                         relative_angle = new_angle - old_angle
                         print(old_angle, new_angle, relative_angle)

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1,3 +1,4 @@
+import math
 import operator
 import os
 import pathlib
@@ -1858,9 +1859,9 @@ class Application(VuetifyTemplate, HubListener):
                         if hasattr(roi, "theta"):
                             angle = getattr(roi, "theta")
                             if old_flip != new_flip:
-                                new_angle = (np.deg2rad(relative_angle) - angle) % 360
+                                new_angle = (np.deg2rad(relative_angle) - angle) % (2 * math.pi)
                             else:
-                                new_angle = (angle - np.deg2rad(relative_angle)) % 360
+                                new_angle = (angle - np.deg2rad(relative_angle)) % (2 * math.pi)
                             roi.theta = new_angle
 
                     elif type(subset_group.subset_state) is RangeSubsetState:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1831,13 +1831,13 @@ class Application(VuetifyTemplate, HubListener):
 
                         elif type(roi) is RectangularROI:
                             x1, y1 = pixel_to_pixel(old_parent.coords, new_parent.coords,
-                                                          roi.xmin, roi.ymin)
+                                                    roi.xmin, roi.ymin)
                             x2, y2 = pixel_to_pixel(old_parent.coords, new_parent.coords,
-                                                          roi.xmin, roi.ymax)
+                                                    roi.xmin, roi.ymax)
                             x3, y3 = pixel_to_pixel(old_parent.coords, new_parent.coords,
-                                                          roi.xmax, roi.ymax)
+                                                    roi.xmax, roi.ymax)
                             x3, y3 = pixel_to_pixel(old_parent.coords, new_parent.coords,
-                                                          roi.xmax, roi.ymin)
+                                                    roi.xmax, roi.ymin)
 
                             # Calculate new width and height from possibly rotated result
                             new_width = np.sqrt((x3-x1)**2 + (y3-y1)**2)
@@ -1855,8 +1855,8 @@ class Application(VuetifyTemplate, HubListener):
 
                         # Account for rotation between orientations
                         if hasattr(roi, "theta"):
-                                angle = getattr(roi, "theta")
-                                setattr(roi, "theta", angle - np.deg2rad(relative_angle))
+                            angle = getattr(roi, "theta")
+                            setattr(roi, "theta", angle - np.deg2rad(relative_angle))
 
                     elif type(subset_group.subset_state) is RangeSubsetState:
                         range_state = subset_group.subset_state

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1993,9 +1993,14 @@ class Application(VuetifyTemplate, HubListener):
 
     def vue_data_item_remove(self, event):
 
+        print(event)
         data_label = event['item_name']
         data = self.data_collection[data_label]
-        self._reparent_subsets(data)
+        if self.config == "imviz":
+            orient = self._jdaviz_helper.plugins["Orientation"].orientation.selected
+            self._reparent_subsets(data, new_parent=orient)
+        else:
+            self._reparent_subsets(data)
 
         # Make sure the data isn't loaded in any viewers
         for viewer_id in self._viewer_store:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1835,8 +1835,6 @@ class Application(VuetifyTemplate, HubListener):
                             x2, y2 = pixel_to_pixel(old_parent.coords, new_parent.coords,
                                                     roi.xmin, roi.ymax)
                             x3, y3 = pixel_to_pixel(old_parent.coords, new_parent.coords,
-                                                    roi.xmax, roi.ymax)
-                            x3, y3 = pixel_to_pixel(old_parent.coords, new_parent.coords,
                                                     roi.xmax, roi.ymin)
 
                             # Calculate new width and height from possibly rotated result

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1,4 +1,3 @@
-import math
 import operator
 import os
 import pathlib
@@ -1857,11 +1856,12 @@ class Application(VuetifyTemplate, HubListener):
 
                         # Account for rotation between orientations
                         if hasattr(roi, "theta"):
-                            angle = getattr(roi, "theta")
+                            angle = roi.theta
                             if old_flip != new_flip:
-                                new_angle = (np.deg2rad(relative_angle) - angle) % (2 * math.pi)
+                                fac = 1.0
                             else:
-                                new_angle = (angle - np.deg2rad(relative_angle)) % (2 * math.pi)
+                                fac = -1.0
+                            new_angle = (fac * (np.deg2rad(relative_angle) - angle)) % (2 * np.pi)
                             roi.theta = new_angle
 
                     elif type(subset_group.subset_state) is RangeSubsetState:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1801,7 +1801,7 @@ class Application(VuetifyTemplate, HubListener):
                         old_angle, _, old_flip = get_compass_info(old_parent.coords, (10, 10))[-3:]
                         new_angle, _, new_flip = get_compass_info(new_parent.coords, (10, 10))[-3:]
                         if old_flip != new_flip:
-                            relative_angle = new_angle + old_angle - 180
+                            relative_angle = 180 - new_angle - old_angle
                         else:
                             relative_angle = new_angle - old_angle
 
@@ -1856,9 +1856,9 @@ class Application(VuetifyTemplate, HubListener):
                         if hasattr(roi, "theta"):
                             angle = getattr(roi, "theta")
                             if old_flip != new_flip:
-                                new_angle = np.deg2rad(relative_angle) - angle
+                                new_angle = (np.deg2rad(relative_angle) - angle) % 360
                             else:
-                                new_angle = angle - np.deg2rad(relative_angle)
+                                new_angle = (angle - np.deg2rad(relative_angle)) % 360
                             setattr(roi, "theta", new_angle)
 
                     elif type(subset_group.subset_state) is RangeSubsetState:

--- a/jdaviz/configs/imviz/tests/test_delete_data.py
+++ b/jdaviz/configs/imviz/tests/test_delete_data.py
@@ -64,6 +64,9 @@ class TestDeleteData(BaseImviz_WCS_WCS):
         # Make sure we re-linked images 2 and 3 (plus WCS-only reference data layer)
         assert len(self.imviz.app.data_collection.external_links) == 2
 
+        # FIXME: 0.25 offset introduced by fake WCS layer, see
+        # https://jira.stsci.edu/browse/JDAT-4256
+
         # Check that the reparenting and coordinate recalculations happened
         assert subset1.subset_state.xatt.parent.label == "Default orientation"
         assert_allclose(subset1.subset_state.center(), (1.75, 1.75))

--- a/jdaviz/configs/imviz/tests/test_delete_data.py
+++ b/jdaviz/configs/imviz/tests/test_delete_data.py
@@ -70,7 +70,7 @@ class TestDeleteData(BaseImviz_WCS_WCS):
 
         assert subset2.subset_state.xatt.parent.label == "Default orientation"
         assert_allclose(subset2.subset_state.roi.xmin, -0.25)
-        assert_allclose(subset2.subset_state.roi.ymin, -0.25, atol=1e-6)
+        assert_allclose(subset2.subset_state.roi.ymin, -0.25)
         assert_allclose(subset2.subset_state.roi.xmax, 1.75)
         assert_allclose(subset2.subset_state.roi.ymax, 1.75)
 

--- a/jdaviz/configs/imviz/tests/test_delete_data.py
+++ b/jdaviz/configs/imviz/tests/test_delete_data.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from astropy.coordinates import Angle
 from astropy.nddata import NDData
 from astropy.tests.helper import assert_quantity_allclose
@@ -66,17 +65,16 @@ class TestDeleteData(BaseImviz_WCS_WCS):
         assert len(self.imviz.app.data_collection.external_links) == 2
 
         # Check that the reparenting and coordinate recalculations happened
-        assert subset1.subset_state.xatt.parent.label == "has_wcs_2[SCI,1]"
-        assert_allclose(subset1.subset_state.center(), (3, 2))
+        assert subset1.subset_state.xatt.parent.label == "Default orientation"
+        assert_allclose(subset1.subset_state.center(), (1.75, 1.75))
 
-        assert subset2.subset_state.xatt.parent.label == "has_wcs_2[SCI,1]"
-        assert_allclose(subset2.subset_state.roi.xmin, 1)
-        assert_allclose(subset2.subset_state.roi.ymin, 0, atol=1e-6)
-        assert_allclose(subset2.subset_state.roi.xmax, 3)
-        assert_allclose(subset2.subset_state.roi.ymax, 2)
+        assert subset2.subset_state.xatt.parent.label == "Default orientation"
+        assert_allclose(subset2.subset_state.roi.xmin, -0.25)
+        assert_allclose(subset2.subset_state.roi.ymin, -0.25, atol=1e-6)
+        assert_allclose(subset2.subset_state.roi.xmax, 1.75)
+        assert_allclose(subset2.subset_state.roi.ymax, 1.75)
 
 
-@pytest.mark.xfail(reason="FIXME: JDAT-3958")
 class TestDeleteWCSLayerWithSubset(BaseImviz_WCS_GWCS):
     """Regression test for https://jira.stsci.edu/browse/JDAT-3958"""
     def test_delete_wcs_layer_with_subset(self):

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -1,8 +1,10 @@
 import pytest
+from astropy import units as u
+from astropy.coordinates import SkyCoord
 from astropy.table import Table
+from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_allclose
-
-from glue.core.roi import EllipticalROI
+from regions import EllipseSkyRegion, RectangleSkyRegion
 
 from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_WCS
 
@@ -155,15 +157,25 @@ class TestNonDefaultOrientation(BaseImviz_WCS_WCS):
                                        set_on_create=True, wrt_data=None)
         assert self.viewer.state.reference_data.label == "CCW 42.00 deg (E-left)"
 
-    def test_delete_orientation_with_subset(self):
+
+class TestDeleteOrientation(BaseImviz_WCS_WCS):
+
+    @pytest.mark.parametrize("klass", [EllipseSkyRegion, RectangleSkyRegion])
+    @pytest.mark.parametrize(
+        ("angle", "sbst_theta"),
+        [(0.5 * u.rad, 2.641593),
+         (-0.5 * u.rad, 3.641589)])
+    def test_delete_orientation_with_subset(self, klass, angle, sbst_theta):
         lc_plugin = self.imviz.plugins['Orientation']
         lc_plugin.link_type = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
         lc_plugin._obj.create_north_up_east_left(set_on_create=True)
 
-        # Create rotated ellipse
-        self.imviz.app.get_viewer("imviz-0").apply_roi(EllipticalROI(3, 5, 1.2, 0.6, 0.5))
+        # Create rotated shape
+        reg = klass(center=SkyCoord(ra=337.51931488, dec=-20.83187472, unit="deg"),
+                    width=2.4 * u.arcsec, height=1.2 * u.arcsec, angle=angle)
+        self.imviz.load_regions(reg)
 
         # Switch to N-up E-right
         lc_plugin._obj.create_north_up_east_right(set_on_create=True)
@@ -172,11 +184,20 @@ class TestNonDefaultOrientation(BaseImviz_WCS_WCS):
 
         # Check that E-right still linked to default
         assert len(self.imviz.app.data_collection.external_links) == 3
-        assert self.imviz.app.data_collection.external_links[2].data1.label == "North-up, East-right"  # noqa
+        assert self.imviz.app.data_collection.external_links[2].data1.label == "North-up, East-right"  # noqa: E501
         assert self.imviz.app.data_collection.external_links[2].data2.label == "Default orientation"
 
-        # Check that the subset got reparented and the angle is correct
+        # Check that the subset got reparented and the angle is correct in the display
         subset_group = self.imviz.app.data_collection.subset_groups[0]
         nuer_data = self.imviz.app.data_collection['North-up, East-right']
         assert subset_group.subset_state.xatt in nuer_data.components
-        assert_allclose(subset_group.subset_state.roi.theta, 2.641593, rtol=1e-5)
+        assert_allclose(subset_group.subset_state.roi.theta, sbst_theta, rtol=1e-5)
+
+        out_reg = self.imviz.app.get_subsets(include_sky_region=True)["Subset 1"][0]["sky_region"]
+        assert_allclose(out_reg.center.ra.deg, reg.center.ra.deg)
+        assert_allclose(out_reg.center.dec.deg, reg.center.dec.deg)
+        assert_quantity_allclose(out_reg.width, reg.width)
+        assert_quantity_allclose(out_reg.height, reg.height)
+        # FIXME: However, sky angle has to stay the same as per regions convention.
+        with pytest.raises(AssertionError, match="Not equal to tolerance"):
+            assert_quantity_allclose(out_reg.angle, reg.angle)


### PR DESCRIPTION
Previously, the subset reparenting didn't properly handle the rotation between two different orientations. This fixes it. I'll add test coverage tomorrow.