### PR TITLE
fix: make standalone work with matplotlib >= 3.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 dependencies = [
     "packaging",
     "astropy>=6",
-    "matplotlib>=3.6,<3.9",
+    "matplotlib>=3.6",
     "traitlets>=5.0.5",
     "bqplot>=0.12.37",
     "bqplot-image-gl>=1.4.11",

--- a/standalone/jdaviz-cli-entrypoint.py
+++ b/standalone/jdaviz-cli-entrypoint.py
@@ -1,4 +1,11 @@
 import sys
+# this avoids:
+# ValueError: Key backend: 'module://matplotlib_inline.backend_inline' is not a valid value for backend; supported values are [...]
+# Although not 100% why, it has two effects:
+#  1. PyInstaller picks it up as a module to include
+#  2. It registers the backend, maybe earlier than it would be otherwise
+import matplotlib_inline
+import matplotlib_inline.backend_inline
 
 def start_as_kernel():
     # similar to https://github.com/astrofrog/voila-qt-app/blob/master/voila_demo.py


### PR DESCRIPTION
Unclear what the real underlying issue is. Code comments give a possible explanation.

Fixes https://github.com/spacetelescope/jdaviz/issues/2921