### PR TITLE
BUG: Fix spectral extraction in the presence of unit conversion

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -578,7 +578,7 @@ def test_default_spectral_extraction(cubeviz_helper, spectrum1d_cube_fluxunit_jy
     assert collapsed.flux.unit == u.MJy
     assert collapsed.uncertainty.unit == u.MJy
     assert_allclose(collapsed.flux.value, extracted_spectra[0].flux.value / 1e6)
-    assert uc.flux_unit.selected == 'MJy'
+    assert uc.flux_unit.selected == "MJy"
 
 
 @pytest.mark.usefixtures('_jail')

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -570,13 +570,15 @@ def test_default_spectral_extraction(cubeviz_helper, spectrum1d_cube_fluxunit_jy
     )
 
     # Also test unit conversion
-    uc = cubeviz_helper.plugins["Unit Conversion"]._obj
-    uc.flux_unit_selected = "MJy"
-    spec_extr_plugin = cubeviz_helper.plugins['Spectral Extraction']._obj
+    uc = cubeviz_helper.plugins["Unit Conversion"]
+    assert uc.flux_unit == "Jy"
+    uc.flux_unit = "MJy"
+    spec_extr_plugin = cubeviz_helper.plugins['Spectral Extraction']
     collapsed = spec_extr_plugin.extract()
     assert collapsed.flux.unit == u.MJy
     assert collapsed.uncertainty.unit == u.MJy
     assert_allclose(collapsed.flux.value, extracted_spectra[0].flux.value / 1e6)
+    assert uc.flux_unit.selected == 'MJy'
 
 
 @pytest.mark.usefixtures('_jail')

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -569,6 +569,15 @@ def test_default_spectral_extraction(cubeviz_helper, spectrum1d_cube_fluxunit_jy
         extracted_spectra[0].flux, extracted_spectra[1].flux
     )
 
+    # Also test unit conversion
+    uc = cubeviz_helper.plugins["Unit Conversion"]._obj
+    uc.flux_unit_selected = "MJy"
+    spec_extr_plugin = cubeviz_helper.plugins['Spectral Extraction']._obj
+    collapsed = spec_extr_plugin.extract()
+    assert collapsed.flux.unit == u.MJy
+    assert collapsed.uncertainty.unit == u.MJy
+    assert_allclose(collapsed.flux.value, extracted_spectra[0].flux.value / 1e6)
+
 
 @pytest.mark.usefixtures('_jail')
 @pytest.mark.remote_data


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to sort of spectral extraction when unit conversion happens.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4734)
