### PR TITLE
Hide flux_unit from unit conversion

### DIFF
--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -27,7 +27,7 @@ def test_value_error_exception(specviz_helper, spectrum1d, new_spectral_axis, ne
         if "reverting selection to" not in repr(e):
             raise
     try:
-        plg.flux_unit = new_flux
+        plg._obj.flux_unit_selected = new_flux
     except ValueError as e:
         if "reverting selection to" not in repr(e):
             raise
@@ -62,7 +62,7 @@ def test_conv_flux_only(specviz_helper, spectrum1d, uncert):
     viewer = specviz_helper.app.get_viewer("spectrum-viewer")
     plg = specviz_helper.plugins["Unit Conversion"]
     new_flux = "erg / (s cm2 Angstrom)"
-    plg.flux_unit = new_flux
+    plg._obj.flux_unit_selected = new_flux
 
     assert len(specviz_helper.app.data_collection) == 1
     assert u.Unit(viewer.state.x_display_unit) == u.Unit('Angstrom')
@@ -80,7 +80,7 @@ def test_conv_wave_flux(specviz_helper, spectrum1d, uncert):
     new_spectral_axis = "micron"
     new_flux = "erg / (s cm2 Angstrom)"
     plg.spectral_unit = new_spectral_axis
-    plg.flux_unit = new_flux
+    plg._obj.flux_unit_selected = new_flux
 
     assert len(specviz_helper.app.data_collection) == 1
     assert u.Unit(viewer.state.x_display_unit) == u.Unit(new_spectral_axis)
@@ -93,8 +93,6 @@ def test_conv_no_data(specviz_helper):
     plg = specviz_helper.plugins["Unit Conversion"]
     with pytest.raises(ValueError, match="no valid unit choices"):
         plg.spectral_unit = "micron"
-    with pytest.raises(ValueError, match="no valid unit choices"):
-        plg.flux_unit = "erg / (s cm2 Angstrom)"
     assert len(specviz_helper.app.data_collection) == 0
 
 

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -79,7 +79,7 @@ class UnitConversion(PluginTemplateMixin):
 
     @property
     def user_api(self):
-        return PluginUserApi(self, expose=('spectral_unit', 'flux_unit'))
+        return PluginUserApi(self, expose=('spectral_unit',))
 
     def _on_glue_x_display_unit_changed(self, x_unit):
         if x_unit is None:


### PR DESCRIPTION
Remove `flux_unit` from the unit conversion user API since we're likely to rename it.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
