### PR TITLE
subset_tools.import_region should have max_num_regions=20 as default, also deprecate/remove duplicate functionality

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,15 +53,22 @@ API Changes
   directly if you wish to test your copy of ``jdaviz``. [#3451]
 
 - ``**kwargs`` from ``viz.plugins['Subset Tools'].import_region(..., **kwargs)`` is removed, ``region_format=None``
-  is now explicitly supported. [#3453]
+  is now explicitly supported. The default value for ``max_num_regions`` option
+  is now 20 instead of ``None`` (load everything). [#3453, #3474]
 
 Cubeviz
 ^^^^^^^
+
+- ``cubeviz.load_regions()`` and ``cubeviz.load_regions_from_file()`` are deprecated.
+  Use ``cubeviz.plugins['Subset Tools'].import_region()`` instead. [#3474]
 
 Imviz
 ^^^^^
 
 - Orientation plugin: ``link_type`` and ``wcs_use_affine`` (previously deprecated) have now been removed. [#3385]
+
+- ``imviz.load_regions()`` and ``imviz.load_regions_from_file()`` are deprecated.
+  Use ``imviz.plugins['Subset Tools'].import_region()`` instead. [#3474]
 
 Mosviz
 ^^^^^^

--- a/docs/cubeviz/import_data.rst
+++ b/docs/cubeviz/import_data.rst
@@ -209,10 +209,6 @@ form ``(region, reason)``:
 
 .. note:: Sky regions are currently unsupported in Cubeviz, unlike Imviz.
 
-For more details on the API, please see
-:py:meth:`~jdaviz.core.helpers.ImageConfigHelper.load_regions_from_file`
-and :py:meth:`~jdaviz.core.helpers.ImageConfigHelper.load_regions` methods
-in Cubeviz.
 
 Loading from a URL or URI
 -------------------------

--- a/docs/imviz/import_data.rst
+++ b/docs/imviz/import_data.rst
@@ -275,9 +275,4 @@ You could also define :ref:`regions:shapes` programmatically and load them; e.g.
     from regions import CirclePixelRegion, PixCoord
     aper_1 = CirclePixelRegion(center=PixCoord(x=42, y=43), radius=4.2)
     aper_2 = CirclePixelRegion(center=PixCoord(x=10, y=20), radius=3)
-    imviz.load_regions([aper_1, aper_2])
-
-For more details on the API, please see
-:meth:`~jdaviz.core.helpers.ImageConfigHelper.load_regions_from_file`
-and :meth:`~jdaviz.core.helpers.ImageConfigHelper.load_regions` methods
-in Imviz.
+    imviz.plugins['Subset Tools'].import_region([aper_1, aper_2])

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
@@ -152,7 +152,8 @@ def test_cubeviz_aperphot_cube_sr_and_pix2(cubeviz_helper,
 
     aper = RectanglePixelRegion(center=PixCoord(x=3, y=1), width=1, height=1)
     bg = RectanglePixelRegion(center=PixCoord(x=2, y=0), width=1, height=1)
-    cubeviz_helper.load_regions([aper, bg])
+    cubeviz_helper.plugins['Subset Tools'].import_region(
+        [aper, bg], combination_mode='new')
 
     plg = cubeviz_helper.plugins["Aperture Photometry"]._obj
     plg.dataset_selected = "test[FLUX]"

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_helper.py
@@ -1,4 +1,5 @@
 import pytest
+from regions import EllipsePixelRegion, PixCoord
 from specutils import SpectralRegion
 
 from jdaviz import Cubeviz
@@ -42,14 +43,12 @@ def test_remote_server_disable_save_serverside():
 
 def test_get_data_spatial_and_spectral(cubeviz_helper, spectrum1d_cube_larger):
     cubeviz_helper.load_data(spectrum1d_cube_larger, data_label="test")
-    # Subset 1 (spatial)
-    cubeviz_helper._apply_interactive_region('bqplot:ellipse', (0, 0), (9, 8))
-
-    # Subset 2 (spectral)
-    subset_plugin = cubeviz_helper.plugins['Subset Tools']
     unit = spectrum1d_cube_larger.spectral_axis.unit
-    subset_plugin.import_region(SpectralRegion(4.62440061e-07 * unit, 4.62520112e-07 * unit))
-
+    subset_plugin = cubeviz_helper.plugins['Subset Tools']
+    subset_plugin.import_region([
+        EllipsePixelRegion(center=PixCoord(x=4.5, y=4), width=9, height=8),  # Subset 1 (spatial)
+        SpectralRegion(4.62440061e-07 * unit, 4.62520112e-07 * unit),  # Subset 2 (spectral)
+    ], combination_mode="new")
     spatial_with_spec = cubeviz_helper.get_data(data_label="Spectrum (Subset 1, sum)",
                                                 spectral_subset="Subset 2")
     assert spatial_with_spec.flux.ndim == 1

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
@@ -47,7 +47,7 @@ def test_basic_unit_conversions(cubeviz_helper, angle_unit):
     ap_plg = cubeviz_helper.plugins["Aperture Photometry"]._obj
     label_mouseover = cubeviz_helper.app.session.application._tools['g-coords-info']
 
-    cubeviz_helper.load_regions(RectanglePixelRegion(PixCoord(1, 1), 1, 1))
+    cubeviz_helper.plugins['Subset Tools'].import_region(RectanglePixelRegion(PixCoord(1, 1), 1, 1))
     ap_plg.background_selected = "Subset 1"
 
     for flux_unit in SPEC_PHOTON_FLUX_DENSITY_UNITS:
@@ -156,7 +156,7 @@ def test_unit_translation(cubeviz_helper, angle_unit):
     cubeviz_helper.load_data(cube, data_label="test")
 
     center = PixCoord(5, 10)
-    cubeviz_helper.load_regions(CirclePixelRegion(center, radius=2.5))
+    cubeviz_helper.plugins['Subset Tools'].import_region(CirclePixelRegion(center, radius=2.5))
 
     uc_plg = cubeviz_helper.plugins['Unit Conversion']
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
@@ -54,13 +54,12 @@ class TestLoadRegions(BaseRegionHandler):
         assert len(bad_regions) == 1 and bad_regions[0][1] == 'Sky region provided but data has no valid WCS'  # noqa
 
     def test_spatial_spectral_mix(self):
-        # Manually draw ellipse.
-        self.cubeviz._apply_interactive_region('bqplot:ellipse', (0, 0), (9, 8))
-
-        # Manually draw wavelength range.
+        # Draw ellipse and wavelength range.
         unit = u.Unit(self.cubeviz.plugins['Unit Conversion'].spectral_unit.selected)
-        self.cubeviz.plugins['Subset Tools'].import_region(SpectralRegion(4.892 * unit,
-                                                                          4.896 * unit))
+        self.cubeviz.plugins['Subset Tools'].import_region([
+            EllipsePixelRegion(center=PixCoord(x=4.5, y=4.0), width=9.0, height=8.0),
+            SpectralRegion(4.892 * unit, 4.896 * unit)
+        ], combination_mode="new")
         self.cubeviz.app.session.edit_subset_mode.edit_subset = None
 
         # Get spatial regions only.
@@ -78,8 +77,8 @@ class TestLoadRegions(BaseRegionHandler):
         with pytest.warns(UserWarning, match='Applying the value from the redshift slider'):
             spectral_subsets = self.cubeviz.specviz.get_spectra()
         assert list(spectral_subsets.keys()) == ['Spectrum (sum)',
-                                                 'Spectrum (Subset 1, sum)',
                                                  'Spectrum (sum) (Subset 2)',
+                                                 'Spectrum (Subset 1, sum)',
                                                  'Spectrum (Subset 1, sum) (Subset 2)']
         for sp in spectral_subsets.values():
             assert isinstance(sp, Spectrum1D)

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -877,7 +877,7 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
         self.app._rename_subset(self.subset.selected, new_label, subset_group=subset_group)
         self._sync_available_from_state()
 
-    def import_region(self, region, combination_mode=None, max_num_regions=None,
+    def import_region(self, region, combination_mode=None, max_num_regions=20,
                       refdata_label=None, return_bad_regions=False, region_format=None):
         """
         Method for creating subsets from regions or region files.
@@ -902,8 +902,8 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
 
         max_num_regions : int or `None`
             Maximum number of regions to load, starting from top of the list.
-            Default is to load everything.  If you are providing a large file/list
-            input for ``region``, it is recommended
+            Default is 20.  If you want to load everything, set it to `None`.
+            Loading a large number of regions is not recommended due to performance impact.
 
         refdata_label : str or `None`
             **This is only applicable to non-spectral regions.**

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -101,13 +101,13 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
         self.viewer.stretch = 'sqrt'
         self.viewer.cuts = (0, 100)
 
-        # Add subsets, both interactive and static.
-        self.imviz._apply_interactive_region('bqplot:truecircle', (1.5, 2.5), (3.6, 4.6))
-        self.imviz.plugins['Subset Tools'].combination_mode = 'new'
+        # Add subsets
         self.imviz.plugins['Subset Tools'].import_region([
+            CirclePixelRegion(center=PixCoord(x=2.55, y=3.55), radius=1.05),
             CirclePixelRegion(center=PixCoord(x=6, y=2), radius=5).to_sky(self.wcs_1),
             PolygonPixelRegion(vertices=PixCoord(x=[1, 2, 2], y=[1, 1, 2])).to_sky(self.wcs_1),
-            PolygonPixelRegion(vertices=PixCoord(x=[2, 3, 3], y=[2, 2, 3])).to_sky(self.wcs_1)])
+            PolygonPixelRegion(vertices=PixCoord(x=[2, 3, 3], y=[2, 2, 3])).to_sky(self.wcs_1)
+        ], combination_mode="new")
 
         # Add markers.
         tbl = Table({'x': (0, 0), 'y': (0, 1)})

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -9,7 +9,7 @@ from astropy.utils.data import download_file
 from astropy.wcs import WCS
 from gwcs import WCS as GWCS
 from numpy.testing import assert_allclose, assert_array_equal
-from regions import CirclePixelRegion, PixCoord, RectanglePixelRegion
+from regions import CirclePixelRegion, EllipsePixelRegion, PixCoord, RectanglePixelRegion
 from skimage.io import imsave
 from stdatamodels import asdf_in_fits
 
@@ -252,13 +252,12 @@ class TestParseImage:
 
         # --- Since download is expensive, we attach GWCS-specific tests here. ---
 
-        # Ensure interactive region supports GWCS. Also see test_regions.py
-        imviz_helper._apply_interactive_region('bqplot:truecircle',
-                                               (965, 1122),
-                                               (976.9, 1110.1))  # Star
-        imviz_helper._apply_interactive_region('bqplot:rectangle',
-                                               (982, 1088),
-                                               (1008, 1077))  # Background
+        # Ensure region supports GWCS. Also see test_regions.py
+        imviz_helper.plugins['Subset Tools'].import_region([
+            CirclePixelRegion(center=PixCoord(x=970.95, y=1116.05), radius=5.95),
+            RectanglePixelRegion(center=PixCoord(x=995.0, y=1082.5), width=26, height=11)
+        ], combination_mode="new")
+
         subsets = imviz_helper.plugins['Subset Tools'].get_regions()
         assert list(subsets.keys()) == ['Subset 1', 'Subset 2'], subsets
         # check that retrieved subsets-as-regions from subset plugin match what was loaded.
@@ -402,9 +401,8 @@ class TestParseImage:
         # --- Since download is expensive, we attach FITS WCS-specific tests here. ---
 
         # Test simple aperture photometry plugin.
-        imviz_helper._apply_interactive_region('bqplot:ellipse',
-                                               (1465, 2541),
-                                               (1512, 2611))  # Galaxy
+        imviz_helper.plugins['Subset Tools'].import_region(
+            EllipsePixelRegion(center=PixCoord(x=1488.5, y=2576), width=47, height=70))  # Galaxy
         phot_plugin = imviz_helper.app.get_tray_item_from_name('imviz-aper-phot-simple')
         phot_plugin.data_selected = 'contents[SCI,1]'
         phot_plugin.aperture_selected = 'Subset 1'

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -212,7 +212,9 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
 
     def test_batch_phot(self):
         self.imviz.link_data(align_by='wcs')  # They are dithered by 1 pixel on X
-        self.imviz._apply_interactive_region('bqplot:truecircle', (0, 0), (9, 9))  # Draw a circle
+        self.imviz.plugins['Subset Tools'].import_region(
+            CirclePixelRegion(center=PixCoord(x=4.5, y=4.5), radius=4.5)
+        )  # Draw a circle
 
         # TODO: remove ._obj when API is made public
         phot_plugin = self.imviz.plugins['Aperture Photometry']._obj
@@ -249,7 +251,9 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
 class TestSimpleAperPhot_NoWCS(BaseImviz_WCS_NoWCS):
     def test_plugin_no_wcs(self):
         # Most things already tested above, so not re-tested here.
-        self.imviz._apply_interactive_region('bqplot:truecircle', (0, 0), (9, 9))  # Draw a circle
+        self.imviz.plugins['Subset Tools'].import_region(
+            CirclePixelRegion(center=PixCoord(x=4.5, y=4.5), radius=4.5)
+        )  # Draw a circle
         phot_plugin = self.imviz.app.get_tray_item_from_name('imviz-aper-phot-simple')
 
         phot_plugin.dataset_selected = 'has_wcs[SCI,1]'

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -630,6 +630,7 @@ class ImageConfigHelper(ConfigHelper):
         (e.g., "imviz-0" or "cubeviz-0")."""
         return self._default_viewer.user_api
 
+    @deprecated(since="4.2", alternative="subset_tools.import_region")
     def load_regions_from_file(self, region_file, region_format='ds9', max_num_regions=20,
                                **kwargs):
         """Load regions defined in the given file.
@@ -662,6 +663,7 @@ class ImageConfigHelper(ConfigHelper):
         raw_regs = Regions.read(region_file, format=region_format)
         return self.load_regions(raw_regs, max_num_regions=max_num_regions, **kwargs)
 
+    @deprecated(since="4.2", alternative="subset_tools.import_region")
     def load_regions(self, regions, max_num_regions=None, refdata_label=None,
                      return_bad_regions=False, **kwargs):
         """Load given region(s) into the viewer.
@@ -896,19 +898,6 @@ class ImageConfigHelper(ConfigHelper):
                 color="warning", timeout=8000, sender=self.app))
 
         return regions
-
-    # See https://github.com/glue-viz/glue-jupyter/issues/253
-    def _apply_interactive_region(self, toolname, from_pix, to_pix):
-        """Mimic interactive region drawing.
-        This is for internal testing only.
-        """
-        self.app.session.edit_subset_mode._mode = NewMode
-        tool = self.default_viewer._obj.toolbar.tools[toolname]
-        tool.activate()
-        tool.interact.brushing = True
-        tool.interact.selected = [from_pix, to_pix]
-        tool.interact.brushing = False
-        self.app.session.edit_subset_mode.edit_subset = None  # No overwrite next iteration
 
     # TODO: Make this public API?
     def _delete_region(self, subset_label):

--- a/notebooks/CubevizExample.ipynb
+++ b/notebooks/CubevizExample.ipynb
@@ -121,7 +121,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "regions = cubeviz.get_interactive_regions()"
+    "regions = cubeviz.plugins['Subset Tools'].get_regions(region_type=\"spatial\")"
    ]
   },
   {

--- a/notebooks/ImvizDitheredExample.ipynb
+++ b/notebooks/ImvizDitheredExample.ipynb
@@ -110,7 +110,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with warnings.catch_warnings():\n",
+    "with warnings.catch_warnings(), imviz.batch_load():\n",
     "    warnings.simplefilter('ignore')\n",
     "    imviz.load_data(uri_acs_47tuc_1, data_label='acs_47tuc_1', cache=True)\n",
     "    imviz.load_data(uri_acs_47tuc_2, data_label='acs_47tuc_2', cache=True)"
@@ -262,7 +262,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "regions = imviz.get_interactive_regions()"
+    "regions = imviz.plugins[\"Subset Tools\"].get_regions()"
    ]
   },
   {
@@ -290,6 +290,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# This only works if the region is pixel region, not sky region.\n",
     "mask = regions['Subset 1'].to_mask(mode='subpixels')"
    ]
   },

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -28,7 +28,6 @@
    "source": [
     "import warnings\n",
     "\n",
-    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "from astropy import units as u\n",
     "from astropy.coordinates import SkyCoord, Angle\n",
@@ -37,24 +36,6 @@
     "from regions import PixCoord, CirclePixelRegion, CircleSkyRegion\n",
     "\n",
     "from jdaviz import Imviz"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dc45bbab-ddb7-4d24-8066-998a1ba17fd3",
-   "metadata": {},
-   "source": [
-    "We also need this to display Matplotlib in the notebook later."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "53fb47da-0427-4a43-9d11-39567a12cdb0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%matplotlib inline"
    ]
   },
   {
@@ -115,10 +96,10 @@
     "    # 'jw02727-o002_t062_nircam_clear-f444w_i2d.fits'\n",
     "]\n",
     "\n",
-    "for fn in filenames:\n",
-    "    uri = f\"mast:JWST/product/{fn}\"\n",
-    "    with warnings.catch_warnings():\n",
-    "        warnings.simplefilter('ignore')\n",
+    "with warnings.catch_warnings(), imviz.batch_load():\n",
+    "    warnings.simplefilter('ignore')\n",
+    "    for fn in filenames:\n",
+    "        uri = f\"mast:JWST/product/{fn}\"\n",
     "        imviz.load_data(uri, cache=True)"
    ]
   },
@@ -298,7 +279,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "regions = imviz.get_interactive_regions()"
+    "regions = imviz.plugins[\"Subset Tools\"].get_regions()"
    ]
   },
   {
@@ -313,48 +294,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11afa633",
-   "metadata": {},
-   "source": [
-    "Since the region is an Astropy region, we can e.g. convert it to a mask:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "71e2191b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mask = regions['Subset 1'].to_mask(mode='subpixels')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0a4e02ef",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data = imviz.get_data('jw02727-o002_t062_nircam_clear-f090w_i2d[DATA]')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "164a1a40",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.imshow(mask.to_image(data.data.shape), origin='lower')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "ee3e07b9",
    "metadata": {},
    "source": [
-    "It is also possible to programmatically pass a `regions` shape, a `photutils` aperture shape, or a Numpy mask into Imviz."
+    "It is possible to programmatically pass a `regions` shape, a `photutils` aperture shape, or a Numpy mask into Imviz."
    ]
   },
   {

--- a/notebooks/concepts/imviz_roman_asdf.ipynb
+++ b/notebooks/concepts/imviz_roman_asdf.ipynb
@@ -212,7 +212,7 @@
    },
    "outputs": [],
    "source": [
-    "regions = imviz.get_interactive_regions()"
+    "regions = imviz.plugins['Subset Tools'].get_regions()"
    ]
   },
   {


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address some of subset API. See https://github.com/spacetelescope/jdaviz/issues/3413

Actions items:

- [x] Set `max_num_regions=20` as default for `subset_tools.import_region()`.
- [x] Deprecate `helper.load_regions_from_file()` and `helper.load_regions()` methods.
- [x] Move any tests related to `load_regions_from_file()` and `load_regions()` to use `subset_tools.import_region()` instead, if any,
- [x] Remove `helper._apply_interactive_region()` without deprecation. If it is used anywhere, replace its usage with `subset_tools` API.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-5124)
