### PR TITLE
Fix type issue in plot options select_all

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,9 @@ Bug Fixes
 
 - Fixed broken histogram pan/zoom in Plot Options plugin. [#3361]
 
+- Fixed bug with Plot Options select_all when data is float32. [#3366]
+
+
 Cubeviz
 ^^^^^^^
 - Removed the deprecated ``save as fits`` option from the Collapse, Moment Maps, and Spectral Extraction plugins; use the Export plugin instead. [#3256]

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -431,3 +431,30 @@ def test_segmentation_image(imviz_helper):
     assert plot_opts.stretch_function.value == 'linear'
     assert plot_opts.image_bias.value == 0.5
     assert plot_opts.image_contrast.value == 1.0
+
+
+def test_imviz_select_all_layers(imviz_helper):
+    """
+    Test to catch a (fixed) bug that was revealed when trying to select
+    all layers when data is float32. This was caused when trying to set
+    `stretch_vmin_value`.
+    """
+
+    arr = np.arange(36.).reshape(6, 6).astype(np.float32)
+
+    # load three images in one viewer
+    with imviz_helper.batch_load():
+        for i in range(3):
+            imviz_helper.load_data(arr, data_label=f"data_{i}")
+
+    plot_options = imviz_helper.plugins['Plot Options']
+
+    plot_options.layer.multiselect = True
+    plot_options.select_all()
+
+    # all layers selected, set stretch function to log for all
+    plot_options.stretch_function = 'log'
+
+    # and make sure each layer picked up this change
+    for layer in plot_options.image_colormap.linked_states:
+        assert layer.as_dict()['stretch'] == 'log'

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -4413,10 +4413,8 @@ class PlotOptionsSyncState(BasePluginComponent):
             # unmixing something in mixed state and results in more consistent and predictable
             # behavior
             if len(current_glue_values) and current_glue_values[0] is not None:
-                self._processing_change_from_glue = True
-                self.value = self._on_glue_value_changed(current_glue_values[0],
-                                                         update_mixed_state=False)
-                self._processing_change_from_glue = False
+                self._on_glue_value_changed(current_glue_values[0],
+                                            update_mixed_state=False)
         self.sync = {**self.sync,
                      'mixed': mixed}
 


### PR DESCRIPTION
Fix a bug that came up when trying to select all layers in plot options when data is float32. The solution is to use the logic in on_glue_value_changed to handle updating mixed state, which takes care of the type issue.

(Need this fix for AAS demo notebook)