### PR TITLE
Spectral extraction in Cubeviz with composite subsets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Cubeviz
 
 - Enable spectral unit conversion in cubeviz. [#2758, #2803]
 
+- Enable spectral extraction for composite subsets. [#2837]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -387,7 +387,6 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
             [subset_group] = [
                 subset_group for subset_group in self.app.data_collection.subset_groups
                 if subset_group.label == self.aperture_selected]
-            # mask_weights = np.logical_not(subset_group.subsets[0].to_mask()).astype(np.float32)
             mask_weights = subset_group.subsets[0].to_mask().astype(np.float32)
             return mask_weights
 

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -288,6 +288,11 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
             # Boolean cube which is True outside of the aperture
             # (i.e., the numpy boolean mask convention)
             mask = np.isclose(shape_mask, 0)
+
+            # composite subset masks are in `nddata.mask`:
+            if nddata.mask is not None and np.all(shape_mask == 0):
+                mask &= nddata.mask
+
         else:
             nddata = spectral_cube.get_object(cls=NDDataArray)
             if uncert_cube:
@@ -376,6 +381,15 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         flux_cube = self._app._jdaviz_helper._loaded_flux_cube.get_object(cls=Spectrum1D,
                                                                           statistic=None)
         display_unit = astropy.units.Unit(self.app._get_display_unit(self.slice_display_unit_name))
+
+        # if subset is a composite subset, skip the other logic:
+        if self.aperture.is_composite:
+            [subset_group] = [
+                subset_group for subset_group in self.app.data_collection.subset_groups
+                if subset_group.label == self.aperture_selected]
+            # mask_weights = np.logical_not(subset_group.subsets[0].to_mask()).astype(np.float32)
+            mask_weights = subset_group.subsets[0].to_mask().astype(np.float32)
+            return mask_weights
 
         # Center is reverse coordinates
         center = (self.aperture.selected_spatial_region.center.y,

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2258,6 +2258,10 @@ class ApertureSubsetSelect(SubsetSelect):
         self._set_mark_visiblities(self.plugin.is_active)
 
     @property
+    def is_composite(self):
+        return hasattr(self.selected_obj, '__len__') and len(self.selected_obj) > 1
+
+    @property
     def image_viewers(self):
         return [viewer for viewer in self.app._viewer_store.values()
                 if isinstance(viewer, BqplotImageView)]

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2319,9 +2319,7 @@ class ApertureSubsetSelect(SubsetSelect):
         # (or selected_spatial_region) will fail.
         if np.any([len(obj) > 1 for obj in objs]):
             validity = {'is_aperture': False,
-                        'aperture_message': 'composite subsets only support extraction '
-                                            'with aperture extraction method "center," and '
-                                            'without wavelength dependence',
+                        'aperture_message': 'composite subsets are not supported',
                         'is_composite': True}
             return [], [], validity
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2319,7 +2319,9 @@ class ApertureSubsetSelect(SubsetSelect):
         # (or selected_spatial_region) will fail.
         if np.any([len(obj) > 1 for obj in objs]):
             validity = {'is_aperture': False,
-                        'aperture_message': 'composite subsets are not supported',
+                        'aperture_message': 'composite subsets only support extraction '
+                                            'with aperture extraction method "center," and '
+                                            'without wavelength dependence',
                         'is_composite': True}
             return [], [], validity
 


### PR DESCRIPTION
This PR introduces spectral extraction to cubeviz for composite subsets. The implementation converts the composite subset to a boolean mask, and applies it in the NDData collapse. The only supported aperture extraction method is "center," since this approach completely avoids the photutils pixel weighting methods.

https://github.com/spacetelescope/jdaviz/assets/3497584/62c4da05-8df8-4d7c-91d7-9521f189594b

I've added a test that extracts two spectra from individual non-composite subsets, and compares their sum with the spectrum of a composite subset that spans the same area as both subsets combined.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
