### PR TITLE
loaders: allow same importer through multiple parsers

### DIFF
--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -81,10 +81,16 @@ class Spectrum2DImporter(BaseImporterToDataCollection):
         if self.app.config not in ('deconfigged', 'specviz2d'):
             # NOTE: temporary during deconfig process
             return False
-        return ((isinstance(self.input, Spectrum1D)
+        if not ((isinstance(self.input, Spectrum1D)
                  and self.input.flux.ndim == 2) or
                 (isinstance(self.input, fits.HDUList)
                  and len([hdu for hdu in self.input if hdu_is_valid(hdu)])))  # noqa
+            return False
+        try:
+            self.output
+        except Exception:
+            return False
+        return True
 
     @property
     def default_viewer_reference(self):

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -84,7 +84,7 @@ class Spectrum2DImporter(BaseImporterToDataCollection):
         if not ((isinstance(self.input, Spectrum1D)
                  and self.input.flux.ndim == 2) or
                 (isinstance(self.input, fits.HDUList)
-                 and len([hdu for hdu in self.input if hdu_is_valid(hdu)])))  # noqa
+                 and len([hdu for hdu in self.input if hdu_is_valid(hdu)]))):  # noqa
             return False
         try:
             self.output

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -62,7 +62,7 @@ class Spectrum2DImporter(BaseImporterToDataCollection):
                                             'ext_data_label_invalid_msg')
 
         self.input_hdulist = not isinstance(self.input, Spectrum1D)
-        if self.is_valid and self.input_hdulist:
+        if self.input_hdulist:
             self.extension = SelectFileExtensionComponent(self,
                                                           items='extension_items',
                                                           selected='extension_selected',

--- a/jdaviz/core/loaders/parsers/fits.py
+++ b/jdaviz/core/loaders/parsers/fits.py
@@ -1,6 +1,5 @@
 from functools import cached_property
 from astropy.io import fits
-from specutils import Spectrum1D
 
 from jdaviz.core.loaders.parsers import BaseParser
 from jdaviz.core.registries import loader_parser_registry
@@ -9,7 +8,7 @@ from jdaviz.core.registries import loader_parser_registry
 __all__ = ['FITSParser']
 
 
-@loader_parser_registry('FITS')
+@loader_parser_registry('fits')
 class FITSParser(BaseParser):
 
     @property
@@ -22,15 +21,7 @@ class FITSParser(BaseParser):
             self.output
         except Exception:
             return False
-
-        # do not use FITS if able to load with specutils
-        # TODO: implement a priority system and use that instead
-        try:
-            Spectrum1D.read(self.input)
-        except Exception:
-            return True
-        else:
-            return False
+        return True
 
     @cached_property
     def output(self):

--- a/jdaviz/core/loaders/parsers/object.py
+++ b/jdaviz/core/loaders/parsers/object.py
@@ -9,7 +9,8 @@ class ObjectParser(BaseParser):
     # pass through an object from the object resolver directly to the importers
     @property
     def is_valid(self):
-        return self.input is not None
+        # resolver already checks to ensure not None, string, Path
+        return True
 
     @cached_property
     def output(self):

--- a/jdaviz/core/loaders/resolvers/file/file.py
+++ b/jdaviz/core/loaders/resolvers/file/file.py
@@ -1,5 +1,5 @@
 import os
-from traitlets import Unicode, observe
+from traitlets import Any, observe
 
 from jdaviz.configs.default.plugins.data_tools.file_chooser import FileChooser
 from jdaviz.core.registries import loader_resolver_registry
@@ -15,7 +15,7 @@ class FileResolver(BaseResolver):
     template_file = __file__, "file.vue"
     default_input = 'filepath'
 
-    filepath = Unicode().tag(sync=True)
+    filepath = Any().tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         start_path = os.environ.get('JDAVIZ_START_DIR', os.path.curdir)
@@ -33,6 +33,10 @@ class FileResolver(BaseResolver):
 
     @observe('filepath')
     def _on_filepath_changed(self, change):
+        if not isinstance(self.filepath, str):
+            # will trigger another call to _on_filepath_changed
+            self.filepath = str(self.filepath)
+            return
         if self._file_upload.file_path != change['new']:
             path, file = os.path.split(change['new'])
             if path == '':

--- a/jdaviz/core/loaders/resolvers/object/object.py
+++ b/jdaviz/core/loaders/resolvers/object/object.py
@@ -1,4 +1,5 @@
 from traitlets import Unicode
+from pathlib import Path
 
 from jdaviz.core.registries import loader_resolver_registry
 from jdaviz.core.loaders.resolvers import BaseResolver
@@ -23,7 +24,7 @@ class ObjectResolver(BaseResolver):
 
     @property
     def is_valid(self):
-        return not isinstance(self.object, str)
+        return self.object is not None and not isinstance(self.object, (str, Path))
 
     @property
     def object(self):

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -288,20 +288,20 @@ def find_matching_resolver(app, inp=None, resolver=None, format=None, target=Non
     valid_resolvers = []
     for resolver_name, Resolver in loader_resolver_registry.members.items():
         if resolver is not None and resolver != resolver_name:
+            invalid_resolvers[resolver_name] = f'not {resolver}'
             continue
         try:
             this_resolver = Resolver.from_input(app, inp, **kwargs)
-        except Exception as e:
+        except Exception as e:  # nosec
             invalid_resolvers[resolver_name] = f'resolver exception: {e}'
-            this_resolver = None
-        if this_resolver is None:
             continue
         try:
             is_valid = this_resolver.is_valid
         except Exception:
-            invalid_resolvers[resolver_name] = 'not valid'
+            invalid_resolvers[resolver_name] = f'is_valid exception: {e}'
             is_valid = False
         if not is_valid:
+            invalid_resolvers.setdefault(resolver_name, 'not valid')
             continue
 
         if target is not None:

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -310,6 +310,9 @@ def find_matching_resolver(app, inp=None, resolver=None, format=None, target=Non
             except ValueError:
                 invalid_resolvers[resolver_name] = this_resolver.format._invalid_importers
                 continue
+        if not len(this_resolver.format.items):
+            invalid_resolvers[resolver_name] = this_resolver.format._invalid_importers
+            continue
         for fmt_item in this_resolver.format.items:
             if (format is not None
                 and not any([format in (fmt_item['label'],

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -67,7 +67,7 @@ class FormatSelect(SelectPluginComponent):
                     if this_parser.is_valid:
                         importer_input = this_parser()
                     else:
-                        self._invalid_importers[parser_name] = 'not valid'
+                        self._invalid_importers[parser_name] = 'parser not valid'
                         importer_input = None
                 except Exception as e:
                     self._invalid_importers[parser_name] = f'parser exception: {e}'
@@ -95,7 +95,7 @@ class FormatSelect(SelectPluginComponent):
                         # so that they can be used when compiling the list of target filters
                         self._importers[label] = this_importer
                     else:
-                        self._invalid_importers[label] = 'not valid'
+                        self._invalid_importers[label] = 'importer not valid'
 
         self.items = all_resolvers
         self._apply_default_selection()
@@ -325,7 +325,7 @@ def find_matching_resolver(app, inp=None, resolver=None, format=None, target=Non
             valid_resolvers.append((this_resolver, resolver_name, fmt_item['label']))
 
     if len(valid_resolvers) == 0:
-        raise ValueError("no valid loaders found for input, tried", invalid_resolvers)
+        raise ValueError(f"no valid loaders found for input, tried: {invalid_resolvers}")
     elif len(valid_resolvers) > 1:
         vrs = [f"resolver={vr[1]} > format={vr[2]}" for vr in valid_resolvers]
         raise ValueError(f"multiple valid loaders found for input: {vrs}")

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -297,7 +297,7 @@ def find_matching_resolver(app, inp=None, resolver=None, format=None, target=Non
             continue
         try:
             is_valid = this_resolver.is_valid
-        except Exception:
+        except Exception as e:  # nosec
             invalid_resolvers[resolver_name] = f'is_valid exception: {e}'
             is_valid = False
         if not is_valid:

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -72,18 +72,22 @@ class FormatSelect(SelectPluginComponent):
                 if importer_input is None:
                     continue
                 for importer_name, Importer in loader_importer_registry.members.items():
-                    this_importer = Importer(app=self.plugin.app,
-                                             resolver=self.plugin,
-                                             input=importer_input)
+                    try:
+                        this_importer = Importer(app=self.plugin.app,
+                                                 resolver=self.plugin,
+                                                 input=importer_input)
+                    except Exception:  # nosec
+                        continue
                     if this_importer.is_valid:
+                        label = f"{parser_name} > {importer_name}"
                         if self._is_valid_item(this_importer):
-                            all_resolvers.append({'label': importer_name,
+                            all_resolvers.append({'label': label,
                                                   'parser': parser_name,
                                                   'importer': importer_name,
                                                   'target': this_importer.target})
                         # we'll store the importer even if it isn't valid according to the filters
                         # so that they can be used when compiling the list of target filters
-                        self._importers[importer_name] = this_importer
+                        self._importers[label] = this_importer
 
         self.items = all_resolvers
         self._apply_default_selection()

--- a/jdaviz/core/loaders/test_loaders.py
+++ b/jdaviz/core/loaders/test_loaders.py
@@ -43,7 +43,7 @@ def test_resolver_matching(specviz_helper):
 
     res_sp = find_matching_resolver(specviz_helper.app, sp)
     assert res_sp._obj._registry_label == 'object'
-    assert res_sp.format == '1D Spectrum'
+    assert res_sp.format == 'object > 1D Spectrum'
 
     specviz_helper._load(sp)
     assert len(specviz_helper.app.data_collection) == 1
@@ -56,12 +56,12 @@ def test_trace_importer(specviz2d_helper, spectrum2d):
 
     res_sp = find_matching_resolver(specviz2d_helper.app, trace)
     assert res_sp._obj._registry_label == 'object'
-    assert res_sp.format == 'Trace'
+    assert res_sp.format == 'object > Trace'
 
     # import through loader API
     ldr = specviz2d_helper.loaders['object']
     ldr.object = trace
-    assert ldr.format == 'Trace'
+    assert ldr.format == 'object > Trace'
     ldr.importer.data_label = 'Trace 1'
     ldr.importer()
     assert specviz2d_helper.app.data_collection[-1].label == 'Trace 1'
@@ -90,20 +90,20 @@ def test_resolver_url(deconfigged_helper):
     assert len(loader.format.choices) == 0
 
     loader.url = 'https://stsci.box.com/shared/static/exnkul627fcuhy5akf2gswytud5tazmw.fits'  # noqa
-    assert len(loader.format.choices) == 3  # may change with future importers
-    assert loader.format.selected == '2D Spectrum'  # default may change with future importers
+    assert len(loader.format.choices) == 4  # may change with future importers
+    assert loader.format.selected == 'fits > 2D Spectrum'  # noqa: default may change with future importers
 
     # test target filtering
     assert len(loader.target.choices) > 1
     assert loader.target.selected == 'Any'
     loader.target = '1D Spectrum'
     assert len(loader.format.choices) == 2  # may change with future importers
-    assert loader.format == '1D Spectrum List'  # default may change with future importers
+    assert loader.format.selected == 'specutils.Spectrum > 1D Spectrum List'  # noqa: default may change with future importers
     assert loader.importer.data_label == '1D Spectrum'
 
     loader.target = 'Any'
-    assert len(loader.format.choices) == 3
-    loader.format = '2D Spectrum'
+    assert len(loader.format.choices) == 4
+    loader.format = 'specutils.Spectrum > 2D Spectrum'
     assert loader.importer.data_label == '2D Spectrum'
 
     assert len(deconfigged_helper.app.data_collection) == 0

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -68,7 +68,7 @@ class UserApiWrapper:
             # .selected traitlet
             if isinstance(exp_obj, UnitSelectPluginComponent) and isinstance(value, u.Unit):
                 value = value.to_string()
-            elif isinstance(exp_obj, SelectExtensionComponent) and isinstance(value, int):
+            elif isinstance(exp_obj, SelectFileExtensionComponent) and isinstance(value, int):
                 # allow setting by index
                 value = exp_obj.choices[value]
             elif isinstance(exp_obj, FormatSelect):

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -62,19 +62,24 @@ class UserApiWrapper:
                                                 PlotOptionsSyncState,
                                                 AddResults,
                                                 AutoTextField)
+        from jdaviz.core.loaders.resolvers.resolver import FormatSelect
         if isinstance(exp_obj, SelectPluginComponent):
             # this allows setting the selection directly without needing to access the underlying
             # .selected traitlet
             if isinstance(exp_obj, UnitSelectPluginComponent) and isinstance(value, u.Unit):
                 value = value.to_string()
-            elif isinstance(exp_obj, SelectFileExtensionComponent):
-                if isinstance(value, int):
-                    # allow setting by index
-                    value = exp_obj.choices[exp_obj.indices.index(value)]
-                elif isinstance(value, str):
-                    # allow setting without index
-                    if value not in exp_obj.choices:
-                        value = exp_obj.choices[exp_obj.names.index(value)]
+            elif isinstance(exp_obj, SelectExtensionComponent) and isinstance(value, int):
+                # allow setting by index
+                value = exp_obj.choices[value]
+            elif isinstance(exp_obj, FormatSelect):
+                if value not in exp_obj.choices:
+                    # allow setting by just parser or just importer if a unique match
+                    parsers = [item['parser'] for item in exp_obj.items]
+                    importers = [item['importer'] for item in exp_obj.items]
+                    if value in parsers and value not in importers:
+                        value = exp_obj.choices[parsers.index(value)]
+                    elif value in importers and value not in parsers:
+                        value = exp_obj.choices[importers.index(value)]
             exp_obj.selected = value
             return
         elif isinstance(exp_obj, AddResults):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request allows the user to choose between loader paths through multiple parsers by including the parser in the format.  For example, if both are valid, the user can choose between `fits > 2D Spectrum` (with options for extension, transposing etc) and `specutils.Spectrum > 2D Spectrum`.

This however still allows setting (or passing) format as just the importer.  So `viz.load(filename, format='2D Spectrum')` is allowed.  Currently this does not require a single unique match, but we could change that behavior to require passing the parser if multiple format options are matched with the passed `format`.

This PR also tracks the reason that loaders were unsuccessful for easier debugging when inputs are unsuccessful.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
