### PR TITLE
Remove deprecated methods and properties since 4.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ Cubeviz
 
 Imviz
 ^^^^^
+- In the Orientation plugin, the following deprecated properties were removed: ``link_type`` (use ``align_by``),
+  ``wcs_use_affine`` (use ``wcs_fast_approximation``). [#3247]
+
+- Removed deprecated ``imviz.get_link_type()`` method. Use ``imviz.get_alignment_method()``
+  instead. [#3247]
 
 Mosviz
 ^^^^^^

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -202,7 +202,7 @@ From the API within the Jupyter notebook (if linking by WCS):
 
 .. code-block:: python
 
-    imviz.link_data(link_type='wcs')
+    imviz.link_data(align_by='wcs')
 
 .. _imviz-orientation-rotation:
 

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -3,7 +3,6 @@ import re
 import warnings
 from copy import deepcopy
 
-from astropy.utils import deprecated
 import numpy as np
 from glue.core.link_helpers import LinkSame
 
@@ -251,10 +250,6 @@ class Imviz(ImageConfigHelper):
         plg._obj.wcs_use_fallback = wcs_fallback_scheme == 'pixels'
         plg.wcs_fast_approximation = wcs_fast_approximation
         plg.align_by = align_by_msg_to_trait[align_by]
-
-    @deprecated(since="4.0", alternative="get_alignment_method")
-    def get_link_type(self, data_label_1, data_label_2):
-        return self.get_alignment_method(data_label_1, data_label_2)
 
     def get_alignment_method(self, data_label_1, data_label_2):
         """Find the type of ``glue`` linking between the given

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -1,5 +1,4 @@
 from astropy import units as u
-from astropy.utils import deprecated
 from astropy.wcs.wcsapi import BaseHighLevelWCS
 from glue.core.link_helpers import LinkSame
 from glue.core.message import (
@@ -142,31 +141,11 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         return PluginUserApi(
             self,
             expose=(
-                'align_by', 'link_type', 'wcs_fast_approximation', 'wcs_use_affine',
+                'align_by', 'wcs_fast_approximation',
                 'delete_subsets', 'viewer', 'orientation',
                 'rotation_angle', 'east_left', 'add_orientation'
             )
         )
-
-    @property
-    @deprecated(since="4.0", alternative="align_by")
-    def link_type(self):
-        return self.align_by
-
-    @link_type.setter
-    @deprecated(since="4.0", alternative="align_by")
-    def link_type(self, link_type):
-        self.align_by = link_type
-
-    @property
-    @deprecated(since="4.0", alternative="wcs_fast_approximation")
-    def wcs_use_affine(self):
-        return self.wcs_fast_approximation
-
-    @wcs_use_affine.setter
-    @deprecated(since="4.0", alternative="wcs_fast_approximation")
-    def wcs_use_affine(self, wcs_use_affine):
-        self.wcs_fast_approximation = wcs_use_affine
 
     def _link_image_data(self):
         self.linking_in_progress = True

--- a/jdaviz/configs/imviz/tests/test_helper.py
+++ b/jdaviz/configs/imviz/tests/test_helper.py
@@ -2,8 +2,6 @@ import numpy as np
 import pytest
 
 
-@pytest.mark.filterwarnings(r"ignore:The link_type function is deprecated")
-@pytest.mark.filterwarnings(r"ignore:The wcs_use_affine function is deprecated")
 def test_plugin_user_apis(imviz_helper):
     for plugin_name, plugin_api in imviz_helper.plugins.items():
         plugin = plugin_api._obj

--- a/jdaviz/configs/imviz/tests/test_helper.py
+++ b/jdaviz/configs/imviz/tests/test_helper.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 
 def test_plugin_user_apis(imviz_helper):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to remove methods and properties that were deprecated since v4.0.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
