### PR TITLE
Prevent composite array calls on subsets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -127,6 +127,9 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Fix Data Quality plugin bug that attempted to apply array compositing logic to
+  spatial subsets. [#2854]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/default/plugins/data_quality/data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.py
@@ -197,8 +197,10 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
                     self.app._jdaviz_helper._default_uncert_viewer_reference_name
                 )
                 for layer in uncert_viewer.layers:
-                    layer.composite._allow_bad_alpha = True
-                    layer.force_update()
+                    # allow bad alpha for image layers, not subsets:
+                    if not hasattr(layer, 'subset_array'):
+                        layer.composite._allow_bad_alpha = True
+                        layer.force_update()
 
             flag_bits = np.array([flag['flag'] for flag in self.decoded_flags])
 


### PR DESCRIPTION
This PR prevents the DQ plugin from applying array compositing logic on spatial subsets that should be specific to image layers. I added a regression test that causes an AttributeError on main (thanks to @javerbukh for reporting!).

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
