### PR TITLE
Fix Orientation selection/creation with no loaded data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Improved behavior when orientations are created or selected without having data loaded in the viewer. [#2789]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -275,6 +275,9 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
     def _get_wcs_angles(self, first_loaded_image=None):
         if first_loaded_image is None:
             first_loaded_image = self.viewer.selected_obj.first_loaded_data
+            if first_loaded_image is None:
+                # These won't end up getting used in this case, but need an actual number
+                return 0,0,0
         degn, dege, flip = get_compass_info(
             first_loaded_image.coords, first_loaded_image.shape
         )[-3:]
@@ -293,7 +296,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         return 0 * u.deg
 
     def add_orientation(self, rotation_angle=None, east_left=None, label=None,
-                        set_on_create=True, wrt_data=None):
+                        set_on_create=True, wrt_data=None, from_ui=False):
         """
         Add new orientation options.
 
@@ -332,6 +335,12 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             # default rotation:
             wrt_data = self.viewer.selected_obj.first_loaded_data
             if wrt_data is None:  # Nothing in viewer
+                msg = "Viewer must have data loaded to add an orientation."
+                if from_ui:
+                    self.hub.broadcast(SnackbarMessage(msg, color="error",
+                                                       timeout=6000, sender=self))
+                else:
+                    raise ValueError(msg)
                 return
 
         rotation_angle = self.rotation_angle_deg(rotation_angle)
@@ -414,7 +423,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             self.viewer.selected_obj.state.reset_limits()
 
     def vue_add_orientation(self, *args, **kwargs):
-        self.add_orientation(set_on_create=True)
+        self.add_orientation(set_on_create=True, from_ui=True)
 
     @observe('orientation_layer_selected')
     def _change_reference_data(self, *args, **kwargs):
@@ -486,7 +495,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             if ref_data.label in self.orientation.choices:
                 self.orientation.selected = ref_data.label
 
-    def create_north_up_east_left(self, label="North-up, East-left", set_on_create=False):
+    def create_north_up_east_left(self, label="North-up, East-left", set_on_create=False,
+                                  from_ui=False):
         """
         Set the rotation angle and flip to achieve North up and East left
         according to the reference image WCS.
@@ -494,11 +504,13 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         if label not in self.orientation.choices:
             degn = self._get_wcs_angles()[-3]
             self.add_orientation(rotation_angle=degn, east_left=True,
-                                 label=label, set_on_create=set_on_create)
+                                 label=label, set_on_create=set_on_create,
+                                 from_ui=from_ui)
         elif set_on_create:
             self.orientation.selected = label
 
-    def create_north_up_east_right(self, label="North-up, East-right", set_on_create=False):
+    def create_north_up_east_right(self, label="North-up, East-right", set_on_create=False,
+                                   from_ui=False):
         """
         Set the rotation angle and flip to achieve North up and East right
         according to the reference image WCS.
@@ -506,15 +518,16 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         if label not in self.orientation.choices:
             degn = self._get_wcs_angles()[-3]
             self.add_orientation(rotation_angle=180 - degn, east_left=False,
-                                 label=label, set_on_create=set_on_create)
+                                 label=label, set_on_create=set_on_create,
+                                 from_ui=from_ui)
         elif set_on_create:
             self.orientation.selected = label
 
     def vue_select_north_up_east_left(self, *args, **kwargs):
-        self.create_north_up_east_left(set_on_create=True)
+        self.create_north_up_east_left(set_on_create=True, from_ui=True)
 
     def vue_select_north_up_east_right(self, *args, **kwargs):
-        self.create_north_up_east_right(set_on_create=True)
+        self.create_north_up_east_right(set_on_create=True, from_ui=True)
 
     def vue_select_default_orientation(self, *args, **kwargs):
         self.orientation.selected = base_wcs_layer_label

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -296,7 +296,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         return 0 * u.deg
 
     def add_orientation(self, rotation_angle=None, east_left=None, label=None,
-                        set_on_create=True, wrt_data=None, from_ui=False):
+                        set_on_create=True, wrt_data=None):
         """
         Add new orientation options.
 
@@ -327,6 +327,12 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             nothing will be done.
 
         """
+        self._add_orientation(rotation_angle=rotation_angle, east_left=east_left, label=label,
+                              set_on_create=set_on_create, wrt_data=wrt_data)
+
+    def _add_orientation(self, rotation_angle=None, east_left=None, label=None,
+                         set_on_create=True, wrt_data=None, from_ui=False):
+
         if self.link_type_selected != 'WCS':
             raise ValueError("must be aligned by WCS to add orientation options")
 
@@ -423,7 +429,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             self.viewer.selected_obj.state.reset_limits()
 
     def vue_add_orientation(self, *args, **kwargs):
-        self.add_orientation(set_on_create=True, from_ui=True)
+        self._add_orientation(set_on_create=True, from_ui=True)
 
     @observe('orientation_layer_selected')
     def _change_reference_data(self, *args, **kwargs):
@@ -503,7 +509,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         """
         if label not in self.orientation.choices:
             degn = self._get_wcs_angles()[-3]
-            self.add_orientation(rotation_angle=degn, east_left=True,
+            self._add_orientation(rotation_angle=degn, east_left=True,
                                  label=label, set_on_create=set_on_create,
                                  from_ui=from_ui)
         elif set_on_create:
@@ -517,7 +523,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         """
         if label not in self.orientation.choices:
             degn = self._get_wcs_angles()[-3]
-            self.add_orientation(rotation_angle=180 - degn, east_left=False,
+            self._add_orientation(rotation_angle=180 - degn, east_left=False,
                                  label=label, set_on_create=set_on_create,
                                  from_ui=from_ui)
         elif set_on_create:

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -276,8 +276,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         if first_loaded_image is None:
             first_loaded_image = self.viewer.selected_obj.first_loaded_data
             if first_loaded_image is None:
-                # These won't end up getting used in this case, but need an actual number
-                return 0,0,0
+                # These won't end up getting used in this case, but we need an actual number
+                return 0, 0, 0
         degn, dege, flip = get_compass_info(
             first_loaded_image.coords, first_loaded_image.shape
         )[-3:]

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -510,8 +510,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         if label not in self.orientation.choices:
             degn = self._get_wcs_angles()[-3]
             self._add_orientation(rotation_angle=degn, east_left=True,
-                                 label=label, set_on_create=set_on_create,
-                                 from_ui=from_ui)
+                                  label=label, set_on_create=set_on_create,
+                                  from_ui=from_ui)
         elif set_on_create:
             self.orientation.selected = label
 
@@ -524,8 +524,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         if label not in self.orientation.choices:
             degn = self._get_wcs_angles()[-3]
             self._add_orientation(rotation_angle=180 - degn, east_left=False,
-                                 label=label, set_on_create=set_on_create,
-                                 from_ui=from_ui)
+                                  label=label, set_on_create=set_on_create,
+                                  from_ui=from_ui)
         elif set_on_create:
             self.orientation.selected = label
 

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -245,3 +245,4 @@ class TestOrientationNoData(BaseImviz_WCS_WCS):
         lc_plugin.viewer = "imviz-1"
         # This would error prior to bugfix
         lc_plugin.orientation = "North-up, East-left"
+        self.imviz.app.add_data_to_viewer("imviz-1", "has_wcs_1[SCI,1]")

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -224,12 +224,13 @@ class TestDeleteOrientation(BaseImviz_WCS_WCS):
         with pytest.raises(AssertionError, match="Not equal to tolerance"):
             assert_quantity_allclose(out_reg.angle, reg.angle)
 
+
 class TestOrientationNoData(BaseImviz_WCS_WCS):
     def test_create_no_data(self):
         lc_plugin = self.imviz.plugins['Orientation']
         lc_plugin.link_type = 'WCS'
 
-        viewer_2 = self.imviz.create_image_viewer()
+        self.imviz.create_image_viewer()
         lc_plugin.viewer = "imviz-1"
 
         with pytest.raises(ValueError, match="Viewer must have data loaded"):
@@ -241,7 +242,7 @@ class TestOrientationNoData(BaseImviz_WCS_WCS):
 
         lc_plugin._obj.create_north_up_east_left(set_on_create=True)
 
-        viewer_2 = self.imviz.create_image_viewer()
+        self.imviz.create_image_viewer()
         lc_plugin.viewer = "imviz-1"
         # This would error prior to bugfix
         lc_plugin.orientation = "North-up, East-left"

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -223,3 +223,25 @@ class TestDeleteOrientation(BaseImviz_WCS_WCS):
         # FIXME: However, sky angle has to stay the same as per regions convention.
         with pytest.raises(AssertionError, match="Not equal to tolerance"):
             assert_quantity_allclose(out_reg.angle, reg.angle)
+
+class TestOrientationNoData(BaseImviz_WCS_WCS):
+    def test_create_no_data(self):
+        lc_plugin = self.imviz.plugins['Orientation']
+        lc_plugin.link_type = 'WCS'
+
+        viewer_2 = self.imviz.create_image_viewer()
+        lc_plugin.viewer = "imviz-1"
+
+        with pytest.raises(ValueError, match="Viewer must have data loaded"):
+            lc_plugin._obj.create_north_up_east_left(set_on_create=True)
+
+    def test_select_no_data(self):
+        lc_plugin = self.imviz.plugins['Orientation']
+        lc_plugin.link_type = 'WCS'
+
+        lc_plugin._obj.create_north_up_east_left(set_on_create=True)
+
+        viewer_2 = self.imviz.create_image_viewer()
+        lc_plugin.viewer = "imviz-1"
+        # This would error prior to bugfix
+        lc_plugin.orientation = "North-up, East-left"

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -201,6 +201,10 @@ class FreezableBqplotImageViewerState(BqplotImageViewerState, FreezableState):
 
         x_min, x_max, y_min, y_max = self._get_reset_limits()
 
+        # If any bound wasn't set to a real value, don't update
+        if np.any(~np.isfinite([x_min, x_max, y_min, y_max])):
+            return
+
         with delay_callback(self, 'x_min', 'x_max', 'y_min', 'y_max'):
             self.x_min, self.x_max, self.y_min, self.y_max = x_min, x_max, y_min, y_max
             # We need to adjust the limits in here to avoid triggering all


### PR DESCRIPTION
This improves the orientation code to catch the error and raise a snackbar warning if an orientation is added before loading data into the viewer, and stops the backend from trying to set bounds to `inf` if an orientation is selected in the data menu before data is loaded.