### PR TITLE
disable file imports when running on external server (#3239)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Remove "From File.." option when running on an external server. [#3239]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -34,11 +34,13 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
+        cat_options = ['SDSS']
+        if not self.app.state.settings.get('server_is_remote', False):
+            cat_options.append('From File...')
         self.catalog = FileImportSelectPluginComponent(self,
                                                        items='catalog_items',
                                                        selected='catalog_selected',
-                                                       manual_options=['SDSS', 'From File...'])
+                                                       manual_options=cat_options)
 
         # set the custom file parser for importing catalogs
         self.catalog._file_parser = self._file_parser

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -118,7 +118,8 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
             preset_options = list(preset_regions._instruments.keys())
         else:
             preset_options = ['None']
-        preset_options.append('From File...')
+        if not self.app.state.settings.get('server_is_remote', False):
+            preset_options.append('From File...')
         self.preset = FileImportSelectPluginComponent(self,
                                                       items='preset_items',
                                                       selected='preset_selected',


### PR DESCRIPTION
This PR is a manual backport of #3239 onto 3.10.x.  Conflicts were the changelog and catalogs having 'Gaia' available in 4.0.x, but not in 3.10.x, both of which have been addressed here.