### PR TITLE
loaders: improved URL resolver error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -130,6 +130,8 @@ Bug Fixes
 
 - Fixed viewer layer to persist when changing jupyter/browser tabs. [#3551]
 
+- Improved error messaging when passing invalid URL to ``load``. [#3580]
+
 Cubeviz
 ^^^^^^^
 - Replace file and fix label in example notebook. [#3537]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -128,7 +128,7 @@ Bug Fixes
 
 - Fixed bug on MOSVIZ where an exception was raised when loading JWST S2D file from a directory. [#3570]
 
-- Fixed viewer layer to persist when changing jupyter/browser tabs. [#3551]
+- Fixed viewer layout to persist when changing jupyter/browser tabs. [#3551]
 
 - Improved error messaging when passing invalid URL to ``load``. [#3580]
 

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -318,6 +318,10 @@ def find_matching_resolver(app, inp=None, resolver=None, format=None, target=Non
     invalid_resolvers = {}
     valid_resolvers = []
     for resolver_name, Resolver in loader_resolver_registry.members.items():
+        if resolver_name == 'file drop':
+            # no API input, so let's avoid always returning the confusing
+            # message that default_input is undefined
+            continue
         if resolver is not None and resolver != resolver_name:
             invalid_resolvers[resolver_name] = f'not {resolver}'
             continue

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -46,6 +46,12 @@ class FormatSelect(SelectPluginComponent):
             self._apply_default_selection()
             return
 
+        all_resolvers = []
+        self._dbg_parsers = {}
+        self._dbg_importers = {}
+        self._invalid_importers = {}
+        self._importers = {}
+
         # check for valid parser > importer combinations given the current filters
         # and resolver inputs
         try:
@@ -53,16 +59,12 @@ class FormatSelect(SelectPluginComponent):
             # but is actually the resolver.  This calls the implemented __call__ method
             # on the parent resolver.
             parser_input = self.plugin()
-        except Exception:
+        except Exception as e:
             self.items = []
+            self._invalid_importers = f'resolver exception: {e}'
             self._apply_default_selection()
             return
 
-        all_resolvers = []
-        self._dbg_parsers = {}
-        self._dbg_importers = {}
-        self._invalid_importers = {}
-        self._importers = {}
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             for parser_name, Parser in loader_parser_registry.members.items():

--- a/jdaviz/core/loaders/test_loaders.py
+++ b/jdaviz/core/loaders/test_loaders.py
@@ -115,6 +115,8 @@ def test_resolver_url(deconfigged_helper):
     assert len(deconfigged_helper.app.data_collection) == 2
     assert len(deconfigged_helper.viewers) == 2
 
+    with pytest.raises(ValueError, match="Failed query for URI"):
+        deconfigged_helper.load('mast:invalid')
 
 def test_invoke_from_plugin(specviz_helper, spectrum1d, tmp_path):
     s = SpectralRegion(5*u.um, 6*u.um)

--- a/jdaviz/core/loaders/test_loaders.py
+++ b/jdaviz/core/loaders/test_loaders.py
@@ -118,6 +118,7 @@ def test_resolver_url(deconfigged_helper):
     with pytest.raises(ValueError, match="Failed query for URI"):
         deconfigged_helper.load('mast:invalid')
 
+
 def test_invoke_from_plugin(specviz_helper, spectrum1d, tmp_path):
     s = SpectralRegion(5*u.um, 6*u.um)
     local_path = str(tmp_path / 'spectral_region.ecsv')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request improves the error when passing a URL to `.load(...)` which does not result in any object passed to the parsers.  This also skip attempting to the the "URL drop" resolver when called `.load(...)` (but is still available from `.loaders` and the UI)

For example, `jd.load('mast:invalid')` now gives:

```
ValueError: ('no valid loaders found for input, tried', {'file': 'not valid', 'url': "resolver exception: Failed query for URI 'mast:invalid' at '[https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:invalid':\n\nHTTPError](https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:invalid%27:\n\nHTTPError): 400 Client Error: Bad Request for url: https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:invalid", 'object': 'not valid'})
```

instead of:

```
ValueError: ('no valid loaders found for input, tried', {'file': 'not valid', 'file drop': 'resolver exception: Resolver subclass must implement default_input', 'url': {}, 'object': 'not valid'})
```

which hopefully will make it more obvious that there was a typo or the server is down, etc.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
