### PR TITLE
Removing filter warning for mpl-scatter-density

### DIFF
--- a/jdaviz/core/linelists.py
+++ b/jdaviz/core/linelists.py
@@ -1,4 +1,4 @@
-import pkg_resources
+from importlib import resources
 import json
 
 from astropy.table import QTable
@@ -8,8 +8,7 @@ __all__ = ['get_linelist_metadata', 'get_available_linelists', 'load_preset_line
 
 def get_linelist_metadata():
     """Return metadata for line lists."""
-    metadata_file = pkg_resources.resource_filename("jdaviz",
-                                                    "data/linelists/linelist_metadata.json")
+    metadata_file = resources.files("jdaviz").joinpath("data/linelists/linelist_metadata.json")
     with open(metadata_file) as f:
         metadata = json.load(f)
     return metadata
@@ -34,8 +33,7 @@ def load_preset_linelist(name):
         raise ValueError("Line name not in available set of line lists. " +
                          "Valid list names are: {}".format(list(metadata.keys())))
     fname_base = metadata[name]["filename_base"]
-    fname = pkg_resources.resource_filename("jdaviz",
-                                            "data/linelists/{}.csv".format(fname_base))
+    fname = resources.files("jdaviz").joinpath("data/linelists/{}.csv".format(fname_base))
     units = metadata[name]["units"]
     linetable = QTable.read(fname)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,8 +138,6 @@ filterwarnings = [
     "ignore::DeprecationWarning:glue",
     "ignore::DeprecationWarning:asteval",
     "ignore:::specutils.spectra.spectrum1d",
-    # Remove the following line once https://github.com/astrofrog/mpl-scatter-density/issues/46 is addressed
-    "ignore:pkg_resources is deprecated as an API:DeprecationWarning:mpl_scatter_density",
     # Ignore numpy 2.0 warning, see https://github.com/astropy/astropy/pull/15495
     # and https://github.com/scipy/scipy/pull/19275
     "ignore:.*numpy\\.core.*:DeprecationWarning",


### PR DESCRIPTION
### Description

The filtered warning for `mpl-scatter-density` may be unnecessary since the release of v0.8. Trying that out in this PR.

It turns out that there was an in situ `pkg_resources` warning stemming from `linelists.py`, too.

Related PRs:

* https://github.com/glue-viz/glue/pull/2521
* https://github.com/astrofrog/mpl-scatter-density/pull/47
* https://github.com/spacetelescope/lcviz/pull/156
* https://github.com/spacetelescope/jdaviz/pull/3317

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?