### PR TITLE
POC: Markers as circle, not dots

### DIFF
--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -588,6 +588,8 @@ class SelectedSpaxel(Lines):
 class MarkersMark(PluginScatter):
     def __init__(self, viewer, **kwargs):
         kwargs.setdefault('marker', 'circle')
+        kwargs.setdefault('fill', False)
+        kwargs.setdefault('default_size', 128)
         super().__init__(viewer, **kwargs)
 
 


### PR DESCRIPTION
As requested for "have markers not just as point sources but as apertures". Not sure what is the full scope but this is to show at least it is somewhat possible by changing the default. When you do it like this, the color isn't so great anymore but changing color is not mentioned in the request.

<img width="305" alt="Screenshot 2024-07-16 142717" src="https://github.com/user-attachments/assets/eb0932e2-be6f-4301-9220-f0591320217f">

[🐶](https://innerspace.stsci.edu/display/DATB/Catalog+performance+hack+preparation)