### PR TITLE
Backport PR #2906 on branch v3.10.x (Pin min version of matplotlib)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 dependencies = [
     "packaging",
     "astropy>=4.3",
-    "matplotlib",
+    "matplotlib>=3.8.4",
     "traitlets>=5.0.5",
     "bqplot>=0.12.37",
     "bqplot-image-gl>=1.4.11",


### PR DESCRIPTION
Manual backport of #2906 .