### PR TITLE
markers: ensure units stored as string

### DIFF
--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -495,7 +495,7 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                 dq_text = ''
             self.row1b_text = f'{value:+10.5e} {unit}{dq_text}'
             self._dict['value'] = float(value)
-            self._dict['value:unit'] = unit
+            self._dict['value:unit'] = str(unit)
             self._dict['value:unreliable'] = unreliable_pixel
         else:
             self.row1b_title = ''
@@ -518,9 +518,9 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
     def _spectrum_viewer_update(self, viewer, x, y):
         def _cursor_fallback():
             self._dict['axes_x'] = x
-            self._dict['axes_x:unit'] = viewer.state.x_display_unit
+            self._dict['axes_x:unit'] = str(viewer.state.x_display_unit)
             self._dict['axes_y'] = y
-            self._dict['axes_y:unit'] = viewer.state.y_display_unit
+            self._dict['axes_y:unit'] = str(viewer.state.y_display_unit)
             self._dict['data_label'] = ''
 
         def _copy_axes_to_spectral():
@@ -642,7 +642,7 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
         self.row3_title = 'Flux'
         self.row3_text = f'{closest_flux:10.5e} {flux_unit}'
         self._dict['axes_y'] = closest_flux
-        self._dict['axes_y:unit'] = viewer.state.y_display_unit
+        self._dict['axes_y:unit'] = str(viewer.state.y_display_unit)
 
         if closest_icon is not None:
             self.icon = closest_icon


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request ensures the units in the markers plugin are in string and fixes adding a marker to the spectrum viewer followed by one of the cube viewers.  This bug is confirmed to not be present in 3.10.x, so should not need backporting or a changelog entry.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
