### PR TITLE
Better menu selection labels for spectral lines in line analysis plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,8 @@ Specviz2d
 Other Changes and Additions
 ---------------------------
 
+- Line menu in Redshift from Centroid section of Line Analysis now shows values in current units. [#2816]
+
 3.9.1 (unreleased)
 ==================
 
@@ -81,7 +83,7 @@ Cubeviz
 
 Imviz
 ^^^^^
-- Fix bugs where API created footprints did not overlay and only last 
+- Fix bugs where API created footprints did not overlay and only last
   footprint displayed if added before linking. [#2790, #2797]
 
 - Improved behavior when orientations are created or selected without having data loaded in the viewer. [#2789]

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -254,7 +254,6 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         self.line_items = msg.names_rest
         menu_labels = [f"{msg.marks[i].name} {msg.marks[i].rest_value} {msg.marks[i].xunit}" for i in range(len(msg.marks))]  # noqa
         self.line_menu_items = [{"title": menu_labels[i], "value": msg.names_rest[i]} for i in range(len(msg.names_rest))]  # noqa
-        print(self.line_menu_items)
         if self.selected_line not in self.line_items:
             # default to identified line if available
             self.selected_line = self.identified_line

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -102,7 +102,6 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
     results_computing = Bool(False).tag(sync=True)
     results = List().tag(sync=True)
     results_centroid = Float().tag(sync=True)  # stored in AA units
-    line_items = List([]).tag(sync=True)
     line_menu_items = List([{}]).tag(sync=True)
     sync_identify = Bool(True).tag(sync=True)
     sync_identify_icon_enabled = Unicode(read_icon(os.path.join(ICON_DIR, 'line_select.svg'), 'svg+xml')).tag(sync=True)  # noqa
@@ -173,6 +172,11 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         # user API and the property and setter above as soon as 3.11.
         return PluginUserApi(self, expose=('dataset', 'spatial_subset', 'spectral_subset',
                                            'continuum', 'width', 'continuum_width', 'get_results'))
+
+    @property
+    def line_items(self):
+        # Return list of only the table indices ("name_rest" in line table) from line_menu_items
+        return [item["value"] for item in self.line_menu_items]
 
     def _on_viewer_data_changed(self, msg):
         viewer_id = self.app._viewer_item_by_reference(
@@ -251,8 +255,8 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
 
     def _on_plotted_lines_changed(self, msg):
         self.line_marks = msg.marks
-        self.line_items = msg.names_rest
-        self.line_menu_items = [{"title": f"{mark.name} {mark.rest_value} {mark.xunit}", "value": name_rest} for mark, name_rest in zip(msg.marks, msg.names_rest)]  # noqa
+        self.line_menu_items = [{"title": f"{mark.name} {mark.rest_value} {mark.xunit}", "value": name_rest}  # noqa
+                                for mark, name_rest in zip(msg.marks, msg.names_rest)]
         if self.selected_line not in self.line_items:
             # default to identified line if available
             self.selected_line = self.identified_line

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -103,6 +103,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
     results = List().tag(sync=True)
     results_centroid = Float().tag(sync=True)  # stored in AA units
     line_items = List([]).tag(sync=True)
+    line_menu_items = List([{}]).tag(sync=True)
     sync_identify = Bool(True).tag(sync=True)
     sync_identify_icon_enabled = Unicode(read_icon(os.path.join(ICON_DIR, 'line_select.svg'), 'svg+xml')).tag(sync=True)  # noqa
     sync_identify_icon_disabled = Unicode(read_icon(os.path.join(ICON_DIR, 'line_select_disabled.svg'), 'svg+xml')).tag(sync=True)  # noqa
@@ -250,7 +251,10 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
 
     def _on_plotted_lines_changed(self, msg):
         self.line_marks = msg.marks
-        self.line_items = [f"{msg.marks[i].name} {msg.marks[i].rest_value} {msg.marks[i].xunit}" for i in range(len(msg.marks))]   # noqa
+        self.line_items = msg.names_rest
+        menu_labels = [f"{msg.marks[i].name} {msg.marks[i].rest_value} {msg.marks[i].xunit}" for i in range(len(msg.marks))]   # noqa
+        self.line_menu_items = [{"title": menu_labels[i], "value": msg.names_rest[i]} for i in range(len(msg.names_rest))]
+        print(self.line_menu_items)
         if self.selected_line not in self.line_items:
             # default to identified line if available
             self.selected_line = self.identified_line

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -252,8 +252,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
     def _on_plotted_lines_changed(self, msg):
         self.line_marks = msg.marks
         self.line_items = msg.names_rest
-        menu_labels = [f"{msg.marks[i].name} {msg.marks[i].rest_value} {msg.marks[i].xunit}" for i in range(len(msg.marks))]  # noqa
-        self.line_menu_items = [{"title": menu_labels[i], "value": msg.names_rest[i]} for i in range(len(msg.names_rest))]  # noqa
+        self.line_menu_items = [{"title": f"{mark.name} {mark.rest_value} {mark.xunit}", "value": name_rest} for mark, name_rest in zip(msg.marks, msg.names_rest)]  # noqa
         if self.selected_line not in self.line_items:
             # default to identified line if available
             self.selected_line = self.identified_line

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -242,14 +242,15 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
 
         if not self.spectral_subset_valid:
             valid, spec_range, subset_range = self._check_dataset_spectral_subset_valid(return_ranges=True)  # noqa
-            raise ValueError(f"spectral subset '{self.spectral_subset.selected}' {subset_range} is outside data range of '{self.dataset.selected}' {spec_range}")  # noqa
+            raise ValueError(f"spectral subset '{self.spectral_subset.selected}' {subset_range}"
+                             f" is outside data range of '{self.dataset.selected}' {spec_range}")
 
         self._calculate_statistics()
         return self.results
 
     def _on_plotted_lines_changed(self, msg):
         self.line_marks = msg.marks
-        self.line_items = msg.names_rest
+        self.line_items = [f"{msg.marks[i].name} {msg.marks[i].rest_value} {msg.marks[i].xunit}" for i in range(len(msg.marks))]   # noqa
         if self.selected_line not in self.line_items:
             # default to identified line if available
             self.selected_line = self.identified_line

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -252,8 +252,8 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
     def _on_plotted_lines_changed(self, msg):
         self.line_marks = msg.marks
         self.line_items = msg.names_rest
-        menu_labels = [f"{msg.marks[i].name} {msg.marks[i].rest_value} {msg.marks[i].xunit}" for i in range(len(msg.marks))]   # noqa
-        self.line_menu_items = [{"title": menu_labels[i], "value": msg.names_rest[i]} for i in range(len(msg.names_rest))]
+        menu_labels = [f"{msg.marks[i].name} {msg.marks[i].rest_value} {msg.marks[i].xunit}" for i in range(len(msg.marks))]  # noqa
+        self.line_menu_items = [{"title": menu_labels[i], "value": msg.names_rest[i]} for i in range(len(msg.names_rest))]  # noqa
         print(self.line_menu_items)
         if self.selected_line not in self.line_items:
             # default to identified line if available

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -33,7 +33,7 @@
       hint="Select which region's collapsed spectrum to analyze."
     />
 
-    <plugin-subset-select 
+    <plugin-subset-select
       :items="spectral_subset_items"
       :selected.sync="spectral_subset_selected"
       :show_if_single_entry="true"
@@ -50,13 +50,13 @@
     <j-plugin-section-header>Continuum</j-plugin-section-header>
     <v-row>
       <j-docs-link>
-        {{continuum_subset_selected=='Surrounding' && spectral_subset_selected=='Entire Spectrum' ? "Since using the entire spectrum, the end points will be used to fit a linear continuum." : "Choose a region to fit a linear line as the underlying continuum."}}  
+        {{continuum_subset_selected=='Surrounding' && spectral_subset_selected=='Entire Spectrum' ? "Since using the entire spectrum, the end points will be used to fit a linear continuum." : "Choose a region to fit a linear line as the underlying continuum."}}
         {{continuum_subset_selected=='Surrounding' && spectral_subset_selected!='Entire Spectrum' ? "Choose a width in number of data points to consider on each side of the line region defined above." : null}}
         When this plugin is opened, a visual indicator will show on the spectrum plot showing the continuum fitted as a thick line, and interpolated into the line region as a thin line.
       </j-docs-link>
     </v-row>
 
-    <plugin-subset-select 
+    <plugin-subset-select
       :items="continuum_subset_items"
       :selected.sync="continuum_subset_selected"
       :show_if_single_entry="true"
@@ -96,17 +96,17 @@
           <v-col cols=6><U>Function</U></v-col>
           <v-col cols=6><U>Result</U></v-col>
         </v-row>
-        <v-row 
+        <v-row
           v-for="item in results"
           :key="item.function">
           <v-col cols=6>
             {{  item.function  }}
             <j-tooltip :tooltipcontent="'specutils '+item.function+' documentation'">
-              <a v-bind:href="'https://specutils.readthedocs.io/en/stable/api/specutils.analysis.'+item.function.toLowerCase().replaceAll(' ', '_')+'.html'" 
-                target="__blank" 
+              <a v-bind:href="'https://specutils.readthedocs.io/en/stable/api/specutils.analysis.'+item.function.toLowerCase().replaceAll(' ', '_')+'.html'"
+                target="__blank"
                 style="color: #A75000">
                 <v-icon x-small color="#A75000">mdi-open-in-new</v-icon>
-              </a> 
+              </a>
             </j-tooltip>
           </v-col>
           <v-col cols=6>
@@ -123,7 +123,7 @@
       </div>
       <div v-if="results_computing"
            class="text-center"
-           style="grid-area: 1/1; 
+           style="grid-area: 1/1;
                   z-index:2;
                   margin-left: -24px;
                   margin-right: -24px;
@@ -154,7 +154,9 @@
             <v-select
               :menu-props="{ left: true }"
               attach
-              :items="line_items"
+              :items="line_menu_items"
+              item-text="title"
+              item-value="value"
               v-model="selected_line"
               label="Line"
               hint="Select reference line."
@@ -177,7 +179,7 @@
 
         <v-row justify="end">
           <j-tooltip tipid='plugin-line-analysis-assign'>
-            <v-btn 
+            <v-btn
             color="accent"
             style="padding-left: 8px; padding-right: 8px;"
             text
@@ -188,6 +190,6 @@
           </j-tooltip>
         </v-row>
       </div>
-    </div>  
+    </div>
   </j-tray-plugin>
 </template>


### PR DESCRIPTION
Previously, the line menu under `Redshift from Centroid` showed the name and originally defined value for the lines, which could have been in different units. Now it shows name + rest value in current units + unit.

Before: 
![image](https://github.com/spacetelescope/jdaviz/assets/39831871/3725d66a-4751-4942-a104-ce8609536461)

Now:
![Screenshot 2024-04-17 at 2 58 02 PM](https://github.com/spacetelescope/jdaviz/assets/39831871/064914fb-990e-4ed2-ba63-19956e31dec4)
