### PR TITLE
remove _get_region_from_spatial_subset

### DIFF
--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -757,11 +757,14 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
 
         from astropy.wcs.utils import pixel_to_pixel
         from photutils.aperture import ApertureStats
-        from jdaviz.core.region_translators import regions2aperture, _get_region_from_spatial_subset
+        from jdaviz.core.region_translators import regions2aperture
 
         def _do_recentering(subset, subset_state):
             try:
-                reg = _get_region_from_spatial_subset(self, subset_state)
+                type = 'sky_region' if self.app.config == 'imviz' and self.app._align_by == 'wcs' else 'region'  # noqa: E501
+                reg = self.app.get_subsets(subset_name=subset,
+                                           include_sky_region=self.app.config == 'imviz',
+                                           spatial_only=True)[0][type]
                 aperture = regions2aperture(reg)
                 data = self.recenter_dataset.selected_dc_item
                 comp = data.get_component(data.main_components[0])

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -763,7 +763,7 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
             try:
                 type = 'sky_region' if self.app.config == 'imviz' and self.app._align_by == 'wcs' else 'region'  # noqa: E501
                 reg = self.app.get_subsets(subset_name=subset,
-                                           include_sky_region=self.app.config == 'imviz',
+                                           include_sky_region=type == 'sky_region',
                                            spatial_only=True)[0][type]
                 aperture = regions2aperture(reg)
                 data = self.recenter_dataset.selected_dc_item

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -19,7 +19,7 @@ from jdaviz.core.custom_traitlets import FloatHandleEmpty
 from jdaviz.core.custom_units_and_equivs import PIX2
 from jdaviz.core.events import (GlobalDisplayUnitChanged, SnackbarMessage,
                                 LinkUpdatedMessage, SliceValueUpdatedMessage)
-from jdaviz.core.region_translators import regions2aperture, _get_region_from_spatial_subset
+from jdaviz.core.region_translators import regions2aperture
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin, DatasetMultiSelectMixin,
                                         SubsetSelect, ApertureSubsetSelectMixin,
@@ -547,7 +547,10 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             return
 
         try:
-            reg = _get_region_from_spatial_subset(self, self.background.selected_subset_state)
+            type = 'sky_region' if self.app.config == 'imviz' and self.app._align_by == 'wcs' else 'region'  # noqa: E501
+            reg = self.app.get_subsets(subset_name=self.background_selected,
+                                       include_sky_region=self.app.config == 'imviz',
+                                       spatial_only=True)[0][type]
             self.background_value = self._calc_background_median(reg)
         except Exception as e:
             self.background_value = 0

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -549,7 +549,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
         try:
             type = 'sky_region' if self.app.config == 'imviz' and self.app._align_by == 'wcs' else 'region'  # noqa: E501
             reg = self.app.get_subsets(subset_name=self.background_selected,
-                                       include_sky_region=self.app.config == 'imviz',
+                                       include_sky_region=type == 'sky_region',
                                        spatial_only=True)[0][type]
             self.background_value = self._calc_background_median(reg)
         except Exception as e:

--- a/jdaviz/core/region_translators.py
+++ b/jdaviz/core/region_translators.py
@@ -22,43 +22,6 @@ from regions import (CirclePixelRegion, CircleSkyRegion,
 __all__ = ['regions2roi', 'regions2aperture', 'aperture2regions']
 
 
-def _get_region_from_spatial_subset(plugin_obj, subset_state):
-    """Convert the given ``glue`` ROI subset state to ``regions`` shape.
-
-    .. note:: This is for internal use only in Imviz plugins.
-
-    Parameters
-    ----------
-    plugin_obj : obj
-        Plugin instance that needs this translation.
-        The plugin is assumed to have a special setup that gives
-        it access to these attributes: ``app`` and ``app._align_by``.
-
-    subset_state : obj
-        ROI subset state to translate.
-
-    Returns
-    -------
-    reg : `regions.Region`
-        An equivalent ``regions`` shape. This can be a pixel or sky
-        region, so the plugin needs to be able to deal with both.
-
-    See Also
-    --------
-    regions2roi
-
-    """
-    from glue_astronomy.translators.regions import roi_subset_state_to_region
-
-    # Subset is defined against its parent. This is not necessarily
-    # the current viewer reference data, which can be changed.
-
-    # Mixed link types no longer allowed, so just check app setting.
-    align_by = plugin_obj.app._align_by
-
-    return roi_subset_state_to_region(subset_state, to_sky=(align_by == 'wcs'))
-
-
 def regions2roi(region_shape, wcs=None):
     """Convert a given ``regions`` shape to ``glue`` ROI.
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2315,7 +2315,7 @@ class SubsetSelect(SelectPluginComponent):
 
         type = 'sky_region' if self.app.config == 'imviz' and self.app._align_by == 'wcs' else 'region'  # noqa: E501
         reg = self.app.get_subsets(subset_name=subset,
-                                   include_sky_region=self.app.config == 'imviz',
+                                   include_sky_region=type == 'sky_region',
                                    spatial_only=True)[0][type]
         reg.meta['label'] = subset
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -54,8 +54,7 @@ from jdaviz.core.marks import (LineAnalysisContinuum,
                                LineAnalysisContinuumLeft,
                                LineAnalysisContinuumRight,
                                ShadowLine, ApertureMark)
-from jdaviz.core.region_translators import (regions2roi, regions2aperture,
-                                            _get_region_from_spatial_subset)
+from jdaviz.core.region_translators import regions2roi, regions2aperture
 from jdaviz.core.tools import ICON_DIR
 from jdaviz.core.user_api import UserApiWrapper, PluginUserApi
 from jdaviz.core.registries import tray_registry
@@ -2313,9 +2312,14 @@ class SubsetSelect(SelectPluginComponent):
             subset_state = self._get_subset_state(subset)
         if subset_state is None:
             return None
-        region = _get_region_from_spatial_subset(self.plugin, subset_state)
-        region.meta['label'] = subset
-        return region
+
+        type = 'sky_region' if self.app.config == 'imviz' and self.app._align_by == 'wcs' else 'region'  # noqa: E501
+        reg = self.app.get_subsets(subset_name=subset,
+                                   include_sky_region=self.app.config == 'imviz',
+                                   spatial_only=True)[0][type]
+        reg.meta['label'] = subset
+
+        return reg
 
     @cached_property
     def selected_spatial_region(self):


### PR DESCRIPTION
This PR removes the function get_region_from_spatial_subset and replaces it with calls to get_subsets. The previous behavior of returning pixel/sky subsets in imviz based on alignment type, and always pixel regions in cubeviz is maintained.