### PR TITLE
Rampviz fixes for unexpected viewer limit resets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ New Features
 
 - The standalone version of jdaviz now uses solara instead of voila, resulting in faster load times. [#2909]
 
-- New configuration for ramp/Level 1 data products from Roman WFI and JWST [#3120, #3148, #3167]
+- New configuration for ramp/Level 1 data products from Roman WFI and JWST [#3120, #3148, #3167, #3171]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -198,11 +198,11 @@ class JdavizViewerMixin(WithCache):
             return
 
         # default visibility based on the visibility of the "parent" data layer
-        if self.__class__.__name__ != 'RampvizProfileView':
-            layer_state.visible = self._get_layer(layer_state.layer.data.label).visible
-        else:
+        if self.__class__.__name__ == 'RampvizProfileView':
             # Rampviz doesn't show subset profiles by default:
             layer_state.visible = False
+        else:
+            layer_state.visible = self._get_layer(layer_state.layer.data.label).visible
 
     def _update_layer_icons(self):
         # update visible_layers (TODO: move this somewhere that can update on color change, etc)

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -198,7 +198,11 @@ class JdavizViewerMixin(WithCache):
             return
 
         # default visibility based on the visibility of the "parent" data layer
-        layer_state.visible = self._get_layer(layer_state.layer.data.label).visible
+        if self.__class__.__name__ != 'RampvizProfileView':
+            layer_state.visible = self._get_layer(layer_state.layer.data.label).visible
+        else:
+            # Rampviz doesn't show subset profiles by default:
+            layer_state.visible = False
 
     def _update_layer_icons(self):
         # update visible_layers (TODO: move this somewhere that can update on color change, etc)

--- a/jdaviz/configs/rampviz/plugins/ramp_extraction/ramp_extraction.py
+++ b/jdaviz/configs/rampviz/plugins/ramp_extraction/ramp_extraction.py
@@ -186,6 +186,8 @@ class RampExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
             if getattr(mark, 'label', None) != subset_lbl
         ] + marks
 
+        self.integration_viewer.reset_limits()
+
     def _on_subset_delete(self, msg={}):
         subset_lbl = msg.subset.label
         self.integration_viewer.figure.marks = [
@@ -200,7 +202,6 @@ class RampExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         if not hasattr(self.app._jdaviz_helper, '_default_integration_viewer_reference_name'):
             return
 
-        redraw_limits = False
         for mark in self.integration_viewer.figure.marks:
             if isinstance(mark, PluginLine) and mark.label is not None:
                 new_visibility = (
@@ -209,10 +210,8 @@ class RampExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
                 )
                 if mark.visible != new_visibility:
                     mark.visible = new_visibility
-                    redraw_limits = True
 
-        if redraw_limits:
-            self.integration_viewer.reset_limits()
+        self.integration_viewer.reset_limits()
 
     @property
     def _subset_preview_visible(self):

--- a/jdaviz/configs/rampviz/plugins/tools.py
+++ b/jdaviz/configs/rampviz/plugins/tools.py
@@ -23,7 +23,7 @@ class RampPerPixel(ProfileFromCube):
     def on_mouse_move(self, data):
         if data['event'] == 'mouseleave':
             self._mark.visible = False
-            self._reset_profile_viewer_bounds()
+            self._profile_viewer.reset_limits()
             return
 
         x = int(np.round(data['domain']['x']))
@@ -41,3 +41,4 @@ class RampPerPixel(ProfileFromCube):
                 return
             self._mark.update_xy(np.arange(y_values.size), y_values)
             self._mark.visible = True
+            self._profile_viewer.reset_limits()


### PR DESCRIPTION
### Description

Three bugs to fix: 
* When updating the selected slice in the integration viewer in Rampviz, the integration viewer's y-limits change twice and the data flash and move around a bit. 

* When a subset is created in the group-viewer, the integration viewer gets a subset profile by default via glue. That profile layer's icon appears in the legend and `layer.visible == True`, even though the subset profile can't be seen in the viewer. Glue ensures that profile viewers create visible subset profiles by default, it's on us to override that behavior, and some minor bits of logic are missing.

* When using the single-pixel ramp-extraction-on-hover tool, integration-viewer limits do not get reset when the preview exceeds the y-limits.

This PR fixes these bugs by: 
* adjusting the logic in `integration_viewer.reset_limits` to avoid redundant calls
* ensuring that the automatic subset extractions in the integration viewer are never visible

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4746)