### PR TITLE
Remove incorrect changelog entry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -208,9 +208,6 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
-- Fixed the data menu in Model Fitting not being populated if Cube Fit was toggled
-  while a spectral subset was selected. [#3123]
-
 Cubeviz
 ^^^^^^^
 


### PR DESCRIPTION
I milestoned #3123 to the wrong version and added a changelog entry that wasn't needed - this bug was never released so I don't think we need a changelog entry for the fix at all.