### PR TITLE
UI-searchable API methods/attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ New Features
   methods to change active selection to all table items or clear all selected
   items without clearing the table. [#3381]
 
+- Plugin API methods and attributes are now searchable from the plugin tray (and visible when API hints are enabled). [#3384]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2848,6 +2848,7 @@ class Application(VuetifyTemplate, HubListener):
                 'name': name,
                 'label': tray_item_label,
                 'tray_item_description': tray_item_description,
+                'api_methods': tray_item_instance.api_methods,
                 'is_relevant': len(tray_item_instance.irrelevant_msg) == 0,
                 'widget': "IPY_MODEL_" + tray_item_instance.model_id
             })

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -128,6 +128,9 @@
                         <v-list-item-subtitle v-if="state.show_api_hints" style="white-space: normal; font-size: 8pt; padding-top: 4px; padding-bottom: 4px" class="api-hint">
                           <span class="api-hint" :style="state.tray_items_open.includes(index) ? 'font-weight: bold' : null">plg = {{  config }}.plugins['{{ trayItem.label }}']</span>
                         </v-list-item-subtitle>
+                        <v-list-item-subtitle v-if="state.show_api_hints && state.tray_items_filter.length" v-for="api_method in trayItemMethodMatch(trayItem, state.tray_items_filter)" style="white-space: normal; font-size: 8pt; padding-top: 4px; padding-bottom: 4px" class="api-hint">
+                          <span class="api-hint">plg.{{ api_method }}</span>
+                        </v-list-item-subtitle>
                         <v-list-item-subtitle style="white-space: normal; font-size: 8pt">
                           {{ trayItem.tray_item_description }}
                         </v-list-item-subtitle>
@@ -194,8 +197,17 @@ export default {
       if (tray_items_filter === null || tray_items_filter.length == 0) {
         return true
       }
-      // simple exact text search match on the plugin title for now.
-      return trayItem.label.toLowerCase().indexOf(tray_items_filter.toLowerCase()) !== -1 || trayItem.tray_item_description.toLowerCase().indexOf(tray_items_filter.toLowerCase()) !== -1
+      // simple exact text search match on the plugin title/description for now.
+      return trayItem.label.toLowerCase().includes(tray_items_filter.toLowerCase()) || trayItem.tray_item_description.toLowerCase().includes(tray_items_filter.toLowerCase()) || this.trayItemMethodMatch(trayItem, tray_items_filter).length > 0
+    },
+    trayItemMethodMatch(trayItem, tray_items_filter ) {
+      if (tray_items_filter === null) {
+        return []
+      }
+      if (tray_items_filter === '.') {
+        return trayItem.api_methods
+      }
+      return trayItem.api_methods.filter((item) => ("."+item.toLowerCase()).includes(tray_items_filter.toLowerCase()))
     },
     onLayoutChange() {
       /* Workaround for #1677, can be removed when bqplot/bqplot#1531 is released */

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -419,6 +419,7 @@ class PluginTemplateMixin(TemplateMixin):
     previews_temp_disabled = Bool(False).tag(sync=True)  # noqa use along-side @with_temp_disable() and <plugin-previews-temp-disabled :previews_temp_disabled.sync="previews_temp_disabled" :previews_last_time="previews_last_time" :show_live_preview.sync="show_live_preview"/>
     previews_last_time = Float(0).tag(sync=True)
     supports_auto_update = Bool(False).tag(sync=True)  # noqa whether this plugin supports auto-updating plugin results (requires __call__ method)
+    api_methods = List([]).tag(sync=True)  # noqa list of methods exposed to the user API, searchable
 
     def __init__(self, app, tray_instance=False, **kwargs):
         self._plugin_name = kwargs.pop('plugin_name', None)
@@ -464,6 +465,11 @@ class PluginTemplateMixin(TemplateMixin):
         self.supports_auto_update = hasattr(self, '__call__')
 
         super().__init__(app=app, **kwargs)
+
+        # set user-API methods
+        self.api_methods = sorted([attr
+                                   for attr in self.user_api.__dir__()
+                                   if attr not in ('open_in_tray', 'show', 'api_hints_enabled', 'close_in_tray')])
 
     def new(self):
         new = self.__class__(app=self.app)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -468,7 +468,11 @@ class PluginTemplateMixin(TemplateMixin):
         super().__init__(app=app, **kwargs)
 
         # set user-API methods
-        self.api_methods = sorted([name+"()" if type(obj).__name__ == 'method' else name
+        def get_api_text(name, obj):
+            if type(obj).__name__ == 'method':
+                return f"{name}{inspect.signature(obj)}"
+            return name
+        self.api_methods = sorted([get_api_text(name, obj)
                                    for name, obj in inspect.getmembers(self.user_api)])
 
     def new(self):

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -6,6 +6,7 @@ import astropy.units as u
 import bqplot
 from contextlib import contextmanager
 import numpy as np
+import inspect
 import logging
 import os
 import threading
@@ -467,9 +468,8 @@ class PluginTemplateMixin(TemplateMixin):
         super().__init__(app=app, **kwargs)
 
         # set user-API methods
-        self.api_methods = sorted([attr
-                                   for attr in self.user_api.__dir__()
-                                   if attr not in ('open_in_tray', 'show', 'api_hints_enabled', 'close_in_tray')])
+        self.api_methods = sorted([name+"()" if type(obj).__name__ == 'method' else name
+                                   for name, obj in inspect.getmembers(self.user_api)])
 
     def new(self):
         new = self.__class__(app=self.app)

--- a/jdaviz/main_styles.vue
+++ b/jdaviz/main_styles.vue
@@ -59,6 +59,15 @@ div.output_wrapper {
   padding: 0px;
 }
 
+.plugin-header {
+  /* ensure dropdown arrow aligns to the top for tall headers */
+  align-items: start !important;
+}
+
+.plugin-header .v-expansion-panel-header__icon {
+  margin-top: 4px;
+}
+
 .plugin-expansion-panel-content .row {
   /* override -12px margins */
   margin-left: 0px;


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements plugin-tray filtering of plugins by their exposed methods/attributes.  (Note that this also helps expose to us places where we expose args/kwargs that probably shouldn't be exposed and should work to clean those up [:cat:](https://jira.stsci.edu/browse/JDAT-5070))

https://github.com/user-attachments/assets/f670eeba-10cf-473d-923c-3ff944d6998b


Note that currently this filtering still happens when API hints are off (so "Plot Options" still appears for a search of "RGB"), but that could easily be changed if preferred.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
