### PR TITLE
disable user-access to auto-updating results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,6 @@
 New Features
 ------------
 
-- Infrastructure to support auto-updating plugin results, not yet available to users. [#2680, #2834]
-
 - The filename entry in the export plugin is now automatically populated based on the selection. [#2824]
 
 Cubeviz

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 New Features
 ------------
 
-- Infrastructure to support auto-updating plugin results. [#2680]
+- Infrastructure to support auto-updating plugin results, not yet available to users. [#2680, #2834]
 
 - The filename entry in the export plugin is now automatically populated based on the selection. [#2824]
 

--- a/jdaviz/components/plugin_add_results.vue
+++ b/jdaviz/components/plugin_add_results.vue
@@ -52,7 +52,9 @@
 
     <slot></slot>
 
-    <v-row v-if="false && auto_update_result !== undefined">
+    <!-- currently not exposed to users, uncomment this block and include in the 
+         user API for the AutoUpdate component to re-enable
+    <v-row v-if="auto_update_result !== undefined">
       <v-switch
         v-model="auto_update_result"
         @change="(e) => {$emit('update:auto_update_result', auto_update_result)}"
@@ -62,6 +64,7 @@
       >
       </v-switch>
     </v-row>
+    -->
 
     <v-row justify="end">
       <j-tooltip :tooltipcontent="label_overwrite ? action_tooltip+' and replace existing entry' : action_tooltip">

--- a/jdaviz/components/plugin_add_results.vue
+++ b/jdaviz/components/plugin_add_results.vue
@@ -52,7 +52,7 @@
 
     <slot></slot>
 
-    <v-row v-if="auto_update_result !== undefined">
+    <v-row v-if="false && auto_update_result !== undefined">
       <v-switch
         v-model="auto_update_result"
         @change="(e) => {$emit('update:auto_update_result', auto_update_result)}"

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -430,7 +430,7 @@ def test_autoupdate_results(cubeviz_helper, spectrum1d_cube_largest):
     extract_plg = cubeviz_helper.plugins['Spectral Extraction']
     extract_plg.aperture = 'Subset 1'
     extract_plg.add_results.label = 'extracted'
-    extract_plg.add_results.auto_update_result = True
+    extract_plg.add_results._obj.auto_update_result = True
     _ = extract_plg.collapse_to_spectrum()
 
 #    orig_med_flux = np.median(cubeviz_helper.get_data('extracted').flux)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3680,7 +3680,7 @@ class AddResults(BasePluginComponent):
 
     @property
     def user_api(self):
-        return UserApiWrapper(self, ('label', 'auto', 'viewer', 'auto_update_result'))
+        return UserApiWrapper(self, ('label', 'auto', 'viewer'))
 
     @property
     def label(self):


### PR DESCRIPTION


<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request removes user-access to auto-updating plugin results for the 3.10 release (will be used internally for #2827 and may or may not be exposed to the user in the future).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
