### PR TITLE
orientation: remove deprecated link_type, wcs_use_affine

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Orientation plugin: ``link_type`` and ``wcs_use_affine`` (previously deprecated) have now been removed. [#3385]
+
 Mosviz
 ^^^^^^
 

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -202,7 +202,7 @@ From the API within the Jupyter notebook (if linking by WCS):
 
 .. code-block:: python
 
-    imviz.link_data(link_type='wcs')
+    imviz.link_data(align_by='wcs')
 
 .. _imviz-orientation-rotation:
 

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -1,5 +1,4 @@
 from astropy import units as u
-from astropy.utils import deprecated
 from astropy.wcs.wcsapi import BaseHighLevelWCS
 from glue.core.link_helpers import LinkSame
 from glue.core.message import (
@@ -152,32 +151,12 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         return PluginUserApi(
             self,
             expose=(
-                'align_by', 'link_type', 'wcs_fast_approximation', 'wcs_use_affine',
+                'align_by', 'wcs_fast_approximation',
                 'delete_subsets', 'viewer', 'orientation',
                 'rotation_angle', 'east_left', 'add_orientation',
                 'set_north_up_east_left', 'set_north_up_east_right',
             )
         )
-
-    @property
-    @deprecated(since="4.0", alternative="align_by")
-    def link_type(self):
-        return self.align_by
-
-    @link_type.setter
-    @deprecated(since="4.0", alternative="align_by")
-    def link_type(self, link_type):
-        self.align_by = link_type
-
-    @property
-    @deprecated(since="4.0", alternative="wcs_fast_approximation")
-    def wcs_use_affine(self):
-        return self.wcs_fast_approximation
-
-    @wcs_use_affine.setter
-    @deprecated(since="4.0", alternative="wcs_fast_approximation")
-    def wcs_use_affine(self, wcs_use_affine):
-        self.wcs_fast_approximation = wcs_use_affine
 
     def _link_image_data(self):
         self.linking_in_progress = True

--- a/jdaviz/configs/imviz/tests/test_helper.py
+++ b/jdaviz/configs/imviz/tests/test_helper.py
@@ -1,9 +1,6 @@
 import numpy as np
-import pytest
 
 
-@pytest.mark.filterwarnings(r"ignore:The link_type function is deprecated")
-@pytest.mark.filterwarnings(r"ignore:The wcs_use_affine function is deprecated")
 def test_plugin_user_apis(imviz_helper):
     for plugin_name, plugin_api in imviz_helper.plugins.items():
         plugin = plugin_api._obj

--- a/notebooks/ImvizDitheredExample.ipynb
+++ b/notebooks/ImvizDitheredExample.ipynb
@@ -568,7 +568,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imviz.link_data(link_type='wcs')"
+    "imviz.link_data(align_by='wcs')"
    ]
   },
   {


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request removes `link_type` and `wcs_use_affine` from the user APIs in the orientation plugin (Imviz) for the 4.2 release (deprecated since 4.0).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
