### PR TITLE
update datamodels example to include more info

### DIFF
--- a/docs/imviz/import_data.rst
+++ b/docs/imviz/import_data.rst
@@ -99,7 +99,7 @@ object, you can load it into Imviz as follows:
     from jdaviz import Imviz
 
     # mydatamodel is a jwst.datamodels object
-    ndd = NDData(np.array(mydatamodel.data), wcs=mydatamodel.get_fits_wcs())
+    ndd = NDData(mydatamodel.data, StdDevUncertainty(mydatamodel.err), mydatamodel.dq, mydatamodel.meta.wcs, meta=dict(mydatamodel.meta.items()))
     imviz = Imviz()
     imviz.load_data(ndd, data_label='my_data_model')
     imviz.show()

--- a/docs/imviz/import_data.rst
+++ b/docs/imviz/import_data.rst
@@ -98,8 +98,12 @@ object, you can load it into Imviz as follows:
     from astropy.nddata import NDData
     from jdaviz import Imviz
 
-    # mydatamodel is a jwst.datamodels object
-    ndd = NDData(mydatamodel.data, uncertainty=StdDevUncertainty(mydatamodel.err), mask=mydatamodel.dq, wcs=mydatamodel.meta.wcs, meta=dict(mydatamodel.meta.items()))
+    # mydatamodel is a jwst.datamodels object with stddev ERR array
+    ndd = NDData(mydatamodel.data,
+                 uncertainty=StdDevUncertainty(mydatamodel.err),
+                 mask=mydatamodel.dq,
+                 wcs=mydatamodel.meta.wcs,
+                 meta=dict(mydatamodel.meta.items()))
     imviz = Imviz()
     imviz.load_data(ndd, data_label='my_data_model')
     imviz.show()

--- a/docs/imviz/import_data.rst
+++ b/docs/imviz/import_data.rst
@@ -94,8 +94,7 @@ object, you can load it into Imviz as follows:
 
 .. code-block:: python
 
-    import numpy as np
-    from astropy.nddata import NDData
+    from astropy.nddata import NDData, StdDevUncertainty
     from jdaviz import Imviz
 
     # mydatamodel is a jwst.datamodels object with stddev ERR array

--- a/docs/imviz/import_data.rst
+++ b/docs/imviz/import_data.rst
@@ -99,7 +99,7 @@ object, you can load it into Imviz as follows:
     from jdaviz import Imviz
 
     # mydatamodel is a jwst.datamodels object
-    ndd = NDData(mydatamodel.data, StdDevUncertainty(mydatamodel.err), mydatamodel.dq, mydatamodel.meta.wcs, meta=dict(mydatamodel.meta.items()))
+    ndd = NDData(mydatamodel.data, uncertainty=StdDevUncertainty(mydatamodel.err), mask=mydatamodel.dq, wcs=mydatamodel.meta.wcs, meta=dict(mydatamodel.meta.items()))
     imviz = Imviz()
     imviz.load_data(ndd, data_label='my_data_model')
     imviz.show()


### PR DESCRIPTION
This is a follow-on from #3252 that updates the docs to reflect a more complete version of creating and `NDData` object from a jwst data model.

The `dq` and maybe the `err` parts I think should be generic across jwst instruments, even though the exact interpretation is a bit variable (that is they should all be self-consistent, but different instruments I think use slightly conceptually different uncertainty models).