### PR TITLE
fix typo in data_quality vue

### DIFF
--- a/jdaviz/configs/default/plugins/data_quality/data_quality.vue
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.vue
@@ -3,7 +3,7 @@
     :config="config"
     plugin_key="Data Quality"
     :api_hints_enabled.sync="api_hints_enabled"
-    :description="docs_description'"
+    :description="docs_description"
     :link="docs_link || 'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#data-quality'"
     @plugin-ping="plugin_ping($event)"
     :popout_button="popout_button">


### PR DESCRIPTION
This PR fixes a typo introduced in #3268 preventing the DQ plugin from rendering.  #3268 was not backported or released, so this does not need to be backported or have a changelog entry.