### PR TITLE
Backport PR #3358 on branch v4.0.x (Fix aperture weight mask with loaded mask cube)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,7 +29,7 @@ Cubeviz
 
 - Fixed initializing a Gaussian1D model component when ``Cube Fit`` is toggled on. [#3295]
 
-- Spectral extraction now correctly respects the loaded mask cube. [#3319]
+- Spectral extraction now correctly respects the loaded mask cube. [#3319, #3358]
 
 Imviz
 ^^^^^

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -207,8 +207,34 @@ def test_numpy_cube(cubeviz_helper):
     assert flux.units == 'ct'
 
 
+def test_loading_with_mask(cubeviz_helper):
+    # This also tests that spaxel is converted to pix**2
+    custom_spec = Spectrum1D(flux=[[[20, 1], [9, 1]], [[3, 1], [6, np.nan]]] * u.Unit("erg / Angstrom s cm**2 spaxel"),  # noqa
+                             spectral_axis=[1, 2]*u.AA,
+                             mask=[[[1, 0], [0, 0]], [[0, 0], [0, 0]]])
+    cubeviz_helper.load_data(custom_spec)
+
+    uc = cubeviz_helper.plugins['Unit Conversion']
+    uc.spectral_y_type = "Surface Brightness"
+
+    se = cubeviz_helper.plugins['Spectral Extraction']
+    se.function = "Mean"
+    se.extract()
+    extracted = cubeviz_helper.get_data("Spectrum (mean)")
+    assert_allclose(extracted.flux.value, [6, 1])
+    assert extracted.unit == u.Unit("erg / Angstrom s cm**2 pix**2")
+
+
 @pytest.mark.remote_data
-def test_manga_cube(cubeviz_helper):
+@pytest.mark.parametrize(
+    'function, expected_value,',
+    (
+        ('Mean', 5.566169e-18),
+        ('Sum', 1.553518e-14),
+        ('Max', 1e20),
+    )
+)
+def test_manga_with_mask(cubeviz_helper, function, expected_value):
     # Remote data test of loading and extracting an up-to-date (as of 11/19/2024) MaNGA cube
     # This also tests that spaxel is converted to pix**2
     with warnings.catch_warnings():
@@ -219,11 +245,14 @@ def test_manga_cube(cubeviz_helper):
     uc.spectral_y_type = "Surface Brightness"
 
     se = cubeviz_helper.plugins['Spectral Extraction']
-    se.function = "Mean"
+    se.function = function
     se.extract()
-    extracted_max = cubeviz_helper.get_data("Spectrum (mean)").max()
-    assert_allclose(extracted_max.value, 2.836957E-18, rtol=1E-5)
-    assert extracted_max.unit == u.Unit("erg / Angstrom s cm**2 pix**2")
+    extracted_max = cubeviz_helper.get_data(f"Spectrum ({function.lower()})").max()
+    assert_allclose(extracted_max.value, expected_value, rtol=5e-7)
+    if function == "Sum":
+        assert extracted_max.unit == u.Unit("erg / Angstrom s cm**2")
+    else:
+        assert extracted_max.unit == u.Unit("erg / Angstrom s cm**2 pix**2")
 
 
 def test_invalid_data_types(cubeviz_helper):

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -248,7 +248,7 @@ def test_manga_with_mask(cubeviz_helper, function, expected_value):
     se.function = function
     se.extract()
     extracted_max = cubeviz_helper.get_data(f"Spectrum ({function.lower()})").max()
-    assert_allclose(extracted_max.value, expected_value, rtol=5e-7)
+    assert_allclose(extracted_max.value, expected_value, rtol=5e-6)
     if function == "Sum":
         assert extracted_max.unit == u.Unit("erg / Angstrom s cm**2")
     else:


### PR DESCRIPTION
Manual backport of #3358.