### PR TITLE
Collapse 3D y before calculating initial model guess for gaussian model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,6 +89,8 @@ Cubeviz
 
 - Fixed "spectrum at spaxel" tool so it no longer resets spectral axis zoom. [#3249]
 
+- Fixed initializing a Gaussian1D model component when ``Cube Fit`` is toggled on. [#3295]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/default/plugins/model_fitting/initializers.py
+++ b/jdaviz/configs/default/plugins/model_fitting/initializers.py
@@ -188,6 +188,10 @@ class _LineProfile1DInitializer(object):
             The initialized model.
         """
 
+        if y.ndim == 3:
+            # For cube fitting, need to collapse before these calculations
+            y = np.nanmean(y, axis=(0, 1))
+
         # X centroid estimates the position
         centroid = np.sum(x * y) / np.sum(y)
 

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -155,7 +155,15 @@ def test_register_cube_model(cubeviz_helper, spectrum1d_cube):
         modelfit_plugin.calculate_fit()
     assert test_label in cubeviz_helper.app.data_collection
 
-    # We also check that we can initialize a Gaussian1D with cube fit toggled on
+
+def test_initialize_gaussian_with_cube(cubeviz_helper, spectrum1d_cube_larger):
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        cubeviz_helper.load_data(spectrum1d_cube_larger)
+    modelfit_plugin = cubeviz_helper.plugins['Model Fitting']
+
+    modelfit_plugin.cube_fit = True
+    # Check that we can initialize a Gaussian1D with cube fit toggled on
     modelfit_plugin.create_model_component('Gaussian1D', 'G')
 
 

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -155,10 +155,13 @@ def test_register_cube_model(cubeviz_helper, spectrum1d_cube):
         modelfit_plugin.calculate_fit()
     assert test_label in cubeviz_helper.app.data_collection
 
+    # We also check that we can initialize a Gaussian1D with cube fit toggled on
+    modelfit_plugin.create_model_component('Gaussian1D', 'G')
+
 
 def test_fit_cube_no_wcs(cubeviz_helper):
-    # This is like when user do something to a cube outside of Jdaviz
-    # and then load it back into a new instance of Cubeviz for further analysis.
+    # This is like when user does something to a cube outside of Jdaviz
+    # and then loads it back into a new instance of Cubeviz for further analysis.
     sp = Spectrum1D(flux=np.ones((7, 8, 9)) * u.nJy)  # nx, ny, nz
     cubeviz_helper.load_data(sp, data_label="test_cube")
     mf = cubeviz_helper.plugins['Model Fitting']


### PR DESCRIPTION
Fixes a traceback that was occurring when adding a Gaussian model component with `Cube Fit` toggled on.