### PR TITLE
Bugfix: lcviz TPFs are sliced by cube index rather than time slice

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,6 +89,8 @@ Bug Fixes
 
 - Fixes data-menu visibility when app is scrolled out of view. [#3391]
 
+- Fix Slice plugin for indexing through temporal slices. [#3235]
+
 Cubeviz
 ^^^^^^^
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description

TPFs in lcviz should be sliceable by their time axes. Somewhere since jdaviz v3.9, a bug was introduced that causes the step size in the lcviz Time Selector plugin to be fixed to integer values. 

https://github.com/user-attachments/assets/2a0cf55a-29e6-4fac-a007-98b57fbbb335

This PR corrects the slice values for cube axes defined by temporal WCS. Here's a demo after this PR:

https://github.com/user-attachments/assets/c215d30a-3b0f-4724-a369-a413b86f0b60

The failing devdeps tests in this PR should be fixed by #3232.


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
