### PR TITLE
Adding default DQ flag mappings and IO methods

### DIFF
--- a/jdaviz/configs/default/plugins/data_quality/__init__.py
+++ b/jdaviz/configs/default/plugins/data_quality/__init__.py
@@ -1,0 +1,1 @@
+from .dq_utils import *  # noqa

--- a/jdaviz/configs/default/plugins/data_quality/dq_utils.py
+++ b/jdaviz/configs/default/plugins/data_quality/dq_utils.py
@@ -1,0 +1,73 @@
+from importlib import resources
+from pathlib import Path
+from astropy.table import Table
+
+dq_flag_map_paths = {
+    'jwst': Path('data', 'data_quality', 'jwst.csv'),
+    'roman': Path('data', 'data_quality', 'roman.csv'),
+}
+
+
+def load_flag_map(mission_or_instrument=None, path=None):
+    """
+    Load a flag map from disk.
+
+    Parameters
+    ----------
+    mission_or_instrument : {"jwst", "roman"}, optional
+        Load the flag map for this mission or instrument.
+    path : path-like
+        Path to a flag map file (CSV).
+
+    Returns
+    -------
+    flag_mapping : dict
+        Flag mapping definitions. Keys are powers of two,
+        values are the "name" and "description" for each flag.
+    """
+    if mission_or_instrument is not None and path is None:
+        flag_map_path = dq_flag_map_paths.get(mission_or_instrument)
+
+        if flag_map_path is None:
+            raise NotImplementedError("No flag map found for "
+                                      f"mission/instrument '{mission_or_instrument}'.")
+
+    elif mission_or_instrument is None and path is not None:
+        # load directly from a CSV file:
+        flag_map_path = path
+
+    with resources.as_file(resources.files('jdaviz').joinpath(flag_map_path)) as path:
+        flag_table = Table.read(path, format='ascii.csv')
+
+    flag_mapping = {}
+    for flag, name, desc in flag_table.iterrows():
+        flag_mapping[flag] = dict(name=name, description=desc)
+
+    return flag_mapping
+
+
+def write_flag_map(flag_mapping, csv_path, **kwargs):
+    """
+    Write a table containing bitmask flags and their descriptions
+    to a CSV file.
+
+    Parameters
+    ----------
+    flag_mapping : dict
+        Flag mapping definitions. Keys are powers of two,
+        values are the "name" and "description" for each flag.
+    csv_path : path-like
+        Where to save the CSV output.
+    **kwargs : dict
+        Other keywords passed to `~astropy.table.Table.write`
+    """
+    names = ['flag', 'name', 'description']
+    dtype = (int, str, str)
+    table = Table(names=names, dtype=dtype)
+
+    for key, value in flag_mapping.items():
+        row = {'flag': key}
+        row.update(value)
+        table.add_row(row)
+
+    table.write(csv_path, format='ascii.csv', **kwargs)

--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -1,5 +1,3 @@
-import os
-import tempfile
 import pytest
 import numpy as np
 
@@ -23,22 +21,20 @@ def test_flag_map_utils(mission_or_instrument, flag, name):
     assert flag_map[flag]['name'] == name
 
 
-def test_load_write_load():
+def test_load_write_load(tmp_path):
     # load the JWST flag map
     flag_map = load_flag_map('jwst')
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
+    # write out the flag map to a temporary CSV file
+    path = tmp_path / 'test_flag_map.csv'
+    write_flag_map(flag_map, path)
 
-        # write out the flag map to a temporary CSV file
-        path = os.path.join(tmp_dir, 'test_flag_map.csv')
-        write_flag_map(flag_map, path)
+    # load that temporary CSV file back in
+    reloaded_flag_map = load_flag_map(path=path)
 
-        # load that temporary CSV file back in
-        reloaded_flag_map = load_flag_map(path=path)
-
-        # confirm all values round-trip successfully:
-        for flag, orig_value in flag_map.items():
-            assert orig_value == reloaded_flag_map[flag]
+    # confirm all values round-trip successfully:
+    for flag, orig_value in flag_map.items():
+        assert orig_value == reloaded_flag_map[flag]
 
 
 def test_jwst_against_stdatamodels():

--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -1,0 +1,36 @@
+import os
+import tempfile
+import pytest
+from jdaviz.configs.default.plugins.data_quality.dq_utils import (
+    load_flag_map, write_flag_map
+)
+
+
+@pytest.mark.parametrize(
+    "mission_or_instrument, flag, name,",
+    [['jwst', 26, 'OPEN'],
+     ['roman', 26, 'RESERVED_5'],
+     ['jwst', 15, 'TELEGRAPH'],
+     ['roman', 15, 'TELEGRAPH']]
+)
+def test_flag_map_utils(mission_or_instrument, flag, name):
+    flag_map = load_flag_map(mission_or_instrument)
+    assert flag_map[flag]['name'] == name
+
+
+def test_load_write_load():
+    # load the JWST flag map
+    flag_map = load_flag_map('jwst')
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+
+        # write out the flag map to a temporary CSV file
+        path = os.path.join(tmp_dir, 'test_flag_map.csv')
+        write_flag_map(flag_map, path)
+
+        # load that temporary CSV file back in
+        reloaded_flag_map = load_flag_map(path=path)
+
+        # confirm all values round-trip successfully:
+        for flag, orig_value in flag_map.items():
+            assert orig_value == reloaded_flag_map[flag]

--- a/jdaviz/data/data_quality/jwst.csv
+++ b/jdaviz/data/data_quality/jwst.csv
@@ -1,0 +1,33 @@
+flag,name,description
+0,DO_NOT_USE,Bad pixel. Do not use.
+1,SATURATED,Pixel saturated during exposure
+2,JUMP_DET,Jump detected during exposure
+3,DROPOUT,Data lost in transmission
+4,OUTLIER,Flagged by outlier detection (was RESERVED_1)
+5,PERSISTENCE,High persistence (was RESERVED_2)
+6,AD_FLOOR,Below A/D floor (0 DN; was RESERVED_3)
+7,CHARGELOSS,Charge migration (was RESERVED_4)
+8,UNRELIABLE_ERROR,Uncertainty exceeds quoted error
+9,NON_SCIENCE,Pixel not on science portion of detector
+10,DEAD,Dead pixel
+11,HOT,Hot pixel
+12,WARM,Warm pixel
+13,LOW_QE,Low quantum efficiency
+14,RC,RC pixel
+15,TELEGRAPH,Telegraph pixel
+16,NONLINEAR,Pixel highly nonlinear
+17,BAD_REF_PIXEL,Reference pixel cannot be used
+18,NO_FLAT_FIELD,Flat field cannot be measured
+19,NO_GAIN_VALUE,Gain cannot be measured
+20,NO_LIN_CORR,Linearity correction not available
+21,NO_SAT_CHECK,Saturation check not available
+22,UNRELIABLE_BIAS,Bias variance large
+23,UNRELIABLE_DARK,Dark variance large
+24,UNRELIABLE_SLOPE,Slope variance large (i.e. noisy pixel)
+25,UNRELIABLE_FLAT,Flat variance large
+26,OPEN,Open pixel (counts move to adjacent pixels)
+27,ADJ_OPEN,Adjacent to open pixel
+28,FLUX_ESTIMATED,Pixel flux estimated due to missing/bad data
+29,MSA_FAILED_OPEN,Pixel sees light from failed-open shutter
+30,OTHER_BAD_PIXEL,A catch-all flag
+31,REFERENCE_PIXEL,Pixel is a reference pixel

--- a/jdaviz/data/data_quality/roman.csv
+++ b/jdaviz/data/data_quality/roman.csv
@@ -1,0 +1,32 @@
+flag,name,description
+0,DO_NOT_USE,Bad pixel. Do not use.
+1,SATURATED,Pixel saturated during exposure
+2,JUMP_DET,Jump detected during exposure
+3,DROPOUT,Data lost in transmission
+4,GW_AFFECTED_DATA,Data affected by the GW read window
+5,PERSISTENCE,High persistence (was RESERVED_2)
+6,AD_FLOOR,Below A/D floor (0 DN; was RESERVED_3)
+7,OUTLIER,Flagged by outlier detection (was RESERVED_4)
+8,UNRELIABLE_ERROR,Uncertainty exceeds quoted error
+9,NON_SCIENCE,Pixel not on science portion of detector
+10,DEAD,Dead pixel
+11,HOT,Hot pixel
+12,WARM,Warm pixel
+13,LOW_QE,Low quantum efficiency
+15,TELEGRAPH,Telegraph pixel
+16,NONLINEAR,Pixel highly nonlinear
+17,BAD_REF_PIXEL,Reference pixel cannot be used
+18,NO_FLAT_FIELD,Flat field cannot be measured
+19,NO_GAIN_VALUE,Gain cannot be measured
+20,NO_LIN_CORR,Linearity correction not available
+21,NO_SAT_CHECK,Saturation check not available
+22,UNRELIABLE_BIAS,Bias variance large
+23,UNRELIABLE_DARK,Dark variance large
+24,UNRELIABLE_SLOPE,Slope variance large (i.e.; noisy pixel)
+25,UNRELIABLE_FLAT,Flat variance large
+26,RESERVED_5,
+27,RESERVED_6,
+28,UNRELIABLE_RESET,Sensitive to reset anomaly
+29,RESERVED_7,
+30,OTHER_BAD_PIXEL,A catch-all flag
+31,REFERENCE_PIXEL,Pixel is a reference pixel


### PR DESCRIPTION
### Description

This PR adds data quality flag definitions for JWST and Roman. This PR is independent from #2761, and can be merged before or after.

The flag definitions are written in `stdatamodels` ([see here](https://github.com/spacetelescope/stdatamodels/blob/41d4a43c1bec37d097a25866c1a76d93460ee306/src/stdatamodels/jwst/datamodels/dqflags.py#L26)) and `roman_datamodels` ([see here](https://github.com/spacetelescope/roman_datamodels/blob/62d7c96ea993bb354acf4b05e7e265ba0c7d32fa/src/roman_datamodels/dqflags.py#L27)) respectively. 

We could use the flag maps stored in these dependencies directly, since jdaviz already depends on `stdatamodels`, and `roman_datamodels` is an optional dependency. In this PR, I've chosen to save the definition tables as jdaviz package data in static CSV files. This ensures that they are impervious to upstream changes. While I don't expect that the _definitions_ are likely to change, the data structure that they're stored in, or their locations, may change. In this PR, I've added tests which compare the static CSV definitions with the upstream flag definitions in each package, to ensure going forward that both mappings contain all of the same flags, and the names for each flag match.

I've implemented `load_flag_map` to load flag maps from either a mission name ("jwst" or "roman") or a file path. I implemented `write_flag_map` so custom flag maps may be written to disk in the format that is expected by `load_flag_map`.

The tests do a spot-check on two flags in each mission, ensure that flag map load/write/load successfully round-trips, and ensure that the static CSV flag maps match their analogs in `stdatamodels` and `roman_datamodels`.


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4355)
