### PR TITLE
loaders: lcviz support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ New Features
 
 - Added an STC-S string region parser to the Footprints plugin. [#3479]
 
-- General (work-in-progress) centralized app-instance available at top package-level. [#3475, #3526, #3522]
+- General (work-in-progress) centralized app-instance available at top package-level. [#3475, #3526, #3522, #3531]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2808,7 +2808,7 @@ class Application(VuetifyTemplate, HubListener):
         self._viewer_store[vid] = viewer
 
         # Add viewer locally
-        if self.config in ('deconfigged', 'specviz', 'specviz2d'):
+        if self.config in ('deconfigged', 'specviz', 'specviz2d', 'lcviz'):
             # add to bottom (eventually will want more control in placement)
             self.state.stack_items[0]['children'].append(new_stack_item)
         else:

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -6,7 +6,7 @@
       <v-toolbar-items v-for="(item, index) in state.tool_items">
         <!-- this logic assumes the first entry is g-data-tools, if that changes, this may need to be modified -->
         <v-divider v-if="index > 1" vertical style="margin: 0px 10px"></v-divider>
-        <j-tooltip v-if="item.name === 'g-data-tools' && ['specviz', 'specviz2d'].indexOf(config) !== -1" tooltipcontent="Open data menu in sidebar (this button will be removed in a future release)">
+        <j-tooltip v-if="item.name === 'g-data-tools' && ['specviz', 'specviz2d', 'lcviz'].indexOf(config) !== -1" tooltipcontent="Open data menu in sidebar (this button will be removed in a future release)">
           <v-btn tile depressed color="turquoise" @click="state.drawer_content = 'loaders'">
             Import Data
           </v-btn>

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -376,8 +376,8 @@ class ConfigHelper(HubListener):
             self.app.layout.height = height
             self.app.state.settings['context']['notebook']['max_height'] = height
 
-        if self.app.config == 'specviz' or self.app.state.dev_loaders:
-            if not len(self.viewers):
+        if self.app.config in ('specviz', 'specviz2d', 'lcviz') or self.app.state.dev_loaders:
+            if not len(self.app.data_collection):
                 self.app.state.drawer_content = 'loaders'
 
         show_widget(self.app, loc=loc, title=title)

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -114,7 +114,7 @@ class BaseImporterToDataCollection(BaseImporter):
                 added += 1
                 viewer.data_menu.add_data(data_label)
         if added == 0:
-            if self.app.config != 'deconfigged':
+            if self.app.config not in ('deconfigged', 'lcviz'):
                 # do not add additional viewers
                 msg = SnackbarMessage(
                     "Data units are incompatible with viewer units, unload all data from viewer to add",  # noqa

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -78,6 +78,10 @@ class BaseImporterToDataCollection(BaseImporter):
         raise NotImplementedError("Importer subclass must implement default_viewer_reference")  # noqa pragma: nocover
 
     @property
+    def ignore_viewers_with_cls(self):
+        return ()
+
+    @property
     def default_viewer_label(self):
         return vid_map.get(self.default_viewer_reference, self.default_viewer_reference)
 
@@ -110,6 +114,8 @@ class BaseImporterToDataCollection(BaseImporter):
     def load_into_viewer(self, data_label, default_viewer_reference=None):
         added = 0
         for viewer in self.app._jdaviz_helper.viewers.values():
+            if isinstance(viewer._obj, self.ignore_viewers_with_cls):
+                continue
             if data_label in viewer.data_menu.data_labels_unloaded:
                 added += 1
                 viewer.data_menu.add_data(data_label)

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -143,7 +143,10 @@ class BaseImporterToDataCollection(BaseImporter):
         if data_label is None:
             data_label = self.data_label_value
         if hasattr(data, 'meta'):
-            data.meta = standardize_metadata(data.meta)
+            try:
+                data.meta = standardize_metadata(data.meta)
+            except TypeError:
+                pass
         self.app.add_data(data, data_label=data_label)
         if show_in_viewer:
             self.load_into_viewer(data_label)

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -7,7 +7,7 @@ from specutils import Spectrum1D
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import loader_importer_registry
 from jdaviz.core.loaders.importers import BaseImporterToDataCollection
-from jdaviz.core.template_mixin import AutoTextField, SelectPluginComponent, SelectFileExtensionComponent
+from jdaviz.core.template_mixin import AutoTextField, SelectFileExtensionComponent
 from jdaviz.core.user_api import ImporterUserApi
 from jdaviz.utils import standardize_metadata, PRIHDR_KEY
 

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -7,18 +7,12 @@ from specutils import Spectrum1D
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import loader_importer_registry
 from jdaviz.core.loaders.importers import BaseImporterToDataCollection
-from jdaviz.core.template_mixin import AutoTextField, SelectPluginComponent
+from jdaviz.core.template_mixin import AutoTextField, SelectPluginComponent, SelectFileExtensionComponent
 from jdaviz.core.user_api import ImporterUserApi
 from jdaviz.utils import standardize_metadata, PRIHDR_KEY
 
 
 __all__ = ['Spectrum2DImporter']
-
-
-class SelectExtensionComponent(SelectPluginComponent):
-    @property
-    def selected_index(self):
-        return self.choices.index(self.selected)
 
 
 @loader_importer_registry('2D Spectrum')
@@ -55,15 +49,15 @@ class Spectrum2DImporter(BaseImporterToDataCollection):
             extension_options = [f"{i}: {hdu.name} {hdu.shape}"
                                  for i, hdu in enumerate(self.input)
                                  if len(getattr(hdu, 'shape', [])) == 2]
-            self.extension = SelectExtensionComponent(self,
-                                                      items='extension_items',
-                                                      selected='extension_selected',
-                                                      manual_options=extension_options)
+            self.extension = SelectFileExtensionComponent(self,
+                                                          items='extension_items',
+                                                          selected='extension_selected',
+                                                          manual_options=extension_options)
 
     @property
     def user_api(self):
         expose = ['auto_extract', 'ext_data_label']
-        if isinstance(self.input, fits.HDUList):
+        if not isinstance(self.input, Spectrum1D):
             expose += ['extension', 'transpose']
         return ImporterUserApi(self, expose)
 

--- a/jdaviz/core/loaders/parsers/fits.py
+++ b/jdaviz/core/loaders/parsers/fits.py
@@ -14,7 +14,7 @@ class FITSParser(BaseParser):
 
     @property
     def is_valid(self):
-        if self.app.config not in ('deconfigged', 'specviz2d'):
+        if self.app.config not in ('deconfigged', 'specviz2d', 'lcviz'):
             # NOTE: temporary during deconfig process
             return False
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1181,7 +1181,8 @@ class SelectPluginComponent(BasePluginComponent, HasTraits):
 class SelectFileExtensionComponent(SelectPluginComponent):
     @property
     def selected_index(self):
-        return int(float(self.selected.split(':')[0])) ## TODO: store in internal dict
+        return int(float(self.selected.split(':')[0]))  # TODO: store in internal dict
+
 
 class UnitSelectPluginComponent(SelectPluginComponent):
     def __init__(self, *args, **kwargs):

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -74,6 +74,7 @@ __all__ = ['show_widget', 'TemplateMixin', 'PluginTemplateMixin',
            'BasePluginComponent',
            'MultiselectMixin',
            'SelectPluginComponent', 'UnitSelectPluginComponent', 'EditableSelectPluginComponent',
+           'SelectFileExtensionComponent',
            'PluginSubcomponent',
            'SubsetSelect', 'SubsetSelectMixin',
            'SpatialSubsetSelectMixin', 'SpectralSubsetSelectMixin',
@@ -1176,6 +1177,11 @@ class SelectPluginComponent(BasePluginComponent, HasTraits):
                 self.selected = event['old']
                 raise ValueError(f"\'{event['new']}\' not one of {valid}, reverting selection to \'{event['old']}\'")  # noqa
 
+
+class SelectFileExtensionComponent(SelectPluginComponent):
+    @property
+    def selected_index(self):
+        return int(float(self.selected.split(':')[0])) ## TODO: store in internal dict
 
 class UnitSelectPluginComponent(SelectPluginComponent):
     def __init__(self, *args, **kwargs):

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -67,9 +67,14 @@ class UserApiWrapper:
             # .selected traitlet
             if isinstance(exp_obj, UnitSelectPluginComponent) and isinstance(value, u.Unit):
                 value = value.to_string()
-            elif isinstance(exp_obj, SelectFileExtensionComponent) and isinstance(value, int):
-                # allow setting by index
-                value = exp_obj.choices[value]
+            elif isinstance(exp_obj, SelectFileExtensionComponent):
+                if isinstance(value, int):
+                    # allow setting by index
+                    value = exp_obj.choices[exp_obj.indices.index(value)]
+                elif isinstance(value, str):
+                    # allow setting without index
+                    if value not in exp_obj.choices:
+                        value = exp_obj.choices[exp_obj.names.index(value)]
             exp_obj.selected = value
             return
         elif isinstance(exp_obj, AddResults):

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -58,16 +58,16 @@ class UserApiWrapper:
             raise AttributeError(f"{attr} is a callable, cannot set to a value.  See help({attr}) for input arguments.")  # noqa
         from jdaviz.core.template_mixin import (SelectPluginComponent,
                                                 UnitSelectPluginComponent,
+                                                SelectFileExtensionComponent,
                                                 PlotOptionsSyncState,
                                                 AddResults,
                                                 AutoTextField)
-        from jdaviz.core.loaders.importers.spectrum2d.spectrum2d import SelectExtensionComponent
         if isinstance(exp_obj, SelectPluginComponent):
             # this allows setting the selection directly without needing to access the underlying
             # .selected traitlet
             if isinstance(exp_obj, UnitSelectPluginComponent) and isinstance(value, u.Unit):
                 value = value.to_string()
-            elif isinstance(exp_obj, SelectExtensionComponent) and isinstance(value, int):
+            elif isinstance(exp_obj, SelectFileExtensionComponent) and isinstance(value, int):
                 # allow setting by index
                 value = exp_obj.choices[value]
             exp_obj.selected = value


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements additional flexibility into the loaders framework that is necessary for downstream use by lcviz via https://github.com/spacetelescope/lcviz/pull/187, including:

* failing gracefully if standardizing metadata fails
* enable lcviz (alongside "deconfigged", "specviz", and "specviz2d") to use loaders by default
* allow lcviz to use fits parser (needed for DVT importer)
* allow importers to provide list of viewer classes to ignore when attempting to load data - allowing them to give a different viewer (to potentially create) as priority over other viewers that might support loading the data.  For lcviz, TPF data _can_ be loaded into the light curve viewer, but should not be by default, and instead we want the importer to automatically create an image/cube viewer if it does not already exist.
* move `SelectExtensionComponent` to template mixin (and rename to `SelectFileExtensionComponent`) so that it can be shared with other importers (used to be isolated to spectrum2d)
* generalize `SelectFileExtensionComponent` to be able to use filters and to track the indices in the hdulist of each item
* multiselect support for `SelectFileExtensionComponent`
* `viz.show()` now defaults to showing the loaders panel if there are no data loaded (rather than the previous implementation of no viewers)
* generalize `app.return_unique_label` to allow passing a list of strings (useful for plugin component selections that might be used by downstream loaders, etc).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
