### PR TITLE
Fix aperture weight mask with loaded mask cube

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,7 +114,7 @@ Cubeviz
 
 - Fixed initializing a Gaussian1D model component when ``Cube Fit`` is toggled on. [#3295]
 
-- Spectral extraction now correctly respects the loaded mask cube. [#3319]
+- Spectral extraction now correctly respects the loaded mask cube. [#3319, #3358]
 
 Imviz
 ^^^^^

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -385,8 +385,6 @@ def _parse_jwst_s3d(app, hdulist, data_label, ext='SCI',
         app._jdaviz_helper._loaded_flux_cube = app.data_collection[data_label]
     elif data_type == 'uncert':
         app._jdaviz_helper._loaded_uncert_cube = app.data_collection[data_label]
-    elif data_type == 'mask':
-        app._jdaviz_helper._loaded_mask_cube = app.data_collection[data_label]
 
 
 def _parse_esa_s3d(app, hdulist, data_label, ext='DATA', flux_viewer_reference_name=None):

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -385,6 +385,8 @@ def _parse_jwst_s3d(app, hdulist, data_label, ext='SCI',
         app._jdaviz_helper._loaded_flux_cube = app.data_collection[data_label]
     elif data_type == 'uncert':
         app._jdaviz_helper._loaded_uncert_cube = app.data_collection[data_label]
+    elif data_type == 'mask':
+        app._jdaviz_helper._loaded_mask_cube = app.data_collection[data_label]
 
 
 def _parse_esa_s3d(app, hdulist, data_label, ext='DATA', flux_viewer_reference_name=None):

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -392,7 +392,7 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         # of the detector. For JWST spectral cubes, these pixels are also marked in
         # the DQ array with flag `513`. Also respect the loaded mask, if it exists
         nan_mask = np.isnan(self.dataset.selected_obj.flux.value)
-        return np.logical_not(np.logical_or(self.mask_cube.get_component('flux').data,
+        return np.logical_not(np.logical_or(self.mask_cube.get_component('flux').data.astype(bool),
                                             nan_mask)).astype(float)
 
     @property

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -390,7 +390,8 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         # Aperture masks begin by removing from consideration any pixel
         # set to NaN, which corresponds to a pixel on the "non-science" portions
         # of the detector. For JWST spectral cubes, these pixels are also marked in
-        # the DQ array with flag `513`. Also respect the loaded mask, if it exists
+        # the DQ array with flag `513`. Also respect the loaded mask, if it exists.
+        # This "inverted mask" is `True` where the data are included, `False` where excluded.
         mask_non_science = np.isnan(self.dataset.selected_obj.flux.value)
         if self.mask_cube is not None:
             mask_non_science = np.logical_or(self.mask_cube.get_component('flux').data,

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -391,7 +391,7 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         # set to NaN, which corresponds to a pixel on the "non-science" portions
         # of the detector. For JWST spectral cubes, these pixels are also marked in
         # the DQ array with flag `513`. Also respect the loaded mask, if it exists
-        nan_mask =  np.isnan(self.dataset.selected_obj.flux.value)
+        nan_mask = np.isnan(self.dataset.selected_obj.flux.value)
         return np.logical_not(np.logical_or(self.mask_cube.get_component('flux').data,
                                             nan_mask)).astype(float)
 

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -391,9 +391,11 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         # set to NaN, which corresponds to a pixel on the "non-science" portions
         # of the detector. For JWST spectral cubes, these pixels are also marked in
         # the DQ array with flag `513`. Also respect the loaded mask, if it exists
-        nan_mask = np.isnan(self.dataset.selected_obj.flux.value)
-        return np.logical_not(np.logical_or(self.mask_cube.get_component('flux').data.astype(bool),
-                                            nan_mask)).astype(float)
+        mask_non_science = np.isnan(self.dataset.selected_obj.flux.value)
+        if self.mask_cube is not None:
+            mask_non_science = np.logical_or(self.mask_cube.get_component('flux').data,
+                                             mask_non_science)
+        return np.logical_not(mask_non_science).astype(float)
 
     @property
     def aperture_weight_mask(self):
@@ -421,7 +423,7 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
             return np.zeros_like(self.dataset.selected_obj.flux.value)
 
         return (
-            self.mask_non_science *
+            self.inverted_mask_non_science *
             self.background.get_mask(
                 self.dataset.selected_obj,
                 self.aperture_method_selected,

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -208,6 +208,24 @@ def test_numpy_cube(cubeviz_helper):
     assert isinstance(data.coords, PaddedSpectrumWCS)
     assert flux.units == 'ct / pix2'
 
+@pytest.mark.remote_data
+def test_manga_cube(cubeviz_helper):
+    # Remote data test of loading and extracting an up-to-date (as of 11/19/2024) MaNGA cube
+    # This also tests that spaxel is converted to pix**2
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore")
+        cubeviz_helper.load_data("https://stsci.box.com/shared/static/gts87zqt5265msuwi4w5u003b6typ6h0.gz", cache=True)  # noqa
+
+    uc = cubeviz_helper.plugins['Unit Conversion']
+    uc.spectral_y_type = "Surface Brightness"
+
+    se = cubeviz_helper.plugins['Spectral Extraction']
+    se.function = "Mean"
+    se.extract()
+    extracted_max = cubeviz_helper.get_data("Spectrum (mean)").max()
+    assert_allclose(extracted_max.value, 2.836957E-18)
+    assert extracted_max.unit == u.Unit("erg / Angstrom s cm**2 pix**2")
+
 
 @pytest.mark.remote_data
 def test_manga_cube(cubeviz_helper):

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -211,12 +211,10 @@ def test_numpy_cube(cubeviz_helper):
 
 def test_loading_with_mask(cubeviz_helper):
     # This also tests that spaxel is converted to pix**2
-    custom_spec = Spectrum1D(flux=[[[20, 1], [9, 1]], [[3, 1], [6, 5]]] * u.Unit("erg / Angstrom s cm**2 spaxel"),  # noqa
+    custom_spec = Spectrum1D(flux=[[[20, 1], [9, 1]], [[3, 1], [6, np.nan]]] * u.Unit("erg / Angstrom s cm**2 spaxel"),  # noqa
                              spectral_axis=[1, 2]*u.AA,
                              mask=[[[1, 0], [0, 0]], [[0, 0], [0, 0]]])
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore")
-        cubeviz_helper.load_data(custom_spec)
+    cubeviz_helper.load_data(custom_spec)
 
     uc = cubeviz_helper.plugins['Unit Conversion']
     uc.spectral_y_type = "Surface Brightness"
@@ -225,7 +223,7 @@ def test_loading_with_mask(cubeviz_helper):
     se.function = "Mean"
     se.extract()
     extracted = cubeviz_helper.get_data("Spectrum (mean)")
-    assert_allclose(extracted.flux.value, [6, 2])
+    assert_allclose(extracted.flux.value, [6, 1])
     assert extracted.unit == u.Unit("erg / Angstrom s cm**2 pix**2")
 
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -211,9 +211,9 @@ def test_numpy_cube(cubeviz_helper):
 
 def test_loading_with_mask(cubeviz_helper):
     # This also tests that spaxel is converted to pix**2
-    custom_spec = Spectrum1D(flux=[[[20, 1],[9, 1]],[[3, 1],[6, 5]]] * u.Unit("erg / Angstrom s cm**2 spaxel"),  # noqa
-                             spectral_axis = [1, 2]*u.AA,
-                             mask=[[[1, 0],[0, 0]],[[0, 0],[0, 0]]])
+    custom_spec = Spectrum1D(flux=[[[20, 1], [9, 1]], [[3, 1], [6, 5]]] * u.Unit("erg / Angstrom s cm**2 spaxel"),  # noqa
+                             spectral_axis=[1, 2]*u.AA,
+                             mask=[[[1, 0], [0, 0]], [[0, 0], [0, 0]]])
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore")
         cubeviz_helper.load_data(custom_spec)
@@ -233,24 +233,6 @@ def test_loading_with_mask(cubeviz_helper):
 @pytest.mark.remote_data
 def test_manga_with_mask(cubeviz_helper):
     # Remote data test of loading and extracting an up-to-date (as of 11/19/2024) MaNGA cube
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore")
-        cubeviz_helper.load_data("https://stsci.box.com/shared/static/gts87zqt5265msuwi4w5u003b6typ6h0.gz", cache=True)  # noqa
-
-    uc = cubeviz_helper.plugins['Unit Conversion']
-    uc.spectral_y_type = "Surface Brightness"
-
-    se = cubeviz_helper.plugins['Spectral Extraction']
-    se.function = "Mean"
-    se.extract()
-    extracted_max = cubeviz_helper.get_data("Spectrum (mean)").max()
-    assert_allclose(extracted_max.value, 5.566169e-18)
-    assert extracted_max.unit == u.Unit("erg / Angstrom s cm**2 pix**2")
-
-
-@pytest.mark.remote_data
-def test_manga_cube(cubeviz_helper):
-    # Remote data test of loading and extracting an up-to-date (as of 11/19/2024) MaNGA cube
     # This also tests that spaxel is converted to pix**2
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore")
@@ -263,7 +245,7 @@ def test_manga_cube(cubeviz_helper):
     se.function = "Mean"
     se.extract()
     extracted_max = cubeviz_helper.get_data("Spectrum (mean)").max()
-    assert_allclose(extracted_max.value, 2.836957E-18)
+    assert_allclose(extracted_max.value, 5.566169e-18)
     assert extracted_max.unit == u.Unit("erg / Angstrom s cm**2 pix**2")
 
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -217,7 +217,6 @@ def test_loading_with_mask(cubeviz_helper):
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore")
         cubeviz_helper.load_data(custom_spec)
-        #cubeviz_helper.load_data("https://stsci.box.com/shared/static/gts87zqt5265msuwi4w5u003b6typ6h0.gz", cache=True)  # noqa
 
     uc = cubeviz_helper.plugins['Unit Conversion']
     uc.spectral_y_type = "Surface Brightness"

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -208,6 +208,7 @@ def test_numpy_cube(cubeviz_helper):
     assert isinstance(data.coords, PaddedSpectrumWCS)
     assert flux.units == 'ct / pix2'
 
+
 @pytest.mark.remote_data
 def test_manga_cube(cubeviz_helper):
     # Remote data test of loading and extracting an up-to-date (as of 11/19/2024) MaNGA cube


### PR DESCRIPTION
Updates the value in the test from #3319 to be, I think, correct this time, and adds a simpler test that exposes the problem that I had with that test. I'm out of time to add a changelog, I'll do it tomorrow.