### PR TITLE
Background subtraction in spectral extraction (cubeviz)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Cubeviz
   the label of the flux cube) as well as to several plugins: model fitting, gaussian smooth,
   line analysis, and moment maps. [#2827]
 
+- Background subtraction support within Spectral Extraction. [#2859]
+
 Imviz
 ^^^^^
 
@@ -48,6 +50,8 @@ Cubeviz
 - In the Slice plugin, the following deprecated properties were removed: ``wavelength`` (use ``value``),
   ``wavelength_unit`` (use ``value_unit``), ``show_wavelength`` (use ``show_value``),
   ``slice`` (use ``value``). [#2878]
+
+- Spectral Extraction: renamed ``collapse_to_spectrum(...)`` to ``extract(...)``. [#2859]
 
 Imviz
 ^^^^^

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -57,8 +57,8 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
       ``wavelength_dependent`` to also be set to ``True``). The cone is defined
       to intersect ``background`` at ``reference_spectral_value``.
     * ```bg_spec_per_spaxel``:
-        Whether to normalize the resulting summed background per spaxel when calling
-        ``extract_bg_spectrum``.  Otherwise, the spectrum will be scaled by the ratio between the
+        Whether to normalize the background per spaxel when calling ``extract_bg_spectrum``.
+        Otherwise, the spectrum will be scaled by the ratio between the
         areas of the aperture and the background aperture. Only applicable if ``function`` is 'Sum'.
     * ``bg_spec_add_results`` (:class:`~jdaviz.core.template_mixin.AddResults`)
     * :meth:`extract_bg_spectrum`

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -202,7 +202,7 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
     def slice_display_unit_name(self):
         return 'spectral'
 
-    @observe('active_step')
+    @observe('active_step', 'is_active')
     def _active_step_changed(self, *args):
         self.aperture._set_mark_visiblities(self.active_step in ('', 'ap', 'ext'))
         self.background._set_mark_visiblities(self.active_step == 'bg')

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -315,7 +315,7 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         # wavelength, on the range [0, 1].
         if self.aperture.selected == self.aperture.default_text:
             # Entire Cube
-            return np.ones_like(self.dataset.selected_obj.flux)
+            return np.ones_like(self.dataset.selected_obj.flux.value)
         return self.aperture.get_mask(self.dataset.selected_obj,
                                       self.aperture_method_selected,
                                       self.spectral_display_unit,
@@ -325,7 +325,7 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
     def bg_weight_mask(self):
         if self.background.selected == self.background.default_text:
             # NO background
-            return np.zeros_like(self.dataset.selected_obj.flux)
+            return np.zeros_like(self.dataset.selected_obj.flux.value)
         return self.background.get_mask(self.dataset.selected_obj,
                                         self.aperture_method_selected,
                                         self.spectral_display_unit,

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
@@ -133,6 +133,32 @@
           </v-row>
         </div>
       </div>
+
+      <v-row v-if="bg_selected !== 'None'">
+        <v-expansion-panels accordion>
+          <v-expansion-panel>
+            <v-expansion-panel-header v-slot="{ open }">
+              <span style="padding: 6px">Export Background Spectrum</span>
+            </v-expansion-panel-header>
+            <v-expansion-panel-content class="plugin-expansion-panel-content">
+              <plugin-add-results
+                :label.sync="bg_spec_results_label"
+                :label_default="bg_spec_results_label_default"
+                :label_auto.sync="bg_spec_results_label_auto"
+                :label_invalid_msg="bg_spec_results_label_invalid_msg"
+                :label_overwrite="bg_spec_results_label_overwrite"
+                label_hint="Label for the background spectrum"
+                :add_to_viewer_items="bg_spec_add_to_viewer_items"
+                :add_to_viewer_selected.sync="bg_spec_add_to_viewer_selected"
+                action_label="Export"
+                action_tooltip="Create Background Spectrum"
+                @click:action="create_bg_spec"
+              ></plugin-add-results>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </v-row>
+
     </div>
 
     <div @mouseover="() => active_step='ext'">

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
@@ -85,7 +85,7 @@
       </div>
     </div>
 
-    <div v-if="dev_bg_support" @mouseover="() => active_step='bg'">
+    <div @mouseover="() => active_step='bg'">
       <j-plugin-section-header :active="active_step==='bg'">Background</j-plugin-section-header>
       <plugin-subset-select
         :items="bg_items"

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
@@ -145,7 +145,7 @@
                 <v-switch
                   v-model="bg_spec_per_spaxel"
                   label="Normalize per-spaxel"
-                  hint="Whether to normalize the resulting summed background per spaxel (not shown in preview).  Otherwise, the spectrum will be scaled by the ratio between the areas of the aperture to the background aperture."
+                  hint="Whether to normalize the background per spaxel (not shown in preview). Otherwise, the spectrum will be scaled by the ratio between the areas of the extraction aperture to the background aperture."
                   persistent-hint
                 ></v-switch>
               </v-row>

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
@@ -141,6 +141,14 @@
               <span style="padding: 6px">Export Background Spectrum</span>
             </v-expansion-panel-header>
             <v-expansion-panel-content class="plugin-expansion-panel-content">
+              <v-row v-if="function_selected === 'Sum'">
+                <v-switch
+                  v-model="bg_spec_per_spaxel"
+                  label="Normalize per-spaxel"
+                  hint="Whether to normalize the resulting summed background per spaxel (not shown in preview).  Otherwise, the spectrum will be scaled by the ratio between the areas of the aperture to the background aperture."
+                  persistent-hint
+                ></v-switch>
+              </v-row>
               <plugin-add-results
                 :label.sync="bg_spec_results_label"
                 :label_default="bg_spec_results_label_default"

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -30,7 +30,7 @@ def test_version_after_nddata_update(cubeviz_helper, spectrum1d_cube_with_uncert
     collapsed_cube_nddata = spectral_cube.sum(axis=(0, 1))  # return NDDataArray
 
     # Collapse the spectral cube using the methods in jdaviz:
-    collapsed_cube_s1d = plg.collapse_to_spectrum(add_data=False)  # returns Spectrum1D
+    collapsed_cube_s1d = plg.extract(add_data=False)  # returns Spectrum1D
 
     assert plg._obj.disabled_msg == ''
     assert isinstance(spectral_cube, NDDataArray)
@@ -80,7 +80,7 @@ def test_gauss_smooth_before_spec_extract(cubeviz_helper, spectrum1d_cube_with_u
     expected_uncert = 2
 
     extract_plugin.aperture = 'Subset 1'
-    collapsed_spec = extract_plugin.collapse_to_spectrum()
+    collapsed_spec = extract_plugin.extract()
 
     # this single pixel has two wavelengths, and all uncertainties are unity
     # irrespective of which collapse function is applied:
@@ -89,7 +89,7 @@ def test_gauss_smooth_before_spec_extract(cubeviz_helper, spectrum1d_cube_with_u
 
     # this two-pixel region has four unmasked data points per wavelength:
     extract_plugin.aperture = 'Subset 2'
-    collapsed_spec_2 = extract_plugin.collapse_to_spectrum()
+    collapsed_spec_2 = extract_plugin.extract()
     assert_array_equal(collapsed_spec_2.uncertainty.array, expected_uncert)
 
 
@@ -120,7 +120,7 @@ def test_subset(
 
     # single pixel region:
     plg.aperture = 'Subset 1'
-    collapsed_spec_1 = plg.collapse_to_spectrum()
+    collapsed_spec_1 = plg.extract()
 
     # this single pixel has two wavelengths, and all uncertainties are unity
     # irrespective of which collapse function is applied:
@@ -129,7 +129,7 @@ def test_subset(
 
     # this two-pixel region has four unmasked data points per wavelength:
     plg.aperture = 'Subset 2'
-    collapsed_spec_2 = plg.collapse_to_spectrum()
+    collapsed_spec_2 = plg.extract()
 
     assert_array_equal(collapsed_spec_2.uncertainty.array, expected_uncert)
 
@@ -251,13 +251,13 @@ def test_cone_aperture_with_different_methods(cubeviz_helper, spectrum1d_cube_la
     extract_plg.wavelength_dependent = True
     extract_plg.function = 'Sum'
 
-    collapsed_spec = extract_plg.collapse_to_spectrum()
+    collapsed_spec = extract_plg.extract()
 
     assert_allclose(collapsed_spec.flux.value[1000:1010], expected_flux_1000, rtol=1e-6)
     assert_allclose(collapsed_spec.flux.value[2400:2410], expected_flux_2400, rtol=1e-6)
 
     extract_plg.function = 'Mean'
-    collapsed_spec_mean = extract_plg.collapse_to_spectrum()
+    collapsed_spec_mean = extract_plg.extract()
 
     assert_allclose(collapsed_spec_mean.flux.value, 1)
 
@@ -283,12 +283,12 @@ def test_cylindrical_aperture_with_different_methods(cubeviz_helper, spectrum1d_
     extract_plg.wavelength_dependent = False
     extract_plg.function = 'Sum'
 
-    collapsed_spec = extract_plg.collapse_to_spectrum()
+    collapsed_spec = extract_plg.extract()
 
     assert_allclose(collapsed_spec.flux.value, expected_flux_wav)
 
     extract_plg.function = 'Mean'
-    collapsed_spec_mean = extract_plg.collapse_to_spectrum()
+    collapsed_spec_mean = extract_plg.extract()
 
     assert_allclose(collapsed_spec_mean.flux.value, 1)
 
@@ -304,7 +304,7 @@ def test_rectangle_aperture_with_exact(cubeviz_helper, spectrum1d_cube_largest):
     extract_plg.aperture_method.selected = "Exact"
     extract_plg.wavelength_dependent = True
     extract_plg.function = 'Sum'
-    collapsed_spec = extract_plg.collapse_to_spectrum()
+    collapsed_spec = extract_plg.extract()
 
     # The extracted spectrum has "steps" (aliased) but perhaps that is due to
     # how photutils is extracting a boxy aperture. There is still a slope.
@@ -313,7 +313,7 @@ def test_rectangle_aperture_with_exact(cubeviz_helper, spectrum1d_cube_largest):
     assert_allclose(collapsed_spec.flux.value[::301], expected_flux_step)
 
     extract_plg.wavelength_dependent = False
-    collapsed_spec = extract_plg.collapse_to_spectrum()
+    collapsed_spec = extract_plg.extract()
 
     assert_allclose(collapsed_spec.flux.value, 16)  # 4 x 4
 
@@ -333,16 +333,16 @@ def test_cone_and_cylinder_errors(cubeviz_helper, spectrum1d_cube_largest):
 
     extract_plg.function = 'Min'
     with pytest.raises(ValueError, match=extract_plg._obj.conflicting_aperture_error_message):
-        extract_plg.collapse_to_spectrum()
+        extract_plg.extract()
 
     extract_plg.function = 'Max'
     with pytest.raises(ValueError, match=extract_plg._obj.conflicting_aperture_error_message):
-        extract_plg.collapse_to_spectrum()
+        extract_plg.extract()
 
     extract_plg.function = 'Sum'
     extract_plg.aperture = 'Subset 2'
     with pytest.raises(NotImplementedError, match=".* is not supported"):
-        extract_plg.collapse_to_spectrum()
+        extract_plg.extract()
 
 
 def test_cone_aperture_with_frequency_units(cubeviz_helper, spectral_cube_wcs):
@@ -358,19 +358,19 @@ def test_cone_aperture_with_frequency_units(cubeviz_helper, spectral_cube_wcs):
     extract_plg.function = 'Sum'
 
     with pytest.raises(ValueError, match="Spectral axis unit physical type is"):
-        extract_plg.collapse_to_spectrum()
+        extract_plg.extract()
 
 
 def test_cube_extraction_with_nan(cubeviz_helper, image_cube_hdu_obj):
     image_cube_hdu_obj[1].data[:, :2, :2] = np.nan
     cubeviz_helper.load_data(image_cube_hdu_obj, data_label="with_nan")
     extract_plg = cubeviz_helper.plugins['Spectral Extraction']
-    sp = extract_plg.collapse_to_spectrum()  # Default settings (sum)
+    sp = extract_plg.extract()  # Default settings (sum)
     assert_allclose(sp.flux.value, 96)  # (10 x 10) - 4
 
     cubeviz_helper.load_regions(RectanglePixelRegion(PixCoord(1.5, 1.5), width=4, height=4))
     extract_plg.aperture = 'Subset 1'
-    sp_subset = extract_plg.collapse_to_spectrum()  # Default settings but on Subset
+    sp_subset = extract_plg.extract()  # Default settings but on Subset
     assert_allclose(sp_subset.flux.value, 12)  # (4 x 4) - 4
 
 
@@ -383,7 +383,7 @@ def test_autoupdate_results(cubeviz_helper, spectrum1d_cube_largest):
     extract_plg.aperture = 'Subset 1'
     extract_plg.add_results.label = 'extracted'
     extract_plg.add_results._obj.auto_update_result = True
-    _ = extract_plg.collapse_to_spectrum()
+    _ = extract_plg.extract()
 
 #    orig_med_flux = np.median(cubeviz_helper.get_data('extracted').flux)
 
@@ -445,10 +445,10 @@ def test_extraction_composite_subset(cubeviz_helper, spectrum1d_cube):
     flux_viewer.apply_roi(upper_aperture)
 
     spec_extr_plugin.aperture_selected = 'Subset 1'
-    spectrum_1 = spec_extr_plugin.collapse_to_spectrum()
+    spectrum_1 = spec_extr_plugin.extract()
 
     spec_extr_plugin.aperture_selected = 'Subset 2'
-    spectrum_2 = spec_extr_plugin.collapse_to_spectrum()
+    spectrum_2 = spec_extr_plugin.extract()
 
     subset_plugin.subset_selected = 'Create New'
     rectangle = RectangularROI(-0.5, 1.5, -0.5, 3.5)
@@ -465,7 +465,7 @@ def test_extraction_composite_subset(cubeviz_helper, spectrum1d_cube):
 
     assert spec_extr_plugin.aperture.is_composite
 
-    spectrum_3 = spec_extr_plugin.collapse_to_spectrum()
+    spectrum_3 = spec_extr_plugin.extract()
 
     np.testing.assert_allclose(
         (spectrum_1 + spectrum_2).flux.value,

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -343,6 +343,9 @@ def test_background_subtraction(cubeviz_helper, spectrum1d_cube_largest):
         assert extract_plg._obj.marks['bg_spec'].visible
 
         bg_spec = extract_plg.extract_bg_spectrum()
+        extract_plg.bg_spec_per_spaxel = True
+        bg_spec_normed = extract_plg.extract_bg_spectrum()
+        assert np.all(bg_spec_normed.flux.value < bg_spec.flux.value)
         spec = extract_plg.extract()
 
     assert np.allclose(spec.flux, spec_no_bg.flux - bg_spec.flux)

--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -153,7 +153,7 @@ def test_unit_translation(cubeviz_helper):
 
     # all spectra will pass through spectral extraction,
     # this will store a scale factor for use in translations.
-    collapsed_spec = extract_plg.collapse_to_spectrum()
+    collapsed_spec = extract_plg.extract()
 
     # test that the scale factor was set
     assert collapsed_spec.meta['_pixel_scale_factor'] != 1
@@ -224,7 +224,7 @@ def test_sb_unit_conversion(cubeviz_helper):
     extract_plg.wavelength_dependent = True
     extract_plg.function = 'Sum'
     extract_plg.reference_spectral_value = 0.000001
-    extract_plg.collapse_to_spectrum()
+    extract_plg.extract()
 
     uc_plg._obj.show_translator = True
     uc_plg._obj.flux_or_sb_selected = 'Flux'

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -17,7 +17,7 @@ __all__ = ['OffscreenLinesMarks', 'BaseSpectrumVerticalLine', 'SpectralLine',
            'LineAnalysisContinuum', 'LineAnalysisContinuumCenter',
            'LineAnalysisContinuumLeft', 'LineAnalysisContinuumRight',
            'LineUncertainties', 'ScatterMask', 'SelectedSpaxel', 'MarkersMark', 'FootprintOverlay',
-           'ApertureMark', 'SpectralExtractionPreview']
+           'ApertureMark']
 
 accent_color = "#c75d2c"
 
@@ -609,11 +609,6 @@ class FootprintOverlay(PluginLine):
 class ApertureMark(PluginLine):
     def __init__(self, viewer, id, **kwargs):
         self._id = id
-        super().__init__(viewer, **kwargs)
-
-
-class SpectralExtractionPreview(PluginLine):
-    def __init__(self, viewer, **kwargs):
         super().__init__(viewer, **kwargs)
 
 

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -220,7 +220,7 @@ def test_to_unit(cubeviz_helper):
     # set so pixel scale factor != 1
     extract_plg.reference_spectral_value = 0.000001
 
-    extract_plg.collapse_to_spectrum()
+    extract_plg.extract()
 
     cid = cubeviz_helper.app.data_collection[0].data.find_component_id('flux')
     data = cubeviz_helper.app.data_collection[-1].data


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements support for background subtraction in cubeviz's spectral extraction.

Since this has now gone far beyond "collapsing", this PR also takes this and the 4.0 major version bump as an excuse to rename `collapse_to_spectrum(...)` to `extract(...)` and then also adds a new `extract_bg_spectrum(...)` (using the same name as in specviz2d in case we ever do want to support extracting the background as well... we could consider just naming this to `extract_background(...)` if we don't want to account for that possibility down the road).


https://github.com/spacetelescope/jdaviz/assets/877591/cdc5eebe-2405-4dda-9aab-df3e659334d0


**TODO**:
- [x] live preview of background spectrum
- [x] ability to export background spectrum independently (in same way as is done in specviz2d)
- [x] determine what to do for sum case with different sized subsets (possibly by rescaling the background spectrum by the relative areas - `*= aperture_area / background_area`?)
- [x] test coverage
- [ ] investigate glitchy disappearing of preview markers - this seems to have been happening before as well so might be better as a follow-up effort

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
