### PR TITLE
adjusting links to enable pixel, wavelength linking in specviz2d

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -749,6 +749,40 @@ Specviz
   display label for the y axis in spectral viewer. Previously it was hard coded
   to always display ``flux density`` no matter the input unit. [#2703]
 
+Specviz2d
+^^^^^^^^^
+
+Other Changes and Additions
+---------------------------
+
+3.8.3 (unreleased)
+==================
+
+Bug Fixes
+---------
+
+- Fix redshifted line lists that were displaying at rest wavelengths, by assuming a global redshift. [#2726]
+
+- Order of RGB preset colors now matches for less than and greater than 5 layers. [#2731]
+
+- Fix subset linking/displaying between pixel/wavelength in Specviz2d viewers. [#2736]
+
+Cubeviz
+^^^^^^^
+
+Imviz
+^^^^^
+
+- Histogram in Plot Options no longer stalls for a very large image. [#2735]
+
+Mosviz
+^^^^^^
+
+Specviz
+^^^^^^^
+
+Specviz2d
+^^^^^^^^^
 
 3.8.2 (2024-02-23)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -116,6 +116,8 @@ Specviz
 Specviz2d
 ^^^^^^^^^
 
+- Fix subset linking/displaying between pixel/wavelength in Specviz2d viewers. [#2736]
+
 4.1.1 (2025-01-31)
 ==================
 
@@ -146,8 +148,6 @@ Specviz
 
 Specviz2d
 ^^^^^^^^^
-
-- Fix subset linking/displaying between pixel/wavelength in Specviz2d viewers. [#2736]
 
 4.1 (2024-12-23)
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -751,8 +751,6 @@ Specviz
   display label for the y axis in spectral viewer. Previously it was hard coded
   to always display ``flux density`` no matter the input unit. [#2703]
 
-Specviz2d
-^^^^^^^^^
 
 3.8.2 (2024-02-23)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -147,6 +147,8 @@ Specviz
 Specviz2d
 ^^^^^^^^^
 
+- Fix subset linking/displaying between pixel/wavelength in Specviz2d viewers. [#2736]
+
 4.1 (2024-12-23)
 ================
 
@@ -748,38 +750,6 @@ Specviz
 - Check unit type (e.g., flux density, surface brightness, counts, etc) for generating
   display label for the y axis in spectral viewer. Previously it was hard coded
   to always display ``flux density`` no matter the input unit. [#2703]
-
-Specviz2d
-^^^^^^^^^
-
-Other Changes and Additions
----------------------------
-
-3.8.3 (unreleased)
-==================
-
-Bug Fixes
----------
-
-- Fix redshifted line lists that were displaying at rest wavelengths, by assuming a global redshift. [#2726]
-
-- Order of RGB preset colors now matches for less than and greater than 5 layers. [#2731]
-
-- Fix subset linking/displaying between pixel/wavelength in Specviz2d viewers. [#2736]
-
-Cubeviz
-^^^^^^^
-
-Imviz
-^^^^^
-
-- Histogram in Plot Options no longer stalls for a very large image. [#2735]
-
-Mosviz
-^^^^^^
-
-Specviz
-^^^^^^^
 
 Specviz2d
 ^^^^^^^^^

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -766,8 +766,13 @@ class Application(VuetifyTemplate, HubListener):
                  linked_data.ndim < 3 and  # Cube linking requires special logic. See below
                  ref_data.ndim < 3)
               ):
-            links = [LinkSame(linked_data.components[0], ref_data.components[0]),
-                     LinkSame(linked_data.components[1], ref_data.components[1])]
+            if self.config == 'specviz2d':
+                links = [LinkSameWithUnits(linked_data.components[0], ref_data.components[1]),
+                         LinkSameWithUnits(linked_data.components[1], ref_data.components[3])]
+            else:
+                links = [LinkSame(linked_data.components[0], ref_data.components[0]),
+                         LinkSame(linked_data.components[1], ref_data.components[1])]
+
             dc.add_link(links)
             return
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -767,8 +767,17 @@ class Application(VuetifyTemplate, HubListener):
                  ref_data.ndim < 3)
               ):
             if self.config == 'specviz2d':
-                links = [LinkSameWithUnits(linked_data.components[0], ref_data.components[1]),
-                         LinkSameWithUnits(linked_data.components[1], ref_data.components[3])]
+                links = []
+                if linked_data.ndim == 2:
+                    # extracted image added to data collection
+                    ref_wavelength_component = ref_data.components[1]
+                else:
+                    # extracted spectrum added to data collection
+                    ref_wavelength_component = ref_data.components[3]
+                    links += [LinkSameWithUnits(linked_data.components[0], ref_data.components[1])]
+
+                links += [LinkSameWithUnits(linked_data.components[0], ref_data.components[0]),
+                          LinkSameWithUnits(linked_data.components[1], ref_wavelength_component)]
             else:
                 links = [LinkSame(linked_data.components[0], ref_data.components[0]),
                          LinkSame(linked_data.components[1], ref_data.components[1])]

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -787,6 +787,7 @@ def test_draw2d_linking_specviz2d(specviz2d_helper):
     assert np.allclose(max_value_subset1, expected_max1, atol=tolerance1)
 
 
+'''
 def test_draw1d_linking_specviz2d(specviz2d_helper):
     # custom test data to predict values for different viewers
     header = {
@@ -803,7 +804,7 @@ def test_draw1d_linking_specviz2d(specviz2d_helper):
     y_values = np.linspace(0, 5, 256)
 
     # Create a continuous 2D image
-    data = np.sin(x_values[:, np.newaxis]) * np.cos(y_values) * u.one
+    data = np.sin(x_values[:, np.newaxis]) * np.cos(y_values) * u.Jy
     spectrum_data = Spectrum1D(data, wcs=wcs, meta=header)
 
     specviz2d_helper.load_data(spectrum_2d=spectrum_data)
@@ -814,20 +815,22 @@ def test_draw1d_linking_specviz2d(specviz2d_helper):
 
     # subset drawn in 1d viewer, want data in 2d viewer
     viewer_1d.apply_roi(XRangeROI(.0001, .0002))
-    subset_drawn_1d = viewer_2d.native_marks[-1].image
+    #subset_drawn_1d = viewer_2d.native_marks[-1].image
 
-    subset_highlighted_region2 = np.atleast_1d(np.nonzero(subset_drawn_1d))[1]
+    subset_highlighted_region2 = np.atleast_1d(np.nonzero(subset_drawn_1d))[0]
 
     # Get the start and stop indices
     min_value_subset2 = np.min(subset_highlighted_region2)
     max_value_subset2 = np.max(subset_highlighted_region2)
 
     tolerance2 = 2
-    expected_min2 = 338
-    expected_max2 = 674
+    expected_min2 = 209
+    expected_max2 = 300
 
     assert np.allclose(min_value_subset2, expected_min2, atol=tolerance2)
     assert np.allclose(max_value_subset2, expected_max2, atol=tolerance2)
+
+    '''
 
 
 def test_multi_mask_subset(specviz_helper, spectrum1d):

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -4,7 +4,8 @@ from astropy import units as u
 from astropy.wcs import WCS
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.data import get_pkg_data_filename
-from glue.core.roi import CircularROI, CircularAnnulusROI, EllipticalROI, RectangularROI
+from glue.core.roi import CircularROI, CircularAnnulusROI, EllipticalROI, RectangularROI, XRangeROI
+
 from glue.core.subset_group import GroupedSubset
 from regions import (PixCoord, CirclePixelRegion, CircleSkyRegion, RectanglePixelRegion,
                      EllipsePixelRegion, CircleAnnulusPixelRegion)

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -791,13 +791,14 @@ def test_draw2d_linking_specviz2d(specviz2d_helper):
 def test_draw1d_linking_specviz2d(specviz2d_helper):
     # custom test data to predict values for different viewers
     header = {
-        'WCSAXES': 2,
-        'CRPIX1': 0.0, 'CRPIX2': 8.5,
-        'CDELT1': 1E-06, 'CDELT2': 7.5E-05,
-        'CUNIT1': 'm', 'CUNIT2': 'deg',
-        'CTYPE1': 'WAVE', 'CTYPE2': 'OFFSET',
-        'CRVAL1': 0.0, 'CRVAL2': 5.0,
-        'RADESYS': 'ICRS', 'SPECSYS': 'BARYCENT'}
+            'WCSAXES': 2,
+
+            'CRPIX1': 0.0, 'CRPIX2': 8.5,
+            'CDELT1': 1E-06, 'CDELT2': 7.5E-05,
+            'CUNIT1': 'm', 'CUNIT2': 'deg',
+            'CTYPE1': 'WAVE', 'CTYPE2': 'OFFSET',
+            'CRVAL1': 0.0, 'CRVAL2': 5.0,
+            'RADESYS': 'ICRS', 'SPECSYS': 'BARYCENT'}
     wcs = WCS(header)
 
     x_values = np.linspace(0, 10, 128)
@@ -808,16 +809,23 @@ def test_draw1d_linking_specviz2d(specviz2d_helper):
     spectrum_data = Spectrum1D(data, wcs=wcs, meta=header)
 
     specviz2d_helper.load_data(spectrum_2d=spectrum_data)
+    se = specviz2d_helper.plugins['Spectral Extraction']
+    se.export_extract()
+
     viewer_1d = specviz2d_helper.app.get_viewer(
         specviz2d_helper._default_spectrum_viewer_reference_name)
     viewer_2d = specviz2d_helper.app.get_viewer(
         specviz2d_helper._default_spectrum_2d_viewer_reference_name)
 
     # subset drawn in 1d viewer, want data in 2d viewer
-    viewer_1d.apply_roi(XRangeROI(.0001, .0002))
-    #subset_drawn_1d = viewer_2d.native_marks[-1].image
+    spec_reg = SpectralRegion(0. * u.m, 10000000 * u.m)
+    spec_reg = SpectralRegion(0.0001 * u.m, .0002 * u.m)
+    st = specviz2d_helper.plugins['Subset Tools']
+    st.import_region(spec_reg)
 
-    subset_highlighted_region2 = np.atleast_1d(np.nonzero(subset_drawn_1d))[0]
+    subset_drawn_1d = viewer_2d.native_marks[-1]
+
+    subset_highlighted_region2 = np.atleast_1d(np.nonzero(subset_drawn_1d))[1]
 
     # Get the start and stop indices
     min_value_subset2 = np.min(subset_highlighted_region2)
@@ -829,8 +837,7 @@ def test_draw1d_linking_specviz2d(specviz2d_helper):
 
     assert np.allclose(min_value_subset2, expected_min2, atol=tolerance2)
     assert np.allclose(max_value_subset2, expected_max2, atol=tolerance2)
-
-    '''
+'''
 
 
 def test_multi_mask_subset(specviz_helper, spectrum1d):

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -740,6 +740,76 @@ def test_only_overlapping_in_specviz2d(specviz2d_helper, mos_spectrum2d):
     assert reg[1].lower.value == 7600 and reg[1].upper.value == 7800
 
 
+def test_subset_linking_specviz2d(specviz2d_helper, mos_spectrum2d):
+    specviz2d_helper.load_data(spectrum_2d=mos_spectrum2d)
+    viewer_1d = specviz2d_helper.app.get_viewer(
+        specviz2d_helper._default_spectrum_viewer_reference_name)
+    viewer_2d = specviz2d_helper.app.get_viewer(
+        specviz2d_helper._default_spectrum_2d_viewer_reference_name)
+
+    print(np.min(mos_spectrum2d.data))
+    print(np.max(mos_spectrum2d.data))
+
+    # appear to be in meters
+    viewer_2d.apply_roi(XRangeROI(6400, 6800))
+
+    # reg1 = specviz2d_helper.app.get_subsets("Subset 1")
+    # print(reg1)
+
+    # subset drawn in 2d viewer, want data in the 1d viewer
+    subset_drawn_2d = viewer_1d.native_marks[-1]
+
+    # get x and y components to compute subset mask
+    y1 = subset_drawn_2d.y
+    x1 = subset_drawn_2d.x
+
+    # print(len(y1))
+    # print(len(x1))
+
+    sub_highlighted1 = x1[np.isfinite(y1)]
+    min_sub1 = np.min(sub_highlighted1)
+    max_sub1 = np.max(sub_highlighted1)
+
+    # print(min_sub1)
+    # print(max_sub1)
+
+    '''
+    Need to update asserts with pixel to wavelength science case
+    '''
+
+    assert min_sub1 == 1
+    assert max_sub1 == 1
+
+    # appear to be in meters
+    viewer_1d.apply_roi(XRangeROI(6000, 6400))
+
+    # reg2 = specviz2d_helper.app.get_subsets("Subset 1")
+
+    # subset drawn in 1d viewer, want data in 2d viewer
+    subset_drawn_1d = viewer_1d.native_marks[-1]
+
+    # get x and y components to compute subset mask
+    y2 = subset_drawn_1d.y
+    x2 = subset_drawn_1d.x
+
+    sub_highlighted2 = x2[np.isfinite(y2)]
+    min_sub2 = np.min(sub_highlighted2)
+    max_sub2 = np.max(sub_highlighted2)
+
+    # print(len(y2))
+    # print(len(x2))
+
+    # reg2 = specviz2d_helper.app.get_subsets("Subset 1")
+    # print(reg2)
+
+    '''
+    Need to update asserts with wavelength to pixel science case
+    '''
+
+    assert min_sub2 == 1
+    assert max_sub2 == 1
+
+
 def test_multi_mask_subset(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d)
     subset_plugin = specviz_helper.plugins['Subset Tools']._obj

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -786,58 +786,23 @@ def test_draw2d_linking_specviz2d(specviz2d_helper):
     assert np.allclose(min_value_subset1, expected_min1, atol=tolerance1)
     assert np.allclose(max_value_subset1, expected_max1, atol=tolerance1)
 
-
-'''
-def test_draw1d_linking_specviz2d(specviz2d_helper):
-    # custom test data to predict values for different viewers
-    header = {
-            'WCSAXES': 2,
-
-            'CRPIX1': 0.0, 'CRPIX2': 8.5,
-            'CDELT1': 1E-06, 'CDELT2': 7.5E-05,
-            'CUNIT1': 'm', 'CUNIT2': 'deg',
-            'CTYPE1': 'WAVE', 'CTYPE2': 'OFFSET',
-            'CRVAL1': 0.0, 'CRVAL2': 5.0,
-            'RADESYS': 'ICRS', 'SPECSYS': 'BARYCENT'}
-    wcs = WCS(header)
-
-    x_values = np.linspace(0, 10, 128)
-    y_values = np.linspace(0, 5, 256)
-
-    # Create a continuous 2D image
-    data = np.sin(x_values[:, np.newaxis]) * np.cos(y_values) * u.Jy
-    spectrum_data = Spectrum1D(data, wcs=wcs, meta=header)
-
-    specviz2d_helper.load_data(spectrum_2d=spectrum_data)
-    se = specviz2d_helper.plugins['Spectral Extraction']
-    se.export_extract()
-
-    viewer_1d = specviz2d_helper.app.get_viewer(
-        specviz2d_helper._default_spectrum_viewer_reference_name)
-    viewer_2d = specviz2d_helper.app.get_viewer(
-        specviz2d_helper._default_spectrum_2d_viewer_reference_name)
-
-    # subset drawn in 1d viewer, want data in 2d viewer
-    spec_reg = SpectralRegion(0. * u.m, 10000000 * u.m)
+    # now create a subset in the spectrum-viewer, and determine if
+    # subset is linked correctly in spectrum2d-viewer
     spec_reg = SpectralRegion(0.0001 * u.m, .0002 * u.m)
     st = specviz2d_helper.plugins['Subset Tools']
     st.import_region(spec_reg)
 
-    subset_drawn_1d = viewer_2d.native_marks[-1]
+    mask = viewer_2d._get_layer('Subset 1')._get_image()
+    x_coords = np.nonzero(mask)[1]
+    min_value_subset2 = x_coords.min()
+    max_value_subset2 = x_coords.max()
 
-    subset_highlighted_region2 = np.atleast_1d(np.nonzero(subset_drawn_1d))[1]
-
-    # Get the start and stop indices
-    min_value_subset2 = np.min(subset_highlighted_region2)
-    max_value_subset2 = np.max(subset_highlighted_region2)
-
-    tolerance2 = 2
-    expected_min2 = 209
-    expected_max2 = 300
+    tolerance2 = 1
+    expected_min2 = 100
+    expected_max2 = 199
 
     assert np.allclose(min_value_subset2, expected_min2, atol=tolerance2)
     assert np.allclose(max_value_subset2, expected_max2, atol=tolerance2)
-'''
 
 
 def test_multi_mask_subset(specviz_helper, spectrum1d):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address subset linking in specviz2d [:cat:](https://jira.stsci.edu/browse/JDAT-3508).

**Description:**
This update updates LinkSame to LinkSameWithUnits, and appropriate components depending on the spectrum dimensionality is handled so subsets load within the bounds of both viewers, irregardless of which they were created in, nor if additional data items are added to the data collection (eg. via Spectral Extraction Plugin). 

These updates should also ensure that unit handling for subsets is occurring. Unit changes can be seen in the plugin.

Note:
- If using `specviz2d.app.get_subsets(use_display_units=True)` needs the use_display_units argument. 
 
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

**Bug Behavior**:

https://github.com/spacetelescope/jdaviz/assets/42986583/84cd834a-6827-460b-adf0-0751f29930af


**Updated Behavior**:

https://github.com/user-attachments/assets/ecc0c45b-b83a-4640-96fb-5fe7fc343564


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
