### PR TITLE
Add ability to export subsets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ New Features
 
 - "Export Plot" plugin is now replaced with the more general "Export" plugin. [#2722]
 
-- "Export" plugin supports exporting plugin tables. [#2755]
+- "Export" plugin supports exporting plugin tables and non non-composite spatial subsets.[#2755, #2760]
 
 Cubeviz
 ^^^^^^^

--- a/docs/cubeviz/plugins.rst
+++ b/docs/cubeviz/plugins.rst
@@ -330,7 +330,11 @@ have valid flux units. For 3D data, the current :ref:`slice` is used.
 Export
 ======
 
-This plugin allows exporting the plot in a given viewer to various image formats.
+This plugin allows exporting:
+
+* the plot in a given viewer to a PNG or SVG file,
+* a table in a plugin to ecsv
+* subsets as a region to .fits or .reg file.
 
 .. _cubeviz-export-video:
 

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -409,3 +409,4 @@ This plugin allows exporting:
 
 * the plot in a given viewer to a PNG or SVG file,
 * a table in a plugin to ecsv
+* subsets as a region to .fits or .reg file.

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -9,6 +9,8 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin, SelectPluginCompone
                                         ViewerSelectMixin, DatasetMultiSelectMixin,
                                         SubsetSelectMixin, PluginTableSelectMixin,
                                         MultiselectMixin, with_spinner)
+from glue.core.message import SubsetCreateMessage, SubsetDeleteMessage, SubsetUpdateMessage
+
 from jdaviz.core.events import AddDataMessage, SnackbarMessage
 from jdaviz.core.user_api import PluginUserApi
 
@@ -46,7 +48,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
     # feature flag for cone support
     dev_dataset_support = Bool(False).tag(sync=True)  # when enabling: add entries to docstring
-    dev_subset_support = Bool(False).tag(sync=True)  # when enabling: add entries to docstring
+
     dev_plot_support = Bool(False).tag(sync=True)  # when enabling: add entries to docstring
     dev_multi_support = Bool(False).tag(sync=True)  # when enabling: add entries to docstring
 
@@ -59,7 +61,13 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     table_format_items = List().tag(sync=True)
     table_format_selected = Unicode().tag(sync=True)
 
+    subset_format_items = List().tag(sync=True)
+    subset_format_selected = Unicode().tag(sync=True)
+
     filename = Unicode().tag(sync=True)
+
+    # if selected subset is spectral or composite, display message and disable export
+    subset_invalid_msg = Unicode().tag(sync=True)
 
     # For Cubeviz movie.
     movie_enabled = Bool(False).tag(sync=True)
@@ -100,6 +108,12 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                                                   selected='table_format_selected',
                                                   manual_options=table_format_options)
 
+        subset_format_options = ['fits', 'reg']
+        self.subset_format = SelectPluginComponent(self,
+                                                   items='subset_format_items',
+                                                   selected='subset_format_selected',
+                                                   manual_options=subset_format_options)
+
         # default selection:
         self.dataset._default_mode = 'empty'
         self.table._default_mode = 'empty'
@@ -110,19 +124,26 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         if self.config == "cubeviz":
             self.session.hub.subscribe(self, AddDataMessage, handler=self._on_cubeviz_data_added)  # noqa: E501
 
+        self.session.hub.subscribe(self, SubsetCreateMessage,
+                                   handler=self._set_subset_not_supported_msg)
+        self.session.hub.subscribe(self, SubsetUpdateMessage,
+                                   handler=self._set_subset_not_supported_msg)
+        self.session.hub.subscribe(self, SubsetDeleteMessage,
+                                   handler=self._set_subset_not_supported_msg)
+
     @property
     def user_api(self):
         # TODO: backwards compat for save_figure, save_movie,
         # i_start, i_end, movie_fps, movie_filename
         # TODO: expose export method once API is finalized
+
         expose = ['viewer', 'viewer_format',
+                  'subset', 'subset_format',
                   'table', 'table_format',
                   'filename', 'export']
 
         if self.dev_dataset_support:
             expose += ['dataset']
-        if self.dev_subset_support:
-            expose += ['subset']
         if self.dev_plot_support:
             expose += ['plot']
         if self.dev_multi_support:
@@ -150,6 +171,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     @observe('viewer_selected', 'dataset_selected', 'subset_selected',
              'table_selected', 'plot_selected')
     def _sync_singleselect(self, event):
+
         if not hasattr(self, 'dataset') or not hasattr(self, 'viewer'):
             # plugin not fully intialized
             return
@@ -163,6 +185,27 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                      'table_selected', 'plot_selected'):
             if name != attr:
                 setattr(self, attr, '')
+            if attr == 'subset_selected':
+                self._set_subset_not_supported_msg()
+
+    def _set_subset_not_supported_msg(self, msg=None):
+        """
+        Check if selected subset is spectral or composite, and warn and
+        disable Export button until these are supported.
+        """
+
+        if self.subset.selected is not None:
+            subset = self.app.get_subsets(self.subset.selected)
+            if self.subset.selected == '':
+                self.subset_invalid_msg = ''
+            elif self.app._is_subset_spectral(subset[0]):
+                self.subset_invalid_msg = 'Export for spectral subsets not supported.'
+            elif len(subset) > 1:
+                self.subset_invalid_msg = 'Export for composite subsets not supported.'
+            else:
+                self.subset_invalid_msg = ''
+        else:  # no subset selected (can be '' instead of None if previous selection made)
+            self.subset_invalid_msg = ''
 
     @with_spinner()
     def export(self, filename=None, show_dialog=None):
@@ -176,8 +219,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         """
         if self.dataset.selected is not None and len(self.dataset.selected):
             raise NotImplementedError("dataset export not yet supported")
-        if self.subset.selected is not None and len(self.subset.selected):
-            raise NotImplementedError("subset export not yet supported")
+
         if self.plot.selected is not None and len(self.plot.selected):
             raise NotImplementedError("plot export not yet supported")
         if self.multiselect:
@@ -200,11 +242,21 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                 self.save_movie(viewer, filename, filetype)
             else:
                 self.save_figure(viewer, filename, filetype, show_dialog=show_dialog)
+
         elif len(self.table.selected):
             filetype = self.table_format.selected
             if not filename.endswith(filetype):
                 filename += f".{filetype}"
             self.table.selected_obj.export_table(filename, overwrite=True)
+
+        elif len(self.subset.selected):
+            selected_subset_label = self.subset.selected
+            filetype = self.subset_format.selected
+            if len(filename):
+                if not filename.endswith(filetype):
+                    filename += f".{filetype}"
+            self.save_subset_as_region(selected_subset_label, filename)
+
         else:
             raise ValueError("nothing selected for export")
         return filename
@@ -221,6 +273,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                     f"Exported to {filename}", sender=self, color="success"))
 
     def save_figure(self, viewer, filename=None, filetype="png", show_dialog=False):
+
         if filetype == "png":
             if filename is None or show_dialog:
                 viewer.figure.save_png(str(filename) if filename is not None else None)
@@ -402,6 +455,31 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         ).start()
 
         return filename
+
+    def save_subset_as_region(self, selected_subset_label, filename):
+        """
+        Save a subset to file as a Region object in the working directory.
+        Currently only enabled for non-composite spatial subsets. Can be saved
+        as a .fits or .reg file. If link type is currently set to 'pixel',
+        then a pixel region will be saved. If link type is 'wcs', then a sky
+        region will be saved. If a file with the same name already exists in the
+        working directory, it will be overwriten.
+        """
+
+        # type of region saved depends on link type
+        link_type = getattr(self.app, '_link_type', None)
+
+        region = self.app.get_subsets(subset_name=selected_subset_label,
+                                      include_sky_region=link_type == 'wcs')
+
+        # warn when trying to export a composite subset
+        if len(region) > 1:
+            self.not_supported_warn = True
+            raise NotImplementedError("Export not yet supported for composite subsets.")
+
+        region = region[0][f'{"sky_" if link_type == "wcs" else ""}region']
+
+        region.write(filename, overwrite=True)
 
     def vue_interrupt_recording(self, *args):  # pragma: no cover
         self.movie_interrupt = True

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -474,7 +474,6 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         region = self.app.get_subsets(subset_name=selected_subset_label,
                                       include_sky_region=link_type == 'wcs')
 
-
         region = region[0][f'{"sky_" if link_type == "wcs" else ""}region']
 
         region.write(filename, overwrite=True)

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -255,6 +255,8 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             if len(filename):
                 if not filename.endswith(filetype):
                     filename += f".{filetype}"
+            if self.subset_invalid_msg != '':
+                raise NotImplementedError(f'Subset can not be exported - {self.subset_invalid_msg}')
             self.save_subset_as_region(selected_subset_label, filename)
 
         else:
@@ -472,10 +474,6 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         region = self.app.get_subsets(subset_name=selected_subset_label,
                                       include_sky_region=link_type == 'wcs')
 
-        # warn when trying to export a composite subset
-        if len(region) > 1:
-            self.not_supported_warn = True
-            raise NotImplementedError("Export not yet supported for composite subsets.")
 
         region = region[0][f'{"sky_" if link_type == "wcs" else ""}region']
 

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -91,7 +91,9 @@
 
       <div v-if="subset_items.length > 0">
         <j-plugin-section-header style="margin-top: 12px">Subsets</j-plugin-section-header>
-          <v-subheader style="font-size: 10px; padding-top: 3px; padding-bottom: 3px;">Export subset as astropy region.</v-subheader>
+        <v-row>
+          <span class="v-messages v-messages__message text--secondary"> Save subset as astropy region. </span>
+        </v-row>
         <div class="section-description">
         <plugin-inline-select
           :items="subset_items"

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -89,16 +89,37 @@
       </plugin-inline-select>
     </div>
 
-    <div v-if="dev_subset_support && subset_items.length > 0">
-      <j-plugin-section-header style="margin-top: 12px">Subsets</j-plugin-section-header>
-      <plugin-inline-select
-        :items="subset_items"
-        :selected.sync="subset_selected"
-        :multiselect="multiselect"
-        :single_select_allow_blank="true"
-      >
-      </plugin-inline-select>
-    </div>
+      <div v-if="subset_items.length > 0">
+        <j-plugin-section-header style="margin-top: 12px">Subsets</j-plugin-section-header>
+          <v-subheader style="font-size: 10px; padding-top: 3px; padding-bottom: 3px;">Export subset as astropy region.</v-subheader>
+        <div class="section-description">
+        <plugin-inline-select
+          :items="subset_items"
+          :selected.sync="subset_selected"
+          :multiselect="multiselect"
+          :single_select_allow_blank="true"
+        >
+        </plugin-inline-select>
+      </div>
+
+    <v-row v-if="subset_invalid_msg.length > 0">
+      <span class="v-messages v-messages__message text--secondary" style="color: red !important">
+                {{subset_invalid_msg}}
+      </span>
+    </v-row>
+
+      <v-row v-if="subset_selected" class="row-min-bottom-padding">
+        <v-select
+          :menu-props="{ left: true }"
+          attach
+          v-model="subset_format_selected"
+          :items="subset_format_items.map(i => i.label)"
+          label="Format"
+          hint="Format for exporting subsets."
+          persistent-hint
+        >
+        </v-select>
+      </v-row>
 
     <div v-if="table_items.length > 0">
       <j-plugin-section-header style="margin-top: 12px">Plugin Tables</j-plugin-section-header>
@@ -152,7 +173,6 @@
              :results_isolated_to_plugin="true"
              @click="interrupt_recording"
              :disabled="!movie_recording"
-          >
             <v-icon>stop</v-icon>
           </plugin-action-button>
       </j-tooltip>
@@ -162,13 +182,13 @@
         @click="export_from_ui"
         :spinner="spinner"
         :disabled="filename.length === 0 || 
-                   movie_recording || 
+                   movie_recording ||
+                   subset_invalid_msg.length > 0 || 
                    (viewer_selected.length > 0 && viewer_format_selected == 'mp4' && !movie_enabled)"
       >
         Export
       </plugin-action-button>
     </v-row>
-
 
   </j-tray-plugin>
 </template>

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -173,6 +173,7 @@
              :results_isolated_to_plugin="true"
              @click="interrupt_recording"
              :disabled="!movie_recording"
+          >
             <v-icon>stop</v-icon>
           </plugin-action-button>
       </j-tooltip>

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -1,0 +1,185 @@
+import numpy as np
+import os
+import pytest
+import re
+
+from astropy.io import fits
+from astropy.nddata import NDData
+import astropy.units as u
+from glue.core.edit_subset_mode import AndMode, NewMode
+from glue.core.roi import CircularROI, XRangeROI
+from regions import Regions, CircleSkyRegion
+from specutils import Spectrum1D
+
+
+class TestExportSubsets():
+    """
+    Tests for exporting subsets. Currently limited to non-composite spatial
+    subsets.
+    """
+
+    def test_basic_export_subsets_imviz(self, tmp_path, imviz_helper):
+
+        data = NDData(np.ones((500, 500)) * u.nJy)
+
+        imviz_helper.load_data(data)
+
+        imviz_helper.app.get_viewer('imviz-0').apply_roi(CircularROI(xc=250,
+                                                                     yc=250,
+                                                                     radius=100))
+        export_plugin = imviz_helper.plugins['Export']._obj
+        export_plugin.subset.selected = 'Subset 1'
+
+        assert export_plugin.subset_format.selected == 'fits'  # default format
+        assert export_plugin.subset_invalid_msg == ''  # for non-composite spatial
+
+        export_plugin.export()
+        assert os.path.isfile('imviz_export.fits')
+
+        # read exported file back in
+        with fits.open('imviz_export.fits') as hdu:
+            fits_region = hdu[1].data[0]
+
+        assert fits_region[0] == 'circle'
+        assert fits_region[1] == fits_region[2] == 250.0
+        assert fits_region[3] == 100.0
+        assert fits_region[4] == 0.0
+
+        # now test changing file format
+        export_plugin.subset_format.selected = 'reg'
+        export_plugin.export()
+        assert os.path.isfile('imviz_export.reg')
+
+        # read exported file back in
+        region = Regions.read('imviz_export.reg')[0]
+        assert region.center.x == 250.0
+        assert region.center.y == 250.0
+        assert region.radius == 100.0
+
+        # changing file name
+        export_plugin.filename = 'test'
+        export_plugin.export()
+        assert os.path.isfile('test.reg')
+
+        # test that invalid file extension raises an error
+        with pytest.raises(ValueError,
+                           match=re.escape("x not one of ['fits', 'reg'], reverting selection to reg")):  # noqa
+            export_plugin.subset_format.selected = 'x'
+
+    def test_not_implemented(self, cubeviz_helper, spectral_cube_wcs):
+        """
+        Test that trying to export non-supported subsets
+        (spectral and composite) produces
+        the correct warning message to display in UI).
+        """
+
+        data = Spectrum1D(flux=np.ones((500, 500, 2)) * u.nJy,
+                          wcs=spectral_cube_wcs)
+        cubeviz_helper.load_data(data)
+
+        cubeviz_helper.app.get_viewer('flux-viewer').apply_roi(CircularROI(xc=255,
+                                                                           yc=255,
+                                                                           radius=50))
+        cubeviz_helper.app.session.edit_subset_mode.mode = AndMode
+        cubeviz_helper.app.get_viewer('flux-viewer').apply_roi(CircularROI(xc=200,
+                                                                           yc=250,
+                                                                           radius=50))
+
+        export_plugin = cubeviz_helper.plugins['Export']._obj
+        export_plugin.subset.selected = 'Subset 1'
+
+        assert export_plugin.subset_invalid_msg == 'Export for composite subsets not supported.'
+
+        cubeviz_helper.app.session.edit_subset_mode.mode = NewMode
+        cubeviz_helper.app.get_viewer("spectrum-viewer").apply_roi(XRangeROI(5, 15.5))
+        export_plugin.subset.selected = 'Subset 2'
+
+        assert export_plugin.subset_invalid_msg == 'Export for spectral subsets not supported.'
+
+    def test_export_subsets_wcs(self, tmp_path, imviz_helper, spectral_cube_wcs):
+
+        # using cube WCS instead of 2d imaging wcs for consistancy with
+        # cubeviz test. accessing just the spatial part of this.
+        wcs = spectral_cube_wcs.celestial
+
+        data = NDData(np.ones((500, 500)) * u.nJy, wcs=wcs)
+
+        imviz_helper.load_data(data)  # load data twice so we can link them
+        imviz_helper.load_data(data)
+
+        imviz_helper.link_data(link_type='wcs')
+
+        imviz_helper.app.get_viewer('imviz-0').apply_roi(CircularROI(xc=8,
+                                                                     yc=6,
+                                                                     radius=.2))
+
+        export_plugin = imviz_helper.plugins['Export']._obj
+        export_plugin.subset.selected = 'Subset 1'
+
+        assert export_plugin.subset_invalid_msg == ''  # for non-composite spatial
+
+        # test changing link type results in an output file with a sky region
+        export_plugin.filename = 'sky_region'
+        export_plugin.subset_format.selected = 'reg'
+        export_plugin.export()
+
+        assert os.path.isfile('sky_region.reg')
+
+        assert isinstance(Regions.read('sky_region.reg')[0], CircleSkyRegion)
+
+    def test_basic_export_subsets_cubeviz(self, tmp_path, cubeviz_helper, spectral_cube_wcs):
+
+        data = Spectrum1D(flux=np.ones((128, 128, 256)) * u.nJy, wcs=spectral_cube_wcs)
+
+        cubeviz_helper.load_data(data)
+
+        cubeviz_helper.app.get_viewer('flux-viewer').apply_roi(CircularROI(xc=50,
+                                                                           yc=50,
+                                                                           radius=10))
+
+        export_plugin = cubeviz_helper.plugins['Export']._obj
+        export_plugin.subset.selected = 'Subset 1'
+
+        assert export_plugin.subset_format.selected == 'fits'  # default format
+
+        export_plugin.export()
+        assert os.path.isfile('cubeviz_export.fits')
+
+        # read exported file back in
+        with fits.open('cubeviz_export.fits') as hdu:
+            fits_region = hdu[1].data[0]
+
+        assert fits_region[0] == 'circle'
+        assert fits_region[1] == fits_region[2] == 50.0
+        assert fits_region[3] == 10.0
+        assert fits_region[4] == 0.0
+
+        # now test changing file format
+        export_plugin.subset_format.selected = 'reg'
+        export_plugin.export()
+        assert os.path.isfile('cubeviz_export.reg')
+
+        # read exported file back in
+        region = Regions.read('cubeviz_export.reg')[0]
+        assert region.center.x == 50.0
+        assert region.center.y == 50.0
+        assert region.radius == 10.0
+
+        # changing file name
+        export_plugin.filename = 'test'
+        export_plugin.export()
+        assert os.path.isfile('test.reg')
+
+        # test that invalid file extension raises an error
+        with pytest.raises(ValueError,
+                           match=re.escape("x not one of ['fits', 'reg'], reverting selection to reg")):  # noqa
+            export_plugin.subset_format.selected = 'x'
+
+        # test that attempting to save a composite subset raises an error
+        cubeviz_helper.app.session.edit_subset_mode.mode = AndMode
+        cubeviz_helper.app.get_viewer('flux-viewer').apply_roi(CircularROI(xc=25, yc=25, radius=5))
+        cubeviz_helper.app.get_viewer('flux-viewer').apply_roi(CircularROI(xc=20, yc=25, radius=5))
+
+        with pytest.raises(NotImplementedError,
+                           match='Export not yet supported for composite subsets.'):
+            export_plugin.export()

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -181,5 +181,5 @@ class TestExportSubsets():
         cubeviz_helper.app.get_viewer('flux-viewer').apply_roi(CircularROI(xc=20, yc=25, radius=5))
 
         with pytest.raises(NotImplementedError,
-                           match='Export not yet supported for composite subsets.'):
+                           match='Subset can not be exported - Export for composite subsets not supported.'):
             export_plugin.export()

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -181,5 +181,5 @@ class TestExportSubsets():
         cubeviz_helper.app.get_viewer('flux-viewer').apply_roi(CircularROI(xc=20, yc=25, radius=5))
 
         with pytest.raises(NotImplementedError,
-                           match='Subset can not be exported - Export for composite subsets not supported.'):
+                           match='Subset can not be exported - Export for composite subsets not supported.'):  # noqa
             export_plugin.export()


### PR DESCRIPTION
### Blocked by

* #2755 

### Description
This PR adds the ability to export non-composite spatial subsets through the export plugin.
 (JDAT 4239)

(I branched off of https://github.com/spacetelescope/jdaviz/pull/2755, which should be merged first.)

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
