### PR TITLE
MNT: Compat with photutils 2.2.0

### DIFF
--- a/jdaviz/core/tests/test_region_translators.py
+++ b/jdaviz/core/tests/test_region_translators.py
@@ -15,7 +15,7 @@ from regions import (CirclePixelRegion, EllipsePixelRegion, RectanglePixelRegion
                      RectangleAnnulusPixelRegion, PolygonPixelRegion, PixCoord)
 
 from jdaviz.core.region_translators import (
-    regions2roi, regions2aperture, aperture2regions)
+    regions2roi, regions2aperture, aperture2regions, PHOTUTILS_LT_2_2)
 
 
 # TODO: Use proper method from upstream when that is available.
@@ -86,7 +86,10 @@ def test_translation_ellipse(image_2d_wcs):
     assert_allclose(aperture.positions, region_shape.center.xy)
     assert_allclose(aperture.a * 2, region_shape.width)
     assert_allclose(aperture.b * 2, region_shape.height)
-    assert_allclose(aperture.theta, region_shape.angle.radian)
+    if PHOTUTILS_LT_2_2:
+        assert_allclose(aperture.theta, region_shape.angle.radian)
+    else:
+        assert_quantity_allclose(aperture.theta, region_shape.angle)
 
     region_sky = region_shape.to_sky(image_2d_wcs)
     aperture_sky = regions2aperture(region_sky)
@@ -139,7 +142,10 @@ def test_translation_rectangle(image_2d_wcs):
     assert_allclose(aperture.positions, region_shape.center.xy)
     assert_allclose(aperture.w, region_shape.width)
     assert_allclose(aperture.h, region_shape.height)
-    assert_allclose(aperture.theta, region_shape.angle.radian)
+    if PHOTUTILS_LT_2_2:
+        assert_allclose(aperture.theta, region_shape.angle.radian)
+    else:
+        assert_quantity_allclose(aperture.theta, region_shape.angle)
 
     region_sky = region_shape.to_sky(image_2d_wcs)
     aperture_sky = regions2aperture(region_sky)
@@ -228,7 +234,10 @@ def test_translation_ellipse_annulus(image_2d_wcs):
     assert_allclose(aperture.a_out * 2, region_shape.outer_width)
     assert_allclose(aperture.b_in * 2, region_shape.inner_height)
     assert_allclose(aperture.b_out * 2, region_shape.outer_height)
-    assert_allclose(aperture.theta, region_shape.angle.radian)
+    if PHOTUTILS_LT_2_2:
+        assert_allclose(aperture.theta, region_shape.angle.radian)
+    else:
+        assert_quantity_allclose(aperture.theta, region_shape.angle)
 
     region_sky = region_shape.to_sky(image_2d_wcs)
     aperture_sky = regions2aperture(region_sky)
@@ -283,7 +292,10 @@ def test_translation_rectangle_annulus(image_2d_wcs):
     assert_allclose(aperture.w_out, region_shape.outer_width)
     assert_allclose(aperture.h_in, region_shape.inner_height)
     assert_allclose(aperture.h_out, region_shape.outer_height)
-    assert_allclose(aperture.theta, region_shape.angle.radian)
+    if PHOTUTILS_LT_2_2:
+        assert_allclose(aperture.theta, region_shape.angle.radian)
+    else:
+        assert_quantity_allclose(aperture.theta, region_shape.angle)
 
     region_sky = region_shape.to_sky(image_2d_wcs)
     aperture_sky = regions2aperture(region_sky)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address compatibility with unreleased photutils 2.2.0 as a result of:

* https://github.com/astropy/photutils/pull/2008

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-5147)
