### PR TITLE
deconfigged: set_relevant for all plugins

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ New Features
 
 - Added an STC-S string region parser to the Footprints plugin. [#3479]
 
-- General (work-in-progress) centralized app-instance available at top package-level. [#3475]
+- General (work-in-progress) centralized app-instance available at top package-level. [#3475, #3526]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -56,10 +56,9 @@ def test_version_after_nddata_update(cubeviz_helper, spectrum1d_cube_with_uncert
 
 
 def test_gauss_smooth_before_spec_extract(cubeviz_helper, spectrum1d_cube_with_uncerts):
-    # Also test if gaussian smooth plugin is run before spec extract
+    # Test if gaussian smooth plugin is run before spec extract
     # that spec extract yields results of correct cube data
-
-    # give uniform unit uncertainties for spec extract test:
+    # give uniform unit uncertainties for spec extract test
     spectrum1d_cube_with_uncerts.uncertainty = StdDevUncertainty(
         np.ones_like(spectrum1d_cube_with_uncerts.data)
     )

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -58,7 +58,6 @@ def test_version_after_nddata_update(cubeviz_helper, spectrum1d_cube_with_uncert
 def test_gauss_smooth_before_spec_extract(cubeviz_helper, spectrum1d_cube_with_uncerts):
     # Also test if gaussian smooth plugin is run before spec extract
     # that spec extract yields results of correct cube data
-    gs_plugin = cubeviz_helper.plugins['Gaussian Smooth']._obj
 
     # give uniform unit uncertainties for spec extract test:
     spectrum1d_cube_with_uncerts.uncertainty = StdDevUncertainty(
@@ -66,6 +65,7 @@ def test_gauss_smooth_before_spec_extract(cubeviz_helper, spectrum1d_cube_with_u
     )
 
     cubeviz_helper.load_data(spectrum1d_cube_with_uncerts)
+    gs_plugin = cubeviz_helper.plugins['Gaussian Smooth']._obj
 
     gs_plugin.dataset_selected = f'{cubeviz_helper.app.data_collection[0].label}'
     gs_plugin.mode_selected = 'Spatial'

--- a/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
@@ -50,6 +50,8 @@ def test_export_movie_cubeviz_exceptions(cubeviz_helper, spectrum1d_cube):
     assert plugin._obj.i_start == 0
     assert plugin._obj.i_end == 1
 
+    assert len(plugin.viewer.choices) == 2  # uncert-viewer empty
+
     plugin.viewer_format = 'mp4'
     plugin._obj.i_end = 0
     with pytest.raises(ValueError, match="No frames to write"):
@@ -65,7 +67,7 @@ def test_export_movie_cubeviz_exceptions(cubeviz_helper, spectrum1d_cube):
     with pytest.raises(ValueError, match="Invalid path"):
         plugin.export()
 
-    plugin.viewer = 'uncert-viewer'
+    plugin.viewer = 'flux-viewer'
     plugin.filename = ""
     with pytest.raises(ValueError, match="Invalid filename"):
         plugin.export()
@@ -77,8 +79,9 @@ def test_export_movie_cubeviz_empty(cubeviz_helper):
     assert plugin._obj.i_start == 0
     assert plugin._obj.i_end == 0
 
+    assert len(plugin.viewer.choices) == 0  # no data loaded
     plugin.viewer_format = 'mp4'
-    with pytest.raises(ValueError, match="Selected viewer has no display shape"):
+    with pytest.raises(ValueError, match="nothing selected for export"):
         plugin.export()
 
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
@@ -82,7 +82,8 @@ def test_export_movie_cubeviz_empty(cubeviz_helper):
         plugin.export()
 
 
-def test_export_plot_exceptions(cubeviz_helper):
+def test_export_plot_exceptions(cubeviz_helper, spectrum1d_cube):
+    cubeviz_helper.load_data(spectrum1d_cube, data_label="test")
     plugin = cubeviz_helper.plugins["Export"]
 
     plugin.filename = "/fake/path/image.png"

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -195,6 +195,8 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     @observe('viewer_items', 'dataset_items', 'subset_items',
              'plugin_table_items', 'plugin_plot_items')
     def _set_relevant(self, *args):
+        if self.app.config != 'deconfigged':
+            return
         if not (len(self.viewer_items) or len(self.dataset_items) or len(self.subset_items)
                 or len(self.plugin_table_items) or len(self.plugin_plot_items)):
             self.irrelevant_msg = 'Nothing to export'

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -124,6 +124,8 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         self.dataset.filters = ['is_not_wcs_only', 'not_child_layer',
                                 'from_plugin']
 
+        self.viewer.add_filter('is_not_empty')
+
         viewer_format_options = ['png', 'svg']
         if self.config == 'cubeviz':
             if not self.app.state.settings.get('server_is_remote'):

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -190,6 +190,17 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             # on the user's machine, so export support in cubeviz should be disabled
             self.serverside_enabled = False
 
+        self._set_relevant()
+
+    @observe('viewer_items', 'dataset_items', 'subset_items',
+             'plugin_table_items', 'plugin_plot_items')
+    def _set_relevant(self, *args):
+        if not (len(self.viewer_items) or len(self.dataset_items) or len(self.subset_items)
+                or len(self.plugin_table_items) or len(self.plugin_plot_items)):
+            self.irrelevant_msg = 'Nothing to export'
+        else:
+            self.irrelevant_msg = ''
+
     @property
     def user_api(self):
         # TODO: backwards compat for save_figure, save_movie,

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -192,6 +192,8 @@ class TestExportSubsets:
         subset_plugin.import_region(CircularROI(xc=25, yc=25, radius=5))
         subset_plugin.import_region(CircularROI(xc=20, yc=25, radius=5))
 
+        export_plugin.subset.selected = 'Subset 1'
+        assert export_plugin.subset_invalid_msg == 'Export for composite subsets not yet supported.'
         with pytest.raises(NotImplementedError,
                            match='Subset can not be exported - Export for composite subsets not yet supported.'):  # noqa
             export_plugin.export()

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -77,6 +77,8 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
 
     @observe('dataset_items')
     def _set_relevant(self, *args):
+        if self.app.config != 'deconfigged':
+            return
         if not len(self.dataset_items):
             self.irrelevant_msg = 'No valid datasets loaded'
         else:

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -73,6 +73,15 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
         # description displayed under plugin title in tray
         self._plugin_description = 'Smooth data with a Gaussian kernel.'
 
+        self._set_relevant()
+
+    @observe('dataset_items')
+    def _set_relevant(self, *args):
+        if not len(self.dataset_items):
+            self.irrelevant_msg = 'No valid datasets loaded'
+        else:
+            self.irrelevant_msg = ''
+
     @property
     def _default_spectrum_viewer_reference_name(self):
         return getattr(

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -131,7 +131,10 @@ class LineListTool(PluginTemplateMixin):
         if sv is None:
             self.irrelevant_msg = 'Line Lists unavailable without spectrum viewer'
         elif not len(sv.layers):
-            self.irrelevant_msg = ''
+            if self.app.config == 'deconfigged':
+                self.irrelevant_msg = 'No data in spectrum viewer'
+            else:
+                self.irrelevant_msg = ''
             self.disabled_msg = 'Line Lists unavailable without data loaded in spectrum viewer'
         else:
             self.irrelevant_msg = ''

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -45,6 +45,15 @@ class MetadataViewer(PluginTemplateMixin, DatasetSelectMixin):
         # description displayed under plugin title in tray
         self._plugin_description = 'View metadata.'
 
+        self._set_relevant()
+
+    @observe('dataset_items')
+    def _set_relevant(self, *args):
+        if not len(self.dataset_items):
+            self.irrelevant_msg = 'No data loaded'
+        else:
+            self.irrelevant_msg = ''
+
     @property
     def user_api(self):
         return PluginUserApi(self, expose=('dataset', 'show_primary'),

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -49,6 +49,8 @@ class MetadataViewer(PluginTemplateMixin, DatasetSelectMixin):
 
     @observe('dataset_items')
     def _set_relevant(self, *args):
+        if self.app.config != 'deconfigged':
+            return
         if not len(self.dataset_items):
             self.irrelevant_msg = 'No data loaded'
         else:

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -172,6 +172,8 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
     @observe('dataset_items')
     def _set_relevant(self, *args):
+        if self.app.config != 'deconfigged':
+            return
         if not len(self.dataset_items):
             self.irrelevant_msg = 'No valid datasets loaded'
         else:

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -168,6 +168,15 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         self.hub.subscribe(self, GlobalDisplayUnitChanged,
                            handler=self._on_global_display_unit_changed)
 
+        self._set_relevant()
+
+    @observe('dataset_items')
+    def _set_relevant(self, *args):
+        if not len(self.dataset_items):
+            self.irrelevant_msg = 'No valid datasets loaded'
+        else:
+            self.irrelevant_msg = ''
+
     @property
     def _default_spectrum_viewer_reference_name(self):
         return getattr(

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -4,6 +4,7 @@ import warnings
 
 import matplotlib
 import numpy as np
+from functools import cached_property
 from echo import delay_callback
 from astropy.visualization import ManualInterval, ContrastBiasStretch
 from glue.core.subset_group import GroupedSubset
@@ -539,40 +540,6 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
                                                    'stretch_params_value', 'stretch_params_sync',
                                                    state_filter=is_image)
 
-        self.stretch_histogram = Plot(self, name='stretch_hist', viewer_type='histogram',
-                                      update_callback=self._update_stretch_histogram)
-        # Add the stretch bounds tool to the default Plot viewer.
-        self.stretch_histogram.tools_nested.append(["jdaviz:stretch_bounds"])
-        self.stretch_histogram._initialize_toolbar(["jdaviz:stretch_bounds"])
-
-        self.stretch_histogram._add_data('histogram', x=[0, 1])
-
-        self.stretch_histogram.add_line('vmin', x=[0, 0], y=[0, 1], ynorm=True, color='#c75d2c')
-        self.stretch_histogram.add_line('vmax', x=[0, 0], y=[0, 1], ynorm='vmin', color='#c75d2c')
-        self.stretch_histogram.add_line(
-            label='stretch_curve',
-            x=[], y=[],
-            ynorm='vmin',
-            color="#007BA1",  # "inactive" blue
-            opacities=[0.5],
-        )
-        self.stretch_histogram.add_scatter(
-            label='stretch_knots',
-            x=[], y=[],
-            ynorm='vmin',
-            color="#c75d2c",  # "active" orange (tool enabled by default)
-        )
-        self.stretch_histogram.add_scatter('colorbar', x=[], y=[], ynorm='vmin', marker='square', stroke_width=33)  # noqa: E501
-        self.stretch_histogram.viewer.state.update_bins_on_reset_limits = False
-        self.stretch_histogram.viewer.state.x_limits_percentile = 95
-        with self.stretch_histogram.figure.hold_sync():
-            self.stretch_histogram.figure.axes[0].label = 'pixel value'
-            self.stretch_histogram.figure.axes[0].num_ticks = 3
-            self.stretch_histogram.figure.axes[0].tick_format = '0.1e'
-            self.stretch_histogram.figure.axes[1].label = 'density'
-            self.stretch_histogram.figure.axes[1].num_ticks = 2
-        self.stretch_histogram_widget = f'IPY_MODEL_{self.stretch_histogram.model_id}'
-
         self.subset_visible = PlotOptionsSyncState(self, self.viewer, self.layer, 'visible',
                                                    'subset_visible_value', 'subset_visible_sync',
                                                    state_filter=is_spatial_subset)
@@ -689,6 +656,44 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
             "This currently sets viewer_multiselect and layer_multiselect", DeprecationWarning)
         self.viewer_multiselect = value
         self.layer_multiselect = value
+
+    @cached_property
+    def stretch_histogram(self):
+        stretch_histogram = Plot(self, name='stretch_hist', viewer_type='histogram',
+                                 update_callback=self._update_stretch_histogram)
+        # Add the stretch bounds tool to the default Plot viewer.
+        stretch_histogram.tools_nested.append(["jdaviz:stretch_bounds"])
+        stretch_histogram._initialize_toolbar(["jdaviz:stretch_bounds"])
+
+        stretch_histogram._add_data('histogram', x=[0, 1])
+
+        stretch_histogram.add_line('vmin', x=[0, 0], y=[0, 1], ynorm=True, color='#c75d2c')
+        stretch_histogram.add_line('vmax', x=[0, 0], y=[0, 1], ynorm='vmin', color='#c75d2c')
+        stretch_histogram.add_line(
+            label='stretch_curve',
+            x=[], y=[],
+            ynorm='vmin',
+            color="#007BA1",  # "inactive" blue
+            opacities=[0.5],
+        )
+        stretch_histogram.add_scatter(
+            label='stretch_knots',
+            x=[], y=[],
+            ynorm='vmin',
+            color="#c75d2c",  # "active" orange (tool enabled by default)
+        )
+        stretch_histogram.add_scatter('colorbar', x=[], y=[], ynorm='vmin', marker='square', stroke_width=33)  # noqa: E501
+        stretch_histogram.viewer.state.update_bins_on_reset_limits = False
+        stretch_histogram.viewer.state.x_limits_percentile = 95
+        with stretch_histogram.figure.hold_sync():
+            stretch_histogram.figure.axes[0].label = 'pixel value'
+            stretch_histogram.figure.axes[0].num_ticks = 3
+            stretch_histogram.figure.axes[0].tick_format = '0.1e'
+            stretch_histogram.figure.axes[1].label = 'density'
+            stretch_histogram.figure.axes[1].num_ticks = 2
+        self.stretch_histogram_widget = f'IPY_MODEL_{stretch_histogram.model_id}'
+        self.send_state('stretch_histogram_widget')
+        return stretch_histogram
 
     def select_all(self, viewers=True, layers=True):
         """

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -640,6 +640,15 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
         self.hub.subscribe(self, ChangeRefDataMessage,
                            handler=self._on_refdata_change)
 
+        self._set_relevant()
+
+    @observe('viewer_items')
+    def _set_relevant(self, *args):
+        if not len(self.viewer_items):
+            self.irrelevant_msg = 'No viewers'
+        else:
+            self.irrelevant_msg = ''
+
     @property
     def user_api(self):
         expose = ['multiselect', 'viewer', 'viewer_multiselect', 'layer', 'layer_multiselect',

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -611,7 +611,9 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
 
     @observe('viewer_items')
     def _set_relevant(self, *args):
-        if not len(self.viewer_items):
+        if self.app.config != 'deconfigged':
+            return
+        if not len(self.viewer_items) or not len(self.layer_items):
             self.irrelevant_msg = 'No viewers'
         else:
             self.irrelevant_msg = ''

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -613,7 +613,7 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
     def _set_relevant(self, *args):
         if self.app.config != 'deconfigged':
             return
-        if not len(self.viewer_items) or not len(self.layer_items):
+        if not len(self.viewer_items):
             self.irrelevant_msg = 'No viewers'
         else:
             self.irrelevant_msg = ''

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -225,6 +225,8 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
             self._viewer_mouse_clear_event(viewer)
             return
 
+        self.app.state.show_toolbar_buttons = False
+
         # update last known cursor position (so another event like a change in layers can update
         # the coordinates with the last known position)
         self._x, self._y = x, y
@@ -252,7 +254,6 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
 
     def update_display(self, viewer, x, y):
         self._dict = {}
-        self.app.state.show_toolbar_buttons = False
         if isinstance(viewer, (Spectrum1DViewer, RampvizProfileView)):
             self._spectrum_viewer_update(viewer, x, y)
         elif isinstance(viewer,

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -141,16 +141,25 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelect
         self.hub.subscribe(self, ViewerRemovedMessage,
                            handler=self._on_viewers_changed)
 
-    def _set_relevant(self):
-        sv = self.spectrum_viewer
-        if sv is None:
-            self.irrelevant_msg = 'Line Analysis unavailable without spectrum viewer'
-        elif not len(sv.layers):
-            self.irrelevant_msg = ''
-            self.disabled_msg = 'Line Analysis unavailable without data loaded in spectrum viewer'
+        self._set_relevant()
+
+    @observe('dataset_items')
+    def _set_relevant(self, *args):
+        if self.app.config == 'deconfigged':
+            if not len(self.dataset_items):
+                self.irrelevant_msg = 'Line Analysis unavailable without data loaded in spectrum viewer'  # noqa
+            else:
+                self.irrelevant_msg = ''
         else:
-            self.irrelevant_msg = ''
-            self.disabled_msg = ''
+            sv = self.spectrum_viewer
+            if sv is None:
+                self.irrelevant_msg = 'Line Analysis unavailable without spectrum viewer'
+            elif not len(sv.layers):
+                self.irrelevant_msg = ''
+                self.disabled_msg = 'Line Analysis unavailable without data loaded in spectrum viewer'  # noqa
+            else:
+                self.irrelevant_msg = ''
+                self.disabled_msg = ''
 
     @property
     def user_api(self):

--- a/jdaviz/configs/specviz/specviz.yaml
+++ b/jdaviz/configs/specviz/specviz.yaml
@@ -21,7 +21,6 @@ tray:
   - g-plot-options
   - g-subset-tools
   - g-markers
-  - spectral-extraction
   - g-gaussian-smooth
   - g-model-fitting
   - g-unit-conversion

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -410,6 +410,8 @@ class SpectralExtraction(PluginTemplateMixin):
 
     @observe('trace_dataset_items')
     def _set_relevant(self, *args):
+        if self.app.config != 'deconfigged':
+            return
         if len(self.trace_dataset_items) < 1:
             self.irrelevant_msg = 'Requires at least one 2D spectrum'
         else:

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -384,8 +384,7 @@ class SpectralExtraction(PluginTemplateMixin):
 
     @property
     def user_api(self):
-        return PluginUserApi(self, expose=('viewer',
-                                           'interactive_extract',
+        return PluginUserApi(self, expose=('interactive_extract',
                                            'trace_dataset', 'trace_type',
                                            'trace_order', 'trace_peak_method',
                                            'trace_pixel',

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3063,6 +3063,7 @@ class PluginPlotSelectMixin(VuetifyTemplate, HubListener):
         self.plugin_plot = PluginPlotSelect(self,
                                             'plugin_plot_items',
                                             'plugin_plot_selected',
+                                            filters=['not_empty_plot'],
                                             multiselect='multiselect' if hasattr(self, 'multiselect') else None)  # noqa
 
     @observe('plugin_plot_selected')

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3048,7 +3048,7 @@ class PluginPlotSelect(SelectPluginComponent):
         def not_empty_plot(plot):
             # checks plot.figure.marks to determine if figure is of an empty plot
             # not sure if this is a foolproof way to do this?
-            return len(plot.figure.marks) > 0
+            return len([m for m in plot.figure.marks if m.visible]) > 0
 
         return super()._is_valid_item(plot, locals())
 
@@ -3526,12 +3526,15 @@ class ViewerSelect(SelectPluginComponent):
 
     def add_filter(self, *filters):
         super().add_filter(*filters)
-        if 'reference_has_wcs' in filters:
+        if 'reference_has_wcs' in filters or 'is_not_empty' in filters:
             # reference data can change whenever data is added OR removed from a viewer
             self.hub.subscribe(self, AddDataMessage, handler=self._update_items)
             self.hub.subscribe(self, RemoveDataMessage, handler=self._update_items)
 
     def _is_valid_item(self, viewer):
+        def is_not_empty(viewer):
+            return len(viewer.layers) > 0
+
         def is_spectrum_viewer(viewer):
             return ('ProfileView' in viewer.__class__.__name__
                     or viewer.__class__.__name__ == 'Spectrum1DViewer')

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -57,16 +57,16 @@ def test_spectralsubsetselect(specviz_helper, spectrum1d):
 @pytest.mark.filterwarnings('ignore:No observer defined on WCS')
 def test_viewer_select(cubeviz_helper, spectrum1d_cube):
     app = cubeviz_helper.app
-    app.add_data(spectrum1d_cube, 'test')
-    app.add_data_to_viewer("flux-viewer", "test")
+    cubeviz_helper.load_data(spectrum1d_cube, data_label='test')
     fv = app.get_viewer("flux-viewer")
     sv = app.get_viewer('spectrum-viewer')
 
     # export plugin uses the mixin
     p = cubeviz_helper.plugins['Export']
-    assert len(p.viewer.ids) == 3
-    assert len(p.viewer.references) == 3
-    assert len(p.viewer.labels) == 3
+    # 2 viewers available (no uncertainty cube loaded)
+    assert len(p.viewer.ids) == 2
+    assert len(p.viewer.references) == 2
+    assert len(p.viewer.labels) == 2
     assert p.viewer.selected_obj == fv
 
     # set by reference


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request sets the default relevance for all specviz + specviz2d plugins so that they only appear when the necessary data/viewers are present.

This also fixes a "bug" where the stretch histogram was showing in the export plugin for configs that do not contain stretch options (could be backported separately, if anyone would prefer).

This attempts to keep behavior unchanged for plugins that used to show a disabled message - we could consider either turning off this logic entirely for configs OR applying relevance to those cases as well - reviewers please let me know what you think.

The only plugins that currently show in the deconfigged app before adding any viewers or data are:

* Subset Tools (could argue this shouldn't show, but we currently don't listen to data or viewers, so we'd have to add a listener just to handle relevance - and this will apply to any type of data so that may not be warranted)
* Markers (same as above)
* Unit Conversion (possibly same as above)
* About (should be there on load)


https://github.com/user-attachments/assets/74abc19b-a554-40e4-8776-a1304aa02621



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
