### PR TITLE
MNT: Bump photutils minversion to 1.12.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,8 @@ Specviz2d
 Other Changes and Additions
 ---------------------------
 
+- Bumped minimum version of ``photutils`` to v1.12.1. [#3432]
+
 4.1.2 (unreleased)
 ==================
 

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -17,7 +17,6 @@ from jdaviz.configs.imviz.plugins.aper_phot_simple.aper_phot_simple import (
     _curve_of_growth, _radial_profile)
 from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_WCS, BaseImviz_WCS_NoWCS
 from jdaviz.core.custom_units_and_equivs import PIX2
-from jdaviz.tests.test_utils import PHOTUTILS_LT_1_12_1
 
 
 class TestSimpleAperPhot(BaseImviz_WCS_WCS):
@@ -338,17 +337,10 @@ class TestAdvancedAperPhot:
 def test_annulus_background(imviz_helper):
     gauss4 = make_4gaussians_image()  # The background has a mean of 5 with noise
     ones = np.ones(gauss4.shape)
-
-    if PHOTUTILS_LT_1_12_1:
-        bg_4gauss_1 = 5.745596129482831
-        bg_4gauss_2 = 5.13918435824334
-        bg_4gauss_3 = 44.72559981461203
-        bg_4gauss_4 = 4.89189
-    else:
-        bg_4gauss_1 = 5.802287
-        bg_4gauss_2 = 5.052332
-        bg_4gauss_3 = 45.416834
-        bg_4gauss_4 = 4.939397
+    bg_4gauss_1 = 5.802287
+    bg_4gauss_2 = 5.052332
+    bg_4gauss_3 = 45.416834
+    bg_4gauss_4 = 4.939397
 
     imviz_helper.load_data(gauss4, data_label='four_gaussians')
     imviz_helper.load_data(ones, data_label='ones')

--- a/jdaviz/core/tests/test_tools.py
+++ b/jdaviz/core/tests/test_tools.py
@@ -7,8 +7,6 @@ from numpy.testing import assert_allclose
 from photutils.datasets import make_4gaussians_image
 from specutils import Spectrum1D
 
-from jdaviz.tests.test_utils import PHOTUTILS_LT_1_12_1
-
 
 def test_boxzoom(cubeviz_helper, image_cube_hdu_obj_microns):
     cubeviz_helper.load_data(image_cube_hdu_obj_microns, data_label="Test Flux")
@@ -100,15 +98,9 @@ def test_stretch_bounds_and_spline(imviz_helper):
             "domain": {"x": 11.639166666374734, "y": 970.9392968750001},
         }
 
-        if PHOTUTILS_LT_1_12_1:
-            knots_after_drag_move = (
-                [0.0, 0.1, 0.21712585033417825, 0.7, 1.0],
-                [0.0, 0.05, 0.2852214046563617, 0.9, 1.0],
-            )
-        else:
-            knots_after_drag_move = (
-                [0.0, 0.1, 0.21712585033417825, 0.7, 1.0],
-                [0.0, 0.05, 0.2698132855572785, 0.9, 1.0])
+        knots_after_drag_move = (
+            [0.0, 0.1, 0.21712585033417825, 0.7, 1.0],
+            [0.0, 0.05, 0.2698132855572785, 0.9, 1.0])
 
         stretch_tool.on_mouse_event(knot_move_msg)
 

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -1,11 +1,9 @@
 import os
 import warnings
 
-import photutils
 import pytest
 from asdf.exceptions import AsdfWarning
 from astropy import units as u
-from astropy.utils import minversion
 from astropy.wcs import FITSFixedWarning
 from numpy.testing import assert_allclose
 from specutils import Spectrum1D
@@ -13,8 +11,6 @@ from specutils import Spectrum1D
 from jdaviz.core.custom_units_and_equivs import PIX2
 from jdaviz.utils import (alpha_index, download_uri_to_path, flux_conversion,
                           _indirect_conversion, _eqv_pixar_sr)
-
-PHOTUTILS_LT_1_12_1 = not minversion(photutils, "1.12.1.dev")
 
 
 def test_spec_sb_flux_conversion():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pyyaml>=5.4.1",
     "specutils>=1.18",
     "specreduce>=1.4.1",
-    "photutils>=1.4",
+    "photutils>=1.12.1",
     "glue-astronomy>=0.10",
     "asteval>=0.9.23",
     "idna",


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

photutils is at v2.1 now. By bumping the minversion to 1.12.1, we can simplify some tests.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-5132)
