### PR TITLE
Try pinning pyinstaller<6

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -34,7 +34,7 @@ jobs:
       run: pip install .[test]
 
     - name: Install pyinstaller
-      run: pip install pyinstaller==6.6
+      run: pip install pyinstaller<6
 
     - name: Create standalone binary
       env:

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -34,7 +34,7 @@ jobs:
       run: pip install .[test]
 
     - name: Install pyinstaller
-      run: pip install pyinstaller<6
+      run: pip install "pyinstaller<6"
 
     - name: Create standalone binary
       env:
@@ -102,7 +102,7 @@ jobs:
       run: pip install .[test]
 
     - name: Install pyinstaller
-      run: pip install pyinstaller==6.6
+      run: pip install "pyinstaller<6"
 
     - name: Create standalone binary
       env:


### PR DESCRIPTION
Previously was pinned on 5.13, I'm curious to see if the symlink issue is a 6.x problem.