### PR TITLE
Model Fitting: Prevent non-finite data from polluting initial guess

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -134,6 +134,8 @@ Specviz2d
 
 - Fixes missing API entry for spectral extraction's export_bg_spectrum.  [#3447]
 
+- Fixed linking in fitted model to link to 1D spectrum instead of 2D. [#3450]
+
 4.1.1 (2025-01-31)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -108,6 +108,8 @@ Bug Fixes
 
 - Fix showing dataset dropdown in cubeviz's spectral extraction for flux-cube products from other plugins. [#3411]
 
+- Model Fitting: Prevent non-finite data from producing NaNs as initial guesses for some models. [#3450]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -737,12 +737,15 @@ class Application(VuetifyTemplate, HubListener):
 
         dc = self.data_collection
         # This will need to be changed for cubeviz to support multiple cubes
+        linked_data = dc[data_to_be_linked] if data_to_be_linked else dc[-1]
         default_refdata_index = 0
-        if self.config == 'mosviz':
-            # In Mosviz, first data is always MOS Table. Use the next data
+        if (self.config == 'mosviz' or
+                (self.config == "specviz2d" and
+                 linked_data.meta.get("Plugin", "") == "Model Fitting")):
+            # In Mosviz, first data is always MOS Table. Use the next data.
+            # In Specviz2d, always link model fit to derived 1D Spectrum, not input 2D spectrum.
             default_refdata_index = 1
         ref_data = dc[reference_data] if reference_data else dc[default_refdata_index]
-        linked_data = dc[data_to_be_linked] if data_to_be_linked else dc[-1]
 
         if 'Trace' in linked_data.meta:
             links = [LinkSame(linked_data.components[1], ref_data.components[0]),

--- a/jdaviz/configs/default/plugins/model_fitting/initializers.py
+++ b/jdaviz/configs/default/plugins/model_fitting/initializers.py
@@ -81,7 +81,8 @@ class _Linear1DInitializer:
             # For cube fitting, need to collapse before this calculation
             y = np.nanmean(y, axis=(0, 1))
         i_good = np.isfinite(y)
-        slope, intercept = np.polynomial.Polynomial.fit(x.value[i_good].flatten(), y.value[i_good].flatten(), 1)
+        slope, intercept = np.polynomial.Polynomial.fit(
+            x.value[i_good].flatten(), y.value[i_good].flatten(), 1)
 
         instance.slope.value = slope
         instance.intercept.value = intercept

--- a/jdaviz/configs/default/plugins/model_fitting/initializers.py
+++ b/jdaviz/configs/default/plugins/model_fitting/initializers.py
@@ -80,7 +80,8 @@ class _Linear1DInitializer(object):
         if y.ndim == 3:
             # For cube fitting, need to collapse before this calculation
             y = np.nanmean(y, axis=(0, 1))
-        slope, intercept = np.polynomial.Polynomial.fit(x.value.flatten(), y.value.flatten(), 1)
+        i_good = np.isfinite(y)
+        slope, intercept = np.polynomial.Polynomial.fit(x.value[i_good].flatten(), y.value[i_good].flatten(), 1)
 
         instance.slope.value = slope
         instance.intercept.value = intercept
@@ -191,6 +192,10 @@ class _LineProfile1DInitializer(object):
         if y.ndim == 3:
             # For cube fitting, need to collapse before these calculations
             y = np.nanmean(y, axis=(0, 1))
+        else:
+            i_good = np.isfinite(y)
+            x = x[i_good]
+            y = y[i_good]
 
         # X centroid estimates the position
         centroid = np.sum(x * y) / np.sum(y)

--- a/jdaviz/configs/default/plugins/model_fitting/initializers.py
+++ b/jdaviz/configs/default/plugins/model_fitting/initializers.py
@@ -50,7 +50,7 @@ def _get_model_name(model):
     return class_string.split('\'>')[0].split(".")[-1]
 
 
-class _Linear1DInitializer(object):
+class _Linear1DInitializer:
     """
     Initialization that is specific to the Linear1D model.
 
@@ -89,7 +89,7 @@ class _Linear1DInitializer(object):
         return instance
 
 
-class _WideBand1DInitializer(object):
+class _WideBand1DInitializer:
     """
     Initialization that is applicable to all "wide band"
     models
@@ -135,7 +135,7 @@ class _WideBand1DInitializer(object):
         return instance
 
 
-class _LineProfile1DInitializer(object):
+class _LineProfile1DInitializer:
     """
     Initialization that is applicable to all "line profile"
     models.

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -547,3 +547,21 @@ def test_cube_fit_after_unit_change(cubeviz_helper, solid_angle_unit):
 
     model_flux = cubeviz_helper.app.data_collection[-1].get_component('flux')
     assert model_flux.units == expected_unit_string
+
+
+def test_fit_spec2d(specviz2d_helper, spectrum2d):
+    specviz2d_helper.load_data(spectrum2d)
+    assert len(specviz2d_helper.app.data_collection) == 2  # 1D is extracted
+
+    mf = specviz2d_helper.plugins['Model Fitting']
+    mf.create_model_component('Const1D')
+    assert mf.equation == 'C'
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', message='Model is linear in parameters.*')
+        mf.calculate_fit()
+
+    assert len(specviz2d_helper.app.data_collection) == 3  # model is created
+
+    elink = specviz2d_helper.app.data_collection.external_links[-1]
+    assert elink.data1.label == "Spectrum 1D" and elink.data2.label == "model", (elink.data1.label, elink.data2.label)  # noqa: E501


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to prevent non-finite input data from causing NaN in model fitting some initial guesses.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-5120)
