### PR TITLE
Fix cube fit toggle with spectral subset selected

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -197,6 +197,9 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Fixed the data menu in Model Fitting not being populated if Cube Fit was toggled
+  while a spectral subset was selected. [#3123]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -174,6 +174,18 @@ def test_fit_cube_no_wcs(cubeviz_helper):
     assert fitted_data.shape == output_cube.shape
 
 
+def test_toggle_cube_fit_subset(cubeviz_helper):
+    sp = Spectrum1D(flux=np.ones((7, 8, 9)) * u.nJy)  # ny, nx, nz
+    cubeviz_helper.load_data(sp, data_label="test_cube")
+    mf = cubeviz_helper.plugins['Model Fitting']
+
+    sv = cubeviz_helper.app.get_viewer('spectrum-viewer')
+    sv.apply_roi(XRangeROI(7.5, 8))
+
+    mf.spectral_subset = 'Subset 1'
+    mf.cube_fit = True
+
+
 def test_refit_plot_options(specviz_helper, spectrum1d):
     specviz_helper.load_data(spectrum1d)
     modelfit_plugin = specviz_helper.plugins['Model Fitting']
@@ -284,6 +296,7 @@ def test_reestimate_parameters(specviz_helper, spectrum1d):
     sv.apply_roi(XRangeROI(7500, 8000))
 
     mf.spectral_subset = 'Subset 1'
+
     mf.reestimate_model_parameters()
     mc = mf.get_model_component('G')
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2810,7 +2810,7 @@ class DatasetSpectralSubsetValidMixin(VuetifyTemplate, HubListener):
 
     @observe("dataset_selected", "spectral_subset_selected")
     def _check_dataset_spectral_subset_valid(self, event={}, return_ranges=False):
-        if not hasattr(self, 'dataset'):
+        if not hasattr(self, 'dataset') or self.dataset.selected_obj is None:
             # plugin not fully initialized
             return
         if self.spectral_subset_selected == "Entire Spectrum":


### PR DESCRIPTION
This fixes a bug where toggling to Cube Fit in the model fitting plugin when a spectral subset was selected would result in a traceback and no data being available in the dataset menu. It appears that the dataset is briefly set to None in this case before the appropriate cube data is populated in the menu.