### PR TITLE
fix formatting of unit after appending angle

### DIFF
--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -399,6 +399,9 @@ class UnitConversion(PluginTemplateMixin):
             sb_unit_selected = flux_unit + ' / ' + angle_unit
 
         if sb_unit_selected:
-            self.sb_unit_selected = sb_unit_selected
+            # convert string to and from u.Unit to get rid of any
+            # formatting inconstancies, order of units in string
+            # for a composite unit matters
+            sb_unit_selected = u.Unit(sb_unit_selected).to_string()
 
         return sb_unit_selected


### PR DESCRIPTION
This PR fixes a traceback when changing flux units via API. When changing between Jy and erg/c/cm2/A, the traceback said the unit was not in the list of available options for the y axis because the strings differed. This happens when handing contours. To reproduce:

`from jdaviz.conftest import _create_spectrum1d_cube_with_fluxunit`
`from jdaviz import Cubeviz`
`import astropy.units as u`
`cube = _create_spectrum1d_cube_with_fluxunit(shape=(25, 25, 4), fluxunit=u.Jy / u.sr, with_uncerts=True)`
`cubeviz_helper = Cubeviz()`
`cubeviz_helper.load_data(cube, data_label="test")`
`uc = cubeviz_helper.plugins['Unit Conversion']._obj`
`uc.flux_unit.selected='erg / (Angstrom s cm2)'`


In the unit conversion plugin, the '_append_angle_correctly' method to combine chosen flux and angle units sometimes produces unit strings that aren't in the required order for setting the spectral axis. These options are hard coded in UnitConverterWithSpectral (app.py). Additionally, this method was setting the sb_unit_selected read-only attribute twice in a row, so this redundancy was removed.

There is a remaining traceback coming from contours when changing flux unit, which is described in JDAT-4785.
