### PR TITLE
TST: Update result for test_data_quality_plugin

### DIFF
--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -139,7 +139,7 @@ def test_data_quality_plugin(imviz_helper, tmp_path):
 
     # check that the decomposed DQ flag is at the end of the flux label's line:
     flux_label_idx = label_mouseover_text.index(expected_flux_label)
-    assert label_mouseover_text[flux_label_idx + len(expected_flux_label) + 1:] == '(DQ: 1)'
+    assert label_mouseover_text[flux_label_idx + len(expected_flux_label) + 1:] == '(DQ: 3)'
 
     # check that a flagged pixel that is not marked with the bit 0 has a flux in mouseover label:
     label_mouseover._viewer_mouse_event(viewer,


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

The data label has changed from `(DQ: 1)` to `(DQ: 3)`. Since I don't have an older copy of the MAST image that @bmorris3 used to make that test, I am not sure why. The new label seems in line with existing parser logic in that it uses EXTNUM instead of EXTVER to make the label, so not sure why it was 1 before.

Goal is to fix the test so it does not block unrelated PRs. I am not sure if you want me to refactor the DQ parser.

```
Filename: jw01895001004_07101_00001_nrca3_cal.fits
No.    Name      Ver    Type      Cards   Dimensions   Format
  0  PRIMARY       1 PrimaryHDU     347   ()
  1  SCI           1 ImageHDU       156   (2048, 2048)   float32
  2  ERR           1 ImageHDU        10   (2048, 2048)   float32
  3  DQ            1 ImageHDU        11   (2048, 2048)   int32 (rescales to uint32)
  4  AREA          1 ImageHDU         9   (2048, 2048)   float32
  5  VAR_POISSON    1 ImageHDU         9   (2048, 2048)   float32
  6  VAR_RNOISE    1 ImageHDU         9   (2048, 2048)   float32
  7  VAR_FLAT      1 ImageHDU         9   (2048, 2048)   float32
  8  ASDF          1 BinTableHDU     11   1R x 1C   [27021B]
```

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [x] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
