### PR TITLE
Show path to file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ New Features
 
 - The colormap menu for image layers now shows in-line previews of the colormaps. [#2900]
 
+- Display default filepath in Export plugin, re-enable API exporting, enable relative and absolute
+  path exports from the UI. [#2896]
+
 Cubeviz
 ^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,9 +16,6 @@ New Features
 
 - The colormap menu for image layers now shows in-line previews of the colormaps. [#2900]
 
-- Display default filepath in Export plugin, re-enable API exporting, enable relative and absolute
-  path exports from the UI. [#2896]
-
 Cubeviz
 ^^^^^^^
 
@@ -189,6 +186,9 @@ Other Changes and Additions
 
 Bug Fixes
 ---------
+
+- Display default filepath in Export plugin, re-enable API exporting, enable relative and absolute
+  path exports from the UI. [#2896]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -537,8 +537,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
     def save_figure(self, viewer, filename=None, filetype="png", show_dialog=False):
         if filetype == "png":
-            # support writing without save dialog
-            # https://github.com/bqplot/bqplot/pull/1397
+
             if filename is None:
                 filename = self.filename_default
 

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -264,6 +264,15 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
     @observe('filename_value')
     def _is_filename_changed(self, event):
+        # Update the UI Filepath if relative or absolute paths are provided
+        # by user via self.filename_value
+        if '/' in self.filename_value and \
+           ('.' in self.filename_value or '..' in self.filename_value):
+            abs_path = Path(self.filename_value).resolve()
+            self.default_filepath = str(abs_path)
+        elif '/' in self.filename_value:
+            self.default_filepath = str(self.filename_value)
+
         # Clear overwrite warning when user changes filename
         self.overwrite_warn = False
 

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -556,8 +556,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                         sender=self, color="success"))
 
             if viewer.figure._upload_png_callback is not None:
-                raise ValueError("previous png export is still in progress.  Wait to complete "
-                                 "before making another call to save_figure")
+                raise ValueError("previous png export is still in progress. Wait to complete before making another call to save_figure")  # noqa: E501 # pragma: no cover
 
             viewer.figure.get_png_data(on_img_received)
 

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -375,8 +375,11 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             if not filepath.is_absolute():
                 abs_path = filepath.resolve()
                 self.default_filepath = str(abs_path)
+            # set default path for standalone
+            if os.environ.get("JDAVIZ_START_DIR", ""):
+                self.default_filepath = os.environ["JDAVIZ_START_DIR"]
 
-        if filename.exists() and not overwrite:
+        if filename.exists() and not overwrite and not default_path:
             self.overwrite_warn = True
         else:
             self.overwrite_warn = False

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -266,16 +266,9 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     def _is_filename_changed(self, event):
         # Update the UI Filepath if relative or absolute paths are provided
         # by user via self.filename_value
-        if '~' in self.filename_value and '/' in self.filename_value:
-            expanded_path = os.path.expanduser(self.filename_value)
-            abs_path = Path(expanded_path).resolve()
-            self.default_filepath = str(abs_path)
-        elif '/' in self.filename_value and \
-             ('.' in self.filename_value or '..' in self.filename_value):
-            abs_path = Path(self.filename_value).resolve()
-            self.default_filepath = str(abs_path)
-        elif '/' in self.filename_value:
-            self.default_filepath = str(self.filename_value)
+        expanded_path = os.path.expanduser(self.filename_value)
+        abs_path = Path(expanded_path).resolve()
+        self.default_filepath = str(abs_path)
 
         # Clear overwrite warning when user changes filename
         self.overwrite_warn = False

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -275,7 +275,7 @@
         absolute
         opacity=0.5
         :value="overwrite_warn"
-        :zIndex=0
+        :zIndex=3
         style="grid-area: 1/1;
                margin-left: -24px;
                margin-right: -24px">

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -222,20 +222,20 @@
       </v-row>
     </div>
 
-    <div style="display: grid; position: relative"> <!-- overlay container -->
-    <div style="grid-area: 1/1">
-
     <v-row class="row-no-outside-padding row-min-bottom-padding">
       <v-col>
         <v-text-field
-          :value="filepath_value"
+          :value="default_filepath"
           label="Filepath"
-          hint="Default filepath export location."
+          hint="Filepath export location."
           persistent-hint
           disabled
         ></v-text-field>
       </v-col>
     </v-row>
+
+    <div style="display: grid; position: relative"> <!-- overlay container -->
+    <div style="grid-area: 1/1">
 
     <plugin-auto-label
       :value.sync="filename_value"
@@ -243,7 +243,7 @@
       :auto.sync="filename_auto"
       :invalid_msg="filename_invalid_msg"
       label="Filename"
-      hint="Export to a file on disk"
+      hint="Export to a file on disk."
     ></plugin-auto-label>
 
     <v-row justify="end">

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -273,9 +273,9 @@
 
       <v-overlay
         absolute
-        opacity=1.0
+        opacity=0.5
         :value="overwrite_warn"
-        :zIndex=3
+        :zIndex=0
         style="grid-area: 1/1;
                margin-left: -24px;
                margin-right: -24px">

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -225,6 +225,18 @@
     <div style="display: grid; position: relative"> <!-- overlay container -->
     <div style="grid-area: 1/1">
 
+    <v-row class="row-no-outside-padding row-min-bottom-padding">
+      <v-col>
+        <v-text-field
+          :value="filepath_value"
+          label="Filepath"
+          hint="Default filepath export location."
+          persistent-hint
+          disabled
+        ></v-text-field>
+      </v-col>
+    </v-row>
+
     <plugin-auto-label
       :value.sync="filename_value"
       :default="filename_default"

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -348,3 +348,42 @@ class TestExportPluginPlots:
 
         # just check that it doesn't crash, since we can't download
         export_plugin.export()
+
+    def test_figure_export(self, imviz_helper):
+
+        data = NDData(np.ones((500, 500)) * u.nJy)
+
+        imviz_helper.load_data(data)
+
+        export_plugin = imviz_helper.plugins['Export']._obj
+
+        export_plugin.export(filename=None)
+
+        # attempting to save a figure back to back
+        try:
+            export_plugin.export(filename='img.png')
+        except ValueError as e:
+            assert str(e) == "previous png export is still in progress. Wait to complete before making another call to save_figure"  # noqa: E501
+
+    def test_filepath_convention(self, imviz_helper):
+
+        data = NDData(np.ones((500, 500)) * u.nJy)
+
+        imviz_helper.load_data(data)
+
+        export_plugin = imviz_helper.plugins['Export']._obj
+
+        export_plugin.filename_value = '~/img.png'
+        expected_path = os.path.expanduser('~/img.png')
+
+        assert export_plugin.default_filepath == expected_path
+
+        export_plugin.filename_value = '../img.png'
+        expected_path = os.path.abspath('../img.png')
+
+        assert export_plugin.default_filepath == expected_path
+
+        export_plugin.filename_value = './img.png'
+        expected_path = os.path.abspath('./img.png')
+
+        assert export_plugin.default_filepath == expected_path

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -374,7 +374,7 @@ class TestExportPluginPlots:
         export_plugin = imviz_helper.plugins['Export']._obj
 
         export_plugin.filename_value = '/img.png'
-        assert export_plugin.default_filepath == export_plugin.filename_value
+        assert os.path.normpath(export_plugin.default_filepath) == os.path.normpath(export_plugin.filename_value)  # noqa: E501
 
         export_plugin.filename_value = '~/img.png'
         expected_path = os.path.normpath(os.path.expanduser('~/img.png'))

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -374,7 +374,7 @@ class TestExportPluginPlots:
         export_plugin = imviz_helper.plugins['Export']._obj
 
         export_plugin.filename_value = '/img.png'
-        assert os.path.normpath(export_plugin.default_filepath) == os.path.normpath(export_plugin.filename_value)  # noqa: E501
+        assert os.path.abspath(export_plugin.default_filepath) == os.path.abspath(export_plugin.filename_value)  # noqa: E501
 
         export_plugin.filename_value = '~/img.png'
         expected_path = os.path.normpath(os.path.expanduser('~/img.png'))

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -374,7 +374,7 @@ class TestExportPluginPlots:
         export_plugin = imviz_helper.plugins['Export']._obj
 
         export_plugin.filename_value = '~/img.png'
-        expected_path = os.path.expanduser('~/img.png')
+        expected_path = os.path.normpath(os.path.expanduser('~/img.png'))
 
         assert export_plugin.default_filepath == expected_path
 

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -359,7 +359,7 @@ class TestExportPluginPlots:
 
         export_plugin.export(filename=None)
 
-        # attempting to save a figure back to back
+        # attempt to save a figure back to back
         try:
             export_plugin.export(filename='img.png')
         except ValueError as e:
@@ -372,6 +372,9 @@ class TestExportPluginPlots:
         imviz_helper.load_data(data)
 
         export_plugin = imviz_helper.plugins['Export']._obj
+
+        export_plugin.filename_value = '/img.png'
+        assert export_plugin.default_filepath == export_plugin.filename_value
 
         export_plugin.filename_value = '~/img.png'
         expected_path = os.path.normpath(os.path.expanduser('~/img.png'))

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -10,6 +10,7 @@ from glue.core.edit_subset_mode import AndMode, NewMode
 from glue.core.roi import CircularROI, XRangeROI
 from regions import Regions, CircleSkyRegion
 from specutils import Spectrum1D
+from pathlib import Path
 
 
 @pytest.mark.usefixtures('_jail')
@@ -366,27 +367,22 @@ class TestExportPluginPlots:
             assert str(e) == "previous png export is still in progress. Wait to complete before making another call to save_figure"  # noqa: E501
 
     def test_filepath_convention(self, imviz_helper):
-
         data = NDData(np.ones((500, 500)) * u.nJy)
-
         imviz_helper.load_data(data)
-
         export_plugin = imviz_helper.plugins['Export']._obj
 
-        export_plugin.filename_value = '/img.png'
+        # Set filename value using OS-independent Path methods
+        export_plugin.filename_value = str(Path('/') / 'img.png')
         assert os.path.abspath(export_plugin.default_filepath) == os.path.abspath(export_plugin.filename_value)  # noqa: E501
 
-        export_plugin.filename_value = '~/img.png'
-        expected_path = os.path.normpath(os.path.expanduser('~/img.png'))
-
+        export_plugin.filename_value = str(Path('~') / 'img.png')
+        expected_path = str(Path('~').expanduser() / 'img.png')
         assert export_plugin.default_filepath == expected_path
 
-        export_plugin.filename_value = '../img.png'
-        expected_path = os.path.abspath('../img.png')
-
+        export_plugin.filename_value = str(Path('..') / 'img.png')
+        expected_path = str((Path('..') / 'img.png').resolve())
         assert export_plugin.default_filepath == expected_path
 
-        export_plugin.filename_value = './img.png'
-        expected_path = os.path.abspath('./img.png')
-
+        export_plugin.filename_value = str(Path('.') / 'img.png')
+        expected_path = str((Path('.') / 'img.png').resolve())
         assert export_plugin.default_filepath == expected_path


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address displaying the default file path in the Export plugin UI. The default path shall update if the user inputs a relative or absolute path into the filename input field in the UI.

 It also re-enables exporting for them the API. If a user provides a path via in the API, the file shall be exported there. 

In the UI, the default filepath will be used (cwd), or, if a user provides a path, it will export to that location instead of exporting only to the users Downloads directory. 

Follow up tickets are needed to address:

- [x] updating file path when the user is in standalone
- [ ] updating mp4 exporting (on main, exporting mp4 results in a traceback, with this PR the mp4 downloads and is viewable, but the video is white screen with no content)
- [ ]  loading images from the import directory interface in standalone does not work

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
