### PR TITLE
Prevent recursive matched zoom in Imviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,9 @@ Imviz
 
 - Add "Random" colormap for visualizing image segmentation maps. [#2671]
 
+- Enabling any matched zoom tool in a viewer disables other matched zoom tools in other viewers
+  to avoid recursion. [#2764]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/tools.py
+++ b/jdaviz/configs/imviz/plugins/tools.py
@@ -17,7 +17,7 @@ ICON_DIR = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'data', 'ic
 
 class _ImvizMatchedZoomMixin(_MatchedZoomMixin):
     match_keys = ('x_min', 'x_max', 'y_min', 'y_max')
-    disable_matched_zoom_in_other_viewer = False
+    disable_matched_zoom_in_other_viewer = True
 
     def _is_matched_viewer(self, viewer):
         return isinstance(viewer, BqplotImageView)

--- a/jdaviz/core/tools.py
+++ b/jdaviz/core/tools.py
@@ -43,7 +43,7 @@ class _BaseZoomHistory:
 
 class _MatchedZoomMixin:
     match_axes = ('x', 'y')
-    disable_matched_zoom_in_other_viewer = False
+    disable_matched_zoom_in_other_viewer = True
 
     def _is_matched_viewer(self, viewer):
         return True


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request enables the option in the matched zoom within Imviz to disable matched zoom tools in other viewers to avoid unintended recursion.  This is consistent with the handling in specviz2d for a similar issue there.  We could instead implement some tolerance to break out of the recursion, but I fear that won't be robust and might not behave consistently.

~Perhaps #2751 would avoid the need for this, since this was not necessary before the new image rotation work broke roundtripping of the zoom limits.~

Note that this was not an issue in 3.8.x, so is not milestoned for backporting.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
