### PR TITLE
Fix compute_scale when fiducial coordinates are outside bounding box

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -151,6 +151,8 @@ Imviz
 
 - Fix dropdowns for overlay not showing in UI. [#3640]
 
+- Prevent image wrapping in Imviz with Roman L2 images with GWCS. [#2887]
+
 Mosviz
 ^^^^^^
 
@@ -389,8 +391,6 @@ Bug Fixes
 - Fixes data-menu visibility when app is scrolled out of view. [#3391]
 
 - Fix Slice plugin for indexing through temporal slices. [#3235]
-
-- Prevent image wrapping in Imviz with Roman L2 images with GWCS. [#2887]
 
 Cubeviz
 ^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -390,6 +390,8 @@ Bug Fixes
 
 - Fix Slice plugin for indexing through temporal slices. [#3235]
 
+- Prevent image wrapping in Imviz with Roman L2 images with GWCS. [#2887]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/imviz/wcs_utils.py
+++ b/jdaviz/configs/imviz/wcs_utils.py
@@ -6,6 +6,7 @@
 import base64
 import math
 from io import BytesIO
+import warnings
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -551,7 +552,13 @@ def compute_scale(wcs, fiducial, disp_axis, pscale_ratio=1):
     if spectral and disp_axis is None:  # pragma: no cover
         raise ValueError('If input WCS is spectral, a disp_axis must be given')
 
-    crpix = np.array(wcs.invert(*fiducial))
+    if wcs.in_image(*fiducial):
+        crpix = np.array(wcs.invert(*fiducial))
+    else:
+        # At this point we know the bounding box is probably defined, so we can
+        # use the central coordinate inside the bounding box
+        warnings.warn("WCS fiducial coordinates not inside bounding box")
+        crpix = np.mean(wcs.pixel_bounds, axis=1)
 
     delta = np.zeros_like(crpix)
     spatial_idx = np.where(np.array(wcs.output_frame.axes_type) == 'SPATIAL')[0]


### PR DESCRIPTION
### Description

This fixes a corner case in ``compute_scale`` when the fiducial coordinates provided are outside of the bounding box.

This is needed if the bounding box on data is not reset, and in order to be compatible with https://github.com/spacetelescope/gwcs/pull/498

cc @bmorris3 

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
