### PR TITLE
BUG: Not all viewers have get_limits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,8 @@ Bug Fixes
   occured when certain flux-to flux-conversions occured, as well as certain conversions between flux and surface
   brightness. This PR also fixed an issue with unit string formatting in the aperture photometry plugin. [#3228]
 
+- Fixed broken histogram pan/zoom in Plot Options plugin. [#3361]
+
 Cubeviz
 ^^^^^^^
 - Removed the deprecated ``save as fits`` option from the Collapse, Moment Maps, and Spectral Extraction plugins; use the Export plugin instead. [#3256]

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -137,6 +137,15 @@ def test_stretch_histogram(cubeviz_helper, spectrum1d_cube_with_uncerts):
     assert po.stretch_histogram.marks['vmin'].x[0] == po.stretch_vmin.value
     assert po.stretch_histogram.marks['vmax'].x[0] == po.stretch_vmax.value
 
+    # Make sure some tools work
+
+    po_panzoom = po.stretch_histogram.toolbar.tools["jdaviz:panzoom"]
+    po_panzoom.activate()
+    po_panzoom.deactivate()
+
+    po_prevzoom = po.stretch_histogram.toolbar.tools["jdaviz:prevzoom"]
+    po_prevzoom.activate()
+
 
 @pytest.mark.filterwarnings('ignore')
 def test_user_api(cubeviz_helper, spectrum1d_cube):

--- a/jdaviz/core/tools.py
+++ b/jdaviz/core/tools.py
@@ -40,7 +40,10 @@ class _BaseZoomHistory:
     # Mixin for custom zoom tools to be able to save their previous zoom state
     # which is then used by the PrevZoom tool
     def save_prev_zoom(self):
-        self.viewer._prev_limits = self.viewer.get_limits()
+        # Cannot use viewer.get_limits() here because viewers from
+        # glue-jupyter does not have that method.
+        self.viewer._prev_limits = (self.viewer.state.x_min, self.viewer.state.x_max,
+                                    self.viewer.state.y_min, self.viewer.state.y_max)
 
 
 class _MatchedZoomMixin:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to fix broken pan/zoom on Plot Options histogram.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4997)
