### PR TITLE
adjust component_id condition for catalog markers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -135,6 +135,9 @@ Imviz
 
 - Fixes changing alignment after creating additional image viewers. [#3553]
 
+- Fix bug where markers from catalog plugin were unable to be added to viewer after orientation
+ change, specifically for case when GWCS data uses Lon/Lat. [#3576]
+
 Mosviz
 ^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -136,7 +136,7 @@ Imviz
 - Fixes changing alignment after creating additional image viewers. [#3553]
 
 - Fix bug where markers from catalog plugin were unable to be added to viewer after orientation
- change, specifically for case when GWCS data uses Lon/Lat. [#3576]
+  change, specifically for case when GWCS data uses Lon/Lat. [#3576]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -351,3 +351,19 @@ def test_markers_gwcs_lonlat(imviz_helper):
     calib_cat = Table({'coord': [SkyCoord(80.6609, -69.4524, unit='deg')]})
     imviz_helper.default_viewer.add_markers(calib_cat, use_skycoord=True, marker_name='my_sky')
     assert imviz_helper.app.data_collection[1].label == 'my_sky'
+
+    viewer = imviz_helper.app.get_viewer('imviz-0')
+    viewer.reset_markers()
+
+    # change orientation and ensure catalogs can be plotted using new orientation
+    # data collection entry
+    orientation = imviz_helper.plugins['Orientation']
+    orientation.align_by = "WCS"
+
+    catalogs_plugin = imviz_helper.plugins['Catalog Search']
+    catalogs_plugin.catalog.selected = 'Gaia'
+    catalogs_plugin.max_sources = 10
+
+    # will fail if RA/Dec components expected in image.state.reference_data
+    with pytest.warns(ResourceWarning):
+        catalogs_plugin.search(error_on_fail=True)

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -336,7 +336,6 @@ class TestMarkers(BaseImviz_WCS_NoWCS):
             self.viewer.add_markers(tbl, use_skycoord=True, marker_name='my_sky')
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_markers_gwcs_lonlat(imviz_helper):
     """GWCS uses Lon/Lat for ICRS."""
     gw_file = get_pkg_data_filename('data/miri_i2d_lonlat_gwcs.asdf')
@@ -366,4 +365,5 @@ def test_markers_gwcs_lonlat(imviz_helper):
     catalogs_plugin.max_sources = 10
 
     # will fail if RA/Dec components expected in image.state.reference_data
-    catalogs_plugin.search(error_on_fail=True)
+    with pytest.warns(ResourceWarning):
+        catalogs_plugin.search(error_on_fail=True)

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -364,6 +364,5 @@ def test_markers_gwcs_lonlat(imviz_helper):
     catalogs_plugin.catalog.selected = 'Gaia'
     catalogs_plugin.max_sources = 10
 
-    # will fail if RA/Dec components expected in image.state.reference_data
     with pytest.warns(ResourceWarning):
         catalogs_plugin.search(error_on_fail=True)

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -336,6 +336,7 @@ class TestMarkers(BaseImviz_WCS_NoWCS):
             self.viewer.add_markers(tbl, use_skycoord=True, marker_name='my_sky')
 
 
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_markers_gwcs_lonlat(imviz_helper):
     """GWCS uses Lon/Lat for ICRS."""
     gw_file = get_pkg_data_filename('data/miri_i2d_lonlat_gwcs.asdf')
@@ -365,5 +366,4 @@ def test_markers_gwcs_lonlat(imviz_helper):
     catalogs_plugin.max_sources = 10
 
     # will fail if RA/Dec components expected in image.state.reference_data
-    with pytest.warns(ResourceWarning):
-        catalogs_plugin.search(error_on_fail=True)
+    catalogs_plugin.search(error_on_fail=True)

--- a/jdaviz/core/astrowidgets_api.py
+++ b/jdaviz/core/astrowidgets_api.py
@@ -1,6 +1,5 @@
 import os
 
-import gwcs
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
@@ -496,10 +495,8 @@ class AstrowidgetsImageViewerMixin:
                 raise AttributeError(f'{getattr(image, "label", None)} does not have a valid WCS')
             sky = table[skycoord_colname]
             t_glue = Data(marker_name, ra=sky.ra.deg, dec=sky.dec.deg)
-            dcomps = image.components
-            if (isinstance(image.coords, gwcs.WCS) and
-                    image.coords.output_frame.reference_frame.name != 'galactic' and
-                    'Lon' in dcomps and 'Lat' in dcomps):
+
+            if (image.find_component_id('Lat') and image.find_component_id('Lon')):
                 ra_str = 'Lon'
                 dec_str = 'Lat'
             else:

--- a/jdaviz/core/astrowidgets_api.py
+++ b/jdaviz/core/astrowidgets_api.py
@@ -499,9 +499,13 @@ class AstrowidgetsImageViewerMixin:
             if (image.find_component_id('Lat') and image.find_component_id('Lon')):
                 ra_str = 'Lon'
                 dec_str = 'Lat'
-            else:
+            elif (image.find_component_id('Right Ascension')
+                  and image.find_component_id('Declination')):
                 ra_str = 'Right Ascension'
                 dec_str = 'Declination'
+            else:
+                raise ValueError("Image must contain either ('Lat', 'Lon') or "
+                                 "('Right Ascension', 'Declination') components.")
             with jglue.data_collection.delay_link_manager_update():
                 jglue.data_collection[marker_name] = t_glue
                 jglue.add_link(t_glue, 'ra', image, ra_str)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address when data's GWCS uses Lon/Lat. A condition existed for adding markers in Imviz that was written before the Orientation plugin was implemented. This PR adjusts this condition to be more accepting when Lat/Lon are in the component ids of the original data/data entry created on orientation change for catalog marks. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
