### PR TITLE
ignore nans when finding brightest pixel for initial trace guess

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,7 @@ Specviz
 
 Specviz2d
 ^^^^^^^^^
+- Improved initial guess for trace for automatic extraction when data has nonfinite values. [#3512]
 
 Other Changes and Additions
 ---------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,7 +54,6 @@ Specviz
 
 Specviz2d
 ^^^^^^^^^
-- Improved initial guess for trace for automatic extraction when data has nonfinite values. [#3512]
 
 Other Changes and Additions
 ---------------------------
@@ -79,6 +78,8 @@ Specviz
 
 Specviz2d
 ^^^^^^^^^
+- Improved initial guess for trace for automatic extraction. May change results
+  for automatic extraction for data with nonfinite values. [#3512]
 
 4.2 (2025-03-17)
 ================

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -400,7 +400,7 @@ class SpectralExtraction(PluginTemplateMixin):
             # default to trace in middle of image
             brightest_pixel = int(trace_flux.shape[0]/2)
         else:
-            brightest_pixel = int(np.nanmedian(np.argmax(trace_flux_ignore_zeros, axis=0)))
+            brightest_pixel = int(np.nanmedian(np.nanargmax(trace_flux_ignore_zeros, axis=0)))
         # do not allow to be an edge pixel
         if brightest_pixel < 1:
             brightest_pixel = 1

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -189,7 +189,6 @@ def test_spectrum_on_top(specviz2d_helper):
     specviz2d_helper.load_data(spectrum_2d=fn)
 
     pext = specviz2d_helper.app.get_tray_item_from_name('spectral-extraction')
-    pext.trace_pixel = 14.2
     assert pext.bg_type_selected == 'TwoSided'
     np.testing.assert_allclose(pext.bg_separation, 6)
 

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -190,7 +190,7 @@ def test_spectrum_on_top(specviz2d_helper):
 
     pext = specviz2d_helper.app.get_tray_item_from_name('spectral-extraction')
     pext.trace_pixel = 14.2
-    assert pext.bg_type_selected == 'OneSided'
+    assert pext.bg_type_selected == 'TwoSided'
     np.testing.assert_allclose(pext.bg_separation, 6)
 
 


### PR DESCRIPTION
Replace argmax with nanargmax when estimating location for trace based on the brightest pixel. If there are nans in a column, argmax will choose the first location of a nan for the location of the maximum. This fix combined with the next release of specreduce fixes the issue of the default extraction failing and producing a trace at the bottom of the image that can be seen in the specviz2d example notebook.

I verified the change in the test - one sided was being selected before based on the fact that the trace was at the bottom of the image (see lines 415-421 of spectral_extraction.py). I also removed the line setting the trace pixel, this was done because the initial guess was poor. With this change and the new default trace, it should be two-sided.