### PR TITLE
remove max pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "solara>=1.40.0",
     "pyyaml>=5.4.1",
     "specutils>=1.18",
-    "specreduce>=1.4.1,<1.5",
+    "specreduce>=1.4.1,!=1.5.0,!=1.5.1",
     "photutils>=2.2",
     "glue-astronomy>=0.10",
     "asteval>=0.9.23",


### PR DESCRIPTION
follow up to [#3503](https://github.com/spacetelescope/jdaviz/pull/3503), need to remove max pin otherwise dev test is installing 1.4.1. this is why spectral extraction tests were not failing when they should be