### PR TITLE
Cubeviz spectral extraction to ignore NaNs by masking them out

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -97,6 +97,8 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Spectral extraction now ignores NaNs. [#2737]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -272,6 +272,9 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         else:
             wcs = spectral_cube.coords.spectral
 
+        # Filter out NaNs (False = good)
+        mask = np.logical_or(mask, np.isnan(flux))
+
         nddata_reshaped = NDDataArray(
             flux, mask=mask, uncertainty=uncertainties, wcs=wcs, meta=nddata.meta
         )

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -356,3 +356,11 @@ def test_cone_aperture_with_frequency_units(cubeviz_helper, spectral_cube_wcs):
 
     with pytest.raises(ValueError, match="Spectral axis unit physical type is"):
         extract_plg.collapse_to_spectrum()
+
+
+def test_allcube_with_nan(cubeviz_helper, image_cube_hdu_obj):
+    image_cube_hdu_obj[1].data[:, :2, :2] = np.nan
+    cubeviz_helper.load_data(image_cube_hdu_obj, data_label="with_nan")
+    extract_plg = cubeviz_helper.plugins['Spectral Extraction']
+    sp = extract_plg.collapse_to_spectrum()  # Default settings
+    assert_allclose(sp.flux.value, 1)

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -358,9 +358,14 @@ def test_cone_aperture_with_frequency_units(cubeviz_helper, spectral_cube_wcs):
         extract_plg.collapse_to_spectrum()
 
 
-def test_allcube_with_nan(cubeviz_helper, image_cube_hdu_obj):
+def test_cube_extraction_with_nan(cubeviz_helper, image_cube_hdu_obj):
     image_cube_hdu_obj[1].data[:, :2, :2] = np.nan
     cubeviz_helper.load_data(image_cube_hdu_obj, data_label="with_nan")
     extract_plg = cubeviz_helper.plugins['Spectral Extraction']
-    sp = extract_plg.collapse_to_spectrum()  # Default settings
-    assert_allclose(sp.flux.value, 1)
+    sp = extract_plg.collapse_to_spectrum()  # Default settings (sum)
+    assert_allclose(sp.flux.value, 96)  # (10 x 10) - 4
+
+    cubeviz_helper.load_regions(RectanglePixelRegion(PixCoord(1.5, 1.5), width=4, height=4))
+    extract_plg.aperture = 'Subset 1'
+    sp_subset = extract_plg.collapse_to_spectrum()  # Default settings but on Subset
+    assert_allclose(sp_subset.flux.value, 12)  # (4 x 4) - 4


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address problem of extracted spectrum being NaN when cube has NaN.

I cannot find option to do this upstream in `astropy.nddata`. Example code upstream: https://github.com/astropy/astropy/blob/47a8dac8f1dab6ce592be6048f70140adead4e1d/astropy/nddata/mixins/ndarithmetic.py#L633-L634

This is also a problem in v3.8.x but direct backport is probably tough with the recent refactoring. If you really want to backport, please change the milestone and set backport label.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱 ](https://jira.stsci.edu/browse/JDAT-4275)
