### PR TITLE
support exporting a plot from an unopened/inactive plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -190,6 +190,8 @@ Bug Fixes
 - Display default filepath in Export plugin, re-enable API exporting, enable relative and absolute
   path exports from the UI. [#2896]
 
+- Fixes exporting the stretch histogram from Plot Options before the Plot Options plugin is ever opened. [#2934]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -73,7 +73,9 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     dataset_format_items = List().tag(sync=True)
     dataset_format_selected = Unicode().tag(sync=True)
 
-    plugin_plot_selected_widget = Unicode().tag(sync=True)  # copy of widget of the selected plugin_plot in case the parent plugin is not opened
+    # copy of widget of the selected plugin_plot in case the parent plugin is not opened
+    plugin_plot_selected_widget = Unicode().tag(sync=True)
+
     plugin_plot_format_items = List().tag(sync=True)
     plugin_plot_format_selected = Unicode().tag(sync=True)
 
@@ -464,10 +466,12 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                 filename = None
 
             if not plot._plugin.is_active:
-                # force an update to the plot.  This requires the plot to have set update_callback when instantiated
+                # force an update to the plot.  This requires the plot to have set
+                # update_callback when instantiated
                 plot._update()
 
-                # create a copy of the widget shown off screen to enable rendering in case one was never created in the parent plugin
+                # create a copy of the widget shown off screen to enable rendering
+                # in case one was never created in the parent plugin
                 self.plugin_plot_selected_widget = f'IPY_MODEL_{plot.model_id}'
 
             self.save_figure(plot, filename, filetype, show_dialog=show_dialog)

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -73,6 +73,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     dataset_format_items = List().tag(sync=True)
     dataset_format_selected = Unicode().tag(sync=True)
 
+    plugin_plot_selected_widget = Unicode().tag(sync=True)  # copy of widget of the selected plugin_plot in case the parent plugin is not opened
     plugin_plot_format_items = List().tag(sync=True)
     plugin_plot_format_selected = Unicode().tag(sync=True)
 
@@ -462,11 +463,14 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             else:
                 filename = None
 
-            with plot._plugin.as_active():
-                # NOTE: could still take some time for the plot itself to update,
-                # for now we'll hardcode a short amount of time for the plot to render any updates
-                time.sleep(0.2)
-                self.save_figure(plot, filename, filetype, show_dialog=show_dialog)
+            if not plot._plugin.is_active:
+                # force an update to the plot.  This requires the plot to have set update_callback when instantiated
+                plot._update()
+
+                # create a copy of the widget shown off screen to enable rendering in case one was never created in the parent plugin
+                self.plugin_plot_selected_widget = f'IPY_MODEL_{plot.model_id}'
+
+            self.save_figure(plot, filename, filetype, show_dialog=show_dialog)
 
         elif len(self.plugin_table.selected):
             filetype = self.plugin_table_format.selected

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -903,8 +903,9 @@ class PlotOptions(PluginTemplateMixin):
             # its type
             msg = {}
 
-        # NOTE: this method is separate from _update_stretch_histogram so that _update_stretch_histogram
-        # can be called manually (or from the update_callback on the Plot object itself) without going through
+        # NOTE: this method is separate from _update_stretch_histogram so that
+        # _update_stretch_histogram can be called manually (or from the
+        # update_callback on the Plot object itself) without going through
         # the skip_if_no_updates_since_last_active check
         self._update_stretch_histogram(msg)
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -567,7 +567,8 @@ class PlotOptions(PluginTemplateMixin):
                                                    'stretch_params_value', 'stretch_params_sync',
                                                    state_filter=is_image)
 
-        self.stretch_histogram = Plot(self, name='stretch_hist', viewer_type='histogram')
+        self.stretch_histogram = Plot(self, name='stretch_hist', viewer_type='histogram',
+                                      update_callback=self._update_stretch_histogram)
         # Add the stretch bounds tool to the default Plot viewer.
         self.stretch_histogram.tools_nested.append(["jdaviz:stretch_bounds"])
         self.stretch_histogram._initialize_toolbar(["jdaviz:stretch_bounds"])
@@ -886,8 +887,7 @@ class PlotOptions(PluginTemplateMixin):
     @observe('is_active', 'layer_selected', 'viewer_selected',
              'stretch_hist_zoom_limits')
     @skip_if_no_updates_since_last_active()
-    @with_spinner('stretch_hist_spinner')
-    def _update_stretch_histogram(self, msg={}):
+    def _request_update_stretch_histogram(self, msg={}):
         if not hasattr(self, 'viewer'):  # pragma: no cover
             # plugin hasn't been fully initialized yet
             return
@@ -903,6 +903,13 @@ class PlotOptions(PluginTemplateMixin):
             # its type
             msg = {}
 
+        # NOTE: this method is separate from _update_stretch_histogram so that _update_stretch_histogram
+        # can be called manually (or from the update_callback on the Plot object itself) without going through
+        # the skip_if_no_updates_since_last_active check
+        self._update_stretch_histogram(msg)
+
+    @with_spinner('stretch_hist_spinner')
+    def _update_stretch_histogram(self, msg={}):
         if not self.stretch_function_sync.get('in_subscribed_states'):  # pragma: no cover
             # no (image) viewer with stretch function options
             return

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -4685,12 +4685,14 @@ class Plot(PluginSubcomponent):
     figure = Any().tag(sync=True, **widget_serialization)
     toolbar = Any().tag(sync=True, **widget_serialization)
 
-    def __init__(self, plugin, name='plot', viewer_type='scatter', app=None, *args, **kwargs):
+    def __init__(self, plugin, name='plot', viewer_type='scatter', update_callback=None,
+                 app=None, *args, **kwargs):
         super().__init__(plugin, 'Plot', *args, **kwargs)
         if app is None:
             app = jglue()
 
         self._app = app
+        self._update_callback = update_callback
         self._plugin = plugin
         self._plot_name = name
         self.viewer = app.new_data_viewer(viewer_type, show=False)
@@ -4747,6 +4749,11 @@ class Plot(PluginSubcomponent):
         self.app.data_collection.remove(dc_entry)
 
         self._plugin.session.hub.broadcast(PluginPlotModifiedMessage(sender=self))
+
+    def _update(self):
+        # call the update callback, if it exists, on the parent plugin.  This is useful for updating the plot when a plugin is inactive
+        if self._update_callback is not None:
+            self._update_callback()
 
     def _update_data(self, label, reset_lims=False, **kwargs):
         self._check_valid_components(**kwargs)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -4751,7 +4751,8 @@ class Plot(PluginSubcomponent):
         self._plugin.session.hub.broadcast(PluginPlotModifiedMessage(sender=self))
 
     def _update(self):
-        # call the update callback, if it exists, on the parent plugin.  This is useful for updating the plot when a plugin is inactive
+        # call the update callback, if it exists, on the parent plugin.
+        # This is useful for updating the plot when a plugin is inactive.
         if self._update_callback is not None:
             self._update_callback()
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes the case of exporting the stretch histogram from the export plugin before the plot options plugin has ever been opened.  It does so by implementing an optional callback on the `Plot` object itself to call a plugin method to update itself, which will be called if the "parent" plugin is not considered active.  In cases where no widget exists because the parent plugin has never been opened, it also renders the widget offscreen in the export plugin.

I'm not really sure the best way to test this since the previous behavior didn't result in errors, just a blank image - but open to any suggestions!

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
