### PR TITLE
Debug orientation operations with multiple viewers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,7 +41,7 @@ Imviz
 ^^^^^
 
 - There is now option for image rotation in Orientation (was Links Control) plugin.
-  This feature requires WCS linking. [#2179, #2673, #2699, #2734]
+  This feature requires WCS linking. [#2179, #2673, #2699, #2734, #2759]
 
 - Add "Random" colormap for visualizing image segmentation maps. [#2671]
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2040,12 +2040,10 @@ class Application(VuetifyTemplate, HubListener):
             self._reparent_subsets(data)
 
         # Make sure the data isn't loaded in any viewers and isn't the selected orientation
-        for viewer_id in self._viewer_store:
+        for viewer_id, viewer in self._viewer_store.items():
             if orientation_plugin is not None:
-                orientation_plugin.viewer.selected = viewer_id
-                orient = orientation_plugin.orientation.selected
-                if orient == data_label:
-                    orientation_plugin.orientation.selected = base_wcs_layer_label
+                if viewer.state.reference_data.label == data_label:
+                    self._change_reference_data(base_wcs_layer_label, viewer_id)
             self.remove_data_from_viewer(viewer_id, data_label)
 
         self.data_collection.remove(self.data_collection[data_label])

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2041,7 +2041,7 @@ class Application(VuetifyTemplate, HubListener):
 
         # Make sure the data isn't loaded in any viewers and isn't the selected orientation
         for viewer_id, viewer in self._viewer_store.items():
-            if orientation_plugin is not None:
+            if orientation_plugin is not None and self._link_type == 'wcs':
                 if viewer.state.reference_data.label == data_label:
                     self._change_reference_data(base_wcs_layer_label, viewer_id)
             self.remove_data_from_viewer(viewer_id, data_label)

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2033,11 +2033,21 @@ class Application(VuetifyTemplate, HubListener):
         if orientation_plugin is not None:
             orient = orientation_plugin.orientation.selected
             self._reparent_subsets(data, new_parent=orient)
+            print(f"Removing item, have {orient} selected")
         else:
             self._reparent_subsets(data)
 
-        # Make sure the data isn't loaded in any viewers
+        # Make sure the data isn't loaded in any viewers and isn't the selected orientation
         for viewer_id in self._viewer_store:
+            print(f"Checking {viewer_id}")
+            if orientation_plugin is not None:
+                orientation_plugin.viewer.selected = viewer_id
+                print(f"Choices are {orientation_plugin.orientation.choices}")
+                orient = orientation_plugin.orientation.selected
+                print(f"{orient} is currently selected, data_label is {data_label}")
+                if orient == data_label:
+                    print(f"Changing selected orientation for {viewer_id}")
+                    orientation_plugin.orientation.selected = "Default orientation"
             self.remove_data_from_viewer(viewer_id, data_label)
 
         self.data_collection.remove(self.data_collection[data_label])

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -507,11 +507,9 @@ class Application(VuetifyTemplate, HubListener):
             return
 
         if viewer_id is None:
-            print("Viewer ID is None")
             viewer = self._jdaviz_helper.default_viewer._obj
         else:
             viewer = self.get_viewer(viewer_id)
-            print(f"Viewer ID is {viewer_id}")
 
         old_refdata = viewer.state.reference_data
 
@@ -2034,7 +2032,6 @@ class Application(VuetifyTemplate, HubListener):
         orientation_plugin = self._jdaviz_helper.plugins.get("Orientation")
         if orientation_plugin is not None:
             orient = orientation_plugin.orientation.selected
-            print(f"Removing {data_label}, have {orient} selected")
             if orient == data_label:
                 orient = "Default orientation"
             self._reparent_subsets(data, new_parent=orient)
@@ -2043,14 +2040,10 @@ class Application(VuetifyTemplate, HubListener):
 
         # Make sure the data isn't loaded in any viewers and isn't the selected orientation
         for viewer_id in self._viewer_store:
-            print(f"Checking {viewer_id}")
             if orientation_plugin is not None:
                 orientation_plugin.viewer.selected = viewer_id
-                print(f"Choices are {orientation_plugin.orientation.choices}")
                 orient = orientation_plugin.orientation.selected
-                print(f"{orient} is currently selected, data_label is {data_label}")
                 if orient == data_label:
-                    print(f"Changing selected orientation for {viewer_id}")
                     orientation_plugin.orientation.selected = "Default orientation"
             self.remove_data_from_viewer(viewer_id, data_label)
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2031,9 +2031,10 @@ class Application(VuetifyTemplate, HubListener):
         data = self.data_collection[data_label]
         orientation_plugin = self._jdaviz_helper.plugins.get("Orientation")
         if orientation_plugin is not None:
+            from jdaviz.configs.imviz.helper import base_wcs_layer_label
             orient = orientation_plugin.orientation.selected
             if orient == data_label:
-                orient = "Default orientation"
+                orient = base_wcs_layer_label
             self._reparent_subsets(data, new_parent=orient)
         else:
             self._reparent_subsets(data)
@@ -2044,7 +2045,7 @@ class Application(VuetifyTemplate, HubListener):
                 orientation_plugin.viewer.selected = viewer_id
                 orient = orientation_plugin.orientation.selected
                 if orient == data_label:
-                    orientation_plugin.orientation.selected = "Default orientation"
+                    orientation_plugin.orientation.selected = base_wcs_layer_label
             self.remove_data_from_viewer(viewer_id, data_label)
 
         self.data_collection.remove(self.data_collection[data_label])

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -507,9 +507,11 @@ class Application(VuetifyTemplate, HubListener):
             return
 
         if viewer_id is None:
+            print("Viewer ID is None")
             viewer = self._jdaviz_helper.default_viewer._obj
         else:
             viewer = self.get_viewer(viewer_id)
+            print(f"Viewer ID is {viewer_id}")
 
         old_refdata = viewer.state.reference_data
 
@@ -2032,8 +2034,10 @@ class Application(VuetifyTemplate, HubListener):
         orientation_plugin = self._jdaviz_helper.plugins.get("Orientation")
         if orientation_plugin is not None:
             orient = orientation_plugin.orientation.selected
+            print(f"Removing {data_label}, have {orient} selected")
+            if orient == data_label:
+                orient = "Default orientation"
             self._reparent_subsets(data, new_parent=orient)
-            print(f"Removing item, have {orient} selected")
         else:
             self._reparent_subsets(data)
 

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -480,7 +480,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             if ref_data.label in self.orientation.choices:
                 self.orientation.selected = ref_data.label
             else:
-                self.orientation.selected = "Default orientation"
+                self.orientation.selected = base_wcs_layer_label
                 # Need to manually trigger this here for...reasons
                 self._change_reference_data()
 

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -327,8 +327,6 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             wrt_data = self.viewer.selected_obj.first_loaded_data
             if wrt_data is None:  # Nothing in viewer
                 return
-            else:
-                print(wrt_data)
 
         rotation_angle = self.rotation_angle_deg(rotation_angle)
         if east_left is None:
@@ -358,14 +356,11 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
 
         # add orientation layer to all viewers:
         for viewer_ref in self.app._viewer_store:
-            print(f"Adding {label} to {viewer_ref}")
             self._add_data_to_viewer(label, viewer_ref)
 
         if set_on_create:
             # Not sure why this is sometimes missing, but we can add it here
-            print("Running set on create")
             if label not in self.orientation.choices:
-                print(f"Trying to add {label} to choices")
                 self.orientation.choices += [label]
             self.orientation.selected = label
 
@@ -374,7 +369,6 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
 
         wcs_only_layers = viewer.state.wcs_only_layers
         if data_label not in wcs_only_layers:
-            print(f"Adding {data_label} to {viewer_id}")
             self.app.add_data_to_viewer(viewer_id, data_label)
 
     def _on_viewer_added(self, msg):
@@ -402,9 +396,6 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
                     self.link_type_selected == 'WCS'
             ):
                 self.orientation.selected = base_wcs_layer_label
-                print(f"Changed selected in _send_wcs_layers for {viewer_ref}")
-            else:
-                print("Did _send_wcs_layers but didn't change orientation.selected")
 
     def _on_data_add_to_viewer(self, msg):
         all_wcs_only_layers = all(
@@ -421,14 +412,12 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
 
     @observe('orientation_layer_selected')
     def _change_reference_data(self, *args, **kwargs):
-        print("Running _change_reference_data")
         if self._refdata_change_available:
-            print("refdata change is available")
             self.app._change_reference_data(
                 self.orientation.selected, viewer_id=self.viewer.selected
             )
             viewer_item = self.app._viewer_item_by_id(self.viewer.selected)
-            if viewer_item != self.orientation.selected:
+            if viewer_item['reference_data_label'] != self.orientation.selected:
                 viewer_item['reference_data_label'] = self.orientation.selected
 
     def _on_refdata_change(self, msg):
@@ -488,12 +477,12 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         # don't update choices until viewer is available:
         ref_data = self.ref_data
         if hasattr(self, 'viewer') and ref_data is not None:
-            print(f"Triggered viewer_selected with ref_data {ref_data.label}")
             if ref_data.label in self.orientation.choices:
                 self.orientation.selected = ref_data.label
             else:
-                print(f"{ref_data.label} not in {self.orientation.choices}!")
-                #self.orientation.selected = "Default orientation"
+                self.orientation.selected = "Default orientation"
+                # Need to manually trigger this here for...reasons
+                self._change_reference_data()
 
     def create_north_up_east_left(self, label="North-up, East-left", set_on_create=False):
         """

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -448,7 +448,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             if msg.data.label not in self.orientation.choices:
                 return
 
-            self.orientation.selected = msg.data.label
+            if msg.viewer_id == self.viewer.selected:
+                self.orientation.selected = msg.data.label
 
             # we never want to highlight subsets of pixels within WCS-only layers,
             # so if this layer is an ImageSubsetLayerState on a WCS-only layer,

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -327,6 +327,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             wrt_data = self.viewer.selected_obj.first_loaded_data
             if wrt_data is None:  # Nothing in viewer
                 return
+            else:
+                print(wrt_data)
 
         rotation_angle = self.rotation_angle_deg(rotation_angle)
         if east_left is None:
@@ -356,9 +358,15 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
 
         # add orientation layer to all viewers:
         for viewer_ref in self.app._viewer_store:
+            print(f"Adding {label} to {viewer_ref}")
             self._add_data_to_viewer(label, viewer_ref)
 
         if set_on_create:
+            # Not sure why this is sometimes missing, but we can add it here
+            print("Running set on create")
+            if label not in self.orientation.choices:
+                print(f"Trying to add {label} to choices")
+                self.orientation.choices += [label]
             self.orientation.selected = label
 
     def _add_data_to_viewer(self, data_label, viewer_id):
@@ -366,6 +374,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
 
         wcs_only_layers = viewer.state.wcs_only_layers
         if data_label not in wcs_only_layers:
+            print(f"Adding {data_label} to {viewer_id}")
             self.app.add_data_to_viewer(viewer_id, data_label)
 
     def _on_viewer_added(self, msg):
@@ -393,6 +402,9 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
                     self.link_type_selected == 'WCS'
             ):
                 self.orientation.selected = base_wcs_layer_label
+                print(f"Changed selected in _send_wcs_layers for {viewer_ref}")
+            else:
+                print("Did _send_wcs_layers but didn't change orientation.selected")
 
     def _on_data_add_to_viewer(self, msg):
         all_wcs_only_layers = all(
@@ -409,7 +421,9 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
 
     @observe('orientation_layer_selected')
     def _change_reference_data(self, *args, **kwargs):
+        print("Running _change_reference_data")
         if self._refdata_change_available:
+            print("refdata change is available")
             self.app._change_reference_data(
                 self.orientation.selected, viewer_id=self.viewer.selected
             )
@@ -473,8 +487,12 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         # don't update choices until viewer is available:
         ref_data = self.ref_data
         if hasattr(self, 'viewer') and ref_data is not None:
+            print(f"Triggered viewer_selected with ref_data {ref_data.label}")
             if ref_data.label in self.orientation.choices:
                 self.orientation.selected = ref_data.label
+            else:
+                print(f"{ref_data.label} not in {self.orientation.choices}!")
+                #self.orientation.selected = "Default orientation"
 
     def create_north_up_east_left(self, label="North-up, East-left", set_on_create=False):
         """

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -479,10 +479,6 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         if hasattr(self, 'viewer') and ref_data is not None:
             if ref_data.label in self.orientation.choices:
                 self.orientation.selected = ref_data.label
-            else:
-                self.orientation.selected = base_wcs_layer_label
-                # Need to manually trigger this here for...reasons
-                self._change_reference_data()
 
     def create_north_up_east_left(self, label="North-up, East-left", set_on_create=False):
         """

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -177,8 +177,8 @@ class TestDeleteOrientation(BaseImviz_WCS_WCS):
         # This would set a different reference to second viewer.
         viewer_2 = self.imviz.create_image_viewer()
         self.imviz.app.add_data_to_viewer("imviz-1", "has_wcs_1[SCI,1]")
-        lc_plugin.viewer.selected = "imviz-1"
-        lc_plugin.orientation.selected = "North-up, East-left"
+        lc_plugin.viewer = "imviz-1"
+        lc_plugin.orientation = "North-up, East-left"
 
         self.imviz.app.vue_data_item_remove({"item_name": "North-up, East-left"})
 

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -130,7 +130,8 @@ class TestNonDefaultOrientation(BaseImviz_WCS_WCS):
         # This would set a different reference to second viewer.
         viewer_2 = self.imviz.create_image_viewer()
         self.imviz.app.add_data_to_viewer("imviz-1", "has_wcs_1[SCI,1]")
-        lc_plugin.viewer.selected = "imviz-1"
+        lc_plugin.viewer = "imviz-1"
+
         lc_plugin._obj.create_north_up_east_right(set_on_create=True)
 
         assert self.viewer.state.reference_data.label == "North-up, East-left"
@@ -156,7 +157,8 @@ class TestNonDefaultOrientation(BaseImviz_WCS_WCS):
     def test_custom_orientation(self):
         lc_plugin = self.imviz.plugins['Orientation']
         lc_plugin.link_type = 'WCS'
-        lc_plugin.viewer.selected = "imviz-0"
+        lc_plugin.viewer = "imviz-0"
+
         lc_plugin.rotation_angle = 42  # Triggers auto-label
         lc_plugin._obj.add_orientation(rotation_angle=None, east_left=True, label=None,
                                        set_on_create=True, wrt_data=None)

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -165,6 +165,24 @@ class TestNonDefaultOrientation(BaseImviz_WCS_WCS):
 
 class TestDeleteOrientation(BaseImviz_WCS_WCS):
 
+    def test_delete_orientation_multi_viewer(self):
+        lc_plugin = self.imviz.plugins['Orientation']
+        lc_plugin.link_type = 'WCS'
+
+        # Should automatically be applied as reference to first viewer.
+        lc_plugin._obj.create_north_up_east_left(set_on_create=True)
+
+        # This would set a different reference to second viewer.
+        viewer_2 = self.imviz.create_image_viewer()
+        self.imviz.app.add_data_to_viewer("imviz-1", "has_wcs_1[SCI,1]")
+        lc_plugin.viewer.selected = "imviz-1"
+        lc_plugin.orientation.selected = "North-up, East-left"
+
+        self.imviz.app.vue_data_item_remove({"item_name": "North-up, East-left"})
+
+        assert self.viewer.state.reference_data.label == "Default orientation"
+        assert viewer_2.state.reference_data.label == "Default orientation"
+
     @pytest.mark.parametrize("klass", [EllipseSkyRegion, RectangleSkyRegion])
     @pytest.mark.parametrize(
         ("angle", "sbst_theta"),

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -130,11 +130,16 @@ class TestNonDefaultOrientation(BaseImviz_WCS_WCS):
         # This would set a different reference to second viewer.
         viewer_2 = self.imviz.create_image_viewer()
         self.imviz.app.add_data_to_viewer("imviz-1", "has_wcs_1[SCI,1]")
-        lc_plugin.viewer = "imviz-1"
+        lc_plugin.viewer.selected = "imviz-1"
         lc_plugin._obj.create_north_up_east_right(set_on_create=True)
 
         assert self.viewer.state.reference_data.label == "North-up, East-left"
         assert viewer_2.state.reference_data.label == "North-up, East-right"
+
+        # Change orientation in imviz-1 from UI and ensure plugin selection is the same
+        lc_plugin.viewer.selected = "imviz-0"
+        self.imviz.app._change_reference_data("Default orientation", "imviz-1")
+        assert lc_plugin.orientation.selected == "North-up, East-left"
 
         # Both viewers should revert back to same reference when pixel-linked.
         lc_plugin.link_type = 'Pixels'
@@ -151,7 +156,7 @@ class TestNonDefaultOrientation(BaseImviz_WCS_WCS):
     def test_custom_orientation(self):
         lc_plugin = self.imviz.plugins['Orientation']
         lc_plugin.link_type = 'WCS'
-        lc_plugin.viewer = "imviz-0"
+        lc_plugin.viewer.selected = "imviz-0"
         lc_plugin.rotation_angle = 42  # Triggers auto-label
         lc_plugin._obj.add_orientation(rotation_angle=None, east_left=True, label=None,
                                        set_on_create=True, wrt_data=None)


### PR DESCRIPTION
This fixes a few bugs with adding, changing and deleting orientations when multiple viewers exist. I don't believe there was an issue open for these to close.

Fixes:
- An if statement that was checking against a callback dict instead of an entry in the dict
- Selecting a new orientation in the viewer data menu will now only change the selection in the Orientation plugin if the correct viewer is selected in the plugin.
- Deleting an orientation in a viewer data menu will not result in Default Orientation being selected in any viewers where the deleted orientation was currently selected.