### PR TITLE
stop counts cube from entering translator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ New Features
 ------------
 
 - Added flux/surface brightness translation and surface brightness
-  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113, #3129]
+  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113, #3129, #3136]
 
 - Plugin tray is now open by default. [#2892]
 

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -228,7 +228,10 @@ class UnitConversion(PluginTemplateMixin):
                 self.can_translate = False
             else:
                 self.can_translate = True
-        elif name == 'flux_or_sb_selected':
+        # Traitlet to translate has been changed. However, when a cube
+        # is in u.count, we set flux_or_sb_selected to 'Flux', entering
+        # the translator, the second condition ensures we don't.
+        elif name == 'flux_or_sb_selected' and self.spectrum_viewer.state.y_display_unit != 'ct':
             self._translate(self.flux_or_sb_selected)
             return
         else:
@@ -310,7 +313,7 @@ class UnitConversion(PluginTemplateMixin):
             u.erg / (u.s * u.cm**2 * u.Hz),
             u.ph / (u.Angstrom * u.s * u.cm**2),
             u.ph / (u.s * u.cm**2 * u.Hz),
-            u.ST, u.bol
+            u.ST, u.bol, u.count
         ]
 
     def _append_angle_correctly(self, flux_unit, angle_unit):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

On app startup, when a cube with u.count units is loaded into Cubeviz, the `flux_or_sb_selected` is set to 'Flux'. This would then trigger `_on_flux_unit_changed()`, and enter the condition for translating. An additional condition has been added to ensure that `flux_or_sb_selected` can be set without entering the translator when the native units are in counts.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
