### PR TITLE
Framework for legend data menu

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 New Features
 ------------
 
-* New design for viewer legend. [#3220]
+* New design for viewer legend. [#3220, #3254]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -206,7 +206,6 @@ class ApplicationState(State):
             'tray': True,
             'tab_headers': True,
         },
-        'viewer_labels': True,
         'dense_toolbar': True,
         'server_is_remote': False,  # sets some defaults, should be set before loading the config
         'context': {

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -132,6 +132,7 @@ custom_components = {'j-tooltip': 'components/tooltip.vue',
                      'j-number-uncertainty': 'components/number_uncertainty.vue',
                      'j-plugin-popout': 'components/plugin_popout.vue',
                      'j-multiselect-toggle': 'components/multiselect_toggle.vue',
+                     'j-subset-icon': 'components/subset_icon.vue',
                      'plugin-previews-temp-disabled': 'components/plugin_previews_temp_disabled.vue',  # noqa
                      'plugin-table': 'components/plugin_table.vue',
                      'plugin-dataset-select': 'components/plugin_dataset_select.vue',

--- a/jdaviz/components/layer_viewer_icon_stylized.vue
+++ b/jdaviz/components/layer_viewer_icon_stylized.vue
@@ -1,5 +1,5 @@
 <template>
-  <j-tooltip :tooltipcontent="tooltipContent(tooltip, label, visible, colormode, colors, linewidth, is_subset)">
+  <j-tooltip :tooltipcontent="tooltipContent(tooltip, label, visible, colormode, colors, linewidth, is_subset)" :disabled="disabled">
     <v-btn
       :rounded="is_subset"
       @click="(e) => $emit('click', e)"

--- a/jdaviz/components/layer_viewer_icon_stylized.vue
+++ b/jdaviz/components/layer_viewer_icon_stylized.vue
@@ -9,7 +9,10 @@
       height="30px"
       :disabled="disabled"
     >
-      <span :style="'color: white; text-shadow: 0px 0px 3px black; '+borderStyle(linewidth)">
+      <v-icon v-if="String(icon).startsWith('mdi-')" style="color: white">
+        {{  icon }}
+      </v-icon>"
+      <span v-else :style="'color: white; text-shadow: 0px 0px 3px black; '+borderStyle(linewidth)">
         {{ icon }}
       </span>
     </v-btn>

--- a/jdaviz/components/plugin_switch.vue
+++ b/jdaviz/components/plugin_switch.vue
@@ -1,6 +1,6 @@
 <template>
   <span v-if="use_eye_icon">
-    <v-btn icon @click.stop="$emit('update:value', !value)">
+    <v-btn icon @click.stop="$emit('update:value', !value); $emit('click', !value)">
       <v-icon>mdi-eye{{ value ? '' : '-off' }}</v-icon>
     </v-btn>
     <span v-if="api_hints_enabled && api_hint" class="api-hint">
@@ -16,7 +16,7 @@
     :class="api_hints_enabled && api_hint ? 'api-hint' : null"
     :hint="hint"
     v-model="value"
-    @change="$emit('update:value', $event)"
+    @change="$emit('update:value', $event); $emit('click', $event)"
     persistent-hint>
   </v-switch>
 </template>

--- a/jdaviz/components/subset_icon.vue
+++ b/jdaviz/components/subset_icon.vue
@@ -1,0 +1,23 @@
+<template>
+  <j-tooltip v-if="subset_type == 'spatial'" span_style="display: inline-block" tooltipcontent="Spatial subset">
+    <v-icon dense>
+      mdi-chart-scatter-plot
+    </v-icon>
+  </j-tooltip>
+  <j-tooltip v-else-if="subset_type == 'spectral'" span_style="display: inline-block" tooltipcontent="Spectral subset">
+   <v-icon dense>
+      mdi-chart-bell-curve
+    </v-icon>
+  </j-tooltip>
+  <j-tooltip v-else-if="subset_type == 'temporal'" span_style="display: inline-block" tooltipcontent="Temporal subset">
+    <v-icon dense>
+      mdi-chart-line
+    </v-icon>
+  </j-tooltip>
+</template>
+
+<script>
+  module.exports = {
+    props: ['subset_type']
+  };
+</script>

--- a/jdaviz/components/tooltip.vue
+++ b/jdaviz/components/tooltip.vue
@@ -128,7 +128,7 @@ module.exports = {
       return tooltips[this.$props.tipid];
     },
     getSpanStyle() {
-      return this.$props.span_style || "height: inherit; display: inherit";
+      return this.$props.span_style || "height: inherit; display: inherit; cursor: default";
     },
     getOpenDelay() {
       return this.$props.delay || "0";

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -1,4 +1,4 @@
-from traitlets import Dict, Unicode
+from traitlets import Bool, Dict, Unicode
 
 from jdaviz.core.template_mixin import TemplateMixin, LayerSelectMixin
 from jdaviz.core.user_api import UserApiWrapper
@@ -27,6 +27,8 @@ class DataMenu(TemplateMixin, LayerSelectMixin):
     visible_layers = Dict().tag(sync=True)  # read-only, set by viewer
 
     cmap_samples = Dict(cmap_samples).tag(sync=True)
+
+    dev_data_menu = Bool(False).tag(sync=True)
 
     def __init__(self, viewer, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -83,8 +83,9 @@ class DataMenu(TemplateMixin, LayerSelectMixin):
         dict
             A dictionary of the current visible layers.
         """
-        # TODO: may need to be generalized to also support subset layers
-        self.app.set_data_visibility(self.viewer_id, layer_label, visible=visible)
+        for layer in self._viewer.layers:
+            if layer.layer.label == layer_label:
+                layer.visible = visible
         return self.visible_layers
 
     def toggle_layer_visibility(self, layer_label):

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -104,7 +104,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin):
         bool
             The new visibility state of the layer.
         """
-        visible = not layer_label in self.visible_layers
+        visible = layer_label not in self.visible_layers
         self.set_layer_visibility(layer_label, visible=visible)
         return visible
 

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -83,14 +83,14 @@ class DataMenu(TemplateMixin, LayerSelectMixin):
         self._during_select_sync = True
         try:
             yield
-        except Exception:
+        except Exception:  # pragma: no cover
             self._during_select_sync = False
             raise
         self._during_select_sync = False
 
     @observe('dm_layer_selected')
     def _dm_layer_selected_changed(self, event={}):
-        if not hasattr(self, 'layer') or not self.layer.multiselect:
+        if not hasattr(self, 'layer') or not self.layer.multiselect:  # pragma: no cover
             return
         if self._during_select_sync:
             return
@@ -109,7 +109,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin):
 
     @observe('layer_selected', 'layer_items')
     def _update_dm_layer_selected(self, event={}):
-        if not hasattr(self, 'layer') or not self.layer.multiselect:
+        if not hasattr(self, 'layer') or not self.layer.multiselect:  # pragma: no cover
             return
         if self._during_select_sync:
             return
@@ -138,6 +138,8 @@ class DataMenu(TemplateMixin, LayerSelectMixin):
         for layer in self._viewer.layers:
             if layer.layer.label == layer_label:
                 layer.visible = visible
+            elif hasattr(layer.layer, 'data') and layer.layer.data.label == layer_label:
+                layer.visible = layer.layer.label in self.visible_layers
         return self.visible_layers
 
     def toggle_layer_visibility(self, layer_label):
@@ -159,4 +161,4 @@ class DataMenu(TemplateMixin, LayerSelectMixin):
         return visible
 
     def vue_set_layer_visibility(self, info, *args):
-        return self.set_layer_visibility(info.get('layer'), info.get('value'))
+        return self.set_layer_visibility(info.get('layer'), info.get('value'))  # pragma: no cover

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -12,7 +12,7 @@
           :linewidth="0"
           :cmap_samples="cmap_samples"
           btn_style="margin-bottom: 0px"
-          disabled="true"
+          @click="() => {data_menu_open = !data_menu_open}"
         />
       </span>
       <span class="invert-if-dark" style="margin-left: 30px; margin-right: 36px; line-height: 28px">{{viewer_reference || viewer_id}}</span>
@@ -31,7 +31,7 @@
             :linewidth="item.linewidth"
             :cmap_samples="cmap_samples"
             btn_style="margin-bottom: 0px"
-            disabled="true"
+            @click="() => {data_menu_open = !data_menu_open}"
           />
         </span>
         <span class="invert-if-dark" style="margin-left: 30px; margin-right: 36px; line-height: 28px">
@@ -49,8 +49,41 @@
       </div>
     </div>
 
+    <div 
+      v-if="data_menu_open" 
+      style="position: absolute; float: right; right: 32px; top: 2px; background-color: white; border: 2px solid black; width: 250px; height: 350px"
+    >
+      <span>
+        <b> {{ viewer_id }}</b>
+      </span>
+      <br/>
+      <span v-for="layer in layer_items">
+        {{ layer.label }}<br/>
+      </span>
+    </div>
+
   </div>
 </template>
+
+<script>
+  module.exports = {
+    data: function () {
+      return {
+        data_menu_open: false,
+      }
+    },
+    methods: {
+      onScroll(e) {
+        const dataMenuHeight = document.getElementById(`menu-button-${this.viewer_id}`).parentElement.getBoundingClientRect().height
+        const top = document.getElementById(`target-${this.viewer_id}`).getBoundingClientRect().y + document.body.parentElement.scrollTop + dataMenuHeight;
+        if (this.data_menu_open && document.getElementById(`target-${this.viewer_id}`)) {
+          const menuContent = document.getElementById(`menu-content-${this.viewer_id}`);
+          menuContent.parentElement.style.top = top + "px";
+        }
+      }
+    },
+  }
+</script>
 
 <style scoped>
   .viewer-label {

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -3,7 +3,7 @@
     <div v-if="Object.keys(viewer_icons).length > 1" class="viewer-label">
       <span style="float: right;">
         <j-layer-viewer-icon-stylized
-          tooltip=""
+          tooltip="View data layers and subsets"
           :label="viewer_id"
           :icon="viewer_icons[viewer_id]"
           :visible="true"
@@ -22,7 +22,7 @@
       <div v-if="item.visible">
         <span style="float: right;">
           <j-layer-viewer-icon-stylized
-            tooltip=""
+            tooltip="View data layers and subsets"
             :label="item.label"
             :icon="item.icon"
             :visible="item.visible"
@@ -51,14 +51,37 @@
 
     <div 
       v-if="data_menu_open" 
-      style="position: absolute; float: right; right: 32px; top: 2px; background-color: white; border: 2px solid black; width: 250px; height: 350px"
+      style="position: absolute; float: right; right: 32px; top: 2px; background-color: white; border: 2px solid black; width: 300px; height: 350px"
     >
       <span>
         <b> {{ viewer_id }}</b>
       </span>
       <br/>
-      <span v-for="layer in layer_items">
-        {{ layer.label }}<br/>
+      <span v-for="item in layer_items.slice().reverse()">
+        <span style="width: 42px; margin: 4px">
+          <j-layer-viewer-icon-stylized
+              :label="item.label"
+              :icon="item.icon"
+              :visible="item.visible"
+              :is_subset="item.is_subset"
+              :colors="item.colors"
+              :linewidth="item.linewidth"
+              :cmap_samples="cmap_samples"
+              btn_style="margin-bottom: 0px"
+              disabled="true"
+            />
+        </span>
+        {{ item.label }}
+        <j-tooltip span_style="float: right" tooltipcontent="Toggle visibility">
+          <plugin-switch
+            :value="item.visible"
+            @click="(value) => {set_layer_visibility({layer: item.label, value: value})}"
+            :api_hint='"dm.set_layer_visibility("+viewer_id+", "'
+            :api_hints_enabled="false"
+            :use_eye_icon="true"
+          />
+        </j-tooltip>
+        <br/>
       </span>
     </div>
 

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -1,6 +1,11 @@
 <template>
   <div>
-    <v-menu offset-x left :close-on-content-click="false" v-model="data_menu_open">
+    <v-menu
+      offset-x
+      left
+      transition="slide-x-reverse-transition"
+      :close-on-content-click="false"
+      v-model="data_menu_open">
       <template v-slot:activator="{ on, attrs }">
         <div>
           <div v-if="Object.keys(viewer_icons).length > 1" :id="'layer-legend-'+ viewer_id" class="viewer-label">

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -56,7 +56,12 @@
         </div>
       </template>
       <v-list :id="'dm-content-' + viewer_id" style="max-height: 500px; width: 465px" class="overflow-y-auto">
-        <v-list-item-group multiple dense>
+        <v-list-item-group
+          active-class="active-list-item"
+          multiple
+          dense
+        >
+          <div>
           <v-list-item v-for="item in layer_items.slice().reverse()">
             <v-list-item-icon>
               <j-layer-viewer-icon-stylized
@@ -86,6 +91,7 @@
               </j-tooltip>
             </v-list-item-action>
           </v-list-item>
+          </div>
         </v-list-item-group>
       </v-list>
     </v-menu>
@@ -156,5 +162,22 @@
 
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
+  }
+  .v-list-item__icon, .v-list-item__content, .v-list-item__action {
+    /* even denser than dense */
+    padding-top: 4px !important;
+    padding-bottom: 4px !important;
+    margin-top: 2px !important;
+    margin-bottom: 2px !important;
+  }
+  .v-list-item__icon {
+    margin-top: 6px !important;
+  }
+  .v-list-item:nth-child(even) {
+    /* alternating row colors */
+    background-color: #f1f2f8;
+  }
+  .active-list-item {
+    background-color: #d1f4ff;
   }
 </style>

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -1,90 +1,93 @@
 <template>
   <div>
-    <div v-if="Object.keys(viewer_icons).length > 1" class="viewer-label">
-      <span style="float: right;">
-        <j-layer-viewer-icon-stylized
-          tooltip="View data layers and subsets"
-          :label="viewer_id"
-          :icon="viewer_icons[viewer_id]"
-          :visible="true"
-          :is_subset="false"
-          :colors="['#939393']"
-          :linewidth="0"
-          :cmap_samples="cmap_samples"
-          btn_style="margin-bottom: 0px"
-          @click="() => {data_menu_open = !data_menu_open}"
-        />
-      </span>
-      <span class="invert-if-dark" style="margin-left: 30px; margin-right: 36px; line-height: 28px">{{viewer_reference || viewer_id}}</span>
-    </div>
+    <v-menu offset-x left :close-on-content-click="false" v-model="data_menu_open">
+      <template v-slot:activator="{ on, attrs }">
+        <div>
+          <div v-if="Object.keys(viewer_icons).length > 1" :id="'layer-legend-'+ viewer_id" class="viewer-label">
+            <span style="float: right;">
+              <j-layer-viewer-icon-stylized
+                tooltip="View data layers and subsets"
+                :label="viewer_id"
+                :icon="viewer_icons[viewer_id]"
+                :visible="true"
+                :is_subset="false"
+                :colors="['#939393']"
+                :linewidth="0"
+                :cmap_samples="cmap_samples"
+                btn_style="margin-bottom: 0px"
+                @click="() => {data_menu_open = !data_menu_open}"
+              />
+            </span>
+            <span class="invert-if-dark" style="margin-left: 30px; margin-right: 36px; line-height: 28px">{{viewer_reference || viewer_id}}</span>
+          </div>
 
-    <div v-for="item in layer_items.slice().reverse()" class="viewer-label">
-      <div v-if="item.visible">
-        <span style="float: right;">
-          <j-layer-viewer-icon-stylized
-            tooltip="View data layers and subsets"
-            :label="item.label"
-            :icon="item.icon"
-            :visible="item.visible"
-            :is_subset="item.is_subset"
-            :colors="item.colors"
-            :linewidth="item.linewidth"
-            :cmap_samples="cmap_samples"
-            btn_style="margin-bottom: 0px"
-            @click="() => {data_menu_open = !data_menu_open}"
-          />
-        </span>
-        <span class="invert-if-dark" style="margin-left: 30px; margin-right: 36px; line-height: 28px">
-          <v-icon v-if="item.subset_type == 'spatial'" dense>
-            mdi-chart-scatter-plot
-          </v-icon>
-          <v-icon v-else-if="item.subset_type == 'spectral'" dense>
-            mdi-chart-bell-curve
-          </v-icon>
-          <v-icon v-else-if="item.subset_type == 'temporal'" dense>
-            mdi-chart-line
-          </v-icon>
-          {{item.label}}
-        </span>
-      </div>
-    </div>
-
-    <div 
-      v-if="data_menu_open" 
-      style="position: absolute; float: right; right: 32px; top: 2px; background-color: white; border: 2px solid black; width: 300px; height: 350px"
-    >
-      <span>
-        <b> {{ viewer_id }}</b>
-      </span>
-      <br/>
-      <span v-for="item in layer_items.slice().reverse()">
-        <span style="width: 42px; margin: 4px">
-          <j-layer-viewer-icon-stylized
-              :label="item.label"
-              :icon="item.icon"
-              :visible="item.visible"
-              :is_subset="item.is_subset"
-              :colors="item.colors"
-              :linewidth="item.linewidth"
-              :cmap_samples="cmap_samples"
-              btn_style="margin-bottom: 0px"
-              disabled="true"
-            />
-        </span>
-        {{ item.label }}
-        <j-tooltip span_style="float: right" tooltipcontent="Toggle visibility">
-          <plugin-switch
-            :value="item.visible"
-            @click="(value) => {set_layer_visibility({layer: item.label, value: value})}"
-            :api_hint='"dm.set_layer_visibility("+viewer_id+", "'
-            :api_hints_enabled="false"
-            :use_eye_icon="true"
-          />
-        </j-tooltip>
-        <br/>
-      </span>
-    </div>
-
+          <div v-for="item in layer_items.slice().reverse()" class="viewer-label">
+            <div v-if="item.visible">
+              <span style="float: right;">
+                <j-layer-viewer-icon-stylized
+                  tooltip="View data layers and subsets"
+                  :label="item.label"
+                  :icon="item.icon"
+                  :visible="item.visible"
+                  :is_subset="item.is_subset"
+                  :colors="item.colors"
+                  :linewidth="item.linewidth"
+                  :cmap_samples="cmap_samples"
+                  btn_style="margin-bottom: 0px"
+                  @click="() => {data_menu_open = !data_menu_open}"
+                />
+              </span>
+              <span class="invert-if-dark" style="margin-left: 30px; margin-right: 36px; line-height: 28px">
+                <v-icon v-if="item.subset_type == 'spatial'" dense>
+                  mdi-chart-scatter-plot
+                </v-icon>
+                <v-icon v-else-if="item.subset_type == 'spectral'" dense>
+                  mdi-chart-bell-curve
+                </v-icon>
+                <v-icon v-else-if="item.subset_type == 'temporal'" dense>
+                  mdi-chart-line
+                </v-icon>
+                {{item.label}}
+              </span>
+            </div>
+          </div>
+        </div>
+      </template>
+      <v-list :id="'dm-content-' + viewer_id" style="max-height: 500px; width: 465px" class="overflow-y-auto">
+        <v-list-item-group multiple dense>
+          <v-list-item v-for="item in layer_items.slice().reverse()">
+            <v-list-item-icon>
+              <j-layer-viewer-icon-stylized
+                  :label="item.label"
+                  :icon="item.icon"
+                  :visible="item.visible"
+                  :is_subset="item.is_subset"
+                  :colors="item.colors"
+                  :linewidth="item.linewidth"
+                  :cmap_samples="cmap_samples"
+                  btn_style="margin-bottom: 0px"
+                  disabled="true"
+                />
+            </v-list-item-icon>
+            <v-list-item-content>
+              {{  item.label }}
+            </v-list-item-content>
+            <v-list-item-action>
+              <j-tooltip tooltipcontent="Toggle visibility">
+                <plugin-switch
+                  :value="item.visible"
+                  @click="(value) => {set_layer_visibility({layer: item.label, value: value})}"
+                  :api_hint='"dm.set_layer_visibility("+viewer_id+", "'
+                  :api_hints_enabled="false"
+                  :use_eye_icon="true"
+                />
+              </j-tooltip>
+            </v-list-item-action>
+          </v-list-item>
+        </v-list-item-group>
+      </v-list>
+    </v-menu>
+    <div :id="'dm-target-' + viewer_id"></div>
   </div>
 </template>
 
@@ -95,12 +98,36 @@
         data_menu_open: false,
       }
     },
+    mounted() {
+      let element = document.getElementById(`dm-target-${this.viewer_id}`).parentElement
+      if (element === null) {
+        return
+      }
+      while (element["tagName"] !== "BODY") {
+        if (["auto", "scroll"].includes(window.getComputedStyle(element).overflowY)) {
+          element.addEventListener("scroll", this.onScroll);
+        }
+        element = element.parentElement;
+      }
+    },
+    beforeDestroy() {
+      let element = document.getElementById(`dm-target-${this.viewer_id}`).parentElement
+      if (element === null) {
+        return
+      }
+      while (element["tagName"] !== "BODY") {
+        if (["auto", "scroll"].includes(window.getComputedStyle(element).overflowY)) {
+          element.removeEventListener("scroll", this.onScroll);
+        }
+        element = element.parentElement;
+      }
+    },
     methods: {
       onScroll(e) {
-        const dataMenuHeight = document.getElementById(`menu-button-${this.viewer_id}`).parentElement.getBoundingClientRect().height
-        const top = document.getElementById(`target-${this.viewer_id}`).getBoundingClientRect().y + document.body.parentElement.scrollTop + dataMenuHeight;
-        if (this.data_menu_open && document.getElementById(`target-${this.viewer_id}`)) {
-          const menuContent = document.getElementById(`menu-content-${this.viewer_id}`);
+        const dataMenuHeight = document.getElementById(`layer-legend-${this.viewer_id}`).parentElement.getBoundingClientRect().height
+        const top = document.getElementById(`dm-target-${this.viewer_id}`).getBoundingClientRect().y + document.body.parentElement.scrollTop + dataMenuHeight;
+        if (this.data_menu_open && document.getElementById(`dm-target-${this.viewer_id}`)) {
+          const menuContent = document.getElementById(`dm-content-${this.viewer_id}`);
           menuContent.parentElement.style.top = top + "px";
         }
       }

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -56,6 +56,37 @@
         </div>
       </template>
       <v-list :id="'dm-content-' + viewer_id" style="max-height: 500px; width: 465px" class="overflow-y-auto">
+        <v-list-item class="dm-header">
+          <v-list-item-icon>
+            <j-tooltip
+              tooltipcontent="Reorder layers (COMING SOON)"
+            >
+              <v-btn
+                icon
+                disabled
+              >
+                <v-icon>mdi-format-vertical-align-center</v-icon>
+              </v-btn>
+            </j-tooltip>
+          </v-list-item-icon>
+          <v-list-item-content>
+            <j-tooltip
+              tooltipcontent="Change orientation (COMING SOON)"
+            >
+              orientation
+            </j-tooltip>
+          </v-list-item-content>
+          <v-list-item-action>
+            <j-tooltip tooltipcontent="Add data or subset (COMING SOON)">
+              <v-btn
+                icon
+                disabled
+              >
+                <v-icon>mdi-plus</v-icon>
+              </v-btn>
+            </j-tooltip>
+          </v-list-item-action>
+        </v-list-item>
         <v-list-item-group
           v-model="dm_layer_selected"
           active-class="active-list-item"
@@ -94,6 +125,44 @@
           </v-list-item>
           </div>
         </v-list-item-group>
+        <v-list-item class="dm-footer">
+          <v-list-item-content style="display: inline-block">
+            <j-tooltip
+              span_style="display: inline-block; float: right"
+              tooltipcontent="Remove data/subset (COMING SOON)"
+            >
+              <v-btn
+                icon
+                disabled
+              >
+                <v-icon>mdi-delete</v-icon>
+              </v-btn>
+            </j-tooltip>
+            <j-tooltip
+              v-if="dm_layer_selected.length == 1 && layer_items[layer_items.length - 1 - dm_layer_selected[0]].icon.length == 1 && !layer_items[layer_items.length - 1 - dm_layer_selected[0]].is_subset && !layer_items[layer_items.length - 1 - dm_layer_selected[0]].from_plugin"
+              span_style="display: inline-block; float: right"
+              tooltipcontent="View Metadata"
+            >
+              <v-btn
+                icon
+                disabled
+                >
+                <v-icon>mdi-label</v-icon>
+              </v-btn>
+            </j-tooltip>
+            <j-tooltip
+              span_style="display: inline-block; float: right"
+              tooltipcontent="Edit Selected Subset (COMING SOON)"
+            >
+              <v-btn
+                text
+                disabled
+              >
+                Edit Subset
+              </v-btn>
+            </j-tooltip>
+          </v-list-item-content>
+        </v-list-item>
       </v-list>
     </v-menu>
     <div :id="'dm-target-' + viewer_id"></div>
@@ -164,6 +233,10 @@
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
+  .v-list {
+    padding-top: 0px !important;
+    padding-bottom: 0px !important;
+  }
   .v-list-item__icon, .v-list-item__content, .v-list-item__action {
     /* even denser than dense */
     padding-top: 4px !important;
@@ -180,5 +253,16 @@
   }
   .active-list-item {
     background-color: #d1f4ff !important;
+  }
+  .dm-header, .dm-footer {
+    background-color: #003B4D;
+    color: white !important;
+    font-weight: bold;
+  }
+  i.dm-header, i.dm-footer {
+    color: white !important;
+  }
+  .dm-header.v-btn--disabled  .v-icon {
+    color: green !important;
   }
 </style>

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -15,7 +15,8 @@
                 :linewidth="0"
                 :cmap_samples="cmap_samples"
                 btn_style="margin-bottom: 0px"
-                @click="() => {data_menu_open = !data_menu_open}"
+                @click="() => {if (dev_data_menu) {data_menu_open = !data_menu_open}}"
+                :disabled="!dev_data_menu"
               />
             </span>
             <span class="invert-if-dark" style="margin-left: 30px; margin-right: 36px; line-height: 28px">{{viewer_reference || viewer_id}}</span>
@@ -34,7 +35,8 @@
                   :linewidth="item.linewidth"
                   :cmap_samples="cmap_samples"
                   btn_style="margin-bottom: 0px"
-                  @click="() => {data_menu_open = !data_menu_open}"
+                  @click="() => {if (dev_data_menu) {data_menu_open = !data_menu_open}}"
+                  :disabled="!dev_data_menu"
                 />
               </span>
               <span class="invert-if-dark" style="margin-left: 30px; margin-right: 36px; line-height: 28px">

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -57,6 +57,7 @@
       </template>
       <v-list :id="'dm-content-' + viewer_id" style="max-height: 500px; width: 465px" class="overflow-y-auto">
         <v-list-item-group
+          v-model="dm_layer_selected"
           active-class="active-list-item"
           multiple
           dense
@@ -178,6 +179,6 @@
     background-color: #f1f2f8;
   }
   .active-list-item {
-    background-color: #d1f4ff;
+    background-color: #d1f4ff !important;
   }
 </style>

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -45,15 +45,7 @@
                 />
               </span>
               <span class="invert-if-dark" style="margin-left: 30px; margin-right: 36px; line-height: 28px">
-                <v-icon v-if="item.subset_type == 'spatial'" dense>
-                  mdi-chart-scatter-plot
-                </v-icon>
-                <v-icon v-else-if="item.subset_type == 'spectral'" dense>
-                  mdi-chart-bell-curve
-                </v-icon>
-                <v-icon v-else-if="item.subset_type == 'temporal'" dense>
-                  mdi-chart-line
-                </v-icon>
+                <j-subset-icon :subset_type="item.subset_type" />
                 {{item.label}}
               </span>
             </div>
@@ -114,7 +106,10 @@
                 />
             </v-list-item-icon>
             <v-list-item-content>
-              {{  item.label }}
+              <span style="display: inline-block">
+                <j-subset-icon :subset_type="item.subset_type" />
+                {{  item.label }}
+              </span>
             </v-list-item-content>
             <v-list-item-action>
               <j-tooltip tooltipcontent="Toggle visibility">

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -8,12 +8,12 @@
       v-model="data_menu_open">
       <template v-slot:activator="{ on, attrs }">
         <div :id="'layer-legend-'+ viewer_id">
-          <div v-if="Object.keys(viewer_icons).length > 1 || Object.keys(visible_layers).length == 0" class="viewer-label">
+          <div v-if="Object.keys(viewer_icons).length > 1 || Object.keys(visible_layers).length == 0 || data_menu_open" class="viewer-label"> 
             <span style="float: right;">
               <j-layer-viewer-icon-stylized
-                tooltip="View data layers and subsets"
+                :tooltip="data_menu_open ? 'close menu' : 'View data layers and subsets'"
                 :label="viewer_id"
-                :icon="viewer_icons[viewer_id]"
+                :icon="data_menu_open ? 'mdi-close' : viewer_icons[viewer_id]"
                 :visible="true"
                 :is_subset="false"
                 :colors="['#939393']"

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -108,7 +108,14 @@
             </v-list-item-icon>
             <v-list-item-content>
               <span style="display: inline-block">
-                <j-subset-icon :subset_type="item.subset_type" />
+                <j-subset-icon v-if="item.subset_type" :subset_type="item.subset_type" />
+                <j-tooltip
+                  v-if="item.icon.length == 2"
+                  :tooltipcontent="'sublayer of '+item.icon[0].toUpperCase()"
+                  span_style="display: inline-block" 
+                >
+                  <v-icon dense>mdi-layers-outline</v-icon>
+                </j-tooltip>
                 {{  item.label }}
               </span>
             </v-list-item-content>

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -3,6 +3,7 @@
     <v-menu
       offset-x
       left
+      nudge-left="8"
       transition="slide-x-reverse-transition"
       :close-on-content-click="false"
       v-model="data_menu_open">

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -7,8 +7,8 @@
       :close-on-content-click="false"
       v-model="data_menu_open">
       <template v-slot:activator="{ on, attrs }">
-        <div>
-          <div v-if="Object.keys(viewer_icons).length > 1" :id="'layer-legend-'+ viewer_id" class="viewer-label">
+        <div :id="'layer-legend-'+ viewer_id">
+          <div v-if="Object.keys(viewer_icons).length > 1 || Object.keys(visible_layers).length == 0" class="viewer-label">
             <span style="float: right;">
               <j-layer-viewer-icon-stylized
                 tooltip="View data layers and subsets"

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -237,7 +237,6 @@
   .viewer-label:hover {
     background-color: #e5e5e5;
     width: auto;
-
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
@@ -264,11 +263,11 @@
   }
   .dm-header, .dm-footer {
     background-color: #003B4D;
-    color: white !important;
     font-weight: bold;
   }
-  i.dm-header, i.dm-footer {
-    color: white !important;
+  .dm-header > .v-list-item__icon, .dm-header > .v-list-item__content, .dm-header > .v-list-item__action,
+  .dm-footer > .v-list-item__icon, .dm-footer > .v-list-item__content, .dm-footer > .v-list-item__action {
+    filter: invert(1);
   }
   .dm-header.v-btn--disabled  .v-icon {
     color: green !important;

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -52,7 +52,7 @@
           </div>
         </div>
       </template>
-      <v-list :id="'dm-content-' + viewer_id" style="max-height: 500px; width: 465px" class="overflow-y-auto">
+      <v-list :id="'dm-content-' + viewer_id" style="width: 400px" class="overflow-y-auto">
         <v-list-item class="dm-header">
           <v-list-item-icon>
             <j-tooltip
@@ -87,6 +87,7 @@
         <v-list-item-group
           v-model="dm_layer_selected"
           active-class="active-list-item"
+          style="max-height: 265px; overflow-y: auto;"
           multiple
           dense
         >

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -261,6 +261,7 @@
   }
   .active-list-item {
     background-color: #d1f4ff75 !important;
+    font-weight: 500;
   }
   .dm-header, .dm-footer {
     background-color: #003B4D;

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -249,10 +249,10 @@
   }
   .v-list-item:nth-child(even) {
     /* alternating row colors */
-    background-color: #f1f2f8;
+    background-color: #f1f2f85a;
   }
   .active-list-item {
-    background-color: #d1f4ff !important;
+    background-color: #d1f4ff75 !important;
   }
   .dm-header, .dm-footer {
     background-color: #003B4D;

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -371,8 +371,6 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
     icon_radialtocheck = Unicode(read_icon(os.path.join(ICON_DIR, 'radialtocheck.svg'), 'svg+xml')).tag(sync=True)  # noqa
     icon_checktoradial = Unicode(read_icon(os.path.join(ICON_DIR, 'checktoradial.svg'), 'svg+xml')).tag(sync=True)  # noqa
 
-    show_viewer_labels = Bool(True).tag(sync=True)
-
     cmap_samples = Dict(cmap_samples).tag(sync=True)
     swatches_palette = List().tag(sync=True)
     apply_RGB_presets_spinner = Bool(False).tag(sync=True)
@@ -625,10 +623,6 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
         self.axes_visible = PlotOptionsSyncState(self, self.viewer, self.layer, 'show_axes',
                                                  'axes_visible_value', 'axes_visible_sync',
                                                  state_filter=not_profile)
-
-        self.show_viewer_labels = self.app.state.settings['viewer_labels']
-        self.app.state.add_callback('settings', self._on_app_settings_changed)
-
         sv = self.spectrum_viewer
         if sv is not None:
             sv.state.add_callback('x_display_unit',
@@ -662,13 +656,6 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
                        'stretch_curve_visible', 'apply_RGB_presets']
 
         return PluginUserApi(self, expose)
-
-    @observe('show_viewer_labels')
-    def _on_show_viewer_labels_changed(self, event):
-        self.app.state.settings['viewer_labels'] = event['new']
-
-    def _on_app_settings_changed(self, value):
-        self.show_viewer_labels = value['viewer_labels']
 
     @property
     def multiselect(self):

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -10,27 +10,6 @@
     :popout_button="popout_button"
     :scroll_to.sync="scroll_to">
 
-    <v-row>
-      <v-expansion-panels popout>
-        <v-expansion-panel>
-          <v-expansion-panel-header v-slot="{ open }">
-            <span style="padding: 6px">Settings</span>
-          </v-expansion-panel-header>
-          <v-expansion-panel-content class="plugin-expansion-panel-content">
-            <v-row>
-              <plugin-switch
-                :value.sync="show_viewer_labels"
-                label="Show labels in viewers"
-                api_hint = 'plg.show_viewer_labels = '
-                :api_hints_enabled="api_hints_enabled"
-                hint="Whether to show viewer/layer labels on each viewer"
-              />
-            </v-row>
-          </v-expansion-panel-content>
-        </v-expansion-panel>
-      </v-expansion-panels>
-    </v-row>
-
     <!-- VIEWER OPTIONS -->
     <plugin-viewer-select
       :items="viewer_items"

--- a/jdaviz/configs/default/tests/test_data_menu.py
+++ b/jdaviz/configs/default/tests/test_data_menu.py
@@ -1,0 +1,68 @@
+import numpy as np
+from specutils import SpectralRegion
+
+
+def test_data_menu_toggles(specviz_helper, spectrum1d):
+    # NOTE: this test is adopted from core.tests.test_data_menu.test_data_menu_toggles
+    # which should be removed once the old data menu is removed from jdaviz
+
+    # load 2 data entries
+    specviz_helper.load_data(spectrum1d, data_label="test")
+    new_spec = specviz_helper.get_spectra(apply_slider_redshift=True)["test"]*0.9
+    specviz_helper.load_data(new_spec, data_label="test2")
+
+    # check that both are enabled in the data menu
+    sv = specviz_helper.viewers['spectrum-viewer']
+    dm = sv._obj.data_menu
+    assert len(dm._obj.layer_items) == 2
+    assert len(dm._obj.visible_layers) == 2
+
+    # disable (hide layer) for second entry
+    dm.set_layer_visibility('test2', False)
+    assert len(dm._obj.layer_items) == 2
+    assert len(dm._obj.visible_layers) == 1
+
+    # add a subset and make sure it appears for the first data entry but not the second
+    specviz_helper.plugins['Subset Tools']._obj.import_region(
+        SpectralRegion(6000 * spectrum1d.spectral_axis.unit, 6500 * spectrum1d.spectral_axis.unit))
+
+    assert len(dm._obj.layer_items) == 3
+    assert len(dm._obj.visible_layers) == 2
+    assert len(sv._obj.layers) == 4
+    assert sv._obj.layers[2].visible is True   # subset corresponding to first (visible) data entry
+    assert sv._obj.layers[3].visible is False  # subset corresponding to second (hidden) data entry
+
+    # enable data layer from menu and subset should also become visible
+    dm.toggle_layer_visibility('test2')
+    assert np.all([layer.visible for layer in sv._obj.layers])
+
+
+def test_data_menu_selection(specviz_helper, spectrum1d):
+    # load 2 data entries
+    specviz_helper.load_data(spectrum1d, data_label="test")
+    new_spec = specviz_helper.get_spectra(apply_slider_redshift=True)["test"]*0.9
+    specviz_helper.load_data(new_spec, data_label="test2")
+
+    sv = specviz_helper.viewers['spectrum-viewer']
+    dm = sv._obj.data_menu
+
+    # no selection by default
+    assert len(dm._obj.dm_layer_selected) == 0
+    assert len(dm.layer.selected) == 0
+
+    # test layer -> UI sync
+    dm.layer.selected = dm.layer.choices[0]
+    assert len(dm._obj.dm_layer_selected) == len(dm.layer.selected)
+
+    # test UI -> layer sync
+    dm._obj.dm_layer_selected = [0, 1]
+    assert len(dm._obj.dm_layer_selected) == len(dm.layer.selected)
+
+    # test that sync remains during layer deletion
+    dm._obj.dm_layer_selected = [1]
+    assert dm.layer.selected == ['test']
+    specviz_helper.app.remove_data_from_viewer("spectrum-viewer", "test2")
+    specviz_helper.app.vue_data_item_remove({"item_name": "test2"})
+    assert len(dm._obj.layer_items) == 1
+    assert dm._obj.dm_layer_selected == [0]
+    assert dm.layer.selected == ['test']

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -62,7 +62,7 @@
 
         <v-card tile flat style="flex: 1; margin-top: -2px; overflow: hidden;">
           <div class="viewer-label-container">
-            <jupyter-widget :widget="viewer.data_menu" v-if="app_settings.viewer_labels"></jupyter-widget>
+            <jupyter-widget :widget="viewer.data_menu"></jupyter-widget>
           </div>
           <jupyter-widget
             :widget="viewer.widget"


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements the framework for the redesigned data-menu launched from the viewer legend - currently including a list of layers with togglable visibilities.  Until this reaches feature-parity with the existing data menu and can be launched in its place, this will be hidden behind a developer flag to avoid confusion.  To enable for testing (note: both this and the `_obj` will be removed when making the data-menu public):

```
for viewer in viz.viewers.values():
    viewer._obj.data_menu._obj.dev_data_menu = True
```

<img width="673" alt="image" src="https://github.com/user-attachments/assets/15d464a6-c840-4cbe-9310-1ea22248e26e">



**TODO / follow-ups**:
- [x] implement as much styling as applicable from the UI design
  - [ ] ~set color of icons in header/footer~ (will be in next PR)
  - [ ] use "toolbar" color for dark mode toggling instead of hardcoding
  - [x] show subset icon where applicable
- [x] fix index > selection mapping when sublayer is included in the list
- [x] fix data-menu selection when adding new layers
- [ ] investigate subset visibility lag and determine if an upstream bug
- [ ] investigate assigning spectral subsets in cube viewer as temporal and create ticket
- [ ] sublayer support (some may be deferred)
  - [ ] ~nest sublayers in UI or keep by z-order?~ (talked to @Jenneh - let's defer for now and she'll work on a design)
  - [ ] toggling visibility of parent should disable visibility of children (see behavior in current data menu)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
