### PR TITLE
BUG: Fix specviz2d loader with ext keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,7 +61,7 @@ Specviz
 Specviz2d
 ^^^^^^^^^
 
-- Loading a specific extension with ``ext`` keyword no longer crashes. [#2829]
+- Loading a specific extension with ``ext`` keyword no longer crashes. [#2830]
 
 Other Changes and Additions
 ---------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,8 @@ Specviz
 Specviz2d
 ^^^^^^^^^
 
+- Loading a specific extension with ``ext`` keyword no longer crashes. [#2829]
+
 Other Changes and Additions
 ---------------------------
 

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -396,16 +396,20 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
             self._dict['world'] = (sky.ra.value, sky.dec.value)
             self._dict['world:unreliable'] = unreliable_world
         elif isinstance(viewer, MosvizProfile2DView) and hasattr(getattr(image, 'coords', None),
-                                                                 'pixel_to_world_values'):
+                                                                 'pixel_to_world'):
             # use WCS to expose the wavelength for a 2d spectrum shown in pixel space
-            wave, pixel = image.coords.pixel_to_world(x, y)
-            self.row2_title = 'Wave'
-            self.row2_text = f'{wave.value:10.5e} {wave.unit.to_string()}'
-            self.row2_unreliable = False
+            try:
+                wave, pixel = image.coords.pixel_to_world(x, y)
+            except Exception:  # WCS might not be valid  # pragma: no cover
+                coords_status = False
+            else:
+                self.row2_title = 'Wave'
+                self.row2_text = f'{wave.value:10.5e} {wave.unit.to_string()}'
+                self.row2_unreliable = False
 
-            self.row3_title = '\u00A0'
-            self.row3_text = ""
-            self.row3_unreliable = False
+                self.row3_title = '\u00A0'
+                self.row3_text = ""
+                self.row3_unreliable = False
         else:
             self.row2_title = '\u00A0'
             self.row2_text = ""
@@ -475,7 +479,7 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
             self.marks[viewer._reference_id].visible = True
 
             for matched_marker_id in self._matched_markers.get(viewer._reference_id, []):
-                if hasattr(getattr(image, 'coords', None), 'pixel_to_world_values'):
+                if coords_status and hasattr(getattr(image, 'coords', None), 'pixel_to_world'):
                     # should already have wave computed from setting the coords-info
                     matched_viewer = self.app.get_viewer(matched_marker_id.split(':matched')[0])
                     wave = wave.to_value(matched_viewer.state.x_display_unit)

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -259,7 +259,7 @@ def mos_spec1d_parser(app, data_obj, data_labels=None,
 
 @data_parser_registry("mosviz-spec2d-parser")
 def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
-                      show_in_viewer=False, ext=None, transpose=False):
+                      show_in_viewer=False, ext=1, transpose=False):
     """
     Attempts to parse a 2D spectrum object.
 
@@ -326,7 +326,7 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
         data_obj = [data_obj]
 
     # See if this is a multi s2d file
-    if (ext is None) and (len(data_obj) == 1) and _check_is_file(data_obj[0]):
+    if app.config == "mosviz" and len(data_obj) == 1 and _check_is_file(data_obj[0]):
         if identify_jwst_s2d_multi_fits("test", data_obj[0]):
             data_obj = SpectrumList.read(data_obj[0])
 

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -259,7 +259,7 @@ def mos_spec1d_parser(app, data_obj, data_labels=None,
 
 @data_parser_registry("mosviz-spec2d-parser")
 def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
-                      show_in_viewer=False, ext=1, transpose=False):
+                      show_in_viewer=False, ext=None, transpose=False):
     """
     Attempts to parse a 2D spectrum object.
 
@@ -326,7 +326,7 @@ def mos_spec2d_parser(app, data_obj, data_labels=None, add_to_table=True,
         data_obj = [data_obj]
 
     # See if this is a multi s2d file
-    if len(data_obj) == 1 and _check_is_file(data_obj[0]):
+    if (ext is None) and (len(data_obj) == 1) and _check_is_file(data_obj[0]):
         if identify_jwst_s2d_multi_fits("test", data_obj[0]):
             data_obj = SpectrumList.read(data_obj[0])
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address user finding the app crashing when providing `ext` for Specviz2d loader.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4389)
