### PR TITLE
Expose catalog search api

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,8 +58,7 @@ Imviz
 - Catalog Search: When catalog is imported from file, its original column names are
   preserved on export. [#3519]
 
-- User API for Catalog Search plugin (including ``results_available``,
-  ``number_of_results``,``catalog``,``max_sources``,``search``
+- User API for Catalog Search plugin (including ``catalog``,``max_sources``,``search``
   and ``table_selected``) is now public. [#3529]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,7 +58,10 @@ Imviz
 - Catalog Search: When catalog is imported from file, its original column names are
   preserved on export. [#3519]
 
-- User API for Catalog Search plugin is now public. [#3529]
+- User API for Catalog Search plugin (including ``results_available``,
+  ``number_of_results``,``catalog``,``max_sources``,``search``
+  and ``table_selected``) is now public. [#3529]
+
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,7 +59,7 @@ Imviz
   preserved on export. [#3519]
 
 - User API for Catalog Search plugin (including ``catalog``,  ``max_sources``,``search``,
- ``table``, and ``table_selected``) is now public. [#3529]
+  ``table``, and ``table_selected``) is now public. [#3529]
 
 
 Mosviz

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,8 @@ Imviz
 - Catalog Search: When catalog is imported from file, its original column names are
   preserved on export. [#3519]
 
+- User API for Catalog Search plugin is now public. [#3529]
+
 Mosviz
 ^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,8 +58,8 @@ Imviz
 - Catalog Search: When catalog is imported from file, its original column names are
   preserved on export. [#3519]
 
-- User API for Catalog Search plugin (including ``catalog``,``catalog_selected``, 
-  ``max_sources``,``search``, ``table``, and ``table_selected``) is now public. [#3529]
+- User API for Catalog Search plugin (including ``catalog``,  ``max_sources``,``search``,
+ ``table``, and ``table_selected``) is now public. [#3529]
 
 
 Mosviz

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,8 +58,8 @@ Imviz
 - Catalog Search: When catalog is imported from file, its original column names are
   preserved on export. [#3519]
 
-- User API for Catalog Search plugin (including ``catalog``,``max_sources``,``search``
-  and ``table_selected``) is now public. [#3529]
+- User API for Catalog Search plugin (including ``catalog``,``catalog_selected``, 
+  ``max_sources``,``search``, ``table``, and ``table_selected``) is now public. [#3529]
 
 
 Mosviz

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -68,7 +68,8 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
         return PluginUserApi(self, expose=('clear_table', 'export_table', 'import_catalog',
                                            'zoom_to_selected', 'select_rows',
                                            'select_all', 'select_none',
-                                           'catalog', 'max_sources', 'search',
+                                           'catalog', 'catalog_selected',
+                                           'max_sources', 'search',
                                            'table', 'table_selected'))
 
     def __init__(self, *args, **kwargs):

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -37,7 +37,6 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
     * :meth:`zoom_to_selected`
     * :meth:`search`
     * :attr:`max_sources`
-    * :attr:`catalog`
     * :attr:`catalog_selected`
     * ``table`` (:class:`~jdaviz.core.template_mixin.Table`):
       Table containing all search results.

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -38,10 +38,7 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
     * :meth:`search`
     * :attr:`results_available`
     * :attr:`number_of_results`
-    * :attr:`catalog`
     * :attr:`max_sources`
-    * :attr:`table`
-    * :attr:`table_selected`
     """
     template_file = __file__, "catalogs.vue"
     uses_active_status = Bool(True).tag(sync=True)

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -33,14 +33,15 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.show`
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.open_in_tray`
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.close_in_tray`
+    * :meth:`import_catalog`
     * :meth:`zoom_to_selected`
+    * :meth:`search`
     * :attr:`results_available`
     * :attr:`number_of_results`
     * :attr:`catalog`
     * :attr:`max_sources`
-    * :meth:`search`
+    * :attr:`table`
     * :attr:`table_selected`
-
     """
     template_file = __file__, "catalogs.vue"
     uses_active_status = Bool(True).tag(sync=True)
@@ -72,7 +73,7 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
                                            'select_all', 'select_none',
                                            'results_available', 'number_of_results',
                                            'catalog', 'max_sources', 'search',
-                                           'table', 'from_file', 'table_selected'))
+                                           'table', 'table_selected'))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -37,7 +37,7 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
     * :meth:`zoom_to_selected`
     * :meth:`search`
     * :attr:`max_sources`
-    * :attr:`catalog_selected`
+    * ``catalog`` (:class:`~jdaviz.core.template_mixin.SelectPluginComponent`)
     * ``table`` (:class:`~jdaviz.core.template_mixin.Table`):
       Table containing all search results.
     * ``table_selected`` (:class:`~jdaviz.core.template_mixin.Table`):

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -71,8 +71,7 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
         return PluginUserApi(self, expose=('clear_table', 'export_table', 'import_catalog',
                                            'zoom_to_selected', 'select_rows',
                                            'select_all', 'select_none',
-                                           'catalog', 'catalog_selected',
-                                           'max_sources', 'search',
+                                           'catalog', 'max_sources', 'search',
                                            'table', 'table_selected'))
 
     def __init__(self, *args, **kwargs):

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -36,9 +36,13 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
     * :meth:`import_catalog`
     * :meth:`zoom_to_selected`
     * :meth:`search`
-    * :attr:`results_available`
-    * :attr:`number_of_results`
     * :attr:`max_sources`
+    * :attr:`catalog`
+    * :attr:`catalog_selected`
+    * ``table`` (:class:`~jdaviz.core.template_mixin.Table`):
+      Table containing all search results.
+    * ``table_selected`` (:class:`~jdaviz.core.template_mixin.Table`):
+      Table containing all selected search results.  
     """
     template_file = __file__, "catalogs.vue"
     uses_active_status = Bool(True).tag(sync=True)

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -42,7 +42,7 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
     * ``table`` (:class:`~jdaviz.core.template_mixin.Table`):
       Table containing all search results.
     * ``table_selected`` (:class:`~jdaviz.core.template_mixin.Table`):
-      Table containing all selected search results.  
+      Table containing all selected search results.
     """
     template_file = __file__, "catalogs.vue"
     uses_active_status = Bool(True).tag(sync=True)

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -34,6 +34,13 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.open_in_tray`
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.close_in_tray`
     * :meth:`zoom_to_selected`
+    * :attr:`results_available`
+    * :attr:`number_of_results`
+    * :attr:`catalog`
+    * :attr:`max_sources`
+    * :meth:`search`
+    * :attr:`table_selected`
+
     """
     template_file = __file__, "catalogs.vue"
     uses_active_status = Bool(True).tag(sync=True)
@@ -62,7 +69,10 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
     def user_api(self):
         return PluginUserApi(self, expose=('clear_table', 'export_table', 'import_catalog',
                                            'zoom_to_selected', 'select_rows',
-                                           'select_all', 'select_none'))
+                                           'select_all', 'select_none',
+                                           'results_available', 'number_of_results',
+                                           'catalog', 'max_sources', 'search',
+                                           'table', 'from_file', 'table_selected'))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -68,7 +68,6 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
         return PluginUserApi(self, expose=('clear_table', 'export_table', 'import_catalog',
                                            'zoom_to_selected', 'select_rows',
                                            'select_all', 'select_none',
-                                           'results_available', 'number_of_results',
                                            'catalog', 'max_sources', 'search',
                                            'table', 'table_selected'))
 

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
@@ -3,6 +3,7 @@
     :description="docs_description"
     :link="docs_link || 'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#catalog-search'"
     :uses_active_status="uses_active_status"
+    :api_hints_enabled.sync="api_hints_enabled"
     @plugin-ping="plugin_ping($event)"
     :keep_active_sync="keep_active"
     :popout_button="popout_button"
@@ -21,6 +22,8 @@
       :selected.sync="catalog_selected"
       label="Catalog"
       hint="Select a catalog to search."
+      api_hint="plg.catalog_selected ="
+      :api_hints_enabled="api_hints_enabled"
       :from_file.sync="from_file"
       :from_file_message="from_file_message"
       dialog_title="Import Catalog"
@@ -59,6 +62,8 @@
         label="Max sources"
         hint="Maximum number of sources."
         persistent-hint
+        :api_hints_enabled="api_hints_enabled"
+        api_hint="plg.max_sources ="
       ></v-text-field>
     </v-row>
 
@@ -68,16 +73,26 @@
             :results_isolated_to_plugin="true"
             @click="do_search"
             :spinner="spinner"
+            :api_hints_enabled="api_hints_enabled"
           >
-            Search
+            {{ api_hints_enabled ?
+              'plg.search()'
+              :
+              'Search'
+            }}
           </plugin-action-button>
        </v-col>
        <v-col>
          <plugin-action-button
             :results_isolated_to_plugin="true"
             @click="zoom_in"
+            :api_hints_enabled="api_hints_enabled"
           >
-            Zoom to Selected
+            {{ api_hints_enabled ?
+              'plg.zoom_to_selected()'
+              :
+              'Zoom to Selected'
+            }}
           </plugin-action-button>
        </v-col>
     </v-row>

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
@@ -62,8 +62,8 @@
         label="Max sources"
         hint="Maximum number of sources."
         persistent-hint
-        :api_hints_enabled="api_hints_enabled"
-        api_hint="plg.max_sources ="
+        :label="api_hints_enabled ? 'plg.max_sources =' : 'Max Sources'"
+        :class="api_hints_enabled ? 'api-hint' : null"
       ></v-text-field>
     </v-row>
 

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.vue
@@ -22,7 +22,7 @@
       :selected.sync="catalog_selected"
       label="Catalog"
       hint="Select a catalog to search."
-      api_hint="plg.catalog_selected ="
+      api_hint="plg.catalog ="
       :api_hints_enabled="api_hints_enabled"
       :from_file.sync="from_file"
       :from_file_message="from_file_message"

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -492,7 +492,7 @@ def test_select_catalog_table_rows(imviz_helper, image_2d_wcs):
 
     # select a single row:
     catalogs_plugin.select_rows(3)
-    assert len(plugin_table._obj.selected_rows) == 1
+    assert len(plugin_table.selected_rows) == 1
     assert plugin_table.selected_rows[0]['Right Ascension (degrees)'] == '337.48000'
 
     # select multiple rows by indices

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -216,7 +216,7 @@ def test_from_file_parsing(imviz_helper, tmp_path):
 
     # setting to a blank string from the API resets the catalog selection to the
     # default/first entry
-    catalogs_plugin.from_file = ''
+    catalogs_plugin._obj.from_file_string = ''
     assert catalogs_plugin.catalog.selected == catalogs_plugin.catalog.choices[0]
 
     not_table_file = tmp_path / 'not_table.tst'
@@ -258,7 +258,7 @@ def test_offline_ecsv_catalog(imviz_helper, image_2d_wcs, tmp_path):
     assert len(imviz_helper.app.data_collection) == 2  # image + markers
 
     catalogs_plugin.table.select_rows(0)
-    assert len(catalogs_plugin.table.selected_rows) == 1
+    assert len(catalogs_plugin.table._obj.selected_rows) == 1
 
     # Test that exported table only has original input column.
     export_plugin = imviz_helper.plugins['Export']
@@ -288,7 +288,7 @@ def test_offline_ecsv_catalog(imviz_helper, image_2d_wcs, tmp_path):
     assert len(imviz_helper.app.data_collection) == 2  # image + markers
 
     catalogs_plugin.clear_table()
-    assert not catalogs_plugin._obj.results_available
+    assert not catalogs_plugin.results_available
     assert len(imviz_helper.app.data_collection) == 1  # markers gone for good
 
     assert imviz_helper.viewers['imviz-0']._obj.state.x_min == -0.5

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -31,7 +31,7 @@ from astropy.nddata import NDData
 from astropy.table import Table, QTable
 
 
-@pytest.mark.remote_data
+#@pytest.mark.remote_data
 class TestCatalogs:
     # testing that the plugin search does not crash when no data/image is provided
     def test_plugin_no_image(self, imviz_helper):
@@ -49,9 +49,9 @@ class TestCatalogs:
 
         imviz_helper.load_data(ndd, data_label='no_results_data')
 
-        catalogs_plugin = imviz_helper.plugins["Catalog Search"]._obj
-        catalogs_plugin.plugin_opened = True
-        catalogs_plugin.vue_do_search()
+        catalogs_plugin = imviz_helper.plugins["Catalog Search"]
+        catalogs_plugin._obj.plugin_opened = True
+        catalogs_plugin._obj.vue_do_search()
 
         # number of results should be 0
         assert catalogs_plugin.results_available
@@ -62,7 +62,7 @@ class TestCatalogs:
     # https://dr12.sdss.org/fields/runCamcolField?field=76&camcol=5&run=7674
     # the z-band FITS image was downloaded and used
     # NOTE: We mark "slow" so it only runs on the dev job that is allowed to fail.
-    @pytest.mark.slow
+    #@pytest.mark.slow
     def test_plugin_image_with_result(self, imviz_helper, tmp_path):
         arr = np.ones((1489, 2048))
 
@@ -89,8 +89,8 @@ class TestCatalogs:
                             'NAXIS2': 1489})
         imviz_helper.load_data(hdu1, data_label='has_wcs')
 
-        catalogs_plugin = imviz_helper.plugins["Catalog Search"]._obj
-        catalogs_plugin.plugin_opened = True
+        catalogs_plugin = imviz_helper.plugins["Catalog Search"]
+        catalogs_plugin._obj.plugin_opened = True
 
         # test SDSS catalog
         catalogs_plugin.catalog.selected = 'SDSS'
@@ -123,7 +123,7 @@ class TestCatalogs:
         assert catalogs_plugin.results_available
         assert catalogs_plugin.number_of_results == 136
         prev_results = catalogs_plugin.number_of_results
-        last_row = catalogs_plugin.table.items[-1]
+        last_row = catalogs_plugin.table._obj.items[-1]
         last_ra = float(last_row['Right Ascension (degrees)'])
         coords = viewer.state.reference_data.coords
         table_calc_ra = coords.pixel_to_world(float(last_row['x_coord']), float(last_row['y_coord'])).ra.value  # noqa
@@ -159,7 +159,7 @@ class TestCatalogs:
         assert catalogs_plugin.number_of_results == prev_results
 
         catalogs_plugin.select_rows(slice(0, 2))
-        assert len(catalogs_plugin.table.selected_rows) == 2
+        assert len(catalogs_plugin.table._obj.selected_rows) == 2
 
         # test Gaia catalog
         catalogs_plugin.catalog.selected = 'Gaia'
@@ -185,8 +185,8 @@ class TestCatalogs:
         with pytest.warns(ResourceWarning):
             catalogs_plugin.search(error_on_fail=True)
         # Ensure at least one row is selected before zooming
-        catalogs_plugin.table.selected_rows = [catalogs_plugin.table.items[0]]
-        assert len(catalogs_plugin.table.selected_rows) > 0
+        catalogs_plugin.table.select_rows(0)
+        assert len(catalogs_plugin.table._obj.selected_rows) > 0
 
         # set 'padding' to reproduce original hard-coded 50 pixel window
         # so test results don't change
@@ -203,11 +203,11 @@ class TestCatalogs:
 
 
 def test_from_file_parsing(imviz_helper, tmp_path):
-    catalogs_plugin = imviz_helper.plugins["Catalog Search"]._obj
+    catalogs_plugin = imviz_helper.plugins["Catalog Search"]
 
     # _on_file_path_changed is fired when changing the selection in the file dialog
     catalogs_plugin.catalog._on_file_path_changed({'new': './invalid_path'})
-    assert catalogs_plugin.from_file_message == 'File path does not exist'
+    assert catalogs_plugin._obj.from_file_message == 'File path does not exist'
 
     # observe('from_file') is fired when setting from_file from the API or via import_file
     # (or after clicking select in the file dialog)
@@ -222,13 +222,13 @@ def test_from_file_parsing(imviz_helper, tmp_path):
     not_table_file = tmp_path / 'not_table.tst'
     not_table_file.touch()
     catalogs_plugin.catalog._on_file_path_changed({'new': not_table_file})
-    assert catalogs_plugin.from_file_message == 'Could not parse file with astropy.table.QTable.read'  # noqa
+    assert catalogs_plugin._obj.from_file_message == 'Could not parse file with astropy.table.QTable.read'  # noqa
 
     qtable = QTable({'not_sky_centroid': [1, 2, 3]})
     not_valid_table = tmp_path / 'not_valid_table.ecsv'
     qtable.write(not_valid_table, overwrite=True)
     catalogs_plugin.catalog._on_file_path_changed({'new': not_valid_table})
-    assert catalogs_plugin.from_file_message == 'Table does not contain required sky_centroid column'  # noqa
+    assert catalogs_plugin._obj.from_file_message == 'Table does not contain required sky_centroid column'  # noqa
 
 
 def test_offline_ecsv_catalog(imviz_helper, image_2d_wcs, tmp_path):
@@ -248,17 +248,17 @@ def test_offline_ecsv_catalog(imviz_helper, image_2d_wcs, tmp_path):
 
     catalogs_plugin = imviz_helper.plugins['Catalog Search']
     catalogs_plugin.import_catalog(tbl)
-    out_tbl = catalogs_plugin._obj.search(error_on_fail=True)
+    out_tbl = catalogs_plugin.search(error_on_fail=True)
     assert tbl.colnames == ["sky_centroid"]  # Ensure input table not overwritten by plugin
     assert len(out_tbl) == n_entries
-    assert catalogs_plugin._obj.number_of_results == n_entries
+    assert catalogs_plugin.number_of_results == n_entries
     # Assert that Object ID is set to index + 1 when the label column is absent
-    for idx, item in enumerate(catalogs_plugin._obj.table.items):
+    for idx, item in enumerate(catalogs_plugin.table._obj.items):
         assert item['Object ID'] == str(idx + 1)
     assert len(imviz_helper.app.data_collection) == 2  # image + markers
 
-    catalogs_plugin._obj.table.selected_rows = [catalogs_plugin._obj.table.items[0]]
-    assert len(catalogs_plugin._obj.table.selected_rows) == 1
+    catalogs_plugin.table.select_rows(0)
+    assert len(catalogs_plugin.table.selected_rows) == 1
 
     # Test that exported table only has original input column.
     export_plugin = imviz_helper.plugins['Export']
@@ -270,9 +270,9 @@ def test_offline_ecsv_catalog(imviz_helper, image_2d_wcs, tmp_path):
     assert len(rt_tbl) == n_entries
 
     # test to ensure sources searched for respect the maximum sources traitlet
-    catalogs_plugin._obj.max_sources = 1
-    catalogs_plugin._obj.search(error_on_fail=True)
-    assert catalogs_plugin._obj.number_of_results == catalogs_plugin._obj.max_sources
+    catalogs_plugin.max_sources = 1
+    catalogs_plugin.search(error_on_fail=True)
+    assert catalogs_plugin.number_of_results == catalogs_plugin.max_sources
 
     catalogs_plugin.clear_table()
 
@@ -282,9 +282,9 @@ def test_offline_ecsv_catalog(imviz_helper, image_2d_wcs, tmp_path):
     n_entries = len(tbl)
 
     catalogs_plugin.import_catalog(tbl)
-    out_tbl = catalogs_plugin._obj.search()
+    out_tbl = catalogs_plugin.search()
     assert len([out_tbl]) == n_entries
-    assert catalogs_plugin._obj.number_of_results == n_entries
+    assert catalogs_plugin.number_of_results == n_entries
     assert len(imviz_helper.app.data_collection) == 2  # image + markers
 
     catalogs_plugin.clear_table()
@@ -296,11 +296,11 @@ def test_offline_ecsv_catalog(imviz_helper, image_2d_wcs, tmp_path):
     assert imviz_helper.viewers['imviz-0']._obj.state.y_min == -0.5
     assert imviz_helper.viewers['imviz-0']._obj.state.y_max == 9.5
     # Re-populate the table with a new search
-    out_tbl = catalogs_plugin._obj.search()
+    out_tbl = catalogs_plugin.search()
     assert len(out_tbl) > 0
     # Ensure at least one row is selected before zooming
-    catalogs_plugin._obj.table.selected_rows = [catalogs_plugin._obj.table.items[0]]
-    assert len(catalogs_plugin._obj.table.selected_rows) > 0
+    catalogs_plugin.table.select_rows(0)
+    assert len(catalogs_plugin.table._obj.selected_rows) > 0
 
     # test the zooming using the default 'padding' of 2% of the viewer size
     # around selected points
@@ -329,7 +329,7 @@ def test_zoom_to_selected(imviz_helper, image_2d_wcs):
 
     catalogs_plugin = imviz_helper.plugins['Catalog Search']
     catalogs_plugin.import_catalog(tbl)
-    catalogs_plugin._obj.search()
+    catalogs_plugin.search()
 
     # select both sources
     catalogs_plugin.select_all()
@@ -358,7 +358,7 @@ def test_zoom_to_selected(imviz_helper, image_2d_wcs):
     assert_allclose(ymax, 204, atol=0.1)  # max y of selected sources plus pad
 
     # select one source now
-    catalogs_plugin._obj.table.selected_rows = catalogs_plugin._obj.table.items[0:1]
+    catalogs_plugin._obj.table.select_rows(0)
 
     # zoom to single selected source, using a new value for 'padding'
     catalogs_plugin.zoom_to_selected(padding=0.05)
@@ -404,34 +404,34 @@ def test_select_tool(imviz_helper, image_2d_wcs):
     mark = catalogs_plugin._obj._get_mark(imviz_helper.viewers['imviz-0']._obj)
     assert tool.is_visible() is False
 
-    catalogs_plugin._obj.search(error_on_fail=True)
+    catalogs_plugin.search(error_on_fail=True)
     assert tool.is_visible()
 
-    assert len(catalogs_plugin._obj.table.selected_rows) == 0
-    assert len(catalogs_plugin._obj.table_selected.items) == 0
+    assert len(catalogs_plugin.table._obj.selected_rows) == 0
+    assert len(catalogs_plugin.table_selected._obj.items) == 0
     assert len(mark.x) == 0
 
     toolbar.active_tool_id = 'jdaviz:selectcatalog'
     tool.on_mouse_event({'domain': {'x': 100, 'y': 110}})
 
-    assert len(catalogs_plugin._obj.table.selected_rows) == 1
-    assert len(catalogs_plugin._obj.table_selected.items) == 1
+    assert len(catalogs_plugin.table._obj.selected_rows) == 1
+    assert len(catalogs_plugin.table_selected._obj.items) == 1
     assert len(mark.x) == 1
 
     tool.on_mouse_event({'domain': {'x': 200, 'y': 210}})
-    assert len(catalogs_plugin._obj.table.selected_rows) == 2
-    assert len(catalogs_plugin._obj.table_selected.items) == 2
+    assert len(catalogs_plugin.table._obj.selected_rows) == 2
+    assert len(catalogs_plugin.table_selected._obj.items) == 2
     assert len(mark.x) == 2
 
     # click to remove
     tool.on_mouse_event({'domain': {'x': 110, 'y': 110}})
-    assert len(catalogs_plugin._obj.table.selected_rows) == 1
-    assert len(catalogs_plugin._obj.table_selected.items) == 1
+    assert len(catalogs_plugin.table._obj.selected_rows) == 1
+    assert len(catalogs_plugin.table_selected._obj.items) == 1
     assert len(mark.x) == 1
 
     catalogs_plugin._obj.table_selected.clear_table()
-    assert len(catalogs_plugin._obj.table.selected_rows) == 0
-    assert len(catalogs_plugin._obj.table_selected.items) == 0
+    assert len(catalogs_plugin.table._obj.selected_rows) == 0
+    assert len(catalogs_plugin.table_selected._obj.items) == 0
     assert len(mark.x) == 0
 
 
@@ -452,16 +452,16 @@ def test_offline_ecsv_catalog_with_extra_columns(imviz_helper, image_2d_wcs):
     imviz_helper.load_data(ndd, data_label='data_with_wcs')
     assert len(imviz_helper.app.data_collection) == 1
 
-    catalogs_plugin = imviz_helper.plugins['Catalog Search']._obj
+    catalogs_plugin = imviz_helper.plugins['Catalog Search']
     catalogs_plugin.import_catalog(tbl)
     catalogs_plugin.search(error_on_fail=True)
 
     extra_columns = ['flux', 'flux_err', 'is_extended', 'roundness', 'sharpness']
     for col in extra_columns:
-        assert col in catalogs_plugin.table.headers_avail
+        assert col in catalogs_plugin.table._obj.headers_avail
 
     # Check if extra columns are populated correctly
-    for idx, item in enumerate(catalogs_plugin.table.items):
+    for idx, item in enumerate(catalogs_plugin.table._obj.items):
         assert float(item['flux']) == tbl['flux'][idx]
         assert float(item['flux_err']) == tbl['flux_err'][idx]
         assert item['is_extended'] == tbl['is_extended'][idx]
@@ -484,15 +484,15 @@ def test_select_catalog_table_rows(imviz_helper, image_2d_wcs):
                           'Source_5', 'Source_6']})
 
     catalogs_plugin = imviz_helper.plugins['Catalog Search']
-    plugin_table = catalogs_plugin._obj.table
+    plugin_table = catalogs_plugin.table._obj
 
     # load catalog
     catalogs_plugin.import_catalog(tbl)
-    catalogs_plugin._obj.search()
+    catalogs_plugin.search()
 
     # select a single row:
     catalogs_plugin.select_rows(3)
-    assert len(plugin_table.selected_rows) == 1
+    assert len(plugin_table._obj.selected_rows) == 1
     assert plugin_table.selected_rows[0]['Right Ascension (degrees)'] == '337.48000'
 
     # select multiple rows by indices

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -31,7 +31,7 @@ from astropy.nddata import NDData
 from astropy.table import Table, QTable
 
 
-#@pytest.mark.remote_data
+@pytest.mark.remote_data
 class TestCatalogs:
     # testing that the plugin search does not crash when no data/image is provided
     def test_plugin_no_image(self, imviz_helper):
@@ -62,7 +62,7 @@ class TestCatalogs:
     # https://dr12.sdss.org/fields/runCamcolField?field=76&camcol=5&run=7674
     # the z-band FITS image was downloaded and used
     # NOTE: We mark "slow" so it only runs on the dev job that is allowed to fail.
-    #@pytest.mark.slow
+    @pytest.mark.slow
     def test_plugin_image_with_result(self, imviz_helper, tmp_path):
         arr = np.ones((1489, 2048))
 

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -49,9 +49,9 @@ class TestCatalogs:
 
         imviz_helper.load_data(ndd, data_label='no_results_data')
 
-        catalogs_plugin = imviz_helper.plugins["Catalog Search"]
-        catalogs_plugin._obj.plugin_opened = True
-        catalogs_plugin._obj.vue_do_search()
+        catalogs_plugin = imviz_helper.plugins["Catalog Search"]._obj
+        catalogs_plugin.plugin_opened = True
+        catalogs_plugin.vue_do_search()
 
         # number of results should be 0
         assert catalogs_plugin.results_available
@@ -99,8 +99,8 @@ class TestCatalogs:
         catalogs_plugin.max_sources = 100
         catalogs_plugin.search(error_on_fail=True)
 
-        assert catalogs_plugin.results_available
-        assert catalogs_plugin.number_of_results == catalogs_plugin.max_sources
+        assert catalogs_plugin._obj.results_available
+        assert catalogs_plugin._obj.number_of_results == catalogs_plugin.max_sources
 
         # reset max_sources to it's default value
         catalogs_plugin.max_sources = 1000
@@ -120,9 +120,9 @@ class TestCatalogs:
 
         assert catalogs_plugin.catalog.selected == 'SDSS'
 
-        assert catalogs_plugin.results_available
-        assert catalogs_plugin.number_of_results == 136
-        prev_results = catalogs_plugin.number_of_results
+        assert catalogs_plugin._obj.results_available
+        assert catalogs_plugin._obj.number_of_results == 136
+        prev_results = catalogs_plugin._obj.number_of_results
         last_row = catalogs_plugin.table._obj.items[-1]
         last_ra = float(last_row['Right Ascension (degrees)'])
         coords = viewer.state.reference_data.coords
@@ -139,7 +139,7 @@ class TestCatalogs:
         viewer.state.y_min = -0.5
         viewer.state.y_max = 1488.5
 
-        assert not catalogs_plugin.results_available
+        assert not catalogs_plugin._obj.results_available
 
         # test loading from file
         table = imviz_helper.app._catalog_source_table
@@ -151,12 +151,12 @@ class TestCatalogs:
         # reset max_sources to it's default value
         catalogs_plugin.max_sources = 1000
 
-        catalogs_plugin.from_file = str(tmp_file)
+        catalogs_plugin._obj.from_file = str(tmp_file)
         # setting filename from API will automatically set catalog to 'From File...'
         assert catalogs_plugin.catalog.selected == 'From File...'
         catalogs_plugin.search(error_on_fail=True)
-        assert catalogs_plugin.results_available
-        assert catalogs_plugin.number_of_results == prev_results
+        assert catalogs_plugin._obj.results_available
+        assert catalogs_plugin._obj.number_of_results == prev_results
 
         catalogs_plugin.select_rows(slice(0, 2))
         assert len(catalogs_plugin.table._obj.selected_rows) == 2
@@ -173,8 +173,8 @@ class TestCatalogs:
         with pytest.warns(ResourceWarning):
             catalogs_plugin.search(error_on_fail=True)
 
-        assert catalogs_plugin.results_available
-        assert catalogs_plugin.number_of_results == catalogs_plugin.max_sources
+        assert catalogs_plugin._obj.results_available
+        assert catalogs_plugin._obj.number_of_results == catalogs_plugin.max_sources
 
         assert imviz_helper.viewers['imviz-0']._obj.state.x_min == 279.0
         assert imviz_helper.viewers['imviz-0']._obj.state.x_max == 1768.0
@@ -251,7 +251,7 @@ def test_offline_ecsv_catalog(imviz_helper, image_2d_wcs, tmp_path):
     out_tbl = catalogs_plugin.search(error_on_fail=True)
     assert tbl.colnames == ["sky_centroid"]  # Ensure input table not overwritten by plugin
     assert len(out_tbl) == n_entries
-    assert catalogs_plugin.number_of_results == n_entries
+    assert catalogs_plugin._obj.number_of_results == n_entries
     # Assert that Object ID is set to index + 1 when the label column is absent
     for idx, item in enumerate(catalogs_plugin.table._obj.items):
         assert item['Object ID'] == str(idx + 1)
@@ -272,7 +272,7 @@ def test_offline_ecsv_catalog(imviz_helper, image_2d_wcs, tmp_path):
     # test to ensure sources searched for respect the maximum sources traitlet
     catalogs_plugin.max_sources = 1
     catalogs_plugin.search(error_on_fail=True)
-    assert catalogs_plugin.number_of_results == catalogs_plugin.max_sources
+    assert catalogs_plugin._obj.number_of_results == catalogs_plugin.max_sources
 
     catalogs_plugin.clear_table()
 
@@ -284,11 +284,11 @@ def test_offline_ecsv_catalog(imviz_helper, image_2d_wcs, tmp_path):
     catalogs_plugin.import_catalog(tbl)
     out_tbl = catalogs_plugin.search()
     assert len([out_tbl]) == n_entries
-    assert catalogs_plugin.number_of_results == n_entries
+    assert catalogs_plugin._obj.number_of_results == n_entries
     assert len(imviz_helper.app.data_collection) == 2  # image + markers
 
     catalogs_plugin.clear_table()
-    assert not catalogs_plugin.results_available
+    assert not catalogs_plugin._obj.results_available
     assert len(imviz_helper.app.data_collection) == 1  # markers gone for good
 
     assert imviz_helper.viewers['imviz-0']._obj.state.x_min == -0.5


### PR DESCRIPTION
This PR exposes the user API for the catalog search plugin. You will see in some of the tests that plugin.table._obj is being accessed - these are for table attributes that aren't public, that would belong in a follow up imo. 
