### PR TITLE
Metadata Viewer: API to return dict, not list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,7 +29,7 @@ API Changes
   
 - Renamed the ``Subset Tools`` plugin to ``Subsets`` which now exposes the ``subset``, ``combination_mode``, ``get_center``, and ``set_center`` in the user API. [#3293]
 
-- Metadata plugin: ``metadata_plugin.metadata`` API as been deprecated; use
+- Metadata plugin: ``metadata_plugin.metadata`` API has been deprecated; use
   ``metadata_plugin.meta`` instead, which will return a Python dictionary instead of
   list of tuples. [#3292]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,10 @@ API Changes
   
 - Renamed the ``Subset Tools`` plugin to ``Subsets`` which now exposes the ``subset``, ``combination_mode``, ``get_center``, and ``set_center`` in the user API. [#3293]
 
+- Metadata plugin: ``metadata_plugin.metadata`` API as been renamed to
+  ``metadata_plugin.meta`` and now is a Python dictionary instead of
+  list of tuples. [#3292]
+
 Cubeviz
 ^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,8 +29,8 @@ API Changes
   
 - Renamed the ``Subset Tools`` plugin to ``Subsets`` which now exposes the ``subset``, ``combination_mode``, ``get_center``, and ``set_center`` in the user API. [#3293]
 
-- Metadata plugin: ``metadata_plugin.metadata`` API as been renamed to
-  ``metadata_plugin.meta`` and now is a Python dictionary instead of
+- Metadata plugin: ``metadata_plugin.metadata`` API as been deprecated; use
+  ``metadata_plugin.meta`` instead, which will return a Python dictionary instead of
   list of tuples. [#3292]
 
 Cubeviz

--- a/jdaviz/configs/default/plugins/metadata_viewer/tests/test_metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/tests/test_metadata_viewer.py
@@ -69,9 +69,11 @@ def test_view_dict(imviz_helper):
     assert mv.show_primary  # Make sure it sticks if possible
     assert mv.has_comments
     assert mv.metadata == [('APERTURE', '#TODO', 'Aperture'),
-                           ('BITPIX', '8', 'array data type'), ('EXTEND', 'True', ''),
+                           ('BITPIX', '8', 'array data type'),
+                           ('EXTEND', 'True', ''),
                            ('NAXIS', '0', 'number of array dimensions'),
                            ('SIMPLE', 'True', 'conforms to FITS standard')]
+    assert sorted(mv.meta.keys()) == ['APERTURE', 'BITPIX', 'EXTEND', 'NAXIS', 'SIMPLE']
 
     mv.dataset_selected = 'no_meta'
     assert not mv.has_primary
@@ -79,6 +81,7 @@ def test_view_dict(imviz_helper):
     assert not mv.has_comments
     assert not mv.has_metadata
     assert mv.metadata == []
+    assert mv.meta == {}
 
 
 def test_view_invalid(imviz_helper):
@@ -94,3 +97,4 @@ def test_view_invalid(imviz_helper):
     assert not mv.has_comments
     assert not mv.has_metadata
     assert mv.metadata == []
+    assert mv.meta == {}

--- a/jdaviz/configs/default/plugins/metadata_viewer/tests/test_metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/tests/test_metadata_viewer.py
@@ -73,7 +73,11 @@ def test_view_dict(imviz_helper):
                            ('EXTEND', 'True', ''),
                            ('NAXIS', '0', 'number of array dimensions'),
                            ('SIMPLE', 'True', 'conforms to FITS standard')]
-    assert sorted(mv.meta.keys()) == ['APERTURE', 'BITPIX', 'EXTEND', 'NAXIS', 'SIMPLE']
+    assert mv.meta == {'APERTURE': {"description": 'Aperture', "value": '#TODO'},
+                       'BITPIX': {"description": 'array data type', "value": '8'},
+                       'EXTEND': {"description": '', "value": 'True'},
+                       'NAXIS': {"description": 'number of array dimensions', "value": '0'},
+                       'SIMPLE': {"description": 'conforms to FITS standard', "value": 'True'}}
 
     mv.dataset_selected = 'no_meta'
     assert not mv.has_primary

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -4,7 +4,7 @@ import astropy.units as u
 __all__ = ['UserApiWrapper', 'PluginUserApi', 'ViewerUserApi']
 
 _internal_attrs = ('_obj', '_expose', '_items', '_readonly', '_exclude_from_dict',
-                   '__doc__', '_deprecation_msg')
+                   '__doc__', '_deprecation_msg', '_deprecated')
 
 
 class UserApiWrapper:
@@ -12,12 +12,13 @@ class UserApiWrapper:
     This is an API wrapper around an internal object.  For a full list of attributes/methods,
     call dir(object).
     """
-    def __init__(self, obj, expose=[], readonly=[], exclude_from_dict=[]):
+    def __init__(self, obj, expose=[], readonly=[], exclude_from_dict=[], deprecated=[]):
         self._obj = obj
         self._expose = list(expose) + list(readonly)
         self._readonly = readonly
         self._exclude_from_dict = exclude_from_dict
         self._deprecation_msg = None
+        self._deprecated = deprecated
         if obj.__doc__ is not None:
             self.__doc__ = self.__doc__ + "\n\n\n" + obj.__doc__
 
@@ -33,6 +34,9 @@ class UserApiWrapper:
     def __getattr__(self, attr):
         if attr in _internal_attrs or attr not in self._expose:
             return super().__getattribute__(attr)
+
+        if attr in self._deprecated:
+            logging.warning("DeprecationWarning: %s is deprecated" % attr)
 
         exp_obj = getattr(self._obj, attr)
         return getattr(exp_obj, 'user_api', exp_obj)
@@ -127,13 +131,13 @@ class PluginUserApi(UserApiWrapper):
     For example::
       help(plugin_object.show)
     """
-    def __init__(self, plugin, expose=[], readonly=[], excl_from_dict=[]):
+    def __init__(self, plugin, expose=[], readonly=[], excl_from_dict=[], deprecated=[]):
         expose = list(set(list(expose) + ['open_in_tray', 'close_in_tray',
                                           'show']))
         if plugin.uses_active_status:
             expose += ['keep_active', 'as_active']
         self._deprecation_msg = None
-        super().__init__(plugin, expose, readonly, excl_from_dict)
+        super().__init__(plugin, expose, readonly, excl_from_dict, deprecated)
 
     def __repr__(self):
         if self._deprecation_msg:
@@ -151,9 +155,9 @@ class ViewerUserApi(UserApiWrapper):
     For example::
       help(viewer_object.show)
     """
-    def __init__(self, viewer, expose=[], readonly=[], excl_from_dict=[]):
+    def __init__(self, viewer, expose=[], readonly=[], excl_from_dict=[], deprecated=[]):
         expose = list(set(list(expose) + []))
-        super().__init__(viewer, expose, readonly, excl_from_dict)
+        super().__init__(viewer, expose, readonly, excl_from_dict, deprecated)
 
     def __repr__(self):
         return f'<{self._obj.reference} API>'


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address the request, "File metadata extracted from the API is hard to parse. Maybe a dictionary is better?"

I avoided changing `metadata` itself because that would mean messing with the front-end stuff that already works. Also might be subtly confusing because the same attribute now returns something different. Maybe best to have a clean break using a different attribute name.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4930)
