### PR TITLE
roman_datamodels compatibility, move `romandeps` test to CI workflows

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -54,23 +54,3 @@ jobs:
         python -m pip install tox
     - name: Test with tox
       run: tox -e py311-test-devdeps-romandeps
-
-  ci_cron_tests_stable_roman:
-    name: Python 3.10 with stable versions of dependencies and Roman
-    runs-on: ubuntu-latest
-    if: (github.repository == 'spacetelescope/jdaviz' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-      with:
-        fetch-depth: 0
-    - name: Set up python
-      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
-      with:
-        python-version: '3.10'
-    - name: Install base dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox
-    - name: Test with tox
-      run: tox -e py310-test-romandeps

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -73,9 +73,10 @@ jobs:
             allow_failure: true
 
           - name: Python 3.11 with stable versions of dependencies and Roman
+            os: ubuntu-latest
             python: '3.11'
-            runs-on: ubuntu-latest
             toxenv: py311-test-romandeps
+            toxposargs: --remote-data
             allow_failure: true
 
     steps:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -76,7 +76,6 @@ jobs:
             os: ubuntu-latest
             python: '3.11'
             toxenv: py311-test-romandeps
-            toxposargs: --remote-data
             allow_failure: true
 
     steps:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -72,6 +72,12 @@ jobs:
             toxposargs: --remote-data --run-slow
             allow_failure: true
 
+          - name: Python 3.11 with stable versions of dependencies and Roman
+            python: '3.11'
+            runs-on: ubuntu-latest
+            toxenv: py311-test-romandeps
+            allow_failure: true
+
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/jdaviz/configs/rampviz/plugins/parsers.py
+++ b/jdaviz/configs/rampviz/plugins/parsers.py
@@ -196,6 +196,12 @@ def _roman_3d_to_glue_data(
     data_reshaped = move_group_axis_last(data)
     diff_data_reshaped = move_group_axis_last(diff_data)
 
+    # if the ramp cube has no units, assume DN:
+    if getattr(data_reshaped, 'unit', None) is None:
+        assumed_unit = u.DN
+        data_reshaped <<= assumed_unit
+        diff_data_reshaped <<= assumed_unit
+
     # load these cubes into the cache:
     app._jdaviz_helper.cube_cache[ramp_cube_data_label] = NDDataArray(
         data_reshaped

--- a/jdaviz/configs/rampviz/plugins/ramp_extraction/ramp_extraction.py
+++ b/jdaviz/configs/rampviz/plugins/ramp_extraction/ramp_extraction.py
@@ -342,7 +342,9 @@ class RampExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
             # after the fancy indexing above, axis=1 corresponds to groups, and
             # operations over axis=0 corresponds to individual pixels:
             axis=0
-        ) << nddata.unit
+        )
+        if nddata.unit is not None:
+            collapsed <<= nddata.unit
 
         def expand(x):
             # put the resulting 1D profile (counts vs. groups) into the

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -64,9 +64,7 @@ def roman_level_1_ramp():
     shape = (10, 25, 25)
     data_model = mk_datamodel(RampModel, shape=shape, dq=False)
 
-    data_model.data = u.Quantity(
-        100 + 3 * np.cumsum(rng.uniform(size=shape), axis=0), u.DN
-    )
+    data_model.data = 100 + 3 * np.cumsum(rng.uniform(size=shape), axis=0)
     return data_model
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ docs = [
     "sphinx_design"
 ]
 roman = [
-    "roman_datamodels>=0.17.1",
+    "roman_datamodels>=0.22.0",
 ]
 
 [build-system]


### PR DESCRIPTION

### Description

Tests that rely on the optional Roman dependencies are currently failing since updates to `roman_datamodels` and `rad` that now save ramps as numpy arrays rather than astropy quantities. I've bumped the pin on rdm, and revised how units are handled for that data model in jdaviz. I've also moved the romandeps cron test into `ci_workflows` under allowed failures, so we'll have faster warning next time we're out of sync.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-5016)
