### PR TITLE
Avoid accessing all pixels in a dataset just to determine pixel limits :zap: 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,8 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Significantly improved performance for panning and zooming with large datasets. [#3513]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -201,8 +201,10 @@ class FreezableBqplotImageViewerState(BqplotImageViewerState, FreezableState):
 
                 pixel_ids = layer.layer.pixel_component_ids
                 world_bottom_left = data.coords.pixel_to_world(0, 0)
-                world_top_right = data.coords.pixel_to_world(layer.layer.data.shape[pixel_ids[1].axis] - 1,
-                                                             layer.layer.data.shape[pixel_ids[0].axis] - 1)
+                world_top_right = data.coords.pixel_to_world(
+                    layer.layer.data.shape[pixel_ids[1].axis] - 1,
+                    layer.layer.data.shape[pixel_ids[0].axis] - 1
+                )
 
                 if return_as_world:
                     x_min = min(x_min, world_bottom_left.ra.value)

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -201,8 +201,8 @@ class FreezableBqplotImageViewerState(BqplotImageViewerState, FreezableState):
 
                 pixel_ids = layer.layer.pixel_component_ids
                 world_bottom_left = data.coords.pixel_to_world(0, 0)
-                world_top_right = data.coords.pixel_to_world(layer.layer.data[pixel_ids[1]].max(),
-                                                             layer.layer.data[pixel_ids[0]].max())
+                world_top_right = data.coords.pixel_to_world(layer.layer.data.shape[pixel_ids[1].axis] - 1,
+                                                             layer.layer.data.shape[pixel_ids[0].axis] - 1)
 
                 if return_as_world:
                     x_min = min(x_min, world_bottom_left.ra.value)

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -234,8 +234,8 @@ class FreezableBqplotImageViewerState(BqplotImageViewerState, FreezableState):
                 pixel_id_x = [comp for comp in pixel_ids if comp.label.endswith('[x]')][0]
                 pixel_id_y = [comp for comp in pixel_ids if comp.label.endswith('[y]')][0]
 
-                x_max = max(x_max, layer.layer.data[pixel_id_x].max() + 0.5)
-                y_max = max(y_max, layer.layer.data[pixel_id_y].max() + 0.5)
+                x_max = max(x_max, layer.layer.data.shape[pixel_id_x.axis] - 0.5)
+                y_max = max(y_max, layer.layer.data.shape[pixel_id_y.axis] - 0.5)
 
         return x_min, x_max, y_min, y_max
 


### PR DESCRIPTION
### Description

This dramatically speeds up interactive operations (zooming/panning) when visualizing large unlinked datasets. The following example includes a (30000,30000) dataset with 23 subsets after the change:

[Screencast from 2025-03-19 13-33-35.webm](https://github.com/user-attachments/assets/2a04e0a5-f464-4030-85c4-808df9445237)

For comparison, this was before:

[Screencast from 2025-03-19 13-39-53.webm](https://github.com/user-attachments/assets/ce606706-c8f9-4639-a2f6-09e030069a5a)

This might not fix performance issues related to when there are datasets linked via WCS, but this at least fixes the biggest bottleneck for single images.

The fix here is to make sure we don't access all pixel values in order to determine the max pixel values. We can get this simply from the data shape.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
