### PR TITLE
data-menu: enforce layer order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 New Features
 ------------
 
-* New design for viewer legend and data-menu. [#3220, #3254, #3263, #3264, #3271, #3272, #3274]
+* New design for viewer legend and data-menu. [#3220, #3254, #3263, #3264, #3271, #3272, #3274, #3289]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -109,6 +109,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
         self.layer.remove_filter('filter_is_root')
         self.layer.add_filter(is_not_wcs_only)
         self.layer.multiselect = True
+        self.layer.sort_by = 'zorder'
         self.layer._default_mode = 'empty'
 
         # we'll use a modified version of the dataset mixin to have a filtered
@@ -227,8 +228,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
         with self.during_select_sync():
             # map index in dm_layer_selected (inverse order of layer_items)
             # to set self.layer.selected
-            length = len(self.layer_items)
-            self.layer.selected = [self.layer_items[length-1-i]['label']
+            self.layer.selected = [self.layer_items[i]['label']
                                    for i in self.dm_layer_selected]
 
     @observe('layer_selected', 'layer_items')
@@ -238,7 +238,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
         if not self._during_select_sync:
             with self.during_select_sync():
                 # map list of strings in self.layer.selected to indices in dm_layer_selected
-                layer_labels = [layer['label'] for layer in self.layer_items][::-1]
+                layer_labels = [layer['label'] for layer in self.layer_items]
                 self.dm_layer_selected = [layer_labels.index(label) for label in self.layer.selected
                                           if label in layer_labels]
 

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -33,7 +33,7 @@
                 <span class="invert-if-dark" style="margin-left: 30px; margin-right: 36px; line-height: 28px">{{viewer_reference || viewer_id}}</span>
               </div>
 
-              <div v-for="item in layer_items.slice().reverse()" class="viewer-label">
+              <div v-for="item in layer_items" class="viewer-label">
                 <div v-if="item.visible">
                   <span style="float: right">
                     <j-layer-viewer-icon-stylized
@@ -159,7 +159,7 @@
             >
               <div>
               <v-list-item 
-                v-for="item in layer_items.slice().reverse()" 
+                v-for="item in layer_items" 
                 class="layer-select" 
               > 
                 <v-list-item-icon>

--- a/jdaviz/configs/default/tests/test_data_menu.py
+++ b/jdaviz/configs/default/tests/test_data_menu.py
@@ -128,15 +128,15 @@ def test_data_menu_remove_subset(specviz_helper, spectrum1d):
                                          6100 * spectrum1d.spectral_axis.unit),
                           combination_mode='new')
 
-    assert dm.layer.choices == ['test', 'test2', 'Subset 1', 'Subset 2']
+    assert dm.layer.choices == ['Subset 2', 'Subset 1', 'test2', 'test']
     dm.layer.selected = ['Subset 1']
     dm.remove_from_viewer()
 
     # subset visibility is set to false, but still appears in menu (unlike removing data)
-    assert dm.layer.choices == ['test', 'test2', 'Subset 1', 'Subset 2']
-    assert dm._obj.layer_items[2]['label'] == 'Subset 1'
+    assert dm.layer.choices == ['Subset 2', 'Subset 1', 'test2', 'test']
+    assert dm._obj.layer_items[1]['label'] == 'Subset 1'
     # TODO: sometimes appearing as mixed right now, known bug
-    assert dm._obj.layer_items[2]['visible'] is not True
+    assert dm._obj.layer_items[1]['visible'] is not True
 
     # selection should not have changed by removing subset from viewer
     assert dm.layer.selected == ['Subset 1']
@@ -178,7 +178,7 @@ def test_data_menu_view_info(specviz_helper, spectrum1d):
                                          6300 * spectrum1d.spectral_axis.unit),
                           combination_mode='new')
 
-    assert dm.layer.choices == ['test', 'test2', 'Subset 1', 'Subset 2']
+    assert dm.layer.choices == ['Subset 2', 'Subset 1', 'test2', 'test']
 
     dm.layer.selected = ["test2"]
     dm.view_info()

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1438,6 +1438,7 @@ class LayerSelect(SelectPluginComponent):
         hint="Select layer."
       />
     """
+    sort_by = Unicode('icon').tag(sync=True)
 
     def __init__(self, plugin, items, selected, viewer,
                  multiselect=None,
@@ -1446,7 +1447,8 @@ class LayerSelect(SelectPluginComponent):
                  only_wcs_layers=False,
                  is_root=True,
                  has_children=False,
-                 is_child_of=None):
+                 is_child_of=None,
+                 sort_by='icon'):
         """
         Parameters
         ----------
@@ -1469,6 +1471,8 @@ class LayerSelect(SelectPluginComponent):
         default_mode : str, optional
             What mode to use when making the default selection.  Valid options: first, default_text,
             empty.
+        sort_by : str, optional
+            How to sort the ordering of items.  Valid options: zorder, icon
         """
         super().__init__(plugin,
                          items=items,
@@ -1491,6 +1495,7 @@ class LayerSelect(SelectPluginComponent):
         self.hub.subscribe(self, SubsetDeleteMessage,
                            handler=lambda _: self._update_layer_items())
 
+        self.sort_by = sort_by
         self.app.state.add_callback('layer_icons', self._update_layer_items)
         self.add_observe(viewer, self._on_viewer_selected_changed)
         self.add_observe(selected, self._update_layer_items)
@@ -1569,6 +1574,7 @@ class LayerSelect(SelectPluginComponent):
     def _layer_to_dict(self, layer_label):
         is_subset = None
         subset_type = None
+        zorder = None
         from_plugin = None
         live_plugin_results = None
         colors = []
@@ -1582,6 +1588,8 @@ class LayerSelect(SelectPluginComponent):
                                      (hasattr(layer, 'layer') and hasattr(layer.layer, 'subset_state')))  # noqa
                         if is_subset:
                             subset_type = get_subset_type(layer.layer)
+                    if zorder is None:
+                        zorder = layer.state.zorder
                     if from_plugin is None:
                         from_plugin = layer.layer.data.meta.get('Plugin', None)
                     if live_plugin_results is None:
@@ -1600,6 +1608,7 @@ class LayerSelect(SelectPluginComponent):
         return {"label": layer_label,
                 "is_subset": is_subset,
                 "subset_type": subset_type,
+                "zorder": zorder,
                 "from_plugin": from_plugin,
                 "live_plugin_results": live_plugin_results,
                 "icon": self.app.state.layer_icons.get(layer_label),
@@ -1631,6 +1640,7 @@ class LayerSelect(SelectPluginComponent):
                     if is_wcs_only(layer.layer):
                         continue
                     layer.remove_callback('color', self._update_layer_items)
+                    layer.remove_callback('zorder', self._update_layer_items)
                     if hasattr(layer, 'cmap'):
                         layer.remove_callback('cmap', self._update_layer_items)
                     if hasattr(layer, 'bitmap_visible'):
@@ -1649,6 +1659,7 @@ class LayerSelect(SelectPluginComponent):
                     if is_wcs_only(layer.layer):
                         continue
                     layer.add_callback('color', self._update_layer_items)
+                    layer.add_callback('zorder', self._update_layer_items)
                     if hasattr(layer, 'cmap'):
                         layer.add_callback('cmap', self._update_layer_items)
                     if hasattr(layer, 'bitmap_visible'):
@@ -1693,7 +1704,7 @@ class LayerSelect(SelectPluginComponent):
 
         self._update_layer_items({'source': 'data_added'})
 
-    @observe('filters')
+    @observe('filters', 'sort_by')
     def _update_layer_items(self, msg={}):
         # NOTE: _on_layers_changed is passed without a msg object during init
         # TODO: Handle changes to just one item without recompiling the whole thing
@@ -1721,7 +1732,14 @@ class LayerSelect(SelectPluginComponent):
             icon = items_dict['icon']
             return icon if icon is not None else ''
 
-        layer_items.sort(key=_sort_by_icon)
+        def _sort_by_zorder(items_dict):
+            # NOTE: this works best if subscribed to a single viewer
+            return -1 * items_dict.get('zorder', 0)
+
+        if self.sort_by == 'zorder':
+            layer_items.sort(key=_sort_by_zorder)
+        else:  # icon
+            layer_items.sort(key=_sort_by_icon)
 
         self.items = manual_items + layer_items
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1472,7 +1472,9 @@ class LayerSelect(SelectPluginComponent):
             What mode to use when making the default selection.  Valid options: first, default_text,
             empty.
         sort_by : str, optional
-            How to sort the ordering of items.  Valid options: zorder, icon
+            How to sort the ordering of items.  Valid options: zorder (top layers are first),
+            icon (alphabetical by icon, effectively by order in which layers were first
+            added and assigned an icon)
         """
         super().__init__(plugin,
                          items=items,


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements a `sort_by` option on the `LayerSelect` component, which defaults to the previous behavior of `icon` (order layer was _added_), but also supports `zorder` (shows layers on TOP first).  The `zorder` ordering is then used for the legend, data-menu, ~and plot options tabs~.

~Note that for plot options, it is possible to subscribe to layers from multiple viewers, and they may have different zorder.  In this case, the zorders are parsed and sorted based on the first viewer they are found in according to the selected viewers.~

NOTE: this now defers re-ordering plot options tab since we need to give more thought on how the RGB presets logic should work in this case.

https://github.com/user-attachments/assets/cfd7069a-cfd2-4782-a06d-68409f4f0cdd


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
