### PR TITLE
for images with GWCS, show world coords on mouseover outside of bounding box using refdata 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Imviz
 - Footprints plugin now supports selecting the closest overlay
   to a clicked point in the image viewer. [#3525]
 
-- Improve performance by using FITS WCS for reference data layers when linked by WCS, rather than GWCS [#3483]
+- Improve performance by using FITS WCS for reference data layers when linked by WCS, rather than GWCS [#3483, #3535]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -209,14 +209,21 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
                 # world_to_pixel return scalar ndarray that we need to convert to float.
                 if align_by == 'wcs':
                     if not reverse:
-                        outside_ref_bounding_box = wcs_utils.data_outside_gwcs_bounding_box(
-                            self.state.reference_data, x, y)
-                        x, y = list(map(float, pixel_to_pixel(
+                        # Convert X,Y from reference data to the one we are actually seeing.
+
+                        x_image_coords, y_image_coords = list(map(float, pixel_to_pixel(
                             self.state.reference_data.coords, image.coords, x, y)))
                         outside_image_bounding_box = wcs_utils.data_outside_gwcs_bounding_box(
-                            image, x, y)
-                        unreliable_pixel = outside_image_bounding_box or outside_ref_bounding_box
-                        unreliable_world = unreliable_pixel
+                            image, x_image_coords, y_image_coords)
+
+                        if outside_image_bounding_box:
+                            # coordinates outside the bounding box are unreliable
+                            unreliable_pixel = unreliable_world = True
+                        else:
+                            x, y = x_image_coords, y_image_coords
+                            # any coordinate inside the bounding box should be reliable
+                            unreliable_pixel = unreliable_world = False
+
                     else:
                         # We don't bother with unreliable_pixel and unreliable_world computation
                         # because this takes input (x, y) in the frame of visible layer and wants


### PR DESCRIPTION
Follow up to #3483 to address comments by @pllim in https://github.com/spacetelescope/jdaviz/pull/3483#pullrequestreview-2730199866
Closes #3534

This PR enables mouseover world coordinate info in imviz on images with GWCS, even outside the bounding box, when linked by WCS. If the cursor is outside of the bounding box for the selected image layer, the coord info is taken from the reference data layer, which will be defined with FITS WCS as of #3483. No pixel coordinates are shown if the cursor is outside of the bounding box for an image with GWCS.

In the image below, the cursor is where the red "X" sits, which is on the top image layer:

<img width="1860" alt="Screenshot 2025-04-10 at 14 17 30" src="https://github.com/user-attachments/assets/14c965c9-fe4a-43fc-92d1-b5062d8b0bbf" />

When the cursor is outside the bounds of the top image layer, the world coordinates are shown in gray, without pixel info:

<img width="1855" alt="Screenshot 2025-04-10 at 14 19 13" src="https://github.com/user-attachments/assets/cba2c6f4-c7c4-4908-80ed-97b8fad7d027" />

The same is true if you hover over the not-selected image layer...:
 
<img width="1846" alt="Screenshot 2025-04-10 at 14 20 34" src="https://github.com/user-attachments/assets/54daa862-1096-4337-8920-c7459f9954ab" />

...unless you toggle through the layers in the coord info to Layer A, and you'll see: 

<img width="1850" alt="Screenshot 2025-04-10 at 14 21 32" src="https://github.com/user-attachments/assets/416785cb-97a9-4265-81c2-a32530ee520a" />

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
