### PR TITLE
get_data(use_display_units=True) to respect flux or sb selection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ New Features
 ------------
 
 - Added flux/surface brightness translation and surface brightness
-  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113]
+  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113, #3129]
 
 - Plugin tray is now open by default. [#2892]
 

--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -137,7 +137,7 @@ def test_unit_translation(cubeviz_helper):
     w = WCS(wcs_dict)
     flux = np.zeros((30, 20, 3001), dtype=np.float32)
     flux[5:15, 1:11, :] = 1
-    cube = Spectrum1D(flux=flux * u.MJy, wcs=w, meta=wcs_dict)
+    cube = Spectrum1D(flux=flux * u.MJy / u.sr, wcs=w, meta=wcs_dict)
     cubeviz_helper.load_data(cube, data_label="test")
 
     center = PixCoord(5, 10)
@@ -152,6 +152,10 @@ def test_unit_translation(cubeviz_helper):
     # data collection item units will be used for translations.
     assert uc_plg._obj.flux_or_sb_selected == 'Flux'
 
+    # accessing from get_data(use_display_units=True) should return flux-like units
+    assert cubeviz_helper.app._get_display_unit('spectral_y') == u.MJy
+    assert cubeviz_helper.get_data('Spectrum (sum)', use_display_units=True).unit == u.MJy
+
     # to have access to display units
     viewer_1d = cubeviz_helper.app.get_viewer(
         cubeviz_helper._default_spectrum_viewer_reference_name)
@@ -164,6 +168,10 @@ def test_unit_translation(cubeviz_helper):
 
     # check if units translated
     assert y_display_unit == u.MJy / u.sr
+
+    # get_data(use_display_units=True) should return surface brightness-like units
+    assert cubeviz_helper.app._get_display_unit('spectral_y') == u.MJy / u.sr
+    assert cubeviz_helper.get_data('Spectrum (sum)', use_display_units=True).unit == u.MJy / u.sr
 
 
 def test_sb_unit_conversion(cubeviz_helper):

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -470,7 +470,7 @@ class ConfigHelper(HubListener):
                 spectral_unit = self.app._get_display_unit('spectral')
                 if not spectral_unit:
                     return data
-                flux_unit = self.app._get_display_unit('flux')
+                y_unit = self.app._get_display_unit('spectral_y')
                 # TODO: any other attributes (meta, wcs, etc)?
                 # TODO: implement uncertainty.to upstream
                 uncertainty = data.uncertainty
@@ -488,26 +488,26 @@ class ConfigHelper(HubListener):
                         new_uncert = uncertainty
                     if ('_pixel_scale_factor' in data.meta):
                         new_uncert_converted = flux_conversion(data, new_uncert.quantity.value,
-                                                               new_uncert.unit, flux_unit)
-                        new_uncert = StdDevUncertainty(new_uncert_converted, unit=flux_unit)
+                                                               new_uncert.unit, y_unit)
+                        new_uncert = StdDevUncertainty(new_uncert_converted, unit=y_unit)
                     else:
                         new_uncert = StdDevUncertainty(new_uncert, unit=data.flux.unit)
 
                 else:
                     new_uncert = None
                 if ('_pixel_scale_factor' in data.meta):
-                    new_flux = flux_conversion(data, data.flux.value, data.flux.unit,
-                                               flux_unit) * u.Unit(flux_unit)
+                    new_y = flux_conversion(data, data.flux.value, data.flux.unit,
+                                            y_unit) * u.Unit(y_unit)
                 else:
-                    new_flux = flux_conversion(data, data.flux.value, data.flux.unit,
-                                               data.flux.unit) * u.Unit(data.flux.unit)
+                    new_y = flux_conversion(data, data.flux.value, data.flux.unit,
+                                            data.flux.unit) * u.Unit(data.flux.unit)
                 new_spec = (spectral_axis_conversion(data.spectral_axis.value,
                                                      data.spectral_axis.unit,
                                                      spectral_unit)
                             * u.Unit(spectral_unit))
 
                 data = Spectrum1D(spectral_axis=new_spec,
-                                  flux=new_flux,
+                                  flux=new_y,
                                   uncertainty=new_uncert,
                                   mask=data.mask)
             else:  # pragma: nocover

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2955,17 +2955,6 @@ class SpectralContinuumMixin(VuetifyTemplate, HubListener):
                 raise ValueError("per-pixel only supported for cubeviz")
             full_spectrum = self.app._jdaviz_helper.get_data(self.dataset.selected,
                                                              use_display_units=True)
-            # TODO: Something like the following code may be needed to get continuum
-            #  with display units working
-            # temp_spec = self.app._jdaviz_helper.get_data(self.dataset.selected,
-            #                                              use_display_units=True)
-            # flux_values = np.sum(np.ones_like(temp_spec.flux.value), axis=(0, 1))
-            # pix_scale = self.dataset.selected_dc_item.meta.get('PIXAR_SR', 1.0)
-            # pix_scale_factor = (flux_values * pix_scale)
-            # temp_spec.meta['_pixel_scale_factor'] = pix_scale_factor
-            # full_spectrum = self._specviz_helper._handle_display_units(temp_spec,
-            #                                                            use_display_units=True)
-
         else:
             full_spectrum = dataset.get_selected_spectrum(use_display_units=True)
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes `viz.get_data(use_display_units=True)` on a 1d spectrum to respect the user choice of surface brightness or flux units.  This then fixes the previews in line-analysis, which are calling `get_data(use_display_units=True)` under-the-hood when computing the continuum.

https://github.com/user-attachments/assets/693fcb14-be3a-4f8a-9df4-8bdfafbdc7e7



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
