### PR TITLE
Improve performance of orientation rerendering

### DIFF
--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -236,8 +236,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         if self.align_by.selected == 'Pixels':
             self.wcs_fast_approximation = True
 
-        self.linking_in_progress = False
         self._link_image_data()
+        # NOTE: _link_image_data will reset linking_in_progress to False
 
         # load data into the viewer that are now compatible with the
         # new link type, remove data from the viewer that are now
@@ -417,6 +417,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         viewers_to_update = kwargs.get(
             'viewers_to_update', self.app._viewer_store.keys()
         )
+        # this is an ugly way to do this - let's see if we can avoid setting internal traitlets
+        # and instead modify the viewer selection from the new data menu
         for viewer_ref in viewers_to_update:
             self.viewer.selected = viewer_ref
             self.orientation.update_wcs_only_filter(wcs_only=self.align_by_selected == 'WCS')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request attempts to improve viewer rendering performance while changing orientation.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
