### PR TITLE
remove magnitude units from display units list

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -80,14 +80,13 @@ class UnitConverterWithSpectral:
                     'erg / (s cm2 Angstrom)', 'erg / (s cm2 Angstrom)',
                     'erg / (s cm2 Hz)', 'erg / (Hz s cm2)',
                     'ph / (Angstrom s cm2)',
-                    'ph / (Hz s cm2)', 'ph / (Hz s cm2)', 'bol', 'AB', 'ST'
+                    'ph / (Hz s cm2)', 'ph / (Hz s cm2)'
                 ]
                 + [
                     'Jy / sr', 'mJy / sr', 'uJy / sr', 'MJy / sr',
                     'W / (Hz sr m2)',
                     'eV / (Hz s sr m2)',
                     'erg / (s sr cm2)',
-                    'AB / sr'
                 ])
         else:  # spectral axis
             # prefer Hz over Bq and um over micron

--- a/jdaviz/core/validunits.py
+++ b/jdaviz/core/validunits.py
@@ -84,7 +84,7 @@ def create_flux_equivalencies_list(flux_unit, spectral_axis_unit):
 
     # Remove overlap units.
     curr_flux_unit_equivalencies = list(set(curr_flux_unit_equivalencies)
-                                        - set(local_units) - set(mag_units))
+                                        - set(local_units))
 
     # Convert equivalencies into readable versions of the units and sort them alphabetically.
     flux_unit_equivalencies_titles = sorted(units_to_strings(curr_flux_unit_equivalencies))

--- a/jdaviz/core/validunits.py
+++ b/jdaviz/core/validunits.py
@@ -67,6 +67,10 @@ def create_flux_equivalencies_list(flux_unit, spectral_axis_unit):
     except u.core.UnitConversionError:
         return []
 
+    mag_units = ['bol', 'AB', 'ST']
+    # remove magnitude units from list
+    curr_flux_unit_equivalencies = [unit for unit in curr_flux_unit_equivalencies if not any(mag in unit.name for mag in mag_units)]  # noqa
+
     # Get local flux units.
     locally_defined_flux_units = ['Jy', 'mJy', 'uJy', 'MJy',
                                   'W / (Hz m2)',
@@ -75,13 +79,12 @@ def create_flux_equivalencies_list(flux_unit, spectral_axis_unit):
                                   'erg / (s cm2 Angstrom)',
                                   'ph / (Angstrom s cm2)',
                                   'ph / (Hz s cm2)',
-                                  'bol', 'AB', 'ST'
                                   ]
     local_units = [u.Unit(unit) for unit in locally_defined_flux_units]
 
     # Remove overlap units.
     curr_flux_unit_equivalencies = list(set(curr_flux_unit_equivalencies)
-                                        - set(local_units))
+                                        - set(local_units) - set(mag_units))
 
     # Convert equivalencies into readable versions of the units and sort them alphabetically.
     flux_unit_equivalencies_titles = sorted(units_to_strings(curr_flux_unit_equivalencies))


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address removing magnitude units from the Unit Conversion plugin, as there may be incorrect scientific calculation made in spectral extraction and aperture photometry when a magnitude unit is selected. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
