### PR TITLE
API hints tweaks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ New Features
 
 - The colormap menu for image layers now shows in-line previews of the colormaps. [#2900]
 
-- Plugins can now expose in-UI API hints. [#3137]
+- Plugins can now expose in-UI API hints. [#3137, #3159]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/components/plugin_color_picker.vue
+++ b/jdaviz/components/plugin_color_picker.vue
@@ -3,7 +3,7 @@
     <plugin-input-header
       v-if="label && !label_inline"
       :label="label"
-      :api_hint="api_hint + value"
+      :api_hint="api_hint + '\''+value+'\''"
       :api_hints_enabled="api_hints_enabled"
     ></plugin-input-header>
     <v-menu>

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.vue
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.vue
@@ -60,8 +60,8 @@
         v-model.number="value"
         @focus="(e) => value_editing = true"
         @blur="(e) => value_editing = false"
-        class="mt-0 pt-0"
         :label="api_hints_enabled ? 'plg.value =' : value_label"
+        :class="api_hints_enabled ? 'api-hint' : null"
         :hint="value_label+' corresponding to slice.'+(snap_to_slice && value_editing ? '  Indicator will snap to slice when clicking or tabbing away from input.' : '')"
         :suffix="value_unit"
       ></v-text-field>

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.vue
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.vue
@@ -1,7 +1,7 @@
 <template>
   <j-tray-plugin
     :config="config"
-    plugin_key="Slice"
+    :plugin_key="plugin_key || 'Slice'"
     :api_hints_enabled.sync="api_hints_enabled"
     :description="docs_description || 'Select slice of the cube to show in the image viewers.  The slice can also be changed interactively in the spectrum viewer by activating the slice tool.'"
     :irrelevant_msg="irrelevant_msg"

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
@@ -1,7 +1,7 @@
 <template>
   <j-tray-plugin
     :config="config"
-    plugin_key="Spectral Extraction"
+    :plugin_key="plugin_key || Spectral Extraction"
     :api_hints_enabled.sync="api_hints_enabled"
     :description="docs_description || 'Extract a '+resulting_product_name+' from a spectral cube.'"
     :link="docs_link || 'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#spectral-extraction'"

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -185,6 +185,7 @@
           <plugin-action-button
             :spinner="apply_RGB_presets_spinner"
             :results_isolated_to_plugin="false"
+            :class="api_hints_enabled ? 'api-hint' : null"
             @click="apply_RGB_presets"
           >
             {{ api_hints_enabled ?

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.vue
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.vue
@@ -68,7 +68,7 @@
             <v-radio
               v-for="item in align_by_items"
               :key="item.label"
-              :label="item.label == 'WCS' ? 'WCS (Sky)' : item.label"
+              :label="item.label == 'WCS' && !api_hints_enabled ? 'WCS (Sky)' : item.label"
               :value="item.label"
             ></v-radio>
           </v-radio-group>

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -394,6 +394,7 @@ class PluginTemplateMixin(TemplateMixin):
     _plugin_name = None  # noqa overwritten by the registry - won't be populated by plugins instantiated directly
     disabled_msg = Unicode("").tag(sync=True)  # noqa if non-empty, will show this message in place of plugin content
     irrelevant_msg = Unicode("").tag(sync=True)  # noqa if non-empty, will exclude from the tray, and show this message in place of any content in other instances
+    plugin_key = Unicode("").tag(sync=True) # set to non-empty to override value in vue file (when supported by vue file)
     docs_link = Unicode("").tag(sync=True)  # set to non-empty to override value in vue file
     docs_description = Unicode("").tag(sync=True)  # set to non-empty to override value in vue file
     plugin_opened = Bool(False).tag(sync=True)  # noqa any instance of the plugin is open (recently sent an "alive" ping)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -394,7 +394,7 @@ class PluginTemplateMixin(TemplateMixin):
     _plugin_name = None  # noqa overwritten by the registry - won't be populated by plugins instantiated directly
     disabled_msg = Unicode("").tag(sync=True)  # noqa if non-empty, will show this message in place of plugin content
     irrelevant_msg = Unicode("").tag(sync=True)  # noqa if non-empty, will exclude from the tray, and show this message in place of any content in other instances
-    plugin_key = Unicode("").tag(sync=True) # set to non-empty to override value in vue file (when supported by vue file)
+    plugin_key = Unicode("").tag(sync=True)  # noqa set to non-empty to override value in vue file (when supported by vue file)
     docs_link = Unicode("").tag(sync=True)  # set to non-empty to override value in vue file
     docs_description = Unicode("").tag(sync=True)  # set to non-empty to override value in vue file
     plugin_opened = Bool(False).tag(sync=True)  # noqa any instance of the plugin is open (recently sent an "alive" ping)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is a follow-up to #3137 to give the flexibility for inherited plugins (i.e. time selector in lcviz or cube extraction in lcviz/rampviz) to override the plugin key shown in the API hints.  It also makes the following small tweaks:
* fix the styling on a component in the slice plugin
* fix styling for "apply RGB presets" button in plot options
* fix options for "align_by" in orientation plugin to be the same options as the API
* add quotes around the color string in color picker

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
