### PR TITLE
fix typo in vue file affecting plugin table format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,8 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Fix dropdown selection for table format in export plugin. [#2793]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -122,7 +122,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         # although not all support passing overwrite
         plugin_table_format_options = ['ecsv', 'csv', 'fits']
         self.plugin_table_format = SelectPluginComponent(self,
-                                                         items='plugin-table_format_items',
+                                                         items='plugin_table_format_items',
                                                          selected='plugin_table_format_selected',
                                                          manual_options=plugin_table_format_options)
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes #2792.

Note that before this:
* export should still work, just will be using ecsv by default
* changing the format would still work from the API, this bug is isolated to the dropdown UI element itself.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
