### PR TITLE
disable file imports when running on external server

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Remove "From File.." option when running on an external server. [#3239]
+
 Mosviz
 ^^^^^^
 
@@ -250,6 +252,17 @@ Other Changes and Additions
 
 - Bump required specutils version to 1.16. Moment 0 calculation is now in units
   of flux*dx (rather than flux) [#3184]
+
+3.10.4 (unreleased)
+===================
+
+Bug Fixes
+---------
+
+Imviz
+^^^^^
+
+- Remove "From File.." option when running on an external server. [#3239]
 
 3.10.3 (2024-07-22)
 ===================

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -57,11 +57,13 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        cat_options = ['SDSS', 'Gaia']
+        if not self.app.state.settings.get('server_is_remote', False):
+            cat_options.append('From File...')
         self.catalog = FileImportSelectPluginComponent(self,
                                                        items='catalog_items',
                                                        selected='catalog_selected',
-                                                       manual_options=['SDSS', 'Gaia',
-                                                                       'From File...'])
+                                                       manual_options=cat_options)
 
         # set the custom file parser for importing catalogs
         self.catalog._file_parser = self._file_parser

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -118,7 +118,8 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
             preset_options = list(preset_regions._instruments.keys())
         else:
             preset_options = ['None']
-        preset_options.append('From File...')
+        if not self.app.state.settings.get('server_is_remote', False):
+            preset_options.append('From File...')
         self.preset = FileImportSelectPluginComponent(self,
                                                       items='preset_items',
                                                       selected='preset_selected',


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request disables "From File..." options for importing catalogs and footprints from a file in cases where jdaviz is running on an external server.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
