### PR TITLE
Random sampling for Plot Options histogram

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -144,8 +144,6 @@ Cubeviz
 Imviz
 ^^^^^
 
-- Histogram in Plot Options no longer stalls for a very large image. [#2735]
-
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -973,12 +973,8 @@ class PlotOptions(PluginTemplateMixin):
                 x_max = x_limits.max()
                 y_min = max(y_limits.min(), 0)
                 y_max = y_limits.max()
+
                 arr = comp.data[y_min:y_max, x_min:x_max]
-                if self.config == "imviz":
-                    # Downsample input data to about 400px (as per compass.vue) for performance.
-                    xstep = max(1, round(arr.shape[1] / 400))
-                    ystep = max(1, round(arr.shape[0] / 400))
-                    arr = arr[::ystep, ::xstep]
                 sub_data = arr.ravel()
 
             else:
@@ -999,14 +995,8 @@ class PlotOptions(PluginTemplateMixin):
                 sub_data = comp.data[inds].ravel()
 
         else:
-            if self.config == "imviz":
-                # Downsample input data to about 400px (as per compass.vue) for performance.
-                xstep = max(1, round(data.shape[1] / 400))
-                ystep = max(1, round(data.shape[0] / 400))
-                arr = comp[::ystep, ::xstep]
-            else:
-                # include all data, regardless of zoom limits
-                arr = comp.data
+            # include all data, regardless of zoom limits
+            arr = comp.data
             sub_data = arr.ravel()
 
         # filter out nans (or else bqplot will fail)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to

* Revert #2735 
* Use random sampling inspired by glue-viz/glue#2478

Since we do not use glue-native histogram directly, not sure if we can take advantage of the following upstream PRs directly:

* https://github.com/glue-viz/glue/pull/2478
* https://github.com/glue-viz/glue-jupyter/pull/424

### TODO

- [ ] There must be some subtlety I am missing here because the random sampling is not giving any performance boost on a 8GB image. 😆 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4310)
