### PR TITLE
Highlight active layer in Plot Options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 New Features
 ------------
 
+- The Plot Options plugin now highlights the tab for the active (top-most) data layer
+  in the selected viewer. [#3514]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/components/layer_viewer_icon_stylized.vue
+++ b/jdaviz/components/layer_viewer_icon_stylized.vue
@@ -11,8 +11,8 @@
     >
       <v-icon v-if="String(icon).startsWith('mdi-')" style="color: white">
         {{  icon }}
-      </v-icon>"
-      <span v-else :style="'color: white; text-shadow: 0px 0px 3px black; '+borderStyle(linewidth)">
+      </v-icon>
+      <span v-else :style="'color: white; text-shadow: 0px 0px 3px black; '+icon_style+borderStyle(linewidth)">
         {{ icon }}
       </span>
     </v-btn>
@@ -22,7 +22,7 @@
 <script>
 module.exports = {
   // tooltip: undefined will use default generated, empty will skip tooltips, any other string will be used directly
-  props: ['label', 'icon', 'visible', 'is_subset', 'colors', 'linewidth', 'colormode', 'cmap_samples', 'btn_style', 'tooltip', 'disabled'],
+  props: ['label', 'icon', 'visible', 'is_subset', 'colors', 'linewidth', 'colormode', 'cmap_samples', 'btn_style', 'icon_style', 'tooltip', 'disabled'],
   methods: {
     tooltipContent(tooltip, label, visible, colormode, colors, linewidth, is_subset) {
       if (tooltip !== undefined) {
@@ -66,13 +66,13 @@ module.exports = {
       var cmap_strip_width = strip_width
       var style_colors = []
       var style = 'repeating-linear-gradient( 135deg, '
-  
+
       for ([mi, color_or_cmap] of colors.entries()) {
         if (color_or_cmap == 'from_list') {
           /* follow-up: use actual colors from the DQ plugins */
           color_or_cmap = 'rainbow'
         }
-  
+
         if (color_or_cmap.startsWith('#')) {
           style_colors = [color_or_cmap]
         } else {
@@ -92,12 +92,12 @@ module.exports = {
           style += ', '
         }
       }
-    
+
       style += ')'
       return style
     },
     borderStyle(linewidth) {
-      if (linewidth != 'mixed' && linewidth > 0) { 
+      if (linewidth != 'mixed' && linewidth > 0) {
         return 'border-bottom: '+Math.min(linewidth, 5)+'px solid white'
       }
       return ''

--- a/jdaviz/components/plugin_layer_select_tabs.vue
+++ b/jdaviz/components/plugin_layer_select_tabs.vue
@@ -22,6 +22,7 @@
           :linewidth="item.linewidth"
           :colormode="colormode"
           :cmap_samples="cmap_samples"
+          :btn_style="item.label===active_layer ? 'border: 2px solid #C75109;' : ''"
           @click="() => {if (!multiselect){$emit('update:selected', item.label)} else if(!selectedAsList.includes(item.label)) {$emit('update:selected', selected.concat(item.label))} else if (selected.length > 1) {$emit('update:selected', selected.filter(select => select != item.label))} }"
         />
     </span>
@@ -31,15 +32,16 @@
 <script>
 module.exports = {
   props: ['items', 'selected', 'multiselect', 'colormode', 'cmap_samples',
-          'show_multiselect_toggle', 'icon_checktoradial', 'icon_radialtocheck'],
+          'show_multiselect_toggle', 'icon_checktoradial', 'icon_radialtocheck',
+          'active_layer'],
   computed: {
     selectedAsList() {
-      if (this.$props.multiselect) { 
+      if (this.$props.multiselect) {
         return this.$props.selected
       }
       return [this.$props.selected]
     }
   },
 };
-  
+
 </script>

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -22,7 +22,7 @@ from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin, ViewerSelectMixin, LayerSelect,
                                         PlotOptionsSyncState, Plot,
                                         skip_if_no_updates_since_last_active, with_spinner)
-from jdaviz.core.events import ChangeRefDataMessage
+from jdaviz.core.events import ChangeRefDataMessage, ViewerAddedMessage
 from jdaviz.core.user_api import PluginUserApi
 from jdaviz.core.tools import ICON_DIR
 from jdaviz.core.custom_traitlets import IntHandleEmpty
@@ -286,6 +286,7 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
     marker_colormap_vmax_sync = Dict().tag(sync=True)
 
     # image viewer/layer options
+    active_layer = Any().tag(sync=True)
     stretch_function_value = Unicode().tag(sync=True)
     stretch_function_sync = Dict().tag(sync=True)
 
@@ -630,6 +631,12 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
             sv.state.add_callback('y_display_unit',
                                   self._on_global_display_unit_changed)
 
+        # Add layer callback to image viewers to track active layer
+        for viewer in self.app._viewer_store.values():
+            viewer.state.add_callback('layers', lambda msg: self._layers_changed(viewer))
+
+        self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewer_added)
+
         self.hub.subscribe(self, ChangeRefDataMessage,
                            handler=self._on_refdata_change)
 
@@ -706,6 +713,17 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
             self.display_units['image'] = 'pix'
         self.send_state('display_units')
         self._update_viewer_zoom_steps()
+
+    def _on_viewer_added(self, msg):
+        viewer = self.app.get_viewer_by_id(msg.viewer_id)
+        viewer.state.add_callback('layers', lambda msg: self._layers_changed(viewer))
+
+    def _layers_changed(self, viewer):
+        if self.viewer_multiselect:
+            self.active_layer = None
+
+        if viewer is self.viewer.selected_obj and self._viewer_is_image_viewer():
+            self.active_layer = viewer.active_image_layer.layer.label
 
     def vue_unmix_state(self, names):
         if isinstance(names, str):

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -633,7 +633,7 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
 
         # Add layer callback to image viewers to track active layer
         for viewer in self.app._viewer_store.values():
-            viewer.state.add_callback('layers', lambda msg: self._layers_changed(viewer))
+            viewer.state.add_callback('layers', lambda msg: self._layers_changed(viewer=viewer))
 
         self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewer_added)
 
@@ -716,18 +716,23 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
 
     def _on_viewer_added(self, msg):
         viewer = self.app.get_viewer_by_id(msg.viewer_id)
-        viewer.state.add_callback('layers', lambda msg: self._layers_changed(viewer))
+        viewer.state.add_callback('layers', lambda msg: self._layers_changed(viewer=viewer))
 
     @observe('viewer_selected')
-    def _layers_changed(self, viewer=None):
+    def _layers_changed(self, msg=None, viewer=None):
+        # We need msg first in the keyword arguments to catch the msg value from the observe,
+        # even though we don't end up using it
         if self.viewer_multiselect or not hasattr(self, 'viewer'):
             self.active_layer = ""
             return
 
         if viewer is None:
-            print(f"viewer is None, setting to {self.viewer.selected}")
             viewer = self.viewer.selected_obj
+
         if viewer is self.viewer.selected_obj and self._viewer_is_image_viewer():  # noqa
+            if viewer.active_image_layer is None:
+                self.active_layer = ""
+                return
             self.active_layer = viewer.active_image_layer.layer.label
 
     def vue_unmix_state(self, names):

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -286,7 +286,7 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
     marker_colormap_vmax_sync = Dict().tag(sync=True)
 
     # image viewer/layer options
-    active_layer = Any().tag(sync=True)
+    active_layer = Unicode().tag(sync=True)
     stretch_function_value = Unicode().tag(sync=True)
     stretch_function_sync = Dict().tag(sync=True)
 
@@ -721,7 +721,7 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
     @observe('viewer_selected')
     def _layers_changed(self, viewer=None):
         if self.viewer_multiselect or not hasattr(self, 'viewer'):
-            self.active_layer = None
+            self.active_layer = ""
             return
 
         if viewer is None:

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -718,11 +718,16 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
         viewer = self.app.get_viewer_by_id(msg.viewer_id)
         viewer.state.add_callback('layers', lambda msg: self._layers_changed(viewer))
 
-    def _layers_changed(self, viewer):
-        if self.viewer_multiselect:
+    @observe('viewer_selected')
+    def _layers_changed(self, viewer=None):
+        if self.viewer_multiselect or not hasattr(self, 'viewer'):
             self.active_layer = None
+            return
 
-        if viewer is self.viewer.selected_obj and self._viewer_is_image_viewer():
+        if viewer is None:
+            print(f"viewer is None, setting to {self.viewer.selected}")
+            viewer = self.viewer.selected_obj
+        if viewer is self.viewer.selected_obj and self._viewer_is_image_viewer():  # noqa
             self.active_layer = viewer.active_image_layer.layer.label
 
     def vue_unmix_state(self, names):

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -116,7 +116,7 @@
                 :api_hints_enabled="api_hints_enabled"
                 @click="reset_viewer_bounds"
               >
-                {{api_hints_enabled ? 
+                {{api_hints_enabled ?
                   'plg.reset_viewer_bounds()'
                   :
                   'Reset viewer bounds'
@@ -223,6 +223,7 @@
       :icon_radialtocheck="icon_radialtocheck"
       :colormode="image_color_mode_sync['mixed'] ? 'mixed' : image_color_mode_value"
       :cmap_samples="cmap_samples"
+      :active_layer="active_layer"
       label="Layers"
       hint="Select the data or subset to set options."
       style="margin-top: 36px"
@@ -279,7 +280,7 @@
             :api_hints_enabled="api_hints_enabled"
             wait="300"
             max="1"
-            step="0.01" 
+            step="0.01"
             :value.sync="subset_opacity_value"
           />
       </glue-state-sync-wrapper>
@@ -774,7 +775,7 @@
 
             <div v-if="contour_mode_value === 'Linear'">
               <glue-state-sync-wrapper :sync="contour_min_sync" :multiselect="layer_multiselect" @unmix-state="unmix_state('contour_min')">
-                <glue-float-field 
+                <glue-float-field
                   :label="api_hints_enabled ? 'plg.contour_min =' : 'Contour Min'"
                   :class="api_hints_enabled ? 'api-hint' : null"
                   :value.sync="contour_min_value"


### PR DESCRIPTION
This implements an outline highlighting the active layer in the plot options plugin. In this example B is selected, but A is the active layer in the viewer:

<img width="393" alt="Screenshot 2025-03-20 at 3 57 01 PM" src="https://github.com/user-attachments/assets/35d06876-79ae-4344-8b11-d5c04e22973f" />

Right now this is the light theme orange accent color - it wasn't immediately clear to me how to use the defined `accent` color in `main_styles.vue` such that it would be responsive to light vs dark mode, if anyone can point me to an example of that I could make that change (or figure it out myself tomorrow).