### PR TITLE
Investigate moment map commented test

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -22,8 +22,6 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         with_spinner)
 from jdaviz.core.validunits import check_if_unit_is_per_solid_angle
 from jdaviz.core.user_api import PluginUserApi
-from jdaviz.utils import _eqv_pixar_sr
-
 
 __all__ = ['MomentMap']
 
@@ -358,9 +356,7 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
                 moment_new_unit = flux_or_sb_display_unit
             else:
                 moment_new_unit = flux_or_sb_display_unit * self.spectrum_viewer.state.x_display_unit  # noqa: E501
-            # TODO: This can be removed when we remove SB->flux unit support from Moment Maps
-            self.moment = self.moment.to(moment_new_unit, _eqv_pixar_sr(
-                self.moment.size * self.dataset.selected_dc_item.meta.get('PIXAR_SR', 1.0)))
+            self.moment = self.moment.to(moment_new_unit)
 
         # Reattach the WCS so we can load the result
         self.moment = CCDData(self.moment, wcs=data_wcs)

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -22,7 +22,7 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         with_spinner)
 from jdaviz.core.validunits import check_if_unit_is_per_solid_angle
 from jdaviz.core.user_api import PluginUserApi
-from jdaviz.utils import flux_conversion
+from jdaviz.utils import _eqv_pixar_sr
 
 
 __all__ = ['MomentMap']
@@ -358,18 +358,9 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
                 moment_new_unit = flux_or_sb_display_unit
             else:
                 moment_new_unit = flux_or_sb_display_unit * self.spectrum_viewer.state.x_display_unit  # noqa: E501
-
-            # Create a temporary Spectrum1D object with ability to convert from surface brightness
-            # to flux
-            temp_spec = Spectrum1D(flux=self.moment)
-            flux_values = np.sum(np.ones_like(temp_spec.flux.value), axis=(0, 1))
-            pix_scale = self.dataset.selected_dc_item.meta.get('PIXAR_SR', 1.0)
-            pix_scale_factor = (flux_values * pix_scale)
-            temp_spec.meta['_pixel_scale_factor'] = pix_scale_factor
-            converted_spec = flux_conversion(temp_spec, self.moment.value,
-                                             self.moment.unit,
-                                             moment_new_unit) * moment_new_unit
-            self.moment = converted_spec
+            # TODO: This can be removed when we remove SB->flux unit support from Moment Maps
+            self.moment = self.moment.to(moment_new_unit, _eqv_pixar_sr(
+                self.moment.size * self.dataset.selected_dc_item.meta.get('PIXAR_SR', 1.0)))
 
         # Reattach the WCS so we can load the result
         self.moment = CCDData(self.moment, wcs=data_wcs)

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -298,10 +298,8 @@ def test_momentmap_nirspec_prism(cubeviz_helper, tmp_path):
 def test_correct_output_flux_or_sb_units(cubeviz_helper, spectrum1d_cube_custom_fluxunit):
     if SPECUTILS_LT_1_15_1:
         moment_unit = "Jy / sr"
-        moment_unit_no_sr = "Jy"
     else:
         moment_unit = "Jy m / sr"
-        moment_unit_no_sr = "Jy m"
 
     # test that the output unit labels in the moment map plugin reflect any
     # changes made in the unit conversion plugin.
@@ -346,16 +344,3 @@ def test_correct_output_flux_or_sb_units(cubeviz_helper, spectrum1d_cube_custom_
     # and that calculated moment has the correct units
     mm.calculate_moment()
     assert mm.moment.unit == moment_unit
-
-    # TODO: All this below can be removed when we remove SB->flux unit support from Moment Maps
-
-    uc.flux_or_sb.selected = 'Flux'
-    mm._set_data_units()
-
-    # and make sure this change is propagated
-    output_unit_moment_0 = mm.output_unit_items[0]
-    assert output_unit_moment_0['label'] == 'Flux'
-    assert output_unit_moment_0['unit_str'] == 'Jy'
-
-    mm.calculate_moment()
-    assert mm.moment.unit == moment_unit_no_sr

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -298,8 +298,10 @@ def test_momentmap_nirspec_prism(cubeviz_helper, tmp_path):
 def test_correct_output_flux_or_sb_units(cubeviz_helper, spectrum1d_cube_custom_fluxunit):
     if SPECUTILS_LT_1_15_1:
         moment_unit = "Jy / sr"
+        moment_unit_no_sr = "Jy"
     else:
         moment_unit = "Jy m / sr"
+        moment_unit_no_sr = "Jy m"
 
     # test that the output unit labels in the moment map plugin reflect any
     # changes made in the unit conversion plugin.
@@ -345,20 +347,15 @@ def test_correct_output_flux_or_sb_units(cubeviz_helper, spectrum1d_cube_custom_
     mm.calculate_moment()
     assert mm.moment.unit == moment_unit
 
+    # TODO: All this below can be removed when we remove SB->flux unit support from Moment Maps
+
     uc.flux_or_sb.selected = 'Flux'
     mm._set_data_units()
 
-    # and make sure this change is propogated
+    # and make sure this change is propagated
     output_unit_moment_0 = mm.output_unit_items[0]
     assert output_unit_moment_0['label'] == 'Flux'
     assert output_unit_moment_0['unit_str'] == 'Jy'
 
-    # TODO: Failing because of dev version of upstream dependency, figure
-    #  out which one
-    # assert mm.calculate_moment()
-
-    # TODO: This test should pass once continuum subtraction works with
-    #  flux to surface brightness conversion
-    # mm.continuum.selected = 'Surrounding'
-    #
-    # assert mm.calculate_moment()
+    mm.calculate_moment()
+    assert mm.moment.unit == moment_unit_no_sr

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -360,9 +360,7 @@ def _eqv_pixar_sr(pixar_sr):
     def iconverter_flux(x):  # Flux -> Surface Brightness
         return x / pixar_sr
 
-    return [(u.MJy / u.sr, u.MJy, converter_flux, iconverter_flux),
-            # TODO: This can be removed when we remove SB->flux unit support from Moment Maps
-            (u.MJy * u.m / u.sr, u.MJy * u.m, converter_flux, iconverter_flux)]
+    return [(u.MJy / u.sr, u.MJy, converter_flux, iconverter_flux)]
 
 
 def spectral_axis_conversion(values, original_units, target_units):


### PR DESCRIPTION
This PR addresses the following unreleased code (hence no change log needed):

* Removing the need to create temporary spectrum just to convert unit for moment map, hence removing the need to "Centralize pixel scale factor information".
  * Update: The whole changes from Jesse in moment map are now reverted. Moment map will stay in surface brightness.
* ~Fixing compatibility with unreleased specutils (hence fixing devdeps).~
* Fixing a possible bug in `flux_conversion` function where equivalencies math is flipped for cases `len(values) != 2` and `len(values) == 2`. This is accomplished by having both logic go through the same math (there is really no good reason to have separate math for those cases anyway).

Out of scope:

* Fallback value for PIXAR_SR when it is not found. Personally, I think any fallback is dangerous unless you can be sure you are able to look up the actual value from somewhere (e.g., handbooks, databases, websites) for any given telescope/instrument combo. Otherwise, better to force user input or just disallow it from happening.

xref #2910 #2873

[🐱](https://jira.stsci.edu/browse/JDAT-4588)