### PR TITLE
Fix incorrect matching of skycoords with pixel coords in catalog results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -107,7 +107,7 @@ Other Changes and Additions
 
 - Refactored flux conversion to use a single function for all plugin/viewer flux/surface brightness
   conversions. [#3457]
-  
+
 
 4.1.2 (unreleased)
 ==================
@@ -123,13 +123,15 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
-- Hide spectral subset layer visibility in flux/uncertainty viewers when slice indicator 
+- Hide spectral subset layer visibility in flux/uncertainty viewers when slice indicator
   is within the spectral subset bounds. [#3437]
 
 Imviz
 ^^^^^
 
 - Improve performance of re-rendering during orientation change. [#3452]
+
+- Fix incorrect matching between RA/Dec and pixel coordinates in Catalog search results. [#3464]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -327,7 +327,7 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
                 row_info = {
                     'Right Ascension (degrees)': row['sky_centroid'].ra.deg,
                     'Declination (degrees)': row['sky_centroid'].dec.deg,
-                    'Object ID': str(row.get('label', f"{len(self.table)}")),
+                    'Object ID': str(row.get('label', f"{len(self.table) + 1}")),
                     'id': len(self.table),
                     'x_coord': row['x_coord'],
                     'y_coord': row['y_coord'],

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -316,8 +316,8 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
                             'Declination (degrees)': row['dec'],
                             'Object ID': row_id.astype(str),
                             'id': len(self.table),
-                            'x_coord': row['x_coord'].item() if row['x_coord'].size == 1 else row['x_coord'],
-                            'y_coord': row['y_coord'].item() if row['x_coord'].size == 1 else row['x_coord']}
+                            'x_coord': row['x_coord'],
+                            'y_coord': row['y_coord']}
                 self.table.add_item(row_info)
 
         # NOTE: If performance becomes a problem, see
@@ -344,7 +344,7 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
                 self.table.add_item(row_info)
 
         filtered_skycoords = viewer.state.reference_data.coords.pixel_to_world(x_coordinates,
-                                                                                    y_coordinates)
+                                                                               y_coordinates)
 
         # QTable stores all the filtered sky coordinate points to be marked
         catalog_results = QTable({'coord': filtered_skycoords})

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -103,20 +103,36 @@ class TestCatalogs:
         #   skycoord_center = SkyCoord(6.62754354, 1.54466139, unit="deg")
         #   zoom_radius = r_max = 3 * u.arcmin
         #   query_region_result = SDSS.query_region(skycoord_center, radius=zoom_radius, ...)
+
+        # Zoom in so we have to filter sources outside the viewer bounds
+        viewer = imviz_helper.app.get_viewer('imviz-0')
+        viewer.state.x_min = 800
+        viewer.state.x_max = 1200
+        viewer.state.y_min = 800
+        viewer.state.y_max = 1200
+
         catalogs_plugin.search(error_on_fail=True)
 
         assert catalogs_plugin.catalog.selected == 'SDSS'
 
-        # number of results should be > 500 or so
-        # Answer was determined by running the search with the image in the notebook.
         assert catalogs_plugin.results_available
-        assert catalogs_plugin.number_of_results > 500
+        assert catalogs_plugin.number_of_results == 136
         prev_results = catalogs_plugin.number_of_results
-        table_last_ra = float(catalogs_plugin.table.items[-1]['Right Ascension (degrees)'])
-        assert_allclose(table_last_ra, imviz_helper.app._catalog_source_table[-1]['ra'], atol=0.0001)  # noqa
+        last_row = catalogs_plugin.table.items[-1]
+        last_ra = float(last_row['Right Ascension (degrees)'])
+        coords = viewer.state.reference_data.coords
+        table_calc_ra = coords.pixel_to_world(float(last_row['x_coord']), float(last_row['y_coord'])).ra.value  # noqa
+        assert_allclose(last_ra, table_calc_ra, rtol=0.00001)
+        assert_allclose(last_ra, imviz_helper.app._catalog_source_table[-1]['ra'], atol=0.0001)  # noqa
 
         # testing that every variable updates accordingly when markers are cleared
         catalogs_plugin.clear_table()
+
+        # Default zoom for the rest of the tests
+        viewer.state.x_min = -0.5
+        viewer.state.x_max = 2047.5
+        viewer.state.y_min = -0.5
+        viewer.state.y_max = 1488.5
 
         assert not catalogs_plugin.results_available
 

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -112,6 +112,8 @@ class TestCatalogs:
         assert catalogs_plugin.results_available
         assert catalogs_plugin.number_of_results > 500
         prev_results = catalogs_plugin.number_of_results
+        table_last_ra = float(catalogs_plugin.table.items[-1]['Right Ascension (degrees)'])
+        assert_allclose(table_last_ra, imviz_helper.app._catalog_source_table[-1]['ra'], atol=0.0001)  # noqa
 
         # testing that every variable updates accordingly when markers are cleared
         catalogs_plugin.clear_table()


### PR DESCRIPTION
This was previously matching the filtered list of N pixel coords in the viewer bounds with the first N skycoords, which led to mismatches between the pixel and sky coords for the results. There's a smarter fix here that involves zipping before filtering both at once rather than doing the check in the loop, this was mostly a quick hack to get the code working properly. If we're worried about performance I can figure out the better way to do this, if not we can merge this for now to fix the bug.