### PR TITLE
Improve overwrite warning behavior in export

### DIFF
--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -457,13 +457,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         elif len(self.plugin_plot.selected):
             plot = self.plugin_plot.selected_obj._obj
             filetype = self.plugin_plot_format.selected
-
-            if len(filename):
-                if not filename.endswith(filetype):
-                    filename += f".{filetype}"
-                filename = Path(filename).expanduser()
-            else:
-                filename = None
+            filename = self._normalize_filename(filename, filetype)
 
             if not plot._plugin.is_active:
                 # force an update to the plot.  This requires the plot to have set
@@ -473,6 +467,11 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                 # create a copy of the widget shown off screen to enable rendering
                 # in case one was never created in the parent plugin
                 self.plugin_plot_selected_widget = f'IPY_MODEL_{plot.model_id}'
+
+            if self.overwrite_warn and not overwrite:
+                if raise_error_for_overwrite:
+                    raise FileExistsError(f"{filename} exists but overwrite=False")
+                return
 
             self.save_figure(plot, filename, filetype, show_dialog=show_dialog)
 

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -457,7 +457,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         elif len(self.plugin_plot.selected):
             plot = self.plugin_plot.selected_obj._obj
             filetype = self.plugin_plot_format.selected
-            filename = self._normalize_filename(filename, filetype)
+            filename = self._normalize_filename(filename, filetype, overwrite=overwrite)
 
             if not plot._plugin.is_active:
                 # force an update to the plot.  This requires the plot to have set
@@ -477,7 +477,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
         elif len(self.plugin_table.selected):
             filetype = self.plugin_table_format.selected
-            filename = self._normalize_filename(filename, filetype)
+            filename = self._normalize_filename(filename, filetype, overwrite=overwrite)
             if self.overwrite_warn and not overwrite:
                 if raise_error_for_overwrite:
                     raise FileExistsError(f"{filename} exists but overwrite=False")
@@ -538,6 +538,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             if filename is not None:
                 self.hub.broadcast(SnackbarMessage(
                     f"Exported to {filename} (overwrite)", sender=self, color="success"))
+            self.overwrite_warn=False
 
     def save_figure(self, viewer, filename=None, filetype="png", show_dialog=False):
         if filetype == "png":


### PR DESCRIPTION
This adds the overwrite warning when exporting plugin plots, and generally does some minor consistency improvements across the file types. This also fixes the bug where the overwrite confirmation overlay did not disappear after confirming that you want to overwrite.