### PR TITLE
Update orientation API to match UI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@ Imviz
 
 - Added Gaia catalog to Catalog plugin. [#3090]
 
+- Updated `link_type` to `align_by` and `wcs_use_affine` to `fast_approximation` in
+  Orientation plugin API to better match UI text. [#3128]
+
 Mosviz
 ^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,7 @@ Imviz
 
 - Added Gaia catalog to Catalog plugin. [#3090]
 
-- Updated `link_type` to `align_by` and `wcs_use_affine` to `fast_approximation` in
+- Updated ``link_type`` to ``align_by`` and ``wcs_use_affine`` to ``fast_approximation`` in
   Orientation plugin API to better match UI text. [#3128]
 
 Mosviz

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,7 @@ Imviz
 
 - Added Gaia catalog to Catalog plugin. [#3090]
 
-- Updated ``link_type`` to ``align_by`` and ``wcs_use_affine`` to ``fast_approximation`` in
+- Updated ``link_type`` to ``align_by`` and ``wcs_use_affine`` to ``wcs_fast_approximation`` in
   Orientation plugin API to better match UI text. [#3128]
 
 Mosviz

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -327,7 +327,7 @@ class Application(VuetifyTemplate, HubListener):
         # Imviz linking
         self._align_by = 'pixels'
         if self.config == "imviz":
-            self._fast_approximation = None
+            self._wcs_fast_approximation = None
 
         # Subscribe to messages indicating that a new viewer needs to be
         #  created. When received, information is passed to the application

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -325,7 +325,7 @@ class Application(VuetifyTemplate, HubListener):
         self.auto_link = kwargs.pop('auto_link', True)
 
         # Imviz linking
-        self._link_type = 'pixels'
+        self._align_by = 'pixels'
         if self.config == "imviz":
             self._fast_approximation = None
 
@@ -1938,7 +1938,7 @@ class Application(VuetifyTemplate, HubListener):
 
                     # Translate bounds through WCS if needed
                     if (self.config == "imviz" and
-                            self._jdaviz_helper.plugins["Orientation"].link_type == "WCS"):
+                            self._jdaviz_helper.plugins["Orientation"].align_by == "WCS"):
 
                         # Default shape for WCS-only layers is 10x10, but it doesn't really matter
                         # since we only need the angles.
@@ -2219,7 +2219,7 @@ class Application(VuetifyTemplate, HubListener):
 
         # Make sure the data isn't loaded in any viewers and isn't the selected orientation
         for viewer_id, viewer in self._viewer_store.items():
-            if orientation_plugin is not None and self._link_type == 'wcs':
+            if orientation_plugin is not None and self._align_by == 'wcs':
                 if viewer.state.reference_data.label == data_label:
                     self._change_reference_data(base_wcs_layer_label, viewer_id)
             self.remove_data_from_viewer(viewer_id, data_label)
@@ -2506,12 +2506,12 @@ class Application(VuetifyTemplate, HubListener):
             msg.cls, data=msg.data, show=False)
         viewer.figure_widget.layout.height = '100%'
 
-        linked_by_wcs = self._link_type == 'wcs'
+        linked_by_wcs = self._align_by == 'wcs'
 
         if hasattr(viewer.state, 'linked_by_wcs'):
             orientation_plugin = self._jdaviz_helper.plugins.get('Orientation', None)
             if orientation_plugin is not None:
-                linked_by_wcs = orientation_plugin.link_type.selected == 'WCS'
+                linked_by_wcs = orientation_plugin.align_by.selected == 'WCS'
             elif len(self._viewer_store) and hasattr(self._jdaviz_helper, 'default_viewer'):
                 # The plugin would only not exist for instances of Imviz where the user has
                 # intentionally removed the Orientation plugin, but in that case we will

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -327,7 +327,7 @@ class Application(VuetifyTemplate, HubListener):
         # Imviz linking
         self._link_type = 'pixels'
         if self.config == "imviz":
-            self._wcs_use_affine = None
+            self._fast_approximation = None
 
         # Subscribe to messages indicating that a new viewer needs to be
         #  created. When received, information is passed to the application

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -728,12 +728,12 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         """
 
         # type of region saved depends on link type
-        link_type = getattr(self.app, '_link_type', None)
+        align_by = getattr(self.app, '_align_by', None)
 
         region = self.app.get_subsets(subset_name=selected_subset_label,
-                                      include_sky_region=link_type == 'wcs')
+                                      include_sky_region=align_by == 'wcs')
 
-        region = region[0][f'{"sky_" if link_type == "wcs" else ""}region']
+        region = region[0][f'{"sky_" if align_by == "wcs" else ""}region']
 
         region.write(str(filename), overwrite=True)
 

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -105,7 +105,7 @@ class TestExportSubsets:
         imviz_helper.load_data(data)  # load data twice so we can link them
         imviz_helper.load_data(data)
 
-        imviz_helper.link_data(link_type='wcs')
+        imviz_helper.link_data(align_by='wcs')
 
         imviz_helper.app.get_viewer('imviz-0').apply_roi(CircularROI(xc=8,
                                                                      yc=6,

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -129,7 +129,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
         orig_world_x = np.asarray(self.table._qtable['world_ra'][in_viewer])
         orig_world_y = np.asarray(self.table._qtable['world_dec'][in_viewer])
 
-        if self.app._link_type.lower() == 'wcs':
+        if self.app._align_by.lower() == 'wcs':
             # convert from the sky coordinates in the table to pixels via the WCS of the current
             # reference data
             new_wcs = viewer.state.reference_data.coords
@@ -139,7 +139,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
             except Exception:
                 # fail gracefully
                 new_x, new_y = [], []
-        elif self.app._link_type == 'pixels':
+        elif self.app._align_by == 'pixels':
             # we need to convert based on the WCS of the individual data layers on which each mark
             # was first created
             new_x, new_y = np.zeros_like(orig_world_x), np.zeros_like(orig_world_y)
@@ -156,7 +156,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
                     new_x, new_y = [], []
                     break
         else:
-            raise NotImplementedError(f"link_type {self.app._link_type} not implemented")
+            raise NotImplementedError(f"align_by {self.app._align_by} not implemented")
 
         # check for entries that do not correspond to a layer or only have pixel coordinates
         pixel_only_inds = data_labels == ''

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -741,7 +741,7 @@ class PlotOptions(PluginTemplateMixin):
         self.send_state('display_units')
 
     def _on_refdata_change(self, *args):
-        if self.app._link_type.lower() == 'wcs':
+        if self.app._align_by.lower() == 'wcs':
             self.display_units['image'] = 'deg'
         else:
             self.display_units['image'] = 'pix'

--- a/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
+++ b/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
@@ -90,8 +90,8 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
         self.subset_states = []
         self.spectral_display_unit = None
 
-        link_type = getattr(self.app, '_link_type', None)
-        self.display_sky_coordinates = (link_type == 'wcs' and not self.multiselect)
+        align_by = getattr(self.app, '_align_by', None)
+        self.display_sky_coordinates = (align_by == 'wcs' and not self.multiselect)
 
     def _on_link_update(self, *args):
         """When linking is changed pixels<>wcs, change display units of the
@@ -100,8 +100,8 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
         to the UI upon link change by calling _get_subset_definition, which
         will re-determine how to display subset information."""
 
-        link_type = getattr(self.app, '_link_type', None)
-        self.display_sky_coordinates = (link_type == 'wcs')
+        align_by = getattr(self.app, '_align_by', None)
+        self.display_sky_coordinates = (align_by == 'wcs')
 
         if self.subset_selected != self.subset_select.default_text:
             self._get_subset_definition(*args)

--- a/jdaviz/configs/default/plugins/subset_plugin/tests/test_subset_plugin.py
+++ b/jdaviz/configs/default/plugins/subset_plugin/tests/test_subset_plugin.py
@@ -138,7 +138,7 @@ def test_circle_recenter_linking(roi_class, subset_info, imviz_helper, image_2d_
     # remove subsets and change link type to wcs
     dc = imviz_helper.app.data_collection
     dc.remove_subset_group(dc.subset_groups[0])
-    imviz_helper.link_data(link_type='wcs')
+    imviz_helper.link_data(align_by='wcs')
     assert plugin.display_sky_coordinates  # linking change should trigger change to True
 
     # apply original subset. transform sky coord of original subset to new pixels

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -224,7 +224,7 @@ class Imviz(ImageConfigHelper):
                     if (has_wcs and linked_by_wcs) or not linked_by_wcs:
                         self.app.add_data_to_viewer(show_in_viewer, applied_label, visible=visible)
 
-    def link_data(self, align_by='pixels', wcs_fallback_scheme=None, fast_approximation=True):
+    def link_data(self, align_by='pixels', wcs_fallback_scheme=None, wcs_fast_approximation=True):
         """(Re)link loaded data in Imviz with the desired link type.
         All existing links will be replaced.
 
@@ -238,7 +238,7 @@ class Imviz(ImageConfigHelper):
             This is only used when ``align_by='wcs'``.
             Choosing `None` may result in some Imviz functionality not working properly.
 
-        fast_approximation : bool
+        wcs_fast_approximation : bool
             Use an affine transform to represent the offset between images if possible
             (requires that the approximation is accurate to within 1 pixel with the
             full WCS transformations). If approximation fails, it will automatically
@@ -249,7 +249,7 @@ class Imviz(ImageConfigHelper):
         from jdaviz.configs.imviz.plugins.orientation.orientation import align_by_msg_to_trait
         plg = self.plugins["Orientation"]
         plg._obj.wcs_use_fallback = wcs_fallback_scheme == 'pixels'
-        plg.fast_approximation = fast_approximation
+        plg.wcs_fast_approximation = wcs_fast_approximation
         plg.align_by = align_by_msg_to_trait[align_by]
 
     @deprecated(since="4.0", alternative="get_alignment_method")

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 import warnings
@@ -190,7 +191,7 @@ class Imviz(ImageConfigHelper):
             show_in_viewer = f"{self.app.config}-0"
 
         if show_in_viewer:
-            linked_by_wcs = self.app._link_type == 'wcs'
+            linked_by_wcs = self.app._align_by == 'wcs'
             if linked_by_wcs:
                 for applied_label, visible, is_wcs_only, has_wcs in zip(
                         applied_labels, applied_visible, layer_is_wcs_only, layer_has_wcs
@@ -211,7 +212,7 @@ class Imviz(ImageConfigHelper):
         else:
             if 'Orientation' not in self.plugins.keys():
                 # otherwise plugin will handle linking automatically with DataCollectionAddMessage
-                self.link_data(link_type='wcs')
+                self.link_data(align_by='wcs')
 
             # One input might load into multiple Data objects.
             # NOTE: If the batch_load context manager was used, it will
@@ -223,35 +224,40 @@ class Imviz(ImageConfigHelper):
                     if (has_wcs and linked_by_wcs) or not linked_by_wcs:
                         self.app.add_data_to_viewer(show_in_viewer, applied_label, visible=visible)
 
-    def link_data(self, link_type='pixels', wcs_fallback_scheme=None, fast_approximation=True):
+    def link_data(self, align_by='pixels', wcs_fallback_scheme=None, fast_approximation=True):
         """(Re)link loaded data in Imviz with the desired link type.
         All existing links will be replaced.
 
         Parameters
         ----------
-        link_type : {'pixels', 'wcs'}
+        align_by : {'pixels', 'wcs'}
             Choose to link by pixels or WCS.
 
         wcs_fallback_scheme : {None, 'pixels'}
             If WCS linking failed, choose to fall back to linking by pixels or not at all.
-            This is only used when ``link_type='wcs'``.
+            This is only used when ``align_by='wcs'``.
             Choosing `None` may result in some Imviz functionality not working properly.
 
         fast_approximation : bool
             Use an affine transform to represent the offset between images if possible
             (requires that the approximation is accurate to within 1 pixel with the
             full WCS transformations). If approximation fails, it will automatically
-            fall back to full WCS transformation. This is only used when ``link_type='wcs'``.
+            fall back to full WCS transformation. This is only used when ``align_by='wcs'``.
             Affine approximation is much more performant at the cost of accuracy.
 
         """
-        from jdaviz.configs.imviz.plugins.orientation.orientation import link_type_msg_to_trait
+        from jdaviz.configs.imviz.plugins.orientation.orientation import align_by_msg_to_trait
         plg = self.plugins["Orientation"]
         plg._obj.wcs_use_fallback = wcs_fallback_scheme == 'pixels'
         plg.fast_approximation = fast_approximation
-        plg.link_type = link_type_msg_to_trait[link_type]
+        plg.align_by = align_by_msg_to_trait[align_by]
 
     def get_link_type(self, data_label_1, data_label_2):
+        logging.warning("DeprecationWarning: get_link_type has been replaced by "
+                        "get_alignment_method and will be removed in the future.")
+        return self.get_alignment_method(data_label_1, data_label_2)
+
+    def get_alignment_method(self, data_label_1, data_label_2):
         """Find the type of ``glue`` linking between the given
         data labels. A link is bi-directional. If there are
         more than 2 data in the collection, one of the given
@@ -264,7 +270,7 @@ class Imviz(ImageConfigHelper):
 
         Returns
         -------
-        link_type : {'pixels', 'wcs', 'self'}
+        align_by : {'pixels', 'wcs', 'self'}
             One of the link types accepted by the Orientation plugin
             or ``'self'`` if the labels are identical.
 
@@ -277,23 +283,23 @@ class Imviz(ImageConfigHelper):
         if data_label_1 == data_label_2:
             return "self"
 
-        link_type = None
+        align_by = None
         for elink in self.app.data_collection.external_links:
             elink_labels = (elink.data1.label, elink.data2.label)
             if data_label_1 in elink_labels and data_label_2 in elink_labels:
                 if isinstance(elink, LinkSame):  # Assumes WCS link never uses LinkSame
-                    link_type = 'pixels'
+                    align_by = 'pixels'
                 else:  # If not pixels, must be WCS
-                    link_type = 'wcs'
+                    align_by = 'wcs'
                 break  # Might have duplicate, just grab first match
 
-        if link_type is None:
+        if align_by is None:
             avail_links = [f"({elink.data1.label}, {elink.data2.label})"
                            for elink in self.app.data_collection.external_links]
             raise ValueError(f'{data_label_1} and {data_label_2} combo not found '
                              f'in data collection external links: {avail_links}')
 
-        return link_type
+        return align_by
 
     def get_aperture_photometry_results(self):
         """Return aperture photometry results, if any.

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -1,9 +1,9 @@
-import logging
 import os
 import re
 import warnings
 from copy import deepcopy
 
+from astropy.utils import deprecated
 import numpy as np
 from glue.core.link_helpers import LinkSame
 
@@ -252,9 +252,8 @@ class Imviz(ImageConfigHelper):
         plg.fast_approximation = fast_approximation
         plg.align_by = align_by_msg_to_trait[align_by]
 
+    @deprecated(since="4.0", alternative="get_alignment_method")
     def get_link_type(self, data_label_1, data_label_2):
-        logging.warning("DeprecationWarning: get_link_type has been replaced by "
-                        "get_alignment_method and will be removed in the future.")
         return self.get_alignment_method(data_label_1, data_label_2)
 
     def get_alignment_method(self, data_label_1, data_label_2):

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -223,7 +223,7 @@ class Imviz(ImageConfigHelper):
                     if (has_wcs and linked_by_wcs) or not linked_by_wcs:
                         self.app.add_data_to_viewer(show_in_viewer, applied_label, visible=visible)
 
-    def link_data(self, link_type='pixels', wcs_fallback_scheme=None, wcs_use_affine=True):
+    def link_data(self, link_type='pixels', wcs_fallback_scheme=None, fast_approximation=True):
         """(Re)link loaded data in Imviz with the desired link type.
         All existing links will be replaced.
 
@@ -237,7 +237,7 @@ class Imviz(ImageConfigHelper):
             This is only used when ``link_type='wcs'``.
             Choosing `None` may result in some Imviz functionality not working properly.
 
-        wcs_use_affine : bool
+        fast_approximation : bool
             Use an affine transform to represent the offset between images if possible
             (requires that the approximation is accurate to within 1 pixel with the
             full WCS transformations). If approximation fails, it will automatically
@@ -248,7 +248,7 @@ class Imviz(ImageConfigHelper):
         from jdaviz.configs.imviz.plugins.orientation.orientation import link_type_msg_to_trait
         plg = self.plugins["Orientation"]
         plg._obj.wcs_use_fallback = wcs_fallback_scheme == 'pixels'
-        plg.wcs_use_affine = wcs_use_affine
+        plg.fast_approximation = fast_approximation
         plg.link_type = link_type_msg_to_trait[link_type]
 
     def get_link_type(self, data_label_1, data_label_2):

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -180,7 +180,7 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
         return '', {path: region}
 
     def _on_link_type_updated(self, msg=None):
-        self.is_pixel_linked = (getattr(self.app, '_link_type', None) == 'pixels' and
+        self.is_pixel_linked = (getattr(self.app, '_align_by', None) == 'pixels' and
                                 len(self.app.data_collection) > 1)
         # toggle visibility as necessary
         self._on_is_active_changed()
@@ -196,7 +196,7 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
         # call other plugin so that other options (fast_approximation, wcs_use_fallback)
         # are retained.  Remove this method if support for plotting footprints
         # when pixel-linked is reintroduced.
-        self.app._jdaviz_helper.plugins['Orientation'].link_type = 'WCS'
+        self.app._jdaviz_helper.plugins['Orientation'].align_by = 'WCS'
 
     def _ensure_first_overlay(self):
         if not len(self._overlays):

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -193,7 +193,7 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
                 self._change_overlay(overlay_selected=choice, center_the_overlay=False)
 
     def vue_link_by_wcs(self, *args):
-        # call other plugin so that other options (wcs_use_affine, wcs_use_fallback)
+        # call other plugin so that other options (fast_approximation, wcs_use_fallback)
         # are retained.  Remove this method if support for plotting footprints
         # when pixel-linked is reintroduced.
         self.app._jdaviz_helper.plugins['Orientation'].link_type = 'WCS'

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -193,7 +193,7 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
                 self._change_overlay(overlay_selected=choice, center_the_overlay=False)
 
     def vue_link_by_wcs(self, *args):
-        # call other plugin so that other options (fast_approximation, wcs_use_fallback)
+        # call other plugin so that other options (wcs_fast_approximation, wcs_use_fallback)
         # are retained.  Remove this method if support for plotting footprints
         # when pixel-linked is reintroduced.
         self.app._jdaviz_helper.plugins['Orientation'].align_by = 'WCS'

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -1,6 +1,5 @@
-import logging
-
 from astropy import units as u
+from astropy.utils import deprecated
 from astropy.wcs.wcsapi import BaseHighLevelWCS
 from glue.core.link_helpers import LinkSame
 from glue.core.message import (
@@ -150,27 +149,23 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         )
 
     @property
+    @deprecated(since="4.0", alternative="align_by")
     def link_type(self):
-        logging.warning("DeprecationWarning: link_type has been replaced by align_by and will "
-                        "be removed in a future version")
         return self.align_by
 
     @link_type.setter
+    @deprecated(since="4.0", alternative="align_by")
     def link_type(self, link_type):
-        logging.warning("DeprecationWarning: link_type has been replaced by align_by and will "
-                        "be removed in a future version")
         self.align_by = link_type
 
     @property
+    @deprecated(since="4.0", alternative="fast_approximation")
     def wcs_use_affine(self):
-        logging.warning("DeprecationWarning: wcs_use_affine has been replaced by "
-                        "fast_approximation and will be removed in a future version")
         return self.fast_approximation
 
     @wcs_use_affine.setter
+    @deprecated(since="4.0", alternative="fast_approximation")
     def wcs_use_affine(self, wcs_use_affine):
-        logging.warning("DeprecationWarning: wcs_use_affine has been replaced by "
-                        "fast_approximation and will be removed in a future version")
         self.fast_approximation = wcs_use_affine
 
     def _link_image_data(self):

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -1,3 +1,5 @@
+import logging
+
 from astropy import units as u
 from astropy.wcs.wcsapi import BaseHighLevelWCS
 from glue.core.link_helpers import LinkSame
@@ -141,11 +143,35 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         return PluginUserApi(
             self,
             expose=(
-                'align_by', 'fast_approximation', 'delete_subsets',
-                'viewer', 'orientation',
+                'align_by', 'link_type', 'fast_approximation', 'wcs_use_affine',
+                'delete_subsets', 'viewer', 'orientation',
                 'rotation_angle', 'east_left', 'add_orientation'
             )
         )
+
+    @property
+    def link_type(self):
+        logging.warning("DeprecationWarning: link_type has been replaced by align_by and will "
+                        "be removed in a future version")
+        return self.align_by
+
+    @link_type.setter
+    def link_type(self, link_type):
+        logging.warning("DeprecationWarning: link_type has been replaced by align_by and will "
+                        "be removed in a future version")
+        self.align_by = link_type
+
+    @property
+    def wcs_use_affine(self):
+        logging.warning("DeprecationWarning: wcs_use_affine has been replaced by "
+                        "fast_approximation and will be removed in a future version")
+        return self.fast_approximation
+
+    @wcs_use_affine.setter
+    def wcs_use_affine(self, wcs_use_affine):
+        logging.warning("DeprecationWarning: wcs_use_affine has been replaced by "
+                        "fast_approximation and will be removed in a future version")
+        self.fast_approximation = wcs_use_affine
 
     def _link_image_data(self):
         self.linking_in_progress = True

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -95,9 +95,9 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         self.icons = {k: v for k, v in self.app.state.icons.items()}
 
         self.align_by = SelectPluginComponent(self,
-                                               items='align_by_items',
-                                               selected='align_by_selected',
-                                               manual_options=['Pixels', 'WCS'])
+                                              items='align_by_items',
+                                              selected='align_by_selected',
+                                              manual_options=['Pixels', 'WCS'])
 
         self.orientation = LayerSelect(
             self, 'orientation_layer_items', 'orientation_layer_selected', 'viewer_selected',

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -448,7 +448,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
 
             # don't select until reference data are available:
             if ref_data is not None:
-                align_by = viewer.get_align_by(ref_data.label)
+                align_by = viewer.get_alignment_method(ref_data.label)
                 if align_by != 'self':
                     self.align_by_selected = align_by_msg_to_trait[align_by]
             elif not len(viewer.data()):

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -29,7 +29,7 @@ from jdaviz.utils import get_reference_image_data, layer_is_2d, _wcs_only_label
 __all__ = ['Orientation']
 
 base_wcs_layer_label = 'Default orientation'
-link_type_msg_to_trait = {'pixels': 'Pixels', 'wcs': 'WCS'}
+align_by_msg_to_trait = {'pixels': 'Pixels', 'wcs': 'WCS'}
 
 
 @tray_registry('imviz-orientation', label="Orientation", viewer_requirements="image")
@@ -50,8 +50,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.show`
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.open_in_tray`
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.close_in_tray`
-    * ``link_type`` (`~jdaviz.core.template_mixin.SelectPluginComponent`)
-    * ``wcs_use_affine``
+    * ``align_by`` (`~jdaviz.core.template_mixin.SelectPluginComponent`)
+    * ``fast_approximation``
     * ``delete_subsets``
     * ``viewer``
     * ``orientation``
@@ -61,10 +61,10 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
     """
     template_file = __file__, "orientation.vue"
 
-    link_type_items = List().tag(sync=True)
-    link_type_selected = Unicode().tag(sync=True)
+    align_by_items = List().tag(sync=True)
+    align_by_selected = Unicode().tag(sync=True)
     wcs_use_fallback = Bool(True).tag(sync=True)
-    wcs_use_affine = Bool(True).tag(sync=True)
+    fast_approximation = Bool(True).tag(sync=True)
     wcs_linking_available = Bool(False).tag(sync=True)
 
     need_clear_astrowidget_markers = Bool(False).tag(sync=True)
@@ -94,9 +94,9 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
 
         self.icons = {k: v for k, v in self.app.state.icons.items()}
 
-        self.link_type = SelectPluginComponent(self,
-                                               items='link_type_items',
-                                               selected='link_type_selected',
+        self.align_by = SelectPluginComponent(self,
+                                               items='align_by_items',
+                                               selected='align_by_selected',
                                                manual_options=['Pixels', 'WCS'])
 
         self.orientation = LayerSelect(
@@ -141,7 +141,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         return PluginUserApi(
             self,
             expose=(
-                'link_type', 'wcs_use_affine', 'delete_subsets',
+                'align_by', 'fast_approximation', 'delete_subsets',
                 'viewer', 'orientation',
                 'rotation_angle', 'east_left', 'add_orientation'
             )
@@ -150,19 +150,19 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
     def _link_image_data(self):
         self.linking_in_progress = True
         try:
-            link_type = self.link_type.selected.lower()
+            align_by = self.align_by.selected.lower()
             link_image_data(
                 self.app,
-                link_type=link_type,
+                align_by=align_by,
                 wcs_fallback_scheme='pixels' if self.wcs_use_fallback else None,
-                wcs_use_affine=self.wcs_use_affine,
+                fast_approximation=self.fast_approximation,
                 error_on_fail=False)
         except Exception:  # pragma: no cover
             raise
         else:
             # Only broadcast after success.
             self.app.hub.broadcast(LinkUpdatedMessage(
-                link_type, self.wcs_use_fallback, self.wcs_use_affine, sender=self.app))
+                align_by, self.wcs_use_fallback, self.fast_approximation, sender=self.app))
         finally:
             self.linking_in_progress = False
 
@@ -193,14 +193,14 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
     def _on_markers_plugin_update(self, msg):
         self.plugin_markers_exist = msg.table_length > 0
 
-    @observe('link_type_selected', 'wcs_use_fallback', 'wcs_use_affine')
+    @observe('align_by_selected', 'wcs_use_fallback', 'fast_approximation')
     def _update_link(self, msg={}):
         """Run link_image_data with the selected parameters."""
-        if not hasattr(self, 'link_type'):
+        if not hasattr(self, 'align_by'):
             # could happen before plugin is fully initialized
             return
 
-        if msg.get('name', None) == 'wcs_use_affine' and self.link_type.selected == 'Pixels':
+        if msg.get('name', None) == 'fast_approximation' and self.align_by.selected == 'Pixels':
             # approximation doesn't apply, avoid updating when not necessary!
             return
 
@@ -222,8 +222,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             raise ValueError(f"cannot change linking with markers present (value reverted to "
                              f"'{msg.get('old')}'), call viewer.reset_markers()")
 
-        if self.link_type.selected == 'Pixels':
-            self.wcs_use_affine = True
+        if self.align_by.selected == 'Pixels':
+            self.fast_approximation = True
 
         self.linking_in_progress = False
         self._link_image_data()
@@ -231,7 +231,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         # load data into the viewer that are now compatible with the
         # new link type, remove data from the viewer that are now
         # incompatible:
-        wcs_linked = self.link_type.selected == 'WCS'
+        wcs_linked = self.align_by.selected == 'WCS'
         viewer_selected = self.app.get_viewer(self.viewer.selected)
 
         data_in_viewer = self.app.get_viewer(viewer_selected.reference).data()
@@ -332,7 +332,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
     def _add_orientation(self, rotation_angle=None, east_left=None, label=None,
                          set_on_create=True, wrt_data=None, from_ui=False):
 
-        if self.link_type_selected != 'WCS':
+        if self.align_by_selected != 'WCS':
             raise ValueError("must be aligned by WCS to add orientation options")
 
         if wrt_data is None:
@@ -406,14 +406,14 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         )
         for viewer_ref in viewers_to_update:
             self.viewer.selected = viewer_ref
-            self.orientation.update_wcs_only_filter(wcs_only=self.link_type_selected == 'WCS')
+            self.orientation.update_wcs_only_filter(wcs_only=self.align_by_selected == 'WCS')
             for wcs_layer in wcs_only_layers:
                 if wcs_layer not in self.viewer.selected_obj.layers:
                     self.app.add_data_to_viewer(viewer_ref, wcs_layer)
             if (
                 self.orientation.selected not in
                     self.viewer.selected_obj.state.wcs_only_layers and
-                    self.link_type_selected == 'WCS'
+                    self.align_by_selected == 'WCS'
             ):
                 self.orientation.selected = base_wcs_layer_label
 
@@ -448,11 +448,11 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
 
             # don't select until reference data are available:
             if ref_data is not None:
-                link_type = viewer.get_link_type(ref_data.label)
-                if link_type != 'self':
-                    self.link_type_selected = link_type_msg_to_trait[link_type]
+                align_by = viewer.get_align_by(ref_data.label)
+                if align_by != 'self':
+                    self.align_by_selected = align_by_msg_to_trait[align_by]
             elif not len(viewer.data()):
-                self.link_type_selected = link_type_msg_to_trait['pixels']
+                self.align_by_selected = align_by_msg_to_trait['pixels']
 
             if msg.data.label not in self.orientation.choices:
                 return
@@ -545,7 +545,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         )
 
 
-def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_affine=True,
+def link_image_data(app, align_by='pixels', wcs_fallback_scheme=None, fast_approximation=True,
                     error_on_fail=False):
     """(Re)link loaded data in Imviz with the desired link type.
 
@@ -561,19 +561,19 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
     app : `~jdaviz.app.Application`
         Application associated with Imviz, e.g., ``imviz.app``.
 
-    link_type : {'pixels', 'wcs'}
+    align_by : {'pixels', 'wcs'}
         Choose to link by pixels or WCS.
 
     wcs_fallback_scheme : {None, 'pixels'}
         If WCS linking failed, choose to fall back to linking by pixels or not at all.
-        This is only used when ``link_type='wcs'``.
+        This is only used when ``align_by='wcs'``.
         Choosing `None` may result in some Imviz functionality not working properly.
 
-    wcs_use_affine : bool
+    fast_approximation : bool
         Use an affine transform to represent the offset between images if possible
         (requires that the approximation is accurate to within 1 pixel with the
         full WCS transformations). If approximation fails, it will automatically
-        fall back to full WCS transformation. This is only used when ``link_type='wcs'``.
+        fall back to full WCS transformation. This is only used when ``align_by='wcs'``.
         Affine approximation is much more performant at the cost of accuracy.
 
     error_on_fail : bool
@@ -588,15 +588,15 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
         Invalid inputs or reference data.
 
     """
-    if len(app.data_collection) <= 1 and link_type != 'wcs':  # No need to link, we are done.
+    if len(app.data_collection) <= 1 and align_by != 'wcs':  # No need to link, we are done.
         return
 
-    if link_type not in ('pixels', 'wcs'):  # pragma: no cover
-        raise ValueError(f"link_type must be 'pixels' or 'wcs', got {link_type}")
-    if link_type == 'wcs' and wcs_fallback_scheme not in (None, 'pixels'):  # pragma: no cover
+    if align_by not in ('pixels', 'wcs'):  # pragma: no cover
+        raise ValueError(f"align_by must be 'pixels' or 'wcs', got {align_by}")
+    if align_by == 'wcs' and wcs_fallback_scheme not in (None, 'pixels'):  # pragma: no cover
         raise ValueError("wcs_fallback_scheme must be None or 'pixels', "
                          f"got {wcs_fallback_scheme}")
-    if link_type == 'wcs':
+    if align_by == 'wcs':
         at_least_one_data_have_wcs = len([
             hasattr(d, 'coords') and isinstance(d.coords, BaseHighLevelWCS)
             for d in app.data_collection
@@ -604,15 +604,15 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
         if not at_least_one_data_have_wcs:  # pragma: no cover
             if wcs_fallback_scheme is None:
                 if error_on_fail:
-                    raise ValueError("link_type can only be 'wcs' when wcs_fallback_scheme "
+                    raise ValueError("align_by can only be 'wcs' when wcs_fallback_scheme "
                                      "is 'None' if at least one image has a valid WCS.")
                 else:
                     return
             else:
                 # fall back on pixel linking
-                link_type = 'pixels'
+                align_by = 'pixels'
 
-    old_link_type = getattr(app, '_link_type', None)
+    old_align_by = getattr(app, '_align_by', None)
 
     # In WCS linking, changing orientation layer is done within Orientation plugin,
     # so here we assume viewer.state.reference_data is already the desired
@@ -622,8 +622,8 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
     #
     # data1 = reference, data2 = actual data
     data_already_linked = []
-    if (link_type == old_link_type and
-            (link_type == "pixels" or wcs_use_affine == app._wcs_use_affine)):
+    if (align_by == old_align_by and
+            (align_by == "pixels" or fast_approximation == app._fast_approximation)):
         # We are only here to link new data with existing configuration,
         # so no need to relink existing data.
         for link in app.data_collection.external_links:
@@ -632,17 +632,17 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
         # Everything has to be relinked.
         for viewer in app._viewer_store.values():
             if len(viewer._marktags):
-                raise ValueError(f"cannot change link_type (from '{app._link_type}' to "
-                                 f"'{link_type}') when markers are present. "
+                raise ValueError(f"cannot change align_by (from '{app._align_by}' to "
+                                 f"'{align_by}') when markers are present. "
                                  f" Clear markers with viewer.reset_markers() first")
 
-    # set internal tracking of link_type before changing reference data for anything that is
+    # set internal tracking of align_by before changing reference data for anything that is
     # subscribed to a change in reference data
-    app._link_type = link_type
-    app._wcs_use_affine = wcs_use_affine
+    app._align_by = align_by
+    app._fast_approximation = fast_approximation
 
     # wcs -> pixels: First loaded real data will be reference.
-    if link_type == 'pixels' and old_link_type == 'wcs':
+    if align_by == 'pixels' and old_align_by == 'wcs':
         # default reference layer is the first-loaded image in default viewer:
         refdata = app._jdaviz_helper.default_viewer._obj.first_loaded_data
         if refdata is None:  # No data in viewer, just use first in collection  # pragma: no cover
@@ -656,7 +656,7 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
             app._change_reference_data(refdata.label, viewer_id=viewer_id)
 
     # pixels -> wcs: Always the default orientation
-    elif link_type == 'wcs' and old_link_type == 'pixels':
+    elif align_by == 'wcs' and old_align_by == 'pixels':
         # Have to create the default orientation first.
         if base_wcs_layer_label not in app.data_collection.labels:
             default_reference_layer = (app._jdaviz_helper.default_viewer._obj.first_loaded_data
@@ -699,18 +699,18 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
         # 4. We are not touching fake WCS layers in pixel linking.
         # 5. We are not touching data without WCS in WCS linking.
         if ((i == iref) or (not layer_is_2d(data)) or (data in data_already_linked) or
-                (link_type == "pixels" and data.meta.get(_wcs_only_label)) or
-                (link_type == "wcs" and not hasattr(data.coords, 'pixel_to_world'))):
+                (align_by == "pixels" and data.meta.get(_wcs_only_label)) or
+                (align_by == "wcs" and not hasattr(data.coords, 'pixel_to_world'))):
             continue
 
         ids1 = data.pixel_component_ids
         new_links = []
         try:
-            if link_type == 'pixels':
+            if align_by == 'pixels':
                 new_links = [LinkSame(ids0[i], ids1[i]) for i in ndim_range]
             else:  # wcs
                 wcslink = WCSLink(data1=refdata, data2=data, cids1=ids0, cids2=ids1)
-                if wcs_use_affine:
+                if fast_approximation:
                     try:
                         new_links = [wcslink.as_affine_link()]
                     except NoAffineApproximation:  # pragma: no cover
@@ -718,7 +718,7 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
                 else:
                     new_links = [wcslink]
         except Exception as e:  # pragma: no cover
-            if link_type == 'wcs' and wcs_fallback_scheme == 'pixels':
+            if align_by == 'wcs' and wcs_fallback_scheme == 'pixels':
                 try:
                     new_links = [LinkSame(ids0[i], ids1[i]) for i in ndim_range]
                 except Exception as e:  # pragma: no cover
@@ -750,7 +750,7 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
             'Images successfully relinked', color='success', timeout=8000, sender=app))
 
     for viewer in app._viewer_store.values():
-        wcs_linked = link_type == 'wcs'
+        wcs_linked = align_by == 'wcs'
         # viewer-state needs to know link type for reset_limits behavior
         viewer.state.linked_by_wcs = wcs_linked
         # also need to store a copy in the viewer item for the data dropdown to access
@@ -760,5 +760,5 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
         viewer_item['linked_by_wcs'] = wcs_linked
 
         # if changing from one link type to another, reset the limits:
-        if link_type != old_link_type:
+        if align_by != old_align_by:
             viewer.state.reset_limits()

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.vue
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.vue
@@ -58,7 +58,7 @@
           <v-switch
             label="Fast approximation"
             hint="Use fast approximation for WCS image alignment, if possible (accurate to <1 pixel)."
-            v-model="fast_approximation"
+            v-model="wcs_fast_approximation"
             v-if="align_by_selected == 'WCS'"
             persistent-hint>
           </v-switch>

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.vue
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.vue
@@ -40,13 +40,13 @@
           <v-radio-group
             label="Align by"
             hint="Align individual image layers by pixels or on the sky by WCS."
-            v-model="link_type_selected"
+            v-model="align_by_selected"
             @change="delete_subsets($event)"
             :disabled="!wcs_linking_available || need_clear_astrowidget_markers || need_clear_subsets"
             persistent-hint
             row>
             <v-radio
-              v-for="item in link_type_items"
+              v-for="item in align_by_items"
               :key="item.label"
               :label="item.label == 'WCS' ? 'WCS (Sky)' : item.label"
               :value="item.label"
@@ -58,8 +58,8 @@
           <v-switch
             label="Fast approximation"
             hint="Use fast approximation for WCS image alignment, if possible (accurate to <1 pixel)."
-            v-model="wcs_use_affine"
-            v-if="link_type_selected == 'WCS'"
+            v-model="fast_approximation"
+            v-if="align_by_selected == 'WCS'"
             persistent-hint>
           </v-switch>
         </v-row>
@@ -73,7 +73,7 @@
           </v-switch>
         </v-row>
 
-        <div v-if="link_type_selected == 'WCS'">
+        <div v-if="align_by_selected == 'WCS'">
 
           <j-plugin-section-header>Orientation</j-plugin-section-header>
           <plugin-viewer-select
@@ -165,7 +165,7 @@
       </div>
       <div v-if="linking_in_progress"
            class="text-center"
-           style="grid-area: 1/1; 
+           style="grid-area: 1/1;
                   z-index:2;
                   margin-left: -24px;
                   margin-right: -24px;

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -199,11 +199,11 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
             # we aren't actually guaranteed to get a SkyCoord out, just for images
             # with valid celestial WCS
             try:
-                link_type = self.get_link_type(image.label).lower()
+                align_by = self.get_alignment_method(image.label).lower()
 
                 # Convert X,Y from reference data to the one we are actually seeing.
                 # world_to_pixel return scalar ndarray that we need to convert to float.
-                if link_type == 'wcs':
+                if align_by == 'wcs':
                     if not reverse:
                         outside_ref_bounding_box = wcs_utils.data_outside_gwcs_bounding_box(
                             self.state.reference_data, x, y)
@@ -288,7 +288,7 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
                 if hasattr(layer_state, 'layer') and
                 layer_is_image_data(layer_state.layer)]
 
-    def get_link_type(self, data_label):
+    def get_alignment_method(self, data_label):
         """Find the type of ``glue`` linking between the given
         data label with the reference data in viewer.
 
@@ -299,7 +299,7 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
 
         Returns
         -------
-        link_type : {'pixels', 'wcs', 'self'}
+        align_by : {'pixels', 'wcs', 'self'}
             One of the link types accepted by the Orientation plugin
             or ``'self'`` if the data label belongs to the reference data itself.
 
@@ -319,25 +319,25 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
         if ref_label in self.state.wcs_only_layers:
             return 'wcs'
 
-        link_type = None
+        align_by = None
         for elink in self.session.application.data_collection.external_links:
             elink_labels = (elink.data1.label, elink.data2.label)
             if data_label in elink_labels and ref_label in elink_labels:
                 if isinstance(elink, LinkSame):  # Assumes WCS link never uses LinkSame
-                    link_type = 'pixels'
+                    align_by = 'pixels'
                 else:  # If not pixels, must be WCS
-                    link_type = 'wcs'
+                    align_by = 'wcs'
                 break  # Might have duplicate, just grab first match
 
-        if link_type is None:
+        if align_by is None:
             raise ValueError(f'{data_label} not found in data collection external links')
 
-        return link_type
+        return align_by
 
     def _get_fov(self, wcs=None):
         if wcs is None:
             wcs = self.state.reference_data.coords
-        if self.jdaviz_app._link_type != "wcs" or wcs is None:
+        if self.jdaviz_app._align_by != "wcs" or wcs is None:
             return
 
         # compute the mean of the height and width of the
@@ -364,7 +364,7 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
         x_cen = (self.state.x_min + self.state.x_max) * 0.5
         y_cen = (self.state.y_min + self.state.y_max) * 0.5
 
-        if (self.jdaviz_app._link_type == "wcs" or data is None
+        if (self.jdaviz_app._align_by == "wcs" or data is None
                 or data.label == self.state.reference_data.label):
             return self.state.reference_data.coords.pixel_to_world(x_cen, y_cen)
 

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -96,7 +96,7 @@ class TestCenterOffset(BaseImviz_WCS_NoWCS):
 class TestCenter(BaseImviz_WCS_WCS):
 
     def test_center_on_pix(self):
-        self.imviz.link_data(link_type='wcs')
+        self.imviz.link_data(align_by='wcs')
 
         # This is the second loaded data that is dithered by 1-pix.
         self.viewer.center_on((0, 0))

--- a/jdaviz/configs/imviz/tests/test_delete_data.py
+++ b/jdaviz/configs/imviz/tests/test_delete_data.py
@@ -25,7 +25,7 @@ class TestDeleteData(BaseImviz_WCS_WCS):
         hdu3 = NDData(arr, wcs=self.wcs_1)
         self.imviz.load_data(hdu3, data_label='has_wcs_3')
 
-        self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None)
+        self.imviz.link_data(align_by='wcs', wcs_fallback_scheme=None)
 
         # Add a subset
         reg = CirclePixelRegion(PixCoord(2, 2), 3).to_sky(self.wcs_1)
@@ -82,7 +82,7 @@ class TestDeleteWCSLayerWithSubset(BaseImviz_WCS_GWCS):
     """Regression test for https://jira.stsci.edu/browse/JDAT-3958"""
     def test_delete_wcs_layer_with_subset(self):
         lc_plugin = self.imviz.plugins['Orientation']
-        lc_plugin.link_type = 'WCS'
+        lc_plugin.align_by = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
         lc_plugin._obj.create_north_up_east_left(set_on_create=True)

--- a/jdaviz/configs/imviz/tests/test_footprints.py
+++ b/jdaviz/configs/imviz/tests/test_footprints.py
@@ -175,7 +175,7 @@ def test_api_after_linking(imviz_helper):
         assert no_marks_displayed is True
 
         # link by wcs and retest
-        imviz_helper.link_data(link_type='wcs')
+        imviz_helper.link_data(align_by='wcs')
 
         viewer_marks = _get_markers_from_viewer(viewer)
         # distinguish default from custom overlay with color
@@ -198,7 +198,7 @@ def test_footprint_updates_on_rotation(imviz_helper):
     ndd = NDData(arr, wcs=image_2d_wcs)
 
     imviz_helper.load_data(ndd)
-    imviz_helper.link_data(link_type='wcs')
+    imviz_helper.link_data(align_by='wcs')
 
     footprints = imviz_helper.plugins['Footprints']
     footprints.keep_active = True

--- a/jdaviz/configs/imviz/tests/test_helper.py
+++ b/jdaviz/configs/imviz/tests/test_helper.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 
-@pytest.mark.filterwarnings(r"ignore:The .* function is deprecated")
+@pytest.mark.filterwarnings(r"ignore:The link_type function is deprecated")
+@pytest.mark.filterwarnings(r"ignore:The wcs_use_affine function is deprecated")
 def test_plugin_user_apis(imviz_helper):
     for plugin_name, plugin_api in imviz_helper.plugins.items():
         plugin = plugin_api._obj

--- a/jdaviz/configs/imviz/tests/test_helper.py
+++ b/jdaviz/configs/imviz/tests/test_helper.py
@@ -1,6 +1,8 @@
 import numpy as np
+import pytest
 
 
+@pytest.mark.filterwarnings(r"ignore:The .* function is deprecated")
 def test_plugin_user_apis(imviz_helper):
     for plugin_name, plugin_api in imviz_helper.plugins.items():
         plugin = plugin_api._obj

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -168,7 +168,8 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
         assert len(self.viewer._marktags) == 0
 
     def test_wcslink_fullblown(self):
-        self.imviz.link_data(align_by='wcs', wcs_fallback_scheme=None, fast_approximation=False)
+        self.imviz.link_data(align_by='wcs', wcs_fallback_scheme=None,
+                             wcs_fast_approximation=False)
         links = self.imviz.app.data_collection.external_links
         assert len(links) == 2
         assert isinstance(links[0], WCSLink)

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -168,7 +168,7 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
         assert len(self.viewer._marktags) == 0
 
     def test_wcslink_fullblown(self):
-        self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None, wcs_use_affine=False)
+        self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None, fast_approximation=False)
         links = self.imviz.app.data_collection.external_links
         assert len(links) == 2
         assert isinstance(links[0], WCSLink)

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -24,7 +24,7 @@ class BaseLinkHandler:
         assert all([isinstance(link, (AffineLink, OffsetLink)) for link in links])
 
     def test_pixel_linking(self):
-        self.imviz.link_data(link_type='pixels')
+        self.imviz.link_data(align_by='pixels')
         self.check_all_pixel_links()
 
     @property
@@ -38,9 +38,9 @@ class BaseLinkHandler:
 class TestLink_WCS_NoWCS(BaseImviz_WCS_NoWCS, BaseLinkHandler):
 
     def test_wcslink_fallback_pixels(self):
-        self.imviz.link_data(link_type='wcs')
+        self.imviz.link_data(align_by='wcs')
 
-        assert self.viewer.get_link_type('has_wcs[SCI,1]') == 'wcs'
+        assert self.viewer.get_alignment_method('has_wcs[SCI,1]') == 'wcs'
 
         # Also check the coordinates display: Last loaded is on top.
 
@@ -63,8 +63,8 @@ class TestLink_WCS_FakeWCS(BaseImviz_WCS_NoWCS, BaseLinkHandler):
 
         self.check_all_pixel_links()
 
-        assert self.viewer.get_link_type('has_wcs[SCI,1]') == 'self'
-        assert self.viewer.get_link_type('no_wcs[SCI,1]') == 'pixels'
+        assert self.viewer.get_alignment_method('has_wcs[SCI,1]') == 'self'
+        assert self.viewer.get_alignment_method('no_wcs[SCI,1]') == 'pixels'
 
         # Also check the coordinates display: Last loaded is on top.
 
@@ -88,11 +88,11 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
         orig_pixel_limits = self.default_viewer_limits
         assert_allclose(orig_pixel_limits, (-0.5, 9.5, -0.5, 9.5))
 
-        self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None)
+        self.imviz.link_data(align_by='wcs', wcs_fallback_scheme=None)
         links = self.imviz.app.data_collection.external_links
         assert len(links) == 2
         assert isinstance(links[0], (AffineLink, OffsetLink))
-        assert self.viewer.get_link_type('has_wcs_2[SCI,1]') == 'wcs'
+        assert self.viewer.get_alignment_method('has_wcs_2[SCI,1]') == 'wcs'
 
         # Customize display on second image (last loaded).
         self.viewer.set_colormap('Viridis')
@@ -159,37 +159,37 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
 
         # Changing link type will raise an error
         with pytest.raises(ValueError, match=".*only be changed after existing subsets are deleted"):  # noqa: E501
-            self.imviz.link_data(link_type='pixels', wcs_fallback_scheme=None)
+            self.imviz.link_data(align_by='pixels', wcs_fallback_scheme=None)
 
         self.viewer.reset_markers()
         self.imviz.plugins["Orientation"].delete_subsets()
-        self.imviz.link_data(link_type='pixels', wcs_fallback_scheme=None)
+        self.imviz.link_data(align_by='pixels', wcs_fallback_scheme=None)
         assert 'xy_markers' not in self.imviz.app.data_collection.labels
         assert len(self.viewer._marktags) == 0
 
     def test_wcslink_fullblown(self):
-        self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None, fast_approximation=False)
+        self.imviz.link_data(align_by='wcs', wcs_fallback_scheme=None, fast_approximation=False)
         links = self.imviz.app.data_collection.external_links
         assert len(links) == 2
         assert isinstance(links[0], WCSLink)
-        assert self.viewer.get_link_type('has_wcs_1[SCI,1]') == 'wcs'
-        assert self.viewer.get_link_type('has_wcs_2[SCI,1]') == 'wcs'
+        assert self.viewer.get_alignment_method('has_wcs_1[SCI,1]') == 'wcs'
+        assert self.viewer.get_alignment_method('has_wcs_2[SCI,1]') == 'wcs'
 
     # Also test other exception handling here.
 
     def test_invalid_inputs(self):
         with pytest.raises(KeyError):
-            self.imviz.link_data(link_type='foo')
+            self.imviz.link_data(align_by='foo')
 
         with pytest.raises(ValueError, match='not found in data collection external links'):
-            self.viewer.get_link_type('foo')
+            self.viewer.get_alignment_method('foo')
 
 
 class TestLink_WCS_GWCS(BaseImviz_WCS_GWCS):
 
     def test_wcslink_rotated(self):
         # FITS WCS will be reference, GWCS is rotated, no_wcs linked by pixel to ref.
-        self.imviz.link_data(link_type='wcs')
+        self.imviz.link_data(align_by='wcs')
 
         # The zoom box for GWCS is now a rotated rombus.
         fits_wcs_zoom_limits = self.viewer._get_zoom_limits(
@@ -263,7 +263,7 @@ class TestLink_WCS_GWCS(BaseImviz_WCS_GWCS):
 class TestLink_GWCS_GWCS(BaseImviz_GWCS_GWCS):
 
     def test_pixel_linking(self):
-        self.imviz.link_data(link_type='pixels')
+        self.imviz.link_data(align_by='pixels')
 
         # Check the coordinates display: Last loaded is on top.
         label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
@@ -300,4 +300,4 @@ def test_imviz_no_data(imviz_helper):
     assert len(links) == 0
 
     with pytest.raises(ValueError, match='No reference data for link look-up'):
-        imviz_helper.default_viewer._obj.get_link_type('foo')
+        imviz_helper.default_viewer._obj.get_alignment_method('foo')

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -13,23 +13,23 @@ class TestDefaultOrientation(BaseImviz_WCS_WCS):
     def test_affine_reset_and_linktype(self):
         lc_plugin = self.imviz.plugins['Orientation']
 
-        lc_plugin.link_type = 'WCS'
+        lc_plugin.align_by = 'WCS'
         lc_plugin.fast_approximation = False
-        assert self.imviz.get_link_type("Default orientation", "has_wcs_2[SCI,1]") == "wcs"
+        assert self.imviz.get_alignment_method("Default orientation", "has_wcs_2[SCI,1]") == "wcs"
 
         # fast_approximation should revert/default to True when change back to Pixels.
-        lc_plugin.link_type = 'Pixels'
+        lc_plugin.align_by = 'Pixels'
         assert lc_plugin.fast_approximation is True
-        assert self.imviz.get_link_type("has_wcs_1[SCI,1]", "has_wcs_2[SCI,1]") == "pixels"
+        assert self.imviz.get_alignment_method("has_wcs_1[SCI,1]", "has_wcs_2[SCI,1]") == "pixels"
 
-        assert self.imviz.get_link_type("has_wcs_1[SCI,1]", "has_wcs_1[SCI,1]") == "self"
+        assert self.imviz.get_alignment_method("has_wcs_1[SCI,1]", "has_wcs_1[SCI,1]") == "self"
 
         with pytest.raises(ValueError, match=".*combo not found"):
-            self.imviz.get_link_type("has_wcs_1[SCI,1]", "foo")
+            self.imviz.get_alignment_method("has_wcs_1[SCI,1]", "foo")
 
     def test_astrowidgets_markers_disable_relinking(self):
         lc_plugin = self.imviz.plugins['Orientation']
-        lc_plugin.link_type = 'Pixels'
+        lc_plugin.align_by = 'Pixels'
 
         # Adding markers should disable changing linking from both UI and API.
         assert lc_plugin._obj.need_clear_astrowidget_markers is False
@@ -38,17 +38,17 @@ class TestDefaultOrientation(BaseImviz_WCS_WCS):
 
         assert lc_plugin._obj.need_clear_astrowidget_markers is True
         with pytest.raises(ValueError, match="cannot change linking"):
-            lc_plugin.link_type = 'WCS'
-        assert lc_plugin.link_type == 'Pixels'
+            lc_plugin.align_by = 'WCS'
+        assert lc_plugin.align_by == 'Pixels'
 
         lc_plugin._obj.vue_reset_astrowidget_markers()
 
         assert lc_plugin._obj.need_clear_astrowidget_markers is False
-        lc_plugin.link_type = 'WCS'
+        lc_plugin.align_by = 'WCS'
 
     def test_markers_plugin_recompute_positions_pixels_to_wcs(self):
         lc_plugin = self.imviz.plugins['Orientation']
-        lc_plugin.link_type = 'Pixels'
+        lc_plugin.align_by = 'Pixels'
 
         # Blink to second image, if we have to.
         if self.viewer.top_visible_data_label != "has_wcs_2[SCI,1]":
@@ -69,7 +69,7 @@ class TestDefaultOrientation(BaseImviz_WCS_WCS):
                 self.viewer, {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
             mp._obj._on_viewer_key_event(self.viewer, {'event': 'keydown', 'key': 'm'})
 
-            lc_plugin.link_type = 'WCS'
+            lc_plugin.align_by = 'WCS'
 
             # Both marks stay the same in sky, so this means X and Y w.r.t. reference
             # same on both entries.
@@ -84,7 +84,7 @@ class TestDefaultOrientation(BaseImviz_WCS_WCS):
 
     def test_markers_plugin_recompute_positions_wcs_to_pixels(self):
         lc_plugin = self.imviz.plugins['Orientation']
-        lc_plugin.link_type = 'WCS'
+        lc_plugin.align_by = 'WCS'
 
         # Blink to second image, if we have to.
         if self.viewer.top_visible_data_label != "has_wcs_2[SCI,1]":
@@ -105,7 +105,7 @@ class TestDefaultOrientation(BaseImviz_WCS_WCS):
                 self.viewer, {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
             mp._obj._on_viewer_key_event(self.viewer, {'event': 'keydown', 'key': 'm'})
 
-            lc_plugin.link_type = 'Pixels'
+            lc_plugin.align_by = 'Pixels'
 
             # Both marks now get separated, so this means X and Y w.r.t. reference
             # are different on both entries.
@@ -122,7 +122,7 @@ class TestDefaultOrientation(BaseImviz_WCS_WCS):
 class TestNonDefaultOrientation(BaseImviz_WCS_WCS):
     def test_N_up_multi_viewer(self):
         lc_plugin = self.imviz.plugins['Orientation']
-        lc_plugin.link_type = 'WCS'
+        lc_plugin.align_by = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
         lc_plugin._obj.create_north_up_east_left(set_on_create=True)
@@ -143,17 +143,17 @@ class TestNonDefaultOrientation(BaseImviz_WCS_WCS):
         assert lc_plugin.orientation.selected == "North-up, East-left"
 
         # Both viewers should revert back to same reference when pixel-linked.
-        lc_plugin.link_type = 'Pixels'
+        lc_plugin.align_by = 'Pixels'
         assert self.viewer.state.reference_data.label == "has_wcs_1[SCI,1]"
         assert viewer_2.state.reference_data.label == "has_wcs_1[SCI,1]"
 
-        lc_plugin.link_type = 'WCS'
+        lc_plugin.align_by = 'WCS'
         assert self.viewer.state.reference_data.label == "Default orientation"
         assert viewer_2.state.reference_data.label == "Default orientation"
 
     def test_custom_orientation(self):
         lc_plugin = self.imviz.plugins['Orientation']
-        lc_plugin.link_type = 'WCS'
+        lc_plugin.align_by = 'WCS'
         lc_plugin.viewer = "imviz-0"
 
         lc_plugin.rotation_angle = 42  # Triggers auto-label
@@ -166,7 +166,7 @@ class TestDeleteOrientation(BaseImviz_WCS_WCS):
 
     def test_delete_orientation_multi_viewer(self):
         lc_plugin = self.imviz.plugins['Orientation']
-        lc_plugin.link_type = 'WCS'
+        lc_plugin.align_by = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
         lc_plugin._obj.create_north_up_east_left(set_on_create=True)
@@ -189,7 +189,7 @@ class TestDeleteOrientation(BaseImviz_WCS_WCS):
          (-0.5 * u.rad, 3.641589)])
     def test_delete_orientation_with_subset(self, klass, angle, sbst_theta):
         lc_plugin = self.imviz.plugins['Orientation']
-        lc_plugin.link_type = 'WCS'
+        lc_plugin.align_by = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
         lc_plugin._obj.create_north_up_east_left(set_on_create=True)
@@ -228,7 +228,7 @@ class TestDeleteOrientation(BaseImviz_WCS_WCS):
 class TestOrientationNoData(BaseImviz_WCS_WCS):
     def test_create_no_data(self):
         lc_plugin = self.imviz.plugins['Orientation']
-        lc_plugin.link_type = 'WCS'
+        lc_plugin.align_by = 'WCS'
 
         self.imviz.create_image_viewer()
         lc_plugin.viewer = "imviz-1"
@@ -238,7 +238,7 @@ class TestOrientationNoData(BaseImviz_WCS_WCS):
 
     def test_select_no_data(self):
         lc_plugin = self.imviz.plugins['Orientation']
-        lc_plugin.link_type = 'WCS'
+        lc_plugin.align_by = 'WCS'
 
         lc_plugin._obj.create_north_up_east_left(set_on_create=True)
 

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -14,12 +14,12 @@ class TestDefaultOrientation(BaseImviz_WCS_WCS):
         lc_plugin = self.imviz.plugins['Orientation']
 
         lc_plugin.link_type = 'WCS'
-        lc_plugin.wcs_use_affine = False
+        lc_plugin.fast_approximation = False
         assert self.imviz.get_link_type("Default orientation", "has_wcs_2[SCI,1]") == "wcs"
 
-        # wcs_use_affine should revert/default to True when change back to Pixels.
+        # fast_approximation should revert/default to True when change back to Pixels.
         lc_plugin.link_type = 'Pixels'
-        assert lc_plugin.wcs_use_affine is True
+        assert lc_plugin.fast_approximation is True
         assert self.imviz.get_link_type("has_wcs_1[SCI,1]", "has_wcs_2[SCI,1]") == "pixels"
 
         assert self.imviz.get_link_type("has_wcs_1[SCI,1]", "has_wcs_1[SCI,1]") == "self"

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -14,12 +14,12 @@ class TestDefaultOrientation(BaseImviz_WCS_WCS):
         lc_plugin = self.imviz.plugins['Orientation']
 
         lc_plugin.align_by = 'WCS'
-        lc_plugin.fast_approximation = False
+        lc_plugin.wcs_fast_approximation = False
         assert self.imviz.get_alignment_method("Default orientation", "has_wcs_2[SCI,1]") == "wcs"
 
-        # fast_approximation should revert/default to True when change back to Pixels.
+        # wcs_fast_approximation should revert/default to True when change back to Pixels.
         lc_plugin.align_by = 'Pixels'
-        assert lc_plugin.fast_approximation is True
+        assert lc_plugin.wcs_fast_approximation is True
         assert self.imviz.get_alignment_method("has_wcs_1[SCI,1]", "has_wcs_2[SCI,1]") == "pixels"
 
         assert self.imviz.get_alignment_method("has_wcs_1[SCI,1]", "has_wcs_1[SCI,1]") == "self"

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -18,7 +18,7 @@ from jdaviz.tests.test_utils import PHOTUTILS_LT_1_12_1
 
 class TestSimpleAperPhot(BaseImviz_WCS_WCS):
     def test_plugin_wcs_dithered(self):
-        self.imviz.link_data(link_type='wcs')  # They are dithered by 1 pixel on X
+        self.imviz.link_data(align_by='wcs')  # They are dithered by 1 pixel on X
 
         reg = CirclePixelRegion(center=PixCoord(x=4.5, y=4.5), radius=4.5).to_sky(self.wcs_1)
         self.imviz.load_regions(reg)
@@ -206,7 +206,7 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
                              'flux_scaling': 3}]
 
     def test_batch_phot(self):
-        self.imviz.link_data(link_type='wcs')  # They are dithered by 1 pixel on X
+        self.imviz.link_data(align_by='wcs')  # They are dithered by 1 pixel on X
         self.imviz._apply_interactive_region('bqplot:truecircle', (0, 0), (9, 9))  # Draw a circle
 
         # TODO: remove ._obj when API is made public
@@ -272,7 +272,7 @@ class TestAdvancedAperPhot:
         imviz_helper.load_data(get_pkg_data_filename('data/gauss100_fits_wcs_block_reduced_rotated.fits'))  # noqa: E501
 
         # Link them by WCS
-        imviz_helper.link_data(link_type='wcs')
+        imviz_helper.link_data(align_by='wcs')
         w = imviz_helper.app.data_collection[0].coords
 
         # Regions to be used for aperture photometry

--- a/jdaviz/configs/imviz/tests/test_subset_centroid.py
+++ b/jdaviz/configs/imviz/tests/test_subset_centroid.py
@@ -37,7 +37,7 @@ class TestImvizSpatialSubsetCentroidWCSLinked(BaseImviz_WCS_GWCS):
     def test_centroiding_wcs(self):
         # FITS WCS and GWCS are rotated from each other.
         # Plain array always by pixel wrt FITS WCS.
-        self.imviz.link_data(link_type='wcs')
+        self.imviz.link_data(align_by='wcs')
 
         reg = CirclePixelRegion(PixCoord(2, 2), 3).to_sky(self.wcs_1)
         self.imviz.load_regions(reg)

--- a/jdaviz/configs/imviz/tests/test_tools.py
+++ b/jdaviz/configs/imviz/tests/test_tools.py
@@ -67,8 +67,8 @@ class TestPanZoomTools(BaseImviz_WCS_WCS):
         t_linkedpan.deactivate()
 
 
-@pytest.mark.parametrize("link_type", ["Pixels", "WCS"])
-def test_panzoom_click_center_linking(imviz_helper, link_type):
+@pytest.mark.parametrize("align_by", ["Pixels", "WCS"])
+def test_panzoom_click_center_linking(imviz_helper, align_by):
     """https://github.com/spacetelescope/jdaviz/issues/2749"""
     v = imviz_helper.default_viewer._obj
 
@@ -85,11 +85,11 @@ def test_panzoom_click_center_linking(imviz_helper, link_type):
     imviz_helper.load_data(NDData(arr_small, wcs=w_small), data_label="small")
 
     lc_plugin = imviz_helper.plugins['Orientation']
-    lc_plugin.link_type = link_type
+    lc_plugin.align_by = align_by
 
     coo = SkyCoord(ra=197.89262754541807, dec=-1.3644568140486624, unit="deg")
 
-    if link_type == "WCS":
+    if align_by == "WCS":
         mouseover_loc = v.state.reference_data.coords.world_to_pixel(coo)
     else:  # Pixels
         mouseover_loc = w_small.world_to_pixel(coo)

--- a/jdaviz/configs/imviz/tests/test_wcs_utils.py
+++ b/jdaviz/configs/imviz/tests/test_wcs_utils.py
@@ -114,7 +114,7 @@ class TestWCSOnly(BaseImviz_WCS_GWCS):
 
     # TODO: Replace private API calls with more public ones when available.
     def test_non_wcs_layer_labels(self):
-        self.imviz.link_data(link_type="wcs")
+        self.imviz.link_data(align_by="wcs")
         assert len(self.imviz.app.data_collection) == 3
 
         # Confirm the WCS-only layer is created by WCS-linking .

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -343,11 +343,11 @@ class SliceToolStateMessage(Message):
 
 class LinkUpdatedMessage(Message):
     '''Message generated when the WCS/pixel linking is changed'''
-    def __init__(self, link_type, wcs_use_fallback, wcs_use_affine, *args, **kwargs):
+    def __init__(self, link_type, wcs_use_fallback, fast_approximation, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._link_type = link_type
         self._wcs_use_fallback = wcs_use_fallback
-        self._wcs_use_affine = wcs_use_affine
+        self._fast_approximation = fast_approximation
 
     @property
     def link_type(self):
@@ -358,8 +358,8 @@ class LinkUpdatedMessage(Message):
         return self._wcs_use_fallback
 
     @property
-    def wcs_use_affine(self):
-        return self._wcs_use_affine
+    def fast_approximation(self):
+        return self._fast_approximation
 
 
 class ExitBatchLoadMessage(Message):

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -343,11 +343,11 @@ class SliceToolStateMessage(Message):
 
 class LinkUpdatedMessage(Message):
     '''Message generated when the WCS/pixel linking is changed'''
-    def __init__(self, link_type, wcs_use_fallback, fast_approximation, *args, **kwargs):
+    def __init__(self, link_type, wcs_use_fallback, wcs_fast_approximation, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._link_type = link_type
         self._wcs_use_fallback = wcs_use_fallback
-        self._fast_approximation = fast_approximation
+        self._wcs_fast_approximation = wcs_fast_approximation
 
     @property
     def link_type(self):
@@ -358,8 +358,8 @@ class LinkUpdatedMessage(Message):
         return self._wcs_use_fallback
 
     @property
-    def fast_approximation(self):
-        return self._fast_approximation
+    def wcs_fast_approximation(self):
+        return self._wcs_fast_approximation
 
 
 class ExitBatchLoadMessage(Message):

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -797,7 +797,7 @@ class ImageConfigHelper(ConfigHelper):
                                     RectangularAperture, CircularAnnulus,
                                     CirclePixelRegion, EllipsePixelRegion,
                                     RectanglePixelRegion, CircleAnnulusPixelRegion))
-                    and self.app._link_type == "wcs"):
+                    and self.app._align_by == "wcs"):
                 bad_regions.append((region, 'Pixel region provided by data is linked by WCS'))
                 continue
 
@@ -898,7 +898,7 @@ class ImageConfigHelper(ConfigHelper):
 
         regions = {}
         failed_regs = set()
-        to_sky = self.app._link_type == 'wcs'
+        to_sky = self.app._align_by == 'wcs'
 
         # Subset is global, so we just use default viewer.
         for lyr in self.default_viewer._obj.layers:

--- a/jdaviz/core/region_translators.py
+++ b/jdaviz/core/region_translators.py
@@ -30,7 +30,7 @@ def _get_region_from_spatial_subset(plugin_obj, subset_state):
     plugin_obj : obj
         Plugin instance that needs this translation.
         The plugin is assumed to have a special setup that gives
-        it access to these attributes: ``app`` and ``app._link_type``.
+        it access to these attributes: ``app`` and ``app._align_by``.
 
     subset_state : obj
         ROI subset state to translate.
@@ -52,9 +52,9 @@ def _get_region_from_spatial_subset(plugin_obj, subset_state):
     # the current viewer reference data, which can be changed.
 
     # Mixed link types no longer allowed, so just check app setting.
-    link_type = plugin_obj.app._link_type
+    align_by = plugin_obj.app._align_by
 
-    return roi_subset_state_to_region(subset_state, to_sky=(link_type == 'wcs'))
+    return roi_subset_state_to_region(subset_state, to_sky=(align_by == 'wcs'))
 
 
 def regions2roi(region_shape, wcs=None):

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -413,7 +413,7 @@ def test_recenter_linked_by_wcs(imviz_helper):
         'data/gauss100_fits_wcs_block_reduced.fits', package='jdaviz.configs.imviz.tests'))
 
     # Link them by WCS
-    imviz_helper.link_data(link_type='wcs')
+    imviz_helper.link_data(align_by='wcs')
     w = imviz_helper.app.data_collection[0].coords
 
     # This rectangle is over a real object in reference image but

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -167,7 +167,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imviz.link_data(link_type='wcs')"
+    "imviz.link_data(align_by='wcs')"
    ]
   },
   {
@@ -702,7 +702,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.12.0"
   }
  },
  "nbformat": 4,

--- a/notebooks/concepts/imviz_advanced_aper_phot.ipynb
+++ b/notebooks/concepts/imviz_advanced_aper_phot.ipynb
@@ -172,7 +172,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imviz.link_data(link_type='wcs')"
+    "imviz.link_data(align_by='wcs')"
    ]
   },
   {

--- a/notebooks/concepts/imviz_compass_mpl.ipynb
+++ b/notebooks/concepts/imviz_compass_mpl.ipynb
@@ -501,7 +501,7 @@
     "imviz.load_data(hdu1, data_label='has_wcs_1')\n",
     "imviz.load_data(hdu2, data_label='has_wcs_2')\n",
     "imviz.load_data(a, data_label='no_wcs')\n",
-    "imviz.link_data(link_type='wcs')\n",
+    "imviz.link_data(align_by='wcs')\n",
     "imviz.show()"
    ]
   },

--- a/notebooks/concepts/imviz_dithered_gwcs.ipynb
+++ b/notebooks/concepts/imviz_dithered_gwcs.ipynb
@@ -102,7 +102,7 @@
    "source": [
     "# Link by WCS\n",
     "imviz.plugins['Orientation'].align_by = 'WCS'\n",
-    "imviz.plugins['Orientation'].fast_approximation = True"
+    "imviz.plugins['Orientation'].wcs_fast_approximation = True"
    ]
   },
   {

--- a/notebooks/concepts/imviz_dithered_gwcs.ipynb
+++ b/notebooks/concepts/imviz_dithered_gwcs.ipynb
@@ -102,7 +102,7 @@
    "source": [
     "# Link by WCS\n",
     "imviz.plugins['Orientation'].align_by = 'WCS'\n",
-    "imviz.plugins['Orientation'].wcs_use_affine = True"
+    "imviz.plugins['Orientation'].fast_approximation = True"
    ]
   },
   {

--- a/notebooks/concepts/imviz_dithered_gwcs.ipynb
+++ b/notebooks/concepts/imviz_dithered_gwcs.ipynb
@@ -101,7 +101,7 @@
    "outputs": [],
    "source": [
     "# Link by WCS\n",
-    "imviz.plugins['Orientation'].link_type = 'WCS'\n",
+    "imviz.plugins['Orientation'].align_by = 'WCS'\n",
     "imviz.plugins['Orientation'].wcs_use_affine = True"
    ]
   },

--- a/notebooks/concepts/imviz_roman_asdf.ipynb
+++ b/notebooks/concepts/imviz_roman_asdf.ipynb
@@ -130,7 +130,7 @@
    "source": [
     "orientation = imviz.plugins['Orientation']\n",
     "\n",
-    "orientation.link_type = 'WCS'"
+    "orientation.align_by = 'WCS'"
    ]
   },
   {

--- a/notebooks/concepts/imviz_simple_aper_phot.ipynb
+++ b/notebooks/concepts/imviz_simple_aper_phot.ipynb
@@ -87,7 +87,7 @@
     "    imviz.load_data(acs_47tuc_2, data_label='acs_47tuc_2')\n",
     "\n",
     "# These are dithered, so we re-link by WCS.\n",
-    "imviz.link_data(link_type='wcs')"
+    "imviz.link_data(align_by='wcs')"
    ]
   },
   {


### PR DESCRIPTION
Changes `link_type` to `align_by` and `wcs_use_affine` to `fast_approximation` to match the text that is in the UI. Opening as draft since I still need to add deprecated versions of the old API.