### PR TITLE
Level 1 and Level 2 data product support in Rampviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,8 @@ New Features
 
 - The standalone version of jdaviz now uses solara instead of voila, resulting in faster load times. [#2909]
 
-- New configuration for ramp/Level 1 data products from Roman WFI and JWST [#3120, #3148, #3167, #3171, #3194]
+- New configuration for ramp/Level 1 and rate image/Level 2 data products from Roman WFI and
+  JWST [#3120, #3148, #3167, #3171, #3194]
 
 - Unit columns are now visible by default in the results table in model fitting. [#3196]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ New Features
 
 - The standalone version of jdaviz now uses solara instead of voila, resulting in faster load times. [#2909]
 
-- New configuration for ramp/Level 1 data products from Roman WFI and JWST [#3120, #3148, #3167, #3171]
+- New configuration for ramp/Level 1 data products from Roman WFI and JWST [#3120, #3148, #3167, #3171, #3194]
 
 - Unit columns are now visible by default in the results table in model fitting. [#3196]
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -1164,10 +1164,12 @@ class PlotOptions(PluginTemplateMixin):
         from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
         from jdaviz.configs.cubeviz.plugins.viewers import CubevizImageView
         from jdaviz.configs.mosviz.plugins.viewers import MosvizImageView, MosvizProfile2DView
+        from jdaviz.configs.rampviz.plugins.viewers import RampvizImageView
 
         def _is_image_viewer(viewer):
             return isinstance(viewer, (ImvizImageView, CubevizImageView,
-                                       MosvizImageView, MosvizProfile2DView))
+                                       MosvizImageView, MosvizProfile2DView,
+                                       RampvizImageView))
 
         viewers = self.viewer.selected_obj
         if not isinstance(viewers, list):

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -262,6 +262,8 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
             # cubeviz case:
             return arr[int(round(x)), int(round(y)), viewer.state.slices[-1]]
         elif image.ndim == 2:
+            if isinstance(viewer, RampvizImageView):
+                x, y = y, x
             return arr[int(round(y)), int(round(x))]
         else:  # pragma: no cover
             raise ValueError(f'does not support ndim={image.ndim}')
@@ -379,6 +381,11 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
 
         elif isinstance(viewer, RampvizImageView):
             coords_status = False
+
+            slice_plugin = self.app._jdaviz_helper.plugins.get('Slice', None)
+            if slice_plugin is not None and len(image.shape) == 3:
+                # float to be compatible with default value of nan
+                self._dict['slice'] = float(viewer.slice)
 
         elif isinstance(viewer, MosvizImageView):
 

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -232,7 +232,7 @@ def _parse_image(app, file_obj, data_label, ext=None, parent=None):
     for data, data_label in data_iter:
 
         # if the science extension hasn't been identified yet, do so here:
-        if sci_ext is None and ('[DATA' in data_label or '[SCI' in data_label):
+        if sci_ext is None and data.ndim == 2 and ('[DATA' in data_label or '[SCI' in data_label):
             sci_ext = data_label
 
         if isinstance(data.coords, GWCS) and (data.coords.bounding_box is not None):

--- a/jdaviz/configs/rampviz/helper.py
+++ b/jdaviz/configs/rampviz/helper.py
@@ -49,8 +49,9 @@ class Rampviz(CubeConfigHelper):
     def _set_x_axis(self, msg={}):
         group_viewer = self.app.get_viewer(self._default_group_viewer_reference_name)
         ref_data = group_viewer.state.reference_data
-        group_viewer.state.x_att = ref_data.id["Pixel Axis 0 [z]"]
-        group_viewer.state.y_att = ref_data.id["Pixel Axis 1 [y]"]
+        if ref_data:
+            group_viewer.state.x_att = ref_data.id["Pixel Axis 0 [z]"]
+            group_viewer.state.y_att = ref_data.id["Pixel Axis 1 [y]"]
 
     def select_group(self, group_index):
         """

--- a/jdaviz/configs/rampviz/helper.py
+++ b/jdaviz/configs/rampviz/helper.py
@@ -114,11 +114,11 @@ class Rampviz(CubeConfigHelper):
             Image viewer instance.
 
         """
-        from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
+        from jdaviz.configs.rampviz.plugins.viewers import RampvizImageView
 
         # Cannot assign data to real Data because it loads but it will
         # not update checkbox in Data menu.
 
         return self.app._on_new_viewer(
-            NewViewerMessage(ImvizImageView, data=None, sender=self.app),
+            NewViewerMessage(RampvizImageView, data=None, sender=self.app),
             vid=viewer_name, name=viewer_name)

--- a/jdaviz/configs/rampviz/helper.py
+++ b/jdaviz/configs/rampviz/helper.py
@@ -1,4 +1,4 @@
-from jdaviz.core.events import SliceSelectSliceMessage
+from jdaviz.core.events import SliceSelectSliceMessage, NewViewerMessage
 from jdaviz.core.helpers import CubeConfigHelper
 from jdaviz.configs.rampviz.plugins.viewers import RampvizImageView
 
@@ -98,3 +98,27 @@ class Rampviz(CubeConfigHelper):
         return self._get_data(data_label=data_label, spatial_subset=spatial_subset,
                               temporal_subset=temporal_subset,
                               cls=cls, use_display_units=use_display_units)
+
+    def create_image_viewer(self, viewer_name=None, data=None):
+        """
+        Create a new image viewer.
+
+        Parameters
+        ----------
+        viewer_name : str or `None`
+            Viewer name/ID to use. If `None`, it is auto-generated.
+
+        Returns
+        -------
+        viewer : `~jdaviz.configs.imviz.plugins.viewers.ImvizImageView`
+            Image viewer instance.
+
+        """
+        from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
+
+        # Cannot assign data to real Data because it loads but it will
+        # not update checkbox in Data menu.
+
+        return self.app._on_new_viewer(
+            NewViewerMessage(ImvizImageView, data=None, sender=self.app),
+            vid=viewer_name, name=viewer_name)

--- a/jdaviz/configs/rampviz/plugins/parsers.py
+++ b/jdaviz/configs/rampviz/plugins/parsers.py
@@ -161,7 +161,7 @@ def move_group_axis_last(x):
     # swap axes per the conventions of ramp cubes
     # (group axis comes first) and the default in
     # rampviz (group axis expected last)
-    return np.swapaxes(x, 0, -1)
+    return np.transpose(x, (1, 2, 0))
 
 
 def _roman_3d_to_glue_data(
@@ -201,7 +201,7 @@ def _roman_3d_to_glue_data(
         data_reshaped
     )
     app._jdaviz_helper.cube_cache[ramp_diff_data_label] = NDDataArray(
-        move_group_axis_last(diff_data)
+        diff_data_reshaped
     )
 
     if meta is not None:
@@ -254,9 +254,12 @@ def _parse_hdulist(
             app._jdaviz_helper.create_image_viewer(viewer_name=new_viewer_name)
 
         # add the SCI extension to the level-2 viewer:
-        if 'SCI' in ext:
+        if not ext:
+            idx = 1
+        elif ext and ('SCI' in ext or ext == '*'):
             idx = len(ext) - ext.index('SCI')
-            app.add_data_to_viewer(new_viewer_name, app.data_collection[-idx].label)
+
+        app.add_data_to_viewer(new_viewer_name, app.data_collection[-idx].label)
         return
 
     elif hdu.header['NAXIS'] != 4:
@@ -301,8 +304,7 @@ def _parse_ramp_cube(app, ramp_cube_data, flux_unit, file_name,
         np.diff(ramp_cube_data, axis=0)
     ])
 
-    ramp_data = move_group_axis_last(ramp_cube_data)
-    ramp_cube = NDDataArray(ramp_data, unit=flux_unit, meta=meta)
+    ramp_cube = NDDataArray(move_group_axis_last(ramp_cube_data), unit=flux_unit, meta=meta)
     diff_cube = NDDataArray(move_group_axis_last(diff_data), unit=flux_unit, meta=meta)
 
     group_data_label = app.return_data_label(file_name, ext="DATA")

--- a/jdaviz/configs/rampviz/plugins/ramp_extraction/ramp_extraction.py
+++ b/jdaviz/configs/rampviz/plugins/ramp_extraction/ramp_extraction.py
@@ -138,7 +138,7 @@ class RampExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
     def _on_data_added(self, msg={}):
         # only perform the default collapse after the first data load:
-        if len(self.app.data_collection) == 2:
+        if len(self.app.data_collection) == 2 and len(self.app._jdaviz_helper.cube_cache):
             self.extract(add_data=True)
             self.integration_viewer._initialize_x_axis()
 

--- a/jdaviz/configs/rampviz/plugins/ramp_extraction/ramp_extraction.py
+++ b/jdaviz/configs/rampviz/plugins/ramp_extraction/ramp_extraction.py
@@ -138,7 +138,7 @@ class RampExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
     def _on_data_added(self, msg={}):
         # only perform the default collapse after the first data load:
-        if len(self.app.data_collection) == 2 and len(self.app._jdaviz_helper.cube_cache):
+        if len(self.app._jdaviz_helper.cube_cache) and not self.extraction_available:
             self.extract(add_data=True)
             self.integration_viewer._initialize_x_axis()
 

--- a/jdaviz/configs/rampviz/plugins/viewers.py
+++ b/jdaviz/configs/rampviz/plugins/viewers.py
@@ -129,7 +129,8 @@ class RampvizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
     def _initial_x_axis(self, *args):
         # Make sure that the x_att is correct on data load
         ref_data = self.state.reference_data
-        if ref_data and ref_data.ndim == 3:
+
+        if ref_data:
             self.state.x_att = ref_data.id["Pixel Axis 0 [z]"]
 
     def set_plot_axes(self):

--- a/jdaviz/configs/rampviz/plugins/viewers.py
+++ b/jdaviz/configs/rampviz/plugins/viewers.py
@@ -131,7 +131,10 @@ class RampvizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
         ref_data = self.state.reference_data
 
         if ref_data:
-            self.state.x_att = ref_data.id["Pixel Axis 0 [z]"]
+            if "Pixel Axis 0 [z]" in [comp.label for comp in ref_data.components]:
+                self.state.x_att = ref_data.id["Pixel Axis 0 [z]"]
+            else:
+                self.state.x_att = ref_data.id["Pixel Axis 0 [y]"]
 
     def set_plot_axes(self):
         self.figure.axes[1].tick_format = None

--- a/jdaviz/configs/rampviz/tests/test_parser.py
+++ b/jdaviz/configs/rampviz/tests/test_parser.py
@@ -41,5 +41,5 @@ def test_load_nirspec_irs2(rampviz_helper, jwst_level_1b_rectangular_ramp):
 
     parsed_cube_shape = rampviz_helper.app.data_collection[0].shape
     assert parsed_cube_shape == (
-        original_cube_shape[1], original_cube_shape[2], original_cube_shape[0]
+        original_cube_shape[2], original_cube_shape[1], original_cube_shape[0]
     )

--- a/jdaviz/configs/rampviz/tests/test_parser.py
+++ b/jdaviz/configs/rampviz/tests/test_parser.py
@@ -12,34 +12,23 @@ def test_load_rectangular_ramp(rampviz_helper, jwst_level_1b_rectangular_ramp):
 
     parsed_cube_shape = rampviz_helper.app.data_collection[0].shape
     assert parsed_cube_shape == (
-        original_cube_shape[2], original_cube_shape[1], original_cube_shape[0]
+        original_cube_shape[1], original_cube_shape[2], original_cube_shape[0]
     )
 
 
-def test_load_nirspec_irs2(rampviz_helper, jwst_level_1b_rectangular_ramp):
-    # update the Level1bModel to have the header cards that are
-    # expected for an exposure from NIRSpec in IRS2 readout mode
-    jwst_level_1b_rectangular_ramp.update(
-        {
-            'meta': {
-                '_primary_header': {
-                    "TELESCOP": "JWST",
-                    "INSTRUME": "NIRSPEC",
-                    "READPATT": "NRSIRS2"
-                }
-            }
-        }
-    )
+def test_load_level_1_and_2(
+        rampviz_helper,
+        jwst_level_1b_rectangular_ramp,
+        jwst_level_2c_rate_image
+):
+    # load level 1 ramp and level 2 rate image
     rampviz_helper.load_data(jwst_level_1b_rectangular_ramp)
+    rampviz_helper.load_data(jwst_level_2c_rate_image)
 
-    # drop the integration axis
-    original_cube_shape = jwst_level_1b_rectangular_ramp.shape[1:]
+    # confirm that a "level-2" viewer is created, and that
+    # the rate image is loaded into it
+    assert len(rampviz_helper.viewers) == 4
+    assert 'level-2' in rampviz_helper.viewers
 
-    # on ramp cube load (1), the parser loads a diff cube (2) and
-    # the ramp extraction plugin produces a default extraction (3):
-    assert len(rampviz_helper.app.data_collection) == 3
-
-    parsed_cube_shape = rampviz_helper.app.data_collection[0].shape
-    assert parsed_cube_shape == (
-        original_cube_shape[2], original_cube_shape[1], original_cube_shape[0]
-    )
+    layers = rampviz_helper.app.get_viewer('level-2').layers
+    assert len(layers) == 1

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -95,6 +95,13 @@ def jwst_level_1b_rectangular_ramp():
 
 
 @pytest.fixture
+def jwst_level_2c_rate_image():
+    flux_hdu = fits.ImageHDU(np.ones((32, 25)))
+    flux_hdu.name = 'FLUX'
+    return fits.HDUList([fits.PrimaryHDU(), flux_hdu])
+
+
+@pytest.fixture
 def image_2d_wcs():
     return WCS({'CTYPE1': 'RA---TAN', 'CUNIT1': 'deg', 'CDELT1': -0.0002777777778,
                 'CRPIX1': 1, 'CRVAL1': 337.5202808,

--- a/jdaviz/core/tools.py
+++ b/jdaviz/core/tools.py
@@ -105,7 +105,7 @@ class _MatchedZoomMixin:
             to_lims = self._map_limits(self.viewer, viewer, from_lims)
             matched_refdata = viewer.state.reference_data
 
-            if hasattr(viewer, '_get_fov'):
+            if hasattr(viewer, '_get_fov') and matched_refdata is not None:
                 to_fov_sky = viewer._get_fov(wcs=matched_refdata.coords)
             else:
                 to_fov_sky = None


### PR DESCRIPTION
This PR introduces adaptations to allow Level 2 data products to be loaded into Rampviz, at the same time as Level 1 products.

The demo video below opens L1 and L2 products for the Carina nebula. The L2 product is opened in an image viewer to the right of the usual Rampviz viewers. I've loaded the L2 product with its DQ extension, so you can see where pixels are flagged. I zoom in on a region where pixels are flagged by jump detection (pink DQ overlay), create a subset, and show that the pixels in the subset indeed have a jump.

https://github.com/user-attachments/assets/e037bfc6-f0c8-4b1f-9a0d-91976938bba9

To reproduce locally, run:
```python
from jdaviz import Rampviz

# carina nebula:
level_2 = 'mast:JWST/product/jw02731001004_02103_00005_nrca3_cal.fits'
level_1 = level_2.replace('_cal', '_uncal')

rampviz = Rampviz()
rampviz.load_data(level_1, cache=True)
rampviz.load_data(level_2, ext=("SCI", "DQ"), cache=True)
rampviz.show()
```

### Follow-up/to-dos

- Should we load the DQ array into the group/diff viewers as well? in some cases this will be helpful, but will require careful adaptations to the data associations used for managing DQ visibility
- We hope to visualize the L2 result – which is the per-pixel count rate during an integration, or the slope of the ramp cube – in the integration-viewer. L2 files are slopes from ramp fits after, e.g., linearity corrections, and _without_ their intercepts. So we can't perfectly display this visualization from the L2 data themselves. Should we even try?
- Do we want to support L2 products without L1 products? As of opening this PR, loading L2 without L1 doesn't work properly.
- L1 files have no WCS, since the WCS solution is computed in the pipeline between L1 and L2.  Without an L2 file, our mouseover info on ramp viewers can only show pixel coords. But if we have a matching L2 file loaded, we _could_ show the world coordinates on hover in ramp viewers by getting the world coordinates from the `level-2` viewer. Should we?
- investigate why matched pan/zoom seems to "twitch" a bit in the ramp viewers

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
