### PR TITLE
orientation: expose create_north_up_east_left/right

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+* Orientation plugin API now exposes create_north_up_east_left and create_north_up_east_right methods. [#3308]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -535,18 +535,18 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             if ref_data.label in self.orientation.choices:
                 self.orientation.selected = ref_data.label
 
-    def _create_north_up_east_left(self, label="North-up, East-left", set_on_create=False,
+    def _create_north_up_east_left(self, label="North-up, East-left", set_as_orientation=False,
                                    from_ui=False):
         if label not in self.orientation.choices:
             degn = self._get_wcs_angles()[-3]
             self._add_orientation(rotation_angle=degn, east_left=True,
-                                  label=label, set_on_create=set_on_create,
+                                  label=label, set_on_create=set_as_orientation,
                                   from_ui=from_ui)
-        elif set_on_create:
+        elif set_as_orientation:
             self.orientation.selected = label
 
     def create_north_up_east_left(self, label="North-up, East-left",
-                                  set_on_create=True):
+                                  set_as_orientation=True):
         """
         Set the rotation angle and flip to achieve North up and East left
         according to the reference image WCS.
@@ -554,24 +554,26 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         Parameters
         ----------
         label : str
-            Data label for this new orientation layer.
-        set_on_create : bool
-            Whether to set the created option as the current orientation.
+            Data label for the orientation layer.  If already exists, will be set as the
+            current orientation layer according to ``set_as_orientation``.  Otherwise,
+            a new layer will be created with this label.
+        set_as_orientation : bool
+            Whether to set as the current orientation.
         """
-        self._create_north_up_east_left(label=label, set_on_create=set_on_create)
+        self._create_north_up_east_left(label=label, set_as_orientation=set_as_orientation)
 
-    def _create_north_up_east_right(self, label="North-up, East-right", set_on_create=False,
+    def _create_north_up_east_right(self, label="North-up, East-right", set_as_orientation=False,
                                     from_ui=False):
         if label not in self.orientation.choices:
             degn = self._get_wcs_angles()[-3]
             self._add_orientation(rotation_angle=180 - degn, east_left=False,
-                                  label=label, set_on_create=set_on_create,
+                                  label=label, set_on_create=set_as_orientation,
                                   from_ui=from_ui)
-        elif set_on_create:
+        elif set_as_orientation:
             self.orientation.selected = label
 
     def create_north_up_east_right(self, label="North-up, East-right",
-                                   set_on_create=True):
+                                   set_as_orientation=True):
         """
         Set the rotation angle and flip to achieve North up and East right
         according to the reference image WCS.
@@ -579,17 +581,19 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         Parameters
         ----------
         label : str
-            Data label for this new orientation layer.
-        set_on_create : bool
-            Whether to set the created option as the current orientation.
+            Data label for the orientation layer.  If already exists, will be set as the
+            current orientation layer according to ``set_as_orientation``.  Otherwise,
+            a new layer will be created with this label.
+        set_as_orientation : bool
+            Whether to set as the current orientation.
         """
-        self._create_north_up_east_right(label=label, set_on_create=set_on_create)
+        self._create_north_up_east_right(label=label, set_as_orientation=set_as_orientation)
 
     def vue_select_north_up_east_left(self, *args, **kwargs):
-        self._create_north_up_east_left(set_on_create=True, from_ui=True)
+        self._create_north_up_east_left(set_as_orientation=True, from_ui=True)
 
     def vue_select_north_up_east_right(self, *args, **kwargs):
-        self._create_north_up_east_right(set_on_create=True, from_ui=True)
+        self._create_north_up_east_right(set_as_orientation=True, from_ui=True)
 
     def vue_select_default_orientation(self, *args, **kwargs):
         self.orientation.selected = base_wcs_layer_label

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -543,7 +543,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             self.orientation.selected = label
 
     def create_north_up_east_left(self, label="North-up, East-left",
-                                  set_on_create=False):
+                                  set_on_create=True):
         """
         Set the rotation angle and flip to achieve North up and East left
         according to the reference image WCS.
@@ -568,7 +568,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             self.orientation.selected = label
 
     def create_north_up_east_right(self, label="North-up, East-right",
-                                   set_on_create=False):
+                                   set_on_create=True):
         """
         Set the rotation angle and flip to achieve North up and East right
         according to the reference image WCS.

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -545,8 +545,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         elif set_as_orientation:
             self.orientation.selected = label
 
-    def set_north_up_east_left(self, label="North-up, East-left",
-                               set_as_orientation=True):
+    def set_north_up_east_left(self, label="North-up, East-left"):
         """
         Set (and create if necessary) the rotation angle and flip to achieve North up
         and East left according to the reference image WCS.
@@ -557,11 +556,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             Data label for the orientation layer.  If already exists, will be set as the
             current orientation layer according to ``set_as_orientation``.  Otherwise,
             a new layer will be created with this label.
-        set_as_orientation : bool
-            Whether to set as the current orientation.  If False, the new layer will still
-            be created and available for selection, but will not be set as the current orientation.
         """
-        self._set_north_up_east_left(label=label, set_as_orientation=set_as_orientation)
+        self._set_north_up_east_left(label=label, set_as_orientation=True)
 
     def _set_north_up_east_right(self, label="North-up, East-right", set_as_orientation=False,
                                  from_ui=False):
@@ -573,8 +569,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         elif set_as_orientation:
             self.orientation.selected = label
 
-    def set_north_up_east_right(self, label="North-up, East-right",
-                                set_as_orientation=True):
+    def set_north_up_east_right(self, label="North-up, East-right"):
         """
         Set (and create, if necessary) the rotation angle and flip to achieve North up
         and East right according to the reference image WCS.
@@ -585,11 +580,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             Data label for the orientation layer.  If already exists, will be set as the
             current orientation layer according to ``set_as_orientation``.  Otherwise,
             a new layer will be created with this label.
-        set_as_orientation : bool
-            Whether to set as the current orientation.  If False, the new layer will still
-            be created and available for selection, but will not be set as the current orientation.
         """
-        self._set_north_up_east_right(label=label, set_as_orientation=set_as_orientation)
+        self._set_north_up_east_right(label=label, set_as_orientation=True)
 
     def vue_select_north_up_east_left(self, *args, **kwargs):
         self._set_north_up_east_left(set_as_orientation=True, from_ui=True)

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -63,7 +63,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
     """
     template_file = __file__, "orientation.vue"
 
-    # defined as traitlet to allow access from UI - leave fixed
+    # defined as traitlet in addition to global variable above to
+    # allow access from UI - leave fixed
     base_wcs_layer_label = Unicode(base_wcs_layer_label).tag(sync=True)
 
     align_by_items = List().tag(sync=True)

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -52,7 +52,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.close_in_tray`
     * ``align_by`` (`~jdaviz.core.template_mixin.SelectPluginComponent`)
     * ``wcs_fast_approximation``
-    * :meth:`delete_subsets``
+    * :meth:`delete_subsets`
     * ``viewer``
     * ``orientation``
     * ``rotation_angle``
@@ -289,6 +289,9 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         self.need_clear_subsets = len(self.app.data_collection.subset_groups) > 0
 
     def delete_subsets(self):
+        """
+        Delete all subsets app-wide.  Required before changing ``align_by``.
+        """
         # subsets will be deleted on changing link type:
         for subset_group in self.app.data_collection.subset_groups:
             self.app.data_collection.remove_subset_group(subset_group)

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -58,8 +58,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
     * ``rotation_angle``
     * ``east_left``
     * :meth:`add_orientation`
-    * :meth:`create_north_up_east_left`
-    * :meth:`create_north_up_east_right`
+    * :meth:`set_north_up_east_left`
+    * :meth:`set_north_up_east_right`
     """
     template_file = __file__, "orientation.vue"
 
@@ -152,7 +152,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
                 'align_by', 'link_type', 'wcs_fast_approximation', 'wcs_use_affine',
                 'delete_subsets', 'viewer', 'orientation',
                 'rotation_angle', 'east_left', 'add_orientation',
-                'create_north_up_east_left', 'create_north_up_east_right',
+                'set_north_up_east_left', 'set_north_up_east_right',
             )
         )
 
@@ -535,8 +535,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             if ref_data.label in self.orientation.choices:
                 self.orientation.selected = ref_data.label
 
-    def _create_north_up_east_left(self, label="North-up, East-left", set_as_orientation=False,
-                                   from_ui=False):
+    def _set_north_up_east_left(self, label="North-up, East-left", set_as_orientation=False,
+                                from_ui=False):
         if label not in self.orientation.choices:
             degn = self._get_wcs_angles()[-3]
             self._add_orientation(rotation_angle=degn, east_left=True,
@@ -545,11 +545,11 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         elif set_as_orientation:
             self.orientation.selected = label
 
-    def create_north_up_east_left(self, label="North-up, East-left",
-                                  set_as_orientation=True):
+    def set_north_up_east_left(self, label="North-up, East-left",
+                               set_as_orientation=True):
         """
-        Set the rotation angle and flip to achieve North up and East left
-        according to the reference image WCS.
+        Set (and create if necessary) the rotation angle and flip to achieve North up
+        and East left according to the reference image WCS.
 
         Parameters
         ----------
@@ -558,12 +558,13 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             current orientation layer according to ``set_as_orientation``.  Otherwise,
             a new layer will be created with this label.
         set_as_orientation : bool
-            Whether to set as the current orientation.
+            Whether to set as the current orientation.  If False, the new layer will still
+            be created and available for selection, but will not be set as the current orientation.
         """
-        self._create_north_up_east_left(label=label, set_as_orientation=set_as_orientation)
+        self._set_north_up_east_left(label=label, set_as_orientation=set_as_orientation)
 
-    def _create_north_up_east_right(self, label="North-up, East-right", set_as_orientation=False,
-                                    from_ui=False):
+    def _set_north_up_east_right(self, label="North-up, East-right", set_as_orientation=False,
+                                 from_ui=False):
         if label not in self.orientation.choices:
             degn = self._get_wcs_angles()[-3]
             self._add_orientation(rotation_angle=180 - degn, east_left=False,
@@ -572,11 +573,11 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         elif set_as_orientation:
             self.orientation.selected = label
 
-    def create_north_up_east_right(self, label="North-up, East-right",
-                                   set_as_orientation=True):
+    def set_north_up_east_right(self, label="North-up, East-right",
+                                set_as_orientation=True):
         """
-        Set the rotation angle and flip to achieve North up and East right
-        according to the reference image WCS.
+        Set (and create, if necessary) the rotation angle and flip to achieve North up
+        and East right according to the reference image WCS.
 
         Parameters
         ----------
@@ -585,15 +586,16 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             current orientation layer according to ``set_as_orientation``.  Otherwise,
             a new layer will be created with this label.
         set_as_orientation : bool
-            Whether to set as the current orientation.
+            Whether to set as the current orientation.  If False, the new layer will still
+            be created and available for selection, but will not be set as the current orientation.
         """
-        self._create_north_up_east_right(label=label, set_as_orientation=set_as_orientation)
+        self._set_north_up_east_right(label=label, set_as_orientation=set_as_orientation)
 
     def vue_select_north_up_east_left(self, *args, **kwargs):
-        self._create_north_up_east_left(set_as_orientation=True, from_ui=True)
+        self._set_north_up_east_left(set_as_orientation=True, from_ui=True)
 
     def vue_select_north_up_east_right(self, *args, **kwargs):
-        self._create_north_up_east_right(set_as_orientation=True, from_ui=True)
+        self._set_north_up_east_right(set_as_orientation=True, from_ui=True)
 
     def vue_select_default_orientation(self, *args, **kwargs):
         self.orientation.selected = base_wcs_layer_label

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -52,14 +52,19 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.close_in_tray`
     * ``align_by`` (`~jdaviz.core.template_mixin.SelectPluginComponent`)
     * ``wcs_fast_approximation``
-    * ``delete_subsets``
+    * :meth:`delete_subsets``
     * ``viewer``
     * ``orientation``
     * ``rotation_angle``
     * ``east_left``
-    * ``add_orientation``
+    * :meth:`add_orientation`
+    * :meth:`create_north_up_east_left`
+    * :meth:`create_north_up_east_right`
     """
     template_file = __file__, "orientation.vue"
+
+    # defined as traitlet to allow access from UI - leave fixed
+    base_wcs_layer_label = Unicode(base_wcs_layer_label).tag(sync=True)
 
     align_by_items = List().tag(sync=True)
     align_by_selected = Unicode().tag(sync=True)
@@ -146,7 +151,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             expose=(
                 'align_by', 'link_type', 'wcs_fast_approximation', 'wcs_use_affine',
                 'delete_subsets', 'viewer', 'orientation',
-                'rotation_angle', 'east_left', 'add_orientation'
+                'rotation_angle', 'east_left', 'add_orientation',
+                'create_north_up_east_left', 'create_north_up_east_right',
             )
         )
 
@@ -526,12 +532,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             if ref_data.label in self.orientation.choices:
                 self.orientation.selected = ref_data.label
 
-    def create_north_up_east_left(self, label="North-up, East-left", set_on_create=False,
-                                  from_ui=False):
-        """
-        Set the rotation angle and flip to achieve North up and East left
-        according to the reference image WCS.
-        """
+    def _create_north_up_east_left(self, label="North-up, East-left", set_on_create=False,
+                                   from_ui=False):
         if label not in self.orientation.choices:
             degn = self._get_wcs_angles()[-3]
             self._add_orientation(rotation_angle=degn, east_left=True,
@@ -540,12 +542,23 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         elif set_on_create:
             self.orientation.selected = label
 
-    def create_north_up_east_right(self, label="North-up, East-right", set_on_create=False,
-                                   from_ui=False):
+    def create_north_up_east_left(self, label="North-up, East-left",
+                                  set_on_create=False):
         """
-        Set the rotation angle and flip to achieve North up and East right
+        Set the rotation angle and flip to achieve North up and East left
         according to the reference image WCS.
+
+        Parameters
+        ----------
+        label : str
+            Data label for this new orientation layer.
+        set_on_create : bool
+            Whether to set the created option as the current orientation.
         """
+        self._create_north_up_east_left(label=label, set_on_create=set_on_create)
+
+    def _create_north_up_east_right(self, label="North-up, East-right", set_on_create=False,
+                                    from_ui=False):
         if label not in self.orientation.choices:
             degn = self._get_wcs_angles()[-3]
             self._add_orientation(rotation_angle=180 - degn, east_left=False,
@@ -554,11 +567,26 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         elif set_on_create:
             self.orientation.selected = label
 
+    def create_north_up_east_right(self, label="North-up, East-right",
+                                   set_on_create=False):
+        """
+        Set the rotation angle and flip to achieve North up and East right
+        according to the reference image WCS.
+
+        Parameters
+        ----------
+        label : str
+            Data label for this new orientation layer.
+        set_on_create : bool
+            Whether to set the created option as the current orientation.
+        """
+        self._create_north_up_east_right(label=label, set_on_create=set_on_create)
+
     def vue_select_north_up_east_left(self, *args, **kwargs):
-        self.create_north_up_east_left(set_on_create=True, from_ui=True)
+        self._create_north_up_east_left(set_on_create=True, from_ui=True)
 
     def vue_select_north_up_east_right(self, *args, **kwargs):
-        self.create_north_up_east_right(set_on_create=True, from_ui=True)
+        self._create_north_up_east_right(set_on_create=True, from_ui=True)
 
     def vue_select_default_orientation(self, *args, **kwargs):
         self.orientation.selected = base_wcs_layer_label

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.vue
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.vue
@@ -128,18 +128,45 @@
             <span style="line-height: 36px">Presets:</span>
             <!-- NOTE: changes to icons here should be manually reflected in layer_icons in app.py -->
             <j-tooltip tooltipcontent="Default orientation">
-              <v-btn icon @click="select_default_orientation">
+              <v-btn
+                :icon="!api_hints_enabled"
+                :class="api_hints_enabled ? 'api-hint' : null"
+                @click="select_default_orientation"
+              >
                 <v-icon>mdi-image-outline</v-icon>
+                {{ api_hints_enabled ?
+                  'plg.orientation = \''+base_wcs_layer_label+'\''
+                  :
+                  null
+                }}
               </v-btn>
             </j-tooltip>
             <j-tooltip tooltipcontent="north up, east left">
-              <v-btn icon @click="select_north_up_east_left">
+              <v-btn
+                :icon="!api_hints_enabled"
+                :class="api_hints_enabled ? 'api-hint' : null"
+                @click="select_north_up_east_left"
+              >
                 <img :src="icons['nuel']" width="24" class="invert-if-dark" style="opacity: 0.65"/>
+                {{ api_hints_enabled ?
+                  'plg.create_north_up_east_left()'
+                  :
+                  null
+                }}
               </v-btn>
             </j-tooltip>
             <j-tooltip tooltipcontent="north up, east right">
-              <v-btn icon @click="select_north_up_east_right">
+              <v-btn
+                :icon="!api_hints_enabled"
+                :class="api_hints_enabled ? 'api-hint' : null"
+                @click="select_north_up_east_right"
+              >
                 <img :src="icons['nuer']" width="24" class="invert-if-dark" style="opacity: 0.65"/>
+                {{ api_hints_enabled ?
+                  'plg.create_north_up_east_right()'
+                  :
+                  null
+                }}
               </v-btn>
             </j-tooltip>
           </v-row>

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.vue
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.vue
@@ -149,7 +149,7 @@
               >
                 <img :src="icons['nuel']" width="24" class="invert-if-dark" style="opacity: 0.65"/>
                 {{ api_hints_enabled ?
-                  'plg.create_north_up_east_left()'
+                  'plg.set_north_up_east_left()'
                   :
                   null
                 }}
@@ -163,7 +163,7 @@
               >
                 <img :src="icons['nuer']" width="24" class="invert-if-dark" style="opacity: 0.65"/>
                 {{ api_hints_enabled ?
-                  'plg.create_north_up_east_right()'
+                  'plg.set_north_up_east_right()'
                   :
                   null
                 }}

--- a/jdaviz/configs/imviz/tests/test_delete_data.py
+++ b/jdaviz/configs/imviz/tests/test_delete_data.py
@@ -87,7 +87,7 @@ class TestDeleteWCSLayerWithSubset(BaseImviz_WCS_GWCS):
         lc_plugin.align_by = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
-        lc_plugin.set_north_up_east_left(set_as_orientation=True)
+        lc_plugin.set_north_up_east_left()
 
         # Create a rotated ellipse.
         reg = EllipsePixelRegion(

--- a/jdaviz/configs/imviz/tests/test_delete_data.py
+++ b/jdaviz/configs/imviz/tests/test_delete_data.py
@@ -87,7 +87,7 @@ class TestDeleteWCSLayerWithSubset(BaseImviz_WCS_GWCS):
         lc_plugin.align_by = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
-        lc_plugin._obj.create_north_up_east_left(set_on_create=True)
+        lc_plugin.create_north_up_east_left(set_as_orientation=True)
 
         # Create a rotated ellipse.
         reg = EllipsePixelRegion(

--- a/jdaviz/configs/imviz/tests/test_delete_data.py
+++ b/jdaviz/configs/imviz/tests/test_delete_data.py
@@ -87,7 +87,7 @@ class TestDeleteWCSLayerWithSubset(BaseImviz_WCS_GWCS):
         lc_plugin.align_by = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
-        lc_plugin.create_north_up_east_left(set_as_orientation=True)
+        lc_plugin.set_north_up_east_left(set_as_orientation=True)
 
         # Create a rotated ellipse.
         reg = EllipsePixelRegion(

--- a/jdaviz/configs/imviz/tests/test_footprints.py
+++ b/jdaviz/configs/imviz/tests/test_footprints.py
@@ -241,7 +241,7 @@ def test_footprint_updates_on_rotation(imviz_helper):
 
     # now rotate to north-up east-left:
     orientation = imviz_helper.plugins['Orientation']
-    orientation.create_north_up_east_left(set_as_orientation=True)
+    orientation.set_north_up_east_left(set_as_orientation=True)
 
     # If all footprint orientations have been updated, the lowest
     # mark should still be centered low. If the footprint

--- a/jdaviz/configs/imviz/tests/test_footprints.py
+++ b/jdaviz/configs/imviz/tests/test_footprints.py
@@ -240,8 +240,8 @@ def test_footprint_updates_on_rotation(imviz_helper):
     assert np.concatenate([marks[0].y, marks[1].y]).min() < -3
 
     # now rotate to north-up east-left:
-    orientation = imviz_helper.plugins['Orientation']._obj
-    orientation.create_north_up_east_left(set_on_create=True)
+    orientation = imviz_helper.plugins['Orientation']
+    orientation.create_north_up_east_left(set_as_orientation=True)
 
     # If all footprint orientations have been updated, the lowest
     # mark should still be centered low. If the footprint

--- a/jdaviz/configs/imviz/tests/test_footprints.py
+++ b/jdaviz/configs/imviz/tests/test_footprints.py
@@ -241,7 +241,7 @@ def test_footprint_updates_on_rotation(imviz_helper):
 
     # now rotate to north-up east-left:
     orientation = imviz_helper.plugins['Orientation']
-    orientation.set_north_up_east_left(set_as_orientation=True)
+    orientation.set_north_up_east_left()
 
     # If all footprint orientations have been updated, the lowest
     # mark should still be centered low. If the footprint

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -125,14 +125,14 @@ class TestNonDefaultOrientation(BaseImviz_WCS_WCS):
         lc_plugin.align_by = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
-        lc_plugin._obj.create_north_up_east_left(set_on_create=True)
+        lc_plugin.create_north_up_east_left(set_as_orientation=True)
 
         # This would set a different reference to second viewer.
         viewer_2 = self.imviz.create_image_viewer()
         self.imviz.app.add_data_to_viewer("imviz-1", "has_wcs_1[SCI,1]")
         lc_plugin.viewer = "imviz-1"
 
-        lc_plugin._obj.create_north_up_east_right(set_on_create=True)
+        lc_plugin.create_north_up_east_right(set_as_orientation=True)
 
         assert self.viewer.state.reference_data.label == "North-up, East-left"
         assert viewer_2.state.reference_data.label == "North-up, East-right"
@@ -157,8 +157,8 @@ class TestNonDefaultOrientation(BaseImviz_WCS_WCS):
         lc_plugin.viewer = "imviz-0"
 
         lc_plugin.rotation_angle = 42  # Triggers auto-label
-        lc_plugin._obj.add_orientation(rotation_angle=None, east_left=True, label=None,
-                                       set_on_create=True, wrt_data=None)
+        lc_plugin.add_orientation(rotation_angle=None, east_left=True, label=None,
+                                  set_on_create=True, wrt_data=None)
         assert self.viewer.state.reference_data.label == "CCW 42.00 deg (E-left)"
 
 
@@ -169,7 +169,7 @@ class TestDeleteOrientation(BaseImviz_WCS_WCS):
         lc_plugin.align_by = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
-        lc_plugin._obj.create_north_up_east_left(set_on_create=True)
+        lc_plugin.create_north_up_east_left(set_as_orientation=True)
 
         # This would set a different reference to second viewer.
         viewer_2 = self.imviz.create_image_viewer()
@@ -192,7 +192,7 @@ class TestDeleteOrientation(BaseImviz_WCS_WCS):
         lc_plugin.align_by = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
-        lc_plugin._obj.create_north_up_east_left(set_on_create=True)
+        lc_plugin.create_north_up_east_left(set_as_orientation=True)
 
         # Create rotated shape
         reg = klass(center=SkyCoord(ra=337.51931488, dec=-20.83187472, unit="deg"),
@@ -200,7 +200,7 @@ class TestDeleteOrientation(BaseImviz_WCS_WCS):
         self.imviz.plugins['Subsets'].import_region(reg)
 
         # Switch to N-up E-right
-        lc_plugin._obj.create_north_up_east_right(set_on_create=True)
+        lc_plugin.create_north_up_east_right(set_as_orientation=True)
 
         self.imviz.app.vue_data_item_remove({"item_name": "North-up, East-left"})
 
@@ -234,13 +234,13 @@ class TestOrientationNoData(BaseImviz_WCS_WCS):
         lc_plugin.viewer = "imviz-1"
 
         with pytest.raises(ValueError, match="Viewer must have data loaded"):
-            lc_plugin._obj.create_north_up_east_left(set_on_create=True)
+            lc_plugin.create_north_up_east_left(set_as_orientation=True)
 
     def test_select_no_data(self):
         lc_plugin = self.imviz.plugins['Orientation']
         lc_plugin.align_by = 'WCS'
 
-        lc_plugin._obj.create_north_up_east_left(set_on_create=True)
+        lc_plugin.create_north_up_east_left(set_as_orientation=True)
 
         self.imviz.create_image_viewer()
         lc_plugin.viewer = "imviz-1"

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -125,14 +125,14 @@ class TestNonDefaultOrientation(BaseImviz_WCS_WCS):
         lc_plugin.align_by = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
-        lc_plugin.create_north_up_east_left(set_as_orientation=True)
+        lc_plugin.set_north_up_east_left(set_as_orientation=True)
 
         # This would set a different reference to second viewer.
         viewer_2 = self.imviz.create_image_viewer()
         self.imviz.app.add_data_to_viewer("imviz-1", "has_wcs_1[SCI,1]")
         lc_plugin.viewer = "imviz-1"
 
-        lc_plugin.create_north_up_east_right(set_as_orientation=True)
+        lc_plugin.set_north_up_east_right(set_as_orientation=True)
 
         assert self.viewer.state.reference_data.label == "North-up, East-left"
         assert viewer_2.state.reference_data.label == "North-up, East-right"
@@ -169,7 +169,7 @@ class TestDeleteOrientation(BaseImviz_WCS_WCS):
         lc_plugin.align_by = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
-        lc_plugin.create_north_up_east_left(set_as_orientation=True)
+        lc_plugin.set_north_up_east_left(set_as_orientation=True)
 
         # This would set a different reference to second viewer.
         viewer_2 = self.imviz.create_image_viewer()
@@ -192,7 +192,7 @@ class TestDeleteOrientation(BaseImviz_WCS_WCS):
         lc_plugin.align_by = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
-        lc_plugin.create_north_up_east_left(set_as_orientation=True)
+        lc_plugin.set_north_up_east_left(set_as_orientation=True)
 
         # Create rotated shape
         reg = klass(center=SkyCoord(ra=337.51931488, dec=-20.83187472, unit="deg"),
@@ -200,7 +200,7 @@ class TestDeleteOrientation(BaseImviz_WCS_WCS):
         self.imviz.plugins['Subsets'].import_region(reg)
 
         # Switch to N-up E-right
-        lc_plugin.create_north_up_east_right(set_as_orientation=True)
+        lc_plugin.set_north_up_east_right(set_as_orientation=True)
 
         self.imviz.app.vue_data_item_remove({"item_name": "North-up, East-left"})
 
@@ -234,13 +234,13 @@ class TestOrientationNoData(BaseImviz_WCS_WCS):
         lc_plugin.viewer = "imviz-1"
 
         with pytest.raises(ValueError, match="Viewer must have data loaded"):
-            lc_plugin.create_north_up_east_left(set_as_orientation=True)
+            lc_plugin.set_north_up_east_left(set_as_orientation=True)
 
     def test_select_no_data(self):
         lc_plugin = self.imviz.plugins['Orientation']
         lc_plugin.align_by = 'WCS'
 
-        lc_plugin.create_north_up_east_left(set_as_orientation=True)
+        lc_plugin.set_north_up_east_left(set_as_orientation=True)
 
         self.imviz.create_image_viewer()
         lc_plugin.viewer = "imviz-1"

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -125,14 +125,14 @@ class TestNonDefaultOrientation(BaseImviz_WCS_WCS):
         lc_plugin.align_by = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
-        lc_plugin.set_north_up_east_left(set_as_orientation=True)
+        lc_plugin.set_north_up_east_left()
 
         # This would set a different reference to second viewer.
         viewer_2 = self.imviz.create_image_viewer()
         self.imviz.app.add_data_to_viewer("imviz-1", "has_wcs_1[SCI,1]")
         lc_plugin.viewer = "imviz-1"
 
-        lc_plugin.set_north_up_east_right(set_as_orientation=True)
+        lc_plugin.set_north_up_east_right()
 
         assert self.viewer.state.reference_data.label == "North-up, East-left"
         assert viewer_2.state.reference_data.label == "North-up, East-right"
@@ -169,7 +169,7 @@ class TestDeleteOrientation(BaseImviz_WCS_WCS):
         lc_plugin.align_by = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
-        lc_plugin.set_north_up_east_left(set_as_orientation=True)
+        lc_plugin.set_north_up_east_left()
 
         # This would set a different reference to second viewer.
         viewer_2 = self.imviz.create_image_viewer()
@@ -192,7 +192,7 @@ class TestDeleteOrientation(BaseImviz_WCS_WCS):
         lc_plugin.align_by = 'WCS'
 
         # Should automatically be applied as reference to first viewer.
-        lc_plugin.set_north_up_east_left(set_as_orientation=True)
+        lc_plugin.set_north_up_east_left()
 
         # Create rotated shape
         reg = klass(center=SkyCoord(ra=337.51931488, dec=-20.83187472, unit="deg"),
@@ -200,7 +200,7 @@ class TestDeleteOrientation(BaseImviz_WCS_WCS):
         self.imviz.plugins['Subsets'].import_region(reg)
 
         # Switch to N-up E-right
-        lc_plugin.set_north_up_east_right(set_as_orientation=True)
+        lc_plugin.set_north_up_east_right()
 
         self.imviz.app.vue_data_item_remove({"item_name": "North-up, East-left"})
 
@@ -234,13 +234,13 @@ class TestOrientationNoData(BaseImviz_WCS_WCS):
         lc_plugin.viewer = "imviz-1"
 
         with pytest.raises(ValueError, match="Viewer must have data loaded"):
-            lc_plugin.set_north_up_east_left(set_as_orientation=True)
+            lc_plugin.set_north_up_east_left()
 
     def test_select_no_data(self):
         lc_plugin = self.imviz.plugins['Orientation']
         lc_plugin.align_by = 'WCS'
 
-        lc_plugin.set_north_up_east_left(set_as_orientation=True)
+        lc_plugin.set_north_up_east_left()
 
         self.imviz.create_image_viewer()
         lc_plugin.viewer = "imviz-1"


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request exposes `create_north_up_east_left(...)` and `create_north_up_east_right(...)` methods via the public API of the Orientation plugin, along with API hints.

This also renames `set_on_create` to `set_as_orientation` in these methods, as it sets them whether or not they are created.  This does not however, rename the already public `set_on_create` within `add_orientation(...)`

Docs updates: [Orientation plugin API docs](https://jdaviz--3308.org.readthedocs.build/en/3308/api/jdaviz.configs.imviz.plugins.orientation.orientation.Orientation.html#jdaviz.configs.imviz.plugins.orientation.orientation.Orientation)

API hints:
<img width="701" alt="image" src="https://github.com/user-attachments/assets/6580ceff-ab67-40f8-81a5-670a5750e9d0">


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
