### PR TITLE
fix gwcs dev test

### DIFF
--- a/jdaviz/configs/imviz/tests/test_wcs_utils.py
+++ b/jdaviz/configs/imviz/tests/test_wcs_utils.py
@@ -168,7 +168,7 @@ def test_get_rotated_nddata_from_label_no_wcs(imviz_helper):
 def test_compute_scale():
     # NOTE: compute_scale does not work with FITS WCS.
     image_gwcs = create_example_gwcs((10, 10))
-    fiducial = [197.8925, -1.36555556] * u.deg
+    fiducial = [197.8925, -1.36555556]
 
     pixscale = wcs_utils.compute_scale(image_gwcs, fiducial, None)
     assert_allclose(pixscale, 3.0555555555555554e-05)


### PR DESCRIPTION
The issue is that a unitless forward transform can not be evaluated on points with units. The fact that this worked before was not intentional or advertised, so the fix to this test is on our end by removing units in the test case.
