### PR TITLE
Backport PR #3267: Fix URI for autoconfig test for specviz2d, add back specviz test

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -596,11 +596,11 @@ def test_spectral_extraction_unit_conv_one_spec(
 @pytest.mark.parametrize(
     "start_slice, aperture, expected_rtol, uri, calspec_url",
     (
-        (5.2, (20.5, 17, 10.9), 0.01,
+        (5.2, (20.5, 17, 10.9), 0.03,
          "mast:jwst/product/jw01524-o003_t002_miri_ch1-shortmediumlong_s3d.fits",
          calspec_url + "delumi_mod_005.fits"),  # delta UMi
 
-        (4.85, (28, 21, 12), 0.01,
+        (4.85, (28, 21, 12), 0.03,
          "mast:jwst/product/jw01050-o003_t005_miri_ch1-shortmediumlong_s3d.fits",
          calspec_url + "hd159222_mod_007.fits"),  # HD 159222
     )

--- a/jdaviz/core/tests/test_autoconfig.py
+++ b/jdaviz/core/tests/test_autoconfig.py
@@ -8,14 +8,13 @@ from astropy.utils.data import download_file
 
 from jdaviz import open as jdaviz_open
 from jdaviz.cli import ALL_JDAVIZ_CONFIGS
-from jdaviz.configs import Specviz2d, Cubeviz, Imviz  # , Specviz
+from jdaviz.configs import Specviz2d, Cubeviz, Imviz, Specviz
 from jdaviz.core.launcher import Launcher, STATUS_HINTS
 
 
 AUTOCONFIG_EXAMPLES = (
-    # ("mast:JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_x1d.fits", Specviz),
-    # Specviz check disabled due to https://github.com/spacetelescope/jdaviz/issues/2229
-    ("mast:JWST/product/jw01538-o160_s00004_nirspec_f170lp-g235h-s1600a1-sub2048_s2d.fits", Specviz2d),  # noqa
+    ("mast:JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_x1d.fits", Specviz),
+    ("mast:JWST/product/jw01538160001_16101_00004_nrs1_s2d.fits", Specviz2d),
     ("mast:JWST/product/jw02727-o002_t062_nircam_clear-f090w_i2d.fits", Imviz),
     ("mast:JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_s3d.fits", Cubeviz),
     ("https://stsci.box.com/shared/static/28a88k1qfipo4yxc4p4d40v4axtlal8y.fits", Cubeviz)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to manually backport https://github.com/spacetelescope/jdaviz/pull/3267 onto v4.0.x