### PR TITLE
Consolidate filename normalization for exports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ New Features
 
 - Live-preview of aperture selection in plugins. [#2664, #2684]
 
-- "Export Plot" plugin is now replaced with the more general "Export" plugin. [#2722]
+- "Export Plot" plugin is now replaced with the more general "Export" plugin. [#2722, #2782]
 
 - "Export" plugin supports exporting plugin tables, data and non-composite spatial subsets.[#2755, #2760, #2772, #2770]
 

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -261,7 +261,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         elif ((not filepath or str(filepath).startswith(".")) and os.environ.get("JDAVIZ_START_DIR", "")):  # noqa: E501 # pragma: no cover
             filename = os.environ["JDAVIZ_START_DIR"] / filename
 
-        return filename
+        return str(filename)
 
     @with_spinner()
     def export(self, filename=None, show_dialog=None):

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -247,7 +247,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
     def _normalize_filename(self, filename=None, filetype=None):
         # Make sure filename is valid and file does not end up in weird places in standalone mode.
-        if filename is None or filename == "":
+        if not filename:
             raise ValueError("Invalid filename")
 
         if isinstance(filename, str):

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -247,10 +247,10 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
     def _normalize_filename(self, filename=None, filetype=None):
         # Make sure filename is valid and file does not end up in weird places in standalone mode.
-        if filename is None:
+        if filename is None or filename == "":
             raise ValueError("Invalid filename")
 
-        if isinstance(filename, str) and len(filename):
+        if isinstance(filename, str):
             if not filename.endswith(filetype):
                 filename += f".{filetype}"
             filename = Path(filename).expanduser()

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -256,13 +256,11 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             filename = Path(filename).expanduser()
 
         filepath = filename.parent
-        self.hub.broadcast(SnackbarMessage(f"Filepath is initially {filepath}", sender=self, color="warning"))
         if filepath and not filepath.exists():
             raise ValueError(f"Invalid path={filepath}")
         elif ((not filepath or str(filepath).startswith(".")) and os.environ.get("JDAVIZ_START_DIR", "")):  # noqa: E501 # pragma: no cover
             filename = os.environ["JDAVIZ_START_DIR"] / filename
-        else:
-            self.hub.broadcast(SnackbarMessage(f"Got to Else case", sender=self, color="warning"))
+
         return filename
 
     @with_spinner()


### PR DESCRIPTION
This consolidates the filename logic for exporting to fix the standalone case for all export types, not just movies. I wasn't sure whether to put the changelog in with the other Export stuff or in Bug Fixes, since I think the standalone issue was present in 3.8.