### PR TITLE
Use codecov token to upload coverage

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -108,6 +108,8 @@ jobs:
         merge-multiple: true
     - name: Upload report to Codecov
       uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         directory: coverage
         fail_ci_if_error: true

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -107,10 +107,10 @@ jobs:
         pattern: coverage_*
         merge-multiple: true
     - name: Upload report to Codecov
+      if: ${{ hashFiles('coverage/') != '' }}
       uses: codecov/codecov-action@v4
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         directory: coverage
         fail_ci_if_error: true
         verbose: true


### PR DESCRIPTION
This won't be used in PRs from forks but is needed to upload coverage from `main`.