### PR TITLE
Fix bug with SkyRegion not working with cube data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ New Features
 Cubeviz
 ^^^^^^^
 
+- Ability to ingest and export ``SkyRegion`` objects. [#3502]
+
 Imviz
 ^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -120,8 +120,6 @@ Cubeviz
 
 - Enhancements for the cube sonification plugin. [#3377, #3387]
 
-- Ability to ingest and export ``SkyRegion`` objects. [#3502]
-
 Imviz
 ^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -120,6 +120,8 @@ Cubeviz
 
 - Enhancements for the cube sonification plugin. [#3377, #3387]
 
+- Ability to ingest and export ``SkyRegion`` objects. [#3502]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
@@ -6,7 +6,8 @@ import numpy as np
 import pytest
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-from regions import PixCoord, CirclePixelRegion, CircleSkyRegion, EllipsePixelRegion
+from regions import (PixCoord, CirclePixelRegion, CircleSkyRegion, EllipsePixelRegion,
+                     EllipseSkyRegion)
 from specutils import Spectrum1D, SpectralRegion
 
 from jdaviz.configs.imviz.tests.test_regions import BaseRegionHandler
@@ -63,9 +64,12 @@ class TestLoadRegions(BaseRegionHandler):
 
         # Get spatial regions only.
         st = self.cubeviz.plugins['Subset Tools']._obj
+
+        # Default return type for get_regions is SkyRegion (if possible)
+        assert isinstance(st.get_regions(region_type='spatial')['Subset 1'], EllipseSkyRegion)
+
         spatial_subsets_as_regions = st.get_regions(region_type='spatial', return_sky_region=False)
         assert list(spatial_subsets_as_regions.keys()) == ['Subset 1'], spatial_subsets_as_regions
-        print(spatial_subsets_as_regions)
         assert isinstance(spatial_subsets_as_regions['Subset 1'], EllipsePixelRegion)
         # ensure agreement between app.get_subsets and subset_tools.get_regions
         ss = self.cubeviz.app.get_subsets()

--- a/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
@@ -63,8 +63,9 @@ class TestLoadRegions(BaseRegionHandler):
 
         # Get spatial regions only.
         st = self.cubeviz.plugins['Subset Tools']._obj
-        spatial_subsets_as_regions = st.get_regions(region_type='spatial')
+        spatial_subsets_as_regions = st.get_regions(region_type='spatial', return_sky_region=False)
         assert list(spatial_subsets_as_regions.keys()) == ['Subset 1'], spatial_subsets_as_regions
+        print(spatial_subsets_as_regions)
         assert isinstance(spatial_subsets_as_regions['Subset 1'], EllipsePixelRegion)
         # ensure agreement between app.get_subsets and subset_tools.get_regions
         ss = self.cubeviz.app.get_subsets()

--- a/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
@@ -50,8 +50,7 @@ class TestLoadRegions(BaseRegionHandler):
         bad_regions = self.cubeviz.plugins['Subset Tools'].import_region(
             my_reg_sky_1, return_bad_regions=True)
 
-        # TODO: Update expected results when we support sky regions in Cubeviz.
-        assert len(bad_regions) == 1 and bad_regions[0][1] == 'Sky region provided but data has no valid WCS'  # noqa
+        assert len(bad_regions) == 0
 
     def test_spatial_spectral_mix(self):
         # Draw ellipse and wavelength range.

--- a/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
@@ -65,10 +65,13 @@ class TestLoadRegions(BaseRegionHandler):
         # Get spatial regions only.
         st = self.cubeviz.plugins['Subset Tools']._obj
 
-        # Default return type for get_regions is SkyRegion (if possible)
-        assert isinstance(st.get_regions(region_type='spatial')['Subset 1'], EllipseSkyRegion)
+        # Default return type for get_regions is PixelRegion, unless you set
+        # return_sky_region to True, in which case a SkyRegion object will be returned
+        assert isinstance(st.get_regions(region_type='spatial',
+                                         return_sky_region=True)['Subset 1'],
+                          EllipseSkyRegion)
 
-        spatial_subsets_as_regions = st.get_regions(region_type='spatial', return_sky_region=False)
+        spatial_subsets_as_regions = st.get_regions(region_type='spatial')
         assert list(spatial_subsets_as_regions.keys()) == ['Subset 1'], spatial_subsets_as_regions
         assert isinstance(spatial_subsets_as_regions['Subset 1'], EllipsePixelRegion)
         # ensure agreement between app.get_subsets and subset_tools.get_regions

--- a/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
@@ -65,13 +65,13 @@ class TestLoadRegions(BaseRegionHandler):
         # Get spatial regions only.
         st = self.cubeviz.plugins['Subset Tools']._obj
 
-        # Default return type for get_regions is PixelRegion, unless you set
-        # return_sky_region to True, in which case a SkyRegion object will be returned
+        assert isinstance(st.get_regions(region_type='spatial')['Subset 1'],
+                          EllipseSkyRegion)
         assert isinstance(st.get_regions(region_type='spatial',
                                          return_sky_region=True)['Subset 1'],
                           EllipseSkyRegion)
 
-        spatial_subsets_as_regions = st.get_regions(region_type='spatial')
+        spatial_subsets_as_regions = st.get_regions(region_type='spatial', return_sky_region=False)
         assert list(spatial_subsets_as_regions.keys()) == ['Subset 1'], spatial_subsets_as_regions
         assert isinstance(spatial_subsets_as_regions['Subset 1'], EllipsePixelRegion)
         # ensure agreement between app.get_subsets and subset_tools.get_regions

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -1161,6 +1161,11 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
                     try:
                         state = regions2roi(region, wcs=data.coords)
                     except ValueError:
+                        if '_orig_spatial_wcs' not in data.meta:
+                            bad_regions.append((region,
+                                                f'Failed to load: _orig_spatial_wcs'
+                                                f' meta tag not in {data.label}'))
+                            continue
                         state = regions2roi(region, wcs=data.meta['_orig_spatial_wcs'].celestial)
                     viewer.apply_roi(state)
 

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -1099,7 +1099,7 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
         else:
             data = self.app.data_collection[refdata_label]
 
-        has_wcs = data_has_valid_wcs(data, ndim=2)
+        has_wcs = data_has_valid_wcs(data, ndim=2) or data_has_valid_wcs(data, ndim=3)
 
         combo_mode_is_list = isinstance(combination_mode, list)
         if combo_mode_is_list and len(combination_mode) != (len(regions)):
@@ -1153,11 +1153,14 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
 
                 # region: Convert to ROI.
                 # NOTE: Out-of-bounds ROI will succeed; this is native glue behavior.
-                if isinstance(region, (CirclePixelRegion, CircleSkyRegion,
-                                       EllipsePixelRegion, EllipseSkyRegion,
-                                       RectanglePixelRegion, RectangleSkyRegion,
-                                       CircleAnnulusPixelRegion, CircleAnnulusSkyRegion)):
-                    state = regions2roi(region, wcs=data.coords)
+                if (isinstance(region, (CirclePixelRegion, CircleSkyRegion,
+                                        EllipsePixelRegion, EllipseSkyRegion,
+                                        RectanglePixelRegion, RectangleSkyRegion,
+                                        CircleAnnulusPixelRegion, CircleAnnulusSkyRegion))):
+                    try:
+                        state = regions2roi(region, wcs=data.coords)
+                    except ValueError:
+                        state = regions2roi(region, wcs=data.meta['_orig_spatial_wcs'].celestial)
                     viewer.apply_roi(state)
 
                 elif isinstance(region, (CircularROI, CircularAnnulusROI,

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -185,7 +185,7 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
         return PluginUserApi(self, expose)
 
     def get_regions(self, region_type=None, list_of_subset_labels=None,
-                    use_display_units=False, return_sky_region=False):
+                    use_display_units=False, return_sky_region=None):
         """
         Return spatial and/or spectral subsets of ``region_type`` (spatial or
         spectral, default both) as ``regions`` or ``SpectralRegions`` objects,
@@ -209,9 +209,11 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
             the native data unit. If True, subsets are returned in the spectral
             axis display unit set in the Unit Conversion plugin.
 
-        return_sky_region : bool, optional
-            The default return type is a ``PixelRegion`` unless this is set to False,
-            in which case a ``SkyRegion`` object is returned instead, if WCS is present.
+        return_sky_region : bool or None, optional
+            If None (default) or True, then the returned region will be ``SkyRegion`` if the
+            configuration is Imviz and the data is linked by WCS, or if the configuration
+            is Cubeviz and the data has '_orig_spatial_wcs' in the metadata. If set to False, a
+            ``PixelRegion`` object will be returned.
 
         Returns
         -------
@@ -234,8 +236,8 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
             region_type = {'imviz': ['spatial'],
                            'specviz': ['spectral']}.get(self.config, ['spatial', 'spectral'])
 
-        sky_region_check = ((self.app._align_by == 'wcs' or self.config == 'cubeviz')
-                            and return_sky_region)
+        sky_region_check = ((self.app._align_by == 'wcs' or self.config == 'cubeviz') and
+                            return_sky_region is None or return_sky_region)
         reg_type = 'sky_region' if sky_region_check else 'region'
 
         # first get ALL subsets of specified spatial/spectral type(s)

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -185,7 +185,7 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
         return PluginUserApi(self, expose)
 
     def get_regions(self, region_type=None, list_of_subset_labels=None,
-                    use_display_units=False, return_sky_region=True):
+                    use_display_units=False, return_sky_region=False):
         """
         Return spatial and/or spectral subsets of ``region_type`` (spatial or
         spectral, default both) as ``regions`` or ``SpectralRegions`` objects,
@@ -210,8 +210,8 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
             axis display unit set in the Unit Conversion plugin.
 
         return_sky_region : bool, optional
-            The default return type is a ``SkyRegion`` unless this is set to False,
-            in which case a ``PixelRegion`` object is returned instead.
+            The default return type is a ``PixelRegion`` unless this is set to False,
+            in which case a ``SkyRegion`` object is returned instead, if WCS is present.
 
         Returns
         -------

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -212,8 +212,8 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
         return_sky_region : bool or None, optional
             If None (default) or True, then the returned region will be ``SkyRegion`` if the
             configuration is Imviz and the data is linked by WCS, or if the configuration
-            is Cubeviz and the data has '_orig_spatial_wcs' in the metadata. If set to False, a
-            ``PixelRegion`` object will be returned.
+            is Cubeviz and the data has a WCS'. If set to False, a ``PixelRegion`` object will
+            be returned.
 
         Returns
         -------

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -185,11 +185,11 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
         return PluginUserApi(self, expose)
 
     def get_regions(self, region_type=None, list_of_subset_labels=None,
-                    use_display_units=False):
+                    use_display_units=False, return_sky_region=True):
         """
         Return spatial and/or spectral subsets of ``region_type`` (spatial or
         spectral, default both) as ``regions`` or ``SpectralRegions`` objects,
-        respectivley.
+        respectively.
 
         Parameters
         ----------
@@ -197,7 +197,7 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
             Specifies the type of subsets to retrieve. Options are ``spatial``
             to retrieve only spatial subsets, ``spectral`` to retrieve only
             spectral subsets or ``None`` (default) to retrieve both spatial
-            and spectral subsets, when relevent to the current configuration.
+            and spectral subsets, when relevant to the current configuration.
 
         list_of_subset_labels : list of str or None, optional
             If specified, only subsets matching these labels will be included.
@@ -208,6 +208,10 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
             (For spectral subsets) If False (default), subsets are returned in
             the native data unit. If True, subsets are returned in the spectral
             axis display unit set in the Unit Conversion plugin.
+
+        return_sky_region : bool, optional
+            The default return type is a ``SkyRegion`` unless this is set to False,
+            in which case a ``PixelRegion`` object is returned instead.
 
         Returns
         -------
@@ -230,7 +234,9 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
             region_type = {'imviz': ['spatial'],
                            'specviz': ['spectral']}.get(self.config, ['spatial', 'spectral'])
 
-        reg_type = 'sky_region' if self.app._align_by == 'wcs' else 'region'
+        sky_region_check = ((self.app._align_by == 'wcs' or self.config == 'cubeviz')
+                            and return_sky_region)
+        reg_type = 'sky_region' if sky_region_check else 'region'
 
         # first get ALL subsets of specified spatial/spectral type(s)
         subsets = self.app.get_subsets(spectral_only=region_type == ['spectral'],

--- a/jdaviz/configs/default/plugins/subset_tools/tests/test_subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/tests/test_subset_tools.py
@@ -1,5 +1,6 @@
 import operator
 import warnings
+
 import numpy as np
 import pytest
 from astropy import units as u
@@ -246,6 +247,7 @@ def test_import_sky_region_in_cubeviz(cubeviz_helper, spectrum1d_cube):
 
     status = plg.import_region(aperture, return_bad_regions=True)
     assert status == []
+    assert cubeviz_helper.app.get_subsets('Subset 1')
 
 
 def test_get_regions(cubeviz_helper, spectrum1d_cube, imviz_helper):

--- a/jdaviz/configs/default/plugins/subset_tools/tests/test_subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/tests/test_subset_tools.py
@@ -376,7 +376,7 @@ def test_get_regions_composite_wcs_linked(imviz_helper, image_2d_wcs):
     st.import_region(sr2, combination_mode='and')
 
     # composite subset should be a sky region, and combined to a compound region
-    regs = st.get_regions()
+    regs = st.get_regions(return_sky_region=True)
 
     cr = regs['Subset 1']
     assert isinstance(cr, CompoundSkyRegion)

--- a/jdaviz/configs/default/plugins/subset_tools/tests/test_subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/tests/test_subset_tools.py
@@ -1,6 +1,5 @@
 import operator
 import warnings
-
 import numpy as np
 import pytest
 from astropy import units as u
@@ -234,6 +233,21 @@ def test_import_spectral_regions_file(cubeviz_helper, spectrum1d_cube, tmp_path)
         plg.combination_mode = 'test'
 
 
+def test_import_sky_region_in_cubeviz(cubeviz_helper, spectrum1d_cube):
+    cubeviz_helper.load_data(spectrum1d_cube)
+    plg = cubeviz_helper.plugins['Subset Tools']
+
+    ra = 339.0149557 * u.deg
+    dec = 33.97591 * u.deg
+    coord = SkyCoord(ra=ra, dec=dec, unit=u.deg)
+    aper_rad = 0.5 * u.arcsec
+
+    aperture = CircleSkyRegion(coord, aper_rad)
+
+    status = plg.import_region(aperture, return_bad_regions=True)
+    assert status == []
+
+
 def test_get_regions(cubeviz_helper, spectrum1d_cube, imviz_helper):
 
     """Test Subset Tools.get regions."""
@@ -460,7 +474,6 @@ def test_update_subset(cubeviz_helper, spectrum1d_cube):
     plg.import_region(spatial_reg, combination_mode='and')
 
     subset_def = plg.update_subset('Subset 1')
-    print(subset_def)
     assert isinstance(subset_def, dict)
     assert len(subset_def) == 2
 

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -127,7 +127,7 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore',
                                     message='Regions skipped: MaskedSubset 1, MaskedSubset 2')
-            subset_as_regions = self.imviz.plugins['Subset Tools'].get_regions()
+            subset_as_regions = self.imviz.plugins['Subset Tools'].get_regions(return_sky_region=True)
         assert sorted(subset_as_regions) == ['Subset 1', 'Subset 2']
         assert_allclose(subset_as_regions['Subset 1'].center.ra.deg, 337.519449)
         assert_allclose(subset_as_regions['Subset 2'].center.ra.deg, 337.518498)

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -127,7 +127,8 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore',
                                     message='Regions skipped: MaskedSubset 1, MaskedSubset 2')
-            subset_as_regions = self.imviz.plugins['Subset Tools'].get_regions(return_sky_region=True)
+            subset_as_regions = self.imviz.plugins['Subset Tools'].get_regions(
+                return_sky_region=True)
         assert sorted(subset_as_regions) == ['Subset 1', 'Subset 2']
         assert_allclose(subset_as_regions['Subset 1'].center.ra.deg, 337.519449)
         assert_allclose(subset_as_regions['Subset 2'].center.ra.deg, 337.518498)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes a bug with SkyRegion objects not working with cube data. The problem was that the `import_region` method was not yet equipped to plot SkyRegion objects onto data with WCS dimensions of 3.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
