### PR TITLE
FEAT: Catalog Search plugin to support import catalog from Table/QTable object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ Cubeviz
 Imviz
 ^^^^^
 
-- Catalog Search now supports importing Astropy table object via ``import_catalog`` method. [#3424]
+- Catalog Search now supports importing Astropy table object via ``import_catalog`` method. [#3425]
 
 - Enhance the Catalog Search plugin to support additional columns when loading catalog data from files. [#3359]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,8 +23,10 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Catalog Search now supports importing Astropy table object via ``import_catalog`` method. [#3424]
+
 - Enhance the Catalog Search plugin to support additional columns when loading catalog data from files. [#3359]
-  
+
 - Catalog Search ``clear_table`` now removes all associated markers from the viewer. [#3359]
 
 Mosviz

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -379,7 +379,7 @@ catalog dropdown menu.
     the Gaia catalog and works best when you only have a single image loaded in a viewer.
 
 To load a catalog from a supported `JWST ECSV catalog file <https://jwst-pipeline.readthedocs.io/en/latest/jwst/source_catalog/main.html#output-products>`_, choose "From File...".
-The file must be able to be parsed by :meth:`astropy.table.Table.read` and contains the following columns:
+The file must be able to be parsed by `astropy.table.Table.read` and contains the following columns:
 
 * ``'sky_centroid'``: Column with `~astropy.coordinates.SkyCoord` sky coordinates of the sources.
 * ``'label'``: (Optional) Column with string identifiers of the sources.

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -379,12 +379,18 @@ catalog dropdown menu.
     the Gaia catalog and works best when you only have a single image loaded in a viewer.
 
 To load a catalog from a supported `JWST ECSV catalog file <https://jwst-pipeline.readthedocs.io/en/latest/jwst/source_catalog/main.html#output-products>`_, choose "From File...".
-The file must be able to be parsed by `astropy.table.Table.read` and contains the following columns:
+The file must be able to be parsed by :meth:`astropy.table.Table.read` and contains the following columns:
 
 * ``'sky_centroid'``: Column with `~astropy.coordinates.SkyCoord` sky coordinates of the sources.
 * ``'label'``: (Optional) Column with string identifiers of the sources.
   If not provided, unique string identifiers will be generated automatically.
   If you have numerical identifiers, they will be recast as strings.
+
+Alternately, if you already have the table object, you could load it in directly via API:
+
+.. code-block:: python
+
+    imviz.plugins["Catalog Search"].import_catalog(table_object)
 
 Clicking :guilabel:`SEARCH` will show markers for any entry within the filtered zoom window.
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to add support for Catalog Search plugin to import table directly from existing Table/QTable object. To do this, we expose a new public API called `import_catalog`.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-5073)
