### PR TITLE
Pin min version of matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 dependencies = [
     "packaging",
     "astropy>=6",
-    "matplotlib",
+    "matplotlib>=3.8.4",
     "traitlets>=5.0.5",
     "bqplot>=0.12.37",
     "bqplot-image-gl>=1.4.11",


### PR DESCRIPTION
We need to pin Matplotlib to a more recent version that works, since ESA Datalabs builds a docker image that has an older incompatible version by default.

3.9 is newer and we could pin that, but I locally had 3.8.4 and know it works.