### PR TITLE
Skip flux conversion for moment maps

### DIFF
--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -486,12 +486,17 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                     dq_value = dq_data[int(round(y)), int(round(x))]
                 unit = image.get_component(attribute).units
             elif isinstance(viewer, (CubevizImageView, RampvizImageView)):
+                skip_spectral_density_eqv = False
                 arr = image.get_component(attribute).data
                 unit = image.get_component(attribute).units
                 value = self._get_cube_value(
                     image, arr, x, y, viewer
                 )
-                if self.image_unit is not None:
+
+                if hasattr(image, "meta") and "Plugin" in image.meta and image.meta["Plugin"] == "Moment Maps":  # noqa: E501
+                    skip_spectral_density_eqv = True
+
+                if self.image_unit is not None and not skip_spectral_density_eqv:
                     if 'PIXAR_SR' in self.app.data_collection[0].meta:
                         # Need current slice value and associated unit to use to compute
                         # spectral density equivalencies that enable Flux to Flux conversions.

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -493,7 +493,9 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                     image, arr, x, y, viewer
                 )
 
-                if hasattr(image, "meta") and "Plugin" in image.meta and image.meta["Plugin"] == "Moment Maps":  # noqa: E501
+                # We don't want to convert for things like moment maps
+                if str(u.Unit(unit).physical_type) not in ("spectral flux density",
+                                                           "surface brightness"):
                     skip_spectral_density_eqv = True
 
                 if self.image_unit is not None and not skip_spectral_density_eqv:


### PR DESCRIPTION
Looks like #3139 broke adding moment maps to a viewer, due to the `coords_info` logic. This skips the flux conversion that breaks it in the case of moment-like units (velocity and higher powers of it) by skipping any unit with incompatible physical type.

~Additionally, calculating moment 0 in flux when the cube is in surface brightness seemed to be broken (again?) so I moved the unit conversion to be before the moment calculation, so we can convert, e.g., MJy/sr to MJy and not have to worry about the extra wavelength unit that comes in via the moment calculation.~

~I also took this opportunity to bump the specutils pin and get rid of the handling for the change in 1.16 for the dev tests and such.~