### PR TITLE
switch order of setting ymin and ymax

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,8 @@ Bug Fixes
 
 - Fixed bug with Plot Options select_all when data is float32. [#3366]
 
+- Fixed an issue with back-to-back calls of set_limits and get_limits. [#3371]
+
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -162,10 +162,13 @@ class JdavizViewerMixin(WithCache):
                 self.state.x_min = x_min
             if x_max is not None:
                 self.state.x_max = x_max
-            if y_min is not None:
-                self.state.y_min = y_min
+            # NOTE: for some reason, setting ymax first avoids an issue
+            # where back-to-back calls of get_limits and set_limits
+            # give different results for y limits.
             if y_max is not None:
                 self.state.y_max = y_max
+            if y_min is not None:
+                self.state.y_min = y_min
 
     def get_limits(self):
         """Return current viewer axes limits.

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -118,18 +118,3 @@ class TestDeleteData(BaseImviz_WCS_NoWCS):
         po.stretch_function = "Square Root"
         self.imviz.destroy_viewer("imviz-1")
         assert len(po.layer.choices) == 2
-
-
-def test_viewer_limits(imviz_helper):
-    """
-    Test that sequential calls to set_limits and get_limits return the same
-    viewer limits.
-    """
-    arr = np.ones((10, 10))
-    imviz_helper.load_data(arr, data_label='my_array')
-    viewer = imviz_helper.default_viewer._obj
-
-    # set limits then get limits and make sure they are the same
-    viewer.set_limits(x_min=0, x_max=5, y_min=0, y_max=5)
-    limits = viewer.get_limits()
-    assert limits == (0, 5, 0, 5)

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -130,6 +130,6 @@ def test_viewer_limits(imviz_helper):
     viewer = imviz_helper.default_viewer._obj
 
     # set limits then get limits and make sure they are the same
-    viewer.set_limits(x_min=0, x_max=20, y_min=0, y_max=20)
+    viewer.set_limits(x_min=0, x_max=5, y_min=0, y_max=5)
     limits = viewer.get_limits()
-    assert limits == (0, 20, 0, 20)
+    assert limits == (0, 5, 0, 5)

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -133,9 +133,3 @@ def test_viewer_limits(imviz_helper):
     viewer.set_limits(x_min=0, x_max=20, y_min=0, y_max=20)
     limits = viewer.get_limits()
     assert limits == (0, 20, 0, 20)
-
-    # calling get_limits again should also return the same original limits, but
-    # it doesn't, uncomment once JDAT-5050 is done
-    # get limits again, make sure they are the same.
-    # limits = viewer.get_limits()
-    # assert limits == (0, 20, 0, 20)

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -118,3 +118,24 @@ class TestDeleteData(BaseImviz_WCS_NoWCS):
         po.stretch_function = "Square Root"
         self.imviz.destroy_viewer("imviz-1")
         assert len(po.layer.choices) == 2
+
+
+def test_viewer_limits(imviz_helper):
+    """
+    Test that sequential calls to set_limits and get_limits return the same
+    viewer limits.
+    """
+    arr = np.ones((10, 10))
+    imviz_helper.load_data(arr, data_label='my_array')
+    viewer = imviz_helper.default_viewer._obj
+
+    # set limits then get limits and make sure they are the same
+    viewer.set_limits(x_min=0, x_max=20, y_min=0, y_max=20)
+    limits = viewer.get_limits()
+    assert limits == (0, 20, 0, 20)
+
+    # calling get_limits again should also return the same original limits, but
+    # it doesn't, uncomment once JDAT-5050 is done
+    # get limits again, make sure they are the same.
+    # limits = viewer.get_limits()
+    # assert limits == (0, 20, 0, 20)


### PR DESCRIPTION
This fixes an issue where back-to-back calls to set_limits and get_limits were producing different results for y limits. For example, 

`viewer.set_limits(x_min=0, x_max=20, y_min=0, y_max=20)`
`limits = viewer.get_limits()`
(0, 20.0, 3.855, 16.145).

For whatever reason, switching the order that ymin and ymax are set fixes this issue. I'm not sure if this entirely fixes the zoom/resize issue noted in #3369, but it resolves this round tripping that should work. There is still a deeper issue going on here.