### PR TITLE
fix var names in aper phot, remove specutils version check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ New Features
 ------------
 
 - Added flux/surface brightness translation and surface brightness
-  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113, #3129, #3139, #3149, #3155, #3178]
+  unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113, #3129,
+                                           #3139, #3149, #3155, #3178, #3187]
 
 - Plugin tray is now open by default. [#2892]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ New Features
 
 - Added flux/surface brightness translation and surface brightness
   unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113, #3129,
-                                           #3139, #3149, #3155, #3178, #3187]
+  #3139, #3149, #3155, #3178, #3185, #3187]
 
 - Plugin tray is now open by default. [#2892]
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -354,10 +354,7 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
 
             # convert unit string to u.Unit so moment map data can be converted
             spectral_y_display_unit = u.Unit(flux_sb_unit)
-            if SPECUTILS_LT_1_15_1:
-                moment_new_unit = spectral_y_display_unit
-            else:
-                moment_new_unit = spectral_y_display_unit * self.spectrum_viewer.state.x_display_unit  # noqa: E501
+            moment_new_unit = spectral_y_display_unit * self.spectrum_viewer.state.x_display_unit  # noqa: E501
             self.moment = self.moment.to(moment_new_unit)
 
         # Reattach the WCS so we can load the result

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
@@ -206,7 +206,7 @@ def test_cubeviz_aperphot_unit_conversion(cubeviz_helper, spectrum1d_cube_custom
     # check that initial units are synced between plugins
     assert uc.flux_unit.selected == 'MJy'
     assert uc.angle_unit.selected == 'sr'
-    assert ap.display_spectral_y_unit == 'MJy / sr'
+    assert ap.display_unit == 'MJy / sr'
     assert ap.flux_scaling_display_unit == 'MJy'
 
     # and defaults for inputs are in the correct unit


### PR DESCRIPTION
This PR changes some of the unit conversion related variable names in aperture photometry to make it clearer that the spectral y axis unit is not being used for the plugin's display unit, but rather the dataset unit type (flux or sb) along with the choice of flux and angle units from the UC plugin for display. This same change needs to be made in moment maps, but since much of the code where these variables are being referenced go away in #3156, that will be addressed there. This also removes a remnant of checking for old specutils version in moment maps which can go away now that the minimum version is 1.16