### PR TITLE
override glue's _convert_units_x_limits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -92,8 +92,8 @@ Mosviz
 Specviz
 ^^^^^^^
 
-- Override glue's profile viewer state _convert_units_x_limits to ensure x-limits
-  update on spectral conversions. [#3518]
+- Fix bug where converting spectral units multiple times caused spectrum viewer limits
+  to stop resetting to correct x-limits. [#3518]
 
 Specviz2d
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -92,6 +92,9 @@ Mosviz
 Specviz
 ^^^^^^^
 
+- Override glue's profile viewer state _convert_units_x_limits to ensure x-limits
+  update on spectral conversions. [#3518]
+
 Specviz2d
 ^^^^^^^^^
 

--- a/jdaviz/configs/specviz/tests/test_viewers.py
+++ b/jdaviz/configs/specviz/tests/test_viewers.py
@@ -43,6 +43,27 @@ def test_spectrum_viewer_keep_unit_when_removed(specviz_helper, spectrum1d):
     assert specviz_helper.app._get_display_unit('spectral_y') == "MJy"
 
 
+def test_limits_on_unit_change(specviz_helper, spectrum1d):
+    """
+    Test that the x-limits are reset when changing units
+    """
+    specviz_helper.load_data(spectrum1d, data_label="Test")
+    uc = specviz_helper.plugins["Unit Conversion"]
+    sv = specviz_helper.viewers['spectrum-viewer']
+
+    assert uc.spectral_unit == "Angstrom"
+    assert np.allclose(sv._obj.get_limits(), (6000.0, 8000.0,
+                                              12.30618014327326, 16.542560043585965))
+
+    uc.spectral_unit = 'Ci'
+    assert np.allclose(sv._obj.get_limits(), (10128.0, 13504.164774774774,
+                                              12.30618014327326, 16.542560043585965))
+
+    uc.spectral_unit = 'erg'
+    assert np.allclose(sv._obj.get_limits(), (2.4830270237304e-12, 3.3107430952482144e-12,
+                                              12.30618014327326, 16.542560043585965))
+
+
 class TestResetLimitsTwoTests:
     """See https://github.com/spacetelescope/lcviz/pull/93"""
 

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -61,6 +61,9 @@ class FreezableProfileViewerState(ProfileViewerState, FreezableState):
         # override glue's _convert_units_x_limits to account
         # for spectral axis conversions that are not supported by glue.
 
+        if self.x_min is None or self.x_max is None:
+            return
+
         if old_unit is None or new_unit is None:
             self._reset_x_limits()
             return

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -61,10 +61,9 @@ class FreezableProfileViewerState(ProfileViewerState, FreezableState):
         # override glue's _convert_units_x_limits to account
         # for spectral axis conversions that are not supported by glue.
 
-        if old_unit != new_unit or (old_unit is None and new_unit is None):
-            if old_unit is None or new_unit is None:
-                self._reset_x_limits()
-                return
+        if old_unit is None or new_unit is None:
+            self._reset_x_limits()
+            return
 
         x_lims_new = spectral_axis_conversion([self.x_min, self.x_max],
                                               old_unit, new_unit)

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -9,7 +9,8 @@ from glue.viewers.matplotlib.state import DeferredDrawCallbackProperty as DDCPro
 
 from jdaviz.utils import get_reference_image_data
 from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
-                                               flux_conversion_general)
+                                               flux_conversion_general,
+                                               spectral_axis_conversion)
 
 __all__ = ['FreezableState', 'FreezableProfileViewerState', 'FreezableBqplotImageViewerState']
 
@@ -55,6 +56,21 @@ class FreezableProfileViewerState(ProfileViewerState, FreezableState):
         with delay_callback(self, 'x_min', 'x_max'):
             self.x_min = x_min
             self.x_max = x_max
+
+    def _convert_units_x_limits(self, old_unit, new_unit):
+        # override glue's _convert_units_x_limits to account
+        # for spectral axis conversions that are not supported by glue.
+
+        if old_unit != new_unit or (old_unit is None and new_unit is None):
+            if old_unit is None or new_unit is None:
+                self._reset_x_limits()
+                return
+
+        x_lims_new = spectral_axis_conversion([self.x_min, self.x_max],
+                                              old_unit, new_unit)
+
+        self.x_min = np.nanmin(x_lims_new)
+        self.x_max = np.nanmax(x_lims_new)
 
     def _convert_units_y_limits(self, old_unit, new_unit):
         # override glue's _convert_units_y_limits to account


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request ensure viewer limits will reset when spectral units are converted by overriding glue's `_convert_units_x_limits`.

**Bug Behavior:**

https://github.com/user-attachments/assets/340b3335-4929-4ae2-9052-afa420115185



**Updated Behavior:**

https://github.com/user-attachments/assets/15e1c6b7-389a-4f4c-ad64-50fe76cc1902




<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
