### PR TITLE
broadcast sb change for mouseover

### DIFF
--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -121,7 +121,7 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
 
     def _on_global_display_unit_changed(self, msg):
         # eventually should observe change in flux OR angle
-        if msg.axis == "flux":
+        if msg.axis == "sb":
             self.image_unit = u.Unit(msg.unit)
 
     @property

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -179,6 +179,7 @@ class UnitConversion(PluginTemplateMixin):
                 self.flux_unit.selected,
                 self.angle_unit.selected
             )
+            self.hub.broadcast(GlobalDisplayUnitChanged("sb", self.sb_unit_selected, sender=self))
 
             if not self.flux_unit.selected:
                 y_display_unit = self.spectrum_viewer.state.y_display_unit
@@ -260,6 +261,7 @@ class UnitConversion(PluginTemplateMixin):
 
             # and broacast that there has been a change in flux
             self.hub.broadcast(GlobalDisplayUnitChanged("flux", flux_or_sb, sender=self))
+
 
         if not check_if_unit_is_per_solid_angle(self.spectrum_viewer.state.y_display_unit):
             self.flux_or_sb_selected = 'Flux'


### PR DESCRIPTION
Adding back in a GlobalDisplayUnitChanged so mouseover can pick up surface brightness info when the spectrum viewer is in flux.

I'm thinking of a better way to do this because having this here does mean a GlobalDisplayUnitChanged will be broadcasted twice for every change in flux unit (once when the unit is changed, and once again when the spectrum viewer y axis is updated), but this needs to be reverted for now to fix the issue with coords_info
