### PR TITLE
BUG: Fix radial profile fitting when NaN in data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,9 @@ Bug Fixes
 
 - Improved performance and removed jittering for the matched box zoom tool. [#3215]
 
+- Fixed Aperture Photometry radial profile fit crashing when NaN is present in
+  aperture data for Cubeviz and Imviz. [#3246]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -893,8 +893,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
                 # Fit Gaussian1D to radial profile data.
                 if self.fit_radial_profile:
                     fitter = TRFLSQFitter()
-                    y_max = y_data.max()
-                    x_mean = x_data[np.where(y_data == y_max)].mean()
+                    y_max = np.nanmax(y_data)
+                    x_mean = np.nanmean(x_data[np.where(y_data == y_max)])
                     std = 0.5 * (phot_table['semimajor_sigma'][0] +
                                  phot_table['semiminor_sigma'][0])
                     if isinstance(std, u.Quantity):

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 import numpy as np
 from astropy import units as u
@@ -419,6 +421,34 @@ def test_annulus_background(imviz_helper):
     subset_plugin._set_value_in_subset_definition(0, "Outer Radius (pixels)", "value", 45)
     subset_plugin.vue_update_subset()
     assert_allclose(phot_plugin.background_value, bg_4gauss_4)
+
+
+def test_fit_radial_profile_with_nan(imviz_helper):
+    from photutils.datasets import make_4gaussians_image
+
+    gauss4 = make_4gaussians_image()  # The background has a mean of 5 with noise
+    # Insert NaN
+    gauss4[25, 150] = np.nan
+
+    imviz_helper.load_data(gauss4, data_label='four_gaussians')
+
+    # Mark an object of interest
+    circle_1 = CirclePixelRegion(center=PixCoord(x=150, y=25), radius=7)
+    imviz_helper.plugins['Subset Tools']._obj.import_region(
+        [circle_1], combination_mode='new')
+
+    phot_plugin = imviz_helper.app.get_tray_item_from_name('imviz-aper-phot-simple')
+    phot_plugin.dataset_selected = 'four_gaussians'
+    phot_plugin.aperture_selected = 'Subset 1'
+    phot_plugin.current_plot_type = 'Radial Profile'
+    phot_plugin.fit_radial_profile = True
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # Fitter warnings do not matter, only want error.
+        phot_plugin.vue_do_aper_phot()
+    tbl = imviz_helper.get_aperture_photometry_results()
+
+    assert phot_plugin.result_failed_msg == ''
+    assert_allclose(tbl['sum'][0], 8590.419296)
 
 
 # NOTE: Extracting the cutout for radial profile is aperture

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -9,6 +9,7 @@ from astropy.utils.data import get_pkg_data_filename
 from numpy.testing import assert_allclose, assert_array_equal
 from photutils.aperture import (ApertureStats, CircularAperture, EllipticalAperture,
                                 RectangularAperture, EllipticalAnnulus)
+from photutils.datasets import make_4gaussians_image
 from regions import (CircleAnnulusPixelRegion, CirclePixelRegion, EllipsePixelRegion,
                      RectanglePixelRegion, PixCoord)
 
@@ -335,8 +336,6 @@ class TestAdvancedAperPhot:
 
 
 def test_annulus_background(imviz_helper):
-    from photutils.datasets import make_4gaussians_image
-
     gauss4 = make_4gaussians_image()  # The background has a mean of 5 with noise
     ones = np.ones(gauss4.shape)
 
@@ -424,8 +423,6 @@ def test_annulus_background(imviz_helper):
 
 
 def test_fit_radial_profile_with_nan(imviz_helper):
-    from photutils.datasets import make_4gaussians_image
-
     gauss4 = make_4gaussians_image()  # The background has a mean of 5 with noise
     # Insert NaN
     gauss4[25, 150] = np.nan


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address profile fitting crashing when NaN is within aperture data.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4701)
