### PR TITLE
Downgrade upload-artifact to version 3, delete scipy dylib files

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -61,14 +61,14 @@ jobs:
 
     - name: Upload Test artifacts
       if: github.event_name != 'pull_request'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: test-results-${{ matrix.os }}
         path: standalone/test-results
 
     - name: Upload jdaviz standalone (non-OSX)
       if: github.event_name != 'pull_request'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: jdaviz-standlone-${{ matrix.os }}
         path: |
@@ -122,6 +122,8 @@ jobs:
         rm -rf standalone/dist/jdaviz.app/Contents/Resources/skimage/.dylibs
         rm -rf standalone/dist/jdaviz.app/Contents/MacOS/shapely/.dylibs
         rm -rf standalone/dist/jdaviz.app/Contents/Resources/shapely/.dylibs
+        rm -rf standalone/dist/jdaviz.app/Contents/MacOS/scipy/.dylibs
+        rm -rf standalone/dist/jdaviz.app/Contents/Resources/scipy/.dylibs
 
     - name: Codesign (OSX)
       if: ${{ matrix.os == 'macos' }}
@@ -181,14 +183,14 @@ jobs:
 
     - name: Upload Test artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: test-results-${{ matrix.os }}
         path: standalone/test-results
 
     - name: Upload jdaviz standalone (OSX)
       if: ${{ always() && (matrix.os == 'macos') }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: jdaviz-standlone-${{ matrix.os }}
         path: standalone/dist/jdaviz.dmg


### PR DESCRIPTION
See https://github.com/actions/upload-artifact/issues/485, it seems for now the answer is to use upload-artifact version 3. The scipy dylib deletions are attempts to get the mac build working.