### PR TITLE
Improve get_subsets performance for single subset case

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,9 @@
 New Features
 ------------
 
-* New design for viewer legend and data-menu. [#3220, #3254, #3263, #3264, #3271, #3272, #3274, #3289, #3310]
+- New design for viewer legend and data-menu. [#3220, #3254, #3263, #3264, #3271, #3272, #3274, #3289, #3310]
 
-* Improve performance while importing multiple regions. [#3321]
+- Improve performance while importing multiple regions. [#3321]
 
 Cubeviz
 ^^^^^^^
@@ -14,9 +14,9 @@ Cubeviz
 Imviz
 ^^^^^
 
-* Orientation plugin API now exposes create_north_up_east_left and create_north_up_east_right methods. [#3308]
+- Orientation plugin API now exposes create_north_up_east_left and create_north_up_east_right methods. [#3308]
 
-* Add Roman WFI and CGI footprints to the Footprints plugin. [#3322]
+- Add Roman WFI and CGI footprints to the Footprints plugin. [#3322]
 
 - Catalog Search plugin now exposes a maximum sources limit for all catalogs and resolves an edge case
   when loading a catalog from a file that only contains one source. [#3337]
@@ -86,8 +86,11 @@ Specviz2d
 
 Other Changes and Additions
 ---------------------------
+
 - Added a short description of each plugin in the side menu, visible before the plugin is opened. Removes redundant descriptions above link
   out to documentation when plugin is opened. Enable search on plugin description in addition to title. [#3268]
+
+- Improved performance of ``app.get_subsets`` for the single-subset case. [#3363]
 
 4.0.1 (2024-12-16)
 ==================

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -960,8 +960,7 @@ class Application(VuetifyTemplate, HubListener):
             if isinstance(subset_name, str):
                 subsets = [subset for subset in subsets if subset.label == subset_name]
                 if subsets == []:
-                    all_labels = [sg.label for sg in dc.subset_groups]
-                    all_labels.sort()
+                    all_labels = sorted(sg.label for sg in dc.subset_groups)
                     raise ValueError(f"{subset_name} not in {all_labels}")
             else:
                 raise ValueError("subset_name must be a string.")

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -958,14 +958,15 @@ class Application(VuetifyTemplate, HubListener):
         # If we only want one subset, no need to loop through them all
         if subset_name is not None:
             if isinstance(subset_name, str):
-                subset_name = subset_name.lower()
-                subsets = [subset for subset in subsets if subset.label.lower() == subset_name]
+                print(subsets)
+                subsets = [subset for subset in subsets if subset.label == subset_name]
+                print(f"Trimmed to {subsets}")
             else:
                 raise ValueError("subset_name must be a string.")
 
         for subset in subsets:
 
-            label = subset.label.lower()
+            label = subset.label
 
             if isinstance(subset.subset_state, CompositeSubsetState):
                 # Region composed of multiple ROI or Range subset

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -958,9 +958,7 @@ class Application(VuetifyTemplate, HubListener):
         # If we only want one subset, no need to loop through them all
         if subset_name is not None:
             if isinstance(subset_name, str):
-                print(subsets)
                 subsets = [subset for subset in subsets if subset.label == subset_name]
-                print(f"Trimmed to {subsets}")
             else:
                 raise ValueError("subset_name must be a string.")
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -959,6 +959,10 @@ class Application(VuetifyTemplate, HubListener):
         if subset_name is not None:
             if isinstance(subset_name, str):
                 subsets = [subset for subset in subsets if subset.label == subset_name]
+                if subsets == []:
+                    all_labels = [sg.label for sg in dc.subset_groups]
+                    all_labels.sort()
+                    raise ValueError(f"{subset_name} not in {all_labels}")
             else:
                 raise ValueError("subset_name must be a string.")
 
@@ -1027,10 +1031,8 @@ class Application(VuetifyTemplate, HubListener):
                 else:
                     all_subsets[label] = subset_region
 
-        if subset_name and subset_name in all_subsets:
+        if subset_name:
             return all_subsets[subset_name]
-        elif subset_name:
-            raise ValueError(f"{subset_name} not in {all_subsets.keys()}")
         else:
             return all_subsets
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -955,9 +955,17 @@ class Application(VuetifyTemplate, HubListener):
 
         all_subsets = {}
 
+        # If we only want one subset, no need to loop through them all
+        if subset_name is not None:
+            if isinstance(subset_name, str):
+                subset_name = subset_name.lower()
+                subsets = [subset for subset in subsets if subset.label.lower() == subset_name]
+            else:
+                raise ValueError("subset_name must be a string.")
+
         for subset in subsets:
 
-            label = subset.label
+            label = subset.label.lower()
 
             if isinstance(subset.subset_state, CompositeSubsetState):
                 # Region composed of multiple ROI or Range subset
@@ -1020,13 +1028,10 @@ class Application(VuetifyTemplate, HubListener):
                 else:
                     all_subsets[label] = subset_region
 
-        # can this be done at the top to avoid traversing all subsets if only
-        # one is requested?
-        all_subset_names = [subset.label for subset in dc.subset_groups]
-        if subset_name and subset_name in all_subset_names:
+        if subset_name and subset_name in all_subsets:
             return all_subsets[subset_name]
         elif subset_name:
-            raise ValueError(f"{subset_name} not in {all_subset_names}")
+            raise ValueError(f"{subset_name} not in {all_subsets.keys()}")
         else:
             return all_subsets
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -956,7 +956,7 @@ class Application(VuetifyTemplate, HubListener):
         all_subsets = {}
 
         # If we only want one subset, no need to loop through them all
-        if subset_name is not None:
+        if subset_name not in (None, ""):
             if isinstance(subset_name, str):
                 subsets = [subset for subset in subsets if subset.label == subset_name]
                 if subsets == []:


### PR DESCRIPTION
As previously noted in the deleted comment, there's no need to process every subset if only one subset was requested. This trims the list down to only the matching subset before going through the loop processing them all.