### PR TITLE
Catalog Search: Keep original columns from file only

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Added ability to load remote data from a S3 URI to Imviz. [#3500]
+
 Mosviz
 ^^^^^^
 
@@ -61,7 +63,9 @@ Cubeviz
 
 Imviz
 ^^^^^
-- Added ability to load remote data from a S3 URI to Imviz. [#3500]
+
+- Catalog Search: Fixed a bug where the plugin modifies the input table if
+  ``import_catalog`` is used on a table instance (not from file). [#3519]
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,9 @@ Imviz
 - Radial profile and curve of growth in Aperture Photometry plugin are now consistent
   with ``photutils.profiles``. [#3510]
 
+- Catalog Search: When catalog is imported from file, its original column names are
+  preserved on export. [#3519]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -125,7 +125,7 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
     def _file_parser(path):
         if isinstance(path, AstropyTable):  # includes QTable
             from_file_string = f'API: {path.__class__.__name__} object'
-            return '', {from_file_string: path}
+            return '', {from_file_string: path, "_orig_colnames_for_jdaviz_export": path.colnames}
 
         try:
             table = QTable.read(path)
@@ -138,7 +138,8 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
         if 'sky_centroid' not in table.colnames:
             return 'Table does not contain required sky_centroid column', {}
 
-        return '', {path: table}
+        table.meta["_orig_colnames_for_jdaviz_export"] = table.colnames
+        return '', {path: table, "_orig_colnames_for_jdaviz_export": table.colnames}
 
     def _on_catalog_select_click_event(self, msg):
         xs, ys = self.table._qtable['x_coord'], self.table._qtable['y_coord']
@@ -356,6 +357,9 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
         viewer.marker = {'color': 'blue', 'alpha': 0.8, 'markersize': 30, 'fill': False}
         viewer.add_markers(table=catalog_results, use_skycoord=True, marker_name=self._marker_name)
 
+        if "_orig_colnames_for_jdaviz_export" in self.catalog._cached_obj:
+            self.table._qtable.meta["_orig_colnames_for_jdaviz_export"] = self.catalog._cached_obj["_orig_colnames_for_jdaviz_export"]  # noqa: E501
+
         msg = CatalogResultsChangedMessage(sender=self)
         self.session.hub.broadcast(msg)
 
@@ -389,6 +393,10 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
         self.table_selected._clear_table()
         for selected_row in selected_rows:
             self.table_selected.add_item(selected_row)
+
+        if (self.table_selected._qtable and
+                "_orig_colnames_for_jdaviz_export" in self.catalog._cached_obj):
+            self.table_selected._qtable.meta["_orig_colnames_for_jdaviz_export"] = self.catalog._cached_obj["_orig_colnames_for_jdaviz_export"]  # noqa: E501
 
         x = [float(coord['x_coord']) for coord in selected_rows]
         y = [float(coord['y_coord']) for coord in selected_rows]

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import numpy as np
 from astropy import units as u
 from astropy.table import QTable, Table as AstropyTable
@@ -124,6 +126,7 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
     @staticmethod
     def _file_parser(path):
         if isinstance(path, AstropyTable):  # includes QTable
+            path = deepcopy(path)  # Avoid overwriting original input
             from_file_string = f'API: {path.__class__.__name__} object'
             return '', {from_file_string: path, "_orig_colnames_for_jdaviz_export": path.colnames}
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -5013,7 +5013,15 @@ class Table(PluginSubcomponent):
             If ``filename`` already exists, should it be overwritten.
         """
         if filename is not None:
-            self._qtable.write(filename, overwrite=overwrite)
+            if "_orig_colnames_for_jdaviz_export" in self._qtable.meta:
+                out_tbl = self._qtable[self._qtable.meta["_orig_colnames_for_jdaviz_export"]]
+                del out_tbl.meta["_orig_colnames_for_jdaviz_export"]
+            else:
+                out_tbl = self._qtable
+
+            out_tbl.write(filename, overwrite=overwrite)
+            return out_tbl
+
         # TODO: default to only showing selected columns?
         return self._qtable
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to not keep internal columns from being exported in Catalog Search plugin.

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [x] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [x] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [x] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-5078)
