### PR TITLE
Unit conversion UI tweaks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ New Features
 ------------
 
 - Added flux/surface brightness translation and surface brightness
-  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113, #3129, #3139, #3149, #3155]
+  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113, #3129, #3139, #3149, #3155, #3178]
 
 - Plugin tray is now open by default. [#2892]
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1301,8 +1301,8 @@ class Application(VuetifyTemplate, HubListener):
                 raise ValueError(f"could not find units for axis='{axis}'")
         uc = self._jdaviz_helper.plugins.get('Unit Conversion')._obj
         if axis == 'spectral_y':
-            # translate options from uc.flux_or_sb to the prefix used in uc.??_unit_selected
-            axis = {'Surface Brightness': 'sb', 'Flux': 'flux'}[uc.flux_or_sb_selected]
+            # translate options from uc.spectral_y_type to the prefix used in uc.??_unit_selected
+            axis = {'Surface Brightness': 'sb', 'Flux': 'flux'}[uc.spectral_y_type_selected]
         try:
             return getattr(uc, f'{axis}_unit_selected')
         except AttributeError:

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -175,9 +175,9 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
         self.send_state("output_unit_selected")
 
         # either 'Flux' or 'Surface Brightness'
-        orig_flux_or_sb = self.output_unit_items[0]['label']
+        orig_spectral_y_type = self.output_unit_items[0]['label']
 
-        unit_dict = {orig_flux_or_sb: "",
+        unit_dict = {orig_spectral_y_type: "",
                      "Spectral Unit": "",
                      "Velocity": "km/s",
                      "Velocity^N": f"km{self.n_moment}/s{self.n_moment}"}
@@ -200,19 +200,19 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
             # get flux/SB units
             if self.spectrum_viewer and hasattr(self.spectrum_viewer.state, 'y_display_unit'):
                 if self.spectrum_viewer.state.y_display_unit is not None:
-                    unit_dict[orig_flux_or_sb] = self.spectrum_viewer.state.y_display_unit
+                    unit_dict[orig_spectral_y_type] = self.spectrum_viewer.state.y_display_unit
                 else:
                     # spectrum_viewer.state will only have x/y_display_unit if unit conversion has
                     # been done if not, get default flux units which should be the units displayed
-                    unit_dict[orig_flux_or_sb] = data.get_component('flux').units
+                    unit_dict[orig_spectral_y_type] = data.get_component('flux').units
             else:
                 # spectrum_viewer.state will only have x/y_display_unit if unit conversion has
                 # been done if not, get default flux units which should be the units displayed
-                unit_dict[orig_flux_or_sb] = data.get_component('flux').units
+                unit_dict[orig_spectral_y_type] = data.get_component('flux').units
 
             # figure out if label should say 'Flux' or 'Surface Brightness'
             sb_or_flux_label = "Flux"
-            is_unit_solid_angle = check_if_unit_is_per_solid_angle(unit_dict[orig_flux_or_sb])
+            is_unit_solid_angle = check_if_unit_is_per_solid_angle(unit_dict[orig_spectral_y_type])
             if is_unit_solid_angle is True:
                 sb_or_flux_label = "Surface Brightness"
 
@@ -353,11 +353,11 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
                 flux_sb_unit = data.get_component('flux').units
 
             # convert unit string to u.Unit so moment map data can be converted
-            flux_or_sb_display_unit = u.Unit(flux_sb_unit)
+            spectral_y_display_unit = u.Unit(flux_sb_unit)
             if SPECUTILS_LT_1_15_1:
-                moment_new_unit = flux_or_sb_display_unit
+                moment_new_unit = spectral_y_display_unit
             else:
-                moment_new_unit = flux_or_sb_display_unit * self.spectrum_viewer.state.x_display_unit  # noqa: E501
+                moment_new_unit = spectral_y_display_unit * self.spectrum_viewer.state.x_display_unit  # noqa: E501
             self.moment = self.moment.to(moment_new_unit)
 
         # Reattach the WCS so we can load the result

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -280,7 +280,7 @@ def test_momentmap_nirspec_prism(cubeviz_helper, tmp_path):
     uc = cubeviz_helper.plugins["Unit Conversion"]
     uc.open_in_tray()  # plugin has to be open for unit change to take hold
     uc._obj.show_translator = True
-    uc.flux_or_sb.selected = 'Surface Brightness'
+    uc.spectral_y_type.selected = 'Surface Brightness'
     mm = cubeviz_helper.plugins['Moment Maps']._obj
     mm.open_in_tray()  # plugin has to be open for unit change to take hold
     mm._set_data_units()
@@ -295,7 +295,7 @@ def test_momentmap_nirspec_prism(cubeviz_helper, tmp_path):
                     (sky_cube.ra.deg, sky_cube.dec.deg))
 
 
-def test_correct_output_flux_or_sb_units(cubeviz_helper, spectrum1d_cube_custom_fluxunit):
+def test_correct_output_spectral_y_units(cubeviz_helper, spectrum1d_cube_custom_fluxunit):
     if SPECUTILS_LT_1_15_1:
         moment_unit = "Jy / sr"
     else:
@@ -316,7 +316,7 @@ def test_correct_output_flux_or_sb_units(cubeviz_helper, spectrum1d_cube_custom_
     uc = cubeviz_helper.plugins["Unit Conversion"]
     uc.open_in_tray()  # plugin has to be open for unit change to take hold
     uc._obj.show_translator = True
-    uc.flux_or_sb.selected = 'Surface Brightness'
+    uc.spectral_y_type.selected = 'Surface Brightness'
     mm = cubeviz_helper.plugins['Moment Maps']._obj
     mm.open_in_tray()  # plugin has to be open for unit change to take hold
     mm._set_data_units()

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
@@ -206,7 +206,7 @@ def test_cubeviz_aperphot_unit_conversion(cubeviz_helper, spectrum1d_cube_custom
     # check that initial units are synced between plugins
     assert uc.flux_unit.selected == 'MJy'
     assert uc.angle_unit.selected == 'sr'
-    assert ap.display_flux_or_sb_unit == 'MJy / sr'
+    assert ap.display_spectral_y_unit == 'MJy / sr'
     assert ap.flux_scaling_display_unit == 'MJy'
 
     # and defaults for inputs are in the correct unit

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -68,7 +68,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
     # Cubeviz only
     cube_slice = Unicode("").tag(sync=True)
     is_cube = Bool(False).tag(sync=True)
-    display_flux_or_sb_unit = Unicode("").tag(sync=True)
+    display_spectral_y_unit = Unicode("").tag(sync=True)
     flux_scaling_display_unit = Unicode("").tag(sync=True)
 
     def __init__(self, *args, **kwargs):
@@ -163,7 +163,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
         if self.config == 'cubeviz':
 
             # get previously selected display units
-            prev_display_flux_or_sb_unit = self.display_flux_or_sb_unit
+            prev_display_spectral_y_unit = self.display_spectral_y_unit
             prev_flux_scale_unit = self.flux_scaling_display_unit
 
             # update display unit traitlets to new selection
@@ -172,13 +172,13 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             # convert the previous background and flux scaling values to new unit so
             # re-calculating photometry with the current selections will produce
             # the previous output with the new unit.
-            if prev_display_flux_or_sb_unit != '':
+            if prev_display_spectral_y_unit != '':
 
                 # convert background to new unit
                 if self.background_value is not None:
 
-                    prev_unit = u.Unit(prev_display_flux_or_sb_unit)
-                    new_unit = u.Unit(self.display_flux_or_sb_unit)
+                    prev_unit = u.Unit(prev_display_spectral_y_unit)
+                    new_unit = u.Unit(self.display_spectral_y_unit)
 
                     bg = self.background_value * prev_unit
                     self.background_value = bg.to_value(
@@ -196,14 +196,14 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
     def _set_display_unit_of_selected_dataset(self):
 
         """
-        Set the display_flux_or_sb_unit and flux_scaling_display_unit traitlets,
+        Set the display_spectral_y_unit and flux_scaling_display_unit traitlets,
         which depend on if the selected data set is flux or surface brightness,
         and the corresponding global display unit for either flux or
         surface brightness.
         """
 
         if not self.dataset_selected or not self.aperture_selected:
-            self.display_flux_or_sb_unit = ''
+            self.display_spectral_y_unit = ''
             self.flux_scaling_display_unit = ''
             return
 
@@ -213,13 +213,13 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             # if data is something-per-solid-angle, its a SB unit and we should
             # use the selected global display unit for SB
             if check_if_unit_is_per_solid_angle(comp.units):
-                flux_or_sb = 'sb'
+                spectral_y_type = 'sb'
             else:
-                flux_or_sb = 'flux'
+                spectral_y_type = 'flux'
 
-            disp_unit = self.app._get_display_unit(flux_or_sb)
+            disp_unit = self.app._get_display_unit(spectral_y_type)
 
-            self.display_flux_or_sb_unit = disp_unit
+            self.display_spectral_y_unit = disp_unit
 
             # now get display unit for flux_scaling_display_unit. this unit will always
             # be in flux, but it will not be derived from the global flux display unit
@@ -228,7 +228,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             self.flux_scaling_display_unit = fs_unit.to_string()
 
         else:
-            self.display_flux_or_sb_unit = ''
+            self.display_spectral_y_unit = ''
             self.flux_scaling_display_unit = ''
 
     def _get_defaults_from_metadata(self, dataset=None):
@@ -251,8 +251,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             mjy2abmag = 0.003631
 
             # if display unit is different, translate
-            if (self.config == 'cubeviz') and (self.display_flux_or_sb_unit != ''):
-                disp_unit = u.Unit(self.display_flux_or_sb_unit)
+            if (self.config == 'cubeviz') and (self.display_spectral_y_unit != ''):
+                disp_unit = u.Unit(self.display_spectral_y_unit)
                 mjy2abmag = (mjy2abmag * u.Unit("MJy/sr")).to_value(disp_unit)
 
             if 'photometry' in meta and 'pixelarea_arcsecsq' in meta['photometry']:
@@ -337,7 +337,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
         # get correct display unit for newly selected dataset
         if self.config == 'cubeviz':
-            # set display_flux_or_sb_unit and flux_scaling_display_unit
+            # set display_spectral_y_unit and flux_scaling_display_unit
             self._set_display_unit_of_selected_dataset()
 
         # auto-populate background, if applicable.
@@ -437,9 +437,9 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
         # convert to display unit, if necessary (cubeviz only)
 
-        if (self.config == 'cubeviz') and (self.display_flux_or_sb_unit != '') and comp.units:
+        if (self.config == 'cubeviz') and (self.display_spectral_y_unit != '') and comp.units:
             bg_md = (bg_md * u.Unit(comp.units)).to_value(
-                u.Unit(self.display_flux_or_sb_unit), u.spectral_density(self._cube_wave))
+                u.Unit(self.display_spectral_y_unit), u.spectral_density(self._cube_wave))
 
         return bg_md
 
@@ -542,7 +542,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             img_unit = None
 
         if self.config == 'cubeviz':
-            display_unit = u.Unit(self.display_flux_or_sb_unit)
+            display_unit = u.Unit(self.display_spectral_y_unit)
 
         if background is not None and background not in self.background.choices:  # pragma: no cover
             raise ValueError(f"background must be one of {self.background.choices}")
@@ -722,7 +722,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             phot_table.add_column(slice_val, name="slice_wave", index=29)
 
             if comp.units:  # convert phot. results from image unit to display unit
-                display_unit = u.Unit(self.display_flux_or_sb_unit)
+                display_unit = u.Unit(self.display_spectral_y_unit)
                 # convert units of certain columns in aperture phot. output table
                 # to reflect display units (i.e if data units are MJy / sr, but
                 # Jy / sr is selected in Unit Conversion plugin)
@@ -762,8 +762,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
         if update_plots:
 
             # for cubeviz unit conversion display units
-            if self.display_flux_or_sb_unit != '':
-                plot_display_unit = self.display_flux_or_sb_unit
+            if self.display_spectral_y_unit != '':
+                plot_display_unit = self.display_spectral_y_unit
             else:
                 plot_display_unit = None
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -80,7 +80,7 @@
             v-model.number="background_value"
             type="number"
             hint="Background to subtract"
-            :suffix="display_flux_or_sb_unit"
+            :suffix="display_spectral_y_unit"
             :disabled="background_selected!='Manual'"
             persistent-hint
           >
@@ -191,7 +191,7 @@
     </v-row>
 
     <v-row v-if="!multiselect && plot_available">
-      <jupyter-widget :widget="plot_widget"/> 
+      <jupyter-widget :widget="plot_widget"/>
     </v-row>
 
     <div v-if="!multiselect && plot_available && fit_radial_profile && current_plot_type != 'Curve of Growth'">
@@ -231,7 +231,7 @@
 
     <div v-if="result_available">
       <j-plugin-section-header>Results History</j-plugin-section-header>
-      <jupyter-widget :widget="table_widget"></jupyter-widget> 
+      <jupyter-widget :widget="table_widget"></jupyter-widget>
     </div>
   </j-tray-plugin>
 </template>

--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -89,7 +89,7 @@ def test_conv_no_data(specviz_helper, spectrum1d):
     """plugin unit selections won't have valid choices yet, preventing
     attempting to set display units."""
     # spectrum not load is in Flux units, sb_unit and flux_unit
-    # should be enabled, flux_or_sb should not be
+    # should be enabled, spectral_y_type should not be
     plg = specviz_helper.plugins["Unit Conversion"]
     with pytest.raises(ValueError, match="no valid unit choices"):
         plg.spectral_unit = "micron"
@@ -100,7 +100,7 @@ def test_conv_no_data(specviz_helper, spectrum1d):
     # make sure we don't expose translations in Specviz
     assert hasattr(plg, 'flux_unit')
     assert hasattr(plg, 'angle_unit')
-    assert not hasattr(plg, 'flux_or_sb')
+    assert not hasattr(plg, 'spectral_y_type')
 
 
 def test_non_stddev_uncertainty(specviz_helper):
@@ -150,7 +150,7 @@ def test_unit_translation(cubeviz_helper):
 
     # When the dropdown is displayed, this ensures the loaded
     # data collection item units will be used for translations.
-    assert uc_plg._obj.flux_or_sb_selected == 'Flux'
+    assert uc_plg._obj.spectral_y_type_selected == 'Flux'
 
     # accessing from get_data(use_display_units=True) should return flux-like units
     assert cubeviz_helper.app._get_display_unit('spectral_y') == u.MJy
@@ -161,9 +161,9 @@ def test_unit_translation(cubeviz_helper):
         cubeviz_helper._default_spectrum_viewer_reference_name)
 
     # change global y-units from Flux -> Surface Brightness
-    uc_plg._obj.flux_or_sb_selected = 'Surface Brightness'
+    uc_plg._obj.spectral_y_type_selected = 'Surface Brightness'
 
-    assert uc_plg._obj.flux_or_sb_selected == 'Surface Brightness'
+    assert uc_plg._obj.spectral_y_type_selected == 'Surface Brightness'
     y_display_unit = u.Unit(viewer_1d.state.y_display_unit)
 
     # check if units translated
@@ -190,7 +190,7 @@ def test_sb_unit_conversion(cubeviz_helper):
     uc_plg.open_in_tray()
 
     # ensure that per solid angle cube defaults to Flux spectrum
-    assert uc_plg.flux_or_sb == 'Flux'
+    assert uc_plg.spectral_y_type == 'Flux'
     # flux choices is populated with flux units
     assert uc_plg.flux_unit.choices
 
@@ -198,7 +198,7 @@ def test_sb_unit_conversion(cubeviz_helper):
     viewer_1d = cubeviz_helper.app.get_viewer(
         cubeviz_helper._default_spectrum_viewer_reference_name)
 
-    uc_plg.flux_or_sb.selected = 'Surface Brightness'
+    uc_plg.spectral_y_type.selected = 'Surface Brightness'
 
     # Surface Brightness conversion
     uc_plg.flux_unit = 'Jy'
@@ -243,7 +243,7 @@ def test_sb_unit_conversion(cubeviz_helper):
             "World 13h39m59.7037s +27d00m03.2400s (ICRS)",
             "204.9987654313 27.0008999946 (deg)")
 
-    uc_plg._obj.flux_or_sb_selected = 'Flux'
+    uc_plg._obj.spectral_y_type_selected = 'Flux'
     uc_plg.flux_unit = 'Jy'
     y_display_unit = u.Unit(viewer_1d.state.y_display_unit)
 
@@ -266,7 +266,7 @@ def test_contour_unit_conversion(cubeviz_helper, spectrum1d_cube_fluxunit_jy_per
 
     assert np.allclose(po_plg.contour_max.value, 199)
 
-    uc_plg._obj.flux_or_sb_selected = 'Surface Brightness'
+    uc_plg._obj.spectral_y_type_selected = 'Surface Brightness'
     uc_plg.flux_unit = 'MJy'
 
     assert np.allclose(po_plg.contour_max.value, 1.99e-4)

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -47,7 +47,7 @@ class UnitConversion(PluginTemplateMixin):
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.close_in_tray`
     * ``spectral_unit`` (:class:`~jdaviz.core.template_mixin.UnitSelectPluginComponent`):
       Global unit to use for all spectral axes.
-    * ``flux_or_sb`` (:class:`~jdaviz.core.template_mixin.SelectPluginComponent`):
+    * ``spectral_y_type`` (:class:`~jdaviz.core.template_mixin.SelectPluginComponent`):
       Select the y-axis physical type for the spectrum-viewer.
     * ``flux_unit`` (:class:`~jdaviz.core.template_mixin.UnitSelectPluginComponent`):
       Global display unit for flux axis.
@@ -67,8 +67,8 @@ class UnitConversion(PluginTemplateMixin):
     angle_unit_items = List().tag(sync=True)
     angle_unit_selected = Unicode().tag(sync=True)
 
-    flux_or_sb_items = List().tag(sync=True)
-    flux_or_sb_selected = Unicode().tag(sync=True)
+    spectral_y_type_items = List().tag(sync=True)
+    spectral_y_type_selected = Unicode().tag(sync=True)
 
     # This is used a warning message if False. This can be changed from
     # bool to unicode when we eventually handle inputing this value if it
@@ -101,10 +101,10 @@ class UnitConversion(PluginTemplateMixin):
                                                        items='spectral_unit_items',
                                                        selected='spectral_unit_selected')
 
-        self.flux_or_sb = SelectPluginComponent(self,
-                                                items='flux_or_sb_items',
-                                                selected='flux_or_sb_selected',
-                                                manual_options=['Surface Brightness', 'Flux'])
+        self.spectral_y_type = SelectPluginComponent(self,
+                                                     items='spectral_y_type_items',
+                                                     selected='spectral_y_type_selected',
+                                                     manual_options=['Surface Brightness', 'Flux'])
 
         self.flux_unit = UnitSelectPluginComponent(self,
                                                    items='flux_unit_items',
@@ -117,7 +117,7 @@ class UnitConversion(PluginTemplateMixin):
     @property
     def user_api(self):
         if self.app.config == 'cubeviz':
-            expose = ('spectral_unit', 'flux_or_sb', 'flux_unit', 'angle_unit', 'sb_unit')
+            expose = ('spectral_unit', 'spectral_y_type', 'flux_unit', 'angle_unit', 'sb_unit')
         else:
             expose = ('spectral_unit', 'flux_unit', 'angle_unit')
         return PluginUserApi(self, expose=expose)
@@ -152,7 +152,7 @@ class UnitConversion(PluginTemplateMixin):
             return
         if self.spectral_unit.selected == "":
             # no spectral unit set yet, cannot determine equivalencies
-            # setting the spectral unit will check len(flux_or_sb_unit.choices)
+            # setting the spectral unit will check len(spectral_y_type_unit.choices)
             # and call this manually in the case that that is triggered second.
             return
         self.spectrum_viewer.set_plot_axes()
@@ -212,15 +212,15 @@ class UnitConversion(PluginTemplateMixin):
                                self.spectral_unit.selected,
                                sender=self))
 
-    @observe('flux_or_sb_selected')
-    def _on_flux_or_sb_selected(self, msg):
+    @observe('spectral_y_type_selected')
+    def _on_spectral_y_type_selected(self, msg):
         """
         Observes toggle between surface brightness or flux selection for
         spectrum viewer to trigger translation.
         """
 
-        if msg.get('name') == 'flux_or_sb_selected':
-            self._translate(self.flux_or_sb_selected)
+        if msg.get('name') == 'spectral_y_type_selected':
+            self._translate(self.spectral_y_type_selected)
 
     @observe('flux_unit_selected')
     def _on_flux_unit_changed(self, msg):
@@ -255,7 +255,7 @@ class UnitConversion(PluginTemplateMixin):
         self.hub.broadcast(GlobalDisplayUnitChanged("flux", flux_unit, sender=self))
         self.hub.broadcast(GlobalDisplayUnitChanged("sb", sb_unit, sender=self))
 
-        spectral_y = sb_unit if self.flux_or_sb == 'Surface Brightness' else flux_unit
+        spectral_y = sb_unit if self.spectral_y_type == 'Surface Brightness' else flux_unit
 
         yunit = _valid_glue_display_unit(spectral_y, self.spectrum_viewer, 'y')
 
@@ -270,12 +270,12 @@ class UnitConversion(PluginTemplateMixin):
             self.hub.broadcast(GlobalDisplayUnitChanged("spectral_y", spectral_y, sender=self))
 
         if not check_if_unit_is_per_solid_angle(self.spectrum_viewer.state.y_display_unit):
-            self.flux_or_sb_selected = 'Flux'
+            self.spectral_y_type_selected = 'Flux'
         else:
-            self.flux_or_sb_selected = 'Surface Brightness'
+            self.spectral_y_type_selected = 'Surface Brightness'
 
         # Always send a surface brightness unit to contours
-        if self.flux_or_sb_selected == 'Flux':
+        if self.spectral_y_type_selected == 'Flux':
             yunit = self._append_angle_correctly(yunit, self.angle_unit.selected)
         self._find_and_convert_contour_units(yunit=yunit)
 
@@ -312,7 +312,7 @@ class UnitConversion(PluginTemplateMixin):
                 if hasattr(layer, 'attribute_display_unit'):
                     layer.attribute_display_unit = yunit
 
-    def _translate(self, flux_or_sb=None):
+    def _translate(self, spectral_y_type=None):
         # currently unsupported, can be supported with a scale factor
         if self.app.config == 'specviz':
             return
@@ -328,14 +328,14 @@ class UnitConversion(PluginTemplateMixin):
             return
 
         # Surface Brightness -> Flux
-        if check_if_unit_is_per_solid_angle(spec_units) and flux_or_sb == 'Flux':
+        if check_if_unit_is_per_solid_angle(spec_units) and spectral_y_type == 'Flux':
             spec_units *= u.sr
             # update display units
             self.spectrum_viewer.state.y_display_unit = str(spec_units)
 
         # Flux -> Surface Brightness
         elif (not check_if_unit_is_per_solid_angle(spec_units)
-              and flux_or_sb == 'Surface Brightness'):
+              and spectral_y_type == 'Surface Brightness'):
             spec_units /= u.sr
             # update display units
             self.spectrum_viewer.state.y_display_unit = str(spec_units)

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -3,7 +3,7 @@
     :config="config"
     plugin_key="Unit Conversion"
     :api_hints_enabled.sync="api_hints_enabled"
-    :description="docs_description || 'Convert the spectral flux density and spectral axis units.'"
+    :description="docs_description || 'Convert the units of displayed physical quantities.'"
     :link="docs_link || 'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#unit-conversion'"
     :disabled_msg="disabled_msg"
     :popout_button="popout_button"
@@ -34,7 +34,7 @@
         persistent-hint
       ></v-select>
     </v-row>
-  
+
     <v-row>
       <v-select
         :menu-props="{ left: true }"
@@ -45,7 +45,7 @@
         :class="api_hints_enabled ? 'api-hint' : null"
         hint="Solid angle unit."
         persistent-hint
-        
+
       ></v-select>
     </v-row>
 
@@ -68,9 +68,9 @@
       <v-select
         :menu-props="{ left: true }"
         attach
-        :items="flux_or_sb_items.map(i => i.label)"
-        v-model="flux_or_sb_selected"
-        :label="api_hints_enabled ? 'plg.flux_or_sb =' : 'Flux or Surface Brightness'"
+        :items="spectral_y_type_items.map(i => i.label)"
+        v-model="spectral_y_type_selected"
+        :label="api_hints_enabled ? 'plg.spectral_y_type =' : 'Spectral y-axis Type'"
         :class="api_hints_enabled ? 'api-hint' : null"
         hint="Select the y-axis physical type for the spectrum-viewer."
         persistent-hint

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -35,7 +35,7 @@
       ></v-select>
     </v-row>
 
-    <v-row>
+    <v-row v-if="config in ['cubeviz', 'imviz', 'mosviz']">
       <v-select
         :menu-props="{ left: true }"
         attach


### PR DESCRIPTION
This changes three things that were requested to be updated:

- update the plugin description to be either config-specific or config-generic
- consider renaming flux_or_sb to spectrum_y_type (or similar) and updating UI language
- determine which cases angle unit should be shown (UI and user API).  Probably can be disabled in anything without an image viewer.

If "Convert the units of displayed physical quantities." doesn't sound good as more generic language to people I can come up with something else.