### PR TITLE
fix json unit error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,8 @@ Mosviz
 Specviz
 ^^^^^^^
 
+- Fixed traceback in model fitting due to units not being represented as strings. [#3412]
+
 Specviz2d
 ^^^^^^^^^
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -118,7 +118,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._units = {}
+        self._units = {}  # string representation of display units
         self._fitted_model = None
         self._fitted_spectrum = None
         self._fitted_models = {}
@@ -325,11 +325,11 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         sb_unit = self.app._get_display_unit('sb')
         spectral_y_unit = self.app._get_display_unit('spectral_y')
         if event.get('new'):
-            self._units['y'] = sb_unit
+            self._units['y'] = str(sb_unit)
             self.dataset.add_filter('is_flux_cube')
             self.dataset.remove_filter('layer_in_spectrum_viewer')
         else:
-            self._units['y'] = spectral_y_unit
+            self._units['y'] = str(spectral_y_unit)
             self.dataset.add_filter('layer_in_spectrum_viewer')
             self.dataset.remove_filter('is_flux_cube')
 
@@ -483,12 +483,12 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         # Need to set the units the first time we initialize a model component, after this
         # we listen for display unit changes
         if self._units.get('x', '') == '':
-            self._units['x'] = self.app._get_display_unit('spectral')
+            self._units['x'] = str(self.app._get_display_unit('spectral'))
         if self._units.get('y', '') == '':
             if self.cube_fit:
-                self._units['y'] = self.app._get_display_unit('sb')
+                self._units['y'] = str(self.app._get_display_unit('sb'))
             else:
-                self._units['y'] = self.app._get_display_unit('spectral_y')
+                self._units['y'] = str(self.app._get_display_unit('spectral_y'))
 
         if model_comp == "Polynomial1D":
             # self.poly_order is the value in the widget for creating


### PR DESCRIPTION
Fixes a traceback in model fitting by forcing all items in model_fitting._units to be strings. They were previously a mix of unit/string types.

(Note: The nicer fix would be to standardize the output type from app._get_display_unit - it returns a mix of Unit, string, and None types for now. I went down this path but ran into issues and since this is a small ticket, it will need to be addressed in a follow up. When this is done, we can clean up model fitting and other plugins by removing casting to/from Unit/str since we will always know the return type of _get_display_unit. For now, forcing to string fixes the traceback.)


