### PR TITLE
fix display units moment maps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ New Features
 ------------
 
 - Added flux/surface brightness translation and surface brightness
-  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113, #3129, #3139, #3149, #3155]
+  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113, #3129, #3139, #3149, #3155, #3169]
 
 - Plugin tray is now open by default. [#2892]
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -209,11 +209,9 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
 
             # is cube data a flux or sb? this check can go away when cubes are forced to sb
             if check_if_unit_is_per_solid_angle(comp.units):
-                print('data unit is sb')
                 sb_or_flux_label = "Surface Brightness"
                 unit_dict[orig_flux_or_sb] = self.app._get_display_unit('sb')
             else:
-                print('data unit is flux')
                 sb_or_flux_label = "Flux"
                 unit_dict[orig_flux_or_sb] = self.app._get_display_unit('flux')
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -49,8 +49,10 @@ def test_user_api(cubeviz_helper, spectrum1d_cube):
         with pytest.raises(ValueError, match="units must be in"):
             mm.calculate_moment()
 
+
 @pytest.mark.parametrize("cube_type", ["Surface Brightness", "Flux"])
-def test_moment_calculation(cubeviz_helper, spectrum1d_cube, spectrum1d_cube_sb_unit, cube_type, tmp_path):
+def test_moment_calculation(cubeviz_helper, spectrum1d_cube,
+                            spectrum1d_cube_sb_unit, cube_type, tmp_path):
 
     if SPECUTILS_LT_1_15_1:
         moment_unit = "Jy"

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -68,6 +68,8 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube,
     elif cube_type == 'Flux':
         cube = spectrum1d_cube
 
+    cube_unit = cube.unit.to_string()
+
     dc = cubeviz_helper.app.data_collection
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="No observer defined on WCS.*")
@@ -104,13 +106,13 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube,
     assert mm._obj.results_label == 'moment 0'
     assert mm._obj.results_label_overwrite is True
 
-    # Make sure coordinate display works
+    # Make sure coordinate display works in flux viewer (loaded data, not the moment map)
     label_mouseover = cubeviz_helper.app.session.application._tools['g-coords-info']
     label_mouseover._viewer_mouse_event(flux_viewer, {'event': 'mousemove',
                                                       'domain': {'x': 0, 'y': 0}})
     assert flux_viewer.state.slices == (0, 0, 1)
     # Slice 0 has 8 pixels, this is Slice 1
-    assert label_mouseover.as_text() == (f"Pixel x=00.0 y=00.0 Value +8.00000e+00 {moment_unit}",
+    assert label_mouseover.as_text() == (f"Pixel x=00.0 y=00.0 Value +8.00000e+00 {cube_unit}",
                                          "World 13h39m59.9731s +27d00m00.3600s (ICRS)",
                                          "204.9998877673 27.0001000000 (deg)")
 

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -264,6 +264,7 @@ def _create_spectrum1d_cube_with_fluxunit(fluxunit=u.Jy, shape=(2, 2, 4), with_u
 def spectrum1d_cube():
     return _create_spectrum1d_cube_with_fluxunit(fluxunit=u.Jy)
 
+
 @pytest.fixture
 def spectrum1d_cube_sb_unit():
     return _create_spectrum1d_cube_with_fluxunit(fluxunit=u.Jy / u.sr)

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -264,6 +264,10 @@ def _create_spectrum1d_cube_with_fluxunit(fluxunit=u.Jy, shape=(2, 2, 4), with_u
 def spectrum1d_cube():
     return _create_spectrum1d_cube_with_fluxunit(fluxunit=u.Jy)
 
+@pytest.fixture
+def spectrum1d_cube_sb_unit():
+    return _create_spectrum1d_cube_with_fluxunit(fluxunit=u.Jy / u.sr)
+
 
 @pytest.fixture
 def spectrum1d_cube_with_uncerts():


### PR DESCRIPTION
(This is needed for #3144)

This fixes an issues where the moment map plugin was incorrectly picking up changes to display unit. It was responding to changes in the spectral y axis, including toggling between flux and surface brightness. The outputs of moment 0 should always be the same type (flux or sb) as the data units (which will, after 3144 is merged, always be surface brightness), and should not be tied to what the spectrum viewer axis is toggled to. Additionally, units were being obtained on global display unit changed and again when moment map was computed, which wasn't necessary to do. 

These issues were causing moment map calculation to fail for any cubes loaded in surface brightness units (to reproduce this bug, try calculating a 0th moment with the cubeviz example notebook, it fails). This wasn't being picked up by tests because all the tests fixtures used in moment map tests have cubes that are in flux units. The basic moment map test is now being tested with a cube in Jy, and one in Jy / sr.
