### PR TITLE
Remove VO plugin API and revert tests to underlying object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,7 +31,7 @@ Imviz
 
 - Catalog Search now shows a table of selected entries and allows selecting/deselecting via a tool in the image viewer. [#3429]
 
-- Virtual Observatory plugin to query resources and download data products. [#2872]
+- Virtual Observatory plugin to query resources and download data products. [#2872, #3470]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/configs/default/plugins/virtual_observatory/tests/test_vo_imviz.py
+++ b/jdaviz/configs/default/plugins/virtual_observatory/tests/test_vo_imviz.py
@@ -37,12 +37,12 @@ class TestVOImvizLocal(BaseImviz_WCS_WCS):
         self.imviz.app.remove_data_from_viewer("imviz-0", "has_wcs_2[SCI,1]")
 
         # Check default viewer is "Manual"
-        vo_plugin = self.imviz.plugins[vo_plugin_label]
-        assert vo_plugin.viewer == "Manual"
+        vo_plugin = self.imviz.plugins[vo_plugin_label]._obj
+        assert vo_plugin.viewer.selected == "Manual"
         assert vo_plugin.source == ""
 
         # Switch to first viewer and verify coordinates have switched
-        vo_plugin.viewer = "imviz-0"
+        vo_plugin.viewer.selected = "imviz-0"
         ra_str, dec_str = vo_plugin.source.split()
         np.testing.assert_allclose(
             float(ra_str), self._data_center_coords["has_wcs_1[SCI,1]"]["ra"]
@@ -52,7 +52,7 @@ class TestVOImvizLocal(BaseImviz_WCS_WCS):
         )
 
         # Switch to second viewer without data and verify autocoord gracefully clears source field
-        vo_plugin.viewer = "imviz-1"
+        vo_plugin.viewer.selected = "imviz-1"
         assert vo_plugin.source == ""
 
         # Now load second data into second viewer and verify coordinates
@@ -70,7 +70,7 @@ class TestVOImvizLocal(BaseImviz_WCS_WCS):
         Tests populating the results table with a mocked SIARsult
         and verifies the default headers populate the correct fields
         """
-        vo_plugin = self.imviz.plugins[vo_plugin_label]
+        vo_plugin = self.imviz.plugins[vo_plugin_label]._obj
         fake_result = fake_siaresult(
             {
                 "title": "Fake Title",
@@ -78,9 +78,9 @@ class TestVOImvizLocal(BaseImviz_WCS_WCS):
                 "dateobs": "Fake Dateobs",
             }
         )
-        vo_plugin._obj._populate_table([fake_result])
+        vo_plugin._populate_table([fake_result])
 
-        assert vo_plugin._obj.table.items == [
+        assert vo_plugin.table.items == [
             {
                 "URL": fake_result.getdataurl(),
                 "Title": fake_result.title,
@@ -91,7 +91,7 @@ class TestVOImvizLocal(BaseImviz_WCS_WCS):
 
     def test_populate_table_custom_headers(self):
         """Tests the ability to control and adjust the table to custom columns"""
-        vo_plugin = self.imviz.plugins[vo_plugin_label]
+        vo_plugin = self.imviz.plugins[vo_plugin_label]._obj
         fake_result = fake_siaresult(
             {
                 "attrA": "Field A",
@@ -99,11 +99,11 @@ class TestVOImvizLocal(BaseImviz_WCS_WCS):
                 "attrC": "Field C",
             }
         )
-        vo_plugin._obj._populate_table(
+        vo_plugin._populate_table(
             [fake_result], {"Title A": "attrA", "Title B": "attrB", "Title C": "attrC"}
         )
 
-        assert vo_plugin._obj.table.items == [
+        assert vo_plugin.table.items == [
             {
                 "URL": fake_result.getdataurl(),
                 "Title A": fake_result.attrA,
@@ -117,7 +117,7 @@ class TestVOImvizLocal(BaseImviz_WCS_WCS):
         If a SIAResult is missing a required header,
         the table should switch to displaying URLs only
         """
-        vo_plugin = self.imviz.plugins[vo_plugin_label]
+        vo_plugin = self.imviz.plugins[vo_plugin_label]._obj
         fake_result = fake_siaresult(
             {
                 "attrA": "Field A",
@@ -125,11 +125,11 @@ class TestVOImvizLocal(BaseImviz_WCS_WCS):
             }
         )
 
-        vo_plugin._obj._populate_table(
+        vo_plugin._populate_table(
             [fake_result], {"Title A": "attrA", "Title B": "attrB", "Title C": "attrC"}
         )
-        assert vo_plugin._obj._populate_url_only is True
-        assert vo_plugin._obj.table.headers_visible == ["URL"]
+        assert vo_plugin._populate_url_only is True
+        assert vo_plugin.table.headers_visible == ["URL"]
 
 
 def test_link_type_autocoord(imviz_helper):
@@ -176,8 +176,8 @@ def test_link_type_autocoord(imviz_helper):
     )
     imviz_helper.load_data(hdu2, data_label="has_wcs_2")
 
-    vo_plugin = imviz_helper.plugins["Virtual Observatory"]
-    vo_plugin.viewer = "imviz-0"
+    vo_plugin = imviz_helper.plugins[vo_plugin_label]._obj
+    vo_plugin.viewer.selected = "imviz-0"
     vo_plugin.center_on_data()
     ra_str, dec_str = vo_plugin.source.split()
     np.testing.assert_allclose(float(ra_str), 284.2101962057667)
@@ -210,22 +210,22 @@ class TestVOImvizRemote:
         vo_plugin_api : `~jdaviz.configs.default.plugins.virtual_observatory.VoPlugin`
             The raw VoPlugin class plugin instance
         """
-        vo_plugin = imviz_helper.plugins[vo_plugin_label]
+        vo_plugin = imviz_helper.plugins[vo_plugin_label]._obj
 
         # Sets common args for Remote Testing
-        vo_plugin.viewer = "Manual"
+        vo_plugin.viewer.selected = "Manual"
         vo_plugin.source = "M51"
         vo_plugin.radius = 1
-        vo_plugin.radius_unit = "deg"
-        vo_plugin.waveband = "optical"
+        vo_plugin.radius_unit.selected = "deg"
+        vo_plugin.waveband.selected = "optical"
 
         return vo_plugin
 
     def test_query_registry_args(self, imviz_helper):
         """Ensure we don't query registry if we're missing required arguments"""
         # If waveband isn't selected, plugin should ignore our registry query attempts
-        vo_plugin = imviz_helper.plugins[vo_plugin_label]
-        vo_plugin.waveband = ""
+        vo_plugin = imviz_helper.plugins[vo_plugin_label]._obj
+        vo_plugin.waveband.selected = ""
         vo_plugin.query_registry_resources()
         assert len(vo_plugin.resource.choices) == 0
 
@@ -237,7 +237,7 @@ class TestVOImvizRemote:
             match="Source is required for registry querying when coverage filtering is enabled.",
         ):
             # Setting the waveband from nothing to something will trigger the query
-            vo_plugin.waveband = "optical"
+            vo_plugin.waveband.selected = "optical"
             # Also verify we get a snackbar message for it
             assert any(
                 "Source is required" in d["text"]
@@ -263,14 +263,14 @@ class TestVOImvizRemote:
         # Retrieve registry options with filtering on
         vo_plugin.resource_filter_coverage = True
         vo_plugin.query_registry_resources()
-        assert vo_plugin._obj.resources_loading is False
+        assert vo_plugin.resources_loading is False
         filtered_resources = vo_plugin.resource.choices
         assert len(filtered_resources) > 0
 
         # Retrieve registry options with filtering off
         vo_plugin.resource_filter_coverage = False
         vo_plugin.query_registry_resources()
-        assert vo_plugin._obj.resources_loading is False
+        assert vo_plugin.resources_loading is False
         nonfiltered_resources = vo_plugin.resource.choices
 
         # Nonfiltered resources should be more than filtered resources
@@ -282,18 +282,18 @@ class TestVOImvizRemote:
         when a provided source is irresolvable
         """
         expected_error_msg = "Unable to resolve source coordinates"
-        vo_plugin = imviz_helper.plugins[vo_plugin_label]
+        vo_plugin = imviz_helper.plugins[vo_plugin_label]._obj
 
         # Manually set the source to a fake target
-        vo_plugin.viewer = "Manual"
+        vo_plugin.viewer.selected = "Manual"
         vo_plugin.source = "ThisIsAFakeTargetThatWontResolveToAnything"
         vo_plugin.radius = 1
-        vo_plugin.radius_unit = "deg"
+        vo_plugin.radius_unit.selected = "deg"
 
         # If we have coverage filtering on, we should get an error
         vo_plugin.resource_filter_coverage = True
         with pytest.raises(LookupError, match=expected_error_msg):
-            vo_plugin.waveband = "optical"
+            vo_plugin.waveband.selected = "optical"
             vo_plugin.query_registry_resources()
             assert any(
                 expected_error_msg in d["text"]
@@ -311,9 +311,9 @@ class TestVOImvizRemote:
         # since the source still isn't resolvable.
         # Clear existing messages
         imviz_helper.app.state.snackbar_history = []
-        vo_plugin.resource = "HST.M51"
+        vo_plugin.resource.selected = "HST.M51"
         with pytest.raises(LookupError, match=expected_error_msg):
-            vo_plugin._obj.vue_query_resource()
+            vo_plugin.vue_query_resource()
             assert any(
                 expected_error_msg in d["text"]
                 for d in imviz_helper.app.state.snackbar_history
@@ -337,11 +337,11 @@ class TestVOImvizRemote:
         vo_plugin.resource_filter_coverage = False
         vo_plugin.query_registry_resources()
         assert "HST.M51" in vo_plugin.resource.choices
-        vo_plugin.resource = "HST.M51"
+        vo_plugin.resource.selected = "HST.M51"
 
         # Query resource
-        vo_plugin._obj.vue_query_resource()
-        assert len(vo_plugin._obj.table.items) > 0
+        vo_plugin.vue_query_resource()
+        assert len(vo_plugin.table.items) > 0
 
         # Add poisoned fake result
         fake_result = fake_siaresult(
@@ -351,18 +351,18 @@ class TestVOImvizRemote:
                 "dateobs": "Fake Dateobs",
             }
         )
-        vo_plugin._obj._populate_table([fake_result])
+        vo_plugin._populate_table([fake_result])
 
         # Put the fake result first to make sure we hit the fake result before the real one
-        vo_plugin._obj.table.selected_rows = [
-            vo_plugin._obj.table.items[-1],
-            vo_plugin._obj.table.items[0],
+        vo_plugin.table.selected_rows = [
+            vo_plugin.table.items[-1],
+            vo_plugin.table.items[0],
         ]
-        assert vo_plugin._obj.table.selected_rows[0]["URL"] == fake_result.getdataurl()
+        assert vo_plugin.table.selected_rows[0]["URL"] == fake_result.getdataurl()
 
         # Load first data product and fake result
         vo_plugin.load_selected_data()
-        assert vo_plugin._obj.data_loading is False
+        assert vo_plugin.data_loading is False
         # Test that user was warned about failed file loading on fake result
         assert any(
             "Unable to load file to viewer" in d["text"]
@@ -377,11 +377,11 @@ class TestVOImvizRemote:
         # User should be warned about misaligned data if WCS linking isn't set
         # and there's already data in the data collection
         assert imviz_helper.plugins["Orientation"].align_by == "Pixels"
-        vo_plugin._obj.table.selected_rows = [
-            vo_plugin._obj.table.items[0]
+        vo_plugin.table.selected_rows = [
+            vo_plugin.table.items[0]
         ]  # Select first entry
         vo_plugin.load_selected_data()
-        assert vo_plugin._obj.data_loading is False
+        assert vo_plugin.data_loading is False
         assert any(
             "WCS linking is not enabled; data layers may not be aligned" in d["text"]
             for d in imviz_helper.app.state.snackbar_history
@@ -392,11 +392,11 @@ class TestVOImvizRemote:
         # If we switch to WCS linking, we shouldn't get a warning anymore
         # since the data will be aligned
         imviz_helper.plugins["Orientation"].align_by = "WCS"
-        vo_plugin._obj.table.selected_rows = [
-            vo_plugin._obj.table.items[0]
+        vo_plugin.table.selected_rows = [
+            vo_plugin.table.items[0]
         ]  # Select first entry
         vo_plugin.load_selected_data()
-        assert vo_plugin._obj.data_loading is False
+        assert vo_plugin.data_loading is False
         assert all(
             "WCS linking is not enabled; data layers may not be aligned"
             not in d["text"]

--- a/jdaviz/configs/default/plugins/virtual_observatory/vo_plugin.py
+++ b/jdaviz/configs/default/plugins/virtual_observatory/vo_plugin.py
@@ -24,7 +24,6 @@ from jdaviz.core.template_mixin import (
     UnitSelectPluginComponent,
     with_spinner,
 )
-from jdaviz.core.user_api import PluginUserApi
 
 __all__ = ["VoPlugin"]
 vo_plugin_label = "Virtual Observatory"

--- a/jdaviz/configs/default/plugins/virtual_observatory/vo_plugin.py
+++ b/jdaviz/configs/default/plugins/virtual_observatory/vo_plugin.py
@@ -109,27 +109,6 @@ class VoPlugin(PluginTemplateMixin, AddResultsMixin, TableMixin):
         self.hub.subscribe(self, RemoveDataMessage, handler=self.vue_center_on_data)
         self.hub.subscribe(self, LinkUpdatedMessage, handler=self.vue_center_on_data)
 
-    @property
-    def user_api(self):
-        return PluginUserApi(
-            self,
-            expose=(
-                # Traitlets
-                "source",
-                "viewer",
-                "radius",
-                "radius_unit",
-                "waveband",
-                "coordframe",
-                "resource_filter_coverage",
-                "resource",
-                # Methods
-                "center_on_data",
-                "query_registry_resources",
-                "load_selected_data",
-            ),
-        )
-
     @observe("viewer_selected", type="change")
     def vue_viewer_changed(self, _=None):
         # Check mixin object initialized


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This is a small PR after discussing with @kecnry architecting the move of the VO plugin to the new Import Data menu. This PR rolls back the plugin API since the VO tool may move from the plugin tray to the new Import Data menu. It seemed easier to just remove the plugin API rather than publishing it and then having to go through the deprecation process before it moves to its new API location.

This also necessitates changing the tests to use the underlying `plugin._obj` rather than the API. It looks like a lot of changes, but it isn't actually; I'll try to detail them here so we can easy CTRL+F and replace later:

- Convert all `vo_plugin` retrieval from the plugin API to the underlying object `vo_plugin = self.imviz.plugins[vo_plugin_label]` > `vo_plugin = self.imviz.plugins[vo_plugin_label]._obj`
- Redirect all Plugin components to underlying `selected` attributes
  - `viewer` > `viewer.selected`
  - `radius_unit` > `radius_unit.selected`
  - `waveband` > `waveband.selected`
  - `resource` > `resource.selected`
- Strip all manual `_obj` calls for non API methods since the `plugin` object is now the `_obj` itself (`vo_plugin._obj` > `vo_plugin`)
  - `vo_plugin._obj._populate_table` > `vo_plugin._populate_table`
  - `vo_plugin._obj.table` > `vo_plugin.table`
  - `vo_plugin._obj.resources_loading` > `vo_plugin.resources_loading`
  - `vo_plugin._obj.vue_query_resource` > `vo_plugin._obj.vue_query_resource`
  - `vo_plugin._obj.data_loading` > `vo_plugin.data_loading`

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
