### PR TITLE
Update model fit result units after toggling flux/surface brightness

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ New Features
 ------------
 
 - Added flux/surface brightness translation and surface brightness
-  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088]
+  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3113]
 
 - Plugin tray is now open by default. [#2892]
 

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -513,7 +513,7 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
             spec = spec - bg_spec
 
         # per https://jwst-docs.stsci.edu/jwst-near-infrared-camera/nircam-performance/nircam-absolute-flux-calibration-and-zeropoints # noqa
-        pix_scale_factor = self.aperture_area_along_spectral * self.spectral_cube.meta.get('PIXAR_SR', 1.0)  # noqa
+        pix_scale_factor = self.spectral_cube.meta.get('PIXAR_SR', 1.0)
         spec.meta['_pixel_scale_factor'] = pix_scale_factor
 
         # inform the user if scale factor keyword not in metadata

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -118,7 +118,6 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         self.component_models = []
         self._initialized_models = {}
         self._display_order = False
-        self._pixel_scale_factor = None
 
         # create the label first so that when model_component defaults to the first selection,
         # the label automatically defaults as well
@@ -332,9 +331,6 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         selected_spec = self.dataset.selected_obj
         if selected_spec is None:
             return
-
-        if '_pixel_scale_factor' in selected_spec.meta:
-            self._pixel_scale_factor = selected_spec.meta['_pixel_scale_factor']
 
         # Replace NaNs from collapsed Spectrum1D in Cubeviz
         # (won't affect calculations because these locations are masked)
@@ -846,10 +842,8 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
             self.hub.broadcast(msg)
             return
 
-        if self._pixel_scale_factor is not None:
-            fitted_spectrum.meta['_pixel_scale_factor'] = self._pixel_scale_factor
-        else:
-            print("No pixel scale factor!")
+        if '_pixel_scale_factor' in selected_spec.meta:
+            fitted_spectrum.meta['_pixel_scale_factor'] = selected_spec.meta['_pixel_scale_factor']
 
         self._fitted_model = fitted_model
         self._fitted_spectrum = fitted_spectrum
@@ -941,8 +935,8 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
                 self.app.fitted_models[temp_label] = m["model"]
 
         output_cube = Spectrum1D(flux=fitted_spectrum.flux, wcs=fitted_spectrum.wcs)
-        if self._pixel_scale_factor is not None:
-            output_cube.meta['_pixel_scale_factor'] = self._pixel_scale_factor
+        if '_pixel_scale_factor' in selected_spec.meta:
+            output_cube.meta['_pixel_scale_factor'] = selected_spec.meta['_pixel_scale_factor']
 
         # Create new data entry for glue
         if add_data:

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -329,17 +329,12 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
             # during initial init, this can trigger before the component is initialized
             return
 
-        selected_spec = self.dataset.selected_spectrum
+        selected_spec = self.dataset.selected_obj
         if selected_spec is None:
             return
 
         if '_pixel_scale_factor' in selected_spec.meta:
             self._pixel_scale_factor = selected_spec.meta['_pixel_scale_factor']
-        elif '_pixel_scale_factor' in self.dataset.selected_obj.meta:
-            self._pixel_scale_factor = self.dataset.selected_obj.meta['_pixel_scale_factor']
-
-        print(f"Selected spec is {selected_spec}")
-        print(selected_spec.meta)
 
         # Replace NaNs from collapsed Spectrum1D in Cubeviz
         # (won't affect calculations because these locations are masked)
@@ -947,7 +942,6 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
         output_cube = Spectrum1D(flux=fitted_spectrum.flux, wcs=fitted_spectrum.wcs)
         if self._pixel_scale_factor is not None:
-            self._pixel_scale_factor
             output_cube.meta['_pixel_scale_factor'] = self._pixel_scale_factor
 
         # Create new data entry for glue

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -842,6 +842,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
             self.hub.broadcast(msg)
             return
 
+        selected_spec = self.dataset.selected_obj
         if '_pixel_scale_factor' in selected_spec.meta:
             fitted_spectrum.meta['_pixel_scale_factor'] = selected_spec.meta['_pixel_scale_factor']
 
@@ -935,6 +936,8 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
                 self.app.fitted_models[temp_label] = m["model"]
 
         output_cube = Spectrum1D(flux=fitted_spectrum.flux, wcs=fitted_spectrum.wcs)
+
+        selected_spec = self.dataset.selected_obj
         if '_pixel_scale_factor' in selected_spec.meta:
             output_cube.meta['_pixel_scale_factor'] = selected_spec.meta['_pixel_scale_factor']
 

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -232,7 +232,7 @@ def test_to_unit(cubeviz_helper):
 
     # will be a uniform array since not wavelength dependent
     # so test first value in array
-    assert np.allclose(value[0], 4.800000041882413e-08)
+    assert np.allclose(value[0], 8e-11)
 
     # Change from Fnu to Flam (with values shape matching spectral axis)
 


### PR DESCRIPTION
This PR makes the plotted model fit results update properly when toggling between flux and surface brightness. It also removes one use of `aperture_area_along_spectral` that was missed in #3088 that was leading to the converted model fit being incorrect.