### PR TITLE
Fix unit conversion from flux to surface brightness

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -117,14 +117,14 @@ class UnitConverterWithSpectral:
                     # target_units dictate the conversion to take place.
 
                     if (u.sr in u.Unit(original_units).bases) and \
-                        (u.sr not in u.Unit(target_units).bases):
+                          (u.sr not in u.Unit(target_units).bases):
                         # Surface Brightness -> Flux
                         eqv = [(u.MJy / u.sr,
                                 u.MJy,
                                 lambda x: (x * spec.meta['_pixel_scale_factor']),
                                 lambda x: x)]
                     elif (u.sr not in u.Unit(original_units).bases) and \
-                        (u.sr in u.Unit(target_units).bases):
+                         (u.sr in u.Unit(target_units).bases):
                         # Flux -> Surface Brightness
                         eqv = [(u.MJy,
                                 u.MJy / u.sr,

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -111,37 +111,27 @@ class UnitConverterWithSpectral:
             else:
                 # Ensure a spectrum passed through Spectral Extraction plugin
                 if '_pixel_scale_factor' in spec.meta:
-                    # if spectrum data collection item is in Surface Brightness units
-                    if u.sr in spec.unit.bases:
-                        # Data item in data collection does not update from conversion/translation.
-                        # App wide orginal data units are used for conversion, orginal_units and
-                        # target_units dicate the conversion to take place.
-                        if (u.sr in u.Unit(original_units).bases) and \
-                           (u.sr not in u.Unit(target_units).bases):
-                            # Surface Brightness -> Flux
-                            eqv = [(u.MJy / u.sr,
-                                    u.MJy,
-                                    lambda x: (x * spec.meta['_pixel_scale_factor']),
-                                    lambda x: x)]
-                        else:
-                            # Flux -> Surface Brightness
-                            eqv = u.spectral_density(spec.spectral_axis)
 
-                    # if spectrum data collection item is in Flux units
-                    elif u.sr not in spec.unit.bases:
-                        # Data item in data collection does not update from conversion/translation.
-                        # App wide orginal data units are used for conversion, orginal_units and
-                        # target_units dicate the conversion to take place.
-                        if (u.sr not in u.Unit(original_units).bases) and \
-                           (u.sr in u.Unit(target_units).bases):
-                            # Flux -> Surface Brightness
-                            eqv = [(u.MJy,
-                                    u.MJy / u.sr,
-                                    lambda x: (x / spec.meta['_pixel_scale_factor']),
-                                    lambda x: x)]
-                        else:
-                            # Surface Brightness -> Flux
-                            eqv = u.spectral_density(spec.spectral_axis)
+                    # Data item in data collection does not update from conversion/translation.
+                    # App wide original data units are used for conversion, original and
+                    # target_units dictate the conversion to take place.
+
+                    if (u.sr in u.Unit(original_units).bases) and \
+                        (u.sr not in u.Unit(target_units).bases):
+                        # Surface Brightness -> Flux
+                        eqv = [(u.MJy / u.sr,
+                                u.MJy,
+                                lambda x: (x * spec.meta['_pixel_scale_factor']),
+                                lambda x: x)]
+                    elif (u.sr not in u.Unit(original_units).bases) and \
+                        (u.sr in u.Unit(target_units).bases):
+                        # Flux -> Surface Brightness
+                        eqv = [(u.MJy,
+                                u.MJy / u.sr,
+                                lambda x: (x / spec.meta['_pixel_scale_factor']),
+                                lambda x: x)]
+                    else:
+                        eqv = u.spectral_density(spec.spectral_axis)
 
                 elif len(values) == 2:
                     # Need this for setting the y-limits

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -225,6 +225,9 @@ def test_to_unit(cubeviz_helper):
     cid = cubeviz_helper.app.data_collection[0].data.find_component_id('flux')
     data = cubeviz_helper.app.data_collection[-1].data
     values = 1
+
+    # Surface brightness to flux
+
     original_units = u.MJy / u.sr
     target_units = u.MJy
 
@@ -232,5 +235,9 @@ def test_to_unit(cubeviz_helper):
 
     assert np.allclose(value, 4.7945742429049767e-11)
 
+    # Flux to surface brightness
+
     original_units = u.MJy
     target_units = u.MJy / u.sr
+
+    value = uc.to_unit(cubeviz_helper, data, cid, values, original_units, target_units)


### PR DESCRIPTION
### Description

While looking at issues with limits not updating when changing to certain units, I spotted an unrelated issue. In ``to_unit``, the units on the original data should be irrelevant, and if glue asks for a conversion from e.g. Jy to MJy, we should ignore the original units on the data, since they might already have been previously converted to Jy which is why glue is asking for Jy to MJy. So looking at spec.unit.bases is not the right thing to do. A lot of the change here is indentation so be sure to check the diff ignoring whitespace.

I've expanded the test for to_unit.

There are other issues with the ``to_unit`` code as written currently, but I thought I'd break it up into conceptual chunks.
 
### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
