### PR TITLE
Disallow negative counts conversion factor in Aperture Photometry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -111,6 +111,8 @@ Bug Fixes
   world and pixel (previously containing SkyCoord and pixel location tuples, respectively) are now
   each two separate columns for world_ra/world_dec and pixel_x/pixel_y, respectively. [#3089]
 
+- Aperture Photometry plugin no longer allows negative counts conversion factor. [#3154]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
@@ -80,6 +80,11 @@ def test_cubeviz_aperphot_cube_orig_flux(cubeviz_helper, image_cube_hdu_obj_micr
     assert_allclose(row["mean"], 36 * flux_unit)
     assert np.isnan(row["slice_wave"])
 
+    # Invalid counts conversion factor
+    plg.counts_factor = -1
+    plg.vue_do_aper_phot()
+    assert "invalid counts" in plg.result_failed_msg
+
 
 def test_cubeviz_aperphot_generated_3d_gaussian_smooth(cubeviz_helper, image_cube_hdu_obj_microns):
     cubeviz_helper.load_data(image_cube_hdu_obj_microns, data_label="test")

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -637,7 +637,9 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
                     include_pixarea_fac = True
             if img_unit != u.count:
                 try:
-                    ctfac = float(counts_factor if counts_factor is not None else self.counts_factor)  # noqa
+                    ctfac = float(counts_factor if counts_factor is not None else self.counts_factor)  # noqa: E501
+                    if ctfac < 0:
+                        raise ValueError('Counts conversion factor cannot be negative.')
                 except ValueError:  # Clearer error message
                     raise ValueError('Missing or invalid counts conversion factor')
                 if not np.allclose(ctfac, 0):

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -113,13 +113,9 @@
             type="number"
             hint="Factor to convert data unit to counts, in unit of flux/counts"
             persistent-hint
+            :rules="[() => counts_factor>=0 || 'Counts conversion factor cannot be negative.']"
           >
           </v-text-field>
-        </v-row>
-        <v-row v-if="counts_factor < 0">
-          <span class="v-messages v-messages__message text--secondary" style="color: red !important">
-            Counts conversion factor cannot be negative.
-          </span>
         </v-row>
 
         <v-row v-if="multiselect">
@@ -180,7 +176,7 @@
             :results_isolated_to_plugin="true"
             @click="do_aper_phot"
             :spinner="spinner"
-            :disabled="aperture_selected === background_selected || !aperture_selected_validity.is_aperture"
+            :disabled="aperture_selected === background_selected || !aperture_selected_validity.is_aperture || counts_factor < 0"
           >
             Calculate
           </plugin-action-button>

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -116,6 +116,11 @@
           >
           </v-text-field>
         </v-row>
+        <v-row v-if="counts_factor < 0">
+          <span class="v-messages v-messages__message text--secondary" style="color: red !important">
+            Counts conversion factor cannot be negative.
+          </span>
+        </v-row>
 
         <v-row v-if="multiselect">
           <v-switch


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to disallow negative counts conversion factor in Aperture Photometry plugin.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4702)
