### PR TITLE
Enable spectral conversion in cubeviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ New Features
 Cubeviz
 ^^^^^^^
 
+- Enable spectral unit conversion in cubeviz. [#2758]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -653,7 +653,7 @@ class Application(VuetifyTemplate, HubListener):
             linked_flux_component = dc[-1].components[-1]
 
             links = [
-                LinkSame(ref_wavelength_component, linked_wavelength_component),
+                LinkSameWithUnits(ref_wavelength_component, linked_wavelength_component),
                 LinkSame(ref_flux_component, linked_flux_component)
             ]
 

--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -23,6 +23,7 @@ tray:
   - g-subset-plugin
   - g-markers
   - cubeviz-slice
+  - g-unit-conversion
   - g-gaussian-smooth
   - g-collapse
   - g-model-fitting

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -96,8 +96,8 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
 
         self.dataset.add_filter('is_cube')
         self.add_results.viewer.filters = ['is_image_viewer']
-        self.session.hub.subscribe(self, GlobalDisplayUnitChanged,
-                                   handler=self._set_data_units)
+        self.hub.subscribe(self, GlobalDisplayUnitChanged,
+                           handler=self._set_data_units)
 
         if self.app.state.settings.get('server_is_remote', False):
             # when the server is remote, saving the file in python would save on the server, not

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -9,7 +9,7 @@ from traitlets import Bool, List, Unicode, observe
 from specutils import manipulation, analysis, Spectrum1D
 
 from jdaviz.core.custom_traitlets import IntHandleEmpty, FloatHandleEmpty
-from jdaviz.core.events import SnackbarMessage
+from jdaviz.core.events import SnackbarMessage, GlobalDisplayUnitChanged
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         DatasetSelectMixin,
@@ -96,6 +96,8 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
 
         self.dataset.add_filter('is_cube')
         self.add_results.viewer.filters = ['is_image_viewer']
+        self.session.hub.subscribe(self, GlobalDisplayUnitChanged,
+                                   handler=self._set_data_units)
 
         if self.app.state.settings.get('server_is_remote', False):
             # when the server is remote, saving the file in python would save on the server, not
@@ -155,12 +157,16 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
         if self.dataset_selected != "":
             # Spectral axis is first in this list
             data = self.app.data_collection[self.dataset_selected]
-            if self.app.data_collection[self.dataset_selected].coords is not None:
+            if (self.spectrum_viewer and hasattr(self.spectrum_viewer.state, 'x_display_unit')
+                    and self.spectrum_viewer.state.x_display_unit is not None):
+                sunit = self.spectrum_viewer.state.x_display_unit
+            elif self.app.data_collection[self.dataset_selected].coords is not None:
                 sunit = data.coords.world_axis_units[0]
-                self.dataset_spectral_unit = sunit
-                unit_dict["Spectral Unit"] = sunit
             else:
-                self.dataset_spectral_unit = ""
+                sunit = ""
+            self.dataset_spectral_unit = sunit
+            unit_dict["Spectral Unit"] = sunit
+
             unit_dict["Flux"] = data.get_component('flux').units
 
         # Update units in selection item dictionary

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -147,7 +147,6 @@ def test_moment_velocity_calculation(cubeviz_helper, spectrum1d_cube):
     uncert_viewer.state._set_axes_aspect_ratio(1)
 
     mm = cubeviz_helper.plugins["Moment Maps"]
-    print(mm._obj.dataset_selected)
     mm._obj.dataset_selected = 'test[FLUX]'
 
     # Test moment 1 in velocity
@@ -169,6 +168,13 @@ def test_moment_velocity_calculation(cubeviz_helper, spectrum1d_cube):
     assert label_mouseover.as_text() == ("Pixel x=00.0 y=00.0 Value -4.14668e+02 km / s",
                                          "World 13h39m59.9731s +27d00m00.3600s (ICRS)",
                                          "204.9998877673 27.0001000000 (deg)")
+
+    # Add test for unit conversion
+    assert mm._obj.output_radio_items[0]['unit_str'] == 'm'
+    uc_plugin = cubeviz_helper.plugins['Unit Conversion']._obj
+    uc_plugin.spectral_unit.selected = 'Angstrom'
+    assert mm._obj.output_radio_items[0]['unit_str'] == 'Angstrom'
+    uc_plugin.spectral_unit.selected = 'm'
 
     # Test moment 2 in velocity
     mm.n_moment = 2

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.py
@@ -122,8 +122,6 @@ class Slice(PluginTemplateMixin):
         for viewer in self.slice_indicator_viewers:
             if str(viewer.state.x_att) not in self.valid_slice_att_names:
                 # avoid setting value to degs, before x_att is changed to wavelength, for example
-                # also clear cache for slice values
-                # viewer._on_global_display_unit_changed()
                 continue
             slice_values = viewer.slice_values
             if len(slice_values):

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.py
@@ -83,6 +83,8 @@ class Slice(PluginTemplateMixin):
                                    handler=self._on_viewer_removed)
         self.hub.subscribe(self, AddDataMessage,
                            handler=self._on_add_data)
+        self.hub.subscribe(self, RemoveDataMessage,
+                           handler=self._on_valid_selection_values_changed)
 
         # connect any pre-existing viewers
         for viewer in self.app._viewer_store.values():
@@ -95,9 +97,6 @@ class Slice(PluginTemplateMixin):
         # so that the current slice number is preserved
         self.session.hub.subscribe(self, GlobalDisplayUnitChanged,
                                    handler=self._on_global_display_unit_changed)
-        self.session.hub.subscribe(self, AddDataMessage,
-                                   handler=self._on_valid_selection_values_changed)
-        self.hub.subscribe(self, RemoveDataMessage, handler=self._on_valid_selection_values_changed)
         self._initialize_location()
 
     def _initialize_location(self, *args):
@@ -124,7 +123,7 @@ class Slice(PluginTemplateMixin):
             if str(viewer.state.x_att) not in self.valid_slice_att_names:
                 # avoid setting value to degs, before x_att is changed to wavelength, for example
                 # also clear cache for slice values
-                viewer._on_global_display_unit_changed()
+                # viewer._on_global_display_unit_changed()
                 continue
             slice_values = viewer.slice_values
             if len(slice_values):
@@ -227,6 +226,7 @@ class Slice(PluginTemplateMixin):
         if isinstance(msg.viewer, WithSliceSelection):
             # instead of just setting viewer.slice_value, we'll make sure the "snapping" logic
             # is updated (if enabled)
+            self._on_valid_selection_values_changed()
             self._on_value_updated({'new': self.value})
 
     def _on_select_slice_message(self, msg):
@@ -251,6 +251,7 @@ class Slice(PluginTemplateMixin):
 
     @cached_property
     def valid_selection_values(self):
+        # all available slice values from cubes (unsorted)
         viewers = self.slice_selection_viewers
         if not len(viewers):
             return np.array([])

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.py
@@ -130,7 +130,7 @@ class Slice(PluginTemplateMixin):
                 return
 
     @property
-    def slice_axis(self):
+    def slice_display_unit_name(self):
         # global display unit "axis" corresponding to the slice axis
         return 'spectral'
 
@@ -233,7 +233,7 @@ class Slice(PluginTemplateMixin):
             self.value = msg.value
 
     def _on_global_display_unit_changed(self, msg):
-        if msg.axis != self.slice_axis:
+        if msg.axis != self.slice_display_unit_name:
             return
         if not self.value_unit:
             self.value_unit = str(msg.unit)

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.py
@@ -236,7 +236,7 @@ class Slice(PluginTemplateMixin):
             return
         prev_unit = u.Unit(self.value_unit)
         self.value_unit = str(msg.unit)
-        self.value = (self.value * prev_unit).to_value(msg.unit)
+        self.value = (self.value * prev_unit).to_value(msg.unit, equivalencies=u.spectral())
 
     @property
     def valid_selection_values(self):

--- a/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
@@ -58,6 +58,16 @@ def test_slice(cubeviz_helper, spectrum1d_cube):
     cubeviz_helper.select_wavelength(4.62360028e-07)
     assert sl.value == slice_values[1]
 
+    # Add test for unit conversion
+    uc_plugin = cubeviz_helper.plugins['Unit Conversion']._obj
+    uc_plugin.spectral_unit.selected = 'Angstrom'
+    assert sl.value_unit == 'Angstrom'
+    cubeviz_helper.select_wavelength(4623.60028)
+    assert sl.value == 4623.600276968349
+
+    # Retrieve updated slice_values
+    slice_values = sl.valid_selection_values_sorted
+
     # Test player buttons API
 
     sl.vue_goto_first()

--- a/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
@@ -30,10 +30,6 @@ def test_slice(cubeviz_helper, spectrum1d_cube):
     slice_values = sl.valid_selection_values_sorted
     assert len(slice_values) == 2
 
-    # TODO: Uncertainty viewer is not set to the correct slice when initialized
-    #  this is a hack to get the test to pass
-    sl.value = slice_values[0]
-    sl.value = slice_values[1]
 
     assert sl.value == slice_values[1]
     assert cubeviz_helper.app.get_viewer("flux-viewer").slice == 1

--- a/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
@@ -30,6 +30,11 @@ def test_slice(cubeviz_helper, spectrum1d_cube):
     slice_values = sl.valid_selection_values_sorted
     assert len(slice_values) == 2
 
+    # TODO: Uncertainty viewer is not set to the correct slice when initialized
+    #  this is a hack to get the test to pass
+    sl.value = slice_values[0]
+    sl.value = slice_values[1]
+
     assert sl.value == slice_values[1]
     assert cubeviz_helper.app.get_viewer("flux-viewer").slice == 1
     assert cubeviz_helper.app.get_viewer("flux-viewer").state.slices[-1] == 1

--- a/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
@@ -30,7 +30,6 @@ def test_slice(cubeviz_helper, spectrum1d_cube):
     slice_values = sl.valid_selection_values_sorted
     assert len(slice_values) == 2
 
-
     assert sl.value == slice_values[1]
     assert cubeviz_helper.app.get_viewer("flux-viewer").slice == 1
     assert cubeviz_helper.app.get_viewer("flux-viewer").state.slices[-1] == 1

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -355,8 +355,7 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         # Retrieve flux cube and create an array to represent the cone mask
         flux_cube = self._app._jdaviz_helper._loaded_flux_cube.get_object(cls=Spectrum1D,
                                                                           statistic=None)
-        # TODO: Replace with code for retrieving display_unit in cubeviz when it is available
-        display_unit = flux_cube.spectral_axis.unit
+        display_unit = astropy.units.Unit(self.app._get_display_unit('spectral'))
 
         # Center is reverse coordinates
         center = (self.aperture.selected_spatial_region.center.y,
@@ -373,7 +372,7 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
                     f'Spectral axis unit physical type is {display_unit.physical_type}, '
                     'must be length for cone aperture')
 
-            fac = flux_cube.spectral_axis.value / self.reference_spectral_value
+            fac = flux_cube.spectral_axis.to_value(display_unit) / self.reference_spectral_value
 
             # TODO: Use flux_cube.spectral_axis.to_value(display_unit) when we have unit conversion.
             if isinstance(aperture, CircularAperture):

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -167,6 +167,10 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         return PluginUserApi(self, expose=expose)
 
     @property
+    def slice_display_unit_name(self):
+        return 'spectral'
+
+    @property
     @deprecated(since="3.9", alternative="aperture")
     def spatial_subset(self):
         return self.user_api.aperture
@@ -355,7 +359,7 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         # Retrieve flux cube and create an array to represent the cone mask
         flux_cube = self._app._jdaviz_helper._loaded_flux_cube.get_object(cls=Spectrum1D,
                                                                           statistic=None)
-        display_unit = astropy.units.Unit(self.app._get_display_unit('spectral'))
+        display_unit = astropy.units.Unit(self.app._get_display_unit(self.slice_display_unit_name))
 
         # Center is reverse coordinates
         center = (self.aperture.selected_spatial_region.center.y,

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -45,7 +45,6 @@ class WithSliceIndicator:
                                                  to_value(display_spectral_units,
                                                           equivalencies=u.spectral()),
                                                  dtype=float))
-                    # return layer.layer.get_component(self.slice_component_label).data
                     return converted_axis
             except (AttributeError, KeyError):
                 # layer either does not have get_component (because its a subset)

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -25,6 +25,10 @@ class WithSliceIndicator:
     def slice_component_label(self):
         return str(self.state.x_att)
 
+    @property
+    def slice_display_unit_name(self):
+        return 'spectral'
+
     @cached_property
     def slice_indicator(self):
         # SliceIndicatorMarks does not yet exist
@@ -36,26 +40,29 @@ class WithSliceIndicator:
     def slice_values(self):
 
         def _get_component(layer):
-            try:
-                # Retrieve display units
-                display_spectral_units = self.jdaviz_app._get_display_unit('spectral')
+            # Retrieve display units
+            slice_display_units = self.jdaviz_app._get_display_unit(
+                self.slice_display_unit_name
+            )
 
+            try:
                 # Retrieve layer data and units
                 data_obj = layer.layer.data.get_component(self.slice_component_label).data
                 data_units = layer.layer.data.get_component(self.slice_component_label).units
-                data_spec_axis = np.asarray(data_obj.data, dtype=float) * u.Unit(data_units)
-
-                # Convert axis if display units are set and are different
-                if display_spectral_units and display_spectral_units != data_units:
-                    return data_spec_axis.to_value(display_spectral_units,
-                                                   equivalencies=u.spectral())
-                else:
-                    return data_spec_axis
             except (AttributeError, KeyError):
                 # layer either does not have get_component (because its a subset)
                 # or slice_component_label is not a component in this layer
                 # either way, return an empty array and skip this layer
                 return np.array([])
+
+            data_spec_axis = np.asarray(data_obj.data, dtype=float) * u.Unit(data_units)
+
+            # Convert axis if display units are set and are different
+            if slice_display_units and slice_display_units != data_units:
+                return data_spec_axis.to_value(slice_display_units,
+                                               equivalencies=u.spectral())
+            else:
+                return data_spec_axis
         try:
             return np.asarray(np.unique(np.concatenate([_get_component(layer) for layer in self.layers])),  # noqa
                               dtype=float)
@@ -81,6 +88,10 @@ class WithSliceSelection:
             raise ValueError("slice plugin must be activated to access slice_component_label")
         return slice_plg._obj.slice_indicator_viewers[0].slice_component_label
 
+    @property
+    def slice_display_unit_name(self):
+        return 'spectral'
+
     @cached_property
     def slice_values(self):
         # TODO: add support for multiple cubes (but then slice selection needs to be more complex)
@@ -89,35 +100,38 @@ class WithSliceSelection:
         # if slice_index is 2, then we want the equivalent of [0, 0, :]
         take_inds = [2, 1, 0]
         take_inds.remove(self.slice_index)
+        converted_axis = np.array([])
         for layer in self.layers:
             world_comp_ids = layer.layer.data.world_component_ids
             if self.slice_index >= len(world_comp_ids):
                 # Case where 2D image is loaded in image viewer
                 continue
-            try:
-                # Retrieve display units
-                display_spectral_units = self.jdaviz_app._get_display_unit('spectral')
 
+            # Retrieve display units
+            slice_display_units = self.jdaviz_app._get_display_unit(
+                self.slice_display_unit_name
+            )
+
+            try:
                 # Retrieve layer data and units using the slice index of the world components ids
                 data_obj = layer.layer.data.get_component(world_comp_ids[self.slice_index]).data
                 data_units = layer.layer.data.get_component(world_comp_ids[self.slice_index]).units
-
-                # Find the spectral axis
-                data_spec_axis = np.asarray(data_obj.take(0, take_inds[0]).take(0, take_inds[1]),  # noqa
-                                            dtype=float)
-                if display_spectral_units and display_spectral_units != data_units:
-                    converted_axis = (data_spec_axis * u.Unit(data_units)).to_value(
-                        display_spectral_units,
-                        equivalencies=u.spectral()
-                    )
-                else:
-                    converted_axis = data_spec_axis
             except (AttributeError, KeyError):
                 continue
+
+            # Find the spectral axis
+            data_spec_axis = np.asarray(data_obj.take(0, take_inds[0]).take(0, take_inds[1]),  # noqa
+                                        dtype=float)
+
+            # Convert to display units if applicable
+            if slice_display_units and slice_display_units != data_units:
+                converted_axis = (data_spec_axis * u.Unit(data_units)).to_value(
+                    slice_display_units,
+                    equivalencies=u.spectral()
+                )
             else:
-                break
-        else:
-            return np.array([])
+                converted_axis = data_spec_axis
+
         return converted_axis
 
     @property

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -222,6 +222,7 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
         return visible_layers[-1]
 
     def _on_global_display_unit_changed(self, msg):
+        # Clear cache of slice values when units change
         if 'slice_values' in self.__dict__:
             del self.__dict__['slice_values']
 
@@ -289,6 +290,7 @@ class CubevizProfileView(SpecvizProfileView, WithSliceIndicator):
         return self.jdaviz_helper._default_flux_viewer_reference_name
 
     def _on_global_display_unit_changed(self, msg=None):
+        # Clear cache of slice values when units change
         if 'slice_values' in self.__dict__:
             del self.__dict__['slice_values']
 

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -106,8 +106,10 @@ class WithSliceSelection:
                 data_spec_axis = np.asarray(data_obj.take(0, take_inds[0]).take(0, take_inds[1]),  # noqa
                                             dtype=float)
                 if display_spectral_units and display_spectral_units != data_units:
-                    converted_axis = (data_spec_axis * u.Unit(data_units)).to_value(display_spectral_units,
-                                                                                    equivalencies=u.spectral())
+                    converted_axis = (data_spec_axis * u.Unit(data_units)).to_value(
+                        display_spectral_units,
+                        equivalencies=u.spectral()
+                    )
                 else:
                     converted_axis = data_spec_axis
             except (AttributeError, KeyError):

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -32,7 +32,7 @@ class WithSliceIndicator:
         self.figure.marks = self.figure.marks + slice_indicator.marks
         return slice_indicator
 
-    @property
+    @cached_property
     def slice_values(self):
 
         def _get_component(layer):
@@ -77,7 +77,7 @@ class WithSliceSelection:
             raise ValueError("slice plugin must be activated to access slice_component_label")
         return slice_plg._obj.slice_indicator_viewers[0].slice_component_label
 
-    @property
+    @cached_property
     def slice_values(self):
         # TODO: make a cached property and invalidate cache on add/remove data
         # TODO: add support for multiple cubes (but then slice selection needs to be more complex)
@@ -192,8 +192,7 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
         return visible_layers[-1]
 
     def _on_global_display_unit_changed(self, msg):
-        # TODO: change slice_values to cached_property and clear cache
-        # del self.slice_values
+        del self.slice_values
         self.slice_values
 
     def _initial_x_axis(self, *args):
@@ -260,8 +259,7 @@ class CubevizProfileView(SpecvizProfileView, WithSliceIndicator):
         return self.jdaviz_helper._default_flux_viewer_reference_name
 
     def _on_global_display_unit_changed(self, msg):
-        # TODO: change slice_values to cached_property and clear cache
-        # del self.slice_values
+        del self.slice_values
         self.slice_values
 
     def _check_if_data_removed(self, msg):

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -315,7 +315,8 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
     def _get_1d_spectrum(self):
         # retrieves the 1d spectrum (accounting for spatial subset for cubeviz, if necessary)
-        return self.dataset.selected_spectrum_for_spatial_subset(self.spatial_subset_selected)  # noqa
+        return self.dataset.selected_spectrum_for_spatial_subset(self.spatial_subset_selected,
+                                                                 use_display_units=True)
 
     @observe("dataset_selected", "spatial_subset_selected")
     def _dataset_selected_changed(self, event=None):
@@ -343,7 +344,6 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         # Replace NaNs from collapsed Spectrum1D in Cubeviz
         # (won't affect calculations because these locations are masked)
         selected_spec.flux[np.isnan(selected_spec.flux)] = 0.0
-
         # TODO: can we simplify this logic?
         self._units["x"] = str(
             selected_spec.spectral_axis.unit)
@@ -508,7 +508,6 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
                                             "value": param_quant.value,
                                             "unit": str(param_quant.unit),
                                             "fixed": False})
-
         self._initialized_models[comp_label] = initialized_model
 
         new_model["Initialized"] = True
@@ -841,7 +840,6 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         models_to_fit = self._reinitialize_with_fixed()
 
         masked_spectrum = self._apply_subset_masks(self._get_1d_spectrum(), self.spectral_subset)
-
         try:
             fitted_model, fitted_spectrum = fit_model_to_spectrum(
                 masked_spectrum,

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -127,18 +127,18 @@ class UnitConversion(PluginTemplateMixin):
 
     @observe('spectral_unit_selected')
     def _on_spectral_unit_changed(self, *args):
-        self.hub.broadcast(GlobalDisplayUnitChanged('spectral',
-                                                    self.spectral_unit.selected,
-                                                    sender=self))
         xunit = _valid_glue_display_unit(self.spectral_unit.selected, self.spectrum_viewer, 'x')
         if self.spectrum_viewer.state.x_display_unit != xunit:
             self.spectrum_viewer.state.x_display_unit = xunit
+            self.hub.broadcast(GlobalDisplayUnitChanged('spectral',
+                                                        self.spectral_unit.selected,
+                                                        sender=self))
 
     @observe('flux_unit_selected')
     def _on_flux_unit_changed(self, *args):
-        self.hub.broadcast(GlobalDisplayUnitChanged('flux',
-                                                    self.flux_unit.selected,
-                                                    sender=self))
         yunit = _valid_glue_display_unit(self.flux_unit.selected, self.spectrum_viewer, 'y')
         if self.spectrum_viewer.state.y_display_unit != yunit:
             self.spectrum_viewer.state.y_display_unit = yunit
+            self.hub.broadcast(GlobalDisplayUnitChanged('flux',
+                                                        self.flux_unit.selected,
+                                                        sender=self))

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -33,7 +33,7 @@
     </v-row>
     <v-row v-if="config === 'cubeviz'">
         <span class="v-messages v-messages__message text--secondary" style="color: red !important">
-          Flux conversion is not yet implemented in cubeviz
+          Flux conversion is not yet implemented in Cubeviz.
         </span>
     </v-row>
   </j-tray-plugin>

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -28,7 +28,13 @@
         label="Flux Unit"
         hint="Global display unit for flux."
         persistent-hint
+        :disabled="config === 'cubeviz'"
       ></v-select>
+    </v-row>
+    <v-row v-if="config === 'cubeviz'">
+        <span class="v-messages v-messages__message text--secondary" style="color: red !important">
+          Flux conversion is not yet implemented in cubeviz
+        </span>
     </v-row>
   </j-tray-plugin>
 </template>

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -494,7 +494,8 @@ class ConfigHelper(HubListener):
                                                                           u.spectral()),
                                       flux=data.flux.to(flux_unit,
                                                         u.spectral_density(data.spectral_axis)),
-                                      uncertainty=new_uncert)
+                                      uncertainty=new_uncert,
+                                      mask=data.mask)
                 else:  # pragma: nocover
                     raise NotImplementedError(f"converting {data.__class__.__name__} to display units is not supported")  # noqa
             return data

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -307,6 +307,12 @@ class SliceIndicatorMarks(BaseSpectrumVerticalLine, HubListener):
     def marks(self):
         return [self, self.label]
 
+    def _on_global_display_unit_changed(self, msg):
+        # Updating the value is handled by the plugin itself, need to update unit string.
+        if msg.axis in ["spectral", "x"]:
+            self.xunit = msg.unit
+        self._update_label()
+
     def _value_handle_oob(self, x=None, update_label=False):
         if x is None:
             x = self.value

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2775,7 +2775,7 @@ class SpectralContinuumMixin(VuetifyTemplate, HubListener):
             if self.app.config != 'cubeviz':
                 raise ValueError("per-pixel only supported for cubeviz")
             full_spectrum = self.app._jdaviz_helper.get_data(self.dataset.selected,
-                                                             use_display_units=False)
+                                                             use_display_units=True)
         else:
             full_spectrum = dataset.selected_spectrum_for_spatial_subset(spatial_subset.selected if spatial_subset is not None else None,  # noqa
                                                                          use_display_units=True)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2774,7 +2774,8 @@ class SpectralContinuumMixin(VuetifyTemplate, HubListener):
         if spatial_subset == 'per-pixel':
             if self.app.config != 'cubeviz':
                 raise ValueError("per-pixel only supported for cubeviz")
-            full_spectrum = self.dataset.selected_obj
+            full_spectrum = self.app._jdaviz_helper.get_data(self.dataset.selected,
+                                                             use_display_units=False)
         else:
             full_spectrum = dataset.selected_spectrum_for_spatial_subset(spatial_subset.selected if spatial_subset is not None else None,  # noqa
                                                                          use_display_units=True)
@@ -2802,8 +2803,8 @@ class SpectralContinuumMixin(VuetifyTemplate, HubListener):
                                       simplify_spectral=True,
                                       use_display_units=True)
             spectrum = extract_region(full_spectrum, sr, return_single_spectrum=True)
-            sr_lower = np.nanmin(spectrum.spectral_axis[spectrum.spectral_axis.value >= sr.lower.value])  # noqa
-            sr_upper = np.nanmax(spectrum.spectral_axis[spectrum.spectral_axis.value <= sr.upper.value])  # noqa
+            sr_lower = np.nanmin(spectrum.spectral_axis[spectrum.spectral_axis >= sr.lower])  # noqa
+            sr_upper = np.nanmax(spectrum.spectral_axis[spectrum.spectral_axis <= sr.upper])  # noqa
 
         if self.continuum_subset_selected == 'None':
             self._update_continuum_marks()
@@ -2861,7 +2862,7 @@ class SpectralContinuumMixin(VuetifyTemplate, HubListener):
             continuum_mask = ~self._specviz_helper.get_data(
                 dataset.selected,
                 spectral_subset=self.continuum_subset_selected,
-                use_display_units=False).mask
+                use_display_units=True).mask
             spectral_axis_nanmasked = spectral_axis.value.copy()
             spectral_axis_nanmasked[~continuum_mask] = np.nan
             if not update_marks:
@@ -2871,8 +2872,8 @@ class SpectralContinuumMixin(VuetifyTemplate, HubListener):
                           'center': spectral_axis.value,
                           'right': []}
             else:
-                mark_x = {'left': spectral_axis_nanmasked[spectral_axis.value < sr_lower.value],
-                          'right': spectral_axis_nanmasked[spectral_axis.value > sr_upper.value]}
+                mark_x = {'left': spectral_axis_nanmasked[spectral_axis < sr_lower],
+                          'right': spectral_axis_nanmasked[spectral_axis > sr_upper]}
                 # Center should extend (at least) across the line region between the full
                 # range defined by the continuum subset(s).
                 # OK for mark_x to be all NaNs.

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2872,8 +2872,8 @@ class SpectralContinuumMixin(VuetifyTemplate, HubListener):
                           'center': spectral_axis.value,
                           'right': []}
             else:
-                mark_x = {'left': spectral_axis_nanmasked[spectral_axis < sr_lower],
-                          'right': spectral_axis_nanmasked[spectral_axis > sr_upper]}
+                mark_x = {'left': spectral_axis_nanmasked[spectral_axis < sr_lower].value,
+                          'right': spectral_axis_nanmasked[spectral_axis > sr_upper].value}
                 # Center should extend (at least) across the line region between the full
                 # range defined by the continuum subset(s).
                 # OK for mark_x to be all NaNs.

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2872,8 +2872,8 @@ class SpectralContinuumMixin(VuetifyTemplate, HubListener):
                           'center': spectral_axis.value,
                           'right': []}
             else:
-                mark_x = {'left': spectral_axis_nanmasked[spectral_axis < sr_lower].value,
-                          'right': spectral_axis_nanmasked[spectral_axis > sr_upper].value}
+                mark_x = {'left': spectral_axis_nanmasked[spectral_axis < sr_lower],
+                          'right': spectral_axis_nanmasked[spectral_axis > sr_upper]}
                 # Center should extend (at least) across the line region between the full
                 # range defined by the continuum subset(s).
                 # OK for mark_x to be all NaNs.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request enables unit conversion in cubeviz only for spectral conversions. The following plugins also need to be updated to account for possible spectral axis unit changes:

- [x] Unit conversion
- [x] Model fitting
- [x] Line analysis
- [x] Moment maps
- [x] Spectral extraction
- [x] Aperture photometry

Potential follow-up efforts:

- [ ] Fix moment map (with continuum equal to anything but `None`) not working with frequency units
- [x] Fix slice indicator disappearing after unit change

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.
- Enable spectral unit conversion in cubeviz and update plugins [2758]

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
