### PR TITLE
add spectral unit to moment map 0 display unit, simplify logic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ New Features
 
 - Added flux/surface brightness translation and surface brightness
   unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113, #3129,
-  #3139, #3149, #3155, #3178, #3185, #3187, #3190, #3156, #3200, #3192, #3206]
+  #3139, #3149, #3155, #3178, #3185, #3187, #3190, #3156, #3200, #3192, #3206, #3211]
 
 - Plugin tray is now open by default. [#2892]
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.vue
@@ -127,7 +127,7 @@
           ></v-radio>
         </v-radio-group>
       </v-row>
-      <v-row v-if="output_unit_selected !== 'Spectral Unit' && output_unit_selected !== 'Flux'">
+      <v-row v-if="output_unit_selected !== 'Spectral Unit' && output_unit_selected !== 'Surface Brightness'">
         <v-text-field
         ref="reference_wavelength"
         type="number"

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -347,9 +347,9 @@ def test_correct_output_spectral_y_units(cubeviz_helper, spectrum1d_cube_custom_
     # in this list. also check that the initial unit is correct.
     output_unit_moment_0 = mm.output_unit_items[0]
     assert output_unit_moment_0['label'] == 'Surface Brightness'
-    assert output_unit_moment_0['unit_str'] == 'MJy / sr'
+    assert output_unit_moment_0['unit_str'] == 'MJy m / sr'
 
-    # check that calculated moment has the correct units
+    # check that calculated moment has the correct units of MJy m / sr
     mm.calculate_moment()
     assert mm.moment.unit == f'M{moment_unit}'
 
@@ -360,8 +360,16 @@ def test_correct_output_spectral_y_units(cubeviz_helper, spectrum1d_cube_custom_
     # and make sure this change is propogated
     output_unit_moment_0 = mm.output_unit_items[0]
     assert output_unit_moment_0['label'] == 'Surface Brightness'
-    assert output_unit_moment_0['unit_str'] == 'Jy / sr'
+    assert output_unit_moment_0['unit_str'] == 'Jy m / sr'
 
     # and that calculated moment has the correct units
     mm.calculate_moment()
     assert mm.moment.unit == moment_unit
+
+    # now change the spectral unit and make sure that change is
+    # reflected in MM plugin
+    uc.spectral_unit = 'um'
+    assert output_unit_moment_0['unit_str'] == 'Jy um / sr'
+
+    mm.calculate_moment()
+    assert mm.moment.unit == moment_unit.replace('m', 'um')

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2953,8 +2953,7 @@ class SpectralContinuumMixin(VuetifyTemplate, HubListener):
         if per_pixel:
             if self.app.config != 'cubeviz':
                 raise ValueError("per-pixel only supported for cubeviz")
-            full_spectrum = self.app._jdaviz_helper.get_data(self.dataset.selected,
-                                                             use_display_units=True)
+            full_spectrum = self.app._jdaviz_helper.get_data(self.dataset.selected)
         else:
             full_spectrum = dataset.get_selected_spectrum(use_display_units=True)
 
@@ -2978,8 +2977,7 @@ class SpectralContinuumMixin(VuetifyTemplate, HubListener):
             spectrum = full_spectrum
         else:
             sr = self.app.get_subsets(spectral_subset.selected,
-                                      simplify_spectral=True,
-                                      use_display_units=True)
+                                      simplify_spectral=True)
             spectrum = extract_region(full_spectrum, sr, return_single_spectrum=True)
             sr_lower = np.nanmin(spectrum.spectral_axis[spectrum.spectral_axis >= sr.lower])  # noqa
             sr_upper = np.nanmax(spectrum.spectral_axis[spectrum.spectral_axis <= sr.upper])  # noqa


### PR DESCRIPTION
There was previously an issue where the moment map plugin was using the spectral y axis unit for moment 0 rather than always using a surface brightness unit. This was fixed in #3156. 

This PR applies some of the changes from #3116, which also fixed that issue but based on an outdated main pre many unit conversion changes, so I found it easier to cherry pick some of the code here rather than rebasing that PR.

The display unit now has the spectral unit because specutils is pinned to the version with the fix for MM units. I made some small tweaks including using _get_display_unit rather than grabbing the UC plugin from the MM plugin and accessing display unit there. 

I think sufficient test coverage was added in #3156 so i didn't add the tests from #3116, but i did expand one of the tests to test that the moment map plugin has the correct units when spectral unit is changed (previously was just testing when flux unit was changed)

This will close JDAT 4651 and #3116 

Closes #3116.