### PR TITLE
Surface brightness -> solid angle conversion updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ New Features
 ------------
 
 - Added flux/surface brightness translation and surface brightness
-  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3113]
+  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113]
 
 - Plugin tray is now open by default. [#2892]
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -182,6 +182,8 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
                      "Velocity": "km/s",
                      "Velocity^N": f"km{self.n_moment}/s{self.n_moment}"}
 
+        sb_or_flux_label = None
+
         if self.dataset_selected != "":
             # Spectral axis is first in this list
             data = self.app.data_collection[self.dataset_selected]
@@ -217,7 +219,7 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
         # Update units in selection item dictionary
         for item in self.output_unit_items:
             item["unit_str"] = unit_dict[item["label"]]
-            if item["label"] in ["Flux", "Surface Brightness"]:
+            if item["label"] in ["Flux", "Surface Brightness"] and sb_or_flux_label:
                 # change unit label to reflect if unit is flux or SB
                 item["label"] = sb_or_flux_label
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -334,7 +334,7 @@ def test_correct_output_flux_or_sb_units(cubeviz_helper, spectrum1d_cube_custom_
 
     # now change surface brightness units in the unit conversion plugin
 
-    uc.sb_unit = 'Jy / sr'
+    uc.flux_unit = 'Jy'
 
     # and make sure this change is propogated
     output_unit_moment_0 = mm.output_unit_items[0]

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_lineflux.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_lineflux.py
@@ -115,10 +115,12 @@ def test_unit_gaussian_mixed_units_per_steradian(specviz_helper):
     '''
     # unit-flux gaussian in wavelength space, mixed units, per steradian
     lam_a = np.arange(1, 2, 0.001)*u.Angstrom
-    flx_wave = _gauss_with_unity_area(lam_a.value, mn, sig)*1E3*u.erg/u.s/u.cm**2/u.Angstrom/u.sr
+    # test changed from Surface Brightness to Flux,
+    # u.erg/u.s/u.cm**2/u.Angstrom/u.sr in untranslatable units (check unit_conversion.py)
+    flx_wave = _gauss_with_unity_area(lam_a.value, mn, sig)*1E3*u.erg/u.s/u.cm**2/u.Angstrom
     fl_wave = Spectrum1D(spectral_axis=lam_a, flux=flx_wave)
 
     specviz_helper.load_data(fl_wave)
     lineflux_result = _calculate_line_flux(specviz_helper)
     assert_quantity_allclose(float(lineflux_result['result']) * u.Unit(lineflux_result['unit']),
-                             1*u.Unit('W/(m2sr)'))
+                             1*u.Unit('W/(m2)'))

--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -88,23 +88,18 @@ def test_conv_wave_flux(specviz_helper, spectrum1d, uncert):
 def test_conv_no_data(specviz_helper, spectrum1d):
     """plugin unit selections won't have valid choices yet, preventing
     attempting to set display units."""
-    plg = specviz_helper.plugins["Unit Conversion"]
     # spectrum not load is in Flux units, sb_unit and flux_unit
     # should be enabled, flux_or_sb should not be
-    assert hasattr(plg, 'sb_unit')
-    assert hasattr(plg, 'flux_unit')
-    assert not hasattr(plg, 'flux_or_sb')
+    plg = specviz_helper.plugins["Unit Conversion"]
     with pytest.raises(ValueError, match="no valid unit choices"):
         plg.spectral_unit = "micron"
     assert len(specviz_helper.app.data_collection) == 0
 
     specviz_helper.load_data(spectrum1d, data_label="Test 1D Spectrum")
-    plg = specviz_helper.plugins["Unit Conversion"]
 
-    # spectrum loaded in Flux units, make sure sb_units don't
-    # display in the API and exposed translation isn't possible
+    # make sure we don't expose translations in Specviz
     assert hasattr(plg, 'flux_unit')
-    assert not hasattr(plg, 'sb_unit')
+    assert hasattr(plg, 'angle_unit')
     assert not hasattr(plg, 'flux_or_sb')
 
 
@@ -198,7 +193,7 @@ def test_sb_unit_conversion(cubeviz_helper):
     uc_plg.flux_or_sb.selected = 'Surface Brightness'
 
     # Surface Brightness conversion
-    uc_plg.sb_unit = 'Jy / sr'
+    uc_plg.flux_unit = 'Jy'
     y_display_unit = u.Unit(viewer_1d.state.y_display_unit)
     assert y_display_unit == u.Jy / u.sr
     label_mouseover = cubeviz_helper.app.session.application._tools["g-coords-info"]
@@ -214,7 +209,7 @@ def test_sb_unit_conversion(cubeviz_helper):
             "204.9987654313 27.0008999946 (deg)")
 
     # Try a second conversion
-    uc_plg.sb_unit = 'W / Hz sr m2'
+    uc_plg.flux_unit = 'W / Hz m2'
     y_display_unit = u.Unit(viewer_1d.state.y_display_unit)
     assert y_display_unit == u.Unit("W / (Hz sr m2)")
 
@@ -230,7 +225,7 @@ def test_sb_unit_conversion(cubeviz_helper):
     # really a translation test, test_unit_translation loads a Flux
     # cube, this test load a Surface Brightness Cube, this ensures
     # two-way translation
-    uc_plg.sb_unit = 'MJy / sr'
+    uc_plg.flux_unit = 'MJy'
     y_display_unit = u.Unit(viewer_1d.state.y_display_unit)
     label_mouseover._viewer_mouse_event(
         flux_viewer, {"event": "mousemove", "domain": {"x": 10, "y": 8}}
@@ -241,10 +236,10 @@ def test_sb_unit_conversion(cubeviz_helper):
             "204.9987654313 27.0008999946 (deg)")
 
     uc_plg._obj.flux_or_sb_selected = 'Flux'
-    uc_plg.flux_unit = 'MJy'
+    uc_plg.flux_unit = 'Jy'
     y_display_unit = u.Unit(viewer_1d.state.y_display_unit)
 
-    assert y_display_unit == u.MJy
+    assert y_display_unit == u.Jy
 
     la = cubeviz_helper.plugins['Line Analysis']._obj
     assert la.dataset.get_selected_spectrum(use_display_units=True)

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -183,12 +183,9 @@ class UnitConversion(PluginTemplateMixin):
                 self.flux_unit.selected,
                 self.angle_unit.selected
             )
-
-        # this is for Specviz, when data collection item is in Surface Brightness
-        '''
-        if not self.flux_unit.selected:
-            self.flux_unit.selected = str(u.Unit(self.spectrum_viewer.state.y_display_unit * u.sr))
-        '''
+            if not self.flux_unit.selected:
+                y_display_unit = self.spectrum_viewer.state.y_display_unit
+                self.flux_unit.selected = (str(u.Unit(y_display_unit * u.sr)))
 
         if check_if_unit_is_per_solid_angle(self.spectrum_viewer.state.y_display_unit):
             self.flux_or_sb = 'Flux'

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -180,10 +180,14 @@ class UnitConversion(PluginTemplateMixin):
             dc_unit = self.app.data_collection[0].get_component("flux").units
             self.angle_unit.choices = create_angle_equivalencies_list(dc_unit)
             self.angle_unit.selected = self.angle_unit.choices[0]
-            self.sb_unit = self._append_angle_correctly(
+            sb_unit = self._append_angle_correctly(
                 self.flux_unit.selected,
                 self.angle_unit.selected
             )
+            self.hub.broadcast(GlobalDisplayUnitChanged('sb',
+                                                        sb_unit,
+                                                        sender=self))
+
             if not self.flux_unit.selected:
                 y_display_unit = self.spectrum_viewer.state.y_display_unit
                 self.flux_unit.selected = (str(u.Unit(y_display_unit * u.sr)))
@@ -242,13 +246,12 @@ class UnitConversion(PluginTemplateMixin):
 
         if self.spectrum_viewer.state.y_display_unit != yunit:
             self.spectrum_viewer.state.y_display_unit = yunit
+            self.spectrum_viewer.reset_limits()
             self.hub.broadcast(
                 GlobalDisplayUnitChanged(
                     "flux" if name == "flux_unit_selected" else "sb", flux_or_sb, sender=self
                     )
                 )
-            self.spectrum_viewer.reset_limits()
-
         if not check_if_unit_is_per_solid_angle(self.spectrum_viewer.state.y_display_unit):
             self.flux_or_sb_selected = 'Flux'
         else:
@@ -325,4 +328,7 @@ class UnitConversion(PluginTemplateMixin):
         else:
             # append angle if there are no parentheses
             sb_unit = flux_unit + ' / ' + angle_unit
+
+        if sb_unit:
+            self.sb_unit = sb_unit
         return sb_unit

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -114,9 +114,10 @@ class UnitConversion(PluginTemplateMixin):
     @property
     def user_api(self):
         if self.app.config == 'cubeviz':
-            return PluginUserApi(self, expose=('spectral_unit', 'flux_or_sb', 'flux_unit', 'angle_unit'))   # noqa
+            expose = ('spectral_unit', 'flux_or_sb', 'flux_unit', 'angle_unit')
         else:
-            return PluginUserApi(self, expose=('spectral_unit', 'flux_unit', 'angle_unit'))
+            expose = ('spectral_unit', 'flux_unit', 'angle_unit')
+        return PluginUserApi(self, expose=expose)
 
     def _on_glue_x_display_unit_changed(self, x_unit):
         if x_unit is None:
@@ -176,7 +177,7 @@ class UnitConversion(PluginTemplateMixin):
 
         # sets the angle unit drop down and the surface brightness read-only text
         if self.app.data_collection[0]:
-            dc_unit = self.app.data_collection[0].get_object().flux.unit
+            dc_unit = self.app.data_collection[0].get_component("flux").units
             self.angle_unit.choices = create_angle_equivalencies_list(dc_unit)
             self.angle_unit.selected = self.angle_unit.choices[0]
             self.sb_unit = self._append_angle_correctly(

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -150,16 +150,11 @@ class UnitConversion(PluginTemplateMixin):
             return
         self.spectrum_viewer.set_plot_axes()
 
-        if check_if_unit_is_per_solid_angle(y_unit):
-            flux_or_sb = 'Surface Brightness'
-        else:
-            flux_or_sb = 'Flux'
-
         x_u = u.Unit(self.spectral_unit.selected)
         y_unit = _valid_glue_display_unit(y_unit, self.spectrum_viewer, 'y')
         y_u = u.Unit(y_unit)
 
-        if flux_or_sb == 'Flux' and y_unit != self.flux_unit.selected:
+        if not check_if_unit_is_per_solid_angle(y_unit) and y_unit != self.flux_unit.selected:
             flux_choices = create_flux_equivalencies_list(y_u, x_u)
             # ensure that original entry is in the list of choices
             if not np.any([y_u == u.Unit(choice) for choice in flux_choices]):
@@ -168,9 +163,9 @@ class UnitConversion(PluginTemplateMixin):
             self.flux_unit.choices = flux_choices
             self.flux_unit.selected = y_unit
 
-        # if the spectral axis is set to surface brightness,
+        # if the y-axis is set to surface brightness,
         # untranslatable units need to be removed from the flux choices
-        if self.flux_or_sb_selected == 'Surface Brightness':
+        if check_if_unit_is_per_solid_angle(y_unit):
             updated_flux_choices = list(set(create_flux_equivalencies_list(y_u * u.sr, x_u))
                                         - set(units_to_strings(self._untranslatable_units)))
             self.flux_unit.choices = updated_flux_choices
@@ -191,9 +186,6 @@ class UnitConversion(PluginTemplateMixin):
             if not self.flux_unit.selected:
                 y_display_unit = self.spectrum_viewer.state.y_display_unit
                 self.flux_unit.selected = (str(u.Unit(y_display_unit * u.sr)))
-
-        if check_if_unit_is_per_solid_angle(self.spectrum_viewer.state.y_display_unit):
-            self.flux_or_sb = 'Flux'
 
     @observe('spectral_unit_selected')
     def _on_spectral_unit_changed(self, *args):

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -180,12 +180,12 @@ class UnitConversion(PluginTemplateMixin):
             dc_unit = self.app.data_collection[0].get_component("flux").units
             self.angle_unit.choices = create_angle_equivalencies_list(dc_unit)
             self.angle_unit.selected = self.angle_unit.choices[0]
-            sb_unit = self._append_angle_correctly(
+            self.sb_unit = self._append_angle_correctly(
                 self.flux_unit.selected,
                 self.angle_unit.selected
             )
             self.hub.broadcast(GlobalDisplayUnitChanged('sb',
-                                                        sb_unit,
+                                                        self.sb_unit,
                                                         sender=self))
 
             if not self.flux_unit.selected:
@@ -322,6 +322,9 @@ class UnitConversion(PluginTemplateMixin):
         ]
 
     def _append_angle_correctly(self, flux_unit, angle_unit):
+        if angle_unit not in ['pix', 'sr']:
+            self.sb_unit = flux_unit
+            return flux_unit
         if '(' in flux_unit:
             pos = flux_unit.rfind(')')
             sb_unit = flux_unit[:pos] + ' ' + angle_unit + flux_unit[pos:]
@@ -331,4 +334,5 @@ class UnitConversion(PluginTemplateMixin):
 
         if sb_unit:
             self.sb_unit = sb_unit
+
         return sb_unit

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -61,7 +61,7 @@ class UnitConversion(PluginTemplateMixin):
     flux_unit_items = List().tag(sync=True)
     flux_unit_selected = Unicode().tag(sync=True)
 
-    sb_unit = Unicode().tag(sync=True)
+    sb_unit_selected = Unicode().tag(sync=True)
 
     angle_unit_items = List().tag(sync=True)
     angle_unit_selected = Unicode().tag(sync=True)
@@ -175,12 +175,12 @@ class UnitConversion(PluginTemplateMixin):
             dc_unit = self.app.data_collection[0].get_component("flux").units
             self.angle_unit.choices = create_angle_equivalencies_list(dc_unit)
             self.angle_unit.selected = self.angle_unit.choices[0]
-            self.sb_unit = self._append_angle_correctly(
+            self.sb_unit_selected = self._append_angle_correctly(
                 self.flux_unit.selected,
                 self.angle_unit.selected
             )
             self.hub.broadcast(GlobalDisplayUnitChanged('sb',
-                                                        self.sb_unit,
+                                                        self.sb_unit_selected,
                                                         sender=self))
 
             if not self.flux_unit.selected:
@@ -315,16 +315,16 @@ class UnitConversion(PluginTemplateMixin):
 
     def _append_angle_correctly(self, flux_unit, angle_unit):
         if angle_unit not in ['pix', 'sr']:
-            self.sb_unit = flux_unit
+            self.sb_unit_selected = flux_unit
             return flux_unit
         if '(' in flux_unit:
             pos = flux_unit.rfind(')')
-            sb_unit = flux_unit[:pos] + ' ' + angle_unit + flux_unit[pos:]
+            sb_unit_selected = flux_unit[:pos] + ' ' + angle_unit + flux_unit[pos:]
         else:
             # append angle if there are no parentheses
-            sb_unit = flux_unit + ' / ' + angle_unit
+            sb_unit_selected = flux_unit + ' / ' + angle_unit
 
-        if sb_unit:
-            self.sb_unit = sb_unit
+        if sb_unit_selected:
+            self.sb_unit_selected = sb_unit_selected
 
-        return sb_unit
+        return sb_unit_selected

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -40,12 +40,13 @@
         label="Solid Angle Unit"
         hint="Solid angle unit."
         persistent-hint
+        
       ></v-select>
     </v-row>
 
     <v-row>
       <v-text-field
-        v-model="sb_unit"
+        v-model="sb_unit_selected"
         label="Surface Brightness Unit"
         hint="Global display unit for surface brightness axis."
         persistent-hint

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -30,19 +30,27 @@
         persistent-hint
       ></v-select>
     </v-row>
-
-    <v-row v-if="flux_or_sb_config_disabler === 'Flux' || config == 'cubeviz'">
+  
+    <v-row v-if="flux_or_sb_config_disabler === 'Surface Brightness' || config == 'cubeviz'">
       <v-select
         :menu-props="{ left: true }"
         attach
-        :items="sb_unit_items.map(i => i.label)"
-        v-model="sb_unit_selected"
+        :items="angle_unit_items.map(i => i.label)"
+        v-model="angle_unit_selected"
+        label="Solid Angle Unit"
+        hint="Solid angle unit."
+        persistent-hint
+      ></v-select>
+    </v-row>
+
+    <v-row v-if="flux_or_sb_config_disabler === 'Flux' || config == 'cubeviz'">
+      <v-text-field
+        v-model="sb_unit"
         label="Surface Brightness Unit"
         hint="Global display unit for surface brightness axis."
         persistent-hint
-        :disabled="!can_translate"
-      ></v-select>
-      <span v-if="!can_translate">Translation is not available due to current unit selection.</span>
+        :disabled='true'
+      ></v-text-field>
     </v-row>
 
     <v-row v-if="config == 'cubeviz'">

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -19,7 +19,7 @@
       ></v-select>
     </v-row>
 
-    <v-row v-if="flux_or_sb_config_disabler === 'Surface Brightness' || config == 'cubeviz'">
+    <v-row>
       <v-select
         :menu-props="{ left: true }"
         attach
@@ -31,7 +31,7 @@
       ></v-select>
     </v-row>
   
-    <v-row v-if="flux_or_sb_config_disabler === 'Surface Brightness' || config == 'cubeviz'">
+    <v-row>
       <v-select
         :menu-props="{ left: true }"
         attach
@@ -43,7 +43,7 @@
       ></v-select>
     </v-row>
 
-    <v-row v-if="flux_or_sb_config_disabler === 'Flux' || config == 'cubeviz'">
+    <v-row>
       <v-text-field
         v-model="sb_unit"
         label="Surface Brightness Unit"

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -486,14 +486,21 @@ class ConfigHelper(HubListener):
                     else:
                         # if not specified as NDUncertainty, assume stddev:
                         new_uncert = uncertainty
-                    new_uncert_converted = flux_conversion(data, new_uncert.quantity.value,
-                                                           new_uncert.unit, flux_unit)
-                    new_uncert = StdDevUncertainty(new_uncert_converted, unit=flux_unit)
+                    if ('_pixel_scale_factor' in data.meta):
+                        new_uncert_converted = flux_conversion(data, new_uncert.quantity.value,
+                                                               new_uncert.unit, flux_unit)
+                        new_uncert = StdDevUncertainty(new_uncert_converted, unit=flux_unit)
+                    else:
+                        new_uncert = StdDevUncertainty(new_uncert, unit=data.flux.unit)
+
                 else:
                     new_uncert = None
-
-                new_flux = flux_conversion(data, data.flux.value, data.flux.unit,
-                                           flux_unit) * u.Unit(flux_unit)
+                if ('_pixel_scale_factor' in data.meta):
+                    new_flux = flux_conversion(data, data.flux.value, data.flux.unit,
+                                               flux_unit) * u.Unit(flux_unit)
+                else:
+                    new_flux = flux_conversion(data, data.flux.value, data.flux.unit,
+                                               data.flux.unit) * u.Unit(data.flux.unit)
                 new_spec = (spectral_axis_conversion(data.spectral_axis.value,
                                                      data.spectral_axis.unit,
                                                      spectral_unit)

--- a/jdaviz/core/validunits.py
+++ b/jdaviz/core/validunits.py
@@ -123,6 +123,7 @@ def create_sb_equivalencies_list(sb_unit, spectral_axis_unit):
     # Concatenate both lists with the local units coming first.
     return sorted(units_to_strings(local_units)) + sb_unit_equivalencies_titles
 
+
 def create_angle_equivalencies_list(unit):
     # first, convert string to u.Unit obj.
     # this will take care of some formatting consistency like
@@ -133,6 +134,8 @@ def create_angle_equivalencies_list(unit):
     elif isinstance(unit, str):
         unit = u.Unit(unit)
         unit_str = unit.to_string()
+    elif unit == 'ct':
+        return ['pix']
     else:
         raise ValueError('Unit must be u.Unit, or string that can be converted into a u.Unit')
 
@@ -143,6 +146,7 @@ def create_angle_equivalencies_list(unit):
     else:
         # this could be where force / u.pix
         return ['pix']
+
 
 def check_if_unit_is_per_solid_angle(unit):
     """

--- a/jdaviz/core/validunits.py
+++ b/jdaviz/core/validunits.py
@@ -90,40 +90,6 @@ def create_flux_equivalencies_list(flux_unit, spectral_axis_unit):
     return sorted(units_to_strings(local_units)) + flux_unit_equivalencies_titles
 
 
-def create_sb_equivalencies_list(sb_unit, spectral_axis_unit):
-    """Get all possible conversions for flux from current flux units."""
-    if ((sb_unit in (u.count, u.dimensionless_unscaled))
-            or (spectral_axis_unit in (u.pix, u.dimensionless_unscaled))):
-        return []
-
-    # Get unit equivalencies. Value passed into u.spectral_density() is irrelevant.
-    try:
-        curr_sb_unit_equivalencies = sb_unit.find_equivalent_units(
-            equivalencies=u.spectral_density(1 * spectral_axis_unit),
-            include_prefix_units=False)
-    except u.core.UnitConversionError:
-        return []
-
-    locally_defined_sb_units = ['Jy / sr', 'mJy / sr',
-                                'uJy / sr', 'MJy / sr',
-                                'W / (Hz sr m2)',
-                                'eV / (Hz s sr m2)',
-                                'AB / sr'
-                                ]
-
-    local_units = [u.Unit(unit) for unit in locally_defined_sb_units]
-
-    # Remove overlap units.
-    curr_sb_unit_equivalencies = list(set(curr_sb_unit_equivalencies)
-                                      - set(local_units))
-
-    # Convert equivalencies into readable versions of the units and sort them alphabetically.
-    sb_unit_equivalencies_titles = sorted(units_to_strings(curr_sb_unit_equivalencies))
-
-    # Concatenate both lists with the local units coming first.
-    return sorted(units_to_strings(local_units)) + sb_unit_equivalencies_titles
-
-
 def create_angle_equivalencies_list(unit):
     # first, convert string to u.Unit obj.
     # this will take care of some formatting consistency like

--- a/jdaviz/core/validunits.py
+++ b/jdaviz/core/validunits.py
@@ -123,6 +123,26 @@ def create_sb_equivalencies_list(sb_unit, spectral_axis_unit):
     # Concatenate both lists with the local units coming first.
     return sorted(units_to_strings(local_units)) + sb_unit_equivalencies_titles
 
+def create_angle_equivalencies_list(unit):
+    # first, convert string to u.Unit obj.
+    # this will take care of some formatting consistency like
+    # turning something like Jy / (degree*degree) to Jy / deg**2
+    # and erg sr^1 to erg / sr
+    if isinstance(unit, u.core.Unit) or isinstance(unit, u.core.CompositeUnit):
+        unit_str = unit.to_string()
+    elif isinstance(unit, str):
+        unit = u.Unit(unit)
+        unit_str = unit.to_string()
+    else:
+        raise ValueError('Unit must be u.Unit, or string that can be converted into a u.Unit')
+
+    if '/' in unit_str:
+        # might be comprised of several units in denom.
+        denom = unit_str.split('/')[-1].split()
+        return denom
+    else:
+        # this could be where force / u.pix
+        return ['pix']
 
 def check_if_unit_is_per_solid_angle(unit):
     """

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -336,6 +336,9 @@ def flux_conversion(spec, values, original_units, target_units):
     if (('_pixel_scale_factor' in spec.meta) and
             (((u.sr in orig_bases) and (u.sr not in targ_bases)) or
              ((u.sr not in orig_bases) and (u.sr in targ_bases)))):
+        with open('example.txt', 'a') as file:
+            file.write(f'utils {original_units}\n')
+            file.write(f'utils {target_units}\n')
         # Data item in data collection does not update from conversion/translation.
         # App-wide original data units are used for conversion, original and
         # target_units dictate the conversion to take place.

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -336,9 +336,6 @@ def flux_conversion(spec, values, original_units, target_units):
     if (('_pixel_scale_factor' in spec.meta) and
             (((u.sr in orig_bases) and (u.sr not in targ_bases)) or
              ((u.sr not in orig_bases) and (u.sr in targ_bases)))):
-        with open('example.txt', 'a') as file:
-            file.write(f'utils {original_units}\n')
-            file.write(f'utils {target_units}\n')
         # Data item in data collection does not update from conversion/translation.
         # App-wide original data units are used for conversion, original and
         # target_units dictate the conversion to take place.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address:

- The surface brightness drop down will become read-only text
- A new drop down will be created for the solid angle unit
- Surface brightness will update when changes to flux or the angle are made
- the “flux or sb” dropdown will no longer update automatically when making a selection to the flux/angle/sb unit drop downs

To be done:

- [x] compatibility with Specviz (flux data, surface brightness data doesn't populate (sb/flux) NEEDS UPDATE AFTER https://github.com/spacetelescope/jdaviz/pull/2931)
- [x] fix limits issue in Specviz NEEDS UPDATE AFTER https://github.com/spacetelescope/jdaviz/pull/2931
- [x] untranslatable units compatibility
- [x] pass existing tests


https://github.com/user-attachments/assets/809aff5d-6409-4a15-ac3c-326b156fce01


Currently, we enable the selection of the surface brightness unit drop down. This ticket will make the surface brightness drop down read-only. A new dropdown will be added, for selecting the denominator, the square angle unit. Surface brightness will then be calculated from the selected flux and angle unit. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
