### PR TITLE
Add helper API call to reset the application to a clean state

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1723,6 +1723,7 @@ class Application(VuetifyTemplate, HubListener):
     def get_viewer_reference_names(self):
         """Return a list of available viewer reference names."""
         # Cannot sort because of None
+
         return [self._viewer_item_by_id(vid).get('reference') for vid in self._viewer_store]
 
     def _update_viewer_reference_name(
@@ -2769,6 +2770,7 @@ class Application(VuetifyTemplate, HubListener):
     def _reset_state(self):
         """ Resets the application state """
         self.state = ApplicationState()
+        self._viewer_store = {}
         self._application_handler._tools = {}
 
     def get_configuration(self, path=None, section=None):

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -464,6 +464,13 @@ class ConfigHelper(HubListener):
                       DeprecationWarning)
         return self.show(loc="sidecar:tab-after", title=title)
 
+    def reset_app(self):
+        """
+        Re-initialize the entire application. Any current settings and loaded data will
+        be lost.
+        """
+        self.app.load_configuration(self.app._loaded_configuration)
+
     def _handle_display_units(self, data, use_display_units=True):
         if use_display_units:
             if isinstance(data, Spectrum1D):


### PR DESCRIPTION
This adds the ability to call `viz.reset_app()` to completely reset the Jdaviz application to a clean state. The only outstanding issue that I'm aware of is that after resetting, creating new subsets continues to iterate from where they left off for labels and colors:

https://github.com/user-attachments/assets/a7abc850-ce0e-4327-8639-7c5acdd04b71

cc @eteq 