### PR TITLE
consider bitmap/contour_visible in logic for top image layer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,9 @@ Other Changes and Additions
 3.9.1 (unreleased)
 ==================
 
+- Fix mouseover display's top-layer logic to account for the visibility and contour toggles in
+  the plot options plugin. [#2818]
+
 Bug Fixes
 ---------
 

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -2,7 +2,6 @@ import numpy as np
 from astropy.io import fits
 from astropy.io import registry as io_registry
 from astropy.utils.decorators import deprecated
-from glue.core import BaseData
 from specutils import Spectrum1D
 from specutils.io.registers import _astropy_has_priorities
 
@@ -179,10 +178,6 @@ class Cubeviz(ImageConfigHelper, LineListMixin):
 
         """
         return self.plugins['Aperture Photometry']._obj.export_table()
-
-
-def layer_is_cube_image_data(layer):
-    return isinstance(layer, BaseData) and layer.ndim in (2, 3)
 
 
 # TODO: We can remove this when specutils supports it, i.e.,

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -9,7 +9,6 @@ from glue_jupyter.bqplot.image import BqplotImageView
 
 from jdaviz.core.registries import viewer_registry
 from jdaviz.core.marks import SliceIndicatorMarks, ShadowSpatialSpectral
-from jdaviz.configs.cubeviz.helper import layer_is_cube_image_data
 from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
 from jdaviz.configs.specviz.plugins.viewers import SpecvizProfileView
 from jdaviz.core.events import AddDataMessage, RemoveDataMessage, GlobalDisplayUnitChanged

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -209,18 +209,6 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
     def _default_uncert_viewer_reference_name(self):
         return self.jdaviz_helper._default_uncert_viewer_reference_name
 
-    @property
-    def active_image_layer(self):
-        """Active image layer in the viewer, if available."""
-        # Find visible layers
-        visible_layers = [layer for layer in self.state.layers
-                          if (layer.visible and layer_is_cube_image_data(layer.layer))]
-
-        if len(visible_layers) == 0:
-            return None
-
-        return visible_layers[-1]
-
     def _on_global_display_unit_changed(self, msg):
         # Clear cache of slice values when units change
         if 'slice_values' in self.__dict__:

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -316,7 +316,8 @@ class JdavizViewerMixin:
         visible_layers = [layer for layer in self.state.layers
                           if (layer.visible and
                               layer_is_image_data(layer.layer) and
-                              layer_is_not_dq(layer.layer))]
+                              layer_is_not_dq(layer.layer) and
+                              (layer.bitmap_visible or layer.contour_visible))]
         if len(visible_layers) == 0:
             return None
 

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -398,8 +398,12 @@ def layer_is_2d(layer):
     return isinstance(layer, BaseData) and layer.ndim == 2
 
 
+def layer_is_2d_or_3d(layer):
+    return isinstance(layer, BaseData) and layer.ndim in (2, 3)
+
+
 def layer_is_image_data(layer):
-    return layer_is_2d(layer) and not layer.meta.get(_wcs_only_label, False)
+    return layer_is_2d_or_3d(layer) and not layer.meta.get(_wcs_only_label, False)
 
 
 def layer_is_wcs_only(layer):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request considers bitmap and contour_visible switches (instead of only the global layer visibility switch from the data menu) in determining the top image layer (used for mouseover).  We could also extend this to consider opacity here or in the future.


https://github.com/spacetelescope/jdaviz/assets/877591/33b8a8e6-2093-4373-9976-22fd0b143ead

This PR also consolidates some repeated logic between cubeviz and imviz (where the only exception before was allowing for cube data in the cubeviz case which should be able to safely be moved to the more general case).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
