### PR TITLE
stretch_global switch in plot options

### DIFF
--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -572,7 +572,7 @@ class PlotOptions(PluginTemplateMixin):
         self.stretch_preset = PlotOptionsSyncState(self, self.viewer, self.layer, 'percentile',
                                                    'stretch_preset_value', 'stretch_preset_sync',
                                                    state_filter=is_image)
-        self.stretch_global = PlotOptionsSyncState(self, self.viewer, self.layer, 'global_limits',
+        self.stretch_global = PlotOptionsSyncState(self, self.viewer, self.layer, 'stretch_global',
                                                    'stretch_global_value', 'stretch_global_sync',
                                                    state_filter=is_image_cube)
         self.stretch_vmin = PlotOptionsSyncState(self, self.viewer, self.layer, 'v_min',

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -173,6 +173,9 @@ class PlotOptions(PluginTemplateMixin):
       not exposed for Specviz
     * ``stretch_preset`` (:class:`~jdaviz.core.template_mixin.PlotOptionsSyncState`):
       not exposed for Specviz
+    * ``stretch_global`` (:class:`~jdaviz.core.template_mixin.PlotOptionsSyncState`):
+      Whether to apply the stretch preset based on the data in entire cube (as opposed
+      to the currently selected slice).  Only exposed for Cubeviz.
     * ``stretch_vmin`` (:class:`~jdaviz.core.template_mixin.PlotOptionsSyncState`):
       not exposed for Specviz
     * ``stretch_vmax`` (:class:`~jdaviz.core.template_mixin.PlotOptionsSyncState`):
@@ -326,6 +329,9 @@ class PlotOptions(PluginTemplateMixin):
     stretch_preset_value = Any().tag(sync=True)  # glue will pass either a float or string
     stretch_preset_sync = Dict().tag(sync=True)
 
+    stretch_global_value = Bool().tag(sync=True)
+    stretch_global_sync = Dict().tag(sync=True)
+
     stretch_vstep = Float(0.1).tag(sync=True)  # dynamic based on full range from image
 
     stretch_vmin_value = Float().tag(sync=True)
@@ -438,6 +444,9 @@ class PlotOptions(PluginTemplateMixin):
 
         def is_image(state):
             return isinstance(state, BqplotImageLayerState)
+
+        def is_image_cube(state):
+            return is_image(state) and state.layer.ndim == 3
 
         def not_image(state):
             return not is_image(state)
@@ -563,6 +572,9 @@ class PlotOptions(PluginTemplateMixin):
         self.stretch_preset = PlotOptionsSyncState(self, self.viewer, self.layer, 'percentile',
                                                    'stretch_preset_value', 'stretch_preset_sync',
                                                    state_filter=is_image)
+        self.stretch_global = PlotOptionsSyncState(self, self.viewer, self.layer, 'global_limits',
+                                                      'stretch_global_value', 'stretch_global_sync',
+                                                      state_filter=is_image_cube)
         self.stretch_vmin = PlotOptionsSyncState(self, self.viewer, self.layer, 'v_min',
                                                  'stretch_vmin_value', 'stretch_vmin_sync',
                                                  state_filter=is_image)
@@ -683,7 +695,7 @@ class PlotOptions(PluginTemplateMixin):
         expose = ['multiselect', 'viewer', 'viewer_multiselect', 'layer', 'layer_multiselect',
                   'select_all', 'subset_visible']
         if self.config == "cubeviz":
-            expose += ['collapse_function', 'uncertainty_visible']
+            expose += ['collapse_function', 'uncertainty_visible', 'stretch_global']
         if self.config != "imviz":
             expose += ['x_min', 'x_max', 'y_min', 'y_max',
                        'axes_visible', 'line_visible', 'line_color', 'line_width', 'line_opacity',

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -559,6 +559,15 @@
         ></v-select>
       </glue-state-sync-wrapper>
 
+      <glue-state-sync-wrapper :sync="stretch_global_sync" :multiselect="layer_multiselect" @unmix-state="unmix_state('stretch_global')">
+        <v-switch
+          v-model="stretch_global_value"
+          label="Global stretch"
+          hint="Determine stretch from stretch preset and display stretch histogram based on data of entire cube (instead of currently selected slice)."
+          :persistent-hint="true"
+          />
+      </glue-state-sync-wrapper>
+
       <!-- for multiselect, show vmin/max here, otherwise they'll be in the "more stretch options" expandable section -->
       <glue-state-sync-wrapper v-if="layer_multiselect" :sync="stretch_vmin_sync" :multiselect="layer_multiselect" @unmix-state="unmix_state('stretch_vmin')">
         <v-text-field


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements support for toggling whether stretch is handled per-slice or globally across the cube (for cubeviz only).


https://github.com/spacetelescope/jdaviz/assets/877591/70f63f0d-ffc2-47fa-acbf-91e40270c988



This replaces #2621 and #2694 and would require https://github.com/glue-viz/glue/pull/2476 to be merged/pinned. 

TODO:
- [x] update histogram data based on selection.
- [ ] if set to per-slice, update histogram on change to selected slice (and update screen recording)
- [ ] fix tests (histogram colorbar needs updating)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
