### PR TITLE
observe display traitlets separately in unit conversion, remove redundant GlobalDisplayUnitChange broadcast

### DIFF
--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -120,7 +120,8 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
         self._create_viewer_callbacks(self.app.get_viewer_by_id(msg.viewer_id))
 
     def _on_global_display_unit_changed(self, msg):
-        if msg.axis == "sb":
+        # eventually should observe change in flux OR angle
+        if msg.axis == "flux":
             self.image_unit = u.Unit(msg.unit)
 
     @property

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -179,9 +179,6 @@ class UnitConversion(PluginTemplateMixin):
                 self.flux_unit.selected,
                 self.angle_unit.selected
             )
-            self.hub.broadcast(GlobalDisplayUnitChanged('sb',
-                                                        self.sb_unit_selected,
-                                                        sender=self))
 
             if not self.flux_unit.selected:
                 y_display_unit = self.spectrum_viewer.state.y_display_unit

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -196,8 +196,21 @@ class UnitConversion(PluginTemplateMixin):
                                self.spectral_unit.selected,
                                sender=self))
 
-    @observe('flux_or_sb_selected', 'flux_unit_selected')
+    @observe('flux_or_sb_selected')
+    def _on_flux_or_sb_selected(self, msg):
+        """
+        Observes toggle between surface brightness or flux selection for
+        spectrum viewer to trigger translation.
+        """
+
+        if msg.get('name') == 'flux_or_sb_selected':
+            self._translate(self.flux_or_sb_selected)
+
+    @observe('flux_unit_selected')
     def _on_flux_unit_changed(self, msg):
+
+        """ Handle changes in selected flux unit."""
+
         # may need to be updated if translations in other configs going to be supported
         if not hasattr(self, 'flux_unit'):
             return
@@ -206,44 +219,37 @@ class UnitConversion(PluginTemplateMixin):
 
         flux_or_sb = None
 
-        name = msg.get('name')
-        # determine if flux or surface brightness unit was changed by user
-        if name == 'flux_unit_selected':
-            # when the configuration is Specviz, translation is not currently supported.
-            # If in Cubeviz, all spectra pass through Spectral Extraction plugin and will
-            # have a scale factor assigned in the metadata, enabling translation.
-            current_y_unit = self.spectrum_viewer.state.y_display_unit
-            if self.angle_unit.selected and check_if_unit_is_per_solid_angle(current_y_unit):
-                flux_or_sb = self._append_angle_correctly(
-                             self.flux_unit.selected,
-                             self.angle_unit.selected
-                )
-            else:
-                flux_or_sb = self.flux_unit.selected
-            untranslatable_units = self._untranslatable_units
-            # disable translator if flux unit is untranslatable,
-            # still can convert flux units, this just disables flux
-            # to surface brightnes translation for units in list.
-            if flux_or_sb in untranslatable_units:
-                self.can_translate = False
-            else:
-                self.can_translate = True
-        elif name == 'flux_or_sb_selected':
-            self._translate(self.flux_or_sb_selected)
+        if msg.get('name') != 'flux_unit_selected':
+            # not sure when this would be encountered but keeping as a safeguard
             return
+
+        # when the configuration is Specviz, translation is not currently supported.
+        # If in Cubeviz, all spectra pass through Spectral Extraction plugin and will
+        # have a scale factor assigned in the metadata, enabling translation.
+        current_y_unit = self.spectrum_viewer.state.y_display_unit
+        if self.angle_unit.selected and check_if_unit_is_per_solid_angle(current_y_unit):
+            flux_or_sb = self._append_angle_correctly(
+                         self.flux_unit.selected,
+                         self.angle_unit.selected
+            )
         else:
-            return
+            flux_or_sb = self.flux_unit.selected
+        untranslatable_units = self._untranslatable_units
+        # disable translator if flux unit is untranslatable,
+        # still can convert flux units, this just disables flux
+        # to surface brightnes translation for units in list.
+        if flux_or_sb in untranslatable_units:
+            self.can_translate = False
+        else:
+            self.can_translate = True
 
         yunit = _valid_glue_display_unit(flux_or_sb, self.spectrum_viewer, 'y')
 
         if self.spectrum_viewer.state.y_display_unit != yunit:
             self.spectrum_viewer.state.y_display_unit = yunit
             self.spectrum_viewer.reset_limits()
-            self.hub.broadcast(
-                GlobalDisplayUnitChanged(
-                    "flux" if name == "flux_unit_selected" else "sb", flux_or_sb, sender=self
-                    )
-                )
+            self.hub.broadcast(GlobalDisplayUnitChanged("flux", flux_or_sb, sender=self))
+
         if not check_if_unit_is_per_solid_angle(self.spectrum_viewer.state.y_display_unit):
             self.flux_or_sb_selected = 'Flux'
         else:

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -210,7 +210,7 @@ class UnitConversion(PluginTemplateMixin):
         Observes changes in selected flux unit.
 
         When the selected flux unit changes, a GlobalDisplayUnitChange needs
-        to be broadcasted indicating that the flux unit has changed. 
+        to be broadcasted indicating that the flux unit has changed.
 
         Note: The 'axis' of the broadcast should always be 'flux', even though a
         change in flux unit indicates a change in surface brightness unit, because
@@ -258,7 +258,7 @@ class UnitConversion(PluginTemplateMixin):
             self.spectrum_viewer.state.y_display_unit = yunit
             self.spectrum_viewer.reset_limits()
 
-            # and broacast that there has been a change in flux 
+            # and broacast that there has been a change in flux
             self.hub.broadcast(GlobalDisplayUnitChanged("flux", flux_or_sb, sender=self))
 
         if not check_if_unit_is_per_solid_angle(self.spectrum_viewer.state.y_display_unit):


### PR DESCRIPTION
In my ongoing work to generalize unit conversion to support non-steradian surface brightness units, traitlets for flux, angle, flux/sb toggling separately. This PR represents some of that reorganization so that rebasing on my eventual PR for others working on unit conversion is less complicated, and to make sure this change doesn't impact anything.

One change to note here is that previously there was some logic to broadcast a GlobalDisplayUnitChange that could either be flux or surface brightness, but in reality it could only ever be flux if you look at the logic (there is a return if 'name' is ever not flux, so that would just never be encountered), so that change is made here as well. 

Anything subscribed to GlobalDisplayUnitChange looking for a change in surface brightness should really be looking for a change in flux (and eventually also a change in angle) since surface brightness is read only. I updated coords_info method subscribed to GlobalDisplayUnitChange to look for changes in the 'flux' axis rather than 'sb' - the unit conversion plugin should only be broadcasting changes in flux or angle. 

I removed (what i think is) a redundant broadcast of GlobalDisplayUnitChange from _on_glue_y_display_unit_changed as well. 