### PR TITLE
Debugging Mac standalone again...again...again...(echo...)

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -103,7 +103,7 @@ jobs:
     # osx signing based on https://melatonin.dev/blog/how-to-code-sign-and-notarize-macos-audio-plugins-in-ci/
     - name: Import Certificates (macOS)
       uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d  # v3
-      if: ${{ matrix.os == 'macos' }}
+      if: ${{ matrix.os == 'macos-14' }}
       with:
         p12-file-base64: ${{ secrets.DEV_ID_APP_CERT }}
         p12-password: ${{ secrets.DEV_ID_APP_PASSWORD }}


### PR DESCRIPTION
Looks like the Certification import step got skipped, is this because matrix.os is `macos-14` and we're checking for exactly `macos`?