### PR TITLE
Fix "Unit conversion when equivalency needed breaks contours in cubeviz"

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -1,12 +1,11 @@
 import os
+from functools import cached_property
 from pathlib import Path
 
 import numpy as np
 import astropy
-from astropy.nddata import (
-    NDDataArray, StdDevUncertainty
-)
-from functools import cached_property
+from astropy import units as u
+from astropy.nddata import NDDataArray, StdDevUncertainty
 from traitlets import Any, Bool, Dict, Float, List, Unicode, observe
 
 from jdaviz.core.custom_traitlets import FloatHandleEmpty
@@ -515,7 +514,10 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
                 # NOTE: just forcing these units for now!! this is in steradians and
                 # needs to be converted to the selected square angle unit but for now just
                 # force to correct units
-                aperture_area = self.cube.meta.get('PIXAR_SR', 1.0) * sq_angle_unit
+                if sq_angle_unit == u.sr:
+                    aperture_area = self.cube.meta.get('PIXAR_SR', 1.0) * sq_angle_unit
+                else:
+                    aperture_area = 1 * sq_angle_unit
                 collapsed_nddata = collapsed_nddata.multiply(aperture_area,
                                                              propagate_uncertainties=True)
         else:

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
@@ -18,7 +18,6 @@ def cubeviz_wcs_dict():
     return w, wcs_dict
 
 
-@pytest.mark.skip(reason="Unskip after JDAT 4785 resolved.")
 @pytest.mark.parametrize("angle_unit", [u.sr, PIX2])
 def test_basic_unit_conversions(cubeviz_helper, angle_unit):
     """

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
@@ -35,7 +35,7 @@ def test_basic_unit_conversions(cubeviz_helper, angle_unit):
     # load cube with flux units of MJy
     w, wcs_dict = cubeviz_wcs_dict()
     flux = np.zeros((3, 4, 5), dtype=np.float32)
-    cube = Spectrum1D(flux=flux * u.MJy / angle_unit, wcs=w, meta=wcs_dict)
+    cube = Spectrum1D(flux=flux * (u.MJy / angle_unit), wcs=w, meta=wcs_dict)
     cubeviz_helper.load_data(cube, data_label="test")
 
     # get all available flux units for translation. Since cube is loaded

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 from astropy import units as u
 from astropy.wcs import WCS
-from regions import PixCoord, CirclePixelRegion
+from numpy.testing import assert_allclose
+from regions import PixCoord, CirclePixelRegion, RectanglePixelRegion
 from specutils import Spectrum1D
 
 from jdaviz.core.custom_units import PIX2, SPEC_PHOTON_FLUX_DENSITY_UNITS
@@ -34,18 +35,91 @@ def test_basic_unit_conversions(cubeviz_helper, angle_unit):
 
     # load cube with flux units of MJy
     w, wcs_dict = cubeviz_wcs_dict()
-    flux = np.zeros((3, 4, 5), dtype=np.float32)
+    flux = np.ones((3, 4, 5), dtype=np.float32)
     cube = Spectrum1D(flux=flux * (u.MJy / angle_unit), wcs=w, meta=wcs_dict)
     cubeviz_helper.load_data(cube, data_label="test")
+    viewer = cubeviz_helper.app.get_viewer("spectrum-viewer")
 
     # get all available flux units for translation. Since cube is loaded
     # in Jy, this will be all items in 'spectral_and_photon_flux_density_units'
 
     uc_plg = cubeviz_helper.plugins['Unit Conversion']
+    ap_plg = cubeviz_helper.plugins["Aperture Photometry"]._obj
+    label_mouseover = cubeviz_helper.app.session.application._tools['g-coords-info']
+
+    cubeviz_helper.load_regions(RectanglePixelRegion(PixCoord(1, 1), 1, 1))
+    ap_plg.background_selected = "Subset 1"
 
     for flux_unit in SPEC_PHOTON_FLUX_DENSITY_UNITS:
+        if flux_unit == 'MJy':
+            if angle_unit == u.sr:
+                ans = 9.6e-10  # 12 * 8e-11
+            else:
+                ans = 12  # 12 * 1
+            bg_ans = 1  # MJy / angle_unit
+        elif flux_unit == 'Jy':
+            if angle_unit == u.sr:
+                ans = 9.6e-04
+            else:
+                ans = 1.2e+07
+            bg_ans = 1e6
+        elif flux_unit == 'mJy':
+            if angle_unit == u.sr:
+                ans = 0.96
+            else:
+                ans = 1.2e+10
+            bg_ans = 1e9
+        elif flux_unit == 'uJy':
+            if angle_unit == u.sr:
+                ans = 960
+            else:
+                ans = 1.2e+13
+            bg_ans = 1e12
+        elif flux_unit == 'W / (Hz m2)':
+            if angle_unit == u.sr:
+                ans = 9.6e-30
+            else:
+                ans = 1.2e-19
+            bg_ans = 1e-20
+        elif flux_unit == 'eV / (Hz s m2)':
+            if angle_unit == u.sr:
+                ans = 5.99185e-11
+            else:
+                ans = 7.48981e-01
+            bg_ans = 0.06241509074460764
+        elif flux_unit == 'erg / (Angstrom s cm2)':
+            if angle_unit == u.sr:
+                ans = 1.34580e-15
+            else:
+                ans = 1.68225e-05
+            bg_ans = 1.4018163962192981e-06
+        elif flux_unit == 'erg / (Hz s cm2)':
+            if angle_unit == u.sr:
+                ans = 9.6e-27
+            else:
+                ans = 1.2e-16
+            bg_ans = 1e-17
+        elif flux_unit == 'ph / (Angstrom s cm2)':
+            if angle_unit == u.sr:
+                ans = 3.133e-04
+            else:
+                ans = 3.91624e+06
+            bg_ans = 326346.6709140777
+        elif flux_unit == 'ph / (Hz s cm2)':
+            if angle_unit == u.sr:
+                ans = 2.23486e-15
+            else:
+                ans = 2.79357e-05
+            bg_ans = 2.328027206660126e-06
+
         uc_plg.flux_unit = flux_unit
         assert cubeviz_helper.app._get_display_unit('spectral_y') == flux_unit
+
+        label_mouseover._viewer_mouse_event(viewer, {
+            'event': 'mousemove', 'domain': {'x': 4.6245e-7, 'y': ans}})
+        assert_allclose(label_mouseover._dict['value'], ans, rtol=1e-4)
+
+        assert_allclose(ap_plg.background_value, bg_ans, rtol=1e-4)
 
 
 @pytest.mark.parametrize("flux_unit, expected_choices", [(u.count, ['ct']),

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -389,8 +389,11 @@ def flux_conversion(values, original_units, target_units, spec=None, eqv=None, s
         # the unit of the data collection item object, could be flux or surface brightness
         spec_unit = str(spec.flux.unit)
 
-        # Need this for setting the y-limits
-        eqv = u.spectral_density(spectral_values)
+        # Need this for setting the y-limits but values from viewer might be downscaled
+        if len(values) == spectral_values.size:
+            eqv = u.spectral_density(spectral_values)
+        else:
+            eqv = u.spectral_density(spec.spectral_axis[0])
     elif slice is not None and eqv:
         image_data = True
         # Need this to convert Flux to Flux for complex conversions/translations of cube image data


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to unit conversion when equivalency needed breaks contours in cubeviz. Unskips a test added in https://github.com/spacetelescope/jdaviz/pull/3204 .

Probably no need for change log since this is patching unreleased feature, I assume.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4785)
