### PR TITLE
Re-enable exporting cubeviz spectrum viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,6 +75,8 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Re-enable support for exporting spectrum-viewer. [#2825]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -221,17 +221,6 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                 self._set_subset_not_supported_msg()
             if attr == 'dataset_selected':
                 self._set_dataset_not_supported_msg()
-            elif self.config == "cubeviz" and attr == "viewer_selected":
-                self._disable_viewer_format_combo(event)
-
-    @observe('viewer_format_selected')
-    def _disable_viewer_format_combo(self, event):
-        if (self.config == "cubeviz" and self.viewer_selected == "spectrum-viewer"
-                and self.viewer_format_selected == "png"):
-            msg = "Exporting the spectrum viewer as a PNG in Cubeviz is not yet supported"
-        else:
-            msg = ""
-        self.viewer_invalid_msg = msg
 
     @observe('filename')
     def _is_filename_changed(self, event):

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -5,6 +5,7 @@ from traitlets import Bool, List, Unicode, observe
 from glue_jupyter.bqplot.image import BqplotImageView
 
 from jdaviz.core.custom_traitlets import FloatHandleEmpty, IntHandleEmpty
+from jdaviz.core.marks import ShadowMixin
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin, SelectPluginComponent,
                                         ViewerSelectMixin, DatasetMultiSelectMixin,
@@ -330,10 +331,31 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                     raise FileExistsError(f"{filename} exists but overwrite=False")
                 return
 
+            # temporarily "clean" incompatible marks of unicode characters, etc
+            restores = []
+            for mark in viewer.figure.marks:
+                restore = {}
+                if len(getattr(mark, 'text', [])):
+                    if not isinstance(mark, ShadowMixin):
+                        # if it is shadowing another mark, that will automatically get updated
+                        # when the other mark is restored, but we'll still ensure that the mark
+                        # is clean of unicode before exporting.
+                        restore['text'] = [t for t in mark.text]
+                    mark.text = [t.strip() for t in mark.text]
+                if len(getattr(mark, 'labels', [])):
+                    restore['labels'] = mark.labels[:]
+                    mark.labels = [lbl.strip() for lbl in mark.labels]
+                restores.append(restore)
+
             if filetype == "mp4":
                 self.save_movie(viewer, filename, filetype)
             else:
                 self.save_figure(viewer, filename, filetype, show_dialog=show_dialog)
+
+            # restore marks to their original state
+            for restore, mark in zip(restores, viewer.figure.marks):
+                for k, v in restore.items():
+                    setattr(mark, k, v)
 
         elif len(self.plugin_plot.selected):
             plot = self.plugin_plot.selected_obj._obj

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -204,6 +204,19 @@ class TestExportSubsets:
 
 
 @pytest.mark.usefixtures('_jail')
+def test_export_cubeviz_spectrum_viewer(cubeviz_helper, spectrum1d_cube):
+    cubeviz_helper.load_data(spectrum1d_cube, data_label='test')
+
+    ep = cubeviz_helper.plugins["Export"]
+    ep.viewer = 'spectrum-viewer'
+    ep.viewer_format = 'png'
+    ep.export()
+
+    ep.viewer_format = 'svg'
+    ep.export()
+
+
+@pytest.mark.usefixtures('_jail')
 def test_export_data(cubeviz_helper, spectrum1d_cube):
     cubeviz_helper.load_data(spectrum1d_cube, data_label='test')
     mm = cubeviz_helper.plugins["Moment Maps"]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request re-enables support for exporting the cubeviz spectrum viewer (to png or svg) by temporarily "cleaning" any unicode from the marks (which currently exist for the slice indicator).

The cleaning/restoring part of this PR could be reverted if support for unicode is fixed upstream (likely in bqplot).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
