### PR TITLE
Implement associations between Data layers

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1283,10 +1283,12 @@ class Application(VuetifyTemplate, HubListener):
             The name associated with this data. If none is given, label is pulled
             from the input data (if `~glue.core.data.Data`) or a generic name is
             generated.
-        notify_done: bool
+        notify_done : bool
             Flag controlling whether a snackbar message is set when the data is
             added to the app. Set to False to avoid overwhelming the user if
             lots of data is getting loaded at once.
+        parent : str, optional
+            Associate the added Data entry as the child of layer ``parent``.
         """
 
         if not data_label and hasattr(data, "label"):
@@ -1300,6 +1302,13 @@ class Application(VuetifyTemplate, HubListener):
         # manage associated Data entries:
         self._add_assoc_data_as_parent(data_label)
         if parent is not None:
+            # Does the parent Data have a parent? If so, raise error:
+            parent_of_parent = self._get_assoc_data_parent(parent)
+            if parent_of_parent is not None:
+                raise NotImplementedError('Data associations are currently supported '
+                                          'between root layers (without parents) and their '
+                                          f'children, but the proposed parent "{parent}" has '
+                                          f'parent "{parent_of_parent}".')
             self._set_assoc_data_as_child(data_label, new_parent_label=parent)
 
         # Send out a toast message

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1302,6 +1302,11 @@ class Application(VuetifyTemplate, HubListener):
         # manage associated Data entries:
         self._add_assoc_data_as_parent(data_label)
         if parent is not None:
+            data_collection_labels = [data.label for data in self.data_collection]
+            if parent not in data_collection_labels:
+                raise ValueError(f'parent "{parent}" is not a valid data label in '
+                                 f'the data collection: {data_collection_labels}.')
+
             # Does the parent Data have a parent? If so, raise error:
             parent_of_parent = self._get_assoc_data_parent(parent)
             if parent_of_parent is not None:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -477,10 +477,13 @@ class Application(VuetifyTemplate, HubListener):
             layer_name = msg.data.label
             is_wcs_only = msg.data.meta.get(_wcs_only_label, False)
             is_not_child = self._get_assoc_data_parent(layer_name) is None
+            children_layers = self._get_assoc_data_children(layer_name)
+
         elif hasattr(msg, 'subset'):
             layer_name = msg.subset.label
             is_wcs_only = False
             is_not_child = True
+            children_layers = []
         else:
             raise NotImplementedError(f"cannot recognize new layer from {msg}")
 
@@ -504,15 +507,18 @@ class Application(VuetifyTemplate, HubListener):
                 }
 
         # all remaining layers at this point have a parent:
+        child_layer_icons = {}
         for layer_name in self.state.layer_icons:
             children_layers = self._get_assoc_data_children(layer_name)
             if children_layers is not None:
                 parent_icon = self.state.layer_icons[layer_name]
                 for i, child_layer in enumerate(children_layers, start=1):
-                    self.state.layer_icons = {
-                        **self.state.layer_icons,
-                        child_layer: f'{parent_icon}{i}'
-                    }
+                    child_layer_icons[child_layer] = f'{parent_icon}{i}'
+
+        self.state.layer_icons = {
+            **self.state.layer_icons,
+            **child_layer_icons
+        }
 
     def _change_reference_data(self, new_refdata_label, viewer_id=None):
         """

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -30,7 +30,7 @@ INFO_MSG = ("The file contains more viewable extensions. Add the '[*]' suffix"
 
 
 @data_parser_registry("imviz-data-parser")
-def parse_data(app, file_obj, ext=None, data_label=None):
+def parse_data(app, file_obj, ext=None, data_label=None, parent=None):
     """Parse a data file into Imviz.
 
     Parameters
@@ -74,17 +74,17 @@ def parse_data(app, file_obj, ext=None, data_label=None):
             else:  # Assume RGB
                 pf = rgb2gray(im)
             pf = pf[::-1, :]  # Flip it
-            _parse_image(app, pf, data_label, ext=ext)
+            _parse_image(app, pf, data_label, ext=ext, parent=parent)
 
         elif file_obj_lower.endswith('.asdf'):
             try:
                 if HAS_ROMAN_DATAMODELS:
                     with rdd.open(file_obj) as pf:
-                        _parse_image(app, pf, data_label, ext=ext)
+                        _parse_image(app, pf, data_label, ext=ext, parent=parent)
             except TypeError:
                 # if roman_datamodels cannot parse the file, load it with asdf:
                 with asdf.open(file_obj) as af:
-                    _parse_image(app, af, data_label, ext=ext)
+                    _parse_image(app, af, data_label, ext=ext, parent=parent)
 
         elif file_obj_lower.endswith('.reg'):
             # This will load DS9 regions as Subset but only if there is already data.
@@ -92,9 +92,9 @@ def parse_data(app, file_obj, ext=None, data_label=None):
 
         else:  # Assume FITS
             with fits.open(file_obj) as pf:
-                _parse_image(app, pf, data_label, ext=ext)
+                _parse_image(app, pf, data_label, ext=ext, parent=parent)
     else:
-        _parse_image(app, file_obj, data_label, ext=ext)
+        _parse_image(app, file_obj, data_label, ext=ext, parent=parent)
 
 
 def get_image_data_iterator(app, file_obj, data_label, ext=None):
@@ -168,7 +168,7 @@ def get_image_data_iterator(app, file_obj, data_label, ext=None):
     return data_iter
 
 
-def _parse_image(app, file_obj, data_label, ext=None):
+def _parse_image(app, file_obj, data_label, ext=None, parent=None):
     if app is None:
         raise ValueError("app is None, cannot proceed")
     if data_label is None:
@@ -186,7 +186,7 @@ def _parse_image(app, file_obj, data_label, ext=None):
             data.coords.bounding_box = None
         if not data.meta.get(_wcs_only_label, False):
             data_label = app.return_data_label(data_label, alt_name="image_data")
-        app.add_data(data, data_label)
+        app.add_data(data, data_label, parent=parent)
 
     # Do not link image data here. We do it at the end in Imviz.load_data()
 

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -189,7 +189,6 @@ def _parse_image(app, file_obj, data_label, ext=None, parent=None):
 
         # TODO: generalize/centralize this for use in other configs too
         if parent is not None and ext == 'DQ':
-            print('data', data.main_components)
             # nans are used to mark "good" flags in the DQ colormap, so
             # convert DQ array to float to support nans:
             cid = data.get_component("DQ")

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -186,6 +186,16 @@ def _parse_image(app, file_obj, data_label, ext=None, parent=None):
             data.coords.bounding_box = None
         if not data.meta.get(_wcs_only_label, False):
             data_label = app.return_data_label(data_label, alt_name="image_data")
+
+        # TODO: generalize/centralize this for use in other configs too
+        if parent is not None and ext == 'DQ':
+            print('data', data.main_components)
+            # nans are used to mark "good" flags in the DQ colormap, so
+            # convert DQ array to float to support nans:
+            cid = data.get_component("DQ")
+            data_arr = np.float32(cid.data)
+            data_arr[data_arr == 0] = np.nan
+            data.update_components({cid: data_arr})
         app.add_data(data, data_label, parent=parent)
 
     # Do not link image data here. We do it at the end in Imviz.load_data()

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1365,6 +1365,12 @@ class LayerSelect(SelectPluginComponent):
         self._update_layer_items()
         self.update_wcs_only_filter(only_wcs_layers)
 
+        # ignore layers that are children in associations:
+        def is_parent(data):
+            return self.app._get_assoc_data_parent(data.label) is None
+
+        self.add_filter(is_parent)
+
     def _get_viewer(self, viewer):
         # newer will likely be the viewer name in most cases, but viewer id in the case
         # of additional viewers in imviz.
@@ -2922,6 +2928,12 @@ class DatasetSelect(SelectPluginComponent):
         self.app.state.add_callback('layer_icons', lambda _: self._on_data_changed())
         # initialize items from original viewers
         self._on_data_changed()
+
+        # ignore layers that are children in associations:
+        def is_parent(data):
+            return self.app._get_assoc_data_parent(data.label) is None
+
+        self.add_filter(is_parent)
 
     def _cubeviz_include_spatial_subsets(self):
         """

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -188,3 +188,7 @@ def test_data_associations(imviz_helper):
     with pytest.raises(NotImplementedError):
         # we don't (yet) allow children of children:
         imviz_helper.load_data(data_child, data_label='grandchild_data', parent='child_data')
+
+    with pytest.raises(ValueError):
+        # ensure the parent actually exists:
+        imviz_helper.load_data(data_child, data_label='child_data', parent='absent parent')

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -184,4 +184,3 @@ def test_data_associations(imviz_helper):
 
     assert imviz_helper.app._get_assoc_data_children('parent_data') == ['child_data']
     assert imviz_helper.app._get_assoc_data_parent('child_data') == 'parent_data'
-

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -1,5 +1,6 @@
 import pytest
 
+import numpy as np
 from jdaviz import Application, Specviz
 from jdaviz.configs.default.plugins.gaussian_smooth.gaussian_smooth import GaussianSmooth
 
@@ -170,3 +171,17 @@ def test_viewer_renaming_imviz(imviz_helper):
             old_reference='non-existent',
             new_reference='this-is-forbidden'
         )
+
+
+def test_data_associations(imviz_helper):
+    shape = (10, 10)
+
+    data_parent = np.ones(shape, dtype=float)
+    data_child = np.zeros(shape, dtype=int)
+
+    imviz_helper.load_data(data_parent, data_label='parent_data')
+    imviz_helper.load_data(data_child, data_label='child_data', parent='parent_data')
+
+    assert imviz_helper.app._get_assoc_data_children('parent_data') == ['child_data']
+    assert imviz_helper.app._get_assoc_data_parent('child_data') == 'parent_data'
+

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -184,3 +184,7 @@ def test_data_associations(imviz_helper):
 
     assert imviz_helper.app._get_assoc_data_children('parent_data') == ['child_data']
     assert imviz_helper.app._get_assoc_data_parent('child_data') == 'parent_data'
+
+    with pytest.raises(NotImplementedError):
+        # we don't (yet) allow children of children:
+        imviz_helper.load_data(data_child, data_label='grandchild_data', parent='child_data')


### PR DESCRIPTION
### Description

This PR adds a dictionary `_data_associations` to the `Application` class, and methods for finding associations between glue Data entries in the `DataCollection`. 

Suppose you have two layers A and B which are associated with one another, e.g., layer B is the DQ array for the science data in layer A. You could load these layers and specify their association like so:
```python
imviz_helper = Imviz()

shape = (10, 10)
data_parent = np.ones(shape, dtype=float)
data_child = np.zeros(shape, dtype=int)

imviz_helper.load_data(data_parent, data_label='A')

# specify this data layer as the child of the  
# previous data layer with the `parent` arg:
imviz_helper.load_data(data_child, data_label='B', parent='A')
```
which gets represented as a dictionary:
```python
>>> imviz_helper.app._data_associations
{
    "A": {
        "parent": None,
        "children": [
            "B"
        ]
    },
    "B": {
        "parent": "A",
        "children": []
    }
}
```

Four simple, private helper methods are added to `Application` to make this easy to use:
* `_add_assoc_data_as_parent`: create an entry in the association dict with this layer as parent (called by default on `add_data`)
* `_set_assoc_data_as_child`: specify that this layer is the child of another
* `_get_assoc_data_parent`/`_get_assoc_data_children`: find the parent/children of this layer

For now, I'm assuming: 
* we will only create hierarchical associations when one Data layer is the DQ layer for a science layer already in the viewer
* we do not want the DQ/child layers in Plot Options

It follows that we need to filter out children Data entries from `DatasetSelect` and `LayerSelect`. This prevents the DQ layers from appearing in Plot Options or plugin data dropdown menus so they are not options in, e.g., Aperture Photometry.

We could choose to expose the child layers in the data menu and/or legend, or hide them in either or both places. For now, I updated the layer icon logic to provide a special icon for child layers. In the above example, the layer labeled "B" will appear in the legend in Imviz as "A1" (for now).


### Other uses to investigate in the future
* Could/should we load all extensions other than the science data as children of the science data?
* Since https://github.com/spacetelescope/jdaviz/pull/2671, we provide super-basic support for image segmentation maps, which are generated with respect to one science data, and can be generated multiple times with different segmentation settings. We could load segmentation maps with their source data as "parent," so their visibilities are synced.
* Resampled (L3+) JWST products have extensions for [context images](https://jwst-pipeline.readthedocs.io/en/latest/jwst/resample/main.html#context-image) (`ext='CON'`), which are represented as integer arrays with the same shape as the science data. 


### Example

Here's an example using glue dev, since merge of https://github.com/glue-viz/glue/pull/2468. It loads two JWST Level 2 images from the [FRESCO](https://arxiv.org/abs/2304.02026) program and their data quality extensions.

```python
imviz = Imviz()

data_dir = "../example_files/"

uris = [
    'mast:JWST/product/jw01895001004_07101_00001_nrca3_cal.fits',

    # # Bonus: try with a second science data+DQ pair:
    'mast:JWST/product/jw01895001004_04101_00001_nrca3_cal.fits'
]

for uri in uris:
    fn = uri.split('/')[-1]
    path = f'{data_dir}/{fn}'
    result = Observations.download_file(uri, local_path=path)
    with warnings.catch_warnings():
        warnings.simplefilter('ignore')
        imviz.load_data(path, ext='SCI')

        # specify parent/child relationship explicitly for this demo,
        # in the future this can be the parser default behavior when ext=DQ
        parent = imviz.app.data_collection[-1].label
        imviz.load_data(path, ext='DQ', parent=parent)

# choose colormap for DQ array:
cmap = plt.cm.prism
cmap.set_bad(color='k', alpha=0)

# set the colormap/stretch/opacity options, without using Plot Options.
# this will be moved to internal DQ-specific methods:
layer = imviz.default_viewer._obj.layers[-1]
layer.composite._allow_bad_alpha = True
layer.state.cmap = cmap
layer.state.v_min = 0
layer.state.v_min = 1000
layer.state.alpha = 0.8

imviz.show()
```

https://github.com/spacetelescope/jdaviz/assets/3497584/db040a63-3522-4490-8bf3-6ddb8c4ea017

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4344)