### PR TITLE
BUG: Fix wrong Subset unit when created in 2D spectrum viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -254,6 +254,8 @@ Specviz
 Specviz2d
 ^^^^^^^^^
 
+- Fixed Subset unit when it is created in 2D spectrum viewer. [#3201]
+
 3.10.3 (2024-07-22)
 ===================
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -14,7 +14,7 @@ from ipygoldenlayout import GoldenLayout
 from ipysplitpanes import SplitPanes
 import matplotlib.cm as cm
 import numpy as np
-from glue.config import colormaps, settings as glue_settings
+from glue.config import colormaps, data_translator, settings as glue_settings
 from glue.core import HubListener
 from glue.core.link_helpers import LinkSame, LinkSameWithUnits
 from glue.core.message import (DataCollectionAddMessage,
@@ -1067,13 +1067,15 @@ class Application(VuetifyTemplate, HubListener):
                                  simplify_spectral=True, use_display_units=False):
         # TODO: Use global display units
         # units = dc[0].data.coords.spectral_axis.unit
-        viewer = self.get_viewer(self._jdaviz_helper. _default_spectrum_viewer_reference_name)
-        data = viewer.data()
-        if data and len(data) > 0 and isinstance(data[0], Spectrum1D):
-            units = data[0].spectral_axis.unit
+        data = subset_state.att.parent
+        ndim = data.get_component("flux").ndim
+        if ndim == 2:
+            units = u.pix
         else:
-            raise ValueError("Unable to find spectral axis units")
-        if use_display_units:
+            handler, _ = data_translator.get_handler_for(Spectrum1D)
+            spec = handler.to_object(data)
+            units = spec.spectral_axis.unit
+        if use_display_units and units != u.pix:
             # converting may result in flipping order (wavelength <-> frequency)
             ret_units = self._get_display_unit('spectral')
             subset_bounds = [(subset_state.lo * units).to(ret_units, u.spectral()),


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address wrong Subset unit when it is extracted from Subset created in Specviz2d on the 2D spectrum viewer. Glue itself does not attach unit natively to Subset, so that means Jdaviz made wrong assumptions in the extraction code. Bug ticket blamed it to the Export plugin but the actual bug has nothing to do with the Export plugin, thought the plugin did expose the bug when user extracted Subset that way but you don't need the plugin to reproduce the bug.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4796)
