### PR TITLE
Exclude subsets from WCS-only layer filter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -207,6 +207,8 @@ Imviz
 - Fix multiple footprints bug that prevented footprint updates on changes to the
   viewer orientation. [#2918]
 
+- Exclude subset layers from the orientation options in the Orientation plugin. [#3097]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -241,16 +241,14 @@ _wcs_only_label = "_WCS_ONLY"
 
 
 def is_wcs_only(layer):
-    # exclude WCS-only layers from the layer choices:
+    # identify WCS-only layers
     if hasattr(layer, 'layer'):
-        state = layer.layer
-    elif hasattr(layer, 'data'):
-        state = layer.data
-    elif hasattr(layer, 'meta'):
-        state = layer
-    else:
-        raise NotImplementedError
-    return getattr(state, 'meta', {}).get(_wcs_only_label, False)
+        layer = layer.layer
+
+    return (
+        # WCS-only layers have a metadata label:
+        getattr(layer, 'meta', {}).get(_wcs_only_label, False)
+    )
 
 
 def is_not_wcs_only(layer):


### PR DESCRIPTION
### Description

If you create a subset in Imviz while WCS-linked, the subset appears in the Orientation plugin's "orientation in viewer" dropdown. It does not appear in the data dropdown. This is an artifact of the way that WCS-only layers are filtered in `LayerSelect`. I've tweaked the filter to be sure to exclude subsets.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4631)