### PR TITLE
implement python s_region parser in imviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -115,6 +115,8 @@ New Features
 
 - Snackbar history logger has been moved from an overlay to a separate tab in the right sidebar tray. [#3466]
 
+- Added an STC-S string region parser to the Footprints plugin. [#3479]
+
 Cubeviz
 ^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ New Features
 - The Plot Options plugin now highlights the tab for the active (top-most) data layer
   in the selected viewer. [#3514]
 
+- Added an STC-S string region parser to the Footprints plugin. [#3479]
+
 Cubeviz
 ^^^^^^^
 
@@ -114,8 +116,6 @@ New Features
 - Plugin API methods and attributes are now searchable from the plugin tray (and visible when API hints are enabled). [#3384]
 
 - Snackbar history logger has been moved from an overlay to a separate tab in the right sidebar tray. [#3466]
-
-- Added an STC-S string region parser to the Footprints plugin. [#3479]
 
 Cubeviz
 ^^^^^^^

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -445,9 +445,9 @@ Footprints
 ==========
 
 This plugin supports loading and overplotting instrument footprint overlays on the image viewers.
-Any number of overlays can be plotted simultaneously from any number of the available
-preset instruments (requires pysiaf to be installed) or by loading an Astropy regions object from
-a file.
+Any number of overlays can be plotted simultaneously from any number of the available preset
+instruments (requires pysiaf to be installed), by loading an Astropy regions object from a file, or
+by passing an STC-S string.
 
 The top dropdown allows renaming, adding, and removing footprint overlays.  To modify the display
 and input parameters for a given overlay, select it in the dropdown, and modify the choices
@@ -458,7 +458,7 @@ position angle, offsets, etc).
 To import a file, choose "From File..." from the presets dropdown and select a valid file (must
 be able to be parsed by `regions.Regions.read`).
 
-To import a regions file or object from the API:
+To import a regions file, object, or STC-S string from the API:
 
 .. code-block:: python
 

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -445,9 +445,9 @@ Footprints
 ==========
 
 This plugin supports loading and overplotting instrument footprint overlays on the image viewers.
-Any number of overlays can be plotted simultaneously from any number of the available preset
-instruments (requires pysiaf to be installed), by loading an Astropy regions object from a file, or
-by passing an STC-S string.
+Any number of overlays can be plotted simultaneously from any number of the available
+preset instruments (requires pysiaf to be installed), by loading an Astropy regions object from
+a file, or by passing an STC-S string.
 
 The top dropdown allows renaming, adding, and removing footprint overlays.  To modify the display
 and input parameters for a given overlay, select it in the dropdown, and modify the choices

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -464,7 +464,8 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
 
     def import_region(self, region):
         """
-        Import an Astropy regions object (or file).
+        Import an Astropy regions object or if a string is provided, attempt to parse it as a
+        STC-S string or region file.
 
         Parameters
         ----------
@@ -479,7 +480,7 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
             else: # TODO: support path objects?
                 self.preset.import_file(region)
         else:
-            raise TypeError("region must be a regions.Regions object or string (file path)")
+            raise TypeError("region must be a regions.Regions object, STC-S string or file path")
         # _preset_args_changed was probably already triggered by from_file traitlet changing, but
         # that may have been before the file was fully parsed and available from preset.selected_obj
         self._preset_args_changed()

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -9,7 +9,7 @@ from glue_jupyter.common.toolbar_vuetify import read_icon
 from jdaviz.core.custom_traitlets import FloatHandleEmpty
 from jdaviz.core.events import LinkUpdatedMessage, ChangeRefDataMessage
 from jdaviz.core.marks import FootprintOverlay
-from jdaviz.core.region_translators import regions2roi
+from jdaviz.core.region_translators import is_stcs_string, regions2roi, stcs_string2region
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin, ViewerSelectMixin,
                                         EditableSelectPluginComponent, SelectPluginComponent,
@@ -473,8 +473,11 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
         self._ensure_first_overlay()
         if isinstance(region, (regions.Region, regions.Regions)):
             self.preset.import_obj(region)
-        elif isinstance(region, str):  # TODO: support path objects?
-            self.preset.import_file(region)
+        elif isinstance(region, str):
+            if is_stcs_string(region):
+                self.preset.import_obj(stcs_string2region(region))
+            else: # TODO: support path objects?
+                self.preset.import_file(region)
         else:
             raise TypeError("region must be a regions.Regions object or string (file path)")
         # _preset_args_changed was probably already triggered by from_file traitlet changing, but

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -477,7 +477,7 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
         elif isinstance(region, str):
             if is_stcs_string(region):
                 self.preset.import_obj(stcs_string2region(region))
-            else: # TODO: support path objects?
+            else:  # TODO: support path objects?
                 self.preset.import_file(region)
         else:
             raise TypeError("region must be a regions.Regions object, STC-S string or file path")

--- a/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
@@ -18,8 +18,7 @@ def jwst_header_to_skyregion(header):
     skyregion = stcs_string2region(s_region)
 
     corners = skyregion.vertices
-    _ra, _dec = zip(*[(sky_coord.ra.value, sky_coord.dec.value) for sky_coord in corners])
-    ra, dec = np.array(_ra, dtype=float), np.array(_dec, dtype=float)
+    ra, dec = corners.ra.degree, corners.dec.degree
 
     # Need these for zooming
     length = corners[0].separation(corners[1])

--- a/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
@@ -1,11 +1,8 @@
 import bqplot
-import numpy as np
-from astropy import units as u
-from astropy.coordinates import Angle, SkyCoord
-from regions import PolygonSkyRegion
 from traitlets import Bool
 
 from jdaviz.core.events import SnackbarMessage
+from jdaviz.core.region_translators import stcs_string2region
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import PluginTemplateMixin
 
@@ -15,17 +12,7 @@ __all__ = ['SlitOverlay', 'jwst_header_to_skyregion']
 def jwst_header_to_skyregion(header):
     """Convert S_REGION in given FITS header for JWST data into sky region."""
     s_region = header['S_REGION']
-    footprint = s_region.split("POLYGON ICRS")[1].split()
-    ra = np.array(footprint[::2], dtype=float)
-    dec = np.array(footprint[1::2], dtype=float)
-    corners = SkyCoord(ra, dec, unit="deg")
-    skyregion = PolygonSkyRegion(corners)
-
-    # Need these for zooming
-    length = corners[0].separation(corners[1])
-    width = corners[1].separation(corners[2])
-    skyregion.height = Angle(max(length, width), u.deg)
-    skyregion.center = SkyCoord(ra.mean(), dec.mean(), unit="deg")
+    skyregion = stcs_string2region(s_region)
 
     return skyregion
 

--- a/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
@@ -1,5 +1,4 @@
 import bqplot
-import numpy as np
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
 from traitlets import Bool

--- a/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/slit_overlay.py
@@ -1,4 +1,7 @@
 import bqplot
+import numpy as np
+from astropy import units as u
+from astropy.coordinates import Angle, SkyCoord
 from traitlets import Bool
 
 from jdaviz.core.events import SnackbarMessage
@@ -13,6 +16,16 @@ def jwst_header_to_skyregion(header):
     """Convert S_REGION in given FITS header for JWST data into sky region."""
     s_region = header['S_REGION']
     skyregion = stcs_string2region(s_region)
+
+    corners = skyregion.vertices
+    _ra, _dec = zip(*[(sky_coord.ra.value, sky_coord.dec.value) for sky_coord in corners])
+    ra, dec = np.array(_ra, dtype=float), np.array(_dec, dtype=float)
+
+    # Need these for zooming
+    length = corners[0].separation(corners[1])
+    width = corners[1].separation(corners[2])
+    skyregion.height = Angle(max(length, width), u.deg)
+    skyregion.center = SkyCoord(ra.mean(), dec.mean(), unit=u.deg)
 
     return skyregion
 

--- a/jdaviz/configs/mosviz/plugins/slit_overlay/tests/test_slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/tests/test_slit_overlay.py
@@ -1,40 +1,39 @@
 import pytest
-# import numpy as np
+import numpy as np
 
-# from glue.core import Data
-# from jdaviz import Application
+from glue.core import Data
+from jdaviz import Application
 from jdaviz.configs.mosviz.plugins.slit_overlay.slit_overlay import jwst_header_to_skyregion
 
-# from regions import RectangleSkyRegion
+from regions import RectangleSkyRegion
 from astropy.coordinates import Angle, SkyCoord
 from astropy import units as u
 
 
-# header = {'S_REGION': 'POLYGON ICRS  5.029236065 4.992154276 5.029513148 '
-#           '4.992154276 5.029513148 4.992468585 5.029236065 4.992468585'}
+header = {'S_REGION': 'POLYGON ICRS  5.029236065 4.992154276 5.029513148 '
+          '4.992154276 5.029513148 4.992468585 5.029236065 4.992468585'}
 
-# skycoord = SkyCoord(5.02937461, 4.99231143,
-#                     unit=(u.Unit(u.deg),
-#                           u.Unit(u.deg)))
+skycoord = SkyCoord(5.02937461, 4.99231143,
+                    unit=(u.Unit(u.deg),
+                          u.Unit(u.deg)))
 
-# sky_region = RectangleSkyRegion(center=skycoord, width=Angle(0.0003143089999999251, u.deg),
-#                                 height=Angle(0.00027603191980735836, u.deg))
+sky_region = RectangleSkyRegion(center=skycoord, width=Angle(0.0003143089999999251, u.deg),
+                                height=Angle(0.00027603191980735836, u.deg))
 
 
 @pytest.mark.skip("Test needs to be fixed")
 def test_slit_overlay(spectral_cube_wcs):
-    pass
-    # app = Application()
-    # dc = app.data_collection
-    # dc.append(Data(x=np.ones((3, 4, 5)), label='test', coords=spectral_cube_wcs))
+    app = Application()
+    dc = app.data_collection
+    dc.append(Data(x=np.ones((3, 4, 5)), label='test', coords=spectral_cube_wcs))
 
-    # # so = SlitOverlay(app=app)
-    # #
-    # # so_sky_region = so.jwst_header_to_skyregion(header)
-    # #
-    # # assert np.allclose(sky_region.width.value, so_sky_region.width.value)
-    # # assert np.allclose(sky_region.height.value, so_sky_region.height.value)
-    # # assert sky_region.center.to_string() == so_sky_region.center.to_string()
+    # so = SlitOverlay(app=app)
+    #
+    # so_sky_region = so.jwst_header_to_skyregion(header)
+    #
+    # assert np.allclose(sky_region.width.value, so_sky_region.width.value)
+    # assert np.allclose(sky_region.height.value, so_sky_region.height.value)
+    # assert sky_region.center.to_string() == so_sky_region.center.to_string()
 
 
 def test_jwst_header_to_skyregion():

--- a/jdaviz/configs/mosviz/plugins/slit_overlay/tests/test_slit_overlay.py
+++ b/jdaviz/configs/mosviz/plugins/slit_overlay/tests/test_slit_overlay.py
@@ -1,33 +1,47 @@
-import numpy as np
+import pytest
+# import numpy as np
 
-from glue.core import Data
-from jdaviz import Application
+# from glue.core import Data
+# from jdaviz import Application
+from jdaviz.configs.mosviz.plugins.slit_overlay.slit_overlay import jwst_header_to_skyregion
 
-from regions import RectangleSkyRegion
+# from regions import RectangleSkyRegion
 from astropy.coordinates import Angle, SkyCoord
 from astropy import units as u
 
-header = {'S_REGION': 'POLYGON ICRS  5.029236065 4.992154276 5.029513148 '
-          '4.992154276 5.029513148 4.992468585 5.029236065 4.992468585'}
 
-skycoord = SkyCoord(5.02937461, 4.99231143,
-                    unit=(u.Unit(u.deg),
-                          u.Unit(u.deg)))
+# header = {'S_REGION': 'POLYGON ICRS  5.029236065 4.992154276 5.029513148 '
+#           '4.992154276 5.029513148 4.992468585 5.029236065 4.992468585'}
 
-sky_region = RectangleSkyRegion(center=skycoord, width=Angle(0.0003143089999999251, u.deg),
-                                height=Angle(0.00027603191980735836, u.deg))
+# skycoord = SkyCoord(5.02937461, 4.99231143,
+#                     unit=(u.Unit(u.deg),
+#                           u.Unit(u.deg)))
+
+# sky_region = RectangleSkyRegion(center=skycoord, width=Angle(0.0003143089999999251, u.deg),
+#                                 height=Angle(0.00027603191980735836, u.deg))
 
 
-def todo_fix_test_slit_overlay(spectral_cube_wcs):
+@pytest.mark.skip("Test needs to be fixed")
+def test_slit_overlay(spectral_cube_wcs):
+    pass
+    # app = Application()
+    # dc = app.data_collection
+    # dc.append(Data(x=np.ones((3, 4, 5)), label='test', coords=spectral_cube_wcs))
 
-    app = Application()
-    dc = app.data_collection
-    dc.append(Data(x=np.ones((3, 4, 5)), label='test', coords=spectral_cube_wcs))
+    # # so = SlitOverlay(app=app)
+    # #
+    # # so_sky_region = so.jwst_header_to_skyregion(header)
+    # #
+    # # assert np.allclose(sky_region.width.value, so_sky_region.width.value)
+    # # assert np.allclose(sky_region.height.value, so_sky_region.height.value)
+    # # assert sky_region.center.to_string() == so_sky_region.center.to_string()
 
-    # so = SlitOverlay(app=app)
-    #
-    # so_sky_region = so.jwst_header_to_skyregion(header)
-    #
-    # assert np.allclose(sky_region.width.value, so_sky_region.width.value)
-    # assert np.allclose(sky_region.height.value, so_sky_region.height.value)
-    # assert sky_region.center.to_string() == so_sky_region.center.to_string()
+
+def test_jwst_header_to_skyregion():
+    header = {'S_REGION': 'POLYGON ICRS 10.0 20.0 30.0 40.0 50.0 60.0 70.0 80.0'}
+    skyregion = jwst_header_to_skyregion(header)
+    height = Angle(26.32660752556319, u.deg)
+    center = SkyCoord(40.0, 50.0, unit=u.deg)
+
+    assert skyregion.height == height
+    assert skyregion.center == center

--- a/jdaviz/core/region_translators.py
+++ b/jdaviz/core/region_translators.py
@@ -1,7 +1,12 @@
 """The ``region_translators`` module houses translations of
 :ref:`regions:shapes` to :ref:`photutils:photutils-aperture` apertures.
 """
+import re
+import numpy as np
+import photutils
 from astropy import units as u
+from astropy.coordinates import Angle, SkyCoord
+from astropy.utils import minversion
 from glue.core.roi import CircularROI, EllipticalROI, RectangularROI, CircularAnnulusROI
 from photutils.aperture import (CircularAperture, SkyCircularAperture,
                                 EllipticalAperture, SkyEllipticalAperture,
@@ -14,7 +19,8 @@ from regions import (CirclePixelRegion, CircleSkyRegion,
                      RectanglePixelRegion, RectangleSkyRegion,
                      CircleAnnulusPixelRegion, CircleAnnulusSkyRegion,
                      EllipseAnnulusPixelRegion, EllipseAnnulusSkyRegion,
-                     RectangleAnnulusPixelRegion, RectangleAnnulusSkyRegion, PixCoord)
+                     RectangleAnnulusPixelRegion, RectangleAnnulusSkyRegion,
+                     PixCoord, PolygonSkyRegion)
 
 __all__ = ['regions2roi', 'regions2aperture', 'aperture2regions']
 
@@ -334,6 +340,188 @@ def aperture2regions(aperture):
         raise NotImplementedError(f'{aperture.__class__.__name__} is not supported')
 
     return region_shape
+
+
+SUPPORTED_STCS_SHAPE_VALUES = ('POLYGON', 'CIRCLE', 'ELLIPSE', )
+SUPPORTED_STCS_FRAME_VALUES = ('ICRS', 'J2000', 'FK5', )
+STCS_SHAPE_PATTERN = '|'.join(SUPPORTED_STCS_SHAPE_VALUES)
+STCS_FRAME_PATTERN = '|'.join(SUPPORTED_STCS_FRAME_VALUES)
+SUPPORTED_STCS_PATTERN = re.compile(
+    fr"^(?P<shape>({'|'.join(SUPPORTED_STCS_SHAPE_VALUES)}))"
+    fr"(?P<frame>(\s+({'|'.join(SUPPORTED_STCS_FRAME_VALUES)})))*"
+    r"(?P<coordinates>(\s+-?\d+\.\d+)+$)",
+    re.IGNORECASE)
+
+def stcs_string2region(stcs_string):
+    """Convert a given STC-S string to ``regions`` shape.
+
+    Parameters
+    ----------
+    stcs_string : str
+        A valid STC-S string.
+
+    Returns
+    -------
+    sky_region : `regions.Region`
+        A supported ``regions`` shape.
+
+    Raises
+    ------
+    NotImplementedError
+        The given STC-S string is not supported.
+
+    ValueError
+        Invalid inputs.
+
+    Examples
+    --------
+    Translate an STC-S region to `regions.PolygonSkyRegion`:
+
+    >>> from jdaviz.core.region_translators import stcs_string2region
+    >>> stcs_string = 'POLYGON ICRS 10.0 20.0 30.0 40.0 50.0 60.0'
+    >>> stcs_string2region(stcs_string)
+    <PolygonSkyRegion(vertices=[<SkyCoord (ICRS): (ra, dec) in deg
+        (10., 20.), (30., 40.), (50., 60.)>])>
+
+    """
+
+    if not isinstance(stcs_string, str):
+        raise ValueError('STC-S string must be a string.')
+
+    _match = SUPPORTED_STCS_PATTERN.match(stcs_string)
+
+    # Check if the STC-S string is valid, otherwise raise an error
+    if not _match:
+        raise ValueError(f'Invalid STC-S string: {stcs_string}')
+
+    # Extract the shape, frame, and coordinates from the STC-S string
+    shape = _match.group('shape').strip().lower()
+    frame = _match.group('frame').strip().lower() if _match.group('frame') else 'icrs'
+    coordinates = list(map(float, _match.group('coordinates').strip().split()))
+
+    sky_region_factory = {
+        'polygon': _create_polygon_skyregion_from_coords,
+        'circle': _create_circle_skyregion_from_coords,
+        'ellipse': _create_ellipse_skyregion_from_coords,
+    }
+
+    return sky_region_factory[shape](coordinates, frame=frame)
+
+
+def _create_polygon_skyregion_from_coords(coords, frame='icrs', unit=u.deg):
+    """Create a `regions.PolygonSkyRegion` from given coordinates.
+
+    Parameters
+    ----------
+    coords : list
+        List of coordinates in the form of [ra1, dec1, ra2, dec2, ...].
+
+    frame : str, optional
+        Coordinate frame. Default is 'icrs'.
+
+    unit : `~astropy.units.Unit`, optional
+        Unit of the coordinates. Default is `~astropy.units.deg`.
+
+    Returns
+    -------
+    sky_region : `regions.PolygonSkyRegion`
+        A polygon sky region.
+
+    Examples
+    --------
+    Create a `regions.PolygonSkyRegion` from given coordinates:
+
+    >>> from jdaviz.core.region_translators import create_polygon_skyregion_from_coords
+    >>> coords = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0]
+    >>> _create_polygon_skyregion_from_coords(coords)
+    <PolygonSkyRegion(vertices=[<SkyCoord (ICRS): (ra, dec) in deg
+        (10., 20.), (30., 40.), (50., 60.)>])>
+
+    """
+    ra = np.array(coords[::2], dtype=float)
+    dec = np.array(coords[1::2], dtype=float)
+    sky_coordinates = SkyCoord(ra, dec, frame=frame, unit=unit)
+    sky_region = PolygonSkyRegion(sky_coordinates)
+
+    # Need these for zooming
+    length = sky_coordinates[0].separation(sky_coordinates[1])
+    width = sky_coordinates[1].separation(sky_coordinates[2])
+    sky_region.height = Angle(max(length, width), unit)
+    sky_region.center = SkyCoord(ra.mean(), dec.mean(), unit=unit)
+
+    return sky_region
+
+
+def _create_circle_skyregion_from_coords(coords, frame='icrs', unit=u.deg):
+    """Create a `regions.CircleSkyRegion` from given coordinates.
+
+    Parameters
+    ----------
+    coords : list
+        List of coordinates in the form of [ra, dec, radius].
+
+    frame : str, optional
+        Coordinate frame. Default is 'icrs'.
+
+    unit : `~astropy.units.Unit`, optional
+        Unit of the coordinates. Default is `~astropy.units.deg`.
+
+    Returns
+    -------
+    sky_region : `regions.CircleSkyRegion`
+        A circle sky region.
+
+    Examples
+    --------
+    Create a `regions.CircleSkyRegion` from given coordinates:
+
+    >>> from jdaviz.core.region_translators import create_circle_skyregion_from_coords
+    >>> coords = [10.0, 20.0, 5.0]
+    >>> _create_circle_skyregion_from_coords(coords)
+    <CircleSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in deg (10., 20.)>, radius=5.0 deg)>
+
+    """
+    sky_coordinates = SkyCoord(coords[0], coords[1], frame=frame, unit=unit)
+    sky_region = CircleSkyRegion(center=sky_coordinates, radius=coords[2] * unit)
+
+    return sky_region
+
+
+def _create_ellipse_skyregion_from_coords(coords, frame='icrs', unit=u.deg):
+    """Create a `regions.EllipseSkyRegion` from given coordinates.
+
+    Parameters
+    ----------
+    coords : list
+        List of coordinates in the form of [ra, dec, width, height, angle].
+
+    frame : str, optional
+        Coordinate frame. Default is 'icrs'.
+
+    unit : `~astropy.units.Unit`, optional
+        Unit of the coordinates. Default is `~astropy.units.deg`.
+
+    Returns
+    -------
+    sky_region : `regions.EllipseSkyRegion`
+        An ellipse sky region.
+
+    Examples
+    --------
+    Create a `regions.EllipseSkyRegion` from given coordinates:
+
+    >>> from jdaviz.core.region_translators import create_ellipse_skyregion_from_coords
+    >>> coords = [10.0, 20.0, 5.0, 3.0, 45.0]
+    >>> _create_ellipse_skyregion_from_coords(coords)
+    <EllipseSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in deg (10., 20.)>,
+        width=5.0 deg, height=3.0 deg, angle=45.0 deg)>
+
+    """
+    sky_coordinates = SkyCoord(coords[0], coords[1], frame=frame, unit=unit)
+    sky_region = EllipseSkyRegion(center=sky_coordinates, width=coords[2] * unit,
+                                  height=coords[3] * unit, angle=coords[4] * unit)
+
+    return sky_region
 
 
 def positions2pixcoord(positions):

--- a/jdaviz/core/region_translators.py
+++ b/jdaviz/core/region_translators.py
@@ -2,10 +2,8 @@
 :ref:`regions:shapes` to :ref:`photutils:photutils-aperture` apertures.
 """
 import re
-import photutils
 from astropy import units as u
-from astropy.coordinates import Angle, SkyCoord
-from astropy.utils import minversion
+from astropy.coordinates import SkyCoord
 from glue.core.roi import CircularROI, EllipticalROI, RectangularROI, CircularAnnulusROI
 from photutils.aperture import (CircularAperture, SkyCircularAperture,
                                 EllipticalAperture, SkyEllipticalAperture,

--- a/jdaviz/core/region_translators.py
+++ b/jdaviz/core/region_translators.py
@@ -368,7 +368,7 @@ def _create_polygon_skyregion_from_coords(coords, frame='icrs', unit=u.deg):
     >>> coords = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0]
     >>> _create_polygon_skyregion_from_coords(coords)
     <PolygonSkyRegion(vertices=<SkyCoord (ICRS): (ra, dec) in deg
-        (10., 20.), (30., 40.), (50., 60.)>)>
+        [(10., 20.), (30., 40.), (50., 60.)]>)>
 
     """
     ra, dec = coords[::2], coords[1::2]
@@ -522,7 +522,7 @@ def stcs_string2region(stcs_string):
     >>> stcs_string = 'POLYGON ICRS 10.0 20.0 30.0 40.0 50.0 60.0'
     >>> stcs_string2region(stcs_string)
     <PolygonSkyRegion(vertices=<SkyCoord (ICRS): (ra, dec) in deg
-        (10., 20.), (30., 40.), (50., 60.)>)>
+        [(10., 20.), (30., 40.), (50., 60.)]>)>
 
     """
 

--- a/jdaviz/core/region_translators.py
+++ b/jdaviz/core/region_translators.py
@@ -2,7 +2,6 @@
 :ref:`regions:shapes` to :ref:`photutils:photutils-aperture` apertures.
 """
 import re
-import numpy as np
 import photutils
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
@@ -372,16 +371,9 @@ def _create_polygon_skyregion_from_coords(coords, frame='icrs', unit=u.deg):
         (10., 20.), (30., 40.), (50., 60.)>])>
 
     """
-    ra = np.array(coords[::2], dtype=float)
-    dec = np.array(coords[1::2], dtype=float)
+    ra, dec = coords[::2], coords[1::2]
     sky_coordinates = SkyCoord(ra, dec, frame=frame, unit=unit)
     sky_region = PolygonSkyRegion(sky_coordinates)
-
-    # Need these for zooming
-    length = sky_coordinates[0].separation(sky_coordinates[1])
-    width = sky_coordinates[1].separation(sky_coordinates[2])
-    sky_region.height = Angle(max(length, width), unit)
-    sky_region.center = SkyCoord(ra.mean(), dec.mean(), unit=unit)
 
     return sky_region
 
@@ -497,7 +489,11 @@ def is_stcs_string(stcs_string):
     True
 
     """
-    return bool(SUPPORTED_STCS_PATTERN.match(stcs_string))
+
+    try:
+        return bool(SUPPORTED_STCS_PATTERN.match(stcs_string))
+    except:
+        return False
 
 
 def stcs_string2region(stcs_string):
@@ -515,9 +511,6 @@ def stcs_string2region(stcs_string):
 
     Raises
     ------
-    NotImplementedError
-        The given STC-S string is not supported.
-
     ValueError
         Invalid inputs.
 

--- a/jdaviz/core/region_translators.py
+++ b/jdaviz/core/region_translators.py
@@ -457,7 +457,7 @@ STCS_FRAME_PATTERN = '|'.join(SUPPORTED_STCS_FRAME_VALUES)
 SUPPORTED_STCS_PATTERN = re.compile(
     fr"^(?P<shape>({'|'.join(SUPPORTED_STCS_SHAPE_VALUES)}))"
     fr"(?P<frame>(\s+({'|'.join(SUPPORTED_STCS_FRAME_VALUES)})))*"
-    r"(?P<coordinates>(\s+-?\d+\.\d+)+$)",
+    r"(?P<coordinates>(\s+-?\d+\.\d+){2,}$)",
     re.IGNORECASE)
 SKY_REGION_FROM_COORDS_FACTORY = {
     'polygon': _create_polygon_skyregion_from_coords,

--- a/jdaviz/core/region_translators.py
+++ b/jdaviz/core/region_translators.py
@@ -342,72 +342,6 @@ def aperture2regions(aperture):
     return region_shape
 
 
-SUPPORTED_STCS_SHAPE_VALUES = ('POLYGON', 'CIRCLE', 'ELLIPSE', )
-SUPPORTED_STCS_FRAME_VALUES = ('ICRS', 'J2000', 'FK5', )
-STCS_SHAPE_PATTERN = '|'.join(SUPPORTED_STCS_SHAPE_VALUES)
-STCS_FRAME_PATTERN = '|'.join(SUPPORTED_STCS_FRAME_VALUES)
-SUPPORTED_STCS_PATTERN = re.compile(
-    fr"^(?P<shape>({'|'.join(SUPPORTED_STCS_SHAPE_VALUES)}))"
-    fr"(?P<frame>(\s+({'|'.join(SUPPORTED_STCS_FRAME_VALUES)})))*"
-    r"(?P<coordinates>(\s+-?\d+\.\d+)+$)",
-    re.IGNORECASE)
-
-def stcs_string2region(stcs_string):
-    """Convert a given STC-S string to ``regions`` shape.
-
-    Parameters
-    ----------
-    stcs_string : str
-        A valid STC-S string.
-
-    Returns
-    -------
-    sky_region : `regions.Region`
-        A supported ``regions`` shape.
-
-    Raises
-    ------
-    NotImplementedError
-        The given STC-S string is not supported.
-
-    ValueError
-        Invalid inputs.
-
-    Examples
-    --------
-    Translate an STC-S region to `regions.PolygonSkyRegion`:
-
-    >>> from jdaviz.core.region_translators import stcs_string2region
-    >>> stcs_string = 'POLYGON ICRS 10.0 20.0 30.0 40.0 50.0 60.0'
-    >>> stcs_string2region(stcs_string)
-    <PolygonSkyRegion(vertices=[<SkyCoord (ICRS): (ra, dec) in deg
-        (10., 20.), (30., 40.), (50., 60.)>])>
-
-    """
-
-    if not isinstance(stcs_string, str):
-        raise ValueError('STC-S string must be a string.')
-
-    _match = SUPPORTED_STCS_PATTERN.match(stcs_string)
-
-    # Check if the STC-S string is valid, otherwise raise an error
-    if not _match:
-        raise ValueError(f'Invalid STC-S string: {stcs_string}')
-
-    # Extract the shape, frame, and coordinates from the STC-S string
-    shape = _match.group('shape').strip().lower()
-    frame = _match.group('frame').strip().lower() if _match.group('frame') else 'icrs'
-    coordinates = list(map(float, _match.group('coordinates').strip().split()))
-
-    sky_region_factory = {
-        'polygon': _create_polygon_skyregion_from_coords,
-        'circle': _create_circle_skyregion_from_coords,
-        'ellipse': _create_ellipse_skyregion_from_coords,
-    }
-
-    return sky_region_factory[shape](coordinates, frame=frame)
-
-
 def _create_polygon_skyregion_from_coords(coords, frame='icrs', unit=u.deg):
     """Create a `regions.PolygonSkyRegion` from given coordinates.
 
@@ -522,6 +456,98 @@ def _create_ellipse_skyregion_from_coords(coords, frame='icrs', unit=u.deg):
                                   height=coords[3] * unit, angle=coords[4] * unit)
 
     return sky_region
+
+
+SUPPORTED_STCS_SHAPE_VALUES = ('POLYGON', 'CIRCLE', 'ELLIPSE', )
+SUPPORTED_STCS_FRAME_VALUES = ('ICRS', 'J2000', 'FK5', )
+STCS_SHAPE_PATTERN = '|'.join(SUPPORTED_STCS_SHAPE_VALUES)
+STCS_FRAME_PATTERN = '|'.join(SUPPORTED_STCS_FRAME_VALUES)
+SUPPORTED_STCS_PATTERN = re.compile(
+    fr"^(?P<shape>({'|'.join(SUPPORTED_STCS_SHAPE_VALUES)}))"
+    fr"(?P<frame>(\s+({'|'.join(SUPPORTED_STCS_FRAME_VALUES)})))*"
+    r"(?P<coordinates>(\s+-?\d+\.\d+)+$)",
+    re.IGNORECASE)
+SKY_REGION_FROM_COORDS_FACTORY = {
+    'polygon': _create_polygon_skyregion_from_coords,
+    'circle': _create_circle_skyregion_from_coords,
+    'ellipse': _create_ellipse_skyregion_from_coords,
+}
+
+
+def is_stcs_string(stcs_string):
+    """Check if the given string is a valid STC-S string.
+
+    Parameters
+    ----------
+    stcs_string : str
+        A string to check.
+
+    Returns
+    -------
+    is_stcs : bool
+        `True` if the given string is a valid STC-S string, otherwise `False`.
+
+    Examples
+    --------
+    Check if a given string is a valid STC-S string:
+
+    >>> from jdaviz.core.region_translators import is_stcs_string
+    >>> stcs_string = 'POLYGON ICRS 10.0 20.0 30.0 40.0 50.0 60.0'
+    >>> is_stcs_string(stcs_string)
+    True
+
+    """
+    return bool(SUPPORTED_STCS_PATTERN.match(stcs_string))
+
+
+def stcs_string2region(stcs_string):
+    """Convert a given STC-S string to ``regions`` shape.
+
+    Parameters
+    ----------
+    stcs_string : str
+        A valid STC-S string.
+
+    Returns
+    -------
+    sky_region : `regions.Region`
+        A supported ``regions`` shape.
+
+    Raises
+    ------
+    NotImplementedError
+        The given STC-S string is not supported.
+
+    ValueError
+        Invalid inputs.
+
+    Examples
+    --------
+    Translate an STC-S region to `regions.PolygonSkyRegion`:
+
+    >>> from jdaviz.core.region_translators import stcs_string2region
+    >>> stcs_string = 'POLYGON ICRS 10.0 20.0 30.0 40.0 50.0 60.0'
+    >>> stcs_string2region(stcs_string)
+    <PolygonSkyRegion(vertices=[<SkyCoord (ICRS): (ra, dec) in deg
+        (10., 20.), (30., 40.), (50., 60.)>])>
+
+    """
+
+    if not isinstance(stcs_string, str):
+        raise ValueError('STC-S string must be a string.')
+
+    _match = SUPPORTED_STCS_PATTERN.match(stcs_string)
+
+    # Check if the STC-S string is valid, otherwise raise an error
+    if not _match:
+        raise ValueError(f'Invalid STC-S string: {stcs_string}')
+
+    # Extract the shape, frame, and coordinates from the STC-S string
+    shape = _match.group('shape').strip().lower()
+    frame = _match.group('frame').strip().lower() if _match.group('frame') else 'icrs'
+    coordinates = list(map(float, _match.group('coordinates').strip().split()))
+
+    return SKY_REGION_FROM_COORDS_FACTORY[shape](coordinates, frame=frame)
 
 
 def positions2pixcoord(positions):

--- a/jdaviz/core/region_translators.py
+++ b/jdaviz/core/region_translators.py
@@ -364,11 +364,11 @@ def _create_polygon_skyregion_from_coords(coords, frame='icrs', unit=u.deg):
     --------
     Create a `regions.PolygonSkyRegion` from given coordinates:
 
-    >>> from jdaviz.core.region_translators import create_polygon_skyregion_from_coords
+    >>> from jdaviz.core.region_translators import _create_polygon_skyregion_from_coords
     >>> coords = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0]
     >>> _create_polygon_skyregion_from_coords(coords)
-    <PolygonSkyRegion(vertices=[<SkyCoord (ICRS): (ra, dec) in deg
-        (10., 20.), (30., 40.), (50., 60.)>])>
+    <PolygonSkyRegion(vertices=<SkyCoord (ICRS): (ra, dec) in deg
+        (10., 20.), (30., 40.), (50., 60.)>)>
 
     """
     ra, dec = coords[::2], coords[1::2]
@@ -401,7 +401,7 @@ def _create_circle_skyregion_from_coords(coords, frame='icrs', unit=u.deg):
     --------
     Create a `regions.CircleSkyRegion` from given coordinates:
 
-    >>> from jdaviz.core.region_translators import create_circle_skyregion_from_coords
+    >>> from jdaviz.core.region_translators import _create_circle_skyregion_from_coords
     >>> coords = [10.0, 20.0, 5.0]
     >>> _create_circle_skyregion_from_coords(coords)
     <CircleSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in deg (10., 20.)>, radius=5.0 deg)>
@@ -436,11 +436,11 @@ def _create_ellipse_skyregion_from_coords(coords, frame='icrs', unit=u.deg):
     --------
     Create a `regions.EllipseSkyRegion` from given coordinates:
 
-    >>> from jdaviz.core.region_translators import create_ellipse_skyregion_from_coords
+    >>> from jdaviz.core.region_translators import _create_ellipse_skyregion_from_coords
     >>> coords = [10.0, 20.0, 5.0, 3.0, 45.0]
     >>> _create_ellipse_skyregion_from_coords(coords)
-    <EllipseSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in deg (10., 20.)>,
-        width=5.0 deg, height=3.0 deg, angle=45.0 deg)>
+    <EllipseSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in deg
+        (10., 20.)>, width=5.0 deg, height=3.0 deg, angle=45.0 deg)>
 
     """
     sky_coordinates = SkyCoord(coords[0], coords[1], frame=frame, unit=unit)
@@ -521,8 +521,8 @@ def stcs_string2region(stcs_string):
     >>> from jdaviz.core.region_translators import stcs_string2region
     >>> stcs_string = 'POLYGON ICRS 10.0 20.0 30.0 40.0 50.0 60.0'
     >>> stcs_string2region(stcs_string)
-    <PolygonSkyRegion(vertices=[<SkyCoord (ICRS): (ra, dec) in deg
-        (10., 20.), (30., 40.), (50., 60.)>])>
+    <PolygonSkyRegion(vertices=<SkyCoord (ICRS): (ra, dec) in deg
+        (10., 20.), (30., 40.), (50., 60.)>)>
 
     """
 

--- a/jdaviz/core/region_translators.py
+++ b/jdaviz/core/region_translators.py
@@ -492,7 +492,7 @@ def is_stcs_string(stcs_string):
 
     try:
         return bool(SUPPORTED_STCS_PATTERN.match(stcs_string))
-    except:
+    except Exception:
         return False
 
 

--- a/jdaviz/core/tests/test_region_translators.py
+++ b/jdaviz/core/tests/test_region_translators.py
@@ -1,6 +1,6 @@
 import pytest
 from astropy import units as u
-from astropy.coordinates import Angle, SkyCoord
+from astropy.coordinates import Angle, ICRS, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 from glue.core.roi import CircularROI, EllipticalROI, RectangularROI
 from numpy.testing import assert_allclose
@@ -10,11 +10,16 @@ from photutils.aperture import (CircularAperture, SkyCircularAperture,
                                 CircularAnnulus, SkyCircularAnnulus,
                                 EllipticalAnnulus, SkyEllipticalAnnulus,
                                 RectangularAnnulus, SkyRectangularAnnulus)
-from regions import (CirclePixelRegion, EllipsePixelRegion, RectanglePixelRegion,
-                     CircleAnnulusPixelRegion, EllipseAnnulusPixelRegion,
-                     RectangleAnnulusPixelRegion, PolygonPixelRegion, PixCoord)
+from regions import (CirclePixelRegion, CircleSkyRegion,
+                     EllipsePixelRegion, EllipseSkyRegion,
+                     RectanglePixelRegion, CircleAnnulusPixelRegion,
+                     EllipseAnnulusPixelRegion, RectangleAnnulusPixelRegion,
+                     PolygonPixelRegion, PolygonSkyRegion,
+                     PixCoord)
 
 from jdaviz.core.region_translators import (
+    _create_polygon_skyregion_from_coords, _create_circle_skyregion_from_coords,
+    _create_ellipse_skyregion_from_coords, is_stcs_string, stcs_string2region,
     regions2roi, regions2aperture, aperture2regions)
 
 
@@ -333,3 +338,91 @@ def test_translation_polygon():
         regions2aperture(region_shape)
     with pytest.raises(NotImplementedError, match='is not supported'):
         regions2roi(region_shape)
+
+
+def test___create_polygon_skyregion_from_coords():
+    coords = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0]
+    reg = _create_polygon_skyregion_from_coords(coords)
+    assert isinstance(reg, PolygonSkyRegion)
+    assert_allclose(reg.vertices.ra.degree, [10, 30, 50])
+    assert_allclose(reg.vertices.dec.degree, [20, 40, 60])
+    # Check that the default frame is ICRS
+    assert isinstance(reg.vertices.frame, ICRS)
+    # Check that the default unit is deg
+    assert reg.vertices.ra.unit == u.deg
+
+
+def test___create_circle_skyregion_from_coords():
+    coords = [10.0, 20.0, 30.0]
+    reg = _create_circle_skyregion_from_coords(coords)
+    assert isinstance(reg, CircleSkyRegion)
+    assert_allclose(reg.center.ra.degree, 10)
+    assert_allclose(reg.center.dec.degree, 20)
+    # Check that the default frame is ICRS
+    assert isinstance(reg.center.frame, ICRS)
+    # Check that the default unit is deg
+    assert reg.center.ra.unit == u.deg
+
+
+def test___create_ellipse_skyregion_from_coords():
+    coords = [10.0, 20.0, 30.0, 40.0, 50.0]
+    reg = _create_ellipse_skyregion_from_coords(coords)
+    assert isinstance(reg, EllipseSkyRegion)
+    assert_allclose(reg.center.ra.degree, 10)
+    assert_allclose(reg.center.dec.degree, 20)
+    # Check that the default frame is ICRS
+    assert isinstance(reg.center.frame, ICRS)
+    # Check that the default unit is deg
+    assert reg.center.ra.unit == u.deg
+
+
+@pytest.mark.parametrize('stcs_string, expected', [
+    ('POLYGON ICRS 10.0 20.0', True),
+    ('CIRCLE ICRS 10.0 20.0', True),
+    ('ELLIPSE ICRS 10.0 20.0', True),
+    ('polygon icrs 10.0 20.0', True),
+    ('circle icrs 10.0 20.0', True),
+    ('ellipse icrs 10.0 20.0', True),
+    ('POLYGON J2000 10.0 20.0', True),
+    ('CIRCLE J2000 10.0 20.0', True),
+    ('ELLIPSE J2000 10.0 20.0', True),
+    ('POLYGON FK5 10.0 20.0', True),
+    ('CIRCLE FK5 10.0 20.0', True),
+    ('ELLIPSE FK5 10.0 20.0', True),
+    ('POLYGON 10.0 20.0', True),
+    ('CIRCLE 10.0 20.0', True),
+    ('ELLIPSE 10.0 20.0', True),
+    ('POLYGON ICRS 1.0', False),
+    ('POLYGON ICRS 1 2 3', False),
+    ('POLYGON 1.0', False),
+    ('POLYGON 1 2 3', False),
+    ('not a STC-S string', False),
+    # Invalid input type (not a string) should return False instead of raising an error
+    (123, False),
+])
+def test_is_stcs_string(stcs_string, expected):
+    assert is_stcs_string(stcs_string) is expected
+
+
+@pytest.mark.parametrize('stcs_string, expected', [
+    ('POLYGON ICRS 10.0 20.0 30.0 40.0 50.0 60.0',
+     PolygonSkyRegion(vertices=SkyCoord(ra=[10, 30, 50], dec=[20, 40, 60], unit='deg'))),
+    ('CIRCLE ICRS 10.0 20.0 30.0',
+     CircleSkyRegion(center=SkyCoord(ra=10, dec=20, unit='deg'), radius=30 * u.deg)),
+    ('ELLIPSE ICRS 10.0 20.0 30.0 40.0 50.0',
+     EllipseSkyRegion(center=SkyCoord(ra=10, dec=20, unit='deg'),
+                      width=30 * u.deg, height=40 * u.deg, angle=50 * u.deg)),
+])
+def test_stcs_string2region_correctness(stcs_string, expected):
+    reg = stcs_string2region(stcs_string)
+    assert isinstance(reg, expected.__class__)
+    assert reg == expected
+
+
+@pytest.mark.parametrize('stcs_string, exception_message', [
+    ('CIRCLE ICRS 10', 'Invalid STC-S string'),
+    (123, 'STC-S string must be a string.'),
+])
+def test_stcs_string2region_exceptions(stcs_string, exception_message):
+    with pytest.raises(ValueError, match=exception_message):
+        stcs_string2region(stcs_string)

--- a/jdaviz/core/tests/test_region_translators.py
+++ b/jdaviz/core/tests/test_region_translators.py
@@ -415,7 +415,6 @@ def test_is_stcs_string(stcs_string, expected):
 ])
 def test_stcs_string2region_correctness(stcs_string, expected):
     reg = stcs_string2region(stcs_string)
-    assert isinstance(reg, expected.__class__)
     assert reg == expected
 
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address the python implementation of an s_region STC-S string parser in imviz.

MAST communicates polygonal instrument footprints with “s_region” strings, which are a subset of [STC-S regions](https://www.ivoa.net/documents/STC-S/20130917/WD-STC-S-1.0-20130917.html).

In jdaviz, add a parser to footprint_plugin.import_region to take STC-S strings as input to create and import astropy regions as a Footprint in the Footprints plugin.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
