### PR TITLE
TST: Test Windows path handling without remote data

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -61,7 +61,6 @@ jobs:
             os: windows-latest
             python: '3.10'
             toxenv: py310-test
-            toxposargs: --remote-data
             allow_failure: false
 
           # This also runs on cron but we want to make sure new changes

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -1,7 +1,8 @@
-import pytest
+import os
 import warnings
 
 import photutils
+import pytest
 from asdf.exceptions import AsdfWarning
 from astropy.utils import minversion
 from astropy.wcs import FITSFixedWarning
@@ -49,6 +50,15 @@ def test_url_to_download_imviz_local_path_warning(imviz_helper):
         pytest.warns(UserWarning, match=match_local_path_msg)
     ):
         imviz_helper.load_data(url, cache=True, local_path='horsehead.fits')
+
+
+def test_uri_to_download_specviz_local_path_check():
+    uri = "mast:JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_x1d.fits"
+    local_path = utils.download_uri_to_path(uri, cache=False, dryrun=True)  # No download
+
+    # Wrong: '.\\JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_x1d.fits'
+    # Correct:  '.\\jw02732-o004_t004_miri_ch1-shortmediumlong_x1d.fits'
+    assert local_path == os.path.join(os.curdir, "jw02732-o004_t004_miri_ch1-shortmediumlong_x1d.fits")  # noqa: E501
 
 
 @pytest.mark.remote_data

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -486,7 +486,8 @@ class MultiMaskSubsetState(SubsetState):
         return cls(masks=masks)
 
 
-def download_uri_to_path(possible_uri, cache=None, local_path=os.curdir, timeout=None):
+def download_uri_to_path(possible_uri, cache=None, local_path=os.curdir, timeout=None,
+                         dryrun=False):
     """
     Retrieve data from a URI (or a URL). Return the input if it
     cannot be parsed as a URI.
@@ -520,6 +521,9 @@ def download_uri_to_path(possible_uri, cache=None, local_path=os.curdir, timeout
         remote requests in seconds (passed to
         `~astropy.utils.data.download_file` or
         `~astroquery.mast.Conf.timeout`).
+    dryrun : bool
+        Set to `True` to skip downloading data from MAST.
+        This is only used for debugging.
 
     Returns
     -------
@@ -574,10 +578,13 @@ def download_uri_to_path(possible_uri, cache=None, local_path=os.curdir, timeout
             # and this web path needs to be split with a forward slash
             local_path = os.path.join(local_path, parsed_uri.path.split('/')[-1])
 
-        with conf.set_temp('timeout', timeout):
-            (status, msg, url) = Observations.download_file(
-                possible_uri, cache=cache, local_path=local_path
-            )
+        if not dryrun:
+            with conf.set_temp('timeout', timeout):
+                (status, msg, url) = Observations.download_file(
+                    possible_uri, cache=cache, local_path=local_path
+                )
+        else:
+            status = "COMPLETE"
 
         if status != 'COMPLETE':
             # pass along the error message from astroquery if the


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

I couldn't easily do this without adding a new `dryrun` option to `download_uri_to_path`.

This follows up on #2875 and #2923 to avoid failure seen in #2924 but without using `--remote-data` on the entire Windows job to avoid unnecessary server hits.

Since this is to patch unreleased code, no need for change log.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4596)
