### PR TITLE
fix unnecessary stretch histogram updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -221,6 +221,8 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Stretch histogram in zoom limits no longer attempts unnecessary updates when zoom limits are changed. [#3151]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -568,7 +568,7 @@ class PlotOptions(PluginTemplateMixin):
                                                    state_filter=is_image)
 
         self.stretch_histogram = Plot(self, name='stretch_hist', viewer_type='histogram',
-                                      update_callback=self._request_update_stretch_histogram)
+                                      update_callback=self._update_stretch_histogram)
         # Add the stretch bounds tool to the default Plot viewer.
         self.stretch_histogram.tools_nested.append(["jdaviz:stretch_bounds"])
         self.stretch_histogram._initialize_toolbar(["jdaviz:stretch_bounds"])
@@ -895,22 +895,18 @@ class PlotOptions(PluginTemplateMixin):
             # plugin hasn't been fully initialized yet
             return
 
-        if not isinstance(msg, dict):  # pragma: no cover
-            # then this is from the limits callbacks
-            # IMPORTANT: this assumes the only non-observe callback to this method comes
-            # from state callbacks from zoom limits.
-            if not self.stretch_hist_zoom_limits:
-                # there isn't anything to update, let's not waste resources
-                return
-            # override msg as an empty dict so that the rest of the logic doesn't have to check
-            # its type
-            msg = {}
-
         # NOTE: this method is separate from _update_stretch_histogram so that
         # _update_stretch_histogram can be called manually (or from the
         # update_callback on the Plot object itself) without going through
-        # the skip_if_no_updates_since_last_active check
+        # the skip_if_no_updates_since_last_active check (and can therefore
+        # be executed even if the plugin is not active)
         self._update_stretch_histogram(msg)
+
+    def _zoom_limits_update_stretch_histogram(self, msg={}):
+        if not self.stretch_hist_zoom_limits:
+            # there isn't anything to update, let's not waste resources
+            return
+        self._update_stretch_histogram()
 
     @with_spinner('stretch_hist_spinner')
     def _update_stretch_histogram(self, msg={}):
@@ -938,7 +934,7 @@ class PlotOptions(PluginTemplateMixin):
                 or not self.stretch_hist_zoom_limits):
             vs = viewer.state
             for attr in ('x_min', 'x_max', 'y_min', 'y_max'):
-                vs.add_callback(attr, self._request_update_stretch_histogram)
+                vs.add_callback(attr, self._zoom_limits_update_stretch_histogram)
         if isinstance(msg, dict) and msg.get('name') == 'viewer_selected':
             viewer_label_old = msg.get('old')
             if isinstance(viewer_label_old, list):
@@ -947,7 +943,7 @@ class PlotOptions(PluginTemplateMixin):
             if viewer_label_old in self.app._viewer_store:
                 vs_old = self.app.get_viewer(viewer_label_old).state
                 for attr in ('x_min', 'x_max', 'y_min', 'y_max'):
-                    vs_old.remove_callback(attr, self._request_update_stretch_histogram)
+                    vs_old.remove_callback(attr, self._zoom_limits_update_stretch_histogram)
 
         if not len(self.layer.selected_obj):
             # skip further updates if no data are available:

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -568,7 +568,7 @@ class PlotOptions(PluginTemplateMixin):
                                                    state_filter=is_image)
 
         self.stretch_histogram = Plot(self, name='stretch_hist', viewer_type='histogram',
-                                      update_callback=self._update_stretch_histogram)
+                                      update_callback=self._request_update_stretch_histogram)
         # Add the stretch bounds tool to the default Plot viewer.
         self.stretch_histogram.tools_nested.append(["jdaviz:stretch_bounds"])
         self.stretch_histogram._initialize_toolbar(["jdaviz:stretch_bounds"])
@@ -938,7 +938,7 @@ class PlotOptions(PluginTemplateMixin):
                 or not self.stretch_hist_zoom_limits):
             vs = viewer.state
             for attr in ('x_min', 'x_max', 'y_min', 'y_max'):
-                vs.add_callback(attr, self._update_stretch_histogram)
+                vs.add_callback(attr, self._request_update_stretch_histogram)
         if isinstance(msg, dict) and msg.get('name') == 'viewer_selected':
             viewer_label_old = msg.get('old')
             if isinstance(viewer_label_old, list):
@@ -947,7 +947,7 @@ class PlotOptions(PluginTemplateMixin):
             if viewer_label_old in self.app._viewer_store:
                 vs_old = self.app.get_viewer(viewer_label_old).state
                 for attr in ('x_min', 'x_max', 'y_min', 'y_max'):
-                    vs_old.remove_callback(attr, self._update_stretch_histogram)
+                    vs_old.remove_callback(attr, self._request_update_stretch_histogram)
 
         if not len(self.layer.selected_obj):
             # skip further updates if no data are available:


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request removes unnecessary updates to the stretch histogram triggered by callbacks on the zoom-limits when the stretch histogram is not set to be restricted to current zoom-limits.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #3146

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
