### PR TITLE
enforce selection made for radio buttons in export plugin

### DIFF
--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -17,7 +17,7 @@
       :items="viewer_items"
       :selected.sync="viewer_selected"
       :multiselect="multiselect"
-      :single_select_allow_blank="true"
+      :single_select_allow_blank="false"
     >
     </plugin-inline-select>
     <v-row v-if="viewer_selected.length > 0" class="row-min-bottom-padding">
@@ -85,7 +85,7 @@
         :items="dataset_items"
         :selected.sync="dataset_selected"
         :multiselect="multiselect"
-        :single_select_allow_blank="true"
+        :single_select_allow_blank="false"
       >
       </plugin-inline-select>
     </div>
@@ -99,7 +99,7 @@
         :items="subset_items"
         :selected.sync="subset_selected"
         :multiselect="multiselect"
-        :single_select_allow_blank="true"
+        :single_select_allow_blank="false"
       >
       </plugin-inline-select>
     </div>
@@ -129,7 +129,7 @@
         :items="table_items"
         :selected.sync="table_selected"
         :multiselect="multiselect"
-        :single_select_allow_blank="true"
+        :single_select_allow_blank="false"
       >
       </plugin-inline-select>
       <v-row v-if="table_selected.length > 0" class="row-min-bottom-padding">
@@ -152,7 +152,7 @@
         :items="plot_items"
         :selected.sync="plot_selected"
         :multiselect="multiselect"
-        :single_select_allow_blank="true"
+        :single_select_allow_blank="false"
       >
       </plugin-inline-select>
     </div>


### PR DESCRIPTION
To be more in line with how radio buttons work, if a selection is made in one of the section export plugin sections, it can't be deselected. The only way to deselect is to select something in another section of the plugin. This fixes https://jira.stsci.edu/browse/JDAT-4381.
