### PR TITLE
BUG: Fix random flip in WCS orientation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,9 +75,12 @@ Cubeviz
 
 Imviz
 ^^^^^
+
 - Fix a bug where footprints did not overlay when created via API. [#2790]
 
 - Improved behavior when orientations are created or selected without having data loaded in the viewer. [#2789]
+
+- Fixed a bug in the Orientation plugin where a WCS orientation could sometimes be flipped. [#2802]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -196,16 +196,21 @@ class TestLink_WCS_GWCS(BaseImviz_WCS_GWCS):
             self.imviz.app.data_collection['fits_wcs[DATA]'])
         gwcs_zoom_limits = self.viewer._get_zoom_limits(
             self.imviz.app.data_collection['gwcs[DATA]'])
+
+        # x_min, y_min
+        # x_min, y_max
+        # x_max, y_max
+        # x_max, y_min
         assert_allclose(fits_wcs_zoom_limits,
-                        [[-1.590838, -0.423662],
-                         [-1.826862, 9.896219],
-                         [8.590838, 9.423662],
-                         [8.826862, -0.896219]], rtol=1e-5)
+                        [[-2.406711, -1.588057],
+                         [-2.697746, 11.137127],
+                         [10.148055, 10.554429],
+                         [10.439091, -2.170755]], rtol=1e-5)
         assert_allclose(gwcs_zoom_limits,
-                        [[3.186753, 11.337468],
-                         [11.895862, 5.072343],
-                         [6.158421, -3.145985],
-                         [-2.550688, 3.119141]], rtol=1e-5)
+                        [[ 2.636299, 12.732915],
+                         [13.375281,  5.007547],
+                         [ 6.300587, -5.126264],
+                         [-4.438394,  2.599103]], rtol=1e-5)
 
         # Also check the coordinates display: Last loaded is on top.
         # Cycle order: GWCS, FITS WCS

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -207,10 +207,10 @@ class TestLink_WCS_GWCS(BaseImviz_WCS_GWCS):
                          [10.148055, 10.554429],
                          [10.439091, -2.170755]], rtol=1e-5)
         assert_allclose(gwcs_zoom_limits,
-                        [[ 2.636299, 12.732915],
-                         [13.375281,  5.007547],
-                         [ 6.300587, -5.126264],
-                         [-4.438394,  2.599103]], rtol=1e-5)
+                        [[2.636299, 12.732915],
+                         [13.375281, 5.007547],
+                         [6.300587, -5.126264],
+                         [-4.438394, 2.599103]], rtol=1e-5)
 
         # Also check the coordinates display: Last loaded is on top.
         # Cycle order: GWCS, FITS WCS

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -167,13 +167,18 @@ class FreezableBqplotImageViewerState(BqplotImageViewerState, FreezableState):
                     y_min = min(y_min, world_bottom_left.dec.value)
                     y_max = max(y_max, world_top_right.dec.value)
                 else:
-                    pixel_bottom_left = self.reference_data.coords.world_to_pixel(world_bottom_left)
-                    pixel_top_right = self.reference_data.coords.world_to_pixel(world_top_right)
+                    x_bl, y_bl = self.reference_data.coords.world_to_pixel(world_bottom_left)
+                    x_tr, y_tr = self.reference_data.coords.world_to_pixel(world_top_right)
 
-                    x_min = min(x_min, pixel_bottom_left[0] - 0.5)
-                    x_max = max(x_max, pixel_top_right[0] + 0.5)
-                    y_min = min(y_min, pixel_bottom_left[1] - 0.5)
-                    y_max = max(y_max, pixel_top_right[1] + 0.5)
+                    x_pix_min = min(x_bl, x_tr)
+                    x_pix_max = max(x_bl, x_tr)
+                    y_pix_min = min(y_bl, y_tr)
+                    y_pix_max = max(y_bl, y_tr)
+
+                    x_min = min(x_min, x_pix_min - 0.5)
+                    x_max = max(x_max, x_pix_max + 0.5)
+                    y_min = min(y_min, y_pix_min - 0.5)
+                    y_max = max(y_max, y_pix_max + 0.5)
                 wcs_success = True
 
         if not wcs_success:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to hopefully address the problem of Ricky (and others) sometimes seeing a WCS orientation getting flipped.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4341)
