### PR TITLE
change imviz reference data coords from GWCS to FITS WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Imviz
 - Footprints plugin now supports selecting the closest overlay
   to a clicked point in the image viewer. [#3525]
 
-- Improve perfomance by using FITS WCS for reference data layers when linked by WCS, rather than GWCS [#3483]
+- Improve performance by using FITS WCS for reference data layers when linked by WCS, rather than GWCS [#3483]
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,8 @@ Imviz
 - Footprints plugin now supports selecting the closest overlay
   to a clicked point in the image viewer. [#3525]
 
+- Improve perfomance by using FITS WCS for reference data layers when linked by WCS, rather than GWCS [#3483]
+
 Mosviz
 ^^^^^^
 

--- a/docs/imviz/displayimages.rst
+++ b/docs/imviz/displayimages.rst
@@ -62,9 +62,9 @@ because all transformations in glue go through the reference data. Such a situat
 is indicated by the affected coordinates becoming gray.
 
 If your data of interest also has a GWCS with a bounding box, only
-the mouseover data where it overlaps with the reference data's
-bounding box is completely reliable. Unreliable coordinates transformation here
-will also gray out in a similar fashion as above.
+the mouseover data inside the bounding box is completely reliable.
+Unreliable coordinates transformation here
+will also be hidden or grayed out in a similar fashion as above.
 
 To avoid inaccurate transforms, consider one of the following workflows:
 

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -433,12 +433,13 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
 
             if "nan" in (world_ra, world_dec, world_ra_deg, world_dec_deg):
                 self.reset_coords_display()
+            else:
+                self.row2_title = 'World'
+                self.row2_text = f'{world_ra} {world_dec} (ICRS)'
+                self.row2_unreliable = unreliable_world
+                self.row3_title = ''
+                self.row3_text = f'{world_ra_deg} {world_dec_deg} (deg)'
 
-            self.row2_title = 'World'
-            self.row2_text = f'{world_ra} {world_dec} (ICRS)'
-            self.row2_unreliable = unreliable_world
-            self.row3_title = ''
-            self.row3_text = f'{world_ra_deg} {world_dec_deg} (deg)'
             self.row3_unreliable = unreliable_world
             self._dict['world_ra'] = sky.ra.value
             self._dict['world_dec'] = sky.dec.value
@@ -475,9 +476,16 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
             self.row3_unreliable = False
 
         maxsize = int(np.ceil(np.log10(np.max(active_layer.layer.shape)))) + 3
-        fmt = 'x={0:0' + str(maxsize) + '.1f} y={1:0' + str(maxsize) + '.1f}'
+        if any(['nan' in map(str, (x, y))]):
+            # don't show nan coordinates:
+            row1a_text = ""
+        else:
+            fmt = 'x={0:0' + str(maxsize) + '.1f} y={1:0' + str(maxsize) + '.1f}'
+            row1a_text = fmt.format(x, y)
+
+        self.row1a_text = row1a_text
         self.row1a_title = 'Pixel'
-        self.row1a_text = (fmt.format(x, y))
+
         self.row1_unreliable = unreliable_pixel
         self._dict['pixel_x'] = float(x)
         self._dict['pixel_y'] = float(y)

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -179,23 +179,27 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
     def as_dict(self):
         return self._dict
 
-    def reset_coords_display(self):
-        self.row1a_title = '\u00A0'  # to force empty line if no other content
-        self.row1a_text = ""
-        self.row1b_title = ""
-        self.row1b_text = ""
-        self.row1_unreliable = False
+    def reset_coords_display(self, clear_rows=[1, 2, 3]):
+        if 1 in clear_rows:
+            self.row1a_title = '\u00A0'  # to force empty line if no other content
+            self.row1a_text = ""
+            self.row1b_title = ""
+            self.row1b_text = ""
+            self.row1_unreliable = False
 
-        self.row2_title = '\u00A0'
-        self.row2_text = ""
-        self.row2_unreliable = False
+        if 2 in clear_rows:
+            self.row2_title = '\u00A0'
+            self.row2_text = ""
+            self.row2_unreliable = False
 
-        self.row3_title = '\u00A0'
-        self.row3_text = ""
-        self.row3_unreliable = False
+        if 3 in clear_rows:
+            self.row3_title = '\u00A0'
+            self.row3_text = ""
+            self.row3_unreliable = False
 
-        self.icon = ""
-        self._dict = {}
+        if clear_rows == [1, 2, 3]:
+            self.icon = ""
+            self._dict = {}
 
     def _viewer_mouse_clear_event(self, viewer, data=None):
         self.reset_coords_display()
@@ -432,7 +436,7 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
             world_dec_deg = celestial_coordinates_deg[1]
 
             if "nan" in (world_ra, world_dec, world_ra_deg, world_dec_deg):
-                self.reset_coords_display()
+                self.reset_coords_display(clear_rows=[2, 3])
             else:
                 self.row2_title = 'World'
                 self.row2_text = f'{world_ra} {world_dec} (ICRS)'

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -483,12 +483,14 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
         if any(['nan' in map(str, (x, y))]):
             # don't show nan coordinates:
             row1a_text = ""
+            row1a_title = ""
         else:
             fmt = 'x={0:0' + str(maxsize) + '.1f} y={1:0' + str(maxsize) + '.1f}'
             row1a_text = fmt.format(x, y)
+            row1a_title = 'Pixel'
 
         self.row1a_text = row1a_text
-        self.row1a_title = 'Pixel'
+        self.row1a_title = row1a_title
 
         self.row1_unreliable = unreliable_pixel
         self._dict['pixel_x'] = float(x)

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -409,7 +409,10 @@ def _roman_asdf_2d_to_glue_data(file_obj, data_label, ext=None, try_gwcs_to_fits
         data = Data(coords=coords, label=new_data_label)
 
         # This could be a quantity or a ndarray:
-        ext_values = getattr(file_obj, cur_ext)
+        if HAS_ROMAN_DATAMODELS and isinstance(file_obj, rdd.DataModel):
+            ext_values = getattr(file_obj, cur_ext)
+        else:
+            ext_values = file_obj['roman'][cur_ext]
         bunit = getattr(ext_values, 'unit', '')
         component = Component.autotyped(np.array(ext_values), units=bunit)
         data.add_component(component=component, label=comp_label)

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -10,6 +10,7 @@ from astropy.utils.data import cache_contents
 
 from glue.core.data import Component, Data
 from gwcs.wcs import WCS as GWCS
+from stdatamodels import asdf_in_fits
 
 from jdaviz.core.registries import data_parser_registry
 from jdaviz.core.events import SnackbarMessage
@@ -29,6 +30,26 @@ __all__ = ['parse_data']
 
 INFO_MSG = ("The file contains more viewable extensions. Add the '[*]' suffix"
             " to the file name to load all of them.")
+
+
+def _try_gwcs_to_fits_sip(gwcs):
+    """
+    Try to convert this GWCS to FITS SIP. Some GWCS models
+    cannot be converted to FITS SIP. In that case, a warning
+    is raised and the GWCS is used, as is.
+    """
+    try:
+        result = WCS(gwcs.to_fits_sip())
+    except ValueError as err:
+        warnings.warn(
+            "The GWCS coordinates could not be simplified to "
+            "a SIP-based FITS WCS, the following error was "
+            f"raised: {err}",
+            UserWarning
+        )
+        result = gwcs
+
+    return result
 
 
 def prep_data_layer_as_dq(data):
@@ -353,33 +374,47 @@ def _jwst_to_glue_data(file_obj, ext, data_label):
     yield data, new_data_label
 
 
-def _try_gwcs_to_fits_sip(gwcs):
-    """
-    Try to convert this GWCS to FITS SIP. Some GWCS models
-    cannot be converted to FITS SIP. In that case, a warning
-    is raised and the GWCS is used, as is.
-    """
-    try:
-        result = WCS(gwcs.to_fits_sip())
-    except ValueError as err:
-        warnings.warn(
-            "The GWCS coordinates could not be simplified to "
-            "a SIP-based FITS WCS, the following error was "
-            f"raised: {err}",
-            UserWarning
-        )
-        result = gwcs
-
-    return result
-
-
 def _jwst2data(file_obj, ext, data_label):
-    if ext == 'data':
-        ext = 'sci'
+    comp_label = ext.upper()
+    new_data_label = f'{data_label}[{comp_label}]'
+    data = Data(label=new_data_label)
+    unit_attr = f'bunit_{ext}'
 
-    hdu = file_obj[ext]
+    try:
+        # This is very specific to JWST pipeline image output.
+        with asdf_in_fits.open(file_obj) as af:
+            dm = af.tree
+            dm_meta = af.tree["meta"]
+            data.meta.update(standardize_metadata(dm_meta))
 
-    return _hdu2data(hdu, data_label, file_obj, include_wcs=False)
+            if unit_attr in dm_meta:
+                bunit = _validate_bunit(dm_meta[unit_attr], raise_error=False)
+            else:
+                bunit = ''
+
+            # This is instance of gwcs.WCS, not astropy.wcs.WCS
+            if 'wcs' in dm_meta:
+                data.coords = dm_meta['wcs']
+
+            imdata = dm[ext]
+            component = Component.autotyped(imdata, units=bunit)
+
+            # Might have bad GWCS. If so, we exclude it.
+            try:
+                data.add_component(component=component, label=comp_label)
+            except Exception:  # pragma: no cover
+                data.coords = None
+                data.add_component(component=component, label=comp_label)
+
+    # TODO: Do not need this when jwst.datamodels finally its own package.
+    # This might happen for grism image; fall back to FITS loader without WCS.
+    except Exception:
+        if ext == 'data':
+            ext = 'sci'
+        hdu = file_obj[ext]
+        return _hdu2data(hdu, data_label, file_obj, include_wcs=False)
+
+    return data, new_data_label
 
 
 # ---- Functions that handle input from Roman ASDF files -----
@@ -414,11 +449,10 @@ def _roman_asdf_2d_to_glue_data(file_obj, data_label, ext=None, try_gwcs_to_fits
         else:
             ext_values = file_obj['roman'][cur_ext]
         bunit = getattr(ext_values, 'unit', '')
-        component = Component.autotyped(np.array(ext_values), units=bunit)
+        component = Component(np.array(ext_values), units=bunit)
         data.add_component(component=component, label=comp_label)
-        data.meta.update(meta)
-
-        if comp_label == 'dq':
+        data.meta.update(standardize_metadata(dict(meta)))
+        if comp_label == 'DQ':
             prep_data_layer_as_dq(data)
 
         yield data, new_data_label

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -85,22 +85,25 @@ class TestCenter(BaseImviz_WCS_WCS):
     def test_center_on_pix(self):
         self.imviz.link_data(align_by='wcs')
 
-        # This is the second loaded data that is dithered by 1-pix.
+        # This is the second loaded data that is dithered by 1-pix in x
+        limits_first_data = np.array([-5.5, 5.5, -5.5, 5.5])
+        limits_dithered_data = limits_first_data.copy()
+        limits_dithered_data[:2] -= 1
+
         self.viewer.center_on((0, 0))
-        expected_position = [-6.75, 4.25, -5.75, 5.25]
         rtol = 1e-4
-        assert_allclose(self.viewer.get_limits(), expected_position, rtol=rtol)
+        assert_allclose(self.viewer.get_limits(), limits_dithered_data, rtol=rtol)
 
         # This is the first data.
         self.viewer.blink_once()
         self.viewer.center_on((0, 0))
-        assert_allclose(self.viewer.get_limits(), [-5.75, 5.25, -5.75, 5.25], rtol=rtol)
+        assert_allclose(self.viewer.get_limits(), limits_first_data, rtol=rtol)
 
         # Centering by sky on second data.
         self.viewer.blink_once()
         sky = self.wcs_2.pixel_to_world(0, 0)
         self.viewer.center_on(sky)
-        assert_allclose(self.viewer.get_limits(), expected_position, rtol=rtol)
+        assert_allclose(self.viewer.get_limits(), limits_dithered_data, rtol=rtol)
 
 
 class TestZoom(BaseImviz_WCS_NoWCS):

--- a/jdaviz/configs/imviz/tests/test_delete_data.py
+++ b/jdaviz/configs/imviz/tests/test_delete_data.py
@@ -70,13 +70,13 @@ class TestDeleteData(BaseImviz_WCS_WCS):
 
         # Check that the reparenting and coordinate recalculations happened
         assert subset1.subset_state.xatt.parent.label == "Default orientation"
-        assert_allclose(subset1.subset_state.center(), (1.75, 1.75))
+        assert_allclose(subset1.subset_state.center(), (2, 2))
 
         assert subset2.subset_state.xatt.parent.label == "Default orientation"
-        assert_allclose(subset2.subset_state.roi.xmin, -0.25)
-        assert_allclose(subset2.subset_state.roi.ymin, -0.25)
-        assert_allclose(subset2.subset_state.roi.xmax, 1.75)
-        assert_allclose(subset2.subset_state.roi.ymax, 1.75)
+        assert_allclose(subset2.subset_state.roi.xmin, 0, atol=1e-8)
+        assert_allclose(subset2.subset_state.roi.ymin, 0, atol=1e-8)
+        assert_allclose(subset2.subset_state.roi.xmax, 2)
+        assert_allclose(subset2.subset_state.roi.ymax, 2)
 
 
 class TestDeleteWCSLayerWithSubset(BaseImviz_WCS_GWCS):

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -1,5 +1,5 @@
 import warnings
-
+import numpy as np
 import pytest
 from astropy.table import Table
 from astropy.wcs import WCS
@@ -51,9 +51,9 @@ class TestLink_WCS_NoWCS(BaseImviz_WCS_NoWCS, BaseLinkHandler):
                                             {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
 
         assert label_mouseover.as_text() == (
-            'Pixel x=00.3 y=00.2 Value +0.00000e+00',
-            'World 22h30m04.8496s -20d49m59.7490s (ICRS)',
-            '337.5202064976 -20.8332636155 (deg)'
+            'Pixel x=00.0 y=-0.0 Value +0.00000e+00',
+            'World 22h30m04.8674s -20d49m59.9990s (ICRS)',
+            '337.5202808000 -20.8333330600 (deg)'
         )
 
 
@@ -130,8 +130,8 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
             subset_as_regions = self.imviz.plugins['Subset Tools'].get_regions(
                 return_sky_region=True)
         assert sorted(subset_as_regions) == ['Subset 1', 'Subset 2']
-        assert_allclose(subset_as_regions['Subset 1'].center.ra.deg, 337.519449)
-        assert_allclose(subset_as_regions['Subset 2'].center.ra.deg, 337.518498)
+        assert_allclose(subset_as_regions['Subset 1'].center.ra.deg, 337.519449, rtol=1e-4)
+        assert_allclose(subset_as_regions['Subset 2'].center.ra.deg, 337.518498, rtol=1e-4)
         # ensure agreement between app.get_subsets and subset_tools.get_regions
         ss = self.imviz.app.get_subsets(include_sky_region=True)
         assert ss['Subset 1'][0]['sky_region'] == subset_as_regions['Subset 1']
@@ -163,16 +163,16 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
                                              'domain': {'x': 0, 'y': 0}})
 
         lmtext = label_mouseover.as_text()
-        assert lmtext[0] == 'Pixel x=01.3 y=00.2 Value +1.00000e+00'
-        assert lmtext[1:] == ('World 22h30m04.8496s -20d49m59.7490s (ICRS)',
-                              '337.5202064976 -20.8332636155 (deg)')
+        assert lmtext[0] == 'Pixel x=01.0 y=-0.0 Value +1.00000e+00'
+        assert lmtext[1:] == ('World 22h30m04.8674s -20d49m59.9990s (ICRS)',
+                              '337.5202808000 -20.8333330600 (deg)')
 
         # blink image through clicking with blink tool
         self.viewer.toolbar.active_tool_id = 'jdaviz:blinkonce'
         self.viewer.toolbar.active_tool.on_click({'event': 'click', 'domain': {'x': 0, 'y': 0}})
-        assert label_mouseover.as_text()[0] == 'Pixel x=00.3 y=00.2 Value +1.00000e+00'
-        assert label_mouseover.as_text()[1:] == ('World 22h30m04.8496s -20d49m59.7490s (ICRS)',
-                                                 '337.5202064976 -20.8332636155 (deg)')
+        assert label_mouseover.as_text()[0] == 'Pixel x=00.0 y=-0.0 Value +1.00000e+00'
+        assert label_mouseover.as_text()[1:] == ('World 22h30m04.8674s -20d49m59.9990s (ICRS)',
+                                                 '337.5202808000 -20.8333330600 (deg)')
 
         # Changing link type will raise an error
         with pytest.raises(ValueError, match=".*only be changed after existing subsets are deleted"):  # noqa: E501
@@ -224,11 +224,10 @@ class TestLink_WCS_GWCS(BaseImviz_WCS_GWCS):
                          [-2.697746, 11.137127],
                          [10.148055, 10.554429],
                          [10.439091, -2.170755]], rtol=1e-5)
-        assert_allclose(gwcs_zoom_limits,
-                        [[2.636299, 12.732915],
-                         [13.375281, 5.007547],
-                         [6.300587, -5.126264],
-                         [-4.438394, 2.599103]], rtol=1e-5)
+
+        # this GWCS has a bounding box, and outside of the bounding box will
+        # return nans:
+        assert_allclose(gwcs_zoom_limits, np.nan)
 
         # Also check the coordinates display: Last loaded is on top.
         # Cycle order: GWCS, FITS WCS
@@ -243,18 +242,21 @@ class TestLink_WCS_GWCS(BaseImviz_WCS_GWCS):
         assert not label_mouseover.row2_unreliable
         assert not label_mouseover.row3_unreliable
 
-        # Make sure GWCS now can extrapolate.
+        # Make sure GWCS does not extrapolate.
         xy = self.viewer._get_real_xy(self.imviz.app.data_collection[1], -1, -1, reverse=True)
         label_mouseover._viewer_mouse_event(
             self.viewer, {'event': 'mousemove', 'domain': {'x': xy[0], 'y': xy[1]}})
-        assert label_mouseover.as_text() == ('Pixel x=-1.0 y=-1.0',
-                                             'World 00h14m19.5829s -30d23m30.9860s (ICRS)',
-                                             '3.5815955408 -30.3919405616 (deg)')
+        assert label_mouseover.as_text() == ('Pixel', '', '')
+
         # FITS WCS is reference data and has no concept of bounding box
         # but cursor is outside GWCS bounding box
         assert label_mouseover.row1_unreliable
-        assert label_mouseover.row2_unreliable
         assert label_mouseover.row3_unreliable
+
+        # row2 was "unreliable" when the WCS-only layer used GWCS.
+        # now with FITS WCS as the coordinate frame, there is no bounding
+        # box and row2 is reliable.
+        assert not label_mouseover.row2_unreliable
 
         xy = self.viewer._get_real_xy(self.imviz.app.data_collection[0], 0, 0, reverse=True)
         self.viewer.blink_once()
@@ -287,12 +289,14 @@ class TestLink_GWCS_GWCS(BaseImviz_GWCS_GWCS):
         label_mouseover = self.imviz._coords_info
         label_mouseover._viewer_mouse_event(self.viewer,
                                             {'event': 'mousemove', 'domain': {'x': -1, 'y': -1}})
-        assert label_mouseover.as_text() == ('Pixel x=-1.0 y=-1.0',
-                                             'World 00h14m19.5987s -30d23m31.0683s (ICRS)',
-                                             '3.5816611274 -30.3919634282 (deg)')
+        assert label_mouseover.as_text() == ('Pixel x=-1.0 y=-1.0', '', '')
         assert not label_mouseover.row1_unreliable
-        assert label_mouseover.row2_unreliable
         assert label_mouseover.row3_unreliable
+
+        # `row2_unreliable` was True when the WCS-only layer used GWCS.
+        # now with FITS WCS as the coordinate frame, there is no bounding
+        # box and row2 is reliable.
+        assert not label_mouseover.row2_unreliable
 
         # Back to reference image with bounds check.
         label_mouseover._viewer_mouse_event(self.viewer,
@@ -300,12 +304,14 @@ class TestLink_GWCS_GWCS(BaseImviz_GWCS_GWCS):
                                              'domain': {'x': -1, 'y': -1}})
         self.viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b',
                                            'domain': {'x': -1, 'y': -1}})
-        assert label_mouseover.as_text() == ('Pixel x=-1.0 y=-1.0',
-                                             'World 00h14m19.5829s -30d23m30.9860s (ICRS)',
-                                             '3.5815955408 -30.3919405616 (deg)')
+        assert label_mouseover.as_text() == ('Pixel x=-1.0 y=-1.0', '', '')
         assert not label_mouseover.row1_unreliable
-        assert label_mouseover.row2_unreliable
         assert label_mouseover.row3_unreliable
+
+        # row2 was "unreliable" when the WCS-only layer used GWCS.
+        # now with FITS WCS as the coordinate frame, there is no bounding
+        # box and row2 is reliable.
+        assert not label_mouseover.row2_unreliable
 
 
 def test_imviz_no_data(imviz_helper):

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -246,7 +246,7 @@ class TestLink_WCS_GWCS(BaseImviz_WCS_GWCS):
         xy = self.viewer._get_real_xy(self.imviz.app.data_collection[1], -1, -1, reverse=True)
         label_mouseover._viewer_mouse_event(
             self.viewer, {'event': 'mousemove', 'domain': {'x': xy[0], 'y': xy[1]}})
-        assert label_mouseover.as_text() == ('Pixel', '', '')
+        assert label_mouseover.as_text() == ('', '', '')
 
         # FITS WCS is reference data and has no concept of bounding box
         # but cursor is outside GWCS bounding box

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -370,7 +370,6 @@ class TestParseImage:
 
     @pytest.mark.remote_data
     def test_parse_jwst_niriss_grism(self, imviz_helper):
-        """No valid image GWCS for Imviz, will fall back to loading without WCS."""
         imviz_helper.load_data(self.jwst_asdf_url_2, cache=True, show_in_viewer=False)
         data = imviz_helper.app.data_collection[0]
         comp = data.get_component('DATA')

--- a/jdaviz/configs/imviz/tests/utils.py
+++ b/jdaviz/configs/imviz/tests/utils.py
@@ -234,7 +234,9 @@ def create_example_gwcs(shape):
 
     pipeline = [(detector_frame, det2sky), (sky_frame, None)]
 
-    return gwcs_wcs.WCS(pipeline)
+    wcs = gwcs_wcs.WCS(pipeline)
+    wcs.bounding_box = [(0, shape[0]), (0, shape[1])]
+    return wcs
 
 
 def create_wfi_image_model(image_shape=(20, 10), **kwargs):

--- a/jdaviz/configs/imviz/wcs_utils.py
+++ b/jdaviz/configs/imviz/wcs_utils.py
@@ -12,12 +12,10 @@ import numpy as np
 from astropy import units as u
 from astropy import coordinates as coord
 from astropy.coordinates import SkyCoord
-from astropy.modeling import models
 from astropy.nddata import NDData
 from astropy.wcs import WCS
 from astropy.wcs.utils import proj_plane_pixel_scales
 
-from gwcs import coordinate_frames as cf
 from gwcs.wcs import WCS as GWCS
 
 from matplotlib.patches import Polygon
@@ -276,10 +274,9 @@ def draw_compass_mpl(image, orig_shape=None, wcs=None, show=True, zoom_limits=No
 def data_outside_gwcs_bounding_box(data, x, y):
     """This is for internal use by Imviz coordinates transformation only."""
     outside_bounding_box = False
-    if hasattr(data.coords, '_orig_bounding_box'):
-        # then coords is a GWCS object and had its bounding box cleared
-        # by the Imviz parser
-        ints = data.coords._orig_bounding_box.intervals
+    if getattr(data.coords, 'bounding_box', None) is not None:
+        # then coords is a GWCS object
+        ints = data.coords.bounding_box.intervals
         if isinstance(ints[0].lower, u.Quantity):
             bb_xmin = ints[0].lower.value
             bb_xmax = ints[0].upper.value
@@ -295,7 +292,7 @@ def data_outside_gwcs_bounding_box(data, x, y):
     return outside_bounding_box
 
 
-def _rotated_gwcs(
+def _rotated_wcs(
     center_world_coord,
     rotation_angle,
     pixel_scales,
@@ -310,63 +307,22 @@ def _rotated_gwcs(
     refdata_extent = image_extent.max()
     pixel_scales = refdata_extent / u.Quantity(refdata_shape, u.pix)
 
-    # multiplying by +/-1 can flip north/south or east/west:
-    flip_direction = (
-        models.Multiply(cdelt_signs[0]) &
-        models.Multiply(cdelt_signs[1])
+    wcs_keywords = dict(
+        wcsaxes=2,
+        ctype1='RA---TAN',
+        ctype2='DEC--TAN',
+        crpix1=refdata_shape[0] / 2 + 1,
+        crpix2=refdata_shape[1] / 2 + 1,
+        crval1=center_world_coord.ra.deg,
+        crval2=center_world_coord.dec.deg,
+        cdelt1=cdelt_signs[0] * pixel_scales[0].to_value(u.deg / u.pix),
+        cdelt2=cdelt_signs[1] * pixel_scales[1].to_value(u.deg / u.pix),
+        lonpole=180 - rotation_angle.to_value(u.deg),
+        cname1='lon',
+        cname2='lat',
     )
-
-    # shift to compensate for the difference between the center and corner:
-    shift = (
-        models.Shift((0.5 - refdata_shape[0])/2 * u.pix) &
-        models.Shift((0.5 - refdata_shape[1])/2 * u.pix)
-    )
-
-    # rotate field of view:
-    rho = rotation_angle
-    sin_rho = np.sin(rho.to_value(u.rad))
-    cos_rho = np.cos(rho.to_value(u.rad))
-    rotation_matrix = np.array([[cos_rho, -sin_rho],
-                                [sin_rho, cos_rho]])
-    rotation = models.AffineTransformation2D(
-        rotation_matrix * u.deg, translation=[0, 0] * u.deg
-    )
-    rotation.input_units_equivalencies = {
-        "x": u.pixel_scale(pixel_scales[0]),
-        "y": u.pixel_scale(pixel_scales[1])
-    }
-    rotation.inverse = models.AffineTransformation2D(
-        np.linalg.inv(rotation_matrix) * u.pix, translation=[0, 0] * u.pix
-    )
-    rotation.inverse.input_units_equivalencies = {
-        "x": u.pixel_scale(1 / pixel_scales[0]),
-        "y": u.pixel_scale(1 / pixel_scales[1])
-    }
-
-    tan = models.Pix2Sky_TAN()
-    celestial_rotation = models.RotateNative2Celestial(
-        center_world_coord.ra, center_world_coord.dec, 180 * u.deg
-    )
-
-    det2sky = shift | flip_direction | rotation | tan | celestial_rotation
-    det2sky.name = "linear_transform"
-
-    detector_frame = cf.Frame2D(
-        name="detector",
-        axes_names=("x", "y"),
-        unit=(u.pix, u.pix)
-    )
-    sky_frame = cf.CelestialFrame(
-        reference_frame=coord.ICRS(),
-        name='icrs',
-        unit=(u.deg, u.deg)
-    )
-    pipeline = [
-        (detector_frame, det2sky),
-        (sky_frame, None)
-    ]
-
-    return GWCS(pipeline)
+    wcs = WCS(wcs_keywords)
+    return wcs
 
 
 def _prepare_rotated_nddata(real_image_shape, wcs, rotation_angle, refdata_shape,
@@ -436,9 +392,9 @@ def _prepare_rotated_nddata(real_image_shape, wcs, rotation_angle, refdata_shape
     center_world_coord = wcs.pixel_to_world(*center_pixel_coord[::-1])
     rotation_angle = coord.Angle(rotation_angle).wrap_at(360 * u.deg)
 
-    # create a GWCS centered on ``filename``,
+    # create a WCS centered on ``filename``,
     # and rotated by ``rotation_angle``:
-    new_rotated_gwcs = _rotated_gwcs(
+    new_rotated_wcs = _rotated_wcs(
         center_world_coord,
         rotation_angle,
         pixel_scales,
@@ -448,12 +404,12 @@ def _prepare_rotated_nddata(real_image_shape, wcs, rotation_angle, refdata_shape
     )
 
     # create a fake NDData (we use arange so data boundaries show up in Imviz
-    # if it ever is accidentally exposed) with the rotated GWCS:
+    # if it ever is accidentally exposed) with the rotated WCS:
     placeholder_data = np.nan * np.ones(refdata_shape)
 
     ndd = NDData(
         data=placeholder_data,
-        wcs=new_rotated_gwcs,
+        wcs=new_rotated_wcs,
         meta={wcs_only_key: True, '_pixel_scales': pixel_scales}
     )
     return ndd
@@ -464,7 +420,7 @@ def _get_rotated_nddata_from_label(
     cdelt_signs=None, target_wcs_east_left=True, target_wcs_north_up=True
 ):
     """
-    Create a synthetic NDData which stores GWCS that approximate
+    Create a synthetic NDData which stores WCS that approximate
     the WCS in the coords attr of the Data object with label ``data_label``
     loaded into ``app``.
 

--- a/jdaviz/configs/imviz/wcs_utils.py
+++ b/jdaviz/configs/imviz/wcs_utils.py
@@ -91,7 +91,10 @@ def add_offset_xy(image_wcs, x, y, delta_deg_x, delta_deg_y):
     ra2_deg, dec2_deg = add_offset_radec(ra_deg, dec_deg, delta_deg_x, delta_deg_y)
 
     if hasattr(image_wcs, 'invert'):
-        return image_wcs.invert(ra2_deg, dec2_deg, with_bounding_box=False)
+        pixel_coords = image_wcs.invert(ra2_deg, dec2_deg, with_bounding_box=False)
+        if hasattr(pixel_coords[0], 'unit'):
+            return u.Quantity(pixel_coords).to_value(u.pix)
+        return pixel_coords
 
     # then back to new pixel coords
     return image_wcs.world_to_pixel_values(ra2_deg, dec2_deg)  # x2, y2
@@ -114,7 +117,6 @@ def calc_compass_radius(image_wcs, x, y, radius_px):
     # a bounding box set.
 
     delta = 0.1 / 3600  # 0.1 arcsec
-
     xe, ye = add_offset_xy(image_wcs, x, y, delta, 0.0)
     xn, yn = add_offset_xy(image_wcs, x, y, 0.0, delta)
 

--- a/jdaviz/configs/imviz/wcs_utils.py
+++ b/jdaviz/configs/imviz/wcs_utils.py
@@ -71,7 +71,7 @@ def add_offset_radec(ra_deg, dec_deg, delta_deg_ra, delta_deg_dec):
 
 def add_offset_xy(image_wcs, x, y, delta_deg_x, delta_deg_y):
     # calculate ra/dec of x,y pixel
-    if hasattr(image_wcs, '__call__'):
+    if isinstance(image_wcs, GWCS):
         c = image_wcs(x, y, with_bounding_box=False)
     else:
         c = image_wcs.pixel_to_world(x, y)
@@ -90,7 +90,7 @@ def add_offset_xy(image_wcs, x, y, delta_deg_x, delta_deg_y):
     # add offsets
     ra2_deg, dec2_deg = add_offset_radec(ra_deg, dec_deg, delta_deg_x, delta_deg_y)
 
-    if hasattr(image_wcs, 'invert'):
+    if isinstance(image_wcs, GWCS):
         pixel_coords = image_wcs.invert(ra2_deg, dec2_deg, with_bounding_box=False)
         if hasattr(pixel_coords[0], 'unit'):
             return u.Quantity(pixel_coords).to_value(u.pix)
@@ -334,8 +334,7 @@ def _rotated_wcs(
         cname1='lon',
         cname2='lat',
     )
-    wcs = WCS(wcs_keywords)
-    return wcs
+    return WCS(wcs_keywords)
 
 
 def _prepare_rotated_nddata(real_image_shape, wcs, rotation_angle, refdata_shape,

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -219,10 +219,17 @@ class FreezableBqplotImageViewerState(BqplotImageViewerState, FreezableState):
 
                 pixel_ids = layer.layer.pixel_component_ids
                 world_bottom_left = data.coords.pixel_to_world(0, 0)
-                world_top_right = data.coords.pixel_to_world(
-                    layer.layer.data.shape[pixel_ids[1].axis] - 1,
-                    layer.layer.data.shape[pixel_ids[0].axis] - 1
-                )
+
+                if getattr(data.coords, 'bounding_box', None) is not None:
+                    bounds = data.coords.pixel_bounds
+                    world_top_right = data.coords.pixel_to_world(
+                        bounds[0][1] - 1, bounds[1][1] - 1
+                    )
+                else:
+                    world_top_right = data.coords.pixel_to_world(
+                        layer.layer.data.shape[pixel_ids[1].axis] - 1,
+                        layer.layer.data.shape[pixel_ids[0].axis] - 1
+                    )
 
                 if return_as_world:
                     x_min = min(x_min, world_bottom_left.ra.value)

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -6,6 +6,7 @@ import warnings
 from collections import deque
 from urllib.parse import urlparse
 
+import asdf
 import numpy as np
 from astropy.io import fits
 from astropy.utils import minversion
@@ -311,8 +312,8 @@ def standardize_roman_metadata(data_model):
     d : dict
         Flattened dictionary of metadata
     """
-    import roman_datamodels.datamodels as rdm
-    if isinstance(data_model, rdm.DataModel):
+    # if the file is a Roman DataModel:
+    if hasattr(data_model, 'to_flat_dict'):
         # Roman metadata are in nested dicts that we flatten:
         flat_dict_meta = data_model.to_flat_dict()
 
@@ -322,6 +323,9 @@ def standardize_roman_metadata(data_model):
             for k, v in flat_dict_meta.items()
             if 'roman.meta' in k
         }
+    elif isinstance(data_model, asdf.AsdfFile):
+        # otherwise use default standardization
+        return standardize_metadata(data_model['roman']['meta'])
 
 
 class ColorCycler:


### PR DESCRIPTION
### Background

Since #2179, Imviz displays images in the sky plane without distortion by creating a glue reference data layer that contains only coordinates (no image). The WCS-only layer was has its coordinates defined by a GWCS object. I chose GWCS over FITS WCS because it seemed to me at the time that encoding reference frame rotation in FITS WCS was nontrivial. Since then, I noticed that longitudinal pole rotation is supported by low level WCS.

### Why swap GWCS for FITS WCS in reference data?

1. The API for creating low level WCS is very very stable, whereas GWCS is evolving to support Roman. This lowers the risk of imviz maintenance burden on our end.
2. Low level WCS computes transformations in C, which will be as fast or faster than GWCS.

When we think about "linking performance", what we're usually talking about is limiting the number of links and removing redundant ones. The floor on the speed of calculations through links is set by the performance of the WCS transformations.

#### Profiling

I ran [profiling tests in this notebook](https://gist.github.com/bmorris3/3b63f6537b8649f2e50bd0b9edc25c3e) to do transformations using the coordinates from a simulated Roman WFI exposure from Build 16 (requires `roman_datamodels==0.22.0`). I compared the GWCS performance with FITS SIP computed by calling the `gwcs.to_fits_sip` method.

FITS WCS transformations are 1.5x faster than GWCS in pixel to world transformations computed on large grids (thousands of pixels per side). FITS WCS and GWCS have roughly equivalent performance in world to pixel transformations on large grids. When computing transformations on smaller numbers of pixels (10s-100s), FITS WCS outperforms GWCS by ~10x in both pixel to world and world to pixel transformations. The gap between FITS WCS and GWCS gets larger for smaller arrays due to overheads in GWCS, which internally initializes new objects on every transformation, so performance sees little improvement once arrays are smaller than ~100x100.

Aside: this profiling was performed on Roman observation coordinates with all of their complexity in both GWCS/FITS SIP representations. The reference data layer doesn't need any of that complexity – it's just the sky plane! The rotated WCS created for reference data in this PR is just RA---TAN/DEC--TAN ± rotation, without distortion.

![gwcs_fits_sip](https://github.com/user-attachments/assets/c4d56e03-a058-401c-bac0-26c1a1345412)

### Next steps

This PR swaps the reference data layer's WCS implementation from GWCS to FITS WCS. A second performance improvement will come from optionally approximating GWCS objects with FITS SIP when possible. When the SIP approximation can be made, this brings significant performance improvements for a small loss in accuracy.

The lower row of the profiling plot above shows the mean, standard deviation, and maximum of the difference between the GWCS and FITS SIP coordinates. The maximum difference is less about 0.1 pixels, where most FITS SIP coordinates are within 0.02 pixels of the GWCS coordinates. For reference, the astrometric precision of Roman source catalog entries from PSF fitting is expected to be about the same size (https://github.com/spacetelescope/romancal/pull/794).

Our goal is to let the user choose via API or UI whether or not to use this approximation for data that they've loaded, which is not enabled by this PR.

As part of this PR, I've added a hidden method `_try_gwcs_to_fits_sip` to the imviz parser which tries to approximate with FITS SIP for data that enters the parser with GWCS. This function never gets called in the code in this PR, but we can use it in the (near!) future when we add support for optional FITS SIP approx from GWCS input.


### Other notes

This PR removes a line in the imviz parser which removes the bounding box from GWCS on load. Among other changes, a similar change was suggested in #2887. That PR is not superseded by this one.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
