### PR TITLE
Remove unit conversion's spectrum viewer dependence

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1355,11 +1355,15 @@ class Application(VuetifyTemplate, HubListener):
             return ''
         elif self._jdaviz_helper.plugins.get('Unit Conversion') is None:  # noqa
             # fallback on native units (unit conversion is not enabled)
+            if hasattr(self._jdaviz_helper, '_default_spectrum_viewer_reference_name'):
+                viewer_name = self._jdaviz_helper._default_spectrum_viewer_reference_name
+            elif hasattr(self._jdaviz_helper, '_default_spectrum_2d_viewer_reference_name'):
+                viewer_name = self._jdaviz_helper._default_spectrum_2d_viewer_reference_name
             if axis == 'spectral':
-                sv = self.get_viewer(self._jdaviz_helper._default_spectrum_viewer_reference_name)
+                sv = self.get_viewer(viewer_name)
                 return sv.data()[0].spectral_axis.unit
             elif axis in ('flux', 'sb', 'spectral_y'):
-                sv = self.get_viewer(self._jdaviz_helper._default_spectrum_viewer_reference_name)
+                sv = self.get_viewer(viewer_name)
                 sv_y_unit = sv.data()[0].flux.unit
                 if axis == 'spectral_y':
                     return sv_y_unit

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1359,8 +1359,11 @@ class Application(VuetifyTemplate, HubListener):
                 viewer_name = self._jdaviz_helper._default_spectrum_viewer_reference_name
             elif hasattr(self._jdaviz_helper, '_default_spectrum_2d_viewer_reference_name'):
                 viewer_name = self._jdaviz_helper._default_spectrum_2d_viewer_reference_name
+            elif axis == 'temporal':
+                # No unit for ramp's time (group/resultant) axis:
+                return None
             else:
-                return ''
+                raise NotImplementedError("No default viewer reference found.")
             if axis == 'spectral':
                 sv = self.get_viewer(viewer_name)
                 return sv.data()[0].spectral_axis.unit
@@ -1401,9 +1404,6 @@ class Application(VuetifyTemplate, HubListener):
                     if sv_y_angle_unit:
                         return sv_y_unit
                     return sv_y_unit / solid_angle_unit
-            elif axis == 'temporal':
-                # No unit for ramp's time (group/resultant) axis:
-                return None
             else:
                 raise ValueError(f"could not find units for axis='{axis}'")
         uc = self._jdaviz_helper.plugins.get('Unit Conversion')._obj

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1360,7 +1360,7 @@ class Application(VuetifyTemplate, HubListener):
             elif hasattr(self._jdaviz_helper, '_default_spectrum_2d_viewer_reference_name'):
                 viewer_name = self._jdaviz_helper._default_spectrum_2d_viewer_reference_name
             else:
-                raise NotImplementedError("No default viewer reference found.")
+                return ''
             if axis == 'spectral':
                 sv = self.get_viewer(viewer_name)
                 return sv.data()[0].spectral_axis.unit

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1359,6 +1359,8 @@ class Application(VuetifyTemplate, HubListener):
                 viewer_name = self._jdaviz_helper._default_spectrum_viewer_reference_name
             elif hasattr(self._jdaviz_helper, '_default_spectrum_2d_viewer_reference_name'):
                 viewer_name = self._jdaviz_helper._default_spectrum_2d_viewer_reference_name
+            else:
+                raise NotImplementedError("No default viewer reference found.")
             if axis == 'spectral':
                 sv = self.get_viewer(viewer_name)
                 return sv.data()[0].spectral_axis.unit

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -607,7 +607,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         self._check_model_equation_invalid()
 
     def _on_global_display_unit_changed(self, msg):
-        if msg.axis == 'spectral_y':
+        if msg.axis in ('spectral_y', 'sb', 'flux'):
             axis = 'y'
         elif msg.axis == 'spectral':
             axis = 'x'

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -614,19 +614,22 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         else:
             return
 
-        if axis == 'y' and self.cube_fit:
+        unit = msg.unit
+
+        if axis == 'y':
             # The units have to be in surface brightness for a cube fit.
             uc = self.app._jdaviz_helper.plugins['Unit Conversion']
-
-            if msg.unit != uc._obj.sb_unit_selected:
+            if self.cube_fit and unit != uc._obj.sb_unit_selected:
                 self._units[axis] = uc._obj.sb_unit_selected
                 self._check_model_component_compat([axis], [u.Unit(uc._obj.sb_unit_selected)])
                 return
+            elif msg.axis == 'flux' and uc._obj.has_sb:
+                unit = u.Unit(self.app._get_display_unit('sb'))
 
         # update internal tracking of current units
-        self._units[axis] = str(msg.unit)
+        self._units[axis] = str(unit)
 
-        self._check_model_component_compat([axis], [msg.unit])
+        self._check_model_component_compat([axis], [unit])
 
     def remove_model_component(self, model_component_label):
         """

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -498,6 +498,8 @@ def test_cube_fit_after_unit_change(cubeviz_helper, solid_angle_unit):
     mf.cube_fit = True
 
     mf.create_model_component("Const1D")
+    # ensure parameters amplitude unit matches display unit
+    assert mf.get_model_component('C').get('parameters').get('amplitude').get('unit') == f'MJy / {solid_angle_string}'  # noqa
     # Check that the parameter is using the current units when initialized
     assert mf._obj.component_models[0]['parameters'][0]['unit'] == f'MJy / {solid_angle_string}'
 
@@ -534,8 +536,10 @@ def test_cube_fit_after_unit_change(cubeviz_helper, solid_angle_unit):
 
     if solid_angle_string == 'sr':
         expected_unit_string = f'erg / (Angstrom s {solid_angle_string} cm2)'
+        assert mf.get_model_component('C').get('parameters').get('amplitude').get('unit') == f'erg / (Angstrom s {solid_angle_string} cm2)'  # noqa
     else:
         expected_unit_string = f'erg / (Angstrom s cm2 {solid_angle_string})'
+        assert mf.get_model_component('C').get('parameters').get('amplitude').get('unit') == f'erg / (Angstrom s cm2 {solid_angle_string})'  # noqa
 
     assert mf._obj.component_models[0]['parameters'][0]['unit'] == expected_unit_string
 

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -536,10 +536,10 @@ def test_cube_fit_after_unit_change(cubeviz_helper, solid_angle_unit):
 
     if solid_angle_string == 'sr':
         expected_unit_string = f'erg / (Angstrom s {solid_angle_string} cm2)'
-        assert mf.get_model_component('C').get('parameters').get('amplitude').get('unit') == f'erg / (Angstrom s {solid_angle_string} cm2)'  # noqa
+        assert mf.get_model_component('C').get('parameters').get('amplitude').get('unit') == expected_unit_string  # noqa
     else:
         expected_unit_string = f'erg / (Angstrom s cm2 {solid_angle_string})'
-        assert mf.get_model_component('C').get('parameters').get('amplitude').get('unit') == f'erg / (Angstrom s cm2 {solid_angle_string})'  # noqa
+        assert mf.get_model_component('C').get('parameters').get('amplitude').get('unit') == expected_unit_string  # noqa
 
     assert mf._obj.component_models[0]['parameters'][0]['unit'] == expected_unit_string
 

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -501,12 +501,16 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                    and u.Unit(self.app._get_display_unit(attribute)).physical_type
                    not in ['frequency', 'wavelength', 'length']
                    and unit != self.app._get_display_unit(attribute)):
+                    to_unit = self.app._get_display_unit(attribute)
+                    if (check_if_unit_is_per_solid_angle(unit) == True and attribute == 'flux'):
+                        to_unit = self.app._get_display_unit('sb')
+
                     equivalencies = all_flux_unit_conversion_equivs(cube_wave=wave)
                     value = flux_conversion_general(value, unit,
-                                                    self.app._get_display_unit(attribute),
-                                                    equivalencies,
-                                                    with_unit=False)
-                    unit = self.app._get_display_unit(attribute)
+                                                to_unit,
+                                                equivalencies,
+                                                with_unit=False)
+                    unit = to_unit
 
             elif isinstance(viewer, (CubevizImageView, RampvizImageView)):
                 arr = image.get_component(attribute).data

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -660,15 +660,9 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                                                                 sp.spectral_axis)
 
                 if sp.flux.unit is not None and viewer.state.y_display_unit is not None:
-                    to_unit = viewer.state.y_display_unit
-                    if (self.app.config != 'cubeviz' and
-                       check_if_unit_is_per_solid_angle(sp.flux.unit)
-                       != check_if_unit_is_per_solid_angle(to_unit)):
-                        to_unit = self.app._get_display_unit('sb')
-
                     disp_flux = flux_conversion_general(sp.flux.value,
                                                         sp.flux.unit,
-                                                        to_unit,
+                                                        viewer.state.y_display_unit,
                                                         equivalencies, with_unit=False)  # noqa: E501
                 else:
                     disp_flux = sp.flux
@@ -727,9 +721,9 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
         else:
             flux_unit = viewer.state.y_display_unit
         self.row3_title = 'Flux'
-        self.row3_text = f'{closest_flux:10.5e} {to_unit}'
+        self.row3_text = f'{closest_flux:10.5e} {flux_unit}'
         self._dict['axes_y'] = closest_flux
-        self._dict['axes_y:unit'] = str(flux_unit)
+        self._dict['axes_y:unit'] = str(viewer.state.y_display_unit)
 
         if closest_icon is not None:
             self.icon = closest_icon

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -23,15 +23,15 @@ from jdaviz.core.unit_conversion_utils import (create_equivalent_spectral_axis_u
 __all__ = ['UnitConversion']
 
 
-def _valid_glue_display_unit(unit_str, sv, axis='x'):
+def _valid_glue_display_unit(unit_str, viewer, axis='x'):
     # need to make sure the unit string is formatted according to the list of valid choices
     # that glue will accept (may not be the same as the defaults of the installed version of
     # astropy)
     if not unit_str:
         return unit_str
-    if sv.__class__.__name__.endswith('ProfileView'):
+    if isinstance(viewer, JdavizProfileView):
         unit_u = u.Unit(unit_str)
-        choices_str = getattr(sv.state.__class__, f'{axis}_display_unit').get_choices(sv.state)
+        choices_str = getattr(viewer.state.__class__, f'{axis}_display_unit').get_choices(sv.state)
         choices_str = [choice for choice in choices_str if choice is not None]
         choices_u = [u.Unit(choice) for choice in choices_str]
         if unit_u not in choices_u:

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -281,8 +281,9 @@ class UnitConversion(PluginTemplateMixin):
             # NOTE: this assumes that all image data is coerced to surface brightness units
             layers = [lyr for lyr in msg.viewer.layers if lyr.layer.data.label == msg.data.label]
 
-            if not len(self.spectral_unit_selected):
+            if not len(self.spectral_unit_selected) and data_obj.__class__.__name__ != 'FlatTrace':
                 try:
+                    print(dir(data_obj))
                     self.spectral_unit.selected = str(data_obj.spectral_axis.unit)
                 except ValueError:
                     self.spectral_unit.selected = ''
@@ -299,7 +300,7 @@ class UnitConversion(PluginTemplateMixin):
                 except ValueError:
                     self.flux_unit.selected = ''
 
-            if not self.angle_unit_selected:
+            if not self.angle_unit_selected and data_obj.__class__.__name__ != 'FlatTrace':
                 self.angle_unit.choices = create_equivalent_angle_units_list(angle_unit)
                 try:
                     if angle_unit is None:

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -37,19 +37,17 @@ def _valid_glue_display_unit(unit_str, sv, axis='x'):
             raise ValueError(f"{unit_str} could not find match in valid {axis} display units {choices_str}")  # noqa
         ind = choices_u.index(unit_u)
         return choices_str[ind]
-    elif sv.__class__.__name__.endswith('2DView'):
+    else:
         return unit_str
 
 
 def _flux_to_sb_unit(flux_unit, angle_unit):
     if angle_unit not in supported_sq_angle_units(as_strings=True):
-        print(angle_unit)
         sb_unit = flux_unit
     else:
         # str > unit > str to remove formatting inconsistencies with
         # parentheses/order of units/etc
         sb_unit = (u.Unit(flux_unit) / u.Unit(angle_unit)).to_string()
-    print('flux to sb unit ', sb_unit)
     return sb_unit
 
 
@@ -223,9 +221,7 @@ class UnitConversion(PluginTemplateMixin):
                     except ValueError:
                         self.spectral_unit.selected = ''
 
-                print('data obj flux :', data_obj.flux.unit, viewer)
                 angle_unit = check_if_unit_is_per_solid_angle(data_obj.flux.unit, return_unit=True)
-                print(angle_unit)
                 flux_unit = data_obj.flux.unit if angle_unit is None else data_obj.flux.unit * angle_unit  # noqa
 
                 if not self.flux_unit_selected:
@@ -235,13 +231,11 @@ class UnitConversion(PluginTemplateMixin):
                     except ValueError:
                         self.flux_unit.selected = ''
 
-                print('ttt', self.angle_unit_selected)
                 if not self.angle_unit_selected and hasattr(self.angle_unit, 'choices'):
                     self.angle_unit.choices = create_equivalent_angle_units_list(angle_unit)
 
                     try:
                         if angle_unit is None:
-                            print('angle unit is none')
                             if self.config in ['specviz', 'specviz2d']:
                                 self.has_angle = False
                                 self.has_sb = False
@@ -249,18 +243,12 @@ class UnitConversion(PluginTemplateMixin):
                                 # default to pix2 if input data is not in surface brightness units
                                 # TODO: for cubeviz, should we check the cube itself?
                                 self.angle_unit = 'pix2'
-                                print('in the pix2 setter', self.angle_unit.selected)
                         else:
                             self.angle_unit.selected = str(angle_unit)
-                            print('in the general setter')
                     except ValueError:
                         self.angle_unit.selected = ''
-                print(self.spectral_y_type_items)
-                print(not len(self.spectral_y_type_selected))
-                print(isinstance(viewer, JdavizProfileView), viewer)
                 if (not len(self.spectral_y_type_selected)
                         and isinstance(viewer, JdavizProfileView)):
-                    print('selecting spectral y type')
                     # set spectral_y_type_selected to 'Flux'
                     # if the y-axis unit is not per solid angle
                     self.spectral_y_type.choices = ['Surface Brightness', 'Flux']
@@ -268,8 +256,6 @@ class UnitConversion(PluginTemplateMixin):
                         self.spectral_y_type_selected = 'Flux'
                     else:
                         self.spectral_y_type_selected = 'Surface Brightness'
-
-                    print('spectral y type ', self.spectral_y_type)
 
                 # setting default values will trigger the observes to set the units
                 # in _on_unit_selected, so return here to avoid setting twice
@@ -329,7 +315,7 @@ class UnitConversion(PluginTemplateMixin):
                 except ValueError:
                     self.angle_unit.selected = ''
 
-            if angle_unit:
+            if self.angle_unit:
                 self._handle_attribute_display_unit(self.sb_unit_selected, layers=layers)
             self._clear_cache('image_layers')
 
@@ -363,7 +349,7 @@ class UnitConversion(PluginTemplateMixin):
         elif axis == 'flux':
             # handle spectral y-unit first since that is a more apparent change to the user
             # and feels laggy if it is done later
-            if self.spectral_y_type and self.spectral_y_type_selected == 'Flux':
+            if self.spectral_y_type_selected == 'Flux':
                 self._handle_spectral_y_unit()
             if self.spectrum_viewer:
                 self.spectrum_viewer.set_plot_axes()
@@ -382,7 +368,6 @@ class UnitConversion(PluginTemplateMixin):
                 # which in turn will call _handle_attribute_display_unit,
                 # _handle_spectral_y_unit (if spectral_y_type_selected == 'Surface Brightness'),
                 #  and send a second GlobalDisplayUnitChanged message for sb
-                print('in angle setter', self.angle_unit.selected)
                 self.sb_unit_selected = _flux_to_sb_unit(self.flux_unit.selected,
                                                          self.angle_unit.selected)
 
@@ -394,7 +379,6 @@ class UnitConversion(PluginTemplateMixin):
 
             self._handle_attribute_display_unit(self.sb_unit_selected)
             if self.spectrum_viewer:
-                self.spectrum_viewer.state.y_display_unit = self.app._get_display_unit('sb')
                 self.spectrum_viewer.set_plot_axes()
 
         # custom axes downstream can override _on_unit_selected if anything needs to be
@@ -412,15 +396,11 @@ class UnitConversion(PluginTemplateMixin):
         the spectrum viewer with the new unit, and then emit a
         GlobalDisplayUnitChanged message to notify
         """
-        print('her')
         if self.spectral_y_type_selected:
             yunit = _valid_glue_display_unit(self.spectral_y_unit, self.spectrum_viewer, 'y')
-            print('a')
         elif self.sb_unit_selected:
-            print('b')
             yunit = _valid_glue_display_unit(self.sb_unit_selected, self.spectrum_viewer, 'y')
         else:
-            print('c')
             yunit = _valid_glue_display_unit(self.flux_unit_selected, self.spectrum_viewer, 'y')
         if self.spectrum_viewer.state.y_display_unit == yunit:
             self.spectrum_viewer.set_plot_axes()

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -283,7 +283,6 @@ class UnitConversion(PluginTemplateMixin):
 
             if not len(self.spectral_unit_selected) and data_obj.__class__.__name__ != 'FlatTrace':
                 try:
-                    print(dir(data_obj))
                     self.spectral_unit.selected = str(data_obj.spectral_axis.unit)
                 except ValueError:
                     self.spectral_unit.selected = ''

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -6,6 +6,7 @@ from glue.core.subset_group import GroupedSubset
 from glue_jupyter.bqplot.image import BqplotImageView
 from specutils import Spectrum1D
 from traitlets import List, Unicode, observe, Bool
+from specreduce import tracing
 
 from jdaviz.configs.default.plugins.viewers import JdavizProfileView
 from jdaviz.core.custom_units_and_equivs import _eqv_flux_to_sb_pixel, _eqv_pixar_sr
@@ -281,8 +282,7 @@ class UnitConversion(PluginTemplateMixin):
             # NOTE: this assumes that all image data is coerced to surface brightness units
             layers = [lyr for lyr in msg.viewer.layers if lyr.layer.data.label == msg.data.label]
 
-            if not len(self.spectral_unit_selected):
-                # and data_obj.__class__.__name__ != 'FlatTrace':
+            if not len(self.spectral_unit_selected) and not isinstance(data_obj, tracing.FlatTrace):
                 try:
                     self.spectral_unit.selected = str(data_obj.spectral_axis.unit)
                 except ValueError:
@@ -300,8 +300,7 @@ class UnitConversion(PluginTemplateMixin):
                 except ValueError:
                     self.flux_unit.selected = ''
 
-            if not self.angle_unit_selected:
-                # and data_obj.__class__.__name__ != 'FlatTrace':
+            if not self.angle_unit_selected and not isinstance(data_obj, tracing.FlatTrace):
                 self.angle_unit.choices = create_equivalent_angle_units_list(angle_unit)
                 try:
                     if angle_unit is None:

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -231,7 +231,7 @@ class UnitConversion(PluginTemplateMixin):
                     except ValueError:
                         self.flux_unit.selected = ''
 
-                if not self.angle_unit_selected and hasattr(self.angle_unit, 'choices'):
+                if not self.angle_unit_selected:
                     self.angle_unit.choices = create_equivalent_angle_units_list(angle_unit)
 
                     try:
@@ -242,7 +242,7 @@ class UnitConversion(PluginTemplateMixin):
                             else:
                                 # default to pix2 if input data is not in surface brightness units
                                 # TODO: for cubeviz, should we check the cube itself?
-                                self.angle_unit = 'pix2'
+                                self.angle_unit.selected = 'pix2'
                         else:
                             self.angle_unit.selected = str(angle_unit)
                     except ValueError:
@@ -281,7 +281,8 @@ class UnitConversion(PluginTemplateMixin):
             # NOTE: this assumes that all image data is coerced to surface brightness units
             layers = [lyr for lyr in msg.viewer.layers if lyr.layer.data.label == msg.data.label]
 
-            if not len(self.spectral_unit_selected) and data_obj.__class__.__name__ != 'FlatTrace':
+            if not len(self.spectral_unit_selected):
+                # and data_obj.__class__.__name__ != 'FlatTrace':
                 try:
                     self.spectral_unit.selected = str(data_obj.spectral_axis.unit)
                 except ValueError:
@@ -299,7 +300,8 @@ class UnitConversion(PluginTemplateMixin):
                 except ValueError:
                     self.flux_unit.selected = ''
 
-            if not self.angle_unit_selected and data_obj.__class__.__name__ != 'FlatTrace':
+            if not self.angle_unit_selected:
+                # and data_obj.__class__.__name__ != 'FlatTrace':
                 self.angle_unit.choices = create_equivalent_angle_units_list(angle_unit)
                 try:
                     if angle_unit is None:

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -31,7 +31,7 @@ def _valid_glue_display_unit(unit_str, viewer, axis='x'):
         return unit_str
     if isinstance(viewer, JdavizProfileView):
         unit_u = u.Unit(unit_str)
-        choices_str = getattr(viewer.state.__class__, f'{axis}_display_unit').get_choices(viewer.state)
+        choices_str = getattr(viewer.state.__class__, f'{axis}_display_unit').get_choices(viewer.state)  # noqa
         choices_str = [choice for choice in choices_str if choice is not None]
         choices_u = [u.Unit(choice) for choice in choices_str]
         if unit_u not in choices_u:

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -31,7 +31,7 @@ def _valid_glue_display_unit(unit_str, viewer, axis='x'):
         return unit_str
     if isinstance(viewer, JdavizProfileView):
         unit_u = u.Unit(unit_str)
-        choices_str = getattr(viewer.state.__class__, f'{axis}_display_unit').get_choices(sv.state)
+        choices_str = getattr(viewer.state.__class__, f'{axis}_display_unit').get_choices(viewer.state)
         choices_str = [choice for choice in choices_str if choice is not None]
         choices_u = [u.Unit(choice) for choice in choices_str]
         if unit_u not in choices_u:

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -404,7 +404,10 @@ class ConfigHelper(HubListener):
                 spectral_unit = self.app._get_display_unit('spectral')
                 if not spectral_unit:
                     return data
-                y_unit = self.app._get_display_unit('spectral_y')
+                if self.app.config == 'specviz' and self.app._get_display_unit('sb'):
+                    y_unit = self.app._get_display_unit('sb')
+                else:
+                    y_unit = self.app._get_display_unit('spectral_y')
 
                 # if there is no pixel scale factor, and the requested conversion
                 # is between flux/sb, then skip. this case is encountered when

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -113,8 +113,12 @@ class PluginMark:
     def set_x_unit(self, unit=None):
         if unit is None:
             if not hasattr(self.viewer.state, 'x_display_unit'):
-                return
-            unit = self.viewer.state.x_display_unit
+                if self.viewer.data():
+                    unit = self.viewer.data()[0].spectral_axis.unit
+                else:
+                    return
+            else:
+                unit = self.viewer.state.x_display_unit
         unit = u.Unit(unit)
 
         if self.xunit is not None and not np.all([s == 0 for s in self.x.shape]):
@@ -126,8 +130,12 @@ class PluginMark:
     def set_y_unit(self, unit=None):
         if unit is None:
             if not hasattr(self.viewer.state, 'y_display_unit'):
-                return
-            unit = self.viewer.state.y_display_unit
+                if self.viewer.data():
+                    unit = self.viewer.data()[0].flux.unit
+                else:
+                    return
+            else:
+                unit = self.viewer.state.y_display_unit
         unit = u.Unit(unit)
 
         # spectrum y-values in viewer have already been converted, don't convert again
@@ -143,7 +151,7 @@ class PluginMark:
                     return
                 spec = self.viewer.state.reference_data.get_object(cls=Spectrum1D)
 
-                pixar_sr = spec.meta.get('PIXAR_SR', 1)
+                pixar_sr = spec.meta.get('PIXAR_SR', None)
                 cube_wave = self.x * self.xunit
                 equivs = all_flux_unit_conversion_equivs(pixar_sr, cube_wave)
                 y = flux_conversion_general(self.y, self.yunit, unit,

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -113,7 +113,7 @@ class PluginMark:
     def set_x_unit(self, unit=None):
         if unit is None:
             if not hasattr(self.viewer.state, 'x_display_unit'):
-                if self.viewer.data():
+                if self.viewer.data() and hasattr(self.viewer.data()[0], 'spectral_axis'):
                     unit = self.viewer.data()[0].spectral_axis.unit
                 else:
                     return
@@ -130,7 +130,7 @@ class PluginMark:
     def set_y_unit(self, unit=None):
         if unit is None:
             if not hasattr(self.viewer.state, 'y_display_unit'):
-                if self.viewer.data():
+                if self.viewer.data() and hasattr(self.viewer.data()[0], 'flux'):
                     unit = self.viewer.data()[0].flux.unit
                 else:
                     return


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address removing Unit Conversion's dependency of the profile-viewer. In the following #3473, an instance of loading 2d spectra with solely an BqplotImageView viewer (with what was formerly known as Specviz2d) is now possible and the expected behavior. With removing the profile-viewer on a Jdaviz instance, unit conversion now must be self-sustaining. 


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
