### PR TITLE
JWST L1 ramp parser for Rampviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ New Features
 
 - The standalone version of jdaviz now uses solara instead of voila, resulting in faster load times. [#2909]
 
+- New configuration for ramp/Level 1 data products from Roman WFI and JWST [#3120, #3148]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/rampviz/plugins/parsers.py
+++ b/jdaviz/configs/rampviz/plugins/parsers.py
@@ -245,7 +245,8 @@ def _parse_hdulist(
         flux_unit = u.DN
 
     # index the ramp array by the integration to load. returns all groups and pixels.
-    ramp_cube = hdu.data[integration]
+    # cast from uint16 to integers:
+    ramp_cube = hdu.data[integration].astype(int)
 
     metadata = standardize_metadata(hdu.header)
     if hdu.name != 'PRIMARY' and 'PRIMARY' in hdulist:
@@ -262,8 +263,6 @@ def _parse_hdulist(
 def _parse_ramp_cube(app, ramp_cube_data, flux_unit, file_name,
                      group_viewer_reference_name, diff_viewer_reference_name,
                      meta=None):
-    ramp_cube = NDDataArray(_swap_axes(ramp_cube_data), unit=flux_unit, meta=meta)
-
     # last axis is the group axis, first two are spatial axes:
     diff_data = np.vstack([
         # begin with a group of zeros, so
@@ -272,6 +271,7 @@ def _parse_ramp_cube(app, ramp_cube_data, flux_unit, file_name,
         np.diff(ramp_cube_data, axis=0)
     ])
 
+    ramp_cube = NDDataArray(_swap_axes(ramp_cube_data), unit=flux_unit, meta=meta)
     diff_cube = NDDataArray(_swap_axes(diff_data), unit=flux_unit, meta=meta)
 
     group_data_label = app.return_data_label(file_name, ext="DATA")

--- a/jdaviz/configs/rampviz/plugins/ramp_extraction/ramp_extraction.py
+++ b/jdaviz/configs/rampviz/plugins/ramp_extraction/ramp_extraction.py
@@ -156,7 +156,9 @@ class RampExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
             return
 
         # glue region has transposed coords relative to cached cube:
-        region_mask = region.to_mask().to_image(self.cube.shape[:-1]).astype(bool).T
+        region_mask = region.to_mask().to_image(
+            self.cube.shape[:-1][::-1]
+        ).astype(bool).T
         cube_subset = self.cube[region_mask]  # shape: (N pixels extracted, M groups)
 
         n_pixels_in_extraction = cube_subset.shape[0]
@@ -292,7 +294,7 @@ class RampExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
     @property
     def cube(self):
-        return self.app._jdaviz_helper.cube_cache[self.dataset.selected]
+        return self.app._jdaviz_helper.cube_cache.get(self.dataset.selected)
 
     @property
     def slice_display_unit(self):

--- a/jdaviz/configs/rampviz/tests/test_helper.py
+++ b/jdaviz/configs/rampviz/tests/test_helper.py
@@ -3,8 +3,24 @@ from jdaviz.configs.imviz.plugins.parsers import HAS_ROMAN_DATAMODELS
 
 
 @pytest.mark.skipif(not HAS_ROMAN_DATAMODELS, reason="roman_datamodels is not installed")
-def test_load_data(rampviz_helper, roman_level_1_ramp):
+def test_load_data_roman(rampviz_helper, roman_level_1_ramp):
     rampviz_helper.load_data(roman_level_1_ramp)
+
+    # on ramp cube load (1), the parser loads a diff cube (2) and
+    # the ramp extraction plugin produces a default extraction (3):
+    assert len(rampviz_helper.app.data_collection) == 3
+
+    # each viewer should have one loaded data entry:
+    for refname in 'group-viewer, diff-viewer, integration-viewer'.split(', '):
+        viewer = rampviz_helper.app.get_viewer(refname)
+        assert len(viewer.state.layers) == 1
+
+    assert viewer.axis_x.label == 'Group'
+    assert viewer.axis_y.label == 'DN'
+
+
+def test_load_data_jwst(rampviz_helper, jwst_level_1b_ramp):
+    rampviz_helper.load_data(jwst_level_1b_ramp)
 
     # on ramp cube load (1), the parser loads a diff cube (2) and
     # the ramp extraction plugin produces a default extraction (3):

--- a/jdaviz/configs/rampviz/tests/test_ramp_extraction.py
+++ b/jdaviz/configs/rampviz/tests/test_ramp_extraction.py
@@ -5,22 +5,30 @@ from jdaviz.configs.imviz.plugins.parsers import HAS_ROMAN_DATAMODELS
 
 
 @pytest.mark.skipif(not HAS_ROMAN_DATAMODELS, reason="roman_datamodels is not installed")
-def test_previews(rampviz_helper, roman_level_1_ramp):
-    rampviz_helper.load_data(roman_level_1_ramp)
+def test_previews_roman(rampviz_helper, roman_level_1_ramp):
+    _ramp_extraction_previews(rampviz_helper, roman_level_1_ramp)
+
+
+def test_previews_jwst(rampviz_helper, jwst_level_1b_ramp):
+    _ramp_extraction_previews(rampviz_helper, jwst_level_1b_ramp)
+
+
+def _ramp_extraction_previews(_rampviz_helper, _ramp_file):
+    _rampviz_helper.load_data(_ramp_file)
 
     # add subset:
     region = CirclePixelRegion(center=PixCoord(12.5, 15.5), radius=2)
-    rampviz_helper.load_regions(region)
-    ramp_extr = rampviz_helper.plugins['Ramp Extraction']._obj
+    _rampviz_helper.load_regions(region)
+    ramp_extr = _rampviz_helper.plugins['Ramp Extraction']._obj
 
-    subsets = rampviz_helper.app.get_subsets()
-    ramp_cube = rampviz_helper.app.data_collection[0]
+    subsets = _rampviz_helper.app.get_subsets()
+    ramp_cube = _rampviz_helper.app.data_collection[0]
     n_groups = ramp_cube.shape[-1]
 
     assert len(subsets) == 1
     assert 'Subset 1' in subsets
 
-    integration_viewer = rampviz_helper.app.get_viewer('integration-viewer')
+    integration_viewer = _rampviz_helper.app.get_viewer('integration-viewer')
 
     # contains a layer for the default ramp extraction and the subset:
     assert len(integration_viewer.layers) == 2

--- a/jdaviz/configs/rampviz/tests/test_slice.py
+++ b/jdaviz/configs/rampviz/tests/test_slice.py
@@ -4,8 +4,16 @@ from jdaviz.configs.imviz.plugins.parsers import HAS_ROMAN_DATAMODELS
 
 
 @pytest.mark.skipif(not HAS_ROMAN_DATAMODELS, reason="roman_datamodels is not installed")
-def test_slice(rampviz_helper, roman_level_1_ramp):
-    app = rampviz_helper.app
+def test_slice_roman(rampviz_helper, roman_level_1_ramp):
+    _slice(rampviz_helper, roman_level_1_ramp)
+
+
+def test_slice_jwst(rampviz_helper, jwst_level_1b_ramp):
+    _slice(rampviz_helper, jwst_level_1b_ramp)
+
+
+def _slice(helper, ramp_cube):
+    app = helper.app
     sl = Slice(app=app)
 
     # No data yet
@@ -19,11 +27,11 @@ def test_slice(rampviz_helper, roman_level_1_ramp):
     sl.vue_play_start_stop()
     assert not sl.is_playing
 
-    rampviz_helper.load_data(roman_level_1_ramp, data_label='test')
+    helper.load_data(ramp_cube, data_label='test')
     app.add_data_to_viewer("group-viewer", "test[DATA]")
     app.add_data_to_viewer("diff-viewer", "test[DATA]")
     app.add_data_to_viewer("integration-viewer", "Ramp (mean)")
-    sv = rampviz_helper.viewers['integration-viewer']._obj
+    sv = helper.viewers['integration-viewer']._obj
 
     # sample ramp only has 10 groups
     assert len(sv.slice_values) == 10
@@ -32,14 +40,14 @@ def test_slice(rampviz_helper, roman_level_1_ramp):
     assert len(slice_values) == 10
 
     assert sl.value == slice_values[len(slice_values) // 2]
-    assert rampviz_helper.app.get_viewer("group-viewer").slice == len(slice_values) // 2
-    assert rampviz_helper.app.get_viewer("group-viewer").state.slices[-1] == 5
-    assert rampviz_helper.app.get_viewer("diff-viewer").state.slices[-1] == 5
-    rampviz_helper.select_group(slice_values[0])
-    assert rampviz_helper.app.get_viewer("group-viewer").slice == 0
+    assert helper.app.get_viewer("group-viewer").slice == len(slice_values) // 2
+    assert helper.app.get_viewer("group-viewer").state.slices[-1] == 5
+    assert helper.app.get_viewer("diff-viewer").state.slices[-1] == 5
+    helper.select_group(slice_values[0])
+    assert helper.app.get_viewer("group-viewer").slice == 0
     assert sl.value == slice_values[0]
 
-    rampviz_helper.select_group(slice_values[1])
+    helper.select_group(slice_values[1])
     assert sl.value == slice_values[1]
 
     # Retrieve updated slice_values
@@ -69,12 +77,20 @@ def test_slice(rampviz_helper, roman_level_1_ramp):
 
 
 @pytest.mark.skipif(not HAS_ROMAN_DATAMODELS, reason="roman_datamodels is not installed")
-def test_indicator_settings(rampviz_helper, roman_level_1_ramp):
-    rampviz_helper.load_data(roman_level_1_ramp, data_label='test')
-    app = rampviz_helper.app
+def test_indicator_settings_roman(rampviz_helper, roman_level_1_ramp):
+    _indicator_settings(rampviz_helper, roman_level_1_ramp)
+
+
+def test_indicator_settings_jwst(rampviz_helper, jwst_level_1b_ramp):
+    _indicator_settings(rampviz_helper, jwst_level_1b_ramp)
+
+
+def _indicator_settings(helper, ramp):
+    helper.load_data(ramp, data_label='test')
+    app = helper.app
     app.add_data_to_viewer("group-viewer", "test[DATA]")
     app.add_data_to_viewer("integration-viewer", "Ramp (mean)")
-    sl = rampviz_helper.plugins['Slice']._obj
+    sl = helper.plugins['Slice']._obj
     sv = app.get_viewer('integration-viewer')
     indicator = sv.slice_indicator
 
@@ -91,11 +107,19 @@ def test_indicator_settings(rampviz_helper, roman_level_1_ramp):
 
 
 @pytest.mark.skipif(not HAS_ROMAN_DATAMODELS, reason="roman_datamodels is not installed")
-def test_init_slice(rampviz_helper, roman_level_1_ramp):
-    rampviz_helper.load_data(roman_level_1_ramp, data_label='test')
+def test_init_slice_roman(rampviz_helper, roman_level_1_ramp):
+    _init_slice(rampviz_helper, roman_level_1_ramp)
 
-    fv = rampviz_helper.app.get_viewer('group-viewer')
-    sl = rampviz_helper.plugins['Slice']
+
+def test_init_slice_jwst(rampviz_helper, jwst_level_1b_ramp):
+    _init_slice(rampviz_helper, jwst_level_1b_ramp)
+
+
+def _init_slice(helper, ramp):
+    helper.load_data(ramp, data_label='test')
+
+    fv = helper.app.get_viewer('group-viewer')
+    sl = helper.plugins['Slice']
     slice_values = sl._obj.valid_selection_values_sorted
 
     assert sl.value == slice_values[len(slice_values)//2]

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -71,6 +71,22 @@ def roman_level_1_ramp():
 
 
 @pytest.fixture
+def jwst_level_1b_ramp():
+    from stdatamodels.jwst.datamodels import Level1bModel
+
+    rng = np.random.default_rng(seed=42)
+
+    # JWST Level 1b ramp files have an additional preceding dimension
+    # compared with Roman. This dimension is the integration number
+    # in a sequence (if there's more than one in the visit).
+    shape = (1, 10, 25, 25)
+    data_model = Level1bModel(shape)
+    data_model.data = 100 + 3 * np.cumsum(rng.uniform(size=shape), axis=0)
+
+    return data_model
+
+
+@pytest.fixture
 def image_2d_wcs():
     return WCS({'CTYPE1': 'RA---TAN', 'CUNIT1': 'deg', 'CDELT1': -0.0002777777778,
                 'CRPIX1': 1, 'CRVAL1': 337.5202808,

--- a/notebooks/concepts/RampvizExample.ipynb
+++ b/notebooks/concepts/RampvizExample.ipynb
@@ -5,7 +5,7 @@
    "id": "39fa8c0d-da61-4704-9bba-c438347abf95",
    "metadata": {},
    "source": [
-    "# Visualize Roman L1 ramp files with Rampviz\n",
+    "# Visualize Level 1 ramp files with Rampviz\n",
     "\n",
     "\n",
     "To install jdaviz from source with the optional Roman dependencies:\n",
@@ -13,6 +13,8 @@
     "pip install .[roman]\n",
     "```\n",
     "\n",
+    "\n",
+    "## Roman WFI\n",
     "\n",
     "First, let's download a ramp file:"
    ]
@@ -122,7 +124,7 @@
     "# # If you re-run this cell, you may need to re-enable previews:\n",
     "# ramp_extract._obj.previews_temp_disabled = False\n",
     "\n",
-    "# ramp_extract.keep_active = True\n",
+    "ramp_extract.keep_active = True\n",
     "ramp_extract.function = 'Median'\n",
     "ramp_extract.aperture = 'Subset 1'\n",
     "\n",
@@ -130,9 +132,53 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "4ec8c7f6-27c6-405e-ac0f-8e943869fec2",
+   "metadata": {},
+   "source": [
+    "## [NIRCam-NIRSpec galaxy assembly survey - GOODS-N](https://www.stsci.edu/jwst/science-execution/program-information?id=1181) with MIRI:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ace3d5db-247e-4136-9851-e4ebab0ea9ea",
+   "id": "4cd6c7df-b997-44ed-81b2-6b9078051017",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "goods_north_uri = \"mast:JWST/product/jw01181003001_08201_00003_mirimage_uncal.fits\"\n",
+    "\n",
+    "rampviz = Rampviz()\n",
+    "rampviz.load_data(goods_north_uri, cache=True)\n",
+    "rampviz.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66b54ea0-cc92-49b7-8cb5-327231d314b1",
+   "metadata": {},
+   "source": [
+    "## [JWST Wide Area 3D Parallel Survey](https://www.stsci.edu/jwst/science-execution/program-information?id=3383) with NIRISS: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98d3f7b8-21dc-460e-bdda-37e1c89f791a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uri = \"mast:JWST/product/jw03383196001_04201_00004_nis_uncal.fits\"\n",
+    "\n",
+    "rampviz = Rampviz()\n",
+    "rampviz.load_data(uri, cache=True)\n",
+    "rampviz.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "653c3c17-b779-4620-bea6-ff2d090660e0",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Follow up after #3120 adding support for JWST L1 ramps.

The only major difference between JWST ramp files (any instrument) and Roman WFI is that JWST bundles time-series observations with multiple integrations into one 4D array of dimensions (integrations, groups, x-pixel, y-pixel), whereas Roman only ships single integrations in a 3D array.

This PR adds a parser for JWST Level 1 data products as fits files or `Level1bModel` models. By default, rampviz will load the zeroth integration, and specific integrations can be selected with, e.g.:
```
rampviz.load_data(path, integration=3)
```

Since this PR adds support for JWST, without the need for the optional Roman dependencies, the project code coverage test here is more useful than in #3120.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
