### PR TITLE
prevent spectral lines from converting y-range

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,7 +72,7 @@ Bug Fixes
 - Fixed Aperture Photometry radial profile fit crashing when NaN is present in
   aperture data for Cubeviz and Imviz. [#3246]
 
-- Prevent line list marks from converting y-range so they maintain their position 
+- Prevent PluginMarks from converting y-range so they maintain their position 
   in the spectrum-viewer when spectral y units are converted. [#3242]
 
 Cubeviz

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,9 @@ Bug Fixes
 - Fixed Aperture Photometry radial profile fit crashing when NaN is present in
   aperture data for Cubeviz and Imviz. [#3246]
 
+- Prevent line list marks from converting y-range so they maintain their position 
+  in the spectrum-viewer when spectral y units are converted. [#3242]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -245,6 +245,8 @@ class SpectralLine(BaseSpectrumVerticalLine):
         self._rest_value = (self._rest_value * prev_unit).to_value(unit, u.spectral())
 
     def set_y_unit(self, unit=None):
+        # prevent spectral lines from entering unit conversion machinery so they maintain
+        # their position in the viewer at the rest + redshifted spectral value
         return
 
     @property

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -340,6 +340,12 @@ class SliceIndicatorMarks(BaseSpectrumVerticalLine, HubListener):
     def marks(self):
         return [self, self.label]
 
+    def _on_global_display_unit_changed(self, msg):
+        # Updating the value is handled by the plugin itself, need to update unit string.
+        if msg.axis in ["spectral", "x"]:
+            self.xunit = msg.unit
+        self._update_label()
+
     def _value_handle_oob(self, x=None, update_label=False):
         if x is None:
             x = self.value

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -119,8 +119,6 @@ class PluginMark:
         self.xunit = unit
 
     def set_y_unit(self, unit=None):
-        if self.__class__.__name__ == 'SpectralLine':
-            return
         if unit is None:
             if not hasattr(self.viewer.state, 'y_display_unit'):
                 return
@@ -245,6 +243,9 @@ class SpectralLine(BaseSpectrumVerticalLine):
         prev_unit = self.xunit
         super().set_x_unit(unit=unit)
         self._rest_value = (self._rest_value * prev_unit).to_value(unit, u.spectral())
+
+    def set_y_unit(self, unit=None):
+        return
 
     @property
     def redshift(self):

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -119,6 +119,8 @@ class PluginMark:
         self.xunit = unit
 
     def set_y_unit(self, unit=None):
+        if self.__class__.__name__ == 'SpectralLine':
+            return
         if unit is None:
             if not hasattr(self.viewer.state, 'y_display_unit'):
                 return


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address line lists and unit conversion compatibility. On main, line marks go through conversion machinery and can cause lines to vanish from the spectrum-viewer depending on the original unit and target unit (are not visible even at updated y-range for line after conversion). This PR prevents SpectralLines from y-converting so they maintain their position in the viewer at the rest + redshifted spectral value.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
