### PR TITLE
Don't send plugin ping while plugin is open if keep_active is True

### DIFF
--- a/jdaviz/components/tray_plugin.vue
+++ b/jdaviz/components/tray_plugin.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container 
+  <v-container
     class="tray-plugin"
     style="padding-left: 24px; padding-right: 24px; padding-top: 12px" >
     <v-row>
@@ -9,9 +9,9 @@
       <div style="width: 32px">
         <j-tooltip tipid='plugin-api-hints'>
           <v-btn
-            v-if="api_hints_enabled !== undefined && config && plugin_key && checkNotebookContext()" 
+            v-if="api_hints_enabled !== undefined && config && plugin_key && checkNotebookContext()"
             id="api-hints-button"
-            icon 
+            icon
             :class="api_hints_enabled ? 'api-hint' : null"
             @click="() => {$emit('update:api_hints_enabled', !api_hints_enabled)}"
           >
@@ -75,7 +75,7 @@ module.exports = {
       if (!this.$el.isConnected) {
         return
       }
-      if (!document.hidden) {
+      if (!document.hidden && !this.keep_active) {
         this.$emit('plugin-ping', Date.now())
       }
       if (this.scroll_to) {
@@ -86,7 +86,7 @@ module.exports = {
         return
       }
       setTimeout(() => {
-        this.sendPing(true)          
+        this.sendPing(true)
       }, 200)  // ms
     },
     checkNotebookContext() {
@@ -141,7 +141,7 @@ module.exports = {
     /* tighten default padding on any sub expansion headers */
     padding: 6px !important;
   }
-  
+
   .v-expansion-panel-header .row {
     /* override margin from above and replace with equal top and bottom margins
     for the text in the panel header */

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -7,6 +7,7 @@
     :link="docs_link || 'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#plot-options'"
     :uses_active_status="uses_active_status"
     @plugin-ping="plugin_ping($event)"
+    :keep_active.sync="keep_active"
     :popout_button="popout_button"
     :scroll_to.sync="scroll_to">
 
@@ -116,7 +117,7 @@
                 :api_hints_enabled="api_hints_enabled"
                 @click="reset_viewer_bounds"
               >
-                {{api_hints_enabled ? 
+                {{api_hints_enabled ?
                   'plg.reset_viewer_bounds()'
                   :
                   'Reset viewer bounds'
@@ -275,7 +276,7 @@
             :api_hints_enabled="api_hints_enabled"
             wait="300"
             max="1"
-            step="0.01" 
+            step="0.01"
             :value.sync="subset_opacity_value"
           />
       </glue-state-sync-wrapper>
@@ -771,7 +772,7 @@
 
             <div v-if="contour_mode_value === 'Linear'">
               <glue-state-sync-wrapper :sync="contour_min_sync" :multiselect="layer_multiselect" @unmix-state="unmix_state('contour_min')">
-                <glue-float-field 
+                <glue-float-field
                   :label="api_hints_enabled ? 'plg.contour_min =' : 'Contour Min'"
                   :class="api_hints_enabled ? 'api-hint' : null"
                   :value.sync="contour_min_value"


### PR DESCRIPTION
Cuts out the plugin ping messages when they aren't needed. Opening as draft because we probably want to add a separate variable to hide the `keep_active` toggle for `Plot Options`. 