### PR TITLE
initialize zoom center even when viewer not shown

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -31,7 +31,7 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # provide reference from state back to viewer to use for zoom syncing
-        self.state._viewer = self
+        self.state._set_viewer(self)
 
         self._subscribe_to_layers_update()
         self.state.add_callback('reference_data', self._initial_x_axis)

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -36,7 +36,7 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # provide reference from state back to viewer to use for zoom syncing
-        self.state._viewer = self
+        self.state._set_viewer(self)
         self.init_astrowidgets_api()
         self._subscribe_to_layers_update()
 

--- a/jdaviz/configs/rampviz/plugins/viewers.py
+++ b/jdaviz/configs/rampviz/plugins/viewers.py
@@ -106,7 +106,7 @@ class RampvizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # provide reference from state back to viewer to use for zoom syncing
-        self.state._viewer = self
+        self.state._set_viewer(self)
 
         self._subscribe_to_layers_update()
         self.state.add_callback('reference_data', self._initial_x_axis)

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -71,6 +71,10 @@ class FreezableBqplotImageViewerState(BqplotImageViewerState, FreezableState):
             self.add_callback(attr, self._set_axes_lim)
         super().__init__(*args, **kwargs)
 
+    def _set_viewer(self, viewer):
+        self._viewer = viewer
+        self._set_axes_lim()
+
     @contextmanager
     def during_zoom_sync(self):
         self._during_zoom_sync = True
@@ -82,7 +86,7 @@ class FreezableBqplotImageViewerState(BqplotImageViewerState, FreezableState):
         self._during_zoom_sync = False
 
     def _set_zoom_radius_center(self, *args):
-        if self._during_zoom_sync or not hasattr(self, '_viewer') or self._viewer.shape is None:
+        if self._during_zoom_sync or not hasattr(self, '_viewer'):
             return
 
         # When WCS-linked (displayed on the sky): zoom_center_x/y and zoom_radius are in sky units,
@@ -117,7 +121,7 @@ class FreezableBqplotImageViewerState(BqplotImageViewerState, FreezableState):
         self._set_axes_lim()
 
     def _set_axes_lim(self, *args):
-        if self._during_zoom_sync or not hasattr(self, '_viewer') or self._viewer.shape is None:
+        if self._during_zoom_sync or not hasattr(self, '_viewer'):
             return
         if None in (self.x_min, self.x_max, self.y_min, self.y_max):
             return


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request sets the zoom center/radius traitlets as soon as the viewer is assigned back to the state to ensure they are initialized immediately rather than waiting for a zoom event when the viewer is shown on the screen.  @duytnguyendtn - can you confirm if this fixes the case that you were running into?

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #3217

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
