### PR TITLE
model fitting: ensure specutils has access to equivs & set targ solid angle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,8 @@ Cubeviz
 ^^^^^^^
 - Removed the deprecated ``save as fits`` option from the Collapse, Moment Maps, and Spectral Extraction plugins; use the Export plugin instead. [#3256]
 
+- Fixed bugs where cube model fitting could fail if Jdaviz custom equivalencies were required. [#3343]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -27,6 +27,7 @@ from jdaviz.core.custom_traitlets import IntHandleEmpty
 from jdaviz.core.user_api import PluginUserApi
 from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
                                                flux_conversion_general)
+from jdaviz.core.custom_units_and_equivs import PIX2
 
 __all__ = ['ModelFitting']
 
@@ -986,6 +987,18 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
             pixar_sr = spec.meta.get('_pixel_scale_factor', None)
             equivalencies = all_flux_unit_conversion_equivs(pixar_sr=pixar_sr,
                                                             cube_wave=spec.spectral_axis)
+
+            pix2_in_flux = 'pix2' in spec.flux.unit.to_string()
+            pix2_in_sb = 'pix2' in sb_unit
+            # Handle various cases when PIX2 angle unit is present in the conversion
+            if pix2_in_flux and pix2_in_sb:
+                spec = spec.with_flux_unit(u.Unit(spec.flux.unit)*PIX2, equivalencies=equivalencies)  # noqa
+                spec = spec.with_flux_unit(u.Unit(sb_unit)*PIX2, equivalencies=equivalencies)
+            elif pix2_in_flux:
+                spec = spec.with_flux_unit(u.Unit(spec.flux.unit) * PIX2, equivalencies=equivalencies)  # noqa
+            elif pix2_in_sb:
+                spec = spec.with_flux_unit(u.Unit(spec.flux.unit) / PIX2, equivalencies=equivalencies)  # noqa
+
             spec = spec.with_flux_unit(sb_unit, equivalencies=equivalencies)
 
         snackbar_message = SnackbarMessage(

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -983,7 +983,9 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         sb_unit = self.app._get_display_unit('sb')
         if spec.flux.unit != sb_unit:
             # ensure specutils has access to jdaviz custom unit equivalencies
-            equivalencies = all_flux_unit_conversion_equivs()
+            pixar_sr = spec.meta.get('_pixel_scale_factor', None)
+            equivalencies = all_flux_unit_conversion_equivs(pixar_sr=pixar_sr,
+                                                            cube_wave=spec.spectral_axis)
             spec = spec.with_flux_unit(sb_unit, equivalencies=equivalencies)
 
         snackbar_message = SnackbarMessage(

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -982,7 +982,9 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
         sb_unit = self.app._get_display_unit('sb')
         if spec.flux.unit != sb_unit:
-            spec = spec.with_flux_unit(sb_unit)
+            # ensure specutils has access to jdaviz custom unit equivalencies
+            equivalencies = all_flux_unit_conversion_equivs()
+            spec = spec.with_flux_unit(sb_unit, equivalencies=equivalencies)
 
         snackbar_message = SnackbarMessage(
             "Fitting model to cube...",

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -505,7 +505,7 @@ def _indirect_conversion(values, orig_units, targ_units, eqv,
     elif image_data or (spec_unit and solid_angle_in_spec):
         if not solid_angle_in_targ:
             targ_units /= solid_angle_in_spec
-        solid_angle_in_targ = solid_angle_in_spec
+            solid_angle_in_targ = solid_angle_in_spec
         if ((u.Unit(targ_units) in indirect_units()) or
            (u.Unit(orig_units) in indirect_units())):
             # SB -> Flux -> Flux -> SB

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -505,6 +505,7 @@ def _indirect_conversion(values, orig_units, targ_units, eqv,
     elif image_data or (spec_unit and solid_angle_in_spec):
         if not solid_angle_in_targ:
             targ_units /= solid_angle_in_spec
+        solid_angle_in_targ = solid_angle_in_spec
         if ((u.Unit(targ_units) in indirect_units()) or
            (u.Unit(orig_units) in indirect_units())):
             # SB -> Flux -> Flux -> SB


### PR DESCRIPTION
This draft PR resolves:
1. UnitConversionError in Model Fitting plugin, specutils `spec.with_flux_unit` did not have access to `pix2` custom unit equivalencies

To reproduce on main:
```
uri ='https://data.science.stsci.edu/redirect/JWST/jwst-data_analysis_tools/IFU_cube_continuum_fit/NGC4151_Hband.fits'

model = cubeviz.plugins['Model Fitting']
model.cube_fit = True
model.create_model_component()
model.calculate_fit()
```

2. TypeError: unsupported operand type(s) for *: 'CompositeUnit' and 'NoneType'. When toggling 'Cube Fit' in Model Fitting plugin, `solid_angle_in_targ` was not being set after `targ_units` was update to include a solid angle unit. Setting 'targ_units' triggered subsequent indirect conversion logic. By setting the `solid_angle_in_targ` we follow the same logic route and ensure we maintain output units in surface brightness.

To reproduce:
```
# example notebook cube
uri = "mast:JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_s3d.fits"

uc = cubeviz.plugins['Unit Conversion']
uc.flux_unit = 'erg / (Angstrom s cm2)'

model = cubeviz.plugins['Model Fitting']
model.cube_fit = True
model.create_model_component()
model.calculate_fit()
```

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
