### PR TITLE
Fix unit conversion of limits from Fnu to Flam

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -147,8 +147,7 @@ class UnitConverterWithSpectral:
 
                 elif len(values) == 2:
                     # Need this for setting the y-limits
-                    spec_limits = [spec.spectral_axis[0].value, spec.spectral_axis[-1].value]
-                    eqv = u.spectral_density(spec_limits * spec.spectral_axis.unit)
+                    eqv = u.spectral_density(spectral_values)
 
                     if '_pixel_scale_factor' in spec.meta:
                         # get min and max scale factors, to use with min and max of spec for

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -120,14 +120,14 @@ class UnitConverterWithSpectral:
                     # target_units dictate the conversion to take place.
 
                     if (u.sr in u.Unit(original_units).bases) and \
-                          (u.sr not in u.Unit(target_units).bases):
+                        (u.sr not in u.Unit(target_units).bases):
                         # Surface Brightness -> Flux
                         eqv = [(u.MJy / u.sr,
                                 u.MJy,
                                 lambda x: (x * np.array(spec.meta['_pixel_scale_factor'])),
                                 lambda x: x)]
                     elif (u.sr not in u.Unit(original_units).bases) and \
-                         (u.sr in u.Unit(target_units).bases):
+                        (u.sr in u.Unit(target_units).bases):
                         # Flux -> Surface Brightness
                         eqv = [(u.MJy,
                                 u.MJy / u.sr,

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -112,6 +112,15 @@ class UnitConverterWithSpectral:
                 eqv = []
             else:
                 eqv = []
+
+                # If there are only two values, this is likely the limits being converted, so then
+                # in case we need to use the spectral density equivalency, we need to provide only
+                # to spectral axis values. If there is only one value
+                if not np.isscalar(values) and len(values) == 2:
+                    spectral_values = spec.spectral_axis[0]
+                else:
+                    spectral_values = spec.spectral_axis
+
                 # Ensure a spectrum passed through Spectral Extraction plugin
                 if '_pixel_scale_factor' in spec.meta and len(values) != 2:
 
@@ -120,21 +129,21 @@ class UnitConverterWithSpectral:
                     # target_units dictate the conversion to take place.
 
                     if (u.sr in u.Unit(original_units).bases) and \
-                        (u.sr not in u.Unit(target_units).bases):
+                           (u.sr not in u.Unit(target_units).bases):
                         # Surface Brightness -> Flux
                         eqv = [(u.MJy / u.sr,
                                 u.MJy,
                                 lambda x: (x * np.array(spec.meta['_pixel_scale_factor'])),
                                 lambda x: x)]
                     elif (u.sr not in u.Unit(original_units).bases) and \
-                        (u.sr in u.Unit(target_units).bases):
+                            (u.sr in u.Unit(target_units).bases):
                         # Flux -> Surface Brightness
                         eqv = [(u.MJy,
                                 u.MJy / u.sr,
                                 lambda x: (x / np.array(spec.meta['_pixel_scale_factor'])),
                                 lambda x: x)]
                     else:
-                        eqv = u.spectral_density(spec.spectral_axis)
+                        eqv = u.spectral_density(spectral_values)
 
                 elif len(values) == 2:
                     # Need this for setting the y-limits
@@ -162,7 +171,7 @@ class UnitConverterWithSpectral:
                                      lambda x: x)]
 
                 else:
-                    eqv = u.spectral_density(spec.spectral_axis)
+                    eqv = u.spectral_density(spectral_values)
 
         else:  # spectral axis
             eqv = u.spectral() + u.pixel_scale(1*u.pix)

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -228,7 +228,7 @@ def test_to_unit(cubeviz_helper):
     original_units = u.MJy / u.sr
     target_units = u.MJy
 
-    value = uc.to_unit(cubeviz_helper, data, cid, value, original_units, target_units)
+    value = uc.to_unit(cubeviz_helper, data, cid, values, original_units, target_units)
 
     # so test first value in array
     assert np.allclose(value[0], 4.800000041882413e-08)

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -228,7 +228,7 @@ def test_to_unit(cubeviz_helper):
     original_units = u.MJy / u.sr
     target_units = u.MJy
 
-    value = uc.to_unit(cubeviz_helper, data, cid, values, original_units, target_units)
+    value = uc.to_unit(cubeviz_helper, data, cid, value, original_units, target_units)
 
     # will be a uniform array since not wavelength dependent
     # so test first value in array

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -230,6 +230,7 @@ def test_to_unit(cubeviz_helper):
 
     value = uc.to_unit(cubeviz_helper, data, cid, values, original_units, target_units)
 
+    # will be a uniform array since not wavelength dependent
     # so test first value in array
     assert np.allclose(value[0], 4.800000041882413e-08)
 

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -230,6 +230,34 @@ def test_to_unit(cubeviz_helper):
 
     value = uc.to_unit(cubeviz_helper, data, cid, value, original_units, target_units)
 
-    # will be a uniform array since not wavelength dependent
     # so test first value in array
     assert np.allclose(value[0], 4.800000041882413e-08)
+
+    # Change from Fnu to Flam (with values shape matching spectral axis)
+
+    values = np.ones(3001)
+    original_units = u.MJy
+    target_units = u.erg / u.cm**2 / u.s / u.AA
+
+    new_values = uc.to_unit(cubeviz_helper, data, cid, values, original_units, target_units)
+
+    assert np.allclose(new_values,
+                       (values * original_units)
+                       .to_value(target_units,
+                                 equivalencies=u.spectral_density(cube.spectral_axis)))
+
+    # Change from Fnu to Flam (with a shape (2,) array of values indicating we
+    # are probably converting the limits)
+
+    values = [1, 2]
+    original_units = u.MJy
+    target_units = u.erg / u.cm**2 / u.s / u.AA
+
+    new_values = uc.to_unit(cubeviz_helper, data, cid, values, original_units, target_units)
+
+    # In this case we do a regular spectral density conversion, but using the
+    # first value in the spectral axis for the equivalency
+    assert np.allclose(new_values,
+                       ([1, 2] * original_units)
+                       .to_value(target_units,
+                                 equivalencies=u.spectral_density(cube.spectral_axis[0])))


### PR DESCRIPTION
### Description

I have expanded the test suite for ``to_unit`` and found that an error occurred when converting limits from Fnu to Flam. The issue in this specific case was that ``if '_pixel_scale_factor' in spec.meta:`` was  ``True`` so the clause relating to ``len(values)==2`` was never invoked, resulting in an issue with incompatible dimensions.

In addition to fixing this logic, I have made it so that we just use one wavelength/frequency in this case for the conversion, as it doesn't specifically make sense to use the first and last spectral axis value. When converting limits we are probably interested in the values being right at the start of the spectral axis.

This builds on top of https://github.com/spacetelescope/jdaviz/pull/2888 and should be rebased once https://github.com/spacetelescope/jdaviz/pull/2888 is merged.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
