### PR TITLE
add app level delete_subsets method, remove/replace others

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ New Features
 
 - Snackbar history logger has been moved from an overlay to a separate tab in the right sidebar tray. [#3466]
 
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1347,6 +1347,43 @@ class Application(VuetifyTemplate, HubListener):
             elif isinstance(subset_state, MultiMaskSubsetState):
                 return self._get_multi_mask_subset_definition(subset_state)
 
+    def delete_subsets(self, subset_labels=None):
+        """
+        Delete all or specified subsets in app.
+
+        This method removes subsets based on the provided ``subset_labels`` (a
+        single subset label or multiple labels). If ``subset_labels``
+        is None (default), all subsets will be removed.
+
+        Parameters
+        ----------
+        subset_labels : str or list of str or None
+            The label(s) of the subsets to delete. If None, all subsets will be
+            removed.
+        """
+
+        # delete all subsets
+        if subset_labels is None:
+            for subset_group in self.data_collection.subset_groups:
+                self.data_collection.remove_subset_group(subset_group)
+
+        else:
+            if isinstance(subset_labels, str):
+                subset_labels = [subset_labels]
+            labels = np.asarray(subset_labels)
+            sg = self.data_collection.subset_groups
+            subset_grp_labels = {s.label: s for s in sg}
+
+            # raise ValueError if any subset in 'subset_labels' isn't actually
+            # in the data collection, before deleting subsets
+            invalid_labels = ~np.isin(labels, list(subset_grp_labels.keys()))
+            if np.any(invalid_labels):
+                bad = ', '.join([x for x in labels[invalid_labels]])
+                raise ValueError(f'{bad} not in data collection, can not delete.')
+            else:
+                for label in labels:
+                    self.data_collection.remove_subset_group(subset_grp_labels[label])
+
     def _get_display_unit(self, axis):
         if self._jdaviz_helper is None:
             # cannot access either the plugin or the spectrum viewer.

--- a/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
@@ -24,7 +24,7 @@ class TestLoadRegions(BaseRegionHandler):
 
     def teardown_method(self, method):
         """Clear all the subsets for the next test method."""
-        self.cubeviz._delete_all_regions()
+        self.cubeviz.app.delete_subsets()
 
     def test_regions_mask(self):
         mask = np.zeros((9, 10), dtype=np.bool_)

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -238,8 +238,9 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
                                        include_sky_region=reg_type == 'sky_region',
                                        use_display_units=use_display_units)
 
-        labels = list_of_subset_labels or subsets.keys()
-        labels = [labels] if not hasattr(labels, '__iter__') else labels
+        labels = list_of_subset_labels or list(subsets.keys())
+        if isinstance(labels, str):
+            labels = [labels]
 
         regions, failed_regs = {}, set()
         for subset_label in labels:

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -276,11 +276,10 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         Delete all subsets app-wide.  Required before changing ``align_by``.
         """
         # subsets will be deleted on changing link type:
-        for subset_group in self.app.data_collection.subset_groups:
-            self.app.data_collection.remove_subset_group(subset_group)
+        self.app.delete_subsets()
 
     def vue_delete_subsets(self, *args):
-        self.delete_subsets()
+        self.app.delete_subsets()
 
     def vue_reset_astrowidget_markers(self, *args):
         for viewer in self.app._viewer_store.values():

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -279,7 +279,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         self.app.delete_subsets()
 
     def vue_delete_subsets(self, *args):
-        self.app.delete_subsets()
+        self.delete_subsets()
 
     def vue_reset_astrowidget_markers(self, *args):
         for viewer in self.app._viewer_store.values():

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -178,7 +178,7 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
             self.imviz.link_data(align_by='pixels', wcs_fallback_scheme=None)
 
         self.viewer.reset_markers()
-        self.imviz.app.delete_subsets()
+        self.imviz.plugins["Orientation"].delete_subsets()
         self.imviz.link_data(align_by='pixels', wcs_fallback_scheme=None)
         assert 'xy_markers' not in self.imviz.app.data_collection.labels
         assert len(self.viewer._marktags) == 0

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -178,7 +178,7 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
             self.imviz.link_data(align_by='pixels', wcs_fallback_scheme=None)
 
         self.viewer.reset_markers()
-        self.imviz.plugins["Orientation"].delete_subsets()
+        self.imviz.app.delete_subsets()
         self.imviz.link_data(align_by='pixels', wcs_fallback_scheme=None)
         assert 'xy_markers' not in self.imviz.app.data_collection.labels
         assert len(self.viewer._marktags) == 0

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -74,7 +74,7 @@ def test_destroy_viewer_with_subset(imviz_helper):
     imviz_helper.destroy_viewer('second')
 
     # Delete the Subset: Should have no traceback.
-    imviz_helper._delete_region('Subset 1')
+    imviz_helper.app.delete_subsets('Subset 1')
 
 
 def test_mastviz_config():

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -909,12 +909,6 @@ class ImageConfigHelper(ConfigHelper):
         subset_grp = self.app.data_collection.subset_groups[i]
         self.app.data_collection.remove_subset_group(subset_grp)
 
-    # TODO: Make this public API?
-    def _delete_all_regions(self):
-        """Delete all regions."""
-        for subset_grp in self.app.data_collection.subset_groups:  # should be a copy
-            self.app.data_collection.remove_subset_group(subset_grp)
-
 
 def _next_subset_num(label_prefix, subset_groups):
     """Assumes ``prefix i`` format.

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -852,7 +852,7 @@ def test_multi_mask_subset(specviz_helper, spectrum1d):
     assert reg["Subset 1"][0]["region"] == 4
 
 
-def test_delete_subsets(cubeviz_helper, spectral_cube_wcs):
+def test_delete_subsets_toolbar_selection(cubeviz_helper, spectral_cube_wcs):
     """
     Test that the toolbar selections get reset when the subset being actively edited gets deleted.
     """
@@ -878,6 +878,52 @@ def test_delete_subsets(cubeviz_helper, spectral_cube_wcs):
     dc.remove_subset_group(dc.subset_groups[0])
 
     assert flux_viewer.toolbar.active_tool is None
+
+
+def test_delete_subsets_app_api(cubeviz_helper, spectral_cube_wcs):
+    """Test app.delete_subsets."""
+
+    data = Spectrum1D(flux=np.ones((128, 128, 256)) * u.nJy, wcs=spectral_cube_wcs)
+    cubeviz_helper.load_data(data, data_label="Test Flux")
+    dc = cubeviz_helper.app.data_collection
+    subset_plugin = cubeviz_helper.plugins['Subset Tools']
+    unit = u.Unit(cubeviz_helper.plugins['Unit Conversion'].spectral_unit.selected)
+
+    # spectral and spatial region to be loaded as subsets
+    spectral = SpectralRegion(6200 * unit, 6800 * unit)
+    spatial = CirclePixelRegion(center=PixCoord(x=25, y=25), radius=5)
+
+    # add one spatial and one spectral subset
+    subset_plugin.import_region([spectral, spatial], combination_mode='new')
+    assert len(dc.subset_groups) == 2  # initially 2 subsets
+    cubeviz_helper.app.delete_subsets()  # no args, will delete all subsets
+    assert len(dc.subset_groups) == 0  # after delete all
+
+    # re-add both subsets, test deletion while specifying single label
+    subset_plugin.import_region([spectral, spatial], combination_mode='new')
+    assert len(dc.subset_groups) == 2
+    cubeviz_helper.app.delete_subsets('Subset 3')
+    assert len(dc.subset_groups) == 1
+    assert dc.subset_groups[0].label == 'Subset 4'  # Subset 4 should remain
+
+    # same as previous scenario, but single label is in list
+    assert len(dc.subset_groups) == 1
+    cubeviz_helper.app.delete_subsets(['Subset 4'])
+    assert len(dc.subset_groups) == 0  # now no subsets remain
+
+    # re-add both subsets, test deletion while specifying list of labels
+    subset_plugin.import_region([spectral, spatial], combination_mode='new')
+    assert len(dc.subset_groups) == 2
+    cubeviz_helper.app.delete_subsets(['Subset 5', 'Subset 6'])
+    assert len(dc.subset_groups) == 0  # both should have been deleted
+
+    # test that the proper error is raised for non-existent subsets
+    match_str = r'not in data collection, can not delete\.'
+    with pytest.raises(ValueError, match='Subset 5 ' + match_str):
+        cubeviz_helper.app.delete_subsets(['Subset 5'])
+
+    with pytest.raises(ValueError, match='Subset 5, Subset 6 ' + match_str):
+        cubeviz_helper.app.delete_subsets(['Subset 5', 'Subset 6'])
 
 
 class TestRegionsFromSubsets:


### PR DESCRIPTION
This PR adds app.delete_subsets. Calling app.delete_subsets() will delete all subsets in the app. You can also specify which subsets labels to delete - if there are two subsets 'Subset 1' and 'Subset 2', delete_subsets('Subset 1') will delete just the first, and delete_subsets(['Subset 1', 'Subset 2']) will delete both (equivalent to  delete_subsets() in this case).

Orientation.delete_subsets now calls this app level method. I did not deprecate this in the Orientation plugin since the ticket did not say to do so, but what does everyone think.

The _delete_regions and _delete_all_regions methods were removed without deprecation since they were never public, and tests calling these now use app.delete_subsets.

Finally, I considered adding a 'delete_regions' method in Subset tools since thats where someone would naturally look for this, I think, but since the ticket did not say to do so I held off. If we did that, it would just be an alias for app.delete_subsets, but called delete_regions to follow suit with other methods in that plugin. Thoughts?

I also snuck in a one line fix for something I noticed in subset_tools.get_regions (when checking if a list of labels or a single label was provided)