### PR TITLE
Sync notebook github links in HTML docs to the git commit used to build them

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@
 # Thus, any C-extensions that are needed to build the documentation will *not*
 # be accessible, and the documentation will not build correctly.
 
+import subprocess
 import sys
 import datetime
 
@@ -145,9 +146,23 @@ dev = "dev" in release
 version = '.'.join(release.split('.')[:2])
 
 extensions += ['sphinx.ext.extlinks', 'sphinx_design']  # noqa: F405
-gh_tag = f'v{release}' if '.dev' not in release else 'main'
-extlinks = {'gh-tree': (f'https://github.com/spacetelescope/jdaviz/tree/{gh_tag}/%s', '%s'),
-            'gh-notebook': (f'https://github.com/spacetelescope/jdaviz/blob/{gh_tag}/notebooks/%s.ipynb', '%s notebook')}  # noqa: E501
+
+# get the most recent git commit hash at build time:
+commit_hash = subprocess.run(
+    # git call for the latest commit hash:
+    'git rev-parse HEAD'.split(),
+    capture_output=True
+).stdout.decode().strip()
+
+# inject the most recent commit hash into the github links used in `sample_notebooks.rst`:
+extlinks = {
+    'gh-tree': (
+        f'https://github.com/spacetelescope/jdaviz/tree/{commit_hash}/%s', '%s'
+    ),
+    'gh-notebook': (
+        f'https://github.com/spacetelescope/jdaviz/blob/{commit_hash}/notebooks/%s.ipynb', '%s notebook'
+    )
+}
 
 # -- Options for HTML output --------------------------------------------------
 


### PR DESCRIPTION
### Description

The HTML docs on RTD like [this page](https://jdaviz.readthedocs.io/en/stable/sample_notebooks.html) point to directories on github like https://github.com/spacetelescope/jdaviz/tree/main/notebooks. We've changed the default RTD page to `stable`, which isn't the same as `main`, so the notebooks linked on RTD will be out of sync with the rest of the HTML docs whenever `main != stable`.

This PR gets the git commit hash at the time the docs are built, and injects that hash into the github URLs for docs links.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4593)
