### PR TITLE
use correct spectral density equivalencies for marker unit changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ New Features
 
 - Added flux/surface brightness translation and surface brightness
   unit conversion in Cubeviz and Specviz. [#2781, #2940, #3088, #3111, #3113, #3129,
-  #3139, #3149, #3155, #3178, #3185, #3187, #3190, #3156, #3200, #3192, #3206, #3211, #3216]
+  #3139, #3149, #3155, #3178, #3185, #3187, #3190, #3156, #3200, #3192, #3206, #3211, #3216, #3219]
 
 - Plugin tray is now open by default. [#2892]
 

--- a/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
+++ b/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
@@ -117,6 +117,30 @@ def test_markers_cubeviz(tmp_path, cubeviz_helper, spectrum1d_cube):
 
     mp._obj._on_viewer_key_event(sv, {'event': 'keydown',
                                       'key': 'm'})
+
+    # test that markers update on unit conversion
+    uc = cubeviz_helper.plugins['Unit Conversion']
+    uc.flux_unit.selected = 'MJy'
+
+    # set the current slice to match the markers spectral axis value
+    slice_plg = (cubeviz_helper.plugins['Slice'])
+    slice_plg.value = 4.623e-7
+
+    # get the spectrum's flux value at the current slice
+    flux_value = cubeviz_helper.get_data('Spectrum (sum)', use_display_units=True)[
+                 np.where(sv.slice_values == slice_plg.value)[0][0]
+                 ].data[0]
+    # using first mark in spectrum viewer as all markers have position y=0,
+    # check if scientific notation unit conversion occurred to marker
+    assert_allclose(mp._obj.marks['cubeviz-2'].y[0], flux_value)
+
+    # check if marks update with unit that requires spectral density equivalency
+    uc.flux_unit.selected = 'erg / (Angstrom s cm2)'
+    flux_value = cubeviz_helper.get_data('Spectrum (sum)', use_display_units=True)[
+                 np.where(sv.slice_values == slice_plg.value)[0][0]
+                 ].data[0]
+    assert_allclose(mp._obj.marks['cubeviz-2'].y[0], flux_value)
+
     assert len(mp.export_table()) == 3
     assert len(_get_markers_from_viewer(fv).x) == 1
     assert len(_get_markers_from_viewer(sv).x) == 2

--- a/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
+++ b/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
@@ -122,23 +122,21 @@ def test_markers_cubeviz(tmp_path, cubeviz_helper, spectrum1d_cube):
     uc = cubeviz_helper.plugins['Unit Conversion']
     uc.flux_unit.selected = 'MJy'
 
-    # set the current slice to match the markers spectral axis value
-    slice_plg = (cubeviz_helper.plugins['Slice'])
-    slice_plg.value = 4.623e-7
+    # find the index of the marker's x-coordinate in the spectral axis of the original input data
+    spec = cubeviz_helper.get_data('Spectrum (sum)', use_display_units=True)
+    marker_index = np.where(spec.spectral_axis.value == mp._obj.marks['cubeviz-2'].x)
+    # use the index to find the associated flux value of the original input
+    flux_value = spec.flux[marker_index].value
 
-    # get the spectrum's flux value at the current slice
-    flux_value = cubeviz_helper.get_data('Spectrum (sum)', use_display_units=True)[
-                 np.where(sv.slice_values == slice_plg.value)[0][0]
-                 ].data[0]
-    # using first mark in spectrum viewer as all markers have position y=0,
-    # check if scientific notation unit conversion occurred to marker
+    # compare the marker's (y) flux value with the flux value of the original input data
     assert_allclose(mp._obj.marks['cubeviz-2'].y[0], flux_value)
 
-    # check if marks update with unit that requires spectral density equivalency
+    # now check if marks update with a unit that requires spectral density equivalency
     uc.flux_unit.selected = 'erg / (Angstrom s cm2)'
-    flux_value = cubeviz_helper.get_data('Spectrum (sum)', use_display_units=True)[
-                 np.where(sv.slice_values == slice_plg.value)[0][0]
-                 ].data[0]
+
+    spec = cubeviz_helper.get_data('Spectrum (sum)', use_display_units=True)
+    flux_value = spec.flux[marker_index].value
+
     assert_allclose(mp._obj.marks['cubeviz-2'].y[0], flux_value)
 
     assert len(mp.export_table()) == 3

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -128,8 +128,7 @@ class PluginMark:
         if self.yunit is not None and not np.all([s == 0 for s in self.y.shape]):
             if self.viewer.default_class is Spectrum1D:
                 # used to obtain spectral density equivalencies with previous data and units
-                original_spec = Spectrum1D(flux=self.y*self.yunit, spectral_axis=self.x*self.xunit)
-                eqv = u.spectral_density(original_spec.spectral_axis)
+                eqv = u.spectral_density(self.x*self.xunit)
 
                 spec = self.viewer.state.reference_data.get_object(cls=Spectrum1D)
 

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -127,8 +127,11 @@ class PluginMark:
 
         if self.yunit is not None and not np.all([s == 0 for s in self.y.shape]):
             if self.viewer.default_class is Spectrum1D:
+                # used to obtain spectral density equivalencies with previous data and units
+                original_spec = Spectrum1D(flux=self.y*self.yunit, spectral_axis=self.x*self.xunit)
+                eqv = u.spectral_density(original_spec.spectral_axis)
+
                 spec = self.viewer.state.reference_data.get_object(cls=Spectrum1D)
-                eqv = u.spectral_density(spec.spectral_axis)
 
                 if ('_pixel_scale_factor' in spec.meta):
                     eqv += _eqv_pixar_sr(spec.meta['_pixel_scale_factor'])


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address updating the spectral density equivalencies to use the original spectral axis so plugin Markers update to the correct position on the spectrum after a unit change. 


Original Behavior:

https://github.com/user-attachments/assets/e1138a05-e7f3-49aa-bb83-6877ca2969dd


Updated Behavior:

https://github.com/user-attachments/assets/00cd6394-4d81-4d66-956d-9e99f26dbe0c


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
