### PR TITLE
Making docs index match better with github 'About' description

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,12 +65,11 @@ Jdaviz
 
          Jump to Rampviz
 
-``jdaviz`` is a package of astronomical data analysis visualization
-tools based on the Jupyter platform.  These GUI-based tools link data
-visualization and interactive analysis.  They are designed to work
-within a Jupyter notebook cell, as a standalone desktop application,
-or as embedded windows within a website -- all with nearly identical
-user interfaces.
+``jdaviz`` is a Python package for interactive data visualization
+and analysis tools for astronomical observations. ``jdaviz`` works
+within a Jupyter notebook, as a standalone desktop app, a
+command-line application, or embedded within a website -- all with
+nearly identical user interfaces.
 
 ``jdaviz`` applications currently include tools for interactive
 visualization of spectroscopic and imaging data.


### PR DESCRIPTION
### Description

We just changed the About section of the repo from:

<img width="312" alt="Screenshot 2024-12-05 at 11 54 51" src="https://github.com/user-attachments/assets/d578799f-58db-4a42-a3a1-e3430d843eec">

to:

<img width="312" alt="Screenshot 2024-12-05 at 11 54 51" src="https://github.com/user-attachments/assets/d37931ab-f0fb-4f07-8d29-26056a25769c">


This PR adjusts the main docs page to make it match more closely.


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
