### PR TITLE
feat: stop jdaviz/voila when the browser window closes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,8 @@ Bug Fixes
 
 - Fix dropdown selection for table format in export plugin. [#2793]
 
+- Standalone mode: stop jdaviz/voila processes when closing app. [#2791]
+
 Cubeviz
 ^^^^^^^
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
This feature closes jdaviz (voila) when a kernel closes, which should happen when a browser page/tab is closed.

Voila itself does not have this feature, although jupyter-server has something along these lines, but only polls every 60 seconds:
https://github.com/jupyter-server/jupyter_server/blob/de6d9047fa414859856198b7b2dfe80e60edd010/jupyter_server/serverapp.py#L2547

This change makes it immediate, but requires monkey patching. This API has been stable from the start of Voila when we wrote it, so I am not too worried that is will break, and I also believe Voila is pinned.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
