### PR TITLE
Update messaging from unit conversion plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ New Features
 ------------
 
 - Added flux/surface brightness translation and surface brightness
-  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113, #3129]
+  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113, #3129, #3155]
 
 - Plugin tray is now open by default. [#2892]
 
@@ -133,8 +133,6 @@ Cubeviz
 
 - No longer incorrectly swap RA and Dec axes when loading Spectrum1D objects. [#3133]
 
-- Improved messaging from unit conversion plugin to handle changes to flux, surface brightness,
-  and spectral y axis independently. This fixes an issue with mouseover units in cubeviz. [#3155]
 
 Imviz
 ^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -134,7 +134,7 @@ Cubeviz
 - No longer incorrectly swap RA and Dec axes when loading Spectrum1D objects. [#3133]
 
 - Improved messaging from unit conversion plugin to handle changes to flux, surface brightness,
-and spectral y axis independently. This fixes an issue with mouseover units in cubeviz. [#3155]
+  and spectral y axis independently. This fixes an issue with mouseover units in cubeviz. [#3155]
 
 Imviz
 ^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -133,6 +133,9 @@ Cubeviz
 
 - No longer incorrectly swap RA and Dec axes when loading Spectrum1D objects. [#3133]
 
+- Improved messaging from unit conversion plugin to handle changes to flux, surface brightness,
+and spectral y axis independently. This fixes an issue with mouseover units in cubeviz. [#3155]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -109,6 +109,8 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
     results_units = Unicode().tag(sync=True)
     spectrum_y_units = Unicode().tag(sync=True)
+    flux_unit = Unicode().tag(sync=True)
+    sb_unit = Unicode().tag(sync=True)
 
     aperture_method_items = List().tag(sync=True)
     aperture_method_selected = Unicode('Center').tag(sync=True)
@@ -178,7 +180,7 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         self.session.hub.subscribe(self, SliceValueUpdatedMessage,
                                    handler=self._on_slice_changed)
         self.hub.subscribe(self, GlobalDisplayUnitChanged,
-                           handler=self._update_results_units)
+                           handler=self._on_gloabl_display_unit_changed)
 
         self._update_disabled_msg()
 
@@ -313,13 +315,25 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         else:
             self.background.scale_factor = self.slice_spectral_value/self.reference_spectral_value
 
+    def _on_gloabl_display_unit_changed(self, msg={}):
+
+
+        if msg.axis == 'spectral_y':
+            self.spectrum_y_units = str(msg.unit)
+
+        if msg.axis == 'flux':
+            self.flux_unit = str(msg.unit)
+        if msg.axis == 'sb':
+            self.sb_unit = str(msg.unit)
+
     @observe('function_selected')
-    def _update_results_units(self, msg={}):
-        self.spectrum_y_units = str(self.app._get_display_unit('spectral_y'))
+    def _update_units_on_function_selection(self):
+
         if self.function_selected.lower() == 'sum':
-            self.results_units = str(self.app._get_display_unit('flux'))
+            self.results_units = self.flux_unit
         else:
-            self.results_units = str(self.app._get_display_unit('sb'))
+            self.results_units = self.sb_unit
+
 
     @observe('function_selected', 'aperture_method_selected')
     def _update_aperture_method_on_function_change(self, *args):

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -336,7 +336,6 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         else:
             self.results_units = self.sb_unit
 
-
     @observe('function_selected', 'aperture_method_selected')
     def _update_aperture_method_on_function_change(self, *args):
         if (self.function_selected.lower() in ('min', 'max') and

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -317,17 +317,19 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
     def _on_gloabl_display_unit_changed(self, msg={}):
 
-
         if msg.axis == 'spectral_y':
             self.spectrum_y_units = str(msg.unit)
 
+        # a 'flux' and 'sb' message should be recieved back to back from
+        # the unit conversion plugin, so don't need to sync them immediatley
+        # within each message recieved
         if msg.axis == 'flux':
             self.flux_unit = str(msg.unit)
         if msg.axis == 'sb':
             self.sb_unit = str(msg.unit)
 
     @observe('function_selected')
-    def _update_units_on_function_selection(self):
+    def _update_units_on_function_selection(self, *args):
 
         if self.function_selected.lower() == 'sum':
             self.results_units = self.flux_unit

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -323,10 +323,15 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         # a 'flux' and 'sb' message should be recieved back to back from
         # the unit conversion plugin, so don't need to sync them immediatley
         # within each message recieved
-        if msg.axis == 'flux':
+        elif msg.axis == 'flux':
             self.flux_unit = str(msg.unit)
-        if msg.axis == 'sb':
+        elif msg.axis == 'sb':
             self.sb_unit = str(msg.unit)
+        else:
+            return
+
+        # and set results_units, which depends on function selected
+        self._update_units_on_function_selection()
 
     @observe('function_selected')
     def _update_units_on_function_selection(self, *args):

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -530,7 +530,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
     def _on_global_display_unit_changed(self, msg):
         if msg.axis == 'spectral_y':
             axis = 'y'
-        elif msg.axis == 'spectral_x':
+        elif msg.axis == 'spectral':
             axis = 'x'
         else:
             return

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -528,8 +528,10 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         self._check_model_equation_invalid()
 
     def _on_global_display_unit_changed(self, msg):
-        if 'spectral' in msg.axis:
-            axis = msg.axis.replace('spectral_', '')  # get 'x' or 'y'
+        if msg.axis == 'spectral_y':
+            axis = 'y'
+        elif msg.axis == 'spectral_x':
+            axis = 'x'
         else:
             return
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -528,7 +528,10 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         self._check_model_equation_invalid()
 
     def _on_global_display_unit_changed(self, msg):
-        axis = {'spectral': 'x', 'spectral_y': 'y'}.get(msg.axis)
+        if 'spectral' in msg.axis:
+            axis = msg.axis.replace('spectral_', '')  # get 'x' or 'y'
+        else:
+            return
 
         # update internal tracking of current units
         self._units[axis] = str(msg.unit)

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -528,7 +528,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         self._check_model_equation_invalid()
 
     def _on_global_display_unit_changed(self, msg):
-        axis = {'spectral': 'x', 'flux': 'y'}.get(msg.axis)
+        axis = {'spectral': 'x', 'spectral_y': 'y'}.get(msg.axis)
 
         # update internal tracking of current units
         self._units[axis] = str(msg.unit)

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -150,7 +150,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
         else:
             self.is_cube = False
 
-    def _on_display_units_changed(self, event={}):
+    def _on_display_units_changed(self, msg={}):
 
         """
         Handle change of display units from Unit Conversion plugin (for now,
@@ -160,76 +160,105 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
         'calculate' is pressed again.
         """
 
+        # only concerned with unit changes in cubeviz, for now
         if self.config == 'cubeviz':
 
-            # get previously selected display units
-            prev_display_flux_or_sb_unit = self.display_flux_or_sb_unit
-            prev_flux_scale_unit = self.flux_scaling_display_unit
+            if msg.axis == 'flux':
+                # update the traitlet for the flux scaling display unit when
+                # the global flux display unit has been changed
+                # a 'flux' message will be immediatley followed by a 'sb'
+                # message upon unit change, so the rest will be handled there
 
-            # update display unit traitlets to new selection
-            self._set_display_unit_of_selected_dataset()
+                self.flux_scaling_display_unit = msg.unit
 
-            # convert the previous background and flux scaling values to new unit so
-            # re-calculating photometry with the current selections will produce
-            # the previous output with the new unit.
-            if prev_display_flux_or_sb_unit != '':
+                # get previously selected display unit
+                prev_flux_scale_unit = self.flux_scaling_display_unit
 
+                if prev_flux_scale_unit = != '':
+                    if self.flux_scaling is not None:
+                        prev_unit = u.Unit(prev_flux_scale_unit)
+                        new_unit = u.Unit(self.flux_scaling_display_unit)
+                        self._convert_flux_scaling_to_new_units(prev_unit, new_unit)
+
+            if msg.axis == 'sb':
+                # get previously selected display unit
+                prev_display_flux_or_sb_unit = self.display_flux_or_sb_unit
+                
+                # update display unit traitlet to new selection
+                disp_unit = msg.unit
+                self._set_display_flux_or_sb_unit_traitlet(msg.unit)
+                
                 # convert background to new unit
-                if self.background_value is not None:
+                if prev_display_flux_or_sb_unit != '':
+                    if self.background_value is not None:
+                        prev_unit = u.Unit(prev_display_flux_or_sb_unit)
+                        new_unit = u.Unit(self.display_flux_or_sb_unit)
+                        self._convert_background_to_new_units(prev_unit, new_unit)
 
-                    prev_unit = u.Unit(prev_display_flux_or_sb_unit)
-                    new_unit = u.Unit(self.display_flux_or_sb_unit)
+    def _set_display_flux_or_sb_unit_traitlet(self, disp_unit):
+        # in its own method rather than setting directly because there is some
+        # additional logic to handle pixel units, and can be called when units
+        # change or when dataset changes
 
-                    bg = self.background_value * prev_unit
-                    self.background_value = bg.to_value(
-                        new_unit, u.spectral_density(self._cube_wave))
+        # temporarily, until non-sr units are suppported, strip 'pix'
+        # from unit if it is a per-pixel sb unit
+        if 'pix' in disp_unit.bases:
+            disp_unit = u.Unit(image_unit) * u.pix
+            disp_unit = disp_unit.to_string()
 
-                # convert flux scaling to new unit
-                if self.flux_scaling is not None:
-                    prev_unit = u.Unit(prev_flux_scale_unit)
-                    new_unit = u.Unit(self.flux_scaling_display_unit)
+        self.display_flux_or_sb_unit = disp_unit
 
-                    fs = self.flux_scaling * prev_unit
-                    self.flux_scaling = fs.to_value(
-                        new_unit, u.spectral_density(self._cube_wave))
+    def _convert_background_to_new_units(self, prev_unit, new_unit):
 
-    def _set_display_unit_of_selected_dataset(self):
+        bg = self.background_value * prev_unit
+        self.background_value = bg.to_value(new_unit,
+                                            u.spectral_density(self._cube_wave))
 
-        """
-        Set the display_flux_or_sb_unit and flux_scaling_display_unit traitlets,
-        which depend on if the selected data set is flux or surface brightness,
-        and the corresponding global display unit for either flux or
-        surface brightness.
-        """
+    def _convert_flux_scaling_to_new_units(self, prev_unit, new_unit):
+        fs = self.flux_scaling * prev_unit
 
-        if not self.dataset_selected or not self.aperture_selected:
-            self.display_flux_or_sb_unit = ''
-            self.flux_scaling_display_unit = ''
+        self.flux_scaling = fs.to_value( new_unit, u.spectral_density(self._cube_wave))
+
+    @observe('dataset_selected')
+    def _dataset_selected_changed(self, event={}):
+        if not hasattr(self, 'dataset'):
+            # plugin not fully initialized
+            return
+        if self.dataset.selected_dc_item is None:
+            return
+        if self.multiselect:
+            # defaults are applied within the loop if the auto-switches are enabled,
+            # but we still need to update the flux-scaling warning
+            self._multiselect_flux_scaling_warning()
             return
 
-        data = self.dataset.selected_dc_item
-        comp = data.get_component(data.main_components[0])
-        if comp.units:
-            # if data is something-per-solid-angle, its a SB unit and we should
-            # use the selected global display unit for SB
-            if check_if_unit_is_per_solid_angle(comp.units):
-                flux_or_sb = 'sb'
+        try:
+            defaults = self._get_defaults_from_metadata()
+            self.counts_factor = 0
+            self.pixel_area = defaults.get('pixel_area', 0)
+            self.flux_scaling = defaults.get('flux_scaling', 0)
+            if 'flux_scaling' in defaults:
+                self.flux_scaling_warning = ''
             else:
-                flux_or_sb = 'flux'
+                self.flux_scaling_warning = ('Could not determine flux scaling for '
+                                             f'{self.dataset.selected}, defaulting to zero.')
 
-            disp_unit = self.app._get_display_unit(flux_or_sb)
+        except Exception as e:
+            self.hub.broadcast(SnackbarMessage(
+                f"Failed to extract {self.dataset_selected}: {repr(e)}",
+                color='error', sender=self))
 
-            self.display_flux_or_sb_unit = disp_unit
+        # get correct display unit for newly selected dataset
+        if self.config == 'cubeviz':
+            # 'get_display_unit' should be used when we are not intercepting
+            # a message with the correct unit from the UC plugin
+            sb_unit = self.app._get_display_unit('sb')
+            self._set_display_flux_or_sb_unit_traitlet(sb_unit)
+            self.flux_scaling_display_unit = self.app._get_display_unit('flux')
 
-            # now get display unit for flux_scaling_display_unit. this unit will always
-            # be in flux, but it will not be derived from the global flux display unit
-            # note : need to generalize this for non-sr units eventually
-            fs_unit = u.Unit(disp_unit) * u.sr
-            self.flux_scaling_display_unit = fs_unit.to_string()
+        # auto-populate background, if applicable.
+        self._aperture_selected_changed()
 
-        else:
-            self.display_flux_or_sb_unit = ''
-            self.flux_scaling_display_unit = ''
 
     def _get_defaults_from_metadata(self, dataset=None):
         defaults = {}
@@ -305,43 +334,6 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
         if not self.multiselect:
             # disable warning once user changes value
             self.flux_scaling_warning = ''
-
-    @observe('dataset_selected')
-    def _dataset_selected_changed(self, event={}):
-        if not hasattr(self, 'dataset'):
-            # plugin not fully initialized
-            return
-        if self.dataset.selected_dc_item is None:
-            return
-        if self.multiselect:
-            # defaults are applied within the loop if the auto-switches are enabled,
-            # but we still need to update the flux-scaling warning
-            self._multiselect_flux_scaling_warning()
-            return
-
-        try:
-            defaults = self._get_defaults_from_metadata()
-            self.counts_factor = 0
-            self.pixel_area = defaults.get('pixel_area', 0)
-            self.flux_scaling = defaults.get('flux_scaling', 0)
-            if 'flux_scaling' in defaults:
-                self.flux_scaling_warning = ''
-            else:
-                self.flux_scaling_warning = ('Could not determine flux scaling for '
-                                             f'{self.dataset.selected}, defaulting to zero.')
-
-        except Exception as e:
-            self.hub.broadcast(SnackbarMessage(
-                f"Failed to extract {self.dataset_selected}: {repr(e)}",
-                color='error', sender=self))
-
-        # get correct display unit for newly selected dataset
-        if self.config == 'cubeviz':
-            # set display_flux_or_sb_unit and flux_scaling_display_unit
-            self._set_display_unit_of_selected_dataset()
-
-        # auto-populate background, if applicable.
-        self._aperture_selected_changed()
 
     def _on_subset_update(self, msg):
         if not self.dataset_selected or not self.aperture_selected:

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -122,17 +122,20 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
 
     def _on_global_display_unit_changed(self, msg):
 
-        # should only listen to changes in surface brightness. even if data
-        # loaded is in 'flux' it can be represented as a per-pixel surface
-        # brightness unit.
-        if msg.axis == "sb":
-            image_unit = u.Unit(msg.unit)
+        # only concerned with handling unit changes for mouseover in cubeviz,
+        # until implemented in other configs
+        if self.config == 'cubeviz':
+            # even if data loaded is in 'flux' it can be represented as a
+            # per-pixel sb unit, so all cube data will be 'sb'
+            if msg.axis == "sb":
+                image_unit = u.Unit(msg.unit)
 
-            # temporarily, until non-sr units are suppported, strip 'pix' from unit
-            if 'pix' in image_unit.bases:
-                image_unit = image_unit * u.pix
+                # temporarily, until non-sr units are suppported, strip 'pix' from
+                # unit if it is a per-pixel unit
+                if 'pix' in image_unit.bases:
+                    image_unit = image_unit * u.pix
 
-            self.image_unit = u.Unit(image_unit)
+                self.image_unit = u.Unit(image_unit)
 
     @property
     def marks(self):

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -121,20 +121,17 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
 
     def _on_global_display_unit_changed(self, msg):
 
-        # only concerned with handling unit changes for mouseover in cubeviz,
-        # until implemented in other configs
-        if self.config == 'cubeviz':
-            # even if data loaded is in 'flux' it can be represented as a
-            # per-pixel sb unit, so all cube data will be 'sb'
-            if msg.axis == "sb":
-                image_unit = u.Unit(msg.unit)
+        # even if data loaded is in 'flux' it can be represented as a
+        # per-pixel sb unit, so all cube data will be 'sb' (cubeviz)
+        if msg.axis == "sb":
+            image_unit = u.Unit(msg.unit)
 
-                # temporarily, until non-sr units are suppported, strip 'pix' from
-                # unit if it is a per-pixel unit
-                if 'pix' in image_unit.bases:
-                    image_unit = image_unit * u.pix
+            # temporarily, until non-sr units are suppported, strip 'pix' from
+            # unit if it is a per-pixel unit
+            if 'pix' in image_unit.bases:
+                image_unit = image_unit * u.pix
 
-                self.image_unit = u.Unit(image_unit)
+            self.image_unit = u.Unit(image_unit)
 
     @property
     def marks(self):

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -18,6 +18,7 @@ from jdaviz.core.marks import PluginScatter, PluginLine
 from jdaviz.core.registries import tool_registry
 from jdaviz.core.template_mixin import TemplateMixin, DatasetSelectMixin
 from jdaviz.utils import _eqv_pixar_sr, _convert_surface_brightness_units
+from jdaviz.core.validunits import check_if_unit_is_per_solid_angle
 
 __all__ = ['CoordsInfo']
 
@@ -126,10 +127,15 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
         # viewer (flux or sb). e.g if data loaded is in MJy / sr, and the spectrum
         # viewer is toggled to 'flux', mouseover should show data in MJy. 
 
-        self.hub.broadcast(SnackbarMessage(f"In _on_global_display_unit_changed, msg = {msg.axis} unit = {msg.unit}", color='error', sender=self))
-
         if msg.axis == "spectral_y":
             self.image_unit = u.Unit(msg.unit)
+
+            # if the data unit is a surface brightness, but the spectral y
+            # axis is a 'flux' with no solid angle, we must convert the display
+            # unit to a SB. this will be changed when angle selection to generalize
+            # to non-steradian units is implemented.
+            if not check_if_unit_is_per_solid_angle(self.image_unit):
+
 
     @property
     def marks(self):

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -122,20 +122,17 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
 
     def _on_global_display_unit_changed(self, msg):
 
-        # display units of mouseover should reflect choice of selected flux and
-        # angle unit, as well as the toggled display unit type for the spectrum
-        # viewer (flux or sb). e.g if data loaded is in MJy / sr, and the spectrum
-        # viewer is toggled to 'flux', mouseover should show data in MJy. 
+        # should only listen to changes in surface brightness. even if data
+        # loaded is in 'flux' it can be represented as a per-pixel surface
+        # brightness unit.
+        if msg.axis == "sb":
+            image_unit = u.Unit(msg.unit)
 
-        if msg.axis == "spectral_y":
-            self.image_unit = u.Unit(msg.unit)
+            # temporarily, until non-sr units are suppported, strip 'pix' from unit
+            if 'pix' in image_unit.bases:
+                image_unit = image_unit * u.pix
 
-            # if the data unit is a surface brightness, but the spectral y
-            # axis is a 'flux' with no solid angle, we must convert the display
-            # unit to a SB. this will be changed when angle selection to generalize
-            # to non-steradian units is implemented.
-            if not check_if_unit_is_per_solid_angle(self.image_unit):
-
+            self.image_unit = u.Unit(image_unit)
 
     @property
     def marks(self):

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -12,13 +12,12 @@ from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
 from jdaviz.configs.mosviz.plugins.viewers import (MosvizImageView, MosvizProfileView,
                                                    MosvizProfile2DView)
 from jdaviz.configs.specviz.plugins.viewers import SpecvizProfileView
-from jdaviz.core.events import ViewerAddedMessage, GlobalDisplayUnitChanged, SnackbarMessage
+from jdaviz.core.events import ViewerAddedMessage, GlobalDisplayUnitChanged
 from jdaviz.core.helpers import data_has_valid_wcs
 from jdaviz.core.marks import PluginScatter, PluginLine
 from jdaviz.core.registries import tool_registry
 from jdaviz.core.template_mixin import TemplateMixin, DatasetSelectMixin
 from jdaviz.utils import _eqv_pixar_sr, _convert_surface_brightness_units
-from jdaviz.core.validunits import check_if_unit_is_per_solid_angle
 
 __all__ = ['CoordsInfo']
 

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -12,7 +12,7 @@ from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
 from jdaviz.configs.mosviz.plugins.viewers import (MosvizImageView, MosvizProfileView,
                                                    MosvizProfile2DView)
 from jdaviz.configs.specviz.plugins.viewers import SpecvizProfileView
-from jdaviz.core.events import ViewerAddedMessage, GlobalDisplayUnitChanged
+from jdaviz.core.events import ViewerAddedMessage, GlobalDisplayUnitChanged, SnackbarMessage
 from jdaviz.core.helpers import data_has_valid_wcs
 from jdaviz.core.marks import PluginScatter, PluginLine
 from jdaviz.core.registries import tool_registry
@@ -120,8 +120,15 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
         self._create_viewer_callbacks(self.app.get_viewer_by_id(msg.viewer_id))
 
     def _on_global_display_unit_changed(self, msg):
-        # eventually should observe change in flux OR angle
-        if msg.axis == "flux":
+
+        # display units of mouseover should reflect choice of selected flux and
+        # angle unit, as well as the toggled display unit type for the spectrum
+        # viewer (flux or sb). e.g if data loaded is in MJy / sr, and the spectrum
+        # viewer is toggled to 'flux', mouseover should show data in MJy. 
+
+        self.hub.broadcast(SnackbarMessage(f"In _on_global_display_unit_changed, msg = {msg.axis} unit = {msg.unit}", color='error', sender=self))
+
+        if msg.axis == "spectral_y":
             self.image_unit = u.Unit(msg.unit)
 
     @property

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -235,7 +235,7 @@ class UnitConversion(PluginTemplateMixin):
         # have a scale factor assigned in the metadata, enabling translation.
         current_y_unit = self.spectrum_viewer.state.y_display_unit
 
-        # various plugins are listening for changes in either flux or sb and 
+        # various plugins are listening for changes in either flux or sb and
         # need to be able to filter messages accordingly, so broadcast both when
         # flux unit is updated. if data was loaded in a flux unit (i.e MJy), it
         # can be reperesented as a per-pixel surface brightness unit

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -262,7 +262,8 @@ class UnitConversion(PluginTemplateMixin):
             self.spectrum_viewer.state.y_display_unit = yunit
             self.spectrum_viewer.reset_limits()
 
-            # and broacast that there has been a change in flux
+            # and broacast that there has been a change in the spectral axis y unit
+            # to either a flux or surface brightness unit
             self.hub.broadcast(GlobalDisplayUnitChanged("spectral_y", flux_or_sb, sender=self))
 
         if not check_if_unit_is_per_solid_angle(self.spectrum_viewer.state.y_display_unit):

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -245,18 +245,18 @@ class UnitConversion(PluginTemplateMixin):
         self.hub.broadcast(GlobalDisplayUnitChanged("flux", flux_unit, sender=self))
         self.hub.broadcast(GlobalDisplayUnitChanged("sb", sb_unit, sender=self))
 
-        flux_or_sb = sb_unit if check_if_unit_is_per_solid_angle(current_y_unit) else flux_unit
+        spectral_y = sb_unit if self.flux_or_sb == 'Surface Brightness' else flux_unit
 
         untranslatable_units = self._untranslatable_units
         # disable translator if flux unit is untranslatable,
         # still can convert flux units, this just disables flux
         # to surface brightness translation for units in list.
-        if flux_or_sb in untranslatable_units:
+        if spectral_y in untranslatable_units:
             self.can_translate = False
         else:
             self.can_translate = True
 
-        yunit = _valid_glue_display_unit(flux_or_sb, self.spectrum_viewer, 'y')
+        yunit = _valid_glue_display_unit(spectral_y, self.spectrum_viewer, 'y')
 
         # update spectrum viewer with new y display unit
         if self.spectrum_viewer.state.y_display_unit != yunit:
@@ -266,7 +266,7 @@ class UnitConversion(PluginTemplateMixin):
             # and broacast that there has been a change in the spectral axis y unit
             # to either a flux or surface brightness unit, for plugins that specifically
             # care about this toggle selection
-            self.hub.broadcast(GlobalDisplayUnitChanged("spectral_y", flux_or_sb, sender=self))
+            self.hub.broadcast(GlobalDisplayUnitChanged("spectral_y", spectral_y, sender=self))
 
         if not check_if_unit_is_per_solid_angle(self.spectrum_viewer.state.y_display_unit):
             self.flux_or_sb_selected = 'Flux'

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -230,11 +230,6 @@ class UnitConversion(PluginTemplateMixin):
         if not self.flux_unit.choices and self.app.config == 'cubeviz':
             return
 
-        # when the configuration is Specviz, translation is not currently supported.
-        # If in Cubeviz, all spectra pass through Spectral Extraction plugin and will
-        # have a scale factor assigned in the metadata, enabling translation.
-        current_y_unit = self.spectrum_viewer.state.y_display_unit
-
         # various plugins are listening for changes in either flux or sb and
         # need to be able to filter messages accordingly, so broadcast both when
         # flux unit is updated. if data was loaded in a flux unit (i.e MJy), it

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -263,7 +263,7 @@ class UnitConversion(PluginTemplateMixin):
             self.spectrum_viewer.reset_limits()
 
             # and broacast that there has been a change in flux
-            self.hub.broadcast(GlobalDisplayUnitChanged("flux", flux_or_sb, sender=self))
+            self.hub.broadcast(GlobalDisplayUnitChanged("spectral_y", flux_or_sb, sender=self))
 
         if not check_if_unit_is_per_solid_angle(self.spectrum_viewer.state.y_display_unit):
             self.flux_or_sb_selected = 'Flux'
@@ -318,7 +318,7 @@ class UnitConversion(PluginTemplateMixin):
         else:
             return
 
-        self.hub.broadcast(GlobalDisplayUnitChanged('flux',
+        self.hub.broadcast(GlobalDisplayUnitChanged('spectral_y',
                                                     spec_units,
                                                     sender=self))
         self.spectrum_viewer.reset_limits()

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -408,7 +408,10 @@ class CanvasRotationChangedMessage(Message):
 
 
 class GlobalDisplayUnitChanged(Message):
-    '''Message generated when the global app-wide display unit is changed'''
+    '''Message generated when the (x or y axis) unit of the spectrum viewer is
+    changed, which is used app-wide to inform display units that depend on the 
+    unit choice and flux<>sb toggle of the spectrum viewer.'''
+
     def __init__(self, axis, unit, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._axis = axis

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -409,7 +409,7 @@ class CanvasRotationChangedMessage(Message):
 
 class GlobalDisplayUnitChanged(Message):
     '''Message generated when the (x or y axis) unit of the spectrum viewer is
-    changed, which is used app-wide to inform display units that depend on the 
+    changed, which is used app-wide to inform display units that depend on the
     unit choice and flux<>sb toggle of the spectrum viewer.'''
 
     def __init__(self, axis, unit, *args, **kwargs):

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -127,7 +127,7 @@ class PluginMark:
         if not self.auto_update_units:
             return
         if self.viewer.__class__.__name__ in ['SpecvizProfileView', 'CubevizProfileView']:
-            axis_map = {'spectral': 'x', 'flux': 'y'}
+            axis_map = {'spectral': 'x', 'spectral_y': 'y'}
         elif self.viewer.__class__.__name__ == 'MosvizProfile2DView':
             axis_map = {'spectral': 'x'}
         else:

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3547,7 +3547,7 @@ class DatasetSelect(SelectPluginComponent):
         self._clear_cache(*self._cached_properties)
 
     def _on_global_display_unit_changed(self, msg=None):
-        if msg.axis in ('spectral', 'flux'):
+        if msg.axis in ('spectral', 'spectral_y'):
             self._clear_cache('selected_spectrum')
 
 


### PR DESCRIPTION
This PR improves the messaging from the unit conversion plugin to broadcast changes in selected display unit. Because some plugins are listening for changes to the spectral y axis (either from toggling flux<>sb, changing flux or angle when it is toggled to SB, or changing flux when it is toggled to flux) this is its own message now.

Every time a new selection of 'flux' is made, there are three GlobalDisplayUnitChanged messages broadcasted : 'flux', 'sb', and 'spectral_y'.

While this is not included in this PR, these changes will make it possible for the correct messaging to be broadcasted when a new angle selection is made (always sending a 'sb' message, and if the spectral y axis is in SB also sending a 'spectral_y' message).

Every time there is a toggle between flux<> sb, the GlobalDisplayUnitChanged axis='spectral_y' message is broadcasted.

A follow up in https://github.com/spacetelescope/jdaviz/pull/3144 will fix how plugins respond to this updated messaging - for now, with the additional broadcasts, there will be some redundant unit conversions in plugins. I fixed some instances of this (in coords_info, spectral extraction) but the follow up for other plugins to intercept the correct message will be in that PR. 
