### PR TITLE
BUG: os.environ does not return Path object

### DIFF
--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -529,10 +529,6 @@ def download_uri_to_path(possible_uri, cache=None, local_path=os.curdir, timeout
         local path to the downloaded file.
     """
 
-    if os.environ.get("JDAVIZ_START_DIR", ""):
-        # avoiding creating local paths in a tmp dir when in standalone:
-        local_path = os.environ["JDAVIZ_START_DIR"] / local_path
-
     if not isinstance(possible_uri, str):
         # only try to parse strings:
         return possible_uri
@@ -540,6 +536,10 @@ def download_uri_to_path(possible_uri, cache=None, local_path=os.curdir, timeout
     if os.path.exists(possible_uri):
         # don't try to parse file paths:
         return possible_uri
+
+    if os.environ.get("JDAVIZ_START_DIR", ""):
+        # avoiding creating local paths in a tmp dir when in standalone:
+        local_path = os.path.join(os.environ["JDAVIZ_START_DIR"], local_path)
 
     parsed_uri = urlparse(possible_uri)
 
@@ -588,7 +588,7 @@ def download_uri_to_path(possible_uri, cache=None, local_path=os.curdir, timeout
 
         if local_path is None:
             # if not specified, this is the default location:
-            # os.path.sep does not work because on windows that is a back slash
+            # os.path.sep does not work because on Windows that is a back slash
             # and this web path needs to be split with a forward slash
             local_path = os.path.join(os.getcwd(), parsed_uri.path.split('/')[-1])
         return local_path


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to fix data loading in "standalone app". Turns out to be a trivial fix. `os.environ` always returns a string but `/` operator is used but that only works for `Path` object.

Introduced in https://github.com/spacetelescope/jdaviz/pull/2875 that is unreleased, so no need for change log. Not sure how to add a meaningful test either.

Also moved the check farther down because this operation is pointless for no-op.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4591)
