### PR TITLE
Change matplotlib min version to 3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 dependencies = [
     "packaging",
     "astropy>=6",
-    "matplotlib>=3.8.4",
+    "matplotlib>=3.6",
     "traitlets>=5.0.5",
     "bqplot>=0.12.37",
     "bqplot-image-gl>=1.4.11",


### PR DESCRIPTION
Keeps our supported versions in lines with https://scientific-python.org/specs/spec-0000/ rather than the semi-random version I originally pinned (thanks @pllim ).