### PR TITLE
fix remote data failures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Cubeviz
 
 - Ability to ingest and export ``SkyRegion`` objects. [#3502]
 
+- Replace file and fix label in example notebook. [#3537]
+
 Imviz
 ^^^^^
 
@@ -34,6 +36,8 @@ Specviz
 
 - Loading data is now done through the loaders menu in the right sidebar.  The "import data" button is
   deprecated and will open the new sidebar.  [#3473]
+
+- Replace file in example notebook. [#3537]
 
 Specviz2d
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,8 +16,6 @@ Cubeviz
 
 - Ability to ingest and export ``SkyRegion`` objects. [#3502]
 
-- Replace file and fix label in example notebook. [#3537]
-
 Imviz
 ^^^^^
 
@@ -36,8 +34,6 @@ Specviz
 
 - Loading data is now done through the loaders menu in the right sidebar.  The "import data" button is
   deprecated and will open the new sidebar.  [#3473]
-
-- Replace file in example notebook. [#3537]
 
 Specviz2d
 ^^^^^^^^^
@@ -112,6 +108,7 @@ Bug Fixes
 
 Cubeviz
 ^^^^^^^
+- Replace file and fix label in example notebook. [#3537]
 
 Imviz
 ^^^^^
@@ -130,6 +127,8 @@ Specviz2d
 
 - Improved initial guess for trace for automatic extraction. May change results
   for automatic extraction for data with nonfinite values. [#3512]
+
+- Replace file in example notebook. [#3537]
 
 4.2.1 (2025-03-24)
 ==================

--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -223,7 +223,7 @@ def test_data_quality_plugin_hst_acs(imviz_helper, tmp_path):
 @pytest.mark.remote_data
 def test_cubeviz_layer_visibility_bug(cubeviz_helper, tmp_path):
     # regression test for bug:
-    uri = "mast:JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_s3d.fits"
+    uri = "mast:JWST/product/jw02732-o004_t004_miri_ch1-short_s3d.fits"
     download_path = str(tmp_path / Path(uri).name)
     Observations.download_file(uri, local_path=download_path)
 

--- a/jdaviz/core/tests/test_autoconfig.py
+++ b/jdaviz/core/tests/test_autoconfig.py
@@ -13,10 +13,10 @@ from jdaviz.core.launcher import Launcher, STATUS_HINTS
 
 
 AUTOCONFIG_EXAMPLES = (
-    ("mast:JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_x1d.fits", Specviz),
+    ("mast:JWST/product/jw02732-o004_t004_miri_ch1-short_x1d.fits", Specviz),
     ("mast:JWST/product/jw01538160001_16101_00004_nrs1_s2d.fits", Specviz2d),
     ("mast:JWST/product/jw02727-o002_t062_nircam_clear-f090w_i2d.fits", Imviz),
-    ("mast:JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_s3d.fits", Cubeviz),
+    ("mast:JWST/product/jw02732-o004_t004_miri_ch1-short_s3d.fits", Cubeviz),
     ("https://stsci.box.com/shared/static/28a88k1qfipo4yxc4p4d40v4axtlal8y.fits", Cubeviz)
     # Check that MaNGA cubes go to cubeviz. This file is originally from:
     # https://data.sdss.org/sas/dr14/manga/spectro/redux/v2_1_2/7495/stack/manga-7495-12704-LOGCUBE.fits.gz)

--- a/jdaviz/core/tests/test_config_detection.py
+++ b/jdaviz/core/tests/test_config_detection.py
@@ -9,10 +9,10 @@ from jdaviz.core.data_formats import identify_helper
 @pytest.mark.filterwarnings(r"ignore::astropy.wcs.wcs.FITSFixedWarning")
 @pytest.mark.parametrize(("uri, expected_helper"), [
     ('mast:HST/product/jclj01010_drz.fits', 'imviz'),
-    ('mast:JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_x1d.fits', 'specviz'),
+    ('mast:JWST/product/jw02732-o004_t004_miri_ch1-short_x1d.fits', 'specviz'),
     ('mast:jwst/product/jw01538-o161_s000000001_nirspec_f290lp-g395h-s1600a1_s2d.fits', 'specviz2d'),  # noqa: E501
     ('mast:JWST/product/jw02727-o002_t062_nircam_clear-f277w_i2d.fits', 'imviz'),
-    ('mast:JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_s3d.fits', 'cubeviz')])
+    ('mast:JWST/product/jw02732-o004_t004_miri_ch1-short_s3d.fits', 'cubeviz')])
 def test_auto_config_detection(uri, expected_helper):
     url = f'https://mast.stsci.edu/api/v0.1/Download/file/?uri={uri}'
     fn = download_file(url, timeout=100)

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -49,17 +49,17 @@ def test_url_to_download_imviz_local_path_warning(imviz_helper):
 
 
 def test_uri_to_download_specviz_local_path_check():
-    uri = "mast:JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_x1d.fits"
+    uri = "mast:JWST/product/jw02732-o004_t004_miri_ch1-short_x1d.fits"
     local_path = download_uri_to_path(uri, cache=False, dryrun=True)  # No download
 
-    # Wrong: '.\\JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_x1d.fits'
-    # Correct:  '.\\jw02732-o004_t004_miri_ch1-shortmediumlong_x1d.fits'
-    assert local_path == os.path.join(os.curdir, "jw02732-o004_t004_miri_ch1-shortmediumlong_x1d.fits")  # noqa: E501
+    # Wrong: '.\\JWST/product/jw02732-o004_t004_miri_ch1-short_x1d.fits'
+    # Correct:  '.\\jw02732-o004_t004_miri_ch1-short_x1d.fits'
+    assert local_path == os.path.join(os.curdir, "jw02732-o004_t004_miri_ch1-short_x1d.fits")  # noqa: E501
 
 
 @pytest.mark.remote_data
 def test_uri_to_download_specviz(specviz_helper, tmp_path):
-    uri = "mast:JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_x1d.fits"
+    uri = "mast:JWST/product/jw02732-o004_t004_miri_ch1-short_x1d.fits"
     local_path = str(tmp_path / uri.split('/')[-1])
     specviz_helper.load_data(uri, cache=True, local_path=local_path)
 

--- a/notebooks/CubevizExample.ipynb
+++ b/notebooks/CubevizExample.ipynb
@@ -71,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "uri = \"mast:JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_s3d.fits\"\n",
+    "uri = \"mast:JWST/product/jw02732-o004_t004_miri_ch1-short_s3d.fits\"\n",
     "\n",
     "with warnings.catch_warnings():\n",
     "    warnings.simplefilter('ignore')\n",
@@ -148,7 +148,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = cubeviz.get_data('jw02732-o004_t004_miri_ch1-shortmediumlong_s3d.fits[SCI]')"
+    "data = cubeviz.get_data('jw02732-o004_t004_miri_ch1-short_s3d[SCI]')"
    ]
   },
   {
@@ -211,7 +211,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "jdaviz1",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -225,7 +225,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/SpecvizExample.ipynb
+++ b/notebooks/SpecvizExample.ipynb
@@ -88,7 +88,7 @@
    },
    "outputs": [],
    "source": [
-    "specviz.load_data(\"mast:JWST/product/jw02732-o004_t004_miri_ch1-shortmediumlong_x1d.fits\", data_label=\"myfile\", cache=True)"
+    "specviz.load_data(\"mast:JWST/product/jw02732-o004_t004_miri_ch1-short_x1d.fits\", data_label=\"myfile\", cache=True)"
    ]
   },
   {
@@ -244,7 +244,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
jw02732-o004_t004_miri_ch1-shortmediumlong_s3d.fits > jw02732-o004_t004_miri_ch1-short_s3d.fits 
jw02732-o004_t004_miri_ch1-shortmediumlong_s3d.fits > jw02732-o004_t004_miri_ch1-short_s3d.fits

also fixes an issue with accessing by data label in the cubeviz notebook, that needs to be addressed further (see JDAT-5293)
