### PR TITLE
deconfigged: allow injecting plugins

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2958,6 +2958,10 @@ class Application(VuetifyTemplate, HubListener):
                 tray_registry_member = tray_registry.members.get(name)
                 self.state.tray_items.append(self._create_tray_item(tray_registry_member))
 
+    def update_loaders_from_registry(self):
+        for loader in self._jdaviz_helper.loaders.values():
+            loader.format._update_items()
+
     def update_tray_items_from_registry(self):
         # need to rebuid in order, just pulling from existing dict if its already there
         tray_items = []

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2963,17 +2963,28 @@ class Application(VuetifyTemplate, HubListener):
             loader.format._update_items()
 
     def update_tray_items_from_registry(self):
-        # need to rebuid in order, just pulling from existing dict if its already there
+        # need to rebuild in order, just pulling from existing dict if its already there
         tray_items = []
+        # NOTE: eventually the core plugins will likely be moved out of the tray
+        # in which case we can either remove the categories OR at least simplify
+        # this down into reduction, manipulation, analysis.
         for category in ['data:info', 'viewer:options',
                          'subset:manipulation',
                          'data:reduction', 'data:manipulation', 'data:analysis',
                          'app:export', 'app:info']:
             for tray_registry_member in tray_registry.members_in_category(category):
-                try:
-                    tray_item = self.get_tray_item_from_name(
-                        tray_registry_member.get('name'), return_widget=False)
-                except KeyError:
+                if not tray_registry_member.get('overwrite', False):
+                    try:
+                        tray_item = self.get_tray_item_from_name(
+                            tray_registry_member.get('name'), return_widget=False)
+                    except KeyError:
+                        create_new = True
+                    else:
+                        create_new = False
+                else:
+                    create_new = True
+
+                if create_new:
                     try:
                         tray_item = self._create_tray_item(tray_registry_member)
                     except Exception as e:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1668,8 +1668,10 @@ class Application(VuetifyTemplate, HubListener):
             exist_labels = self.data_collection.labels
         elif typ == 'viewer':
             exist_labels = list(self._viewer_store.keys())
+        elif isinstance(typ, list):
+            exist_labels = typ
         else:
-            raise ValueError("typ must be either 'data' or 'viewer'")
+            raise ValueError("typ must be either 'data', 'viewer', or a list of strings")
         if label is None:
             label = "Unknown"
 

--- a/jdaviz/configs/deconfigged/deconfigged.yaml
+++ b/jdaviz/configs/deconfigged/deconfigged.yaml
@@ -14,18 +14,5 @@ toolbar:
   - g-data-tools
   - g-subset-tools
   - g-coords-info
-tray:
-  - g-metadata-viewer
-  - g-plot-options
-  - g-subset-tools
-  - g-markers
-  - spectral-extraction
-  - g-gaussian-smooth
-  - g-model-fitting
-  - g-unit-conversion
-  - g-line-list
-  - specviz-line-analysis
-  - export
-  - about
 viewer_area:
   - container: col

--- a/jdaviz/configs/default/plugins/about/about.py
+++ b/jdaviz/configs/default/plugins/about/about.py
@@ -15,7 +15,7 @@ except ImportError:  # pragma: no cover
 __all__ = ['About']
 
 
-@tray_registry('about', label="About")
+@tray_registry('about', label="About", category="app:info")
 class About(PluginTemplateMixin):
     """Show information about Jdaviz."""
     template_file = __file__, "about.vue"

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -32,7 +32,7 @@ else:
 __all__ = ['Export']
 
 
-@tray_registry('export', label="Export")
+@tray_registry('export', label="Export", category="app:export")
 class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
              DatasetMultiSelectMixin, PluginTableSelectMixin, PluginPlotSelectMixin,
              MultiselectMixin):

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -16,8 +16,7 @@ from jdaviz.core.user_api import PluginUserApi
 __all__ = ['GaussianSmooth']
 
 
-@tray_registry('g-gaussian-smooth', label="Gaussian Smooth",
-               viewer_requirements=['spectrum', 'flux'])
+@tray_registry('g-gaussian-smooth', label="Gaussian Smooth", category="data:manipulation")
 class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
     """
     See the :ref:`Gaussian Smooth Plugin Documentation <gaussian-smooth>` for more details.

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -29,10 +29,7 @@ from jdaviz.core.unit_conversion_utils import create_equivalent_spectral_axis_un
 __all__ = ['LineListTool']
 
 
-@tray_registry(
-    'g-line-list', label="Line Lists",
-    viewer_requirements=['spectrum']
-)
+@tray_registry('g-line-list', label="Line Lists", category="data:analysis")
 class LineListTool(PluginTemplateMixin, ViewerSelectMixin):
     dialog = Bool(False).tag(sync=True)
     template_file = __file__, "line_lists.vue"

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -13,7 +13,7 @@ from jdaviz.core.user_api import PluginUserApi
 __all__ = ['Markers']
 
 
-@tray_registry('g-markers', label="Markers")
+@tray_registry('g-markers', label="Markers", category='viewer:options')
 class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
     """
     See the :ref:`Markers Plugin Documentation <markers-plugin>` for more details.

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -8,7 +8,7 @@ from jdaviz.utils import PRIHDR_KEY, COMMENTCARD_KEY
 __all__ = ['MetadataViewer']
 
 
-@tray_registry('g-metadata-viewer', label="Metadata")
+@tray_registry('g-metadata-viewer', label="Metadata", category="data:info")
 class MetadataViewer(PluginTemplateMixin, DatasetSelectMixin):
     """
     See the :ref:`Metadata Viewer Plugin Documentation <imviz_metadata-viewer>` for more details.

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -40,7 +40,7 @@ class _EmptyParam:
                                    self.unit if self.unit is not None else u.dimensionless_unscaled)
 
 
-@tray_registry('g-model-fitting', label="Model Fitting", viewer_requirements='spectrum')
+@tray_registry('g-model-fitting', label="Model Fitting", category="data:analysis")
 class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
                    SpectralSubsetSelectMixin, DatasetSpectralSubsetValidMixin,
                    NonFiniteUncertaintyMismatchMixin,

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -105,7 +105,7 @@ def _round_step(step):
     return float(np.round(step, decimals)), decimals
 
 
-@tray_registry('g-plot-options', label="Plot Options")
+@tray_registry('g-plot-options', label="Plot Options", category='viewer:options')
 class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
     """
     The Plot Options Plugin gives access to per-viewer and per-layer options and enables

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -66,7 +66,7 @@ SUBSET_TO_PRETTY = {v: k for k, v in SUBSET_MODES_PRETTY.items()}
 COMBO_OPTIONS = list(SUBSET_MODES_PRETTY.keys())
 
 
-@tray_registry('g-subset-tools', label="Subset Tools")
+@tray_registry('g-subset-tools', label="Subset Tools", category="subset:manipulation")
 class SubsetTools(PluginTemplateMixin, LoadersMixin):
     """
     See the :ref:`Subset Tools <imviz-subset-plugin>` for more details.

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -64,7 +64,7 @@ def _coerce_unit(quantity):
     return coerced_quantity
 
 
-@tray_registry('specviz-line-analysis', label="Line Analysis", viewer_requirements='spectrum')
+@tray_registry('specviz-line-analysis', label="Line Analysis", category="data:analysis")
 class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMixin,
                    DatasetSpectralSubsetValidMixin, SpectralContinuumMixin):
     """

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -53,7 +53,7 @@ def _flux_to_sb_unit(flux_unit, angle_unit):
     return sb_unit
 
 
-@tray_registry('g-unit-conversion', label="Unit Conversion")
+@tray_registry('g-unit-conversion', label="Unit Conversion", category="viewer:options")
 class UnitConversion(PluginTemplateMixin):
     """
     The Unit Conversion plugin handles global app-wide unit-conversion.

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -33,7 +33,8 @@ _model_cls = {'Spline': models.Spline1D,
               'Chebyshev': models.Chebyshev1D}
 
 
-@tray_registry('spectral-extraction', label="Spectral Extraction")
+@tray_registry('spectral-extraction', label="Spectral Extraction",
+               category="data:reduction")
 class SpectralExtraction(PluginTemplateMixin):
     """
     The Spectral Extraction plugin exposes specreduce methods for tracing, background subtraction,

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from inspect import isclass
 
 import numpy as np
-from glue.core import HubListener
+from glue.core import ComponentID, HubListener
 from glue.core.edit_subset_mode import NewMode
 from glue.core.message import SubsetCreateMessage, SubsetDeleteMessage
 from glue.core.subset import Subset, MaskSubsetState
@@ -56,6 +56,7 @@ class ConfigHelper(HubListener):
         Verbosity of the history logger in the application.
     """
     _default_configuration = 'default'
+    _component_ids = {}
 
     def __init__(self, app=None, verbosity='warning', history_verbosity='info'):
         if app is None:
@@ -230,6 +231,22 @@ class ConfigHelper(HubListener):
             ind += 1
             name = f"{base_name}[{ind}]"
         return name
+
+    def _set_data_component(self, data, component_label, values):
+        if component_label in self._component_ids:
+            component_id = self._component_ids[component_label]
+        else:
+            existing_components = [component.label for component in data.components]
+            if component_label in existing_components:
+                component_id = data.components[existing_components.index(component_label)]
+            else:
+                component_id = ComponentID(component_label)
+                self._component_ids[component_label] = component_id
+
+        if component_id in data.components:
+            data.update_components({component_id: values})
+        else:
+            data.add_component(values, component_id)
 
     @property
     @deprecated(since="4.2", alternative="plugins['Model Fitting'].fitted_models")

--- a/jdaviz/core/registries.py
+++ b/jdaviz/core/registries.py
@@ -105,7 +105,7 @@ class TrayRegistry(UniqueDictRegistry):
     }
 
     def __call__(self, name=None, label=None, icon=None,
-                 viewer_requirements=[], overwrite=False):
+                 viewer_requirements=[], category=None, overwrite=False):
         def decorator(cls):
             # The class must inherit from `VuetifyTemplate` in order to be
             # ingestible by the component initialization.
@@ -115,12 +115,12 @@ class TrayRegistry(UniqueDictRegistry):
                     f"registered components must inherit from "
                     f"`ipyvuetify.VuetifyTemplate`.")
 
-            self.add(name, cls, label, icon, viewer_requirements, overwrite)
+            self.add(name, cls, label, icon, viewer_requirements, category, overwrite)
             return cls
         return decorator
 
     def add(self, name, cls, label=None, icon=None,
-            viewer_requirements=[], overwrite=False):
+            viewer_requirements=[], category=None, overwrite=False):
         """Add an item to the registry.
 
         Parameters
@@ -169,8 +169,13 @@ class TrayRegistry(UniqueDictRegistry):
 
             cls._registry_name = name
             cls._registry_label = label
-            self.members[name] = {'label': label, 'icon': icon, 'cls': cls,
-                                  'viewer_reference_name_kwargs': viewer_reference_name_kwargs}
+            self.members[name] = {'name': name, 'label': label, 'icon': icon, 'cls': cls,
+                                  'viewer_reference_name_kwargs': viewer_reference_name_kwargs,
+                                  'category': category}
+
+    def members_in_category(self, category):
+        members = [m for m in self.members.values() if m['category'] == category]
+        return sorted(members, key=lambda x: x['label'].lower())
 
 
 class ToolRegistry(UniqueDictRegistry):

--- a/jdaviz/core/registries.py
+++ b/jdaviz/core/registries.py
@@ -171,7 +171,7 @@ class TrayRegistry(UniqueDictRegistry):
             cls._registry_label = label
             self.members[name] = {'name': name, 'label': label, 'icon': icon, 'cls': cls,
                                   'viewer_reference_name_kwargs': viewer_reference_name_kwargs,
-                                  'category': category}
+                                  'category': category, 'overwrite': name in self.members}
 
     def members_in_category(self, category):
         members = [m for m in self.members.values() if m['category'] == category]

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1110,7 +1110,7 @@ class SelectPluginComponent(BasePluginComponent, HasTraits):
 
     def _apply_default_selection(self, skip_if_current_valid=True):
         if self.is_multiselect:
-            if skip_if_current_valid and len(self.selected) == 0:
+            if skip_if_current_valid and (self.selected is None or len(self.selected) == 0):
                 # current selection is empty and so should remain that way
                 return
             is_valid = [s in self.labels for s in self.selected]

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1755,7 +1755,7 @@ class LayerSelect(SelectPluginComponent):
             self.viewer = msg.new_viewer_ref
 
     def _get_viewer(self, viewer):
-        # newer will likely be the viewer name in most cases, but viewer id in the case
+        # viewer will likely be the viewer name in most cases, but viewer id in the case
         # of additional viewers in imviz.
         try:
             return self.app.get_viewer(viewer)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1201,6 +1201,10 @@ class SelectFileExtensionComponent(SelectPluginComponent):
         return self.manual_options[self.selected_index]
 
     @property
+    def selected_name(self):
+        return self.selected_item.get('name', None)
+
+    @property
     def indices(self):
         return [item.get('index', None) for item in self.items]
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request allows downstream packages (like lcviz) to inject plugins into the deconfigged app, and displays the plugins in the sidebar based on the entire registry instead of a predefined list of plugins in the yaml file.  Until we develop the concept of core plugins (plot options, markers, subset tools, metadata, export, coords-info) that may live places other than this sidebar, this also implements the concept of categories for sorting the plugins.  And until we develop the ability for downstream apps to add functionality to these core plugins, this temporarily overwrites the base plugin when injecting.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
