### PR TITLE
DOC: Auto-inject CLI help into user doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,9 +25,12 @@
 # Thus, any C-extensions that are needed to build the documentation will *not*
 # be accessible, and the documentation will not build correctly.
 
+import datetime
 import subprocess
 import sys
-import datetime
+
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
 
 from jdaviz import __version__
 
@@ -293,3 +296,17 @@ intersphinx_mapping.update({  # noqa: F405
 
 # Options for linkcheck
 linkcheck_ignore = ['https://github.com/spacetelescope/jdaviz/settings/branches']
+
+
+# -- Custom directive -------------------------------------------
+
+class JdavizCLIHelpDirective(SphinxDirective):
+
+    def run(self):
+        help_text = subprocess.check_output(["jdaviz", "--help"], encoding="utf-8")
+        paragraph_node = nodes.literal_block(text=help_text)
+        return [paragraph_node]
+
+
+def setup(app):
+    app.add_directive('jdavizclihelp', JdavizCLIHelpDirective)

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -38,6 +38,8 @@ To see the syntax and usage, from a terminal, type::
 
     jdaviz --help
 
+.. jdavizclihelp::
+
 Typical usage to load a file into a desired configuration::
 
     jdaviz --layout=[imviz|specviz|cubeviz|mosviz|specviz2d] /path/to/data/file


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address Cami's desire to see `jdaviz --help` printed in user doc.

Rendered doc: https://jdaviz--3286.org.readthedocs.build/en/3286/quickstart.html#as-a-standalone-application

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4913)
