### PR TITLE
Cleanup plugin apis

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,11 @@ API Changes
 - ``jdaviz.test()`` is no longer available. Use ``pytest --pyargs jdaviz <options>``
   directly if you wish to test your copy of ``jdaviz``. [#3451]
 
+- ``**kwargs`` from ``viz.plugins['Subset Tools'].import_region(..., **kwargs)`` is removed, ``region_format=None``
+  is now explicitly supported. [#3453]
+
+- ``viz.plugins['Subset Tools'].set_center()`` now always updates the subset (removing the optional ``update`` keyword argument that defaulted to ``False``). [#3453]
+
 Cubeviz
 ^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,8 +51,6 @@ API Changes
 - ``**kwargs`` from ``viz.plugins['Subset Tools'].import_region(..., **kwargs)`` is removed, ``region_format=None``
   is now explicitly supported. [#3453]
 
-- ``viz.plugins['Subset Tools'].set_center()`` now always updates the subset (removing the optional ``update`` keyword argument that defaulted to ``False``). [#3453]
-
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -852,7 +852,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
         return selected_models
 
-    def get_model_parameters(self, models=None, model_label=None, x=None, y=None):
+    def _get_model_parameters(self, models=None, model_label=None, x=None, y=None):
         """
         Convert each parameter of model inside models into a coordinate that
         maps the model name and parameter name to a `astropy.units.Quantity`
@@ -986,6 +986,35 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
                     param_units[key].get(param_name, None))
 
         return parameters_cube
+
+    def get_model_parameters(self, model_label=None, x=None, y=None):
+        """
+        Convert each parameter of model inside models into a coordinate that
+        maps the model name and parameter name to a `astropy.units.Quantity`
+        object.
+
+        Parameters
+        ----------
+        model_label : str
+            Get model parameters for a particular model by inputting its label.
+        x : int
+            The x coordinate of the model spaxels that will be returned from
+            get_models.
+        y : int
+            The y coordinate of the model spaxels that will be returned from
+            get_models.
+
+        Returns
+        -------
+        :dict: a dictionary of the form
+            {model name: {parameter name: [[`astropy.units.Quantity`]]}}
+            for 3d models or
+            {model name: {parameter name: `astropy.units.Quantity`}} where the
+            Quantity object represents the parameter value and unit of one of
+            spaxel models or the 1d models, respectively.
+        """
+        return self._get_model_parameters(models=None, model_label=model_label,
+                                          x=x, y=y)
 
     def vue_add_model(self, event):
         self.create_model_component()

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -716,12 +716,12 @@ class SubsetTools(PluginTemplateMixin):
                 if not np.all(np.isfinite((x, y))):
                     raise ValueError(f'Invalid centroid ({x}, {y})')
             except Exception as err:
-                self._set_center(self.get_center(subset_name=subset), subset_name=subset,
-                                 update=False)
+                self.set_center(self.get_center(subset_name=subset), subset_name=subset,
+                                update=False)
                 self.hub.broadcast(SnackbarMessage(
                     f"Failed to calculate centroid: {repr(err)}", color='error', sender=self))
             else:
-                self._set_center((x, y), subset_name=subset, update=True)
+                self.set_center((x, y), subset_name=subset, update=True)
 
         if not self.multiselect:
             _do_recentering(self.subset_selected, self.subset.selected_subset_state)
@@ -774,7 +774,7 @@ class SubsetTools(PluginTemplateMixin):
         subset_state = self._get_subset_state(subset_name)
         return subset_state.center()
 
-    def _set_center(self, new_cen, subset_name=None, update=False):
+    def set_center(self, new_cen, subset_name=None, update=False):
         """Set the desired center for the selected Subset, if applicable.
         If Subset is not centerable, nothing is done.
 
@@ -829,26 +829,6 @@ class SubsetTools(PluginTemplateMixin):
             tmp = self.subset_definitions
             self.subset_definitions = []
             self.subset_definitions = tmp
-
-    def set_center(self, new_cen, subset_name=None):
-        """Set the desired center for the selected Subset, if applicable.
-        If Subset is not centerable, nothing is done.
-
-        Parameters
-        ----------
-        new_cen : number or tuple of numbers
-            The new center defined either as ``x`` or ``(x, y)``,
-            depending on the Subset type.
-        subset_name : str
-            The name of the subset that is being updated.
-
-        Raises
-        ------
-        NotImplementedError
-            Subset type is not supported.
-
-        """
-        return self._set_center(new_cen, subset_name, update=True)
 
     # List of JSON-like dict is nice for front-end but a pain to look up,
     # so we use these helper functions.

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -774,7 +774,6 @@ class SubsetTools(PluginTemplateMixin):
         subset_state = self._get_subset_state(subset_name)
         return subset_state.center()
 
-
     def _set_center(self, new_cen, subset_name=None, update=False):
         """Set the desired center for the selected Subset, if applicable.
         If Subset is not centerable, nothing is done.

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -892,7 +892,7 @@ class SubsetTools(PluginTemplateMixin):
         self._sync_available_from_state()
 
     def import_region(self, region, combination_mode=None, max_num_regions=None,
-                      refdata_label=None, return_bad_regions=False, **kwargs):
+                      refdata_label=None, return_bad_regions=False, region_format=None):
         """
         Method for creating subsets from regions or region files.
 
@@ -931,6 +931,10 @@ class SubsetTools(PluginTemplateMixin):
             If `True`, return the regions that failed to load (see ``bad_regions``);
             This is useful for debugging. If `False`, do not return anything (`None`).
 
+        region_format : str or `None`
+            Passed to ``Regions.read(format=region_format)``.  Only applicable if ``region``
+            is a string pointing to a valid file that ``Regions`` can read.
+
         Returns
         -------
         bad_regions : list of (obj, str) or `None`
@@ -943,17 +947,16 @@ class SubsetTools(PluginTemplateMixin):
         if isinstance(region, str):
             if os.path.exists(region):
                 from regions import Regions
-                region_format = kwargs.pop('region_format', None)
                 try:
                     raw_regs = Regions.read(region, format=region_format)
                 except Exception:  # nosec
                     raw_regs = SpectralRegion.read(region)
 
                 return self._load_regions(raw_regs, combination_mode, max_num_regions,
-                                          refdata_label, return_bad_regions, **kwargs)
+                                          refdata_label, return_bad_regions)
         else:
             return self._load_regions(region, combination_mode, max_num_regions, refdata_label,
-                                      return_bad_regions, **kwargs)
+                                      return_bad_regions)
 
     def _load_regions(self, regions, combination_mode=None, max_num_regions=None,
                       refdata_label=None, return_bad_regions=False, **kwargs):

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -716,12 +716,12 @@ class SubsetTools(PluginTemplateMixin):
                 if not np.all(np.isfinite((x, y))):
                     raise ValueError(f'Invalid centroid ({x}, {y})')
             except Exception as err:
-                self.set_center(self.get_center(subset_name=subset), subset_name=subset,
-                                update=False)
+                self._set_center(self.get_center(subset_name=subset), subset_name=subset,
+                                 update=False)
                 self.hub.broadcast(SnackbarMessage(
                     f"Failed to calculate centroid: {repr(err)}", color='error', sender=self))
             else:
-                self.set_center((x, y), subset_name=subset, update=True)
+                self._set_center((x, y), subset_name=subset, update=True)
 
         if not self.multiselect:
             _do_recentering(self.subset_selected, self.subset.selected_subset_state)
@@ -774,7 +774,8 @@ class SubsetTools(PluginTemplateMixin):
         subset_state = self._get_subset_state(subset_name)
         return subset_state.center()
 
-    def set_center(self, new_cen, subset_name=None, update=False):
+
+    def _set_center(self, new_cen, subset_name=None, update=False):
         """Set the desired center for the selected Subset, if applicable.
         If Subset is not centerable, nothing is done.
 
@@ -829,6 +830,26 @@ class SubsetTools(PluginTemplateMixin):
             tmp = self.subset_definitions
             self.subset_definitions = []
             self.subset_definitions = tmp
+
+    def set_center(self, new_cen, subset_name=None):
+        """Set the desired center for the selected Subset, if applicable.
+        If Subset is not centerable, nothing is done.
+
+        Parameters
+        ----------
+        new_cen : number or tuple of numbers
+            The new center defined either as ``x`` or ``(x, y)``,
+            depending on the Subset type.
+        subset_name : str
+            The name of the subset that is being updated.
+
+        Raises
+        ------
+        NotImplementedError
+            Subset type is not supported.
+
+        """
+        return self._set_center(new_cen, subset_name, update=True)
 
     # List of JSON-like dict is nice for front-end but a pain to look up,
     # so we use these helper functions.

--- a/jdaviz/configs/imviz/tests/test_subset_centroid.py
+++ b/jdaviz/configs/imviz/tests/test_subset_centroid.py
@@ -75,7 +75,7 @@ class TestImvizSpatialSubsetCentroidWCSLinked(BaseImviz_WCS_GWCS):
         # The functionality for set_center has changed so that the subset state itself
         # is updated but that change is not propagated to subset_definitions or the UI until
         # vue_update_subset is called.
-        plg._obj.set_center((2, 2), update=False)
+        plg._obj._set_center((2, 2), update=False)
         for key in ("value", "orig"):
             ra = plg._obj._get_value_from_subset_definition(0, "RA Center (degrees)", key)
             dec = plg._obj._get_value_from_subset_definition(0, "Dec Center (degrees)", key)

--- a/jdaviz/configs/imviz/tests/test_subset_centroid.py
+++ b/jdaviz/configs/imviz/tests/test_subset_centroid.py
@@ -18,7 +18,7 @@ class TestImvizSpatialSubsetCentroidPixelLinked(BaseImviz_WCS_GWCS):
         # and nothing should change.
         for data_label in ('fits_wcs[DATA]', 'gwcs[DATA]'):
             plg.recenter_dataset = data_label
-            plg.set_center((2, 2))  # Move the Subset back first.
+            plg.set_center((2, 2), update=True)  # Move the Subset back first.
             plg.recenter()
 
             # Calculate and move to centroid.
@@ -59,7 +59,7 @@ class TestImvizSpatialSubsetCentroidWCSLinked(BaseImviz_WCS_GWCS):
         # GWCS does not extrapolate and this Subset is out of bounds,
         # so will get NaNs and enter the exception handling logic.
         plg.recenter_dataset = 'gwcs[DATA]'
-        plg.set_center((2.6836, 1.6332))  # Move the Subset back first.
+        plg.set_center((2.6836, 1.6332), update=True)  # Move the Subset back first.
         plg.recenter()
         subsets = self.imviz.app.get_subsets(include_sky_region=True)
         subsets_sky = subsets['Subset 1'][0]['sky_region']
@@ -75,7 +75,7 @@ class TestImvizSpatialSubsetCentroidWCSLinked(BaseImviz_WCS_GWCS):
         # The functionality for set_center has changed so that the subset state itself
         # is updated but that change is not propagated to subset_definitions or the UI until
         # vue_update_subset is called.
-        plg._obj._set_center((2, 2), update=False)
+        plg._obj.set_center((2, 2), update=False)
         for key in ("value", "orig"):
             ra = plg._obj._get_value_from_subset_definition(0, "RA Center (degrees)", key)
             dec = plg._obj._get_value_from_subset_definition(0, "Dec Center (degrees)", key)

--- a/jdaviz/configs/imviz/tests/test_subset_centroid.py
+++ b/jdaviz/configs/imviz/tests/test_subset_centroid.py
@@ -18,7 +18,7 @@ class TestImvizSpatialSubsetCentroidPixelLinked(BaseImviz_WCS_GWCS):
         # and nothing should change.
         for data_label in ('fits_wcs[DATA]', 'gwcs[DATA]'):
             plg.recenter_dataset = data_label
-            plg.set_center((2, 2), update=True)  # Move the Subset back first.
+            plg.set_center((2, 2))  # Move the Subset back first.
             plg.recenter()
 
             # Calculate and move to centroid.
@@ -59,7 +59,7 @@ class TestImvizSpatialSubsetCentroidWCSLinked(BaseImviz_WCS_GWCS):
         # GWCS does not extrapolate and this Subset is out of bounds,
         # so will get NaNs and enter the exception handling logic.
         plg.recenter_dataset = 'gwcs[DATA]'
-        plg.set_center((2.6836, 1.6332), update=True)  # Move the Subset back first.
+        plg.set_center((2.6836, 1.6332))  # Move the Subset back first.
         plg.recenter()
         subsets = self.imviz.app.get_subsets(include_sky_region=True)
         subsets_sky = subsets['Subset 1'][0]['sky_region']
@@ -75,7 +75,7 @@ class TestImvizSpatialSubsetCentroidWCSLinked(BaseImviz_WCS_GWCS):
         # The functionality for set_center has changed so that the subset state itself
         # is updated but that change is not propagated to subset_definitions or the UI until
         # vue_update_subset is called.
-        plg.set_center((2, 2), update=False)
+        plg._obj.set_center((2, 2), update=False)
         for key in ("value", "orig"):
             ra = plg._obj._get_value_from_subset_definition(0, "RA Center (degrees)", key)
             dec = plg._obj._get_value_from_subset_definition(0, "Dec Center (degrees)", key)

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -211,9 +211,9 @@ class ConfigHelper(HubListener):
         plg = self.plugins.get('Model Fitting', None)
         if plg is None:
             raise ValueError("Model Fitting plugins is not loaded")
-        return plg.get_models(models=models,
-                              model_label=model_label,
-                              x=x, y=y)
+        return plg._obj.get_models(models=models,
+                                   model_label=model_label,
+                                   x=x, y=y)
 
     @deprecated(since="4.2")
     def get_model_parameters(self, models=None, model_label=None, x=None, y=None):
@@ -248,9 +248,9 @@ class ConfigHelper(HubListener):
         plg = self.plugins.get('Model Fitting', None)
         if plg is None:
             raise ValueError("Model Fitting plugins is not loaded")
-        return plg.get_model_parameters(models=models,
-                                        model_label=model_label,
-                                        x=x, y=y)
+        return plg._obj.get_model_parameters(models=models,
+                                             model_label=model_label,
+                                             x=x, y=y)
 
     def show(self, loc="inline", title=None, height=None):  # pragma: no cover
         """Display the Jdaviz application.

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -116,7 +116,7 @@ def test_region_from_subset_3d(cubeviz_helper):
     assert_allclose(reg.angle.to_value(u.deg), 45)  # Might be stored in radians
 
     # Move the rectangle
-    subset_plugin.set_center((3, 2), update=True)
+    subset_plugin.set_center((3, 2))
     subsets = cubeviz_helper.app.get_subsets()
     reg = subsets.get('Subset 1')[0]['region']
     assert_allclose(reg.center.x, 3)
@@ -198,7 +198,7 @@ def test_region_from_subset_profile(cubeviz_helper, spectral_cube_wcs):
     assert_quantity_allclose(reg.upper, 15.5 * u.Hz)
 
     # Move the Subset.
-    subset_plugin.set_center(10, update=True)
+    subset_plugin.set_center(10)
     subsets = cubeviz_helper.app.get_subsets(spectral_only=True)
     reg = subsets.get('Subset 1')
     assert_quantity_allclose(reg.lower, 7.25 * u.Hz)
@@ -230,7 +230,7 @@ def test_disjoint_spectral_subset(cubeviz_helper, spectral_cube_wcs):
 
     # Make sure that certain things are not possible because we are
     # dealing with a composite spectral subset
-    subset_plugin.set_center(99, update=True)   # This is no-op
+    subset_plugin.set_center(99)   # This is no-op
     assert subset_plugin.get_center() is None
 
     for key in ("orig", "value"):

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -116,7 +116,7 @@ def test_region_from_subset_3d(cubeviz_helper):
     assert_allclose(reg.angle.to_value(u.deg), 45)  # Might be stored in radians
 
     # Move the rectangle
-    subset_plugin.set_center((3, 2))
+    subset_plugin.set_center((3, 2), update=True)
     subsets = cubeviz_helper.app.get_subsets()
     reg = subsets.get('Subset 1')[0]['region']
     assert_allclose(reg.center.x, 3)
@@ -198,7 +198,7 @@ def test_region_from_subset_profile(cubeviz_helper, spectral_cube_wcs):
     assert_quantity_allclose(reg.upper, 15.5 * u.Hz)
 
     # Move the Subset.
-    subset_plugin.set_center(10)
+    subset_plugin.set_center(10, update=True)
     subsets = cubeviz_helper.app.get_subsets(spectral_only=True)
     reg = subsets.get('Subset 1')
     assert_quantity_allclose(reg.lower, 7.25 * u.Hz)
@@ -230,7 +230,7 @@ def test_disjoint_spectral_subset(cubeviz_helper, spectral_cube_wcs):
 
     # Make sure that certain things are not possible because we are
     # dealing with a composite spectral subset
-    subset_plugin.set_center(99)   # This is no-op
+    subset_plugin.set_center(99, update=True)   # This is no-op
     assert subset_plugin.get_center() is None
 
     for key in ("orig", "value"):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request cleans up exposed plugin APIs which are meant for internal use only, including:
* replacing `**kwargs` from `subset_tools.import_region(..., **kwargs)` with explicit `region_format=None`.  If there are other kwargs passed to `load_regions` that we want the user to access, we should explicitly add and document those as well.
* ~remove `update=False` in `subset_tools.set_center(..., update=False)` and hardcode to `update=True`.  **IMPORTANT**: this is technically a change in behavior.  Do we need to deprecate or is a changelog entry in a minor release sufficient?  `set_center` was first made public in 4.1 by #3304.~. (see discussion at https://github.com/spacetelescope/jdaviz/pull/3453#discussion_r1962302548)
* remove `models=None` from `model_fitting.get_model_parameters(models=None, ...)`.  The helper-method is already deprecated and the plugin-method has not been released yet, so the existing deprecation should be sufficient.
* remove `models=None` from `model_fitting.get_models(models=None, ...)`.  The helper-method is already deprecated and the plugin-method has not been released yet, so the existing deprecation should be sufficient.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
