### PR TITLE
loader support for HLSP 2D spectrum

### DIFF
--- a/jdaviz/__init__.py
+++ b/jdaviz/__init__.py
@@ -23,7 +23,8 @@ _expose = ['show', 'load', 'batch_load',
            'toggle_api_hints',
            'plugins',
            'loaders',
-           'viewers']
+           'viewers',
+           'get_data']
 _incl = ['App', 'enable_hot_reloading', '__version__']
 _temporary_incl = ['open', 'Cubeviz', 'Imviz', 'Mosviz', 'Rampviz', 'Specviz', 'Specviz2d']
 __all__ = _expose + _incl + _temporary_incl

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -629,8 +629,10 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
         if axis == 'y':
             # The units have to be in surface brightness for a cube fit.
-            uc = self.app._jdaviz_helper.plugins['Unit Conversion']
-            if self.cube_fit and unit != uc._obj.sb_unit_selected:
+            uc = self.app._jdaviz_helper.plugins.get('Unit Conversion', None)
+            if uc is None:
+                pass
+            elif self.cube_fit and unit != uc._obj.sb_unit_selected:
                 self._units[axis] = uc._obj.sb_unit_selected
                 self._check_model_component_compat([axis], [u.Unit(uc._obj.sb_unit_selected)])
                 return

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -21,6 +21,7 @@ from jdaviz.core.marks import PluginMarkCollection, PluginLine
 
 from astropy.modeling import models
 from astropy.nddata import StdDevUncertainty, VarianceUncertainty, UnknownUncertainty
+from specutils import Spectrum1D
 from specreduce import tracing
 from specreduce import background
 from specreduce import extract
@@ -245,6 +246,7 @@ class SpectralExtraction(PluginTemplateMixin):
                                            'trace_dataset_items',
                                            'trace_dataset_selected',
                                            filters=['layer_in_spectrum_2d_viewer', 'not_trace'])
+        self.trace_dataset.get_data_cls = Spectrum1D
 
         self.trace_type = SelectPluginComponent(self,
                                                 items='trace_type_items',

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -4,6 +4,7 @@ from astropy import units as u
 from astropy.utils.data import download_file
 from glue.core.edit_subset_mode import NewMode
 from glue.core.roi import XRangeROI
+from specutils import Spectrum1D
 
 from jdaviz.utils import PRIHDR_KEY
 from jdaviz.configs.imviz.tests.utils import create_example_gwcs
@@ -52,6 +53,16 @@ def test_hlsp_goods_s2d(specviz2d_helper):
     specviz2d_helper.load('mast:HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst/hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits ', cache=True)  # noqa
     dc_0 = specviz2d_helper.app.data_collection[0]
     assert dc_0.get_component('flux').shape == (27, 674)
+
+
+@pytest.mark.remote_data
+def test_hlsp_goods_s2d_deconfigged(deconfigged_helper):
+    deconfigged_helper.load('mast:HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst/hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits ', cache=True)  # noqa
+    dc_0 = deconfigged_helper.app.data_collection[0]
+    assert dc_0.get_component('flux').shape == (27, 674)
+    assert isinstance(deconfigged_helper.plugins['Spectral Extraction'].trace_dataset.selected_obj, Spectrum1D)  # noqa
+    # TODO: store expected class in data itself so get_data doesn't need to pass cls
+    assert isinstance(deconfigged_helper.get_data('2D Spectrum', cls=Spectrum1D), Spectrum1D)
 
 
 def test_2d_parser_no_unit(specviz2d_helper, mos_spectrum2d):

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -47,6 +47,13 @@ def test_2d_parser_ext_hdulist(specviz2d_helper):
     assert dc_0.get_component('flux').shape == (29, 3416)
 
 
+@pytest.mark.remote_data
+def test_hlsp_goods_s2d(specviz2d_helper):
+    specviz2d_helper.load('mast:HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst/hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits ', cache=True)  # noqa
+    dc_0 = specviz2d_helper.app.data_collection[0]
+    assert dc_0.get_component('flux').shape == (27, 674)
+
+
 def test_2d_parser_no_unit(specviz2d_helper, mos_spectrum2d):
     specviz2d_helper.load_data(mos_spectrum2d, spectrum_2d_label='my_2d_spec')
     assert len(specviz2d_helper.app.data_collection) == 2

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -30,7 +30,9 @@ def hdu_is_valid(hdu):
         True if the HDU is a valid light curve HDU, False otherwise.
     """
     return (len(getattr(hdu, 'shape', [])) == 2
-            and ('DISPAXIS' in hdu.header or hdu.header.get('CTYPE1', '') == 'WAVE'))
+            and ('DISPAXIS' in hdu.header
+                 or hdu.header.get('CTYPE1', '') == 'WAVE'
+                 or hdu.header.get('EXTNAME', '') == 'FLUX'))
 
 
 @loader_importer_registry('2D Spectrum')

--- a/jdaviz/core/loaders/resolvers/url/url.py
+++ b/jdaviz/core/loaders/resolvers/url/url.py
@@ -27,12 +27,12 @@ class URLResolver(BaseResolver):
 
     @property
     def is_valid(self):
-        return urlparse(self.url).scheme in ['http', 'https', 'mast', 'ftp']
+        return urlparse(self.url.strip()).scheme in ['http', 'https', 'mast', 'ftp']
 
     @observe('url', 'cache')
     def _on_url_changed(self, change):
         self._update_format_items()
 
     def __call__(self, local_path=None, timeout=60):
-        return download_uri_to_path(self.url, cache=self.cache,
+        return download_uri_to_path(self.url.strip(), cache=self.cache,
                                     local_path=local_path, timeout=timeout)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3719,6 +3719,7 @@ class DatasetSelect(SelectPluginComponent):
       />
 
     """
+    get_data_cls = None
 
     def __init__(self, plugin, items, selected,
                  multiselect=None,
@@ -3805,7 +3806,8 @@ class DatasetSelect(SelectPluginComponent):
             if self.selected not in self.labels:
                 # _apply_default_selection will override shortly anyways
                 return None
-            match = self.app._jdaviz_helper.get_data(data_label=self.selected)
+            match = self.app._jdaviz_helper.get_data(data_label=self.selected,
+                                                     cls=self.get_data_cls)
             if match is not None:
                 return match
         # handle the case of empty Application with no viewer, we'll just pull directly


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This PR allows the spectrum 2d importer to accept `mast:HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst/hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits` as a valid input (despite not matching the other checks) and ensures future coverage with a regression test.

In doing so, this PR also (reviewers: feel free to request these in separate PRs if you'd rather, they are just small things I ran into while fixing this that helped track down the cause/solution):
* implements a few additional debugging capabilities
* strips any whitespaces from an input URL
* exposes top-level access to `get_data`
* allows `DatasetSelect` to define a default `cls` to pass to internal `get_data` calls, which then fixes support for loading these same data files into the deconfigged instance
* prevents a traceback in model fitting in the deconfigged instance if the unit conversion plugin is not yet loaded

The checks in 4.2.x are less restrictive (introduced in #3531 to avoid light curves from being parsed as 2 spectra) and so this should not need to be backported or have a bugfix changelog entry.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
