### PR TITLE
set spectral subset visibility to false in cube image viewers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -106,6 +106,9 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Hide spectral subset layer visibility in flux/uncertainty viewers when slice indicator 
+  is within the spectral subset bounds. [#3437]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -237,7 +237,7 @@ class JdavizViewerMixin(WithCache):
             layer_state.add_callback('as_steps', self._show_uncertainty_changed)
 
     def _expected_subset_layer_default(self, layer_state):
-        if self.__class__.__name__ in ('CubevizImageView', 'RampvizImageView'):
+        if self.__class__.__name__ == 'RampvizImageView':
             # Do not override default for subsets as for some reason
             # this isn't getting called when they're first added, but rather when
             # the next state change is made (for example: manually changing the visibility)
@@ -246,6 +246,10 @@ class JdavizViewerMixin(WithCache):
         # default visibility based on the visibility of the "parent" data layer
         if self.__class__.__name__ == 'RampvizProfileView':
             # Rampviz doesn't show subset profiles by default:
+            layer_state.visible = False
+        elif (self.__class__.__name__ == 'CubevizImageView' and
+              get_subset_type(layer_state.layer) != 'spatial'):
+            # set visibility of spectral subsets to false in Cubeviz image-viewers
             layer_state.visible = False
         else:
             layer_state.visible = self._get_layer(layer_state.layer.data.label).visible


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address hiding spectral subset overlays in Cubeviz image-viewers when the slice tool indicator is within the subset bounds of said subset (in the spectrum-viewer).


https://github.com/user-attachments/assets/8c20e5e1-54bf-4d86-a6c3-d1c53fcb6a3c



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
