### PR TITLE
Proof of concept: color magnitude diagrams from catalogs in Imviz

### DIFF
--- a/jdaviz/configs/imviz/imviz.yaml
+++ b/jdaviz/configs/imviz/imviz.yaml
@@ -40,3 +40,6 @@ viewer_area:
           - name: imviz-0
             plot: imviz-image-viewer
             reference: imviz-0
+          - name: imviz-1
+            plot: imviz-scatter-viewer
+            reference: imviz-1

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -15,6 +15,20 @@ from jdaviz.core.registries import viewer_registry
 from jdaviz.core.freezable_state import FreezableBqplotImageViewerState
 from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
 
+from astropy.table import Table
+from glue.core.subset import Subset
+from glue.config import data_translator
+from glue.core import BaseData
+from glue.core.exceptions import IncompatibleAttribute
+from glue.core.roi import RangeROI
+from glue.core.subset_group import GroupedSubset
+from glue.viewers.scatter.state import ScatterViewerState as GlueScatterViewerState
+
+from glue_jupyter.bqplot.scatter import BqplotScatterView
+from jdaviz.configs.specviz.plugins.viewers import SpecvizProfileView
+from jdaviz.configs.imviz.plugins.parsers import component_ids
+
+
 __all__ = ['ImvizImageView']
 
 
@@ -274,8 +288,8 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
             norm=norm))
 
     def set_plot_axes(self):
-        self.figure.axes[1].tick_format = None
-        self.figure.axes[0].tick_format = None
+        # self.figure.axes[1].tick_format = None
+        # self.figure.axes[0].tick_format = None
 
         self.figure.axes[1].label = "y: pixels"
         self.figure.axes[0].label = "x: pixels"
@@ -371,3 +385,230 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
 
         if data.coords is not None:
             return data.coords.pixel_to_world(x_cen, y_cen)
+
+
+class ScatterViewerState(GlueScatterViewerState):
+    def _reset_att_limits(self, ax):
+        # override glue's _reset_x/y_limits to account for all layers,
+        # not just reference data
+        att = f'{ax}_att'
+        if getattr(self, att) is None:  # pragma: no cover
+            return
+
+        ax_min, ax_max = np.inf, -np.inf
+        for layer in self.layers:
+            ax_data = layer.layer.data.get_data(getattr(self, att))
+            if len(ax_data) > 0:
+                ax_min = min(ax_min, np.nanmin(ax_data))
+                ax_max = max(ax_max, np.nanmax(ax_data))
+
+        if not np.all(np.isfinite([ax_min, ax_max])):  # pragma: no cover
+            return
+
+        lim_helper = getattr(self, f'{ax}_lim_helper')
+        lim_helper.lower = ax_min
+        lim_helper.upper = ax_max
+        lim_helper.update_values()
+
+    def _reset_x_limits(self, *event):
+        self._reset_att_limits('x')
+
+    def _reset_y_limits(self, *event):
+        self._reset_att_limits('y')
+
+    def reset_limits(self, *event):
+        x_min, x_max = np.inf, -np.inf
+        y_min, y_max = np.inf, -np.inf
+
+        for layer in self.layers:
+            if not layer.visible:  # pragma: no cover
+                continue
+
+            x_data = layer.layer.data.get_data(self.x_att)
+            y_data = layer.layer.data.get_data(self.y_att)
+
+            x_min = min(x_min, np.nanmin(x_data))
+            x_max = max(x_max, np.nanmax(x_data))
+            y_min = min(y_min, np.nanmin(y_data))
+            y_max = max(y_max, np.nanmax(y_data))
+
+        x_lim_helper = getattr(self, 'x_lim_helper')
+        x_lim_helper.lower = x_min
+        x_lim_helper.upper = x_max
+
+        y_lim_helper = getattr(self, 'y_lim_helper')
+        y_lim_helper.lower = y_min
+        y_lim_helper.upper = y_max
+
+        x_lim_helper.update_values()
+        y_lim_helper.update_values()
+
+        self._adjust_limits_aspect()
+
+
+@viewer_registry("imviz-scatter-viewer", label="scatter-viewer")
+class ImvizScatterView(JdavizViewerMixin, BqplotScatterView):
+    # categories: zoom resets, zoom, pan, subset, select tools, shortcuts
+    tools_nested = [
+                    ['jdaviz:homezoom', 'jdaviz:prevzoom'],
+                    ['jdaviz:boxzoom', 'jdaviz:xrangezoom', 'jdaviz:yrangezoom'],
+                    ['jdaviz:panzoom', 'jdaviz:panzoom_x', 'jdaviz:panzoom_y'],
+                    ['bqplot:rectangle'],
+                    ['bqplot:xrange', 'bqplot:yrange', 'bqplot:rectangle'],
+                    ['jdaviz:sidebar_plot', 'jdaviz:sidebar_export']
+                ]
+
+    default_class = Table
+    _state_cls = ScatterViewerState
+
+    _native_mark_classnames = ('Image', 'ImageGL', 'Scatter', 'ScatterGL')
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.display_mask = False
+        self.time_unit = kwargs.get('time_unit', u.d)
+        self.initialize_toolbar()
+        self._subscribe_to_layers_update()
+        # hack to inherit a small subset of methods from SpecvizProfileView
+        # TODO: refactor jdaviz so these can be included in some mixin
+        self._show_uncertainty_changed = lambda value: SpecvizProfileView._show_uncertainty_changed(self, value)  # noqa
+        self._plot_uncertainties = lambda: SpecvizProfileView._plot_uncertainties(self)
+        # TODO: _plot_uncertainties in specviz is hardcoded to look at spectral_axis and so crashes
+        self._clean_error = lambda: SpecvizProfileView._clean_error(self)
+        self.density_map = kwargs.get('density_map', False)
+
+    def data(self, cls=None):
+        data = []
+
+        # TODO: generalize upstream in jdaviz.
+        # This method is generalized from
+        # jdaviz/configs/specviz/plugins/viewers.py
+        # to support non-spectral viewers.
+        for layer_state in self.state.layers:
+            if hasattr(layer_state, 'layer'):
+                lyr = layer_state.layer
+                # For raw data, just include the data itself
+                if isinstance(lyr, BaseData):
+                    _class = cls or self.default_class
+
+                    if _class is not None:
+                        cache_key = lyr.label
+                        if cache_key in self.jdaviz_app._get_object_cache:
+                            layer_data = self.jdaviz_app._get_object_cache[cache_key]
+                        else:
+                            layer_data = lyr.get_object(cls=_class)
+                            self.jdaviz_app._get_object_cache[cache_key] = layer_data
+
+                        data.append(layer_data)
+
+                # For subsets, make sure to apply the subset mask to the layer data first
+                elif isinstance(lyr, (Subset, GroupedSubset)):
+                    layer_data = lyr
+
+                    if _class is not None:
+                        handler, _ = data_translator.get_handler_for(_class)
+                        try:
+                            layer_data = handler.to_object(layer_data)
+                        except IncompatibleAttribute:
+                            continue
+                    data.append(layer_data)
+
+        return data
+
+    def _apply_layer_defaults(self, layer_state):
+        if getattr(layer_state.layer, 'meta', {}).get('Plugin', None) == 'Binning':
+            # increased size of binned results, by default
+            layer_state.size = 5
+
+    def set_plot_axes(self):
+        # set which components should be plotted
+        dc = self.jdaviz_app.data_collection
+        component_labels = [comp.label for comp in dc[0].components]
+
+        # Get data to be used for axes labels
+        data = self.data()[0]
+        self._set_plot_x_axes(dc, component_labels, data)
+        self._set_plot_y_axes(dc, component_labels, data)
+
+    def _set_plot_x_axes(self, dc, component_labels, light_curve):
+        self.state.x_att = component_ids['ra']
+
+        self.figure.axes[0].label = "RA"
+        self.figure.axes[0].num_ticks = 5
+
+    def _set_plot_y_axes(self, dc, component_labels, light_curve):
+        self.state.y_att = component_ids['dec']
+
+        self.figure.axes[1].label = "Dec"
+
+        # Make it so y axis label is not covering tick numbers (sometimes)
+        self.figure.axes[1].label_offset = "-50"
+
+        # Set (X,Y)-axis to scientific notation if necessary:
+        self.figure.axes[0].tick_format = 'g'
+        self.figure.axes[1].tick_format = 'g'
+
+        self.figure.axes[1].num_ticks = 5
+
+    def _expected_subset_layer_default(self, layer_state):
+        super()._expected_subset_layer_default(layer_state)
+
+        layer_state.linewidth = 3
+
+        # optionally prevent subset from being rendered
+        # as a density map, rather than shaded markers over data:
+        layer_state.density_map = self.density_map
+
+    def add_data(self, data, color=None, alpha=None, **layer_state):
+        """
+        Overrides the base class to handle subset styling defaults.
+
+        Parameters
+        ----------
+        data : :class:`glue.core.data.Data`
+            Data object with the light curve.
+        color : obj
+            Color value for plotting.
+        alpha : float
+            Alpha value for plotting.
+
+        Returns
+        -------
+        result : bool
+            `True` if successful, `False` otherwise.
+        """
+        result = super().add_data(data, color, alpha, **layer_state)
+
+        for layer in self.layers:
+            # optionally render as a density map
+            layer.state.density_map = self.density_map
+
+        # Set default linewidth on any created subset layers
+        for layer in self.state.layers:
+            if "Subset" in layer.layer.label and layer.layer.data.label == data.label:
+                layer.linewidth = 3
+
+        # update viewer limits when data are added
+        self.set_plot_axes()
+        self.state.reset_limits()
+
+        return result
+
+    def _show_uncertainty_changed(*args, **kwargs):
+        # method required by jdaviz
+        pass
+
+    def apply_roi(self, roi, use_current=False):
+        if isinstance(roi, RangeROI):
+            # allow ROIs describing times to be applied with min and max defined as:
+            #  1. floats, representing bounds in units of ``self.time_unit``
+            #  2. Time objects, which get converted to work like (1) via the reference time
+            if isinstance(roi.min, Time) or isinstance(roi.max, Time):
+                reference_time = self.data()[0].meta.get('reference_time', 0)
+                roi = roi.transformed(xfunc=lambda x: (x - reference_time).to_value(self.time_unit))
+
+        super().apply_roi(roi, use_current=use_current)
+
+    def on_limits_change(self):
+        pass

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -118,8 +118,8 @@
   border-top-left-radius: 4px;
 }
 .imviz div.v-card.v-card--flat.v-sheet.v-sheet--tile {
-  /* black background beyond edges of canvas for canvas rotation */
-  background-color: black
+  /* this used to be a black background beyond edges of canvas for canvas rotation */
+  background-color: white
 }
 </style>
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3244,7 +3244,7 @@ class ViewerSelect(SelectPluginComponent):
             return 'ImageView' in viewer.__class__.__name__
 
         def reference_has_wcs(viewer):
-            return getattr(viewer.state.reference_data, 'coords', None) is not None
+            return getattr(getattr(viewer.state, 'reference_data', {}), 'coords', None) is not None
 
         return super()._is_valid_item(viewer, locals())
 

--- a/notebooks/concepts/imviz-catalog-viewer.ipynb
+++ b/notebooks/concepts/imviz-catalog-viewer.ipynb
@@ -1,0 +1,246 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "16f874ae-9141-4bc2-91d4-78256b60da3f",
+   "metadata": {},
+   "source": [
+    "# Image of M4 + linked Gaia DR3 color-magnitude diagram\n",
+    "\n",
+    "Download a DSS2 Red image of M4, and load it into Imviz:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fbda5896-c105-467c-87b5-2d624869ef3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jdaviz import Imviz\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from astroquery.skyview import SkyView\n",
+    "from astroquery.vizier import Vizier\n",
+    "import astropy.units as u\n",
+    "from jdaviz.configs.imviz.plugins.parsers import component_ids\n",
+    "from glue.core.component_link import ComponentLink\n",
+    "from glue.core.roi import RectangularROI\n",
+    "\n",
+    "target_name = 'M4'\n",
+    "\n",
+    "m4 = SkyCoord.from_name(target_name)\n",
+    "image = SkyView.get_images(target_name, survey='DSS2 Red', pixels=4000, radius=0.5 * u.deg)[0]\n",
+    "\n",
+    "imviz = Imviz()\n",
+    "imviz.load_data(image, data_label=target_name)\n",
+    "imviz.show('sidecar:split-bottom')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92bc9bc9-8132-4ad6-8eef-204b8ebcfa43",
+   "metadata": {},
+   "source": [
+    "Set up some plot options:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ccf85fe-066f-4043-809f-0b9648bc36d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_options = imviz.plugins['Plot Options']._obj\n",
+    "plot_options.axes_visible_value = True\n",
+    "plot_options.show_viewer_labels = True\n",
+    "plot_options.layer_selected = f'{target_name}[PRIMARY,1]'\n",
+    "plot_options.image_colormap_value = 'viridis'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "379f6b56-6707-4eda-9bd1-a24d75d76e07",
+   "metadata": {},
+   "source": [
+    "Query the Gaia DR3 catalog for stars brighter than $V<10$  within 0.05$^\\circ$ of M4:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6af0efc5-7c41-456a-a1ca-d52da5e2cbd6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "columns = ['source_id', 'ra', 'dec', 'phot_bp_mean_mag', 'phot_rp_mean_mag', 'parallax']\n",
+    "sources = Vizier(\n",
+    "    catalog='I/355/gaiadr3', columns=columns, row_limit=10_000\n",
+    ").query_region(\n",
+    "    m4, radius=0.05 * u.deg, column_filters={\"Vmag\": \"<10\"}\n",
+    ")[0]\n",
+    "sources['bp-rp'] = sources['BPmag'] - sources['RPmag']\n",
+    "sources.rename_columns(['RA_ICRS', 'DE_ICRS'], ['ra', 'dec'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "311273d4-ea36-45d9-ad97-8e58ca27eba2",
+   "metadata": {},
+   "source": [
+    "Remove units from these QTable columns:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c46b8ec-1347-4e9c-b55d-3dabe03f9851",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for col in sources.colnames:\n",
+    "    if hasattr(sources[col], 'quantity'):\n",
+    "        sources[col] = sources[col].quantity.value\n",
+    "\n",
+    "imviz.load_data(sources)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c346f9f-cc37-4ab2-b2bc-9229167b1e6c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data1, data2 = imviz.app.data_collection[:2]\n",
+    "\n",
+    "links = [\n",
+    "    ComponentLink([data1.id['Right Ascension']], data2.id['ra']),\n",
+    "    ComponentLink([data1.id['Declination']], data2.id['dec'])\n",
+    "]\n",
+    "\n",
+    "for link in links:\n",
+    "    imviz.app.data_collection.add_link(link)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "600891b7-1999-4842-804c-07a7984d4665",
+   "metadata": {},
+   "source": [
+    "Set the scatter plot axes to be the BP-RP color and BP magnitude, flip y-axis limits so brightest sources are at the top of the color magnitude diagram:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58c8a61c-446c-4691-89a7-544c281f91ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz.app.add_data_to_viewer('imviz-1', 'catalog')\n",
+    "scatter_viewer = imviz.viewers['imviz-1']._obj\n",
+    "\n",
+    "scatter_viewer.state.x_att = imviz.app.data_collection[1].id['bp-rp']\n",
+    "scatter_viewer.state.y_att = imviz.app.data_collection[1].id['BPmag']\n",
+    "\n",
+    "scatter_viewer.state.y_lim_helper.flip_limits()\n",
+    "scatter_viewer.set_limits(x_min=0, x_max=2.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "329bb006-35ec-4f79-b11b-99dd1c261747",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_options.layer_selected = 'catalog'\n",
+    "plot_options.marker_color_value = 'gray'\n",
+    "plot_options.marker_opacity_value = 0.6\n",
+    "plot_options.marker_size_scale_value = 10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb07942c-3b50-4be1-8e18-218bae017530",
+   "metadata": {},
+   "source": [
+    "Select horizontal branch stars from the color-magnitude diagram:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c82b561-da4e-4cf2-a212-001aa189f4b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz.viewers['imviz-1']._obj.apply_roi(RectangularROI(0.5, 1.5, 10, 14))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa8f9857-ffe9-43eb-8419-746b6421f533",
+   "metadata": {},
+   "source": [
+    "Make the subset markers easier to see:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a2845cd-6410-431d-a6e8-8d0b268be487",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_options.layer_selected = 'Subset 1'\n",
+    "plot_options.marker_color_value = 'r'\n",
+    "plot_options.marker_opacity_value = 0.9\n",
+    "plot_options.marker_size_scale_value = 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a33570d8-4fff-43ac-b6fe-ef4a4b409abe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_options.layer_selected = 'Subset 2'\n",
+    "plot_options.marker_color_value = 'g'\n",
+    "plot_options.marker_opacity_value = 0.9\n",
+    "plot_options.marker_size_scale_value = 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7a28202-1746-416b-98cd-8761e74886cb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Description

This proof of concept PR visualizes a linked color magnitude diagram with an image in Imviz. This was developed during the [catalog performance hack day](https://innerspace.stsci.edu/display/DATB/2024.07.16+-+Catalog+performance+hack+preparation).

<img width="1420" alt="Screen Shot 2024-07-16 at 15 44 58" src="https://github.com/user-attachments/assets/b2efa36b-59b0-43a5-ae85-7e185929306e">

This was a two hour hack, and many things could be done correctly if we take up this line of work:
* the `ImvizScatterViewer` was adapted from the LCviz `TimeScatterViewer`. We could develop a generic one that LCviz inherits.
* the `ScatterViewerState` is directly copied from LCviz. I would have imported it from LCviz, but LCviz imports jdaviz, so the circular imports made that impossible.
* we need a data translator for an astropy table, which should go upstream in glue astronomy. I made a `TableHandler` class here by copying and modifying the LCviz glue translator for `lightkurve.LightCurve` objects, which are ultimately a specific kind of astropy table. 

### Demo video 

...is too big to embed in GitHub, so watch it via Box: https://stsci.box.com/s/9xzt8367nodxvn15oy9ilohpcot8y7xt

The demo notebook used in the video is located in this PR at `notebooks/concepts/imviz-catalog-viewer.ipynb`.