### PR TITLE
BUG: Fix Cubeviz parsing DN and DN/s

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -6,6 +6,7 @@ from specutils import Spectrum1D, SpectralRegion
 from glue_astronomy.translators.spectrum1d import PaddedSpectrumWCS
 from numpy.testing import assert_allclose, assert_array_equal
 
+from jdaviz.core.custom_units import PIX2
 from jdaviz.utils import PRIHDR_KEY
 
 
@@ -147,8 +148,9 @@ def test_spectrum3d_parse(image_cube_hdu_obj, cubeviz_helper):
     assert label_mouseover.as_text() == ('', '', '')
 
 
-def test_spectrum3d_no_wcs_parse(cubeviz_helper):
-    sc = Spectrum1D(flux=np.ones(24).reshape((2, 3, 4)) * u.nJy)  # x, y, z
+@pytest.mark.parametrize("flux_unit", [u.nJy, u.DN, u.DN / u.s])
+def test_spectrum3d_no_wcs_parse(cubeviz_helper, flux_unit):
+    sc = Spectrum1D(flux=np.ones(24).reshape((2, 3, 4)) * flux_unit)  # x, y, z
     cubeviz_helper.load_data(sc)
     assert sc.spectral_axis.unit == u.pix
 
@@ -158,7 +160,7 @@ def test_spectrum3d_no_wcs_parse(cubeviz_helper):
     assert data.shape == (2, 3, 4)  # x, y, z
     assert isinstance(data.coords, PaddedSpectrumWCS)
     assert_array_equal(flux.data, 1)
-    assert flux.units == 'nJy / pix2'
+    assert flux.units == f'{flux_unit / PIX2}'
 
 
 def test_spectrum1d_parse(spectrum1d, cubeviz_helper):

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -557,7 +557,9 @@ def _eqv_flux_to_sb_pixel():
                   u.erg / (u.s * u.cm**2 * u.Angstrom),
                   u.ph / (u.Angstrom * u.s * u.cm**2),
                   u.ph / (u.Hz * u.s * u.cm**2),
-                  u.ct]
+                  u.ct,
+                  u.DN,
+                  u.DN / u.s]
     return [(flux_unit, flux_unit / PIX2, lambda x: x, lambda x: x)
             for flux_unit in flux_units]
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to fix parsing of cube in DN and DN/s units in Cubeviz. This is a follow-up of #3221 that is not yet released, so no need for change log.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4937)
