### PR TITLE
Stop infinite loop calculating traces due to is_active event

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -159,6 +159,8 @@ Specviz
 Specviz2d
 ^^^^^^^^^
 
+- Cache calculated traces to prevent infinitely looping recalculation in some cases. [#2861]
+
 3.10 (2024-05-03)
 =================
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -260,7 +260,8 @@ class SpectralExtraction(PluginTemplateMixin):
                                       default_text='From Plugin',
                                       filters=['is_trace'])
 
-        # Cache the actual calculated trace
+        # Cache the actual calculated trace. IMPORTANT: Only use for interactive previews,
+        # we should always recalculate when user is calling a method
         self._bg_trace = None
 
         self.bg_statistic = SelectPluginComponent(self,
@@ -311,7 +312,8 @@ class SpectralExtraction(PluginTemplateMixin):
                                        default_text='From Plugin',
                                        filters=['is_trace'])
 
-        # Cache the actual calculated trace
+        # Cache the actual calculated trace. IMPORTANT: Only use for interactive previews,
+        # we should always recalculate when user is calling a method
         self._ext_trace = None
 
         self.ext_type = SelectPluginComponent(self,


### PR DESCRIPTION
Use cached trace when methods are triggered by `is_active` events rather than constantly recalculating. Previous behavior:

https://github.com/spacetelescope/jdaviz/assets/39831871/7fb10d4f-bc82-4e8c-9126-bf8663734f77

