### PR TITLE
Revert "temp fix: auto_label python 3.11"

### DIFF
--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -4243,13 +4243,7 @@ class AddResults(BasePluginComponent):
         Access the ``auto`` property of the ``AutoTextField`` object.  If enabling, the ``label``
         will automatically be changed and kept in sync with the default label.
         """
-        # TODO: remove when long-term fix is implemented
-        try:
-            # This line is causing a massive traceback in CI when run on python 3.11,
-            # temporarily wrap in try/except to get CI passing
-            return self.auto_label.auto
-        except AttributeError:
-            return ""
+        return self.auto_label.auto
 
     @auto.setter
     def auto(self, auto):


### PR DESCRIPTION
Reverts spacetelescope/jdaviz#3562

Looks like the logging issues were from upstream: https://github.com/spacetelescope/roman_datamodels/pull/506
