### PR TITLE
Bugfix for flux unit conversion in spectral cubes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ New Features
 ------------
 
 - Added flux/surface brightness translation and surface brightness
-  unit conversion in Cubeviz and Specviz. [#2781]
+  unit conversion in Cubeviz and Specviz. [#2781, #3088]
 
 - Plugin tray is now open by default. [#2892]
 

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -317,7 +317,7 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
     @property
     def mask_non_science(self):
-        # Aperture masks begin b removing from consideration any pixel
+        # Aperture masks begin by removing from consideration any pixel
         # set to NaN, which corresponds to a pixel on the "non-science" portions
         # of the detector. For JWST spectral cubes, these pixels are also marked in
         # the DQ array with flag `513`.

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -453,8 +453,7 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
             )  # returns an NDDataArray
             # Remove per steradian denominator
             if astropy.units.sr in collapsed_nddata.unit.bases:
-                aperture_area = (self.aperture_area_along_spectral
-                                 * self.spectral_cube.meta.get('PIXAR_SR', 1.0) * u.sr)
+                aperture_area = self.spectral_cube.meta.get('PIXAR_SR', 1.0) * u.sr
                 collapsed_nddata = collapsed_nddata.multiply(aperture_area,
                                                              propagate_uncertainties=True)
         else:
@@ -563,9 +562,7 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
                                                   self.bg_wavelength_dependent,
                                                   self.function_selected.lower(), **kwargs)
             if self.function_selected.lower() == 'sum':
-                if bg_spec_per_spaxel:
-                    bg_spec *= 1 / self.bg_area_along_spectral
-                else:
+                if not bg_spec_per_spaxel:
                     # then scale according to aperture areas across the spectral axis (allowing for
                     # independent wavelength-dependence btwn the aperture and background)
                     bg_spec *= self.aperture_area_along_spectral / self.bg_area_along_spectral


### PR DESCRIPTION
## NOTE

[This PR has a significant update below](https://github.com/spacetelescope/jdaviz/pull/3088#issuecomment-2243114249). I'm keeping the original description here for traceability.

### Original description

Fixes #3086

In (somewhat) recent changes, the default y-axis on the spectrum-viewer in Cubeviz is MJy and the spectral extraction plugin is used directly to produce the default spectrum in the spectrum viewer. If a user makes a spatial subset in Cubeviz that appears to cover every data spaxel, one might expect the live-extracted spectrum to match the default spectral extraction, but it doesn't, see #3086.

This appears to come from the calculation of the pixel area in steradians to convert the flux unit from MJy/sr to MJy. The spectral extraction plugin currently counts every element in the spectral cube towards the sky area, so that the conversion looks like:
```
(spectral flux density [MJy/sr]) * (full cube pixel area coverage [sr]))
```
This would be true if every element of the spectral cube contained data. But in general, they don't. 

Spectral cubes from JWST/MIRI contain many spaxels near the borders that contain no data at any wavelength, and the sky footprint of the MIRI cube changes from wavelength to wavelength within one spectral cube. Here's Cubeviz with the DQ array visible to show the pixels that do not contain observations:
<img width="699" alt="Screen Shot 2024-07-15 at 15 42 52" src="https://github.com/user-attachments/assets/345ef9e2-5b9d-4e38-8f0d-7d113c187620">
Those red-colored pixels should not count towards the pixel area, but on main right now, they are included in the conversion from MJy/sr -> MJy. The bug is exposed in #3086 because @rosteen drew a subset that included some _but not all_ non-science pixels. This is a simple demonstration that the approach counting non-science pixels in the pixel area gives you the wrong answer.

This PR excludes "non-science" pixels from the pixel area calculation during flux unit conversion. This brings the default extraction into agreement with the all-pixel-subset extraction:
<img width="699" alt="Screen Shot 2024-07-15 at 15 48 26" src="https://github.com/user-attachments/assets/6ab081c7-ca7d-4b09-8264-de2ecbb90867">


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4659)
