### PR TITLE
data-menu: add subsets/data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 New Features
 ------------
 
-* New design for viewer legend. [#3220, #3254]
+* New design for viewer legend. [#3220, #3254, #3263]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -151,7 +151,8 @@ custom_components = {'j-tooltip': 'components/tooltip.vue',
                      'plugin-slider': 'components/plugin_slider.vue',
                      'plugin-color-picker': 'components/plugin_color_picker.vue',
                      'plugin-input-header': 'components/plugin_input_header.vue',
-                     'glue-state-sync-wrapper': 'components/glue_state_sync_wrapper.vue'}
+                     'glue-state-sync-wrapper': 'components/glue_state_sync_wrapper.vue',
+                     'data-menu-add-data': 'components/data_menu_add_data.vue'}
 
 _verbosity_levels = ('debug', 'info', 'warning', 'error')
 

--- a/jdaviz/components/data_menu_add_data.vue
+++ b/jdaviz/components/data_menu_add_data.vue
@@ -16,17 +16,17 @@
       </j-tooltip>
     </template>
     <v-list dense style="width: 200px">
-      <v-subheader class="strike" v-if="dataset_items.length > 0"><span>Load Data</span></v-subheader>
+      <v-subheader v-if="dataset_items.length > 0" class="strike"><span>Load Data</span></v-subheader>
       <v-list-item
-        v-for="item in dataset_items"
+        v-for="data in dataset_items"
       >
         <v-list-item-content>
           <j-tooltip tooltipcontent="add data to viewer">
             <span
               style="cursor: pointer; width: 100%"
-              @click="() => {$emit('add-data', item.label)}"
+              @click="() => {$emit('add-data', data.label)}"
             >
-              {{  item.label }}
+              {{ data.label }}
             </span>
           </j-tooltip>
         </v-list-item-content>
@@ -63,7 +63,7 @@ module.exports = {
 <style scoped>
 .strike {
     display: block;
-    text-align: center;
+    text-align: center !important;
     height: 28px !important;
 }
 

--- a/jdaviz/components/data_menu_add_data.vue
+++ b/jdaviz/components/data_menu_add_data.vue
@@ -32,22 +32,19 @@
         </v-list-item-content>
       </v-list-item>
       <v-subheader class="strike"><span>Create Subset</span></v-subheader>
-      <v-list-item>
+      <v-list-item
+      >
         <v-list-item-content style="display: inline-block">
           <j-tooltip
+            v-for="tool in subset_tools"
             span_style="display: inline-block"
-            tooltipcontent="Create new circular subset"
+            :tooltipcontent="'Create new '+tool.name+' subset'"
           >
-            <v-btn icon>
-              <v-icon>mdi-circle</v-icon>
-            </v-btn>
-          </j-tooltip>
-          <j-tooltip
-            span_style="display: inline-block"
-            tooltipcontent="Create new square subset"
-          >
-            <v-btn icon>
-              <v-icon>mdi-square</v-icon>
+            <v-btn 
+              icon
+              @click="() => {$emit('create-subset', tool.name)}"
+            >
+              <img :src="tool.img" width="20"/>
             </v-btn>
           </j-tooltip>
         </v-list-item-content>
@@ -59,7 +56,7 @@
 
 <script>
 module.exports = {
-  props: ['dataset_items'],
+  props: ['dataset_items', 'subset_tools'],
 };
 </script>
 

--- a/jdaviz/components/data_menu_add_data.vue
+++ b/jdaviz/components/data_menu_add_data.vue
@@ -7,8 +7,9 @@
     >
     <template v-slot:activator="{ on, attrs }">
       <j-tooltip
-          tooltipcontent="Add data or subset to viewer"
-       >
+        v-if="dataset_items.length > 0 || subset_tools.length > 0"
+        tooltipcontent="Add data or subset to viewer"
+      >
         <v-btn
           icon
           v-bind="attrs"
@@ -34,7 +35,7 @@
           </j-tooltip>
         </v-list-item-content>
       </v-list-item>
-      <v-subheader class="strike"><span>Create Subset</span></v-subheader>
+      <v-subheader v-if="subset_tools.length > 0" class="strike"><span>Create Subset</span></v-subheader>
       <v-list-item
         v-if="subset_tools.length > 0"
       >

--- a/jdaviz/components/data_menu_add_data.vue
+++ b/jdaviz/components/data_menu_add_data.vue
@@ -1,0 +1,99 @@
+<template>
+  <v-menu
+    absolute
+    offset-y
+    left
+  >
+    <template v-slot:activator="{ on, attrs }">
+      <j-tooltip tooltipcontent="Add data or subset to viewer">
+        <v-btn
+          icon
+          v-bind="attrs"
+          v-on="on"
+        >
+          <v-icon>mdi-plus</v-icon>
+        </v-btn>
+      </j-tooltip>
+    </template>
+    <v-list dense style="width: 200px">
+      <v-subheader class="strike" v-if="dataset_items.length > 0"><span>Load Data</span></v-subheader>
+      <v-list-item
+        v-for="item in dataset_items"
+      >
+        <v-list-item-content>
+          <j-tooltip tooltipcontent="add data to viewer">
+            <span
+              style="cursor: pointer; width: 100%"
+              @click="() => {$emit('add-data', item.label)}"
+            >
+              {{  item.label }}
+            </span>
+          </j-tooltip>
+        </v-list-item-content>
+      </v-list-item>
+      <v-subheader class="strike"><span>Create Subset</span></v-subheader>
+      <v-list-item>
+        <v-list-item-content style="display: inline-block">
+          <j-tooltip
+            span_style="display: inline-block"
+            tooltipcontent="Create new circular subset"
+          >
+            <v-btn icon>
+              <v-icon>mdi-circle</v-icon>
+            </v-btn>
+          </j-tooltip>
+          <j-tooltip
+            span_style="display: inline-block"
+            tooltipcontent="Create new square subset"
+          >
+            <v-btn icon>
+              <v-icon>mdi-square</v-icon>
+            </v-btn>
+          </j-tooltip>
+        </v-list-item-content>
+      </v-list-item>
+    </v-list>
+  </v-menu>
+
+</template>
+
+<script>
+module.exports = {
+  props: ['dataset_items'],
+};
+</script>
+
+<style scoped>
+.strike {
+    display: block;
+    text-align: center;
+    height: 28px !important;
+}
+
+.strike > span {
+    position: relative;
+    display: inline-block;
+    text-transform: uppercase;
+    font-weight: bold;
+}
+
+.strike > span:before,
+.strike > span:after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    width: 9999px;
+    height: 1px;
+    background: gray;
+}
+
+.strike > span:before {
+    right: 100%;
+    margin-right: 6px;
+}
+
+.strike > span:after {
+    left: 100%;
+    margin-left: 6px;
+}
+</style>

--- a/jdaviz/components/data_menu_add_data.vue
+++ b/jdaviz/components/data_menu_add_data.vue
@@ -3,9 +3,12 @@
     absolute
     offset-y
     left
-  >
+    v-if="dataset_items.length > 0 || subset_tools.length > 0"
+    >
     <template v-slot:activator="{ on, attrs }">
-      <j-tooltip tooltipcontent="Add data or subset to viewer">
+      <j-tooltip
+          tooltipcontent="Add data or subset to viewer"
+       >
         <v-btn
           icon
           v-bind="attrs"
@@ -33,6 +36,7 @@
       </v-list-item>
       <v-subheader class="strike"><span>Create Subset</span></v-subheader>
       <v-list-item
+        v-if="subset_tools.length > 0"
       >
         <v-list-item-content style="display: inline-block">
           <j-tooltip

--- a/jdaviz/components/data_menu_add_data.vue
+++ b/jdaviz/components/data_menu_add_data.vue
@@ -20,7 +20,7 @@
       </j-tooltip>
     </template>
     <v-list dense style="width: 200px; max-height: 300px; overflow-y: auto;">
-      <v-subheader v-if="dataset_items.length > 0" class="strike"><span>Load Data</span></v-subheader>
+      <v-subheader v-if="dataset_items.length > 0"><span>Load Data</span></v-subheader>
       <v-list-item
         v-for="data in dataset_items"
       >
@@ -35,7 +35,7 @@
           </j-tooltip>
         </v-list-item-content>
       </v-list-item>
-      <v-subheader v-if="subset_tools.length > 0" class="strike"><span>Create Subset</span></v-subheader>
+      <v-subheader v-if="subset_tools.length > 0"><span>Create Subset</span></v-subheader>
       <v-list-item
         v-if="subset_tools.length > 0"
       >
@@ -64,38 +64,3 @@ module.exports = {
   props: ['dataset_items', 'subset_tools'],
 };
 </script>
-
-<style scoped>
-.strike {
-    display: block;
-    text-align: center !important;
-    height: 28px !important;
-}
-
-.strike > span {
-    position: relative;
-    display: inline-block;
-    text-transform: uppercase;
-    font-weight: bold;
-}
-
-.strike > span:before,
-.strike > span:after {
-    content: "";
-    position: absolute;
-    top: 50%;
-    width: 9999px;
-    height: 1px;
-    background: gray;
-}
-
-.strike > span:before {
-    right: 100%;
-    margin-right: 6px;
-}
-
-.strike > span:after {
-    left: 100%;
-    margin-left: 6px;
-}
-</style>

--- a/jdaviz/components/data_menu_add_data.vue
+++ b/jdaviz/components/data_menu_add_data.vue
@@ -15,7 +15,7 @@
           v-bind="attrs"
           v-on="on"
         >
-          <v-icon>mdi-plus</v-icon>
+          <v-icon class="invert-if-dark">mdi-plus</v-icon>
         </v-btn>
       </j-tooltip>
     </template>
@@ -49,7 +49,7 @@
               icon
               @click="() => {$emit('create-subset', tool.name)}"
             >
-              <img :src="tool.img" width="20"/>
+              <img :src="tool.img" width="20" class="invert-if-dark"/>
             </v-btn>
           </j-tooltip>
         </v-list-item-content>

--- a/jdaviz/components/data_menu_add_data.vue
+++ b/jdaviz/components/data_menu_add_data.vue
@@ -15,7 +15,7 @@
         </v-btn>
       </j-tooltip>
     </template>
-    <v-list dense style="width: 200px">
+    <v-list dense style="width: 200px; max-height: 300px; overflow-y: auto;">
       <v-subheader v-if="dataset_items.length > 0" class="strike"><span>Load Data</span></v-subheader>
       <v-list-item
         v-for="data in dataset_items"

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -39,6 +39,8 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
         # Hide axes by default
         self.state.show_axes = False
 
+        self.data_menu._obj.dataset.add_filter('is_cube_or_image')
+
     @property
     def _default_spectrum_viewer_reference_name(self):
         return self.jdaviz_helper._default_spectrum_viewer_reference_name

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -204,6 +204,8 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
         data_label : str
             The label of the dataset to add to the viewer.
         """
+        if data_label not in self.dataset.choices:
+            raise ValueError(f"Data label '{data_label}' not able to be loaded into '{self.viewer_id}'.  Must be one of: {self.dataset.choices}")  # noqa
         return self.app.add_data_to_viewer(self.viewer_reference, data_label)
 
     def vue_add_data_to_viewer(self, info, *args):

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -206,7 +206,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
         """
         if data_label not in self.dataset.choices:
             raise ValueError(f"Data label '{data_label}' not able to be loaded into '{self.viewer_id}'.  Must be one of: {self.dataset.choices}")  # noqa
-        return self.app.add_data_to_viewer(self.viewer_reference, data_label)
+        return self.app.add_data_to_viewer(self.viewer_id, data_label)
 
     def vue_add_data_to_viewer(self, info, *args):
         self.add_data(info.get('data_label'))  # pragma: no cover

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -82,7 +82,8 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
 
     @property
     def user_api(self):
-        expose = ['layer', 'set_layer_visibility', 'toggle_layer_visibility', 'create_subset', 'add_data']
+        expose = ['layer', 'set_layer_visibility', 'toggle_layer_visibility',
+                  'create_subset', 'add_data']
         return UserApiWrapper(self, expose=expose)
 
     @observe('layer_items')
@@ -219,13 +220,13 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
         Parameters
         ----------
         subset_type : str
-            The type of subset to create.  Must be one of 'circle', 'rectangle', 'ellipse', 'annulus',
-            'xrange', or 'yrange'.
+            The type of subset to create.  Must be one of 'circle', 'rectangle', 'ellipse',
+            'annulus', 'xrange', or 'yrange'.
         """
         # clear previous selection, finalize subsets, temporarily sets default tool
         self._viewer.toolbar.active_tool_id = None
-        # set toolbar tool to the selection, which will also set app-wide subset selection to "Create New"
-        # supports passing either the user-friendly name or the actual ID
+        # set toolbar to the selection, will also set app-wide subset selection to "Create New"
+        # NOTE: supports passing either the user-friendly name or the actual ID
         self._viewer.toolbar.select_tool(SUBSET_TOOL_IDS.get(subset_type, subset_type))
 
     def vue_create_subset(self, info, *args):

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -75,14 +75,11 @@
             </j-tooltip>
           </v-list-item-content>
           <v-list-item-action>
-            <j-tooltip tooltipcontent="Add data or subset (COMING SOON)">
-              <v-btn
-                icon
-                disabled
-              >
-                <v-icon>mdi-plus</v-icon>
-              </v-btn>
-            </j-tooltip>
+            <data-menu-add-data
+              :dataset_items="dataset_items"
+              @add-data="(data_label) => {add_data_to_viewer({data_label: data_label})}"
+            >
+            </data-menu-add-data>
           </v-list-item-action>
         </v-list-item>
         <v-list-item-group

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -63,7 +63,7 @@
                 icon
                 disabled
               >
-                <v-icon>mdi-format-vertical-align-center</v-icon>
+                <v-icon class="invert-if-dark">mdi-format-vertical-align-center</v-icon>
               </v-btn>
             </j-tooltip>
           </v-list-item-icon>
@@ -143,7 +143,7 @@
                 icon
                 disabled
               >
-                <v-icon>mdi-delete</v-icon>
+                <v-icon class="invert-if-dark">mdi-delete</v-icon>
               </v-btn>
             </j-tooltip>
             <j-tooltip
@@ -155,7 +155,7 @@
                 icon
                 disabled
                 >
-                <v-icon>mdi-label</v-icon>
+                <v-icon class="invert-if-dark">mdi-label</v-icon>
               </v-btn>
             </j-tooltip>
             <j-tooltip
@@ -165,6 +165,7 @@
               <v-btn
                 text
                 disabled
+                class="invert-if-dark"
               >
                 Edit Subset
               </v-btn>
@@ -270,6 +271,7 @@
   .dm-footer > .v-list-item__icon, .dm-footer > .v-list-item__content, .dm-footer > .v-list-item__action {
     filter: invert(1);
   }
+
   .dm-header.v-btn--disabled  .v-icon {
     color: green !important;
   }

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -77,7 +77,9 @@
           <v-list-item-action>
             <data-menu-add-data
               :dataset_items="dataset_items"
+              :subset_tools="subset_tools"
               @add-data="(data_label) => {add_data_to_viewer({data_label: data_label})}"
+              @create-subset="(subset_type) => {create_subset({subset_type: subset_type})}"
             >
             </data-menu-add-data>
           </v-list-item-action>

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -79,7 +79,7 @@
               :dataset_items="dataset_items"
               :subset_tools="subset_tools"
               @add-data="(data_label) => {add_data_to_viewer({data_label: data_label})}"
-              @create-subset="(subset_type) => {create_subset({subset_type: subset_type})}"
+              @create-subset="(subset_type) => {create_subset({subset_type: subset_type}); data_menu_open = false}"
             >
             </data-menu-add-data>
           </v-list-item-action>

--- a/jdaviz/configs/default/tests/test_data_menu.py
+++ b/jdaviz/configs/default/tests/test_data_menu.py
@@ -66,3 +66,28 @@ def test_data_menu_selection(specviz_helper, spectrum1d):
     assert len(dm._obj.layer_items) == 1
     assert dm._obj.dm_layer_selected == [0]
     assert dm.layer.selected == ['test']
+
+
+def test_data_menu_add_data(imviz_helper):
+    for i in range(3):
+        imviz_helper.load_data(np.zeros((2, 2)) + i, data_label=f'image_{i}', show_in_viewer=False)
+
+    dm = imviz_helper.viewers['imviz-0']._obj.data_menu
+    assert len(dm._obj.layer_items) == 0
+    assert len(dm.layer.choices) == 0
+    assert len(dm._obj.dataset.choices) == 3
+
+    dm.add_data('image_0')
+    assert dm.layer.choices == ['image_0']
+    assert len(dm._obj.dataset.choices) == 2
+
+
+def test_data_menu_create_subset(imviz_helper):
+    imviz_helper.load_data(np.zeros((2, 2)), data_label=f'image', show_in_viewer=True)
+
+    dm = imviz_helper.viewers['imviz-0']._obj.data_menu
+    assert imviz_helper.app.session.edit_subset_mode.edit_subset == []
+
+    dm.create_subset('circle')
+    assert imviz_helper.app.session.edit_subset_mode.edit_subset == []
+    assert imviz_helper.viewers['imviz-0']._obj.toolbar.active_tool_id == 'bqplot:truecircle'

--- a/jdaviz/configs/default/tests/test_data_menu.py
+++ b/jdaviz/configs/default/tests/test_data_menu.py
@@ -83,7 +83,7 @@ def test_data_menu_add_data(imviz_helper):
 
 
 def test_data_menu_create_subset(imviz_helper):
-    imviz_helper.load_data(np.zeros((2, 2)), data_label=f'image', show_in_viewer=True)
+    imviz_helper.load_data(np.zeros((2, 2)), data_label='image', show_in_viewer=True)
 
     dm = imviz_helper.viewers['imviz-0']._obj.data_menu
     assert imviz_helper.app.session.edit_subset_mode.edit_subset == []

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -63,6 +63,8 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
         # intensive.
         self.state.image_external_padding = 0.5
 
+        self.data_menu._obj.dataset.add_filter('is_image')
+
     def on_mouse_or_key_event(self, data):
         active_image_layer = self.active_image_layer
         if active_image_layer is None:

--- a/jdaviz/configs/mosviz/helper.py
+++ b/jdaviz/configs/mosviz/helper.py
@@ -160,6 +160,10 @@ class Mosviz(ConfigHelper, LineListMixin):
         self._handle_image_zoom(msg)
         # expose the row to vue for each of the viewers
         self.app.state.settings = {**self.app.state.settings, 'mosviz_row': msg.selected_index}
+        # update data filters in each viewer's data_menu
+        for viewer in self.viewers.values():
+            if data_menu := getattr(viewer._obj, '_data_menu', None):
+                data_menu.dataset._on_data_changed()
 
     def _handle_image_zoom(self, msg):
         mos_data = self.app.data_collection['MOS Table']

--- a/jdaviz/configs/mosviz/plugins/viewers.py
+++ b/jdaviz/configs/mosviz/plugins/viewers.py
@@ -43,6 +43,9 @@ class MosvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewe
         self.state.show_axes = False  # Axes are wrong anyway
         self.figure.fig_margin = {'left': 0, 'bottom': 0, 'top': 0, 'right': 0}
 
+        self.data_menu._obj.dataset.add_filter('is_image_not_spectrum')
+        self.data_menu._obj.dataset.add_filter('same_mosviz_row')
+
     def data(self, cls=None):
         return [layer_state.layer.get_object(cls=cls or self.default_class)
                 for layer_state in self.state.layers
@@ -95,9 +98,8 @@ class MosvizProfile2DView(JdavizViewerMixin, BqplotImageView):
         for k in ('x_min', 'x_max'):
             self.state.add_callback(k, self._handle_x_axis_orientation)
 
-        def is_2d_or_trace(data):
-            return data.ndim == 2 or 'Trace' in data.meta
-        self.data_menu._obj.dataset.add_filter(is_2d_or_trace)
+        self.data_menu._obj.dataset.add_filter('is_2d_spectrum_or_trace')
+        self.data_menu._obj.dataset.add_filter('same_mosviz_row')
 
     @cached_property
     def reference_spectral_axis(self):
@@ -251,9 +253,8 @@ class MosvizProfileView(SpecvizProfileView):
         super().__init__(*args, **kwargs)
 
         # NOTE: is_spectrum filter already applied by SpecvizProfileView
-        def is_not_trace(data):
-            return 'Trace' not in getattr(data, 'meta', [])
-        self.data_menu.layer.add_filter(is_not_trace)
+        self.data_menu.layer.add_filter('not_trace')
+        self.data_menu._obj.dataset.add_filter('same_mosviz_row')
 
     def set_plot_axes(self):
         super().set_plot_axes()

--- a/jdaviz/configs/mosviz/plugins/viewers.py
+++ b/jdaviz/configs/mosviz/plugins/viewers.py
@@ -95,6 +95,10 @@ class MosvizProfile2DView(JdavizViewerMixin, BqplotImageView):
         for k in ('x_min', 'x_max'):
             self.state.add_callback(k, self._handle_x_axis_orientation)
 
+        def is_2d_or_trace(data):
+            return data.ndim == 2 or 'Trace' in data.meta
+        self.data_menu._obj.dataset.add_filter(is_2d_or_trace)
+
     @cached_property
     def reference_spectral_axis(self):
         return self.state.reference_data.get_object().spectral_axis.value
@@ -242,6 +246,14 @@ class MosvizProfileView(SpecvizProfileView):
                     ['jdaviz:selectline'],
                     ['jdaviz:sidebar_plot', 'jdaviz:sidebar_export']
                 ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # NOTE: is_spectrum filter already applied by SpecvizProfileView
+        def is_not_trace(data):
+            return 'Trace' not in data.meta
+        self.data_menu.layer.add_filter(is_not_trace)
 
     def set_plot_axes(self):
         super().set_plot_axes()

--- a/jdaviz/configs/mosviz/plugins/viewers.py
+++ b/jdaviz/configs/mosviz/plugins/viewers.py
@@ -252,7 +252,7 @@ class MosvizProfileView(SpecvizProfileView):
 
         # NOTE: is_spectrum filter already applied by SpecvizProfileView
         def is_not_trace(data):
-            return 'Trace' not in data.meta
+            return 'Trace' not in getattr(data, 'meta', [])
         self.data_menu.layer.add_filter(is_not_trace)
 
     def set_plot_axes(self):

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -32,6 +32,10 @@ class SpecvizProfileView(JdavizProfileView):
     _state_cls = FreezableProfileViewerState
     _default_profile_subset_type = 'spectral'
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.data_menu._obj.dataset.add_filter('is_spectrum')
+
     @property
     def redshift(self):
         return self.jdaviz_helper._redshift

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3536,6 +3536,12 @@ class DatasetSelect(SelectPluginComponent):
         def is_cube(data):
             return len(data.shape) == 3
 
+        def is_cube_or_image(data):
+            return len(data.shape) >= 2
+
+        def is_spectrum(data):
+            return len(data.shape) == 1 and hasattr(data, 'spectral_axis')
+
         def is_flux_cube(data):
             if hasattr(self.app._jdaviz_helper, '_loaded_uncert_cube'):
                 uncert_label = getattr(self.app._jdaviz_helper._loaded_uncert_cube, 'label', None)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1527,6 +1527,12 @@ class LayerSelect(SelectPluginComponent):
             # so we want to exclude spatial subsets
             return get_subset_type(lyr) != 'spatial'
 
+        def is_trace(lyr):
+            return 'Trace' in getattr(getattr(lyr, 'data', None), 'meta', [])
+
+        def not_trace(lyr):
+            return not is_trace(lyr)
+
         return super()._is_valid_item(lyr, locals())
 
     def _layer_to_dict(self, layer_label):
@@ -3525,13 +3531,17 @@ class DatasetSelect(SelectPluginComponent):
             return data.label in [lyr.layer.label for lyr in self.flux_viewer.layers]  # noqa E741
 
         def is_trace(data):
-            return hasattr(data, 'meta') and 'Trace' in data.meta
+            return 'Trace' in getattr(data, 'meta', [])
 
         def not_trace(data):
             return not is_trace(data)
 
         def is_image(data):
             return len(data.shape) == 2
+
+        def is_image_not_spectrum(data):
+            return (is_image(data)
+                    and not getattr(data.coords, 'is_spectral', True))
 
         def is_cube(data):
             return len(data.shape) == 3
@@ -3540,7 +3550,14 @@ class DatasetSelect(SelectPluginComponent):
             return len(data.shape) >= 2
 
         def is_spectrum(data):
-            return len(data.shape) == 1 and hasattr(data, 'spectral_axis')
+            return (len(data.shape) == 1
+                    and data.coords is not None
+                    and getattr(data.coords, 'is_spectral', True))
+
+        def is_2d_spectrum_or_trace(data):
+            return (data.ndim == 2
+                    and data.coords is not None
+                    and getattr(data.coords, 'is_spectral', True)) or 'Trace' in data.meta
 
         def is_flux_cube(data):
             if hasattr(self.app._jdaviz_helper, '_loaded_uncert_cube'):
@@ -3555,6 +3572,19 @@ class DatasetSelect(SelectPluginComponent):
         def not_child_layer(data):
             # ignore layers that are children in associations:
             return self.app._get_assoc_data_parent(data.label) is None
+
+        def same_mosviz_row(data):
+            # NOTE: requires calling _on_data_changed on a change to row
+            # currently handled by mosviz helper _row_click_message_handler
+            meta = getattr(data, 'meta', None)
+            if meta is None:
+                return True
+            data_row = meta.get('mosviz_row', None)
+            app_row = self.app.state.settings.get('mosviz_row', None)
+
+            if data_row is None or app_row is None:
+                return True
+            return data_row == app_row
 
         layer_is_not_dq = layer_is_not_dq_global
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request extends on #3254 by implementing the "+" menu to add data and subsets to the current viewer.  This also exposes `data_menu.create_subset(subset_type)` (to enable the matching subset tool in that viewer's toolbar) and `data_menu.add_data(data_label)` - currently via `data_menu = viz.viewers[viewer_label]._obj.data_menu` (although the necessity for the `_obj` will be removed once the data-menu is ready to be exposed to users.

This PR does include logic so that the listed available data entries _are applicable_ to that specific viewer.

This PR does _not_ include the ability to remove data from the viewer or app in the new data-menu: that will be implemented in #3264.  Until then, remove data from the old data-menu or from the API for testing purposes, or create data in a plugin but do not tell it to immediately plot in the viewer.

As in #3254, until finished and officially exposed, the data-menu must be enabled via:

```
for viewer in viz.viewers.values():
    viewer._obj.data_menu._obj.dev_data_menu = True
```


https://github.com/user-attachments/assets/cb5d2823-e7a0-4eaf-895a-c13470ff0a9a



https://github.com/user-attachments/assets/dbafdd8b-6588-4d86-9b05-c65640cffe86




<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
