### PR TITLE
Deprecate imviz.get_catalog_source_results()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,8 @@ Cubeviz
 - ``cubeviz.load_regions()`` and ``cubeviz.load_regions_from_file()`` are deprecated.
   Use ``cubeviz.plugins['Subset Tools'].import_region()`` instead. [#3474]
 
+- Cubeviz-specific helper-level methods are deprecated and will be removed in the future in favor of plugin APIs as configs are centralized. [#3388]
+
 Imviz
 ^^^^^
 
@@ -71,6 +73,11 @@ Imviz
 
 - ``imviz.load_regions()`` and ``imviz.load_regions_from_file()`` are deprecated.
   Use ``imviz.plugins['Subset Tools'].import_region()`` instead. [#3474]
+
+- ``imviz.get_catalog_source_results()`` is deprecated.
+  Use ``imviz.plugins['Catalog Search'].export_table()`` instead. [#3497]
+
+- ``get_aperture_photometry_results`` helper-level method is deprecated and will be removed in the future in favor of plugin APIs as configs are centralized. [#3388]
 
 Mosviz
 ^^^^^^
@@ -98,12 +105,8 @@ Cubeviz
 
 - Fixed copious warnings from spaxel tool when data has INF. [#3368]
 
-- Cubeviz-specific helper-level methods are deprecated and will be removed in the future in favor of plugin APIs as configs are centralized. [#3388]
-
 Imviz
 ^^^^^
-
-- ``get_aperture_photometry_results`` helper-level method is deprecated and will be removed in the future in favor of plugin APIs as configs are centralized. [#3388]
 
 - Fixed "zoom to selected" in Catalog Search plugin when multiple sources are selected. [#3482]
 

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -431,7 +431,7 @@ are not stored. To save the current result before submitting a new query, you ca
 
 .. code-block:: python
 
-    results = imviz.get_catalog_source_results()
+    results = imviz.plugins["Catalog Search"].export_table()
 
 .. note::
 

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -3,8 +3,8 @@ import re
 import warnings
 from copy import deepcopy
 
-from astropy.utils import deprecated
 import numpy as np
+from astropy.utils import deprecated
 from glue.core.link_helpers import LinkSame
 
 from jdaviz.core.events import SnackbarMessage, NewViewerMessage
@@ -313,6 +313,7 @@ class Imviz(ImageConfigHelper):
         """
         return self.plugins['Aperture Photometry'].export_table()
 
+    @deprecated(since="4.2", alternative="plugins['Catalog Search'].export_table()")
     def get_catalog_source_results(self):
         """Return table of sources given by querying from a catalog, if any.
         Results are calculated using :ref:`imviz-catalogs` plugin.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to deprecate `imviz.get_catalog_source_results()` in favor of `imviz.plugins['Catalog Search'].export_table()`. Oddly enough I couldn't find any mention of it in tests and notebooks, so not much else to update.

Meanwhile, `app._catalog_source_table` seems to be used throughout Catalog Search plugin itself internally, so I leave that alone for now.

I also moved 2 change log entries from #3388 that were mistakenly put in Bug Fix section instead of API Change.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-4771)
