### PR TITLE
Fix Cubeviz movie export

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -190,6 +190,8 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Fixed a bug with filename handling for movie exports. [#2942]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -673,7 +673,6 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         if i_end <= i_start:
             raise ValueError(f"No frames to write: i_start={i_start}, i_end={i_end}")
 
-        filename = str(filename.resolve())
         threading.Thread(
             target=lambda: self._save_movie(viewer, i_start, i_end, fps, filename, rm_temp_files)
         ).start()

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -343,6 +343,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                 filename += f".{filetype}"
             filename = Path(filename).expanduser()
 
+        filename = filename.resolve()
         filepath = filename.parent
         if filepath and not filepath.is_dir():
             raise ValueError(f"Invalid path={filepath}")


### PR DESCRIPTION
There was a line pertaining to `Path` filenames, but `_normalize_filename` now turns everything into a string. Exporting movies works for me now.

Not sure what we're milestoning things at at this point...