### PR TITLE
Footprints plugin: handle subsets/markers when linking by WCS

### DIFF
--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -197,7 +197,13 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
         # call other plugin so that other options (wcs_fast_approximation, wcs_use_fallback)
         # are retained.  Remove this method if support for plotting footprints
         # when pixel-linked is reintroduced.
-        self.app._jdaviz_helper.plugins['Orientation'].align_by = 'WCS'
+        op = self.app._jdaviz_helper.plugins['Orientation']
+        try:
+            self.app._jdaviz_helper.plugins['Orientation'].align_by = 'WCS'
+        except ValueError:
+            # require the user to go to through the orientation plugin to
+            # delete subsets and change link type
+            op.open_in_tray()
 
     def _ensure_first_overlay(self):
         if not len(self._overlays):

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.vue
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.vue
@@ -23,12 +23,20 @@
         </v-alert>
 
         <v-alert
-          v-if="wcs_linking_available"
+          v-if="wcs_linking_available && !need_clear_astrowidget_markers &&!need_clear_subsets"
           type='warning'
           class="ignore-api-hints"
           style="margin-left: -12px; margin-right: -12px"
         >
-          Switching link type will reset zoom.
+          Switching alignment will reset zoom.
+        </v-alert>
+
+        <v-alert
+          v-if="plugin_markers_exist && !need_clear_astrowidget_markers &&!need_clear_subsets"
+          type='warning'
+          style="margin-left: -12px; margin-right: -12px"
+        >
+          Marker positions may not be pixel-perfect when changing alignment/linking options.
         </v-alert>
 
         <v-alert v-if="need_clear_astrowidget_markers" type='warning' style="margin-left: -12px; margin-right: -12px">
@@ -38,12 +46,9 @@
           </v-row>
         </v-alert>
 
-        <v-alert v-if="plugin_markers_exist" type='warning' style="margin-left: -12px; margin-right: -12px">
-          Marker positions may not be pixel-perfect when changing alignment/linking options.
-        </v-alert>
 
         <v-alert v-if="need_clear_subsets" type='warning' style="margin-left: -12px; margin-right: -12px">
-          Existing subsets will be deleted on changing alignment/linking options.
+          Existing subsets must be deleted before changing alignment/linking options.
           <v-row justify="end" style="margin-right: 2px; margin-top: 16px">
             <v-btn @click="delete_subsets">
               {{ api_hints_enabled ?


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Previously, pressing the button in the footprints plugin to align by WCS resulted in a traceback if subsets or markers existed.  This now redirects to the orientation plugin itself in cases where the link change fails for either of these reasons.  In the future, we may want to use the same logic as in the orientation plugin to detect these in advance and either add additional buttons or language to allow deleting the subsets/markers directly from footprints.

This PR also updates some language in the alerts in the orientation plugin to match recent API changes.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
