### PR TITLE
ensure footprints overlay when created by API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,7 @@ Cubeviz
 
 Imviz
 ^^^^^
+- Fix a bug where footprints did not overlay when created via API. [#2790]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -368,8 +368,8 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
         self._preset_args_changed()
 
     def _mark_visible(self, viewer_id, overlay=None):
-        if overlay == 'default' and overlay not in self._overlays:
-            return
+        if overlay not in self._overlays:
+            return False
         if not self.is_active:
             return False
         if self.is_pixel_linked:

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -368,6 +368,8 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
         self._preset_args_changed()
 
     def _mark_visible(self, viewer_id, overlay=None):
+        if overlay == 'default' and overlay not in self._overlays:
+            return
         if not self.is_active:
             return False
         if self.is_pixel_linked:

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -368,14 +368,14 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
         self._preset_args_changed()
 
     def _mark_visible(self, viewer_id, overlay=None):
-        if overlay not in self._overlays:
-            return False
         if not self.is_active:
             return False
         if self.is_pixel_linked:
             return False
         if overlay is None:
             overlay = self.overlay_selected
+        if overlay not in self._overlays:
+            return False
         fp = self._overlays[overlay]
         if viewer_id not in fp.get('viewer', []):
             return False


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address Footprints not appearing when created via the API. When Footprints were added, the overlay dictionary did not contain the default footprint, and _mark_visible was unable to plot the default and any subsequent Footprints created via API. By adding a check to make sure that the default is within the _overlay dictionary, all Footprints are plotted.



https://github.com/spacetelescope/jdaviz/assets/42986583/46a1f546-b2ef-4b27-b3a9-d4ff5f74feb9




<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
