### PR TITLE
DQ support for Cubeviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ New Features
 
 - The filename entry in the export plugin is now automatically populated based on the selection. [#2824]
 
+- Adding Data Quality plugin for Imviz and Cubeviz. [#2767, #2817]
+
 Cubeviz
 ^^^^^^^
 

--- a/docs/cubeviz/plugins.rst
+++ b/docs/cubeviz/plugins.rst
@@ -46,6 +46,19 @@ To show axes on image viewers, toggle on the "Show axes" option at the bottom of
     :ref:`Spectral Plot Options <specviz-plot-settings>`
         Documentation on Specviz display settings in the Jdaviz viewers.
 
+.. _cubeviz-data-quality:
+
+Data Quality
+============
+
+Visualize data quality arrays for spectral cubes from JWST.
+
+.. seealso::
+
+    :ref:`Data Quality Plugin <imviz-data-quality>`
+        Follow the link to the rest of the Data Quality plugin documentation.
+
+
 .. _cubeviz-subset-plugin:
 
 Subset Tools

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -35,6 +35,32 @@ This plugin gives access to per-viewer and per-layer plotting options.
     :ref:`Display Settings <imviz-display-settings>`
         Documentation on various display settings in the Jdaviz viewers.
 
+.. _imviz-data-quality:
+
+Data Quality
+============
+
+Visualize data quality arrays for science data. The currently supported
+data quality flag mappings include JWST (all instruments) and Roman/WFI.
+
+Each science data layer can have one associated data quality layer.
+The visibility of the data quality layer can be toggled from the data
+dropdown menu, and toggling the science data visibility will do the
+same for the data quality layer. The mapping between bits and data quality
+flags is defined differently for each mission or instrument, and the
+plugin will infer the correct flag mapping from the file metadata.
+The opacity of the data quality layer can be changed relative to the
+opacity of the science data layer using the slider.
+
+The Quality Flag section contains a dropdown for applying a filter to the
+visualized bits. Select bits from the dropdown to visualize only flags
+containing those bits. The list of data quality flags beneath shows
+every flag in the data quality layer in bold, followed by the
+decomposed bits in that flag in parentheses. Clicking on a row
+will expand to flag to reveal the flag's short name and description,
+as well as a visibility toggle for that flag. Click on the color swatch
+to select a color for any flag.
+
 .. _imviz-subset-plugin:
 
 Subset Tools

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2113,6 +2113,22 @@ class Application(VuetifyTemplate, HubListener):
 
         # if Data has children, update their visibilities to match Data:
         assoc_children = self._get_assoc_data_children(data_label)
+        available_plugins = [tray_item['name'] for tray_item in self.state.tray_items]
+        if assoc_children not in viewer.data_labels_loaded:
+            for child in assoc_children:
+                self.add_data_to_viewer(viewer.reference, child, visible=visible)
+
+                if 'g-data-quality' in available_plugins and visible:
+                    # if we're adding a DQ layer to a viewer, make sure that
+                    # the layer is appropriately colormapped as DQ:
+                    data_quality_plugin = self.get_tray_item_from_name('g-data-quality')
+                    old_viewer = data_quality_plugin.viewer_selected
+                    data_quality_plugin.viewer_selected = viewer.reference
+                    data_quality_plugin.science_layer_selected = data_label
+                    data_quality_plugin.dq_layer_selected = child
+                    data_quality_plugin.init_decoding(viewers=[viewer])
+                    data_quality_plugin.viewer_selected = old_viewer
+
         for layer in viewer.layers:
             if layer.layer.data.label in assoc_children:
                 if visible and not layer.visible:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2734,17 +2734,24 @@ class Application(VuetifyTemplate, HubListener):
         self._data_associations[data_label] = {'parent': None, 'children': []}
 
     def _set_assoc_data_as_child(self, data_label, new_parent_label):
+        for data_item in self.state.data_items:
+            if data_item['name'] == data_label:
+                child_id = data_item['id']
+            elif data_item['name'] == new_parent_label:
+                new_parent_id = data_item['id']
+
         # Data has a new parent:
         self._data_associations[data_label]['parent'] = new_parent_label
+
+        # parent has a new child:
+        self._data_associations[new_parent_label]['children'].append(data_label)
 
         # update the data item so vue can see the change:
         for data_item in self.state.data_items:
             if data_item['name'] == data_label:
-                data_item['parent'] = new_parent_label
-                break
-
-        # parent has a new child:
-        self._data_associations[new_parent_label]['children'].append(data_label)
+                data_item['parent'] = new_parent_id
+            elif data_item['name'] == new_parent_label:
+                data_item['children'].append(child_id)
 
     def _get_assoc_data_children(self, data_label):
         # intentionally not recursive for now, just one generation:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2316,7 +2316,9 @@ class Application(VuetifyTemplate, HubListener):
             'has_wcs': data_has_valid_wcs(data),
             'is_astrowidgets_markers_table': (self.config == "imviz") and layer_is_table_data(data),
             'meta': {k: v for k, v in data.meta.items() if _expose_meta(k)},
-            'children': []}
+            'children': [],
+            'parent': None,
+        }
 
     @staticmethod
     def _create_stack_item(container='gl-stack', children=None, viewers=None):
@@ -2712,6 +2714,13 @@ class Application(VuetifyTemplate, HubListener):
     def _set_assoc_data_as_child(self, data_label, new_parent_label):
         # Data has a new parent:
         self._data_associations[data_label]['parent'] = new_parent_label
+
+        # update the data item so vue can see the change:
+        for data_item in self.state.data_items:
+            if data_item['name'] == data_label:
+                data_item['parent'] = new_parent_label
+                break
+
         # parent has a new child:
         self._data_associations[new_parent_label]['children'].append(data_label)
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2091,10 +2091,12 @@ class Application(VuetifyTemplate, HubListener):
                                               sender=self)
             self.hub.broadcast(add_data_message)
 
+        assoc_children = self._get_assoc_data_children(data_label)
+
         # set visibility state of all applicable layers
         for layer in viewer.layers:
             layer_is_wcs_only = getattr(layer.layer, 'meta', {}).get(_wcs_only_label, False)
-            if layer.layer.data.label == data_label:
+            if layer.layer.data.label in [data_label] + assoc_children:
                 if layer_is_wcs_only:
                     layer.visible = False
                     layer.update()
@@ -2112,22 +2114,21 @@ class Application(VuetifyTemplate, HubListener):
                     layer.visible = False
 
         # if Data has children, update their visibilities to match Data:
-        assoc_children = self._get_assoc_data_children(data_label)
         available_plugins = [tray_item['name'] for tray_item in self.state.tray_items]
-        if assoc_children not in viewer.data_labels_loaded:
-            for child in assoc_children:
+        for child in assoc_children:
+            if child not in viewer.data_labels_loaded:
                 self.add_data_to_viewer(viewer.reference, child, visible=visible)
 
-                if 'g-data-quality' in available_plugins and visible:
-                    # if we're adding a DQ layer to a viewer, make sure that
-                    # the layer is appropriately colormapped as DQ:
-                    data_quality_plugin = self.get_tray_item_from_name('g-data-quality')
-                    old_viewer = data_quality_plugin.viewer_selected
-                    data_quality_plugin.viewer_selected = viewer.reference
-                    data_quality_plugin.science_layer_selected = data_label
-                    data_quality_plugin.dq_layer_selected = child
-                    data_quality_plugin.init_decoding(viewers=[viewer])
-                    data_quality_plugin.viewer_selected = old_viewer
+            if 'g-data-quality' in available_plugins and visible:
+                # if we're adding a DQ layer to a viewer, make sure that
+                # the layer is appropriately colormapped as DQ:
+                data_quality_plugin = self.get_tray_item_from_name('g-data-quality')
+                old_viewer = data_quality_plugin.viewer_selected
+                data_quality_plugin.viewer_selected = viewer.reference
+                data_quality_plugin.science_layer_selected = data_label
+                data_quality_plugin.dq_layer_selected = child
+                data_quality_plugin.init_decoding(viewers=[viewer])
+                data_quality_plugin.viewer_selected = old_viewer
 
         for layer in viewer.layers:
             if layer.layer.data.label in assoc_children:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2121,14 +2121,19 @@ class Application(VuetifyTemplate, HubListener):
                 else:
                     layer.visible = visible
 
-        # update data menu - selected_data_items should be READ ONLY, not modified by the user/UI
+        # update data menu - selected_data_items should be READ ONLY, not modified by the user/UI.
+        # must update the visibility of `data_label` and its children:
         selected_items = viewer_item['selected_data_items']
-        data_id = self._data_id_from_label(data_label)
-        selected_items[data_id] = 'visible' if visible else 'hidden'
-        if replace:
-            for id in selected_items:
-                if id != data_id:
-                    selected_items[id] = 'hidden'
+        update_data_labels = [data_label] + assoc_children
+        for update_data_label in update_data_labels:
+            data_id = self._data_id_from_label(update_data_label)
+
+            if replace and update_data_label == data_label:
+                for id in selected_items:
+                    if id != data_id:
+                        selected_items[id] = 'hidden'
+
+            selected_items[data_id] = 'visible' if visible else 'hidden'
 
         # remove WCS-only data from selected items, add to wcs_only_layers:
         for layer in viewer.layers:

--- a/jdaviz/components/tooltip.vue
+++ b/jdaviz/components/tooltip.vue
@@ -107,6 +107,7 @@ const tooltips = {
   'plugin-footprints-color-picker': 'Change the color of the footprint overlay',
   'plugin-dq-show-all': 'Show all quality flags',
   'plugin-dq-hide-all': 'Hide all quality flags',
+  'plugin-dq-color-picker': 'Change the color of this DQ flag',
 }
 
 

--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -50,7 +50,7 @@
             :icon="layer_icons[item.name]"
             :icons="icons"
             :viewer="viewer"
-            :multi_select="multi_select"
+            :multi_select="multi_select || isChild(item)"
             :is_wcs_only="false"
             :n_data_entries="nDataEntries"
             @data-item-visibility="$emit('data-item-visibility', $event)"
@@ -272,6 +272,10 @@ module.exports = {
     },
     isRefData() {
       return this.$props.item.viewer.reference_data_label === this.$props.item.name
+    },
+    isChild(item) {
+      // only override multi_select choice when data entry is a child, and is in cubeviz:
+      return (this.$props.viewer.config === 'cubeviz' && item.parent !== null)
     },
     selectRefData() {
       this.$emit('change-reference-data', {

--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -306,7 +306,7 @@ module.exports = {
       return this.$props.data_items.filter((item) => this.itemIsVisible(item, false))
     },
     extraDataItems() {
-      return this.$props.data_items.filter((item) => this.itemIsVisible(item, true))
+      return this.$props.data_items.filter((item) => this.itemIsVisible(item, true) && !this.isChild(item))
     },
     nDataEntries() {
       // return number of data entries in the entire plugin that were NOT created by a plugin

--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -274,8 +274,8 @@ module.exports = {
       return this.$props.item.viewer.reference_data_label === this.$props.item.name
     },
     isChild(item) {
-      // only override multi_select choice when data entry is a child, and is in cubeviz:
-      return (this.$props.viewer.config === 'cubeviz' && item.parent !== null)
+      // only override multi_select choice when data entry is a child:
+      return item.parent !== null
     },
     selectRefData() {
       this.$emit('change-reference-data', {

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -191,7 +191,11 @@ module.exports = {
       } else {
         return 'gray'
       }
-    }
+    },
+    isChild(item) {
+      // only override multi_select choice when data entry is a child:
+      return item.parent !== null
+    },
   }
 };
 </script>

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -13,6 +13,20 @@
         </v-btn>
       </j-tooltip>
     </div>
+    <div v-else-if="isChild(item) && !parentIsVisible(item)">
+      <j-tooltip
+        :tooltipcontent="'Select parent data first to make this layer visible'"
+        span_style="width: 36px;"
+      >
+        <v-btn
+          icon
+          color="default"
+          style="cursor: default;"
+          >
+            <v-icon>mdi-checkbox-blank-off-outline</v-icon>
+        </v-btn>
+      </j-tooltip>
+    </div>
     <div v-else-if="isSelected">
       <j-tooltip :tipid="multi_select ? 'viewer-data-select' : 'viewer-data-radio'">
         <v-btn 
@@ -44,7 +58,6 @@
         </v-btn>
       </j-tooltip>
     </div>
-
     <j-tooltip :tooltipcontent="is_wcs_only ? '' : 'data label: '+item.name" span_style="font-size: 12pt; padding-top: 6px; padding-left: 4px; padding-right: 16px; width: calc(100% - 80px); white-space: nowrap; cursor: default;">
       <j-layer-viewer-icon span_style="margin-left: 4px;" :icon="icon" :icons="icons" color="#000000DE"></j-layer-viewer-icon>
 
@@ -112,7 +125,14 @@ module.exports = {
     },
     linkedByWcs() {
       return this.$props.viewer.linked_by_wcs
-    }
+    },
+    isChild(item) {
+      // only override multi_select choice when data entry is a child:
+      return item.parent !== null
+    },
+    parentIsVisible(item) {
+      return this.$props.viewer.selected_data_items[item.parent] === 'visible'
+    },
   },
   computed: {
     itemNamePrefix() {
@@ -191,10 +211,6 @@ module.exports = {
       } else {
         return 'gray'
       }
-    },
-    isChild(item) {
-      // only override multi_select choice when data entry is a child:
-      return item.parent !== null
     },
   }
 };

--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -32,6 +32,7 @@ tray:
   - cubeviz-moment-maps
   - cubeviz-spectral-extraction
   - imviz-aper-phot-simple
+  - g-data-quality
   - export
 viewer_area:
   - container: col

--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -20,6 +20,7 @@ toolbar:
 tray:
   - g-metadata-viewer
   - g-plot-options
+  - g-data-quality
   - g-subset-plugin
   - g-markers
   - cubeviz-slice
@@ -32,7 +33,6 @@ tray:
   - cubeviz-moment-maps
   - cubeviz-spectral-extraction
   - imviz-aper-phot-simple
-  - g-data-quality
   - export
 viewer_area:
   - container: col

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -10,6 +10,7 @@ from astropy.time import Time
 from astropy.wcs import WCS
 from specutils import Spectrum1D
 
+from jdaviz.configs.imviz.plugins.parsers import prep_data_layer_as_dq
 from jdaviz.core.registries import data_parser_registry
 from jdaviz.utils import standardize_metadata, PRIHDR_KEY
 
@@ -22,7 +23,7 @@ EXT_TYPES = dict(flux=['flux', 'sci', 'data'],
 
 
 @data_parser_registry("cubeviz-data-parser")
-def parse_data(app, file_obj, data_type=None, data_label=None):
+def parse_data(app, file_obj, data_type=None, data_label=None, parent=None):
     """
     Attempts to parse a data file and auto-populate available viewers in
     cubeviz.
@@ -84,10 +85,24 @@ def parse_data(app, file_obj, data_type=None, data_label=None):
                                          ('ERR', uncert_viewer_reference_name),
                                          ('DQ', None)):
                     data_label = app.return_data_label(file_name, ext)
+
+                    if ext == 'SCI':
+                        sci_ext = data_label
+
+                    # TODO: generalize/centralize this for use in other configs too
+
+                    if parent is not None:
+                        parent_data_label = parent
+                    elif ext == 'DQ':
+                        parent_data_label = sci_ext
+                    else:
+                        parent_data_label = None
+
                     _parse_jwst_s3d(
                         app, hdulist, data_label, ext=ext, viewer_name=viewer_name,
                         flux_viewer_reference_name=flux_viewer_reference_name,
-                        spectrum_viewer_reference_name=spectrum_viewer_reference_name
+                        spectrum_viewer_reference_name=spectrum_viewer_reference_name,
+                        parent=parent_data_label
                     )
             elif telescop == 'jwst' and filetype == 'r3d' and system == 'esa-pipeline':
                 for ext, viewer_name in (('DATA', flux_viewer_reference_name),
@@ -270,7 +285,7 @@ def _parse_hdulist(app, hdulist, file_name=None,
 
 def _parse_jwst_s3d(app, hdulist, data_label, ext='SCI',
                     viewer_name=None, flux_viewer_reference_name=None,
-                    spectrum_viewer_reference_name=None):
+                    spectrum_viewer_reference_name=None, parent=None):
     hdu = hdulist[ext]
     data_type = _get_data_type_by_hdu(hdu)
 
@@ -305,7 +320,13 @@ def _parse_jwst_s3d(app, hdulist, data_label, ext='SCI',
         metadata[PRIHDR_KEY] = standardize_metadata(hdulist['PRIMARY'].header)
 
     data = _return_spectrum_with_correct_units(flux, wcs, metadata, data_type, hdulist=hdulist)
-    app.add_data(data, data_label)
+    app.add_data(data, data_label, parent=parent)
+
+    # get glue data and update if DQ:
+    if ext == 'DQ':
+        data = app.data_collection[-1]
+        prep_data_layer_as_dq(data, component_id='flux')
+
     if data_type == 'flux':  # Forced wave unit conversion made it lose stuff, so re-add
         app.data_collection[-1].get_component("flux").units = flux.unit
 
@@ -314,6 +335,9 @@ def _parse_jwst_s3d(app, hdulist, data_label, ext='SCI',
     # Also add the collapsed flux to the spectrum viewer
     if viewer_name == flux_viewer_reference_name:
         app.add_data_to_viewer(spectrum_viewer_reference_name, data_label)
+
+    if ext == 'DQ':
+        app.add_data_to_viewer(flux_viewer_reference_name, data_label)
 
     if data_type == 'flux':
         app._jdaviz_helper._loaded_flux_cube = app.data_collection[data_label]

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -337,7 +337,7 @@ def _parse_jwst_s3d(app, hdulist, data_label, ext='SCI',
         app.add_data_to_viewer(spectrum_viewer_reference_name, data_label)
 
     if ext == 'DQ':
-        app.add_data_to_viewer(flux_viewer_reference_name, data_label)
+        app.add_data_to_viewer(flux_viewer_reference_name, data_label, visible=False)
 
     if data_type == 'flux':
         app._jdaviz_helper._loaded_flux_cube = app.data_collection[data_label]

--- a/jdaviz/configs/default/plugins/data_quality/data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.py
@@ -60,7 +60,8 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
 
         self.science_layer = LayerSelect(
             self, 'science_layer_items', 'science_layer_selected',
-            'viewer_selected', 'science_layer_multiselect', is_root=True
+            'viewer_selected', 'science_layer_multiselect',
+            is_root=True, has_children=True
         )
 
         self.dq_layer = LayerSelect(

--- a/jdaviz/configs/default/plugins/data_quality/data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.py
@@ -72,6 +72,14 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
         self.load_default_flag_maps()
         self.init_decoding()
 
+        if self.app.config == 'cubeviz':
+            # cubeviz will show the DQ layer in the flux-viewer only:
+            def is_flux_viewer(viewer):
+                return viewer.reference == 'flux-viewer'
+
+            self.viewer.add_filter(is_flux_viewer)
+            self.viewer._on_viewers_changed()
+
     @observe('science_layer_selected')
     def update_dq_layer(self, *args):
         if not hasattr(self, 'dq_layer'):

--- a/jdaviz/configs/default/plugins/data_quality/data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.py
@@ -134,6 +134,16 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
         dq_layer = self.get_dq_layer()
         dq_layer.composite._allow_bad_alpha = True
 
+        # for cubeviz, also change uncert-viewer defaults to
+        # map the out-of-bounds regions to the cmap's `bad` color:
+        if self.app.config == 'cubeviz':
+            uncert_viewer = self.app.get_viewer(
+                self.app._jdaviz_helper._default_uncert_viewer_reference_name
+            )
+            for layer in uncert_viewer.layers:
+                layer.composite._allow_bad_alpha = True
+                layer.force_update()
+
         flag_bits = np.array([flag['flag'] for flag in self.decoded_flags])
 
         dq_layer.state.stretch = 'lookup'

--- a/jdaviz/configs/default/plugins/data_quality/data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.py
@@ -80,6 +80,15 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
             self.viewer.add_filter(is_flux_viewer)
             self.viewer._on_viewers_changed()
 
+        self._set_irrelevant()
+
+    @observe('dq_layer_items')
+    def _set_irrelevant(self, *args):
+        self.irrelevant_msg = (
+            '' if len(self.dq_layer_items) else
+            "No Data Quality layers available."
+        )
+
     @observe('science_layer_selected')
     def update_dq_layer(self, *args):
         if not hasattr(self, 'dq_layer'):

--- a/jdaviz/configs/default/plugins/data_quality/data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.py
@@ -28,7 +28,7 @@ telescope_names = {
 class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
     template_file = __file__, "data_quality.vue"
 
-    irrelevant_msg = Unicode("Data Quality plugin is in development.").tag(sync=True)
+    irrelevant_msg = Unicode("").tag(sync=True)
 
     # `layer` is the science data layer
     science_layer_multiselect = Bool(False).tag(sync=True)
@@ -244,8 +244,13 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
         # this is defined for JWST and ROMAN, should be upper case:
         telescope = layer[0].layer.meta.get('telescope', None)
 
+        if telescope is None:
+            # for spectral cubes in Cubeviz:
+            telescope = layer[0].layer.meta.get('_primary_header', {}).get('TELESCOP', None)
+
         if telescope is not None:
-            self.flag_map_selected = telescope_names[telescope.lower()]
+            flag_map_to_select = telescope_names.get(telescope.lower())
+            self.flag_map_selected = flag_map_to_select
 
     def vue_hide_all_flags(self, event):
         for flag in self.decoded_flags:

--- a/jdaviz/configs/default/plugins/data_quality/data_quality.vue
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.vue
@@ -1,6 +1,6 @@
 <template>
   <j-tray-plugin
-    :description="docs_description || 'Viewer and data/layer options.'"
+    :description="docs_description || 'Data Quality layer visualization options.'"
     :link="docs_link || 'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#data-quality'"
     @plugin-ping="plugin_ping($event)"
     :popout_button="popout_button">

--- a/jdaviz/configs/default/plugins/data_quality/data_quality.vue
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.vue
@@ -5,19 +5,6 @@
     @plugin-ping="plugin_ping($event)"
     :popout_button="popout_button">
 
-    <!-- VIEWER OPTIONS -->
-    <plugin-viewer-select
-      :items="viewer_items"
-      :selected.sync="viewer_selected"
-      :multiselect.sync="viewer_multiselect"
-      :show_multiselect_toggle="viewer_multiselect || viewer_items.length > 1"
-      :icon_checktoradial="icon_checktoradial"
-      :icon_radialtocheck="icon_radialtocheck"
-      :label="viewer_multiselect ? 'Viewers' : 'Viewer'"
-      :show_if_single_entry="viewer_multiselect"
-      :hint="viewer_multiselect ? 'Select viewers to set options simultaneously' : 'Select the viewer to set options.'"
-    />
-
     <plugin-layer-select
       :items="science_layer_items"
       :selected.sync="science_layer_selected"

--- a/jdaviz/configs/default/plugins/data_quality/data_quality.vue
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.vue
@@ -130,7 +130,7 @@
               <v-col cols=1>
               </v-col>
                 <v-col cols=2>
-                <j-tooltip tipid='plugin-line-lists-color-picker'>
+                <j-tooltip tipid='plugin-dq-color-picker'>
                   <v-menu>
                     <template v-slot:activator="{ on }">
                         <span class="color-menu"

--- a/jdaviz/configs/default/plugins/data_quality/data_quality.vue
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.vue
@@ -1,7 +1,7 @@
 <template>
   <j-tray-plugin
     :description="docs_description || 'Viewer and data/layer options.'"
-    :link="docs_link || 'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#plot-options'"
+    :link="docs_link || 'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#data-quality'"
     @plugin-ping="plugin_ping($event)"
     :popout_button="popout_button">
 

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -71,7 +71,8 @@ class JdavizViewerMixin:
         """
         viewer_item = self.jdaviz_app._get_viewer_item(self.reference_id)
         return [self.jdaviz_app._get_data_item_by_id(data_id)['name']
-                for data_id in viewer_item.get('selected_data_items', {}).keys()]
+                for data_id in viewer_item.get('selected_data_items', {}).keys()
+                if self.jdaviz_app._get_data_item_by_id(data_id) is not None]
 
     @property
     def data_labels_visible(self):

--- a/jdaviz/configs/imviz/imviz.yaml
+++ b/jdaviz/configs/imviz/imviz.yaml
@@ -22,9 +22,9 @@ tray:
   - g-metadata-viewer
   - imviz-orientation
   - g-plot-options
+  - g-data-quality
   - g-subset-plugin
   - g-markers
-  - g-data-quality
   - imviz-compass
   - imviz-line-profile-xy
   - imviz-aper-phot-simple

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -276,13 +276,14 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                 image = None
 
         # If there is one, get the associated DQ layer for the active layer:
-        associated_dq_layer = None
+        associated_dq_layers = None
         available_plugins = [tray_item['name'] for tray_item in self.app.state.tray_items]
         if 'g-data-quality' in available_plugins:
             assoc_children = self.app._get_assoc_data_children(active_layer.layer.label)
             if assoc_children:
                 data_quality_plugin = self.app.get_tray_item_from_name('g-data-quality')
-                associated_dq_layer = data_quality_plugin.get_dq_layer()
+                viewer_obj = self.app.get_viewer(viewer)
+                associated_dq_layers = data_quality_plugin.get_dq_layers(viewer_obj)
 
         unreliable_pixel, unreliable_world = False, False
 
@@ -444,7 +445,8 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
 
             if isinstance(viewer, (ImvizImageView, MosvizImageView, MosvizProfile2DView)):
                 value = image.get_data(attribute)[int(round(y)), int(round(x))]
-                if associated_dq_layer is not None:
+                if associated_dq_layers is not None:
+                    associated_dq_layer = associated_dq_layers[0]
                     dq_attribute = associated_dq_layer.state.attribute
                     dq_data = associated_dq_layer.layer.get_data(dq_attribute)
                     dq_value = dq_data[int(round(y)), int(round(x))]
@@ -454,14 +456,15 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                 unit = image.get_component(attribute).units
                 value = self._get_cube_value(image, arr, x, y, viewer)
 
-                if associated_dq_layer is not None:
+                if associated_dq_layers is not None:
+                    associated_dq_layer = associated_dq_layers[0]
                     dq_attribute = associated_dq_layer.state.attribute
                     dq_data = associated_dq_layer.layer.get_data(dq_attribute)
                     dq_value = self._get_cube_value(image, dq_data, x, y, viewer)
 
             self.row1b_title = 'Value'
 
-            if associated_dq_layer is not None:
+            if associated_dq_layers is not None:
                 if np.isnan(dq_value):
                     dq_text = ''
                 else:

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -453,6 +453,12 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                 arr = image.get_component(attribute).data
                 unit = image.get_component(attribute).units
                 value = self._get_cube_value(image, arr, x, y, viewer)
+
+                if associated_dq_layer is not None:
+                    dq_attribute = associated_dq_layer.state.attribute
+                    dq_data = associated_dq_layer.layer.get_data(dq_attribute)
+                    dq_value = self._get_cube_value(image, dq_data, x, y, viewer)
+
             self.row1b_title = 'Value'
 
             if associated_dq_layer is not None:

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -835,7 +835,7 @@ class SelectPluginComponent(BasePluginComponent, HasTraits):
         return self._cached_properties
 
     def add_filter(self, *filters):
-        self.filters += [filter for filter in filters]
+        self.filters = self.filters + [filter for filter in filters]
 
     @property
     def viewer_dicts(self):

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1379,6 +1379,7 @@ class LayerSelect(SelectPluginComponent):
                  default_mode='first',
                  only_wcs_layers=False,
                  is_root=True,
+                 has_children=False,
                  is_child_of=None):
         """
         Parameters
@@ -1433,13 +1434,14 @@ class LayerSelect(SelectPluginComponent):
         self.update_wcs_only_filter(only_wcs_layers)
 
         self.filter_is_root = is_root
+        self.has_children = has_children
         self.filter_is_child_of = is_child_of
 
         if self.filter_is_root:
-            # ignore layers that are children in associations:
             def filter_is_root(data):
                 return self.app._get_assoc_data_parent(data.label) is None
 
+            # ignore layers that are children in associations:
             self.add_filter(filter_is_root)
 
         elif not self.filter_is_root and self.filter_is_child_of is not None:
@@ -1450,6 +1452,12 @@ class LayerSelect(SelectPluginComponent):
                 return self.app._get_assoc_data_parent(data.label) == self.filter_is_child_of
 
             self.add_filter(has_correct_parent)
+
+        if self.has_children:
+            def filter_has_children(data):
+                return len(self.app._get_assoc_data_children(data.label)) > 0
+
+            self.add_filter(filter_has_children)
 
     def _get_viewer(self, viewer):
         # newer will likely be the viewer name in most cases, but viewer id in the case


### PR DESCRIPTION
This PR follows #2767 to extend the DQ plugin for Cubeviz.

https://github.com/spacetelescope/jdaviz/assets/3497584/31e95fb0-0529-4947-b66b-fa74141ef3a4

The plugin has only one difference from Imviz – it assumes that the `flux-viewer` is the only viewer that will contain the DQ layer. Since the DQ layer will have the same dimensions as the cube, I wanted to make sure no one ever tries to use the cube DQ in the spectrum viewer, for example.

The data dropdown menu offers the DQ layer as a child of the (single) cube loaded into `flux-viewer`. 

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4346)
