### PR TITLE
BUG: Specviz to respect local_path when provided

### DIFF
--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -66,6 +66,11 @@ class Specviz(ConfigHelper, LineListMixin):
         local_path : str, optional
             Cache remote files to this path. This is only used if data is
             requested from `astroquery.mast`.
+        timeout : float, optional
+            If downloading from a remote URI, set the timeout limit for
+            remote requests in seconds (passed to
+            `~astropy.utils.data.download_file` or
+            `~astroquery.mast.Conf.timeout`).
         """
         super().load_data(data,
                           parser_reference='specviz-spectrum1d-parser',
@@ -73,8 +78,9 @@ class Specviz(ConfigHelper, LineListMixin):
                           format=format,
                           show_in_viewer=show_in_viewer,
                           concat_by_file=concat_by_file,
+                          cache=cache,
                           local_path=local_path,
-                          cache=cache)
+                          timeout=timeoout)
 
     def get_spectra(self, data_label=None, spectral_subset=None, apply_slider_redshift="Warn"):
         """Returns the current data loaded into the main viewer

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -73,6 +73,7 @@ class Specviz(ConfigHelper, LineListMixin):
                           format=format,
                           show_in_viewer=show_in_viewer,
                           concat_by_file=concat_by_file,
+                          local_path=local_path,
                           cache=cache)
 
     def get_spectra(self, data_label=None, spectral_subset=None, apply_slider_redshift="Warn"):

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -80,7 +80,7 @@ class Specviz(ConfigHelper, LineListMixin):
                           concat_by_file=concat_by_file,
                           cache=cache,
                           local_path=local_path,
-                          timeout=timeoout)
+                          timeout=timeout)
 
     def get_spectra(self, data_label=None, spectral_subset=None, apply_slider_redshift="Warn"):
         """Returns the current data loaded into the main viewer


### PR DESCRIPTION
This is a direct follow-up of https://github.com/spacetelescope/jdaviz/pull/2875 . Since it is not released, no need for change log.

To see for yourself, run the Specviz example notebook but provide a local path.

```python
local_path = "somewhere/not/here"
specviz.load_data("mast:JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_x1d.fits", data_label="myfile", local_path=local_path, cache=True)
```

Without this patch, it downloads to the `notebooks` source checkout no matter what is given.

[🐱](https://jira.stsci.edu/browse/JDAT-4647)