### PR TITLE
Backport PR #3097: Exclude subsets from WCS-only layer filter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Exclude subset layers from the orientation options in the Orientation plugin. [#3097]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -233,16 +233,14 @@ _wcs_only_label = "_WCS_ONLY"
 
 
 def is_wcs_only(layer):
-    # exclude WCS-only layers from the layer choices:
+    # identify WCS-only layers
     if hasattr(layer, 'layer'):
-        state = layer.layer
-    elif hasattr(layer, 'data'):
-        state = layer.data
-    elif hasattr(layer, 'meta'):
-        state = layer
-    else:
-        raise NotImplementedError
-    return getattr(state, 'meta', {}).get(_wcs_only_label, False)
+        layer = layer.layer
+
+    return (
+        # WCS-only layers have a metadata label:
+        getattr(layer, 'meta', {}).get(_wcs_only_label, False)
+    )
 
 
 def is_not_wcs_only(layer):


### PR DESCRIPTION
Manual backport of #3097.