### PR TITLE
toggle flux <-> surface brightness units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 New Features
 ------------
 
+- Adding flux/surface brightness translation and surface brightness
+  unit conversion in Cubeviz and Specviz. [#2781]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -127,13 +127,6 @@ class UnitConverterWithSpectral:
                             # Flux -> Surface Brightness
                             eqv = u.spectral_density(spec.spectral_axis)
 
-                        # below is the generalized version
-                        '''
-                        eqv = [(u.Unit(original_units),
-                                u.Unit(target_units),
-                                lambda x: (x * spec.meta['_pixel_scale_factor']),
-                                lambda x: x)]
-                        '''
                     # if spectrum data collection item is in Flux units
                     elif u.sr not in spec.unit.bases:
                         # Data item in data collection does not update from conversion/translation.
@@ -150,17 +143,6 @@ class UnitConverterWithSpectral:
                             # Surface Brightness -> Flux
                             eqv = u.spectral_density(spec.spectral_axis)
 
-                        # below is the generalized version
-                        '''
-                        eqv = [(u.Unit(original_units),
-                                u.Unit(target_units),
-                                lambda x: (x / spec.meta['_pixel_scale_factor']),
-                                lambda x: x)]
-                        '''
-
-                # flux cid, but neither Surface Brightness nor Flux units
-                    else:
-                        raise ValueError('flux cid, but not a flux nor surface brightness unit.')
                 elif len(values) == 2:
                     # Need this for setting the y-limits
                     spec_limits = [spec.spectral_axis[0].value, spec.spectral_axis[-1].value]

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -68,10 +68,14 @@ ALL_JDAVIZ_CONFIGS = ['cubeviz', 'specviz', 'specviz2d', 'mosviz', 'imviz']
 class UnitConverterWithSpectral:
 
     def equivalent_units(self, data, cid, units):
+        # to debug
+        # print("eqv unit cid : ", cid, ", units : ", units)
+
         if cid.label == "flux":
             eqv = u.spectral_density(1 * u.m)  # Value does not matter here.
             list_of_units = set(list(map(str, u.Unit(units).find_equivalent_units(
-                include_prefix_units=True, equivalencies=eqv))) + [
+                include_prefix_units=True, equivalencies=eqv)))
+                + [
                     'Jy', 'mJy', 'uJy', 'MJy',
                     'W / (m2 Hz)', 'W / (Hz m2)',  # Order is different in astropy v5.3
                     'eV / (s m2 Hz)', 'eV / (Hz s m2)',
@@ -80,6 +84,14 @@ class UnitConverterWithSpectral:
                     'erg / (s cm2 Hz)', 'erg / (Hz s cm2)',
                     'ph / (s cm2 Angstrom)', 'ph / (Angstrom s cm2)',
                     'ph / (s cm2 Hz)', 'ph / (Hz s cm2)'
+                ]
+                + [
+                    'Jy / sr', 'mJy / sr', 'uJy / sr', 'MJy / sr',
+                    'W / (m2 Hz sr)',
+                    'eV / (s m2 Hz sr)',
+                    'erg / (s cm2 sr)',
+                    'erg / (s cm2 Angstrom sr)', 'erg / (s cm2 Hz sr)',
+                    'ph / (s cm2 Angstrom sr)', 'ph / (s cm2 Hz sr)'
                 ])
         else:  # spectral axis
             # prefer Hz over Bq and um over micron

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -66,11 +66,7 @@ ALL_JDAVIZ_CONFIGS = ['cubeviz', 'specviz', 'specviz2d', 'mosviz', 'imviz']
 
 @unit_converter('custom-jdaviz')
 class UnitConverterWithSpectral:
-
     def equivalent_units(self, data, cid, units):
-        # to debug
-        # print("eqv unit cid : ", cid, ", units : ", units)
-
         if cid.label == "flux":
             eqv = u.spectral_density(1 * u.m)  # Value does not matter here.
             list_of_units = set(list(map(str, u.Unit(units).find_equivalent_units(
@@ -80,18 +76,19 @@ class UnitConverterWithSpectral:
                     'W / (m2 Hz)', 'W / (Hz m2)',  # Order is different in astropy v5.3
                     'eV / (s m2 Hz)', 'eV / (Hz s m2)',
                     'erg / (s cm2)',
-                    'erg / (s cm2 Angstrom)', 'erg / (Angstrom s cm2)',
+                    'erg / (s cm2 Angstrom)', 'erg / (s cm2 Angstrom)',
                     'erg / (s cm2 Hz)', 'erg / (Hz s cm2)',
-                    'ph / (s cm2 Angstrom)', 'ph / (Angstrom s cm2)',
+                    'ph / (s cm2 Angstrom)', 'ph / (s cm2 Angstrom)',
                     'ph / (Hz s cm2)', 'ph / (Hz s cm2)', 'bol', 'AB', 'ST'
                 ]
                 + [
                     'Jy / sr', 'mJy / sr', 'uJy / sr', 'MJy / sr',
-                    'W / (m2 Hz sr)',
+                    'W / (Hz sr m2)',
                     'eV / (s m2 Hz sr)',
                     'erg / (s cm2 sr)',
                     'erg / (s cm2 Angstrom sr)', 'erg / (s cm2 Hz sr)',
-                    'ph / (s cm2 Angstrom sr)', 'ph / (s cm2 Hz sr)'
+                    'ph / (s cm2 Angstrom sr)', 'ph / (s cm2 Hz sr)',
+                    'bol / sr', 'AB / sr', 'ST / sr'
                 ])
         else:  # spectral axis
             # prefer Hz over Bq and um over micron
@@ -111,27 +108,22 @@ class UnitConverterWithSpectral:
                 spec = data.get_object(cls=Spectrum1D)
             except RuntimeError:
                 eqv = []
-            if len(values) == 2:
-                # Need this for setting the y-limits
-                spec_limits = [spec.spectral_axis[0].value, spec.spectral_axis[-1].value]
-                eqv = u.spectral_density(spec_limits * spec.spectral_axis.unit)
 
             # Ensure a spectrum passed through Spectral Extraction plugin
-            elif '_pixel_scale_factor' in spec.meta:
+            if '_pixel_scale_factor' in spec.meta:
                 # if spectrum data collection item is in Surface Brightness units
                 if u.sr in spec.unit.bases:
                     # Data item in data collection does not update from conversion/translation.
                     # App wide orginal data units are used for conversion, orginal_units and
                     # target_units dicate the conversion to take place.
                     if (u.sr in u.Unit(original_units).bases) and \
-                       (u.sr not in u.Unit(target_units).bases) and \
-                       (target_units not in ["AB", "bol", "ST"]):  # astropy supported equivalency
+                       (u.sr not in u.Unit(target_units).bases):
                         # Surface Brightness -> Flux
                         eqv = [(u.MJy / u.sr,
                                 u.MJy,
                                 lambda x: (x * spec.meta['_pixel_scale_factor']),
                                 lambda x: x)]
-                        
+
                         # below is the generalized version
                         '''
                         eqv = [(u.Unit(original_units),
@@ -149,14 +141,13 @@ class UnitConverterWithSpectral:
                     # App wide orginal data units are used for conversion, orginal_units and
                     # target_units dicate the conversion to take place.
                     if (u.sr not in u.Unit(original_units).bases) and \
-                       (u.sr in u.Unit(target_units).bases) and \
-                       (target_units not in ["AB", "bol", "ST"]):  # astropy supported equivalency
+                       (u.sr in u.Unit(target_units).bases):
                         # Flux -> Surface Brightness
                         eqv = [(u.MJy,
                                 u.MJy / u.sr,
                                 lambda x: (x / spec.meta['_pixel_scale_factor']),
                                 lambda x: x)]
-                        
+
                         # below is the generalized version
                         '''
                         eqv = [(u.Unit(original_units),
@@ -171,6 +162,11 @@ class UnitConverterWithSpectral:
                 # flux cid, but neither Surface Brightness nor Flux units
                 else:
                     raise ValueError('flux cid, but not a flux nor surface brightness unit.')
+            elif len(values) == 2:
+                # Need this for setting the y-limits
+                spec_limits = [spec.spectral_axis[0].value, spec.spectral_axis[-1].value]
+                eqv = u.spectral_density(spec_limits * spec.spectral_axis.unit)
+
             else:
                 eqv = u.spectral_density(spec.spectral_axis)
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -134,6 +134,14 @@ class UnitConverterWithSpectral:
                     # to debug
                     print(converted_values)
                     return converted_values
+                # custom equivalency
+                '''
+                eqv = [(u.MJy / u.sr,
+                        u.MJy,
+                        lambda x: (x * spec.meta['_pixel_scale_factor']),
+                        lambda x: x)]
+                '''
+
             else:
                     eqv = u.spectral_density(spec.spectral_axis)
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -108,67 +108,66 @@ class UnitConverterWithSpectral:
                 spec = data.get_object(cls=Spectrum1D)
             except RuntimeError:
                 eqv = []
-
-            # Ensure a spectrum passed through Spectral Extraction plugin
-            if '_pixel_scale_factor' in spec.meta:
-                # if spectrum data collection item is in Surface Brightness units
-                if u.sr in spec.unit.bases:
-                    # Data item in data collection does not update from conversion/translation.
-                    # App wide orginal data units are used for conversion, orginal_units and
-                    # target_units dicate the conversion to take place.
-                    if (u.sr in u.Unit(original_units).bases) and \
-                       (u.sr not in u.Unit(target_units).bases):
-                        # Surface Brightness -> Flux
-                        eqv = [(u.MJy / u.sr,
-                                u.MJy,
-                                lambda x: (x * spec.meta['_pixel_scale_factor']),
-                                lambda x: x)]
-
-                        # below is the generalized version
-                        '''
-                        eqv = [(u.Unit(original_units),
-                                u.Unit(target_units),
-                                lambda x: (x * spec.meta['_pixel_scale_factor']),
-                                lambda x: x)]
-                        '''
-                    else:
-                        # Flux -> Surface Brightness
-                        eqv = u.spectral_density(spec.spectral_axis)
-
-                # if spectrum data collection item is in Flux units
-                elif u.sr not in spec.unit.bases:
-                    # Data item in data collection does not update from conversion/translation.
-                    # App wide orginal data units are used for conversion, orginal_units and
-                    # target_units dicate the conversion to take place.
-                    if (u.sr not in u.Unit(original_units).bases) and \
-                       (u.sr in u.Unit(target_units).bases):
-                        # Flux -> Surface Brightness
-                        eqv = [(u.MJy,
-                                u.MJy / u.sr,
-                                lambda x: (x / spec.meta['_pixel_scale_factor']),
-                                lambda x: x)]
+            else:
+                # Ensure a spectrum passed through Spectral Extraction plugin
+                if '_pixel_scale_factor' in spec.meta:
+                    # if spectrum data collection item is in Surface Brightness units
+                    if u.sr in spec.unit.bases:
+                        # Data item in data collection does not update from conversion/translation.
+                        # App wide orginal data units are used for conversion, orginal_units and
+                        # target_units dicate the conversion to take place.
+                        if (u.sr in u.Unit(original_units).bases) and \
+                           (u.sr not in u.Unit(target_units).bases):
+                            # Surface Brightness -> Flux
+                            eqv = [(u.MJy / u.sr,
+                                    u.MJy,
+                                    lambda x: (x * spec.meta['_pixel_scale_factor']),
+                                    lambda x: x)]
+                        else:
+                            # Flux -> Surface Brightness
+                            eqv = u.spectral_density(spec.spectral_axis)
 
                         # below is the generalized version
                         '''
                         eqv = [(u.Unit(original_units),
                                 u.Unit(target_units),
+                                lambda x: (x * spec.meta['_pixel_scale_factor']),
+                                lambda x: x)]
+                        '''
+                    # if spectrum data collection item is in Flux units
+                    elif u.sr not in spec.unit.bases:
+                        # Data item in data collection does not update from conversion/translation.
+                        # App wide orginal data units are used for conversion, orginal_units and
+                        # target_units dicate the conversion to take place.
+                        if (u.sr not in u.Unit(original_units).bases) and \
+                           (u.sr in u.Unit(target_units).bases):
+                            # Flux -> Surface Brightness
+                            eqv = [(u.MJy,
+                                    u.MJy / u.sr,
+                                    lambda x: (x / spec.meta['_pixel_scale_factor']),
+                                    lambda x: x)]
+                        else:
+                            # Surface Brightness -> Flux
+                            eqv = u.spectral_density(spec.spectral_axis)
+
+                        # below is the generalized version
+                        '''
+                        eqv = [(u.Unit(original_units),
+                                u.Unit(target_units),
                                 lambda x: (x / spec.meta['_pixel_scale_factor']),
                                 lambda x: x)]
                         '''
-                    else:
-                        # Surface Brightness -> Flux
-                        eqv = u.spectral_density(spec.spectral_axis)
 
                 # flux cid, but neither Surface Brightness nor Flux units
-                else:
-                    raise ValueError('flux cid, but not a flux nor surface brightness unit.')
-            elif len(values) == 2:
-                # Need this for setting the y-limits
-                spec_limits = [spec.spectral_axis[0].value, spec.spectral_axis[-1].value]
-                eqv = u.spectral_density(spec_limits * spec.spectral_axis.unit)
+                    else:
+                        raise ValueError('flux cid, but not a flux nor surface brightness unit.')
+                elif len(values) == 2:
+                    # Need this for setting the y-limits
+                    spec_limits = [spec.spectral_axis[0].value, spec.spectral_axis[-1].value]
+                    eqv = u.spectral_density(spec_limits * spec.spectral_axis.unit)
 
-            else:
-                eqv = u.spectral_density(spec.spectral_axis)
+                else:
+                    eqv = u.spectral_density(spec.spectral_axis)
 
         else:  # spectral axis
             eqv = u.spectral()

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -72,7 +72,7 @@ class UnitConverterWithSpectral:
             eqv = u.spectral_density(1 * u.m)  # Value does not matter here.
             list_of_units = set(list(map(str, u.Unit(units).find_equivalent_units(
                 include_prefix_units=True, equivalencies=eqv))) + [
-                    'Jy', 'mJy', 'uJy',
+                    'Jy', 'mJy', 'uJy', 'MJy',
                     'W / (m2 Hz)', 'W / (Hz m2)',  # Order is different in astropy v5.3
                     'eV / (s m2 Hz)', 'eV / (Hz s m2)',
                     'erg / (s cm2)',
@@ -99,13 +99,44 @@ class UnitConverterWithSpectral:
                 spec = data.get_object(cls=Spectrum1D)
             except RuntimeError:
                 eqv = []
-            else:
-                if len(values) == 2:
+            if len(values) == 2:
                     # Need this for setting the y-limits
                     spec_limits = [spec.spectral_axis[0].value, spec.spectral_axis[-1].value]
                     eqv = u.spectral_density(spec_limits * spec.spectral_axis.unit)
+    
+            elif '_pixel_scale_factor' in spec.meta:
+                if (u.sr in u.Unit(original_units).bases) and \
+                   (u.sr not in u.Unit(target_units).bases):
+                    # sb -> flux
+
+                    # to debug
+                    print('first if')
+                    print('values before')
+                    print(values)
+
+                    converted_values = values * spec.meta['_pixel_scale_factor']
+
+                    # to debug
+                    print(converted_values)
+
+                    return converted_values
                 else:
+                    # elif (u.sr in u.Unit(target_units).bases) and \
+                    # (u.sr not in u.Unit(original_units).bases):
+                    # flux -> sb
+
+                    # to debug
+                    print('second elif')
+                    print('values before')
+                    print(values)
+
+                    converted_values = values / spec.meta['_pixel_scale_factor']
+                    # to debug
+                    print(converted_values)
+                    return converted_values
+            else:
                     eqv = u.spectral_density(spec.spectral_axis)
+
         else:  # spectral axis
             eqv = u.spectral()
 

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import numpy as np
 import astropy
-from astropy import units as u
 from astropy.utils.decorators import deprecated
 from astropy.nddata import (
     NDDataArray, StdDevUncertainty
@@ -562,13 +561,3 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         for mark in self.marks.values():
             mark.update_xy(sp.spectral_axis.value, sp.flux.value)
             mark.visible = True
-
-    def translate_units(self, collapsed_spec):
-        # remove sr
-        if u.sr in collapsed_spec._unit.bases:
-            collapsed_spec._data *= collapsed_spec.meta['_pixel_scale_factor']
-            collapsed_spec._unit *= u.sr
-        # add sr
-        elif u.sr not in collapsed_spec._unit.bases:
-            collapsed_spec._data /= collapsed_spec.meta['_pixel_scale_factor']
-            collapsed_spec._unit /= u.sr

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
@@ -135,17 +135,6 @@
       </div>
     </div>
 
-    <div>
-      <v-row>
-      <v-switch
-        v-model="translate_unit"
-        label="Translate units"
-        hint="Toggle between surface brightness and flux units"
-        persistent-hint
-      ></v-switch>
-    </v-row>
-  </div>
-
     <div @mouseover="() => active_step='ext'">
       <j-plugin-section-header :active="active_step==='ext'">Extract</j-plugin-section-header>
 
@@ -280,5 +269,6 @@
         </v-overlay>
       </div>
     </div>
+
   </j-tray-plugin>
 </template>

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
@@ -135,6 +135,17 @@
       </div>
     </div>
 
+    <div>
+      <v-row>
+      <v-switch
+        v-model="translate_unit"
+        label="Translate units"
+        hint="Toggle between surface brightness and flux units"
+        persistent-hint
+      ></v-switch>
+    </v-row>
+  </div>
+
     <div @mouseover="() => active_step='ext'">
       <j-plugin-section-header :active="active_step==='ext'">Extract</j-plugin-section-header>
 
@@ -269,6 +280,5 @@
         </v-overlay>
       </div>
     </div>
-
   </j-tray-plugin>
 </template>

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -375,6 +375,7 @@ def test_cube_extraction_with_nan(cubeviz_helper, image_cube_hdu_obj):
     assert_allclose(sp_subset.flux.value, 12)  # (4 x 4) - 4
 
 
+# this test will have to move
 def test_unit_translation(cubeviz_helper):
     # custom cube so we have PIXAR_SR in metadata, and flux units = Jy/pix
     wcs_dict = {"CTYPE1": "WAVE-LOG", "CTYPE2": "DEC--TAN", "CTYPE3": "RA---TAN",

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -12,7 +12,6 @@ from numpy.testing import assert_allclose, assert_array_equal
 from regions import (CirclePixelRegion, CircleAnnulusPixelRegion, EllipsePixelRegion,
                      RectanglePixelRegion, PixCoord)
 from specutils import Spectrum1D
-from astropy.wcs import WCS
 
 
 def test_version_after_nddata_update(cubeviz_helper, spectrum1d_cube_with_uncerts):
@@ -373,54 +372,6 @@ def test_cube_extraction_with_nan(cubeviz_helper, image_cube_hdu_obj):
     extract_plg.aperture = 'Subset 1'
     sp_subset = extract_plg.collapse_to_spectrum()  # Default settings but on Subset
     assert_allclose(sp_subset.flux.value, 12)  # (4 x 4) - 4
-
-
-# this test will have to move
-def test_unit_translation(cubeviz_helper):
-    # custom cube so we have PIXAR_SR in metadata, and flux units = Jy/pix
-    wcs_dict = {"CTYPE1": "WAVE-LOG", "CTYPE2": "DEC--TAN", "CTYPE3": "RA---TAN",
-                "CRVAL1": 4.622e-7, "CRVAL2": 27, "CRVAL3": 205,
-                "CDELT1": 8e-11, "CDELT2": 0.0001, "CDELT3": -0.0001,
-                "CRPIX1": 0, "CRPIX2": 0, "CRPIX3": 0, "PIXAR_SR": 8e-11}
-    w = WCS(wcs_dict)
-    flux = np.zeros((30, 20, 3001), dtype=np.float32)
-    flux[5:15, 1:11, :] = 1
-    cube = Spectrum1D(flux=flux * u.MJy, wcs=w, meta=wcs_dict)
-    cubeviz_helper.load_data(cube, data_label="test")
-
-    center = PixCoord(5, 10)
-    cubeviz_helper.load_regions(CirclePixelRegion(center, radius=2.5))
-
-    extract_plg = cubeviz_helper.plugins['Spectral Extraction']
-
-    extract_plg.aperture = extract_plg.aperture.choices[-1]
-    extract_plg.aperture_method.selected = 'Exact'
-    extract_plg.wavelength_dependent = True
-    extract_plg.function = 'Sum'
-    # set so pixel scale factor != 1
-    extract_plg.reference_spectral_value = 0.000001
-
-    # collapse to spectrum, now we can get pixel scale factor
-    collapsed_spec = extract_plg.collapse_to_spectrum()
-
-    assert collapsed_spec.meta['_pixel_scale_factor'] != 1
-
-    # store to test second time after calling translate_units
-    mjy_sr_data1 = collapsed_spec._data[0]
-
-    extract_plg._obj.translate_units(collapsed_spec)
-
-    assert collapsed_spec._unit == u.MJy / u.sr
-    # some value in MJy/sr that we know the outcome after translation
-    assert np.allclose(collapsed_spec._data[0], 8.7516529e10)
-
-    extract_plg._obj.translate_units(collapsed_spec)
-
-    # translating again returns the original units
-    assert collapsed_spec._unit == u.MJy
-    # returns to the original values
-    # which is a value in Jy/pix that we know the outcome after translation
-    assert np.allclose(collapsed_spec._data[0], mjy_sr_data1)
 
 
 def test_autoupdate_results(cubeviz_helper, spectrum1d_cube_largest):

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -573,8 +573,18 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
 
                 # Calculations have to happen in the frame of viewer display units.
                 disp_wave = sp.spectral_axis.to_value(viewer.state.x_display_unit, u.spectral())
-                disp_flux = sp.flux.to_value(viewer.state.y_display_unit,
-                                             u.spectral_density(sp.spectral_axis))
+
+                # temporarily here, may be removed after upstream units handling
+                # or will be generalized for any sb <-> flux
+                if '_pixel_scale_factor' in sp.meta:
+                    eqv = [(u.MJy / u.sr,
+                            u.MJy,
+                            lambda x: (x * sp.meta['_pixel_scale_factor']),
+                            lambda x: x)]
+                    disp_flux = sp.flux.to_value(viewer.state.y_display_unit, eqv)
+                else:
+                    disp_flux = sp.flux.to_value(viewer.state.y_display_unit,
+                                                 u.spectral_density(sp.spectral_axis))
 
                 # Out of range in spectral axis.
                 if (self.dataset.selected != lyr.layer.label and

--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -139,6 +139,9 @@ def test_unit_translation(cubeviz_helper):
     center = PixCoord(5, 10)
     cubeviz_helper.load_regions(CirclePixelRegion(center, radius=2.5))
 
+    uc_plg = cubeviz_helper.plugins['Unit Conversion']
+    uc_plg.open_in_tray()
+
     extract_plg = cubeviz_helper.plugins['Spectral Extraction']
 
     extract_plg.aperture = extract_plg.aperture.choices[-1]
@@ -155,7 +158,6 @@ def test_unit_translation(cubeviz_helper):
     # test that the scale factor was set
     assert collapsed_spec.meta['_pixel_scale_factor'] != 1
 
-    uc_plg = cubeviz_helper.plugins['Unit Conversion']
     # When the dropdown is displayed, this ensures the loaded
     # data collection item units will be used for translations.
     uc_plg._obj.show_translator = True
@@ -172,12 +174,12 @@ def test_unit_translation(cubeviz_helper):
     assert y_display_unit == u.MJy / u.sr
 
     # Surface Brightness conversion
-    uc_plg.flux_unit_selected = 'W / (Hz sr m2)'
-    assert y_display_unit == u.W / (u.m**2 * u.sr * u.Hz)
-
-    # A second Surface Brightness conversion
     uc_plg.flux_unit_selected = 'Jy / sr'
     assert y_display_unit == u.Jy / u.sr
+
+    # A second Surface Brightness conversion
+    # uc_plg.flux_unit_selected = 'Jy / sr'
+    # assert y_display_unit == u.Jy / u.sr
 
     # Translate back to Flux
     uc_plg._obj.flux_or_sb_selected = 'Flux'

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -162,6 +162,8 @@ class UnitConversion(PluginTemplateMixin):
     @observe('flux_unit_selected')
     def _on_flux_unit_changed(self, *args):
         yunit = _valid_glue_display_unit(self.flux_unit.selected, self.spectrum_viewer, 'y')
+        # to debug
+        print('y_unit = ', yunit)
         if self.spectrum_viewer.state.y_display_unit != yunit:
             self.spectrum_viewer.state.y_display_unit = yunit
             self.hub.broadcast(GlobalDisplayUnitChanged('flux',

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -162,8 +162,6 @@ class UnitConversion(PluginTemplateMixin):
     @observe('flux_unit_selected')
     def _on_flux_unit_changed(self, *args):
         yunit = _valid_glue_display_unit(self.flux_unit.selected, self.spectrum_viewer, 'y')
-        # to debug
-        print('y_unit = ', yunit)
         if self.spectrum_viewer.state.y_display_unit != yunit:
             self.spectrum_viewer.state.y_display_unit = yunit
             self.hub.broadcast(GlobalDisplayUnitChanged('flux',

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -46,7 +46,7 @@ class UnitConversion(PluginTemplateMixin):
     * ``flux_or_sb_unit`` (:class:`~jdaviz.core.template_mixin.UnitSelectPluginComponent`):
       Global unit to use for all flux/surface brightness (depending on flux_or_sb selection) axes.
     * ``flux_or_sb`` (:class:`~jdaviz.core.template_mixin.SelectPluginComponent`):
-      Y-axis physical type selection. Currently only accessible in Cubeviz (pixel scale factor 
+      Y-axis physical type selection. Currently only accessible in Cubeviz (pixel scale factor
       added in Cubeviz Spectral Extraction, and is used for this translation).
     """
     template_file = __file__, "unit_conversion.vue"

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -41,10 +41,13 @@ class UnitConversion(PluginTemplateMixin):
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.show`
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.open_in_tray`
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.close_in_tray`
-    * ``spectral_unit`` (:class:`~jdaviz.core.template_mixin.SelectPluginComponent`):
+    * ``spectral_unit`` (:class:`~jdaviz.core.template_mixin.UnitSelectPluginComponent`):
       Global unit to use for all spectral axes.
-    * ``flux_or_sb_unit`` (:class:`~jdaviz.core.template_mixin.SelectPluginComponent`):
-      Global unit to use for all flux axes.
+    * ``flux_or_sb_unit`` (:class:`~jdaviz.core.template_mixin.UnitSelectPluginComponent`):
+      Global unit to use for all flux/surface brightness (depending on flux_or_sb selection) axes.
+    * ``flux_or_sb`` (:class:`~jdaviz.core.template_mixin.SelectPluginComponent`):
+      Y-axis physical type selection. Currently only accessible in Cubeviz (pixel scale factor 
+      added in Cubeviz Spectral Extraction, and is used for this translation).
     """
     template_file = __file__, "unit_conversion.vue"
 
@@ -89,7 +92,7 @@ class UnitConversion(PluginTemplateMixin):
 
     @property
     def user_api(self):
-        return PluginUserApi(self, expose=('spectral_unit',))
+        return PluginUserApi(self, expose=('spectral_unit', 'flux_or_sb', 'flux_or_sb_unit'))
 
     def _on_glue_x_display_unit_changed(self, x_unit):
         if x_unit is None:
@@ -137,7 +140,6 @@ class UnitConversion(PluginTemplateMixin):
 
     def translate_units(self, flux_or_sb_selected):
         spec_units = u.Unit(self.spectrum_viewer.state.y_display_unit)
-        print('spec units ', spec_units, '  f or sb ', flux_or_sb_selected)
         # Surface Brightness -> Flux
         if u.sr in spec_units.bases and flux_or_sb_selected == 'Flux':
             spec_units *= u.sr

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -152,12 +152,12 @@ class UnitConversion(PluginTemplateMixin):
 
     @observe('spectral_unit_selected')
     def _on_spectral_unit_changed(self, *args):
-        self.hub.broadcast(GlobalDisplayUnitChanged('spectral',
-                                                    self.spectral_unit.selected,
-                                                    sender=self))
         xunit = _valid_glue_display_unit(self.spectral_unit.selected, self.spectrum_viewer, 'x')
         if self.spectrum_viewer.state.x_display_unit != xunit:
             self.spectrum_viewer.state.x_display_unit = xunit
+            self.hub.broadcast(GlobalDisplayUnitChanged('spectral',
+                               self.spectral_unit.selected,
+                               sender=self))
 
     @observe('flux_unit_selected')
     def _on_flux_unit_changed(self, *args):

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -25,7 +25,7 @@
         attach
         :items="flux_unit_items.map(i => i.label)"
         v-model="flux_unit_selected"
-        :label="translate_unit ? 'Flux Unit' : 'Surface Brightness'"
+        :label="translate_unit ? 'Flux Unit' : 'Surface Brightness Unit'"
         :hint="translate_unit ? 'Global display unit for flux.' : 'Global display unit for surface brightness.'"
         persistent-hint
         :disabled="config === 'cubeviz'"

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -26,7 +26,7 @@
         :items="flux_or_sb_items.map(i => i.label)"
         v-model="flux_or_sb_selected"
         label="Flux or Surface Brightness"
-        hint="Select between Flux and Surface Brightness global display unit for y-axis."
+        hint="Select between Flux or Surface Brightness physical type for y-axis."
         persistent-hint
       ></v-select>
     </v-row>
@@ -40,7 +40,6 @@
         :label="flux_or_sb_selected === 'Flux' ? 'Flux Unit' : 'Surface Brightness Unit'"
         :hint="flux_or_sb_selected === 'Flux' ? 'Global display unit for flux.' : 'Global display unit for surface brightness.'"
         persistent-hint
-        :disabled="config === 'cubeviz'"
       ></v-select>
     </v-row>
   </j-tray-plugin>

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -19,22 +19,29 @@
       ></v-select>
     </v-row>
 
+    <v-row  v-if="config == 'cubeviz' && show_translator">
+      <v-select
+        :menu-props="{ left: true }"
+        attach
+        :items="flux_or_sb_items.map(i => i.label)"
+        v-model="flux_or_sb_selected"
+        label="Flux or Surface Brightness"
+        hint="Select between Flux and Surface Brightness global display unit for y-axis."
+        persistent-hint
+      ></v-select>
+    </v-row>
+
     <v-row>
       <v-select
         :menu-props="{ left: true }"
         attach
         :items="flux_unit_items.map(i => i.label)"
         v-model="flux_unit_selected"
-        :label="translate_unit ? 'Flux Unit' : 'Surface Brightness Unit'"
-        :hint="translate_unit ? 'Global display unit for flux.' : 'Global display unit for surface brightness.'"
+        :label="flux_or_sb_selected === 'Flux' ? 'Flux Unit' : 'Surface Brightness Unit'"
+        :hint="flux_or_sb_selected === 'Flux' ? 'Global display unit for flux.' : 'Global display unit for surface brightness.'"
         persistent-hint
         :disabled="config === 'cubeviz'"
       ></v-select>
-    </v-row>
-    <v-row v-if="config === 'cubeviz'">
-        <span class="v-messages v-messages__message text--secondary" style="color: red !important">
-          Flux conversion is not yet implemented in Cubeviz.
-        </span>
     </v-row>
   </j-tray-plugin>
 </template>

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -25,8 +25,8 @@
         attach
         :items="flux_unit_items.map(i => i.label)"
         v-model="flux_unit_selected"
-        label="Flux Unit"
-        hint="Global display unit for flux."
+        :label="translate_unit ? 'Flux Unit' : 'Surface Brightness'"
+        :hint="translate_unit ? 'Global display unit for flux.' : 'Global display unit for surface brightness.'"
         persistent-hint
         :disabled="config === 'cubeviz'"
       ></v-select>

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -559,9 +559,25 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
         y_display_unit = self.state.y_display_unit
         y_unit = u.Unit(y_display_unit) if y_display_unit else u.dimensionless_unscaled
 
-        if y_unit.is_equivalent(u.Jy / u.sr):
-            flux_unit_type = "Surface brightness"
-        elif y_unit.is_equivalent(u.erg / (u.s * u.cm**2)):
+        # Get local units.
+        locally_defined_flux_units = [
+            u.Jy, u.mJy, u.uJy, u.MJy,
+            u.W / (u.m**2 * u.Hz),
+            u.eV / (u.s * u.m**2 * u.Hz),
+            u.erg / (u.s * u.cm**2),
+            u.erg / (u.s * u.cm**2 * u.Angstrom),
+            u.erg / (u.s * u.cm**2 * u.Hz),
+            u.ph / (u.s * u.cm**2 * u.Angstrom),
+            u.ph / (u.s * u.cm**2 * u.Hz)
+        ]
+
+        locally_defined_sb_units = [
+            unit / u.sr for unit in locally_defined_flux_units
+            ]
+
+        if any(y_unit.is_equivalent(unit) for unit in locally_defined_sb_units):
+            flux_unit_type = "Surface Brightness"
+        elif any(y_unit.is_equivalent(unit) for unit in locally_defined_flux_units):
             flux_unit_type = 'Flux'
         elif y_unit.is_equivalent(u.electron / u.s) or y_unit.physical_type == 'dimensionless':
             # electron / s or 'dimensionless_unscaled' should be labeled counts

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -568,7 +568,8 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
             u.erg / (u.s * u.cm**2 * u.Angstrom),
             u.erg / (u.s * u.cm**2 * u.Hz),
             u.ph / (u.s * u.cm**2 * u.Angstrom),
-            u.ph / (u.s * u.cm**2 * u.Hz)
+            u.ph / (u.s * u.cm**2 * u.Hz),
+            u.bol, u.AB, u.ST
         ]
 
         locally_defined_sb_units = [

--- a/jdaviz/configs/specviz/tests/test_viewers.py
+++ b/jdaviz/configs/specviz/tests/test_viewers.py
@@ -6,8 +6,8 @@ from specutils import Spectrum1D
 
 @pytest.mark.parametrize(
     ('input_unit', 'y_axis_label'),
-    [(u.MJy, 'Flux density'),
-     (u.MJy / u.sr, 'Surface brightness'),
+    [(u.MJy, 'Flux'),
+     (u.MJy / u.sr, 'Surface Brightness'),
      (u.electron / u.s, 'Counts'),
      (u.dimensionless_unscaled, 'Counts'),
      (u.erg / (u.s * u.cm ** 2), 'Flux'),

--- a/jdaviz/core/validunits.py
+++ b/jdaviz/core/validunits.py
@@ -54,7 +54,7 @@ def create_spectral_equivalencies_list(spectral_axis_unit,
 
 def create_flux_equivalencies_list(flux_unit, spectral_axis_unit):
     """Get all possible conversions for flux from current flux units."""
-    if ((flux_unit in (u.count, (u.MJy / u.sr), u.dimensionless_unscaled))
+    if ((flux_unit in (u.count, u.dimensionless_unscaled))
             or (spectral_axis_unit in (u.pix, u.dimensionless_unscaled))):
         return []
 
@@ -67,15 +67,26 @@ def create_flux_equivalencies_list(flux_unit, spectral_axis_unit):
         return []
 
     # Get local units.
-    locally_defined_flux_units = ['Jy', 'mJy', 'uJy', 'MJy',
-                                  'W / (m2 Hz)',
-                                  'eV / (s m2 Hz)',
-                                  'erg / (s cm2)',
-                                  'erg / (s cm2 Angstrom)',
-                                  'erg / (s cm2 Hz)',
-                                  'ph / (s cm2 Angstrom)',
-                                  'ph / (s cm2 Hz)']
-    local_units = [u.Unit(unit) for unit in locally_defined_flux_units]
+    if u.sr not in flux_unit.bases:
+        locally_defined_flux_units = ['Jy', 'mJy', 'uJy', 'MJy', 'Jy',
+                                    'W / (m2 Hz)',
+                                    'eV / (s m2 Hz)',
+                                    'erg / (s cm2)',
+                                    'erg / (s cm2 Angstrom)',
+                                    'erg / (s cm2 Hz)',
+                                    'ph / (s cm2 Angstrom)',
+                                    'ph / (s cm2 Hz)']
+        local_units = [u.Unit(unit) for unit in locally_defined_flux_units]
+    else:
+        locally_defined_flux_units = ['Jy / sr', 'mJy / sr', 'uJy / sr', 'MJy / sr', 'Jy / sr',
+                                    'W / (m2 Hz sr)',
+                                    'eV / (s m2 Hz sr)',
+                                    'erg / (s cm2 sr)',
+                                    'erg / (s cm2 Angstrom sr)',
+                                    'erg / (s cm2 Hz sr)',
+                                    'ph / (s cm2 Angstrom sr)',
+                                    'ph / (s cm2 Hz sr)']
+        local_units = [u.Unit(unit) for unit in locally_defined_flux_units]
 
     # Remove overlap units.
     curr_flux_unit_equivalencies = list(set(curr_flux_unit_equivalencies)

--- a/jdaviz/core/validunits.py
+++ b/jdaviz/core/validunits.py
@@ -67,7 +67,7 @@ def create_flux_equivalencies_list(flux_unit, spectral_axis_unit):
         return []
 
     # Get local units.
-    locally_defined_flux_units = ['Jy', 'mJy', 'uJy',
+    locally_defined_flux_units = ['Jy', 'mJy', 'uJy', 'MJy',
                                   'W / (m2 Hz)',
                                   'eV / (s m2 Hz)',
                                   'erg / (s cm2)',

--- a/jdaviz/core/validunits.py
+++ b/jdaviz/core/validunits.py
@@ -69,7 +69,7 @@ def create_flux_equivalencies_list(flux_unit, spectral_axis_unit):
     # Get local units.
     if u.sr not in flux_unit.bases:
         locally_defined_flux_units = ['Jy', 'mJy', 'uJy', 'MJy', 'Jy',
-                                      'W / (m2 Hz)',
+                                      'W / (Hz m2)',
                                       'eV / (s m2 Hz)',
                                       'erg / (s cm2)',
                                       'erg / (s cm2 Angstrom)',
@@ -79,13 +79,14 @@ def create_flux_equivalencies_list(flux_unit, spectral_axis_unit):
         local_units = [u.Unit(unit) for unit in locally_defined_flux_units]
     else:
         locally_defined_flux_units = ['Jy / sr', 'mJy / sr', 'uJy / sr', 'MJy / sr', 'Jy / sr',
-                                      'W / (m2 Hz sr)',
+                                      'W / (Hz sr m2)',
                                       'eV / (s m2 Hz sr)',
                                       'erg / (s cm2 sr)',
                                       'erg / (s cm2 Angstrom sr)',
                                       'erg / (s cm2 Hz sr)',
                                       'ph / (s cm2 Angstrom sr)',
-                                      'ph / (s cm2 Hz sr)']
+                                      'ph / (s cm2 Hz sr)',
+                                      'bol / sr', 'AB / sr', 'ST / sr']
         local_units = [u.Unit(unit) for unit in locally_defined_flux_units]
 
     # Remove overlap units.

--- a/jdaviz/core/validunits.py
+++ b/jdaviz/core/validunits.py
@@ -69,23 +69,23 @@ def create_flux_equivalencies_list(flux_unit, spectral_axis_unit):
     # Get local units.
     if u.sr not in flux_unit.bases:
         locally_defined_flux_units = ['Jy', 'mJy', 'uJy', 'MJy', 'Jy',
-                                    'W / (m2 Hz)',
-                                    'eV / (s m2 Hz)',
-                                    'erg / (s cm2)',
-                                    'erg / (s cm2 Angstrom)',
-                                    'erg / (s cm2 Hz)',
-                                    'ph / (s cm2 Angstrom)',
-                                    'ph / (s cm2 Hz)']
+                                      'W / (m2 Hz)',
+                                      'eV / (s m2 Hz)',
+                                      'erg / (s cm2)',
+                                      'erg / (s cm2 Angstrom)',
+                                      'erg / (s cm2 Hz)',
+                                      'ph / (s cm2 Angstrom)',
+                                      'ph / (s cm2 Hz)']
         local_units = [u.Unit(unit) for unit in locally_defined_flux_units]
     else:
         locally_defined_flux_units = ['Jy / sr', 'mJy / sr', 'uJy / sr', 'MJy / sr', 'Jy / sr',
-                                    'W / (m2 Hz sr)',
-                                    'eV / (s m2 Hz sr)',
-                                    'erg / (s cm2 sr)',
-                                    'erg / (s cm2 Angstrom sr)',
-                                    'erg / (s cm2 Hz sr)',
-                                    'ph / (s cm2 Angstrom sr)',
-                                    'ph / (s cm2 Hz sr)']
+                                      'W / (m2 Hz sr)',
+                                      'eV / (s m2 Hz sr)',
+                                      'erg / (s cm2 sr)',
+                                      'erg / (s cm2 Angstrom sr)',
+                                      'erg / (s cm2 Hz sr)',
+                                      'ph / (s cm2 Angstrom sr)',
+                                      'ph / (s cm2 Hz sr)']
         local_units = [u.Unit(unit) for unit in locally_defined_flux_units]
 
     # Remove overlap units.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address adding a UI toggle for translating between surface brightness and flux within the unexposed Unit Conversion Plugin. 


Main Notes:

- [x] Cubeviz example notebook data is in MJy / sr. When translating from MJy -> MJy / sr (second trip), `data_item` in `data_collection` is still used and has values in MJy/sr (data_collection doesn't update).
- [x] Address Tracebacks for `UnitConversionError: 'MJy' (spectral flux density) and 'MJy / sr' are not convertible` and `IncompatibleAttribute: flux `.
- [ ] Upstream change needed to reset y-axis limits.
- [x] pixel scale factor moved to app.py (from cubeviz/spec_extract), test needs to move and be rewritten.


PR (buggy) behavior:




https://github.com/spacetelescope/jdaviz/assets/42986583/fe8c0150-e12f-42e9-9b4a-a1224a94bf66








<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
