### PR TITLE
Add nbclassic dependency to resolve popout error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "ipypopout>=2.0.0",
     "astroquery",
     "requests",
+    "nbclassic",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
As said in the title, this is needed to get the Solara-based popouts to work.