### PR TITLE
Enable Row Selection on Plugin Table Component

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -82,6 +82,8 @@ Specviz2d
 API Changes
 -----------
 
+- Plugin Table components now support row selection. [#2856]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/components/plugin_table.vue
+++ b/jdaviz/components/plugin_table.vue
@@ -49,6 +49,9 @@
         dense
         :headers="headers_visible_sorted.map(item => {return {'text': item, 'value': item}})"
         :items="items"
+        :item-key="item_key"
+        :show-select="show_rowselect"
+        v-model="selected_rows"
         class="elevation-1 width-100"
       ></v-data-table>
     </v-row>

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -4361,6 +4361,9 @@ class Table(PluginSubcomponent):
     headers_visible = List([]).tag(sync=True)  # list of strings
     headers_avail = List([]).tag(sync=True)   # list of strings
     items = List().tag(sync=True)  # list of dictionaries, pass single dict to add_row
+    show_rowselect = Bool(False).tag(sync=True)  # Flag to enable row selection boxes
+    item_key = Unicode().tag(sync=True)  # Unique field to identify row for selection
+    selected_rows = List().tag(sync=True)  # List of selected rows
 
     def __init__(self, plugin, name='table', *args, **kwargs):
         self._qtable = None

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -4361,6 +4361,9 @@ class Table(PluginSubcomponent):
     headers_visible = List([]).tag(sync=True)  # list of strings
     headers_avail = List([]).tag(sync=True)   # list of strings
     items = List().tag(sync=True)  # list of dictionaries, pass single dict to add_row
+
+    # NOTE: These UI features are not covered in test coverage. Plugins making use of
+    # this feature should ensure test coverage for their respective tables.
     show_rowselect = Bool(False).tag(sync=True)  # Flag to enable row selection boxes
     item_key = Unicode().tag(sync=True)  # Unique field to identify row for selection
     selected_rows = List().tag(sync=True)  # List of selected rows


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Hello Jdaviz Team!

This PR is a small change to the Plugin Table component to expose the Vuetify row selection attributes for the Virtual Observatory plugin I'm working on. Because this is a frontend component, no new tests were added. A changelog entry will follow the publication of this PR, once a PR number is assigned.

![image](https://github.com/spacetelescope/jdaviz/assets/25206008/a5e70068-ea30-44d6-b93f-1335fb9a4c0c)

It was great to sync my fork again :)
![Screenshot 2024-05-06 150559](https://github.com/spacetelescope/jdaviz/assets/25206008/06017677-deaf-42f5-96b6-f214be36e47b)


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4468)
