### PR TITLE
Adding links to ramp fitting docs for roman and jwst in rampviz

### DIFF
--- a/docs/rampviz/plugins.rst
+++ b/docs/rampviz/plugins.rst
@@ -62,6 +62,17 @@ Slice
 Ramp Extraction
 ===============
 
-Coming soon.
+Extract a ramp from a ramp cube.
 
+Data products from infrared detectors flow through the official
+`JWST <https://jwst-pipeline.readthedocs.io/en/latest/>`_ or
+`Roman <https://roman-pipeline.readthedocs.io/en/latest/>`_ mission pipelines in levels. Infrared detectors use
+an "up-the-ramp" readout pattern, which is summarized in the
+`JWST documentation <https://jwst-docs.stsci.edu/understanding-exposure-times>`_.
 
+The Ramp Extraction plugin is a quick-look tool, and it does not support all of the features of the mission pipelines.
+The mission pipelines produce rate images from ramp cubes by fitting the samples up the ramp while accounting for
+non-linearity, jumps detected during an integration, saturation, and detector defects. These data quality checks and
+corrections are not applied in the Ramp Extraction plugin. For details on how rate images are derived from ramps, see
+the `JWST pipeline's ramp fitting step <https://roman-pipeline.readthedocs.io/en/latest/roman/ramp_fitting/index.html>`_
+or the `Roman pipeline's ramp fitting step <https://jwst-pipeline.readthedocs.io/en/latest/jwst/ramp_fitting/index.html#ramp-fitting-step>`_.

--- a/jdaviz/configs/rampviz/plugins/ramp_extraction/ramp_extraction.vue
+++ b/jdaviz/configs/rampviz/plugins/ramp_extraction/ramp_extraction.vue
@@ -56,6 +56,17 @@
     <div @mouseover="() => active_step='extract'">
       <j-plugin-section-header :active="active_step==='extract'">Extract</j-plugin-section-header>
 
+      <v-row>
+        <span class="v-messages v-messages__message text--secondary">
+          Note: this plugin does not detecting defects in ramps, fit the ramps, or apply corrections. For details on
+          how rate images are derived from ramps, see the documentation for the
+          <a href='https://roman-pipeline.readthedocs.io/en/latest/roman/ramp_fitting/index.html' target="_blank">
+            Roman calibration pipeline</a> or the
+          <a href='https://jwst-pipeline.readthedocs.io/en/latest/jwst/ramp_fitting/index.html#ramp-fitting-step' target="_blank">
+            JWST calibration pipeline</a>.
+        </span>
+      </v-row>
+
       <v-row v-if="aperture_selected !== 'None' && !aperture_selected_validity.is_aperture">
         <span class="v-messages v-messages__message text--secondary">
             Aperture: '{{aperture_selected}}' does not support subpixel: {{aperture_selected_validity.aperture_message}}.


### PR DESCRIPTION
### Description

Rampviz does a quick-look ramp extraction which does not make data quality classifications, or fit ramps, or correct for detector effects/defects. This PR adds notes on these caveats to the Ramp Extraction plugin and the Ramp Extraction section of the docs.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4876)