### PR TITLE
Fix Line Analysis behavior before any lines are loaded

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,7 +66,7 @@ Other Changes and Additions
 
 - Bump required Python version to 3.10. [#2757]
 
-- Line menu in Redshift from Centroid section of Line Analysis now shows values in current units. [#2816]
+- Line menu in Redshift from Centroid section of Line Analysis now shows values in current units. [#2816, #2831]
 
 3.9.2 (unreleased)
 ==================

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -102,7 +102,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
     results_computing = Bool(False).tag(sync=True)
     results = List().tag(sync=True)
     results_centroid = Float().tag(sync=True)  # stored in AA units
-    line_menu_items = List([{}]).tag(sync=True)
+    line_menu_items = List([]).tag(sync=True)
     sync_identify = Bool(True).tag(sync=True)
     sync_identify_icon_enabled = Unicode(read_icon(os.path.join(ICON_DIR, 'line_select.svg'), 'svg+xml')).tag(sync=True)  # noqa
     sync_identify_icon_disabled = Unicode(read_icon(os.path.join(ICON_DIR, 'line_select_disabled.svg'), 'svg+xml')).tag(sync=True)  # noqa

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.vue
@@ -137,7 +137,7 @@
         ></v-progress-circular>
       </div>
 
-      <div v-if="line_items.length > 0">
+      <div v-if="line_menu_items.length > 0">
         <j-plugin-section-header>Redshift from Centroid</j-plugin-section-header>
         <v-row>
           <j-docs-link>Assign the centroid reported above to the observed wavelength of a given line and set the resulting redshift.  Lines must be loaded and plotted through the Line Lists plugin first.</j-docs-link>


### PR DESCRIPTION
#2816 was merged with a small bug where the Redshift from Centroid section would misbehave if no lines were loaded. Now that section is properly hidden if there are no lines. Thanks @kecnry for finding this.