### PR TITLE
Export plugin: table support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ New Features
 
 - "Export Plot" plugin is now replaced with the more general "Export" plugin. [#2722]
 
+- "Export" plugin supports exporting plugin tables. [#2755]
+
 Cubeviz
 ^^^^^^^
 

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -405,4 +405,7 @@ Due to browser limitations, Canvas Rotation is only available on Chromium-based 
 Export
 ======
 
-This plugin allows exporting the plot in a given viewer to a PNG or SVG file.
+This plugin allows exporting:
+
+* the plot in a given viewer to a PNG or SVG file,
+* a table in a plugin to ecsv

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -56,6 +56,9 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     viewer_format_items = List().tag(sync=True)
     viewer_format_selected = Unicode().tag(sync=True)
 
+    table_format_items = List().tag(sync=True)
+    table_format_selected = Unicode().tag(sync=True)
+
     filename = Unicode().tag(sync=True)
 
     # For Cubeviz movie.
@@ -89,6 +92,14 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                                                    selected='viewer_format_selected',
                                                    manual_options=viewer_format_options)
 
+        # NOTE: see self.table.selected_obj.write.list_formats() for full list of options,
+        # although not all support passing overwrite
+        table_format_options = ['ecsv', 'csv', 'fits']
+        self.table_format = SelectPluginComponent(self,
+                                                  items='table_format_items',
+                                                  selected='table_format_selected',
+                                                  manual_options=table_format_options)
+
         # default selection:
         self.dataset._default_mode = 'empty'
         self.table._default_mode = 'empty'
@@ -104,7 +115,9 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         # TODO: backwards compat for save_figure, save_movie,
         # i_start, i_end, movie_fps, movie_filename
         # TODO: expose export method once API is finalized
-        expose = ['viewer', 'viewer_format', 'table', 'filename', 'export']
+        expose = ['viewer', 'viewer_format',
+                  'table', 'table_format',
+                  'filename', 'export']
 
         if self.dev_dataset_support:
             expose += ['dataset']
@@ -188,8 +201,9 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             else:
                 self.save_figure(viewer, filename, filetype, show_dialog=show_dialog)
         elif len(self.table.selected):
-            if "." not in filename:
-                filename += ".ecsv"
+            filetype = self.table_format.selected
+            if not filename.endswith(filetype):
+                filename += f".{filetype}"
             self.table.selected_obj.export_table(filename, overwrite=True)
         else:
             raise ValueError("nothing selected for export")

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -188,18 +188,23 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             else:
                 self.save_figure(viewer, filename, filetype, show_dialog=show_dialog)
         elif len(self.table.selected):
-            if not filename.endswith("csv"):
-                filename += ".csv"
-            self.table.selected_obj.export_table(filename)
+            if "." not in filename:
+                filename += ".ecsv"
+            self.table.selected_obj.export_table(filename, overwrite=True)
         else:
             raise ValueError("nothing selected for export")
+        return filename
 
     def vue_export_from_ui(self, *args, **kwargs):
         try:
-            self.export(show_dialog=True)
+            filename = self.export(show_dialog=True)
         except Exception as e:
             self.hub.broadcast(SnackbarMessage(
                 f"Export failed with: {e}", sender=self, color="error"))
+        else:
+            if filename is not None:
+                self.hub.broadcast(SnackbarMessage(
+                    f"Exported to {filename}", sender=self, color="success"))
 
     def save_figure(self, viewer, filename=None, filetype="png", show_dialog=False):
         if filetype == "png":

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -7,7 +7,8 @@ from jdaviz.core.custom_traitlets import FloatHandleEmpty, IntHandleEmpty
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin, SelectPluginComponent,
                                         ViewerSelectMixin, DatasetMultiSelectMixin,
-                                        SubsetSelectMixin, MultiselectMixin, with_spinner)
+                                        SubsetSelectMixin, PluginTableSelectMixin,
+                                        MultiselectMixin, with_spinner)
 from jdaviz.core.events import AddDataMessage, SnackbarMessage
 from jdaviz.core.user_api import PluginUserApi
 
@@ -25,7 +26,7 @@ __all__ = ['Export']
 
 @tray_registry('export', label="Export")
 class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
-             DatasetMultiSelectMixin, MultiselectMixin):
+             DatasetMultiSelectMixin, PluginTableSelectMixin, MultiselectMixin):
     """
     See the :ref:`Export Plugin Documentation <imviz-export-plot>` for more details.
 
@@ -37,6 +38,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.close_in_tray`
     * ``viewer`` (:class:`~jdaviz.core.template_mixin.ViewerSelect`)
     * ``viewer_format`` (:class:`~jdaviz.core.template_mixin.SelectPluginComponent`)
+    * ``table`` (:class:`~jdaviz.core.template_mixin.PluginTableSelect`)
     * ``filename``
     * :meth:`export`
     """
@@ -45,12 +47,8 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     # feature flag for cone support
     dev_dataset_support = Bool(False).tag(sync=True)  # when enabling: add entries to docstring
     dev_subset_support = Bool(False).tag(sync=True)  # when enabling: add entries to docstring
-    dev_table_support = Bool(False).tag(sync=True)  # when enabling: add entries to docstring
     dev_plot_support = Bool(False).tag(sync=True)  # when enabling: add entries to docstring
     dev_multi_support = Bool(False).tag(sync=True)  # when enabling: add entries to docstring
-
-    table_items = List().tag(sync=True)
-    table_selected = Any().tag(sync=True)
 
     plot_items = List().tag(sync=True)
     plot_selected = Any().tag(sync=True)
@@ -70,13 +68,6 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        self.table = SelectPluginComponent(self,
-                                           items='table_items',
-                                           selected='table_selected',
-                                           multiselect='multiselect',
-                                           default_mode='empty',
-                                           manual_options=['table-tst1', 'table-tst2'])
 
         self.plot = SelectPluginComponent(self,
                                           items='plot_items',
@@ -100,6 +91,8 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
         # default selection:
         self.dataset._default_mode = 'empty'
+        self.table._default_mode = 'empty'
+        self.table.select_default()
         self.viewer.select_default()
         self.filename = f"{self.app.config}_export"
 
@@ -111,14 +104,12 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         # TODO: backwards compat for save_figure, save_movie,
         # i_start, i_end, movie_fps, movie_filename
         # TODO: expose export method once API is finalized
-        expose = ['viewer', 'viewer_format', 'filename', 'export']
+        expose = ['viewer', 'viewer_format', 'table', 'filename', 'export']
 
         if self.dev_dataset_support:
             expose += ['dataset']
         if self.dev_subset_support:
             expose += ['subset']
-        if self.dev_table_support:
-            expose += ['table']
         if self.dev_plot_support:
             expose += ['plot']
         if self.dev_multi_support:

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -165,32 +165,34 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             raise NotImplementedError("dataset export not yet supported")
         if self.subset.selected is not None and len(self.subset.selected):
             raise NotImplementedError("subset export not yet supported")
-        if self.table.selected is not None and len(self.table.selected):
-            raise NotImplementedError("table export not yet supported")
         if self.plot.selected is not None and len(self.plot.selected):
             raise NotImplementedError("plot export not yet supported")
         if self.multiselect:
             raise NotImplementedError("batch export not yet supported")
 
-        if not len(self.viewer.selected):
-            raise ValueError("no viewers selected to export")
-
-        viewer = self.viewer.selected_obj
         filename = filename if filename is not None else self.filename
-        filetype = self.viewer_format.selected
 
-        # at this point, we can assume only a single figure is selected
-        if len(filename):
-            if not filename.endswith(filetype):
-                filename += f".{filetype}"
-            filename = Path(filename).expanduser()
-        else:
-            filename = None
+        # at this point, we can assume only a single export is selected
+        if len(self.viewer.selected):
+            viewer = self.viewer.selected_obj
+            filetype = self.viewer_format.selected
+            if len(filename):
+                if not filename.endswith(filetype):
+                    filename += f".{filetype}"
+                filename = Path(filename).expanduser()
+            else:
+                filename = None
 
-        if filetype == "mp4":
-            self.save_movie(viewer, filename, filetype)
+            if filetype == "mp4":
+                self.save_movie(viewer, filename, filetype)
+            else:
+                self.save_figure(viewer, filename, filetype, show_dialog=show_dialog)
+        elif len(self.table.selected):
+            if not filename.endswith("csv"):
+                filename += ".csv"
+            self.table.selected_obj.export_table(filename)
         else:
-            self.save_figure(viewer, filename, filetype, show_dialog=show_dialog)
+            raise ValueError("nothing selected for export")
 
     def vue_export_from_ui(self, *args, **kwargs):
         try:

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -109,6 +109,18 @@
         :single_select_allow_blank="true"
       >
       </plugin-inline-select>
+      <v-row v-if="table_selected.length > 0" class="row-min-bottom-padding">
+        <v-select
+          :menu-props="{ left: true }"
+          attach
+          v-model="table_format_selected"
+          :items="table_format_items.map(i => i.label)"
+          label="Format"
+          hint="File format for exporting plugin tables."
+          persistent-hint
+        >
+        </v-select>
+      </v-row>
     </div>
 
     <div v-if="dev_plot_support && plot_items.length > 0">

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -100,7 +100,7 @@
       </plugin-inline-select>
     </div>
 
-    <div v-if="dev_table_support && table_items.length > 0">
+    <div v-if="table_items.length > 0">
       <j-plugin-section-header style="margin-top: 12px">Plugin Tables</j-plugin-section-header>
       <plugin-inline-select
         :items="table_items"
@@ -121,6 +121,8 @@
       >
       </plugin-inline-select>
     </div>
+
+    <j-plugin-section-header style="margin-top: 12px">Export To</j-plugin-section-header>
 
     <v-row>
         <v-text-field

--- a/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
+++ b/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
@@ -29,6 +29,10 @@ def test_markers_cubeviz(cubeviz_helper, spectrum1d_cube):
 
     mp = cubeviz_helper.plugins['Markers']
     mp.keep_active = True
+    exp = cubeviz_helper.plugins['Export']
+
+    # no marks yet, so table does not yet appear in export plugin
+    assert "Markers:table" not in exp.table.choices
 
     # test event in flux viewer
     label_mouseover._viewer_mouse_event(fv,
@@ -125,7 +129,6 @@ def test_markers_cubeviz(cubeviz_helper, spectrum1d_cube):
     assert len(_get_markers_from_viewer(sv).x) == 2
 
     # appears as option in export plugin and exports successfully
-    exp = cubeviz_helper.plugins['Export']
     assert "Markers:table" in exp.table.choices
     exp.table = "Markers:table"
     exp.export()

--- a/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
+++ b/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
@@ -124,6 +124,12 @@ def test_markers_cubeviz(cubeviz_helper, spectrum1d_cube):
     assert len(_get_markers_from_viewer(fv).x) == 1
     assert len(_get_markers_from_viewer(sv).x) == 2
 
+    # appears as option in export plugin and exports successfully
+    exp = cubeviz_helper.plugins['Export']
+    assert "Markers:table" in exp.table.choices
+    exp.table = "Markers:table"
+    exp.export()
+
     # clearing table clears markers
     mp.clear_table()
     assert mp.export_table() is None

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -144,7 +144,7 @@ def test_user_api(cubeviz_helper, spectrum1d_cube):
     po = cubeviz_helper.plugins['Plot Options']
 
     assert po.multiselect is False
-    assert "multiselect" in po.viewer._obj.__repr__()
+    assert "multiselect" in po.viewer.__repr__()
 
     # regression test for https://github.com/spacetelescope/jdaviz/pull/1708
     # user calls to select_default should revert even if current entry is valid

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -144,7 +144,7 @@ def test_user_api(cubeviz_helper, spectrum1d_cube):
     po = cubeviz_helper.plugins['Plot Options']
 
     assert po.multiselect is False
-    assert "multiselect" in po.viewer.__repr__()
+    assert "multiselect" in po.viewer._obj.__repr__()
 
     # regression test for https://github.com/spacetelescope/jdaviz/pull/1708
     # user calls to select_default should revert even if current entry is valid
@@ -177,9 +177,9 @@ def test_user_api(cubeviz_helper, spectrum1d_cube):
     # check a plot option with and without choices
     assert hasattr(po.stretch_preset, 'choices')
     assert len(po.stretch_preset.choices) > 1
-    assert "choices" in po.stretch_preset.__repr__()
+    assert "choices" in po.stretch_preset._obj.__repr__()
     assert not hasattr(po.image_contrast, 'choices')
-    assert "choices" not in po.image_contrast.__repr__()
+    assert "choices" not in po.image_contrast._obj.__repr__()
 
     # try setting with both label and value
     po.stretch_preset = 90

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -164,7 +164,7 @@ def test_user_api(specviz2d_helper):
     pext.bg_sub_add_results = 'override label'
     assert pext.bg_sub_add_results.label == 'override label'
     pext.bg_sub_add_results.label = 'override label 2'
-    assert "override label 2" in pext.bg_sub_add_results.__repr__()
+    assert "override label 2" in pext.bg_sub_add_results._obj.__repr__()
     assert "override label 2" in pext.bg_sub_add_results._obj.auto_label.__repr__()
 
     pext.export_bg_sub(add_data=True)

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -10,7 +10,7 @@ __all__ = ['NewViewerMessage', 'ViewerAddedMessage', 'ViewerRemovedMessage', 'Lo
            'AstrowidgetMarkersChangedMessage', 'MarkersPluginUpdate',
            'CanvasRotationChangedMessage',
            'GlobalDisplayUnitChanged', 'ChangeRefDataMessage',
-           'PluginTableAddedMessage']
+           'PluginTableAddedMessage', 'PluginTableModifiedMessage']
 
 
 class NewViewerMessage(Message):
@@ -424,6 +424,20 @@ class GlobalDisplayUnitChanged(Message):
 
 class PluginTableAddedMessage(Message):
     '''Message generated when a plugin table is initialized'''
+    def __init__(self, sender):
+        super().__init__(sender)
+
+    @property
+    def table(self):
+        return self.sender
+
+    @property
+    def plugin(self):
+        return self.sender._plugin
+
+
+class PluginTableModifiedMessage(Message):
+    '''Message generated when the items in a plugin table are changed'''
     def __init__(self, sender):
         super().__init__(sender)
 

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -9,7 +9,8 @@ __all__ = ['NewViewerMessage', 'ViewerAddedMessage', 'ViewerRemovedMessage', 'Lo
            'TableClickMessage', 'LinkUpdatedMessage', 'ExitBatchLoadMessage',
            'AstrowidgetMarkersChangedMessage', 'MarkersPluginUpdate',
            'CanvasRotationChangedMessage',
-           'GlobalDisplayUnitChanged', 'ChangeRefDataMessage']
+           'GlobalDisplayUnitChanged', 'ChangeRefDataMessage',
+           'PluginTableAddedMessage']
 
 
 class NewViewerMessage(Message):
@@ -419,3 +420,17 @@ class GlobalDisplayUnitChanged(Message):
     @property
     def unit(self):
         return u.Unit(self._unit)
+
+
+class PluginTableAddedMessage(Message):
+    '''Message generated when a plugin table is initialized'''
+    def __init__(self, sender):
+        super().__init__(sender)
+
+    @property
+    def table(self):
+        return self.sender
+
+    @property
+    def plugin(self):
+        return self.sender._plugin

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -147,6 +147,10 @@ class ConfigHelper(HubListener):
         return plugins
 
     @property
+    def plugin_tables(self):
+        return self.app._plugin_tables
+
+    @property
     def viewers(self):
         """
         Access API objects for any viewer.

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -4196,7 +4196,7 @@ class Table(PluginSubcomponent):
         # call that, otherwise call the one defined here
         getattr(self._plugin, 'clear_table', self.clear_table)()
 
-    def export_table(self, filename=None):
+    def export_table(self, filename=None, overwrite=False):
         """
         Export the QTable representation of the table.
 
@@ -4205,9 +4205,11 @@ class Table(PluginSubcomponent):
         filename : str, optional
             If provided, will write to the file, otherwise will just return the QTable
             object.
+        overwrite : bool, optional
+            If ``filename`` already exists, should it be overwritten.
         """
         if filename is not None:
-            self._qtable.write(filename)
+            self._qtable.write(filename, overwrite=overwrite)
         # TODO: default to only showing selected columns?
         return self._qtable
 
@@ -4244,7 +4246,7 @@ class TableMixin(VuetifyTemplate, HubListener):
         # (to also clear markers, etc)
         self.clear_table()
 
-    def export_table(self, filename=None):
+    def export_table(self, filename=None, overwrite=False):
         """
         Export the QTable representation of the table.
 
@@ -4253,8 +4255,10 @@ class TableMixin(VuetifyTemplate, HubListener):
         filename : str, optional
             If provided, will write to the file, otherwise will just return the QTable
             object.
+        overwrite : bool, optional
+            If ``filename`` already exists, should it be overwritten.
         """
-        return self.table.export_table(filename=filename)
+        return self.table.export_table(filename=filename, overwrite=overwrite)
 
 
 class Plot(PluginSubcomponent):

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2369,7 +2369,7 @@ class PluginTableSelect(SelectPluginComponent):
 
     Example template (label and hint are optional)::
 
-      <plugin-table-select
+      <v-select
         :items="table_items"
         :selected.sync="table_selected"
         label="Table"

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -71,6 +71,7 @@ __all__ = ['show_widget', 'TemplateMixin', 'PluginTemplateMixin',
            'DatasetSpectralSubsetValidMixin', 'SpectralContinuumMixin',
            'ViewerSelect', 'ViewerSelectMixin',
            'LayerSelect', 'LayerSelectMixin',
+           'PluginTableSelect', 'PluginTableSelectMixin',
            'NonFiniteUncertaintyMismatchMixin',
            'DatasetSelect', 'DatasetSelectMixin', 'DatasetMultiSelectMixin',
            'FileImportSelectPluginComponent', 'HasFileImportSelect',
@@ -2406,7 +2407,6 @@ class PluginTableSelect(SelectPluginComponent):
                          multiselect=multiselect, filters=filters,
                          default_text=default_text, manual_options=manual_options,
                          default_mode=default_mode)
-        from jdaviz.core.events import PluginTableAddedMessage
         self.hub.subscribe(self, PluginTableAddedMessage, handler=self._on_tables_changed)
         self._on_tables_changed()
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1335,10 +1335,13 @@ class LayerSelect(SelectPluginComponent):
         default_text : str or None
             the text to show for no selection.  If not provided or None, no entry will be provided
             in the dropdown for no selection.
-        manual_options: list
+        manual_options : list
             list of options to provide that are not automatically populated by subsets.  If
             ``default`` text is provided but not in ``manual_options`` it will still be included as
             the first item in the list.
+        default_mode : str, optional
+            What mode to use when making the default selection.  Valid options: first, default_text,
+            empty.
         """
         super().__init__(plugin,
                          items=items,
@@ -1700,6 +1703,9 @@ class SubsetSelect(SelectPluginComponent):
             the first item in the list.
         filters : list
             list of strings (for built-in filters) or callables to filter to only valid options.
+        default_mode : str, optional
+            What mode to use when making the default selection.  Valid options: first, default_text,
+            empty.
         """
         super().__init__(plugin,
                          items=items,
@@ -2402,6 +2408,9 @@ class PluginTableSelect(SelectPluginComponent):
             list of options to provide that are not automatically populated by datasets.  If
             ``default`` text is provided but not in ``manual_options`` it will still be included as
             the first item in the list.
+        default_mode : str, optional
+            What mode to use when making the default selection.  Valid options: first, default_text,
+            empty.
         """
         super().__init__(plugin, items=items, selected=selected,
                          multiselect=multiselect, filters=filters,

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -4196,10 +4196,18 @@ class Table(PluginSubcomponent):
         # call that, otherwise call the one defined here
         getattr(self._plugin, 'clear_table', self.clear_table)()
 
-    def export_table(self):
+    def export_table(self, filename=None):
         """
         Export the QTable representation of the table.
+
+        Parameters
+        ----------
+        filename : str, optional
+            If provided, will write to the file, otherwise will just return the QTable
+            object.
         """
+        if filename is not None:
+            self._qtable.write(filename)
         # TODO: default to only showing selected columns?
         return self._qtable
 
@@ -4236,11 +4244,17 @@ class TableMixin(VuetifyTemplate, HubListener):
         # (to also clear markers, etc)
         self.clear_table()
 
-    def export_table(self):
+    def export_table(self, filename=None):
         """
         Export the QTable representation of the table.
+
+        Parameters
+        ----------
+        filename : str, optional
+            If provided, will write to the file, otherwise will just return the QTable
+            object.
         """
-        return self.table.export_table()
+        return self.table.export_table(filename=filename)
 
 
 class Plot(PluginSubcomponent):

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -3,7 +3,7 @@ import astropy.units as u
 
 __all__ = ['UserApiWrapper', 'PluginUserApi', 'ViewerUserApi']
 
-_internal_attrs = ('_obj', '_expose', '_readonly', '__doc__', '_deprecation_msg')
+_internal_attrs = ('_obj', '_expose', '_items', '_readonly', '__doc__', '_deprecation_msg')
 
 
 class UserApiWrapper:
@@ -23,7 +23,7 @@ class UserApiWrapper:
         return self._expose
 
     def __repr__(self):
-        return self._obj.__repr__()
+        return f'<{self._obj.__class__.__name__} API>'
 
     def __eq__(self, other):
         return self._obj.__eq__(other)
@@ -81,6 +81,13 @@ class UserApiWrapper:
             return
 
         return setattr(self._obj, attr, value)
+
+    def _items(self):
+        for attr in self._expose:
+            try:
+                yield attr, self.__getattr__(attr)
+            except AttributeError:
+                continue
 
 
 class PluginUserApi(UserApiWrapper):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request adds support for exporting plugin tables via the new export plugin.

**Up for discussion**:
- how should these tables be labeled?  Here I have `{plugin_name}:{table_name}` where `table_name` defaults to `table`.  This adds flexibility for multiple tables per-plugin, but does NOT support multiple plugin instances of the same plugin (i.e. creating an independent instance of model fitting after app initialization will not be registered here).  We probably will want to follow the same convention for plugin plots, in that case we _know_ that we have multiple plugin plots in at least the line profile plugin in Imviz.
- are we ready to expose `helper.plugin_tables` or should we keep that private for now?
- do we want a follow-up effort for consistent handling of checking and overwriting an existing filename?

https://github.com/spacetelescope/jdaviz/assets/877591/ce2e63dc-4c9d-45dd-bfcf-6d1b4954234c


TODO before ready for review:
- [x] snackbar for success/failures
- [x] test coverage
- [x] documentation

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
