### PR TITLE
Show FootprintSelect tool only when overlays exist

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,12 +22,9 @@ Imviz
 - Added ability to load remote data from a S3 URI to Imviz. [#3500]
 
 - Footprints plugin now supports selecting the closest overlay
-  to a clicked point in the image viewer. [#3525]
+  to a clicked point in the image viewer. [#3525, #3539]
 
 - Improve performance by using FITS WCS for reference data layers when linked by WCS, rather than GWCS [#3483]
-
-- FootprintSelect tool now appears in the viewer toolbar only when
-  overlays are present, reducing toolbar clutter. [#3539]
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ Imviz
 - Footprints plugin now supports selecting the closest overlay
   to a clicked point in the image viewer. [#3525]
 
+- FootprintSelect tool now appears in the viewer toolbar only when
+  overlays are present, reducing toolbar clutter. [#3539]
+
 Mosviz
 ^^^^^^
 
@@ -63,7 +66,6 @@ Imviz
 
 - User API for Catalog Search plugin (including ``catalog``,  ``max_sources``,``search``,
   ``table``, and ``table_selected``) is now public. [#3529]
-
 
 Mosviz
 ^^^^^^

--- a/jdaviz/components/toolbar_nested.py
+++ b/jdaviz/components/toolbar_nested.py
@@ -10,7 +10,7 @@ from glue_jupyter.common.toolbar_vuetify import BasicJupyterToolbar, read_icon
 from jdaviz.core.events import (AddDataMessage, RemoveDataMessage,
                                 ViewerAddedMessage, ViewerRemovedMessage,
                                 SpectralMarksChangedMessage, CatalogResultsChangedMessage,
-                                FootprintMarksChangedMessage)
+                                FootprintMarkVisibilityChangedMessage)
 
 __all__ = ['NestedJupyterToolbar']
 
@@ -71,7 +71,7 @@ class NestedJupyterToolbar(BasicJupyterToolbar, HubListener):
         if hasattr(self.viewer, 'hub'):
             for msg in (AddDataMessage, RemoveDataMessage, ViewerAddedMessage, ViewerRemovedMessage,
                         SpectralMarksChangedMessage, CatalogResultsChangedMessage,
-                        FootprintMarksChangedMessage):
+                        FootprintMarkVisibilityChangedMessage):
                 self.viewer.hub.subscribe(self, msg,
                                           handler=lambda _: self._update_tool_visibilities())
 

--- a/jdaviz/components/toolbar_nested.py
+++ b/jdaviz/components/toolbar_nested.py
@@ -9,7 +9,8 @@ from glue_jupyter.common.toolbar_vuetify import BasicJupyterToolbar, read_icon
 
 from jdaviz.core.events import (AddDataMessage, RemoveDataMessage,
                                 ViewerAddedMessage, ViewerRemovedMessage,
-                                SpectralMarksChangedMessage, CatalogResultsChangedMessage)
+                                SpectralMarksChangedMessage, CatalogResultsChangedMessage,
+                                FootprintMarksChangedMessage)
 
 __all__ = ['NestedJupyterToolbar']
 
@@ -69,7 +70,8 @@ class NestedJupyterToolbar(BasicJupyterToolbar, HubListener):
         # but those in plugins do not
         if hasattr(self.viewer, 'hub'):
             for msg in (AddDataMessage, RemoveDataMessage, ViewerAddedMessage, ViewerRemovedMessage,
-                        SpectralMarksChangedMessage, CatalogResultsChangedMessage):
+                        SpectralMarksChangedMessage, CatalogResultsChangedMessage,
+                        FootprintMarksChangedMessage):
                 self.viewer.hub.subscribe(self, msg,
                                           handler=lambda _: self._update_tool_visibilities())
 

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -8,7 +8,7 @@ from glue_jupyter.common.toolbar_vuetify import read_icon
 
 from jdaviz.core.custom_traitlets import FloatHandleEmpty
 from jdaviz.core.events import (LinkUpdatedMessage, ChangeRefDataMessage,
-                                FootprintSelectClickEventMessage, FootprintMarksChangedMessage)
+                                FootprintSelectClickEventMessage, FootprintMarkVisibilityChangedMessage)
 from jdaviz.core.marks import FootprintOverlay
 from jdaviz.core.region_translators import is_stcs_string, regions2roi, stcs_string2region
 from jdaviz.core.registries import tray_registry
@@ -411,7 +411,8 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
                 continue
             viewer.figure.marks = [m for m in viewer.figure.marks
                                    if getattr(m, 'overlay', None) != lbl]
-        self.hub.broadcast(FootprintMarksChangedMessage(viewer_id=viewer.reference, sender=self))
+        self.hub.broadcast(FootprintMarkVisibilityChangedMessage(
+            viewer_id=viewer.reference, sender=self))
 
     @observe('is_active', 'viewer_items')
     # NOTE: intentionally not using skip_if_no_updates_since_last_active since this only controls
@@ -441,7 +442,7 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
         # Notify toolbar to update tool visibility
         for viewer in self.app._viewer_store.values():
             if hasattr(viewer, 'figure'):
-                self.hub.broadcast(FootprintMarksChangedMessage(
+                self.hub.broadcast(FootprintMarkVisibilityChangedMessage(
                     viewer_id=viewer.reference, sender=self))
 
     def center_on_viewer(self, viewer_ref=None):
@@ -577,7 +578,8 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
                 mark.visible = visible
                 mark.colors = [self.color]
                 mark.fill_opacities = [self.fill_opacity]
-        self.hub.broadcast(FootprintMarksChangedMessage(viewer_id=viewer.reference, sender=self))
+        self.hub.broadcast(FootprintMarkVisibilityChangedMessage(
+            viewer_id=viewer.reference, sender=self))
 
     def import_region(self, region):
         """
@@ -738,5 +740,5 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
 
             if not update_existing and len(new_marks):
                 viewer.figure.marks = viewer.figure.marks + new_marks
-            self.hub.broadcast(FootprintMarksChangedMessage(
+            self.hub.broadcast(FootprintMarkVisibilityChangedMessage(
                 viewer_id=viewer.reference, sender=self))

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -434,24 +434,14 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
         if self.is_active:
             self._ensure_first_overlay()
 
-        selected_obj = self.viewer.selected_obj
-        if selected_obj is None:
-            return
-
-        viewers = self.viewer.selected_obj if self.viewer.is_multiselect else [self.viewer.selected_obj]    # noqa E501
-
-        for viewer in viewers:
-            if not hasattr(viewer, 'figure'):
-                continue
-
-            for overlay, viewer_marks in self.marks.items():
-                marks = viewer_marks.get(viewer.reference, [])
-                visible = self._mark_visible(viewer.reference, overlay)
+        for overlay, viewer_marks in self.marks.items():
+            for viewer_id, marks in viewer_marks.items():
+                visible = self._mark_visible(viewer_id, overlay)
                 for mark in marks:
                     mark.visible = visible
-
-            self.hub.broadcast(FootprintMarkVisibilityChangedMessage(
-                viewer_id=viewer.reference, sender=self))
+                if marks:
+                    self.hub.broadcast(FootprintMarkVisibilityChangedMessage(
+                        viewer_id=viewer_id, sender=self))
 
     def center_on_viewer(self, viewer_ref=None):
         """

--- a/jdaviz/configs/imviz/tests/test_footprints.py
+++ b/jdaviz/configs/imviz/tests/test_footprints.py
@@ -313,23 +313,21 @@ def test_footprint_select(imviz_helper):
     ndd = NDData(arr, wcs=wcs)
     imviz_helper.load_data(ndd)
     fp = imviz_helper.plugins["Footprints"]
+    toolbar = imviz_helper.viewers['imviz-0']._obj.toolbar
+    tool = toolbar.tools['jdaviz:selectfootprint']
+    assert tool.is_visible() is False
 
     with fp.as_active():
         current_overlay = fp.overlay.selected
         assert current_overlay == "default"
         fp.preset = "MIRI"
-        toolbar = imviz_helper.viewers['imviz-0']._obj.toolbar
-        tool = toolbar.tools['jdaviz:selectfootprint']
-        toolbar.active_tool_id = 'jdaviz:selectfootprint'
         tool.on_mouse_event({'domain': {'x': 95, 'y': 140}})
         assert current_overlay == "default"
+        assert tool.is_visible() is True
 
         # Add a new overlay
         fp.add_overlay("layer1")
         fp.overlay = "layer1"
         fp.v3_offset = 10
-        toolbar = imviz_helper.viewers['imviz-0']._obj.toolbar
-        tool = toolbar.tools['jdaviz:selectfootprint']
-        toolbar.active_tool_id = 'jdaviz:selectfootprint'
         tool.on_mouse_event({'domain': {'x': 95, 'y': 140}})
         assert fp.overlay.selected == "layer1"

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -297,7 +297,7 @@ class CatalogResultsChangedMessage(Message):
         super().__init__(*args, **kwargs)
 
 
-class FootprintMarksChangedMessage(Message):
+class FootprintMarkVisibilityChangedMessage(Message):
     """Message to notify that footprint overlays have changed."""
 
     def __init__(self, viewer_id, *args, **kwargs):

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -297,6 +297,18 @@ class CatalogResultsChangedMessage(Message):
         super().__init__(*args, **kwargs)
 
 
+class FootprintMarksChangedMessage(Message):
+    """Message to notify that footprint overlays have changed."""
+
+    def __init__(self, viewer_id, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._viewer_id = viewer_id
+
+    @property
+    def viewer_id(self):
+        return self._viewer_id
+
+
 class CatalogSelectClickEventMessage(Message):
     def __init__(self, x, y, *args, **kwargs):
         self.x = x

--- a/jdaviz/core/tools.py
+++ b/jdaviz/core/tools.py
@@ -19,7 +19,7 @@ from bqplot.interacts import BrushSelector, BrushIntervalSelector
 
 from jdaviz.core.events import (LineIdentifyMessage, SpectralMarksChangedMessage,
                                 CatalogSelectClickEventMessage, FootprintSelectClickEventMessage)
-from jdaviz.core.marks import SpectralLine
+from jdaviz.core.marks import SpectralLine, FootprintOverlay
 
 __all__ = []
 
@@ -428,6 +428,9 @@ class SelectFootprintOverlay(CheckableTool, HubListener):
     def on_mouse_event(self, data):
         msg = FootprintSelectClickEventMessage(data, sender=self)
         self.viewer.session.hub.broadcast(msg)
+
+    def is_visible(self):
+        return len([m for m in self.viewer.figure.marks if isinstance(m, FootprintOverlay)]) > 0
 
 
 @viewer_tool

--- a/jdaviz/core/tools.py
+++ b/jdaviz/core/tools.py
@@ -430,7 +430,10 @@ class SelectFootprintOverlay(CheckableTool, HubListener):
         self.viewer.session.hub.broadcast(msg)
 
     def is_visible(self):
-        return len([m for m in self.viewer.figure.marks if isinstance(m, FootprintOverlay)]) > 0
+        return any(
+            isinstance(m, FootprintOverlay) and m.visible
+            for m in self.viewer.figure.marks
+            )
 
 
 @viewer_tool


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This PR is a temporary solution for controlling the visibility of the FootprintSelect tool. The long-term idea is to have a shared selection tool that can handle different workflows across plugins, depending on what's active.

Until we have that framework in place, this tool will only show up when there are overlay footprints on the image viewer. This helps keep the toolbar cleaner and avoids showing tools that aren’t useful in the current context.

https://github.com/user-attachments/assets/2ab0b96c-ab0b-4b35-af72-72cf66189d68



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
