### PR TITLE
per-config display of unit selections

### DIFF
--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -56,16 +56,24 @@ class UnitConversion(PluginTemplateMixin):
     """
     template_file = __file__, "unit_conversion.vue"
 
+    has_spectral = Bool(False).tag(sync=True)
     spectral_unit_items = List().tag(sync=True)
     spectral_unit_selected = Unicode().tag(sync=True)
 
+    has_flux = Bool(False).tag(sync=True)
     flux_unit_items = List().tag(sync=True)
     flux_unit_selected = Unicode().tag(sync=True)
 
-    sb_unit_selected = Unicode().tag(sync=True)
-
+    has_angle = Bool(False).tag(sync=True)
     angle_unit_items = List().tag(sync=True)
     angle_unit_selected = Unicode().tag(sync=True)
+
+    has_sb = Bool(False).tag(sync=True)
+    sb_unit_selected = Unicode().tag(sync=True)
+
+    has_time = Bool(False).tag(sync=True)
+    time_unit_items = List().tag(sync=True)
+    time_unit_selected = Unicode().tag(sync=True)
 
     spectral_y_type_items = List().tag(sync=True)
     spectral_y_type_selected = Unicode().tag(sync=True)
@@ -97,30 +105,51 @@ class UnitConversion(PluginTemplateMixin):
         self.session.hub.subscribe(self, AddDataToViewerMessage,
                                    handler=self._find_and_convert_contour_units)
 
+        self.has_spectral = self.config in ('specviz', 'cubeviz', 'specviz2d', 'mosviz')
         self.spectral_unit = UnitSelectPluginComponent(self,
                                                        items='spectral_unit_items',
                                                        selected='spectral_unit_selected')
+
+        self.has_flux = self.config in ('specviz', 'cubeviz', 'specviz2d', 'mosviz')
+        self.flux_unit = UnitSelectPluginComponent(self,
+                                                   items='flux_unit_items',
+                                                   selected='flux_unit_selected')
+
+        self.has_angle = self.config in ('cubeviz', 'specviz', 'mosviz')
+        self.angle_unit = UnitSelectPluginComponent(self,
+                                                    items='angle_unit_items',
+                                                    selected='angle_unit_selected')
+
+        self.has_sb = self.has_angle or self.config in ('imviz',)
+        # NOTE: always read_only, exposed through sb_unit property
+
+        self.has_time = False
+        self.time_unit = UnitSelectPluginComponent(self,
+                                                   items='time_unit_items',
+                                                   selected='time_unit_selected')
 
         self.spectral_y_type = SelectPluginComponent(self,
                                                      items='spectral_y_type_items',
                                                      selected='spectral_y_type_selected',
                                                      manual_options=['Surface Brightness', 'Flux'])
 
-        self.flux_unit = UnitSelectPluginComponent(self,
-                                                   items='flux_unit_items',
-                                                   selected='flux_unit_selected')
-
-        self.angle_unit = UnitSelectPluginComponent(self,
-                                                    items='angle_unit_items',
-                                                    selected='angle_unit_selected')
-
     @property
     def user_api(self):
-        if self.app.config == 'cubeviz':
-            expose = ('spectral_unit', 'spectral_y_type', 'flux_unit', 'angle_unit', 'sb_unit')
-        else:
-            expose = ('spectral_unit', 'flux_unit', 'angle_unit')
-        return PluginUserApi(self, expose=expose)
+        expose = []
+        readonly = []
+        if self.has_spectral:
+            expose += ['spectral_unit']
+        if self.has_flux:
+            expose += ['flux_unit']
+        if self.has_angle:
+            expose += ['angle_unit']
+        if self.has_sb:
+            readonly = ['sb_unit']
+        if self.has_time:
+            expose += ['time_unit']
+        if self.config == 'cubeviz':
+            expose += ['spectral_y_type']
+        return PluginUserApi(self, expose=expose, readonly=readonly)
 
     @property
     def sb_unit(self):

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -82,9 +82,9 @@
         <v-select
           :menu-props="{ left: true }"
           attach
-          :items="flux_or_sb_items.map(i => i.label)"
-          v-model="flux_or_sb_selected"
-          :label="api_hints_enabled ? 'plg.flux_or_sb =' : 'Flux or Surface Brightness'"
+          :items="spectral_y_type_items.map(i => i.label)"
+          v-model="spectral_y_type_selected"
+          :label="api_hints_enabled ? 'plg.spectral_y_type =' : 'Flux or Surface Brightness'"
           :class="api_hints_enabled ? 'api-hint' : null"
           hint="Select the y-axis physical type for the spectrum-viewer."
           persistent-hint

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -84,7 +84,7 @@
           attach
           :items="spectral_y_type_items.map(i => i.label)"
           v-model="spectral_y_type_selected"
-          :label="api_hints_enabled ? 'plg.spectral_y_type =' : 'Flux or Surface Brightness'"
+          :label="api_hints_enabled ? 'plg.spectral_y_type =' : 'Spectral y-axis Type'"
           :class="api_hints_enabled ? 'api-hint' : null"
           hint="Select the y-axis physical type for the spectrum-viewer."
           persistent-hint

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -9,7 +9,7 @@
     :popout_button="popout_button"
     :scroll_to.sync="scroll_to">
 
-    <v-row>
+    <v-row v-if="has_spectral">
       <v-select
         :menu-props="{ left: true }"
         attach
@@ -22,7 +22,20 @@
       ></v-select>
     </v-row>
 
-    <v-row>
+    <v-row v-if="has_time">
+      <v-select
+        :menu-props="{ left: true }"
+        attach
+        :items="time_unit_items.map(i => i.label)"
+        v-model="time_unit_selected"
+        :label="api_hints_enabled ? 'plg.time_unit =' : 'Time Unit'"
+        :class="api_hints_enabled ? 'api-hint' : null"
+        hint="Global display unit for time axis."
+        persistent-hint
+      ></v-select>
+    </v-row>
+
+    <v-row v-if="has_flux">
       <v-select
         :menu-props="{ left: true }"
         attach
@@ -34,8 +47,8 @@
         persistent-hint
       ></v-select>
     </v-row>
-
-    <v-row v-if="config in ['cubeviz', 'imviz', 'mosviz']">
+  
+    <v-row v-if="has_angle">
       <v-select
         :menu-props="{ left: true }"
         attach
@@ -49,7 +62,7 @@
       ></v-select>
     </v-row>
 
-    <v-row>
+    <v-row v-if="has_spectral">
       <v-text-field
         v-model="sb_unit_selected"
         :label="api_hints_enabled ? 'plg.sb_unit' : 'Surface Brightness Unit'"
@@ -60,27 +73,29 @@
       ></v-text-field>
     </v-row>
 
-    <v-row v-if="config == 'cubeviz'">
-      <v-divider></v-divider>
-    </v-row>
+    <div v-if="config == 'cubeviz'">
+      <v-row>
+        <v-divider></v-divider>
+      </v-row>
 
-    <v-row  v-if="config == 'cubeviz'">
-      <v-select
-        :menu-props="{ left: true }"
-        attach
-        :items="spectral_y_type_items.map(i => i.label)"
-        v-model="spectral_y_type_selected"
-        :label="api_hints_enabled ? 'plg.spectral_y_type =' : 'Spectral y-axis Type'"
-        :class="api_hints_enabled ? 'api-hint' : null"
-        hint="Select the y-axis physical type for the spectrum-viewer."
-        persistent-hint
-      ></v-select>
-    </v-row>
+      <v-row>
+        <v-select
+          :menu-props="{ left: true }"
+          attach
+          :items="flux_or_sb_items.map(i => i.label)"
+          v-model="flux_or_sb_selected"
+          :label="api_hints_enabled ? 'plg.flux_or_sb =' : 'Flux or Surface Brightness'"
+          :class="api_hints_enabled ? 'api-hint' : null"
+          hint="Select the y-axis physical type for the spectrum-viewer."
+          persistent-hint
+        ></v-select>
+      </v-row>
 
-    <v-alert type="warning" v-if="!pixar_sr_exists && config == 'cubeviz'">
-          PIXAR_SR FITS header keyword not found when parsing spectral cube.
-          Flux/Surface Brightness will use default PIXAR_SR value of 1.
-    </v-alert>
+      <v-alert type="warning" v-if="!pixar_sr_exists">
+            PIXAR_SR FITS header keyword not found when parsing spectral cube.
+            Flux/Surface Brightness will use default PIXAR_SR value of 1.
+      </v-alert>
+    </div>
 
   </j-tray-plugin>
 </template>


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request provides the infrastructure for configs (and downstream apps) to dictate which display units should be shown in the plugin, as well as including a time unit (currently unused for all configs, but needed by lcviz).  The individual logic may need to be adjusted as unit conversion is enabled for the remaining configs (I just made a rough guess).  This PR also makes the surface-brightness API access read-only.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
