### PR TITLE
Fix NaN handling in cube fitting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -142,6 +142,7 @@ Cubeviz
 
 - No longer incorrectly swap RA and Dec axes when loading Spectrum1D objects. [#3133]
 
+- Fixed fitting a model to the entire cube when NaNs are present. [#3190]
 
 Imviz
 ^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -142,8 +142,6 @@ Cubeviz
 
 - No longer incorrectly swap RA and Dec axes when loading Spectrum1D objects. [#3133]
 
-- Fixed fitting a model to the entire cube when NaNs are present. [#3190]
-
 Imviz
 ^^^^^
 
@@ -239,6 +237,8 @@ Bug Fixes
 
 Cubeviz
 ^^^^^^^
+
+- Fixed fitting a model to the entire cube when NaNs are present. [#3191]
 
 Imviz
 ^^^^^

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -735,8 +735,9 @@ class Application(VuetifyTemplate, HubListener):
             return
 
         elif self.config == 'cubeviz' and linked_data.ndim == 1:
-            ref_wavelength_component = dc[0].components[-2]
-            ref_flux_component = dc[0].components[-1]
+            # Don't want to use negative indices in case there are extra components like a mask
+            ref_wavelength_component = dc[0].components[5]
+            ref_flux_component = dc[0].components[6]
             linked_wavelength_component = dc[-1].components[1]
             linked_flux_component = dc[-1].components[-1]
 

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -471,6 +471,9 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
             wcs = cube.meta['_orig_spec'].wcs.spectral
         elif hasattr(cube.coords, 'spectral'):
             wcs = cube.coords.spectral
+        elif hasattr(cube.coords, 'spectral_wcs'):
+            # This is the attribute for a PaddedSpectrumWCS in the 3D case
+            wcs = cube.coords.spectral_wcs
         else:
             wcs = None
 

--- a/jdaviz/configs/default/plugins/model_fitting/initializers.py
+++ b/jdaviz/configs/default/plugins/model_fitting/initializers.py
@@ -119,7 +119,7 @@ class _WideBand1DInitializer(object):
         instance: `~astropy.modeling.Model`
             The initialized model.
         """
-        y_mean = np.mean(y)
+        y_mean = np.nanmean(y)
         x_range = x[-1] - x[0]
         position = x_range / 2.0 + x[0]
 
@@ -190,7 +190,7 @@ class _LineProfile1DInitializer(object):
 
         # width can be estimated by the weighted
         # 2nd moment of the X coordinate.
-        dx = x - np.mean(x)
+        dx = x - np.nanmean(x)
         fwhm = 2 * np.sqrt(np.sum((dx * dx) * y) / np.sum(y))
 
         # amplitude is derived from area.

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -7,7 +7,6 @@ from astropy.io import fits
 from astropy.modeling import models
 from astropy.nddata import StdDevUncertainty
 from astropy.tests.helper import assert_quantity_allclose
-from astropy.utils.exceptions import AstropyUserWarning
 from astropy.wcs import WCS
 from glue.core.roi import XRangeROI
 from numpy.testing import assert_allclose, assert_array_equal
@@ -391,7 +390,8 @@ def test_cube_fit_with_nans(cubeviz_helper):
     mf = cubeviz_helper.plugins["Model Fitting"]
     mf.cube_fit = True
     mf.create_model_component("Const1D")
-    with pytest.warns(AstropyUserWarning, match='Model is linear in parameters'):
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', message='Model is linear in parameters.*')
         mf.calculate_fit()
     result = cubeviz_helper.app.data_collection['model']
     assert np.all(result.get_component("flux").data == 1)
@@ -412,7 +412,8 @@ def test_cube_fit_with_subset_and_nans(cubeviz_helper):
     mf.cube_fit = True
     mf.spectral_subset = 'Subset 1'
     mf.create_model_component("Const1D")
-    with pytest.warns(AstropyUserWarning, match='Model is linear in parameters'):
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', message='Model is linear in parameters.*')
         mf.calculate_fit()
     result = cubeviz_helper.app.data_collection['model']
     assert np.all(result.get_component("flux").data == 1)

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -7,6 +7,7 @@ from astropy.io import fits
 from astropy.modeling import models
 from astropy.nddata import StdDevUncertainty
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils.exceptions import AstropyUserWarning
 from astropy.wcs import WCS
 from glue.core.roi import XRangeROI
 from numpy.testing import assert_allclose, assert_array_equal
@@ -390,7 +391,8 @@ def test_cube_fit_with_nans(cubeviz_helper):
     mf = cubeviz_helper.plugins["Model Fitting"]
     mf.cube_fit = True
     mf.create_model_component("Const1D")
-    mf.calculate_fit()
+    with pytest.warns(AstropyUserWarning, match='Model is linear in parameters'):
+        mf.calculate_fit()
     result = cubeviz_helper.app.data_collection['model']
     assert np.all(result.get_component("flux").data == 1)
 
@@ -410,7 +412,8 @@ def test_cube_fit_with_subset_and_nans(cubeviz_helper):
     mf.cube_fit = True
     mf.spectral_subset = 'Subset 1'
     mf.create_model_component("Const1D")
-    mf.calculate_fit()
+    with pytest.warns(AstropyUserWarning, match='Model is linear in parameters'):
+        mf.calculate_fit()
     result = cubeviz_helper.app.data_collection['model']
     print(cubeviz_helper.app.data_collection['model'].get_object(statistic=None).flux.max())
     assert np.all(result.get_component("flux").data == 1)

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -392,3 +392,21 @@ def test_cube_fit_with_nans(cubeviz_helper):
     mf.calculate_fit()
     result = cubeviz_helper.app.data_collection['model']
     assert np.all(result.get_component("flux").data == 1)
+
+def test_cube_fit_with_mask_and_nans(cubeviz_helper):
+    # Also test with existing mask
+    flux = np.ones((7, 8, 9)) * u.nJy
+    flux[:, :, 0] = np.nan
+    spec = Spectrum1D(flux=flux)
+    spec.mask = np.zeros((7, 8, 9)).astype(bool)
+    spec.mask[5,5,5] = True
+    spec.flux[5,5,5] = 10*u.nJy
+    cubeviz_helper.load_data(spec, data_label="test")
+
+    mf = cubeviz_helper.plugins["Model Fitting"]
+    mf.cube_fit = True
+    mf.create_model_component("Const1D")
+    mf.calculate_fit()
+    result = cubeviz_helper.app.data_collection['model']
+    print(cubeviz_helper.app.data_collection['model'].get_object(statistic=None).flux.max())
+    assert np.all(result.get_component("flux").data == 1)

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -388,7 +388,6 @@ def test_cube_fit_with_nans(cubeviz_helper):
 
     mf = cubeviz_helper.plugins["Model Fitting"]
     mf.cube_fit = True
-    #mf.dataset = "test[FLUX]"
     mf.create_model_component("Const1D")
     mf.calculate_fit()
     result = cubeviz_helper.app.data_collection['model']

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -415,5 +415,4 @@ def test_cube_fit_with_subset_and_nans(cubeviz_helper):
     with pytest.warns(AstropyUserWarning, match='Model is linear in parameters'):
         mf.calculate_fit()
     result = cubeviz_helper.app.data_collection['model']
-    print(cubeviz_helper.app.data_collection['model'].get_object(statistic=None).flux.max())
     assert np.all(result.get_component("flux").data == 1)

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -378,3 +378,18 @@ def test_incompatible_units(specviz_helper, spectrum1d):
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', message='Model is linear in parameters.*')
         mf.calculate_fit(add_data=True)
+
+
+def test_cube_fit_with_nans(cubeviz_helper):
+    flux = np.ones((7, 8, 9)) * u.nJy
+    flux[:, :, 0] = np.nan
+    spec = Spectrum1D(flux=flux)
+    cubeviz_helper.load_data(spec, data_label="test")
+
+    mf = cubeviz_helper.plugins["Model Fitting"]
+    mf.cube_fit = True
+    #mf.dataset = "test[FLUX]"
+    mf.create_model_component("Const1D")
+    mf.calculate_fit()
+    result = cubeviz_helper.app.data_collection['model']
+    assert np.all(result.get_component("flux").data == 1)

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -394,12 +394,13 @@ def test_cube_fit_with_nans(cubeviz_helper):
     result = cubeviz_helper.app.data_collection['model']
     assert np.all(result.get_component("flux").data == 1)
 
+
 def test_cube_fit_with_subset_and_nans(cubeviz_helper):
     # Also test with existing mask
     flux = np.ones((7, 8, 9)) * u.nJy
     flux[:, :, 0] = np.nan
     spec = Spectrum1D(flux=flux)
-    spec.flux[5,5,7] = 10*u.nJy
+    spec.flux[5, 5, 7] = 10 * u.nJy
     cubeviz_helper.load_data(spec, data_label="test")
 
     sv = cubeviz_helper.app.get_viewer('spectrum-viewer')


### PR DESCRIPTION
I split this out from #3190 so it can be backported to 3.10. Still need to add a test and move the changelog.

Edit: ready for review. Note that simply adding `filter_non_finite` to the `specutils.fit_lines` call like in the 1D case didn't seem to work, so I masked out the NaN locations instead. Why that didn't work might be worth further investigation in the future.