### PR TITLE
fix andNot subset bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -107,6 +107,9 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Fixed bug where subsets applied with remove / andNot mode when wcs linked were not able to return
+  sky regions. [#3547]
+
 Cubeviz
 ^^^^^^^
 - Replace file and fix label in example notebook. [#3537]

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1335,7 +1335,9 @@ class Application(VuetifyTemplate, HubListener):
                 # This gets triggered in the InvertState case where state1
                 # is an object and state2 is None
                 return self.get_sub_regions(subset_state.state1,
-                                            simplify_spectral, use_display_units)
+                                            simplify_spectral,
+                                            use_display_units,
+                                            get_sky_regions=get_sky_regions)
         elif subset_state is not None:
             # This is the leaf node of the glue subset state tree where
             # a subset_state is either ROI, Range, or MultiMask.

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -981,7 +981,8 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
         combination_mode : list, str, or `None`
             The way that regions are created or combined. If a list, then it must be the
             same length as regions. If `None`, then it will follow the default glue
-            functionality for subset creation.
+            functionality for subset creation. Options are ['new', 'replace', 'or', 'and',
+            'xor', 'andnot']
 
         max_num_regions : int or `None`
             Maximum number of regions to load, starting from top of the list.

--- a/jdaviz/configs/default/plugins/subset_tools/tests/test_subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/tests/test_subset_tools.py
@@ -6,6 +6,7 @@ import pytest
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.nddata import NDData
+from astropy.tests.helper import assert_quantity_allclose
 from glue.core.edit_subset_mode import ReplaceMode, OrMode, NewMode
 from glue.core.roi import EllipticalROI, CircularROI, CircularAnnulusROI, RectangularROI
 from numpy.testing import assert_allclose
@@ -385,11 +386,10 @@ def test_get_regions_composite_wcs_linked(imviz_helper, image_2d_wcs):
     assert cr.operator == operator.and_
 
 
-@pytest.mark.skip(reason="Unskip after JDAT-5186.")
 def test_get_composite_sky_region_remove(imviz_helper, image_2d_wcs):
     """
-    Test to ensure bug fixed by JDAT-5186 is fixed, where get_subsets
-    for compoisute subset applied with 'remove' when WCS linked was not
+    Test to ensure bug is fixed, where get_subsets
+    for composie subset applied with 'remove' when WCS linked was not
     correctly retrieving the second subset.
     """
     data = NDData(np.ones((128, 128)) * u.nJy, wcs=image_2d_wcs)
@@ -403,21 +403,24 @@ def test_get_composite_sky_region_remove(imviz_helper, image_2d_wcs):
                           dec=-20.808486*u.deg), radius=0.008*u.deg)
     sr2 = CircleSkyRegion(center=SkyCoord(ra=337.51*u.deg, dec=-20.81*u.deg),
                           radius=0.007*u.deg)
-    st.import_region(sr1, combination_mode='new')
-    st.import_region(sr2, combination_mode='andnot')
+    regions = [sr1, sr2]
+    st.import_region(regions, combination_mode=['new', 'andnot'])
 
-    # app.get_subsets
+    # app.get_subsets, composite region should be returned as 2 sky regions
     ss = imviz_helper.app.get_subsets(include_sky_region=True)
-
-    # composite region should be returned as 2 sky regions
-    assert isinstance(ss['Subset 1'][0]['sky_region'], CircleSkyRegion)
-    assert isinstance(ss['Subset 1'][1]['sky_region'], CircleSkyRegion)
+    for expected_region, actual in zip(regions, ss['Subset 1']):
+        sky_region = actual['sky_region']
+        assert_quantity_allclose(sky_region.center.ra, expected_region.center.ra)
+        assert_quantity_allclose(sky_region.center.dec, expected_region.center.dec)
+        assert_quantity_allclose(sky_region.radius, expected_region.radius)
 
     # now make sure Subset Tools get_regions agrees and both sky regions
     # are returned for Subset 1
     regs = st.get_regions()
-    assert isinstance(regs['Subset 1'][0], CircleSkyRegion)
-    assert isinstance(regs['Subset 1'][1], CircleSkyRegion)
+    for expected_region, actual in zip(regions, regs['Subset 1']):
+        assert_quantity_allclose(actual[0].center.ra, expected_region.center.ra)
+        assert_quantity_allclose(actual[0].center.dec, expected_region.center.dec)
+        assert_quantity_allclose(actual[0].radius, expected_region.radius)
 
 
 def test_check_valid_subset_label(imviz_helper):

--- a/jdaviz/configs/default/plugins/subset_tools/tests/test_subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/tests/test_subset_tools.py
@@ -389,7 +389,7 @@ def test_get_regions_composite_wcs_linked(imviz_helper, image_2d_wcs):
 def test_get_composite_sky_region_remove(imviz_helper, image_2d_wcs):
     """
     Test to ensure bug is fixed, where get_subsets
-    for composie subset applied with 'remove' when WCS linked was not
+    for composite subset applied with 'remove' when WCS linked was not
     correctly retrieving the second subset.
     """
     data = NDData(np.ones((128, 128)) * u.nJy, wcs=image_2d_wcs)

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -377,33 +377,37 @@ def test_composite_region_with_imviz(imviz_helper, image_2d_wcs):
     data_label = 'image-data'
     imviz_helper.load_data(arr, data_label=data_label, show_in_viewer=True)
     subset_plugin.import_region(CircularROI(xc=5, yc=5, radius=2))
-    reg = imviz_helper.app.get_subsets("Subset 1")
+    reg = imviz_helper.app.get_subsets("Subset 1", include_sky_region=True)
     circle1 = CirclePixelRegion(center=PixCoord(x=5, y=5), radius=2)
     assert reg[-1] == {'name': 'CircularROI', 'glue_state': 'RoiSubsetState', 'region': circle1,
-                       'sky_region': None, 'subset_state': reg[-1]['subset_state']}
+                       'sky_region': circle1.to_sky(image_2d_wcs),
+                       'subset_state': reg[-1]['subset_state']}
 
     subset_plugin.combination_mode.selected = 'andnot'
     subset_plugin.import_region(RectangularROI(xmin=2, xmax=4, ymin=2, ymax=4))
-    reg = imviz_helper.app.get_subsets("Subset 1")
+    reg = imviz_helper.app.get_subsets("Subset 1", include_sky_region=True)
     rectangle1 = RectanglePixelRegion(center=PixCoord(x=3, y=3),
                                       width=2, height=2, angle=0.0 * u.deg)
     assert reg[-1] == {'name': 'RectangularROI', 'glue_state': 'AndNotState', 'region': rectangle1,
-                       'sky_region': None, 'subset_state': reg[-1]['subset_state']}
+                       'sky_region': rectangle1.to_sky(image_2d_wcs),
+                       'subset_state': reg[-1]['subset_state']}
 
     subset_plugin.combination_mode.selected = 'andnot'
     subset_plugin.import_region(EllipticalROI(xc=3, yc=3, radius_x=3, radius_y=6))
-    reg = imviz_helper.app.get_subsets("Subset 1")
+    reg = imviz_helper.app.get_subsets("Subset 1", include_sky_region=True)
     ellipse1 = EllipsePixelRegion(center=PixCoord(x=3, y=3),
                                   width=6, height=12, angle=0.0 * u.deg)
     assert reg[-1] == {'name': 'EllipticalROI', 'glue_state': 'AndNotState', 'region': ellipse1,
-                       'sky_region': None, 'subset_state': reg[-1]['subset_state']}
+                       'sky_region': ellipse1.to_sky(image_2d_wcs),
+                       'subset_state': reg[-1]['subset_state']}
 
     subset_plugin.combination_mode.selected = 'or'
     subset_plugin.import_region(CircularAnnulusROI(xc=5, yc=5, inner_radius=2.5, outer_radius=5))
-    reg = imviz_helper.app.get_subsets("Subset 1")
+    reg = imviz_helper.app.get_subsets("Subset 1", include_sky_region=True)
     ann1 = CircleAnnulusPixelRegion(center=PixCoord(x=5, y=5), inner_radius=2.5, outer_radius=5)
     assert reg[-1] == {'name': 'CircularAnnulusROI', 'glue_state': 'OrState', 'region': ann1,
-                       'sky_region': None, 'subset_state': reg[-1]['subset_state']}
+                       'sky_region': ann1.to_sky(image_2d_wcs),
+                       'subset_state': reg[-1]['subset_state']}
 
     assert subset_plugin.subset_selected == "Subset 1"
     assert subset_plugin.subset_types == ['CircularROI', 'RectangularROI', 'EllipticalROI',


### PR DESCRIPTION
This PR fixes a bug for composite subsets applied with remove/andnot when wcs linked, which previously were not returning the sky region through app.get_subsets or subset_tools.get_regions. Unskipped a test already written for this case, and modified a few existing tests to also test returning sky regions. (as a bonus I also added valid combination modes to the docstring of import_region, because i noticed this was unclear while i was investigating this bug)