### PR TITLE
Export spatial regions to ecsv

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,8 @@ Other Changes and Additions
 New Features
 ------------
 
+- Enable exporting spatial regions to ECSV files readable by ``astropy.table.Table``. [#2847]
+
 Cubeviz
 ^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,7 +81,7 @@ Other Changes and Additions
 New Features
 ------------
 
-- Enable exporting spatial regions to ECSV files readable by ``astropy.table.Table``. [#2847]
+- Enable exporting spatial regions to ECSV files readable by ``astropy.table.Table``. [#2874]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -714,7 +714,8 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             attributes = []
             att_values = []
             att_units = []
-            for att in ("angle", "center", "height", "width", "radius"):
+            for att in ("angle", "center", "height", "width", "radius", "inner_radius",
+                        "outer_radius"):
                 if hasattr(region, att):
                     attribute = getattr(region, att)
                     if att == "center":

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -742,7 +742,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                             att_units.append("pix")
 
             table = Table([attributes, att_values, att_units], names=("attribute", "value", "unit"))
-            print(table)
+            table.meta["Region Class"] = str(type(region))
             table.write(filename, overwrite=True)
 
     def vue_interrupt_recording(self, *args):  # pragma: no cover

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -153,6 +153,10 @@ class TestExportSubsets:
         assert fits_region[4] == 0.0
 
         # now test changing file format
+        export_plugin.subset_format.selected = 'ecsv'
+        export_plugin.export()
+        assert os.path.isfile(export_plugin.filename.value)
+
         export_plugin.subset_format.selected = 'reg'
         export_plugin.export()
         assert os.path.isfile(export_plugin.filename.value)
@@ -191,10 +195,6 @@ class TestExportSubsets:
         with pytest.raises(ValueError,
                            match=re.escape("x not one of ['fits', 'reg', 'ecsv'], reverting selection to reg")):  # noqa
             export_plugin.subset_format.selected = 'x'
-
-        # Test that selecting disabled option raises an error
-        with pytest.raises(ValueError, match="Cannot export Subset 1 in ecsv format, reverting selection to fits"):  # noqa
-            export_plugin.subset_format.selected = 'ecsv'
 
         # test that attempting to save a composite subset raises an error
         cubeviz_helper.app.session.edit_subset_mode.mode = AndMode


### PR DESCRIPTION
Reading these back in would be another ticket, but this adds parity with spectral regions so that we have a common file format that both can be written out to. This logic could eventually be moved upstream.