### PR TITLE
Fix model component initialization

### DIFF
--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -571,7 +571,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
             pixar_sr = masked_spectrum.meta.get('_pixel_scale_factor', 1.0)
             equivs = all_flux_unit_conversion_equivs(pixar_sr, init_x)
 
-            init_y = flux_conversion_general([init_y.value],
+            init_y = flux_conversion_general(init_y.value,
                                              init_y.unit,
                                              self._units['y'],
                                              equivs)


### PR DESCRIPTION
These list brackets are causing some model components to fail to initialize, however once I got past this bug I'm hitting a unit compatibility error. So it probably needs a little more thought, and an additional test to catch this case (fails when adding a gaussian component). This was added in https://github.com/spacetelescope/jdaviz/pull/3228.