### PR TITLE
Update pyinstaller version to see if it fixes dylib problem

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -39,7 +39,7 @@ jobs:
       run: pip install .[test]
 
     - name: Install pyinstaller
-      run: pip install pyinstaller==5.11
+      run: pip install pyinstaller==6.6
 
     - name: Create standalone binary
       env:


### PR DESCRIPTION
If this doesn't work, we'll have to remove the `scipy` dylib files in the same step as the `skimage` and `shapely` ones.