### PR TITLE
Fix empty flux menu in Specviz with spectrum in surface brightness units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ New Features
 ------------
 
 - Added flux/surface brightness translation and surface brightness
-  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113, #3129, #3139, #3149, #3155, #3178]
+  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113, #3129, #3139, #3149, #3155, #3178, #3185]
 
 - Plugin tray is now open by default. [#2892]
 

--- a/jdaviz/configs/specviz/plugins/parsers.py
+++ b/jdaviz/configs/specviz/plugins/parsers.py
@@ -11,6 +11,7 @@ from specutils import Spectrum1D, SpectrumList, SpectrumCollection
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import data_parser_registry
 from jdaviz.utils import standardize_metadata, download_uri_to_path
+from jdaviz.core.validunits import check_if_unit_is_per_solid_angle
 
 
 __all__ = ["specviz_spectrum1d_parser"]
@@ -158,6 +159,17 @@ def specviz_spectrum1d_parser(app, data, data_label=None, format=None, show_in_v
 
             # Make metadata layout conform with other viz.
             spec.meta = standardize_metadata(spec.meta)
+
+            # If this is the first loaded data, we want to set spectral y unit type to Flux or
+            # Surface Brightness as appropriate
+            if len(app.data_collection) == 0:
+                print("Nothing in data collection yet")
+                uc = self.app._jdaviz_helper.plugins["Unit Conversion"]
+                if check_if_unit_is_per_solid_angle(flux_units):
+                    print("Unit is per solid angle")
+                    uc.spectral_y_type = "Surface Brightness"
+                else:
+                    uc.spectral_y_type = "Flux"
 
             app.add_data(spec, data_label[i])
 

--- a/jdaviz/configs/specviz/plugins/parsers.py
+++ b/jdaviz/configs/specviz/plugins/parsers.py
@@ -162,7 +162,7 @@ def specviz_spectrum1d_parser(app, data, data_label=None, format=None, show_in_v
 
             # If this is the first loaded data, we want to set spectral y unit type to Flux or
             # Surface Brightness as appropriate
-            if len(app.data_collection) == 0:
+            if len(app.data_collection) == 0 and "Unit Conversion" in app._jdaviz_helper.plugins:
                 uc = app._jdaviz_helper.plugins["Unit Conversion"]
                 if check_if_unit_is_per_solid_angle(flux_units):
                     uc._obj.spectral_y_type = "Surface Brightness"

--- a/jdaviz/configs/specviz/plugins/parsers.py
+++ b/jdaviz/configs/specviz/plugins/parsers.py
@@ -163,13 +163,11 @@ def specviz_spectrum1d_parser(app, data, data_label=None, format=None, show_in_v
             # If this is the first loaded data, we want to set spectral y unit type to Flux or
             # Surface Brightness as appropriate
             if len(app.data_collection) == 0:
-                print("Nothing in data collection yet")
-                uc = self.app._jdaviz_helper.plugins["Unit Conversion"]
+                uc = app._jdaviz_helper.plugins["Unit Conversion"]
                 if check_if_unit_is_per_solid_angle(flux_units):
-                    print("Unit is per solid angle")
-                    uc.spectral_y_type = "Surface Brightness"
+                    uc._obj.spectral_y_type = "Surface Brightness"
                 else:
-                    uc.spectral_y_type = "Flux"
+                    uc._obj.spectral_y_type = "Flux"
 
             app.add_data(spec, data_label[i])
 

--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -35,6 +35,14 @@ def test_value_error_exception(specviz_helper, spectrum1d, new_spectral_axis, ne
     assert u.Unit(viewer.state.y_display_unit) == u.Unit(expected_flux)
 
 
+def test_initialize_specviz_sb(specviz_helper, spectrum1d):
+    spec_sb = Spectrum1D(spectrum1d.flux/u.sr, spectrum1d.spectral_axis)
+    specviz_helper.load_data(spec_sb, data_label="Test 1D Spectrum")
+    plg = specviz_helper.plugins["Unit Conversion"]
+    assert plg._obj.flux_unit == "Jy"
+    assert plg._obj.spectral_y_type == "Surface Brightness"
+    assert plg._obj.angle_unit == "sr"
+
 @pytest.mark.parametrize('uncert', (False, True))
 def test_conv_wave_only(specviz_helper, spectrum1d, uncert):
     if uncert is False:

--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -43,6 +43,7 @@ def test_initialize_specviz_sb(specviz_helper, spectrum1d):
     assert plg._obj.spectral_y_type == "Surface Brightness"
     assert plg._obj.angle_unit == "sr"
 
+
 @pytest.mark.parametrize('uncert', (False, True))
 def test_conv_wave_only(specviz_helper, spectrum1d, uncert):
     if uncert is False:

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -176,6 +176,9 @@ class UnitConversion(PluginTemplateMixin):
             flux_choices = create_flux_equivalencies_list(y_unit * u.sr, x_unit)
             self.flux_unit.choices = flux_choices
             flux_unit = str(y_unit * u.sr)
+            # We need to set the angle_unit before triggering _on_flux_unit_changed
+            self.angle_unit.choices = create_angle_equivalencies_list(y_unit)
+            self.angle_unit.selected = self.angle_unit.choices[0]
             if flux_unit in self.flux_unit.choices and flux_unit != self.flux_unit.selected:
                 self.flux_unit.selected = flux_unit
 
@@ -248,16 +251,11 @@ class UnitConversion(PluginTemplateMixin):
         if not self.flux_unit.choices and self.app.config == 'cubeviz':
             return
 
-        print(f"flux_or_sb is {self.flux_or_sb}")
-
         # various plugins are listening for changes in either flux or sb and
         # need to be able to filter messages accordingly, so broadcast both when
         # flux unit is updated. if data was loaded in a flux unit (i.e MJy), it
         # can be reperesented as a per-pixel surface brightness unit
         flux_unit = self.flux_unit.selected
-        if self.angle_unit.selected is None or self.angle_unit.selected == "":
-            # Plugin isn't completely initialized, can't run the rest of this logic yet.
-            return
         sb_unit = self._append_angle_correctly(flux_unit, self.angle_unit.selected)
 
         self.hub.broadcast(GlobalDisplayUnitChanged("flux", flux_unit, sender=self))

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -144,7 +144,7 @@ class UnitConversion(PluginTemplateMixin):
             self.spectral_unit.selected = x_unit_str
             if not len(self.flux_unit.choices) or not len(self.angle_unit.choices):
                 # in case flux_unit was triggered first (but could not be set because there
-                # as no spectral_unit to determine valid equivalencies)
+                # was no spectral_unit to determine valid equivalencies)
                 self._on_glue_y_display_unit_changed(self.spectrum_viewer.state.y_display_unit)
 
     def _on_glue_y_display_unit_changed(self, y_unit_str):
@@ -156,12 +156,10 @@ class UnitConversion(PluginTemplateMixin):
             # and call this manually in the case that that is triggered second.
             return
         self.spectrum_viewer.set_plot_axes()
-        print(f"y_unit_str is {y_unit_str}")
 
         x_unit = u.Unit(self.spectral_unit.selected)
         y_unit_str = _valid_glue_display_unit(y_unit_str, self.spectrum_viewer, 'y')
         y_unit = u.Unit(y_unit_str)
-        print(f"y_unit is {y_unit}")
 
         if not check_if_unit_is_per_solid_angle(y_unit_str) and y_unit_str != self.flux_unit.selected:  # noqa
             flux_choices = create_flux_equivalencies_list(y_unit, x_unit)
@@ -179,7 +177,6 @@ class UnitConversion(PluginTemplateMixin):
             self.flux_unit.choices = flux_choices
             flux_unit = str(y_unit * u.sr)
             if flux_unit in self.flux_unit.choices and flux_unit != self.flux_unit.selected:
-                print(f"Setting flux unit to {flux_unit}")
                 self.flux_unit.selected = flux_unit
 
         # sets the angle unit drop down and the surface brightness read-only text
@@ -256,6 +253,9 @@ class UnitConversion(PluginTemplateMixin):
         # flux unit is updated. if data was loaded in a flux unit (i.e MJy), it
         # can be reperesented as a per-pixel surface brightness unit
         flux_unit = self.flux_unit.selected
+        if self.angle_unit.selected is None or self.angle_unit.selected == "":
+            # Plugin isn't completely initialized, can't run the rest of this logic yet.
+            return
         sb_unit = self._append_angle_correctly(flux_unit, self.angle_unit.selected)
 
         self.hub.broadcast(GlobalDisplayUnitChanged("flux", flux_unit, sender=self))

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -156,10 +156,12 @@ class UnitConversion(PluginTemplateMixin):
             # and call this manually in the case that that is triggered second.
             return
         self.spectrum_viewer.set_plot_axes()
+        print(f"y_unit_str is {y_unit_str}")
 
         x_unit = u.Unit(self.spectral_unit.selected)
         y_unit_str = _valid_glue_display_unit(y_unit_str, self.spectrum_viewer, 'y')
         y_unit = u.Unit(y_unit_str)
+        print(f"y_unit is {y_unit}")
 
         if not check_if_unit_is_per_solid_angle(y_unit_str) and y_unit_str != self.flux_unit.selected:  # noqa
             flux_choices = create_flux_equivalencies_list(y_unit, x_unit)
@@ -175,6 +177,10 @@ class UnitConversion(PluginTemplateMixin):
         if check_if_unit_is_per_solid_angle(y_unit_str):
             flux_choices = create_flux_equivalencies_list(y_unit * u.sr, x_unit)
             self.flux_unit.choices = flux_choices
+            flux_unit = str(y_unit * u.sr)
+            if flux_unit in self.flux_unit.choices and flux_unit != self.flux_unit.selected:
+                print(f"Setting flux unit to {flux_unit}")
+                self.flux_unit.selected = flux_unit
 
         # sets the angle unit drop down and the surface brightness read-only text
         if self.app.data_collection[0]:

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -176,7 +176,9 @@ class UnitConversion(PluginTemplateMixin):
             flux_choices = create_flux_equivalencies_list(y_unit * u.sr, x_unit)
             self.flux_unit.choices = flux_choices
             flux_unit = str(y_unit * u.sr)
-            # We need to set the angle_unit before triggering _on_flux_unit_changed
+            # We need to set the angle_unit before triggering _on_flux_unit_changed via
+            # setting self.flux_unit.selected below, or the lack of angle unit will make it think
+            # we're in Flux units.
             self.angle_unit.choices = create_angle_equivalencies_list(y_unit)
             self.angle_unit.selected = self.angle_unit.choices[0]
             if flux_unit in self.flux_unit.choices and flux_unit != self.flux_unit.selected:

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -248,6 +248,8 @@ class UnitConversion(PluginTemplateMixin):
         if not self.flux_unit.choices and self.app.config == 'cubeviz':
             return
 
+        print(f"flux_or_sb is {self.flux_or_sb}")
+
         # various plugins are listening for changes in either flux or sb and
         # need to be able to filter messages accordingly, so broadcast both when
         # flux unit is updated. if data was loaded in a flux unit (i.e MJy), it


### PR DESCRIPTION
This fixes problems on `main` with loading a the spectrum in the SpectrumExample notebook related to the Unit Conversion plugin (or presumably any other spectrum in surface brightness units). Mainly, this sets `spectral_y_type` to the correct selection on loading the first spectrum, and avoids having a blank angle unit selection when triggering `_on_flux_unit_changed`.