### PR TITLE
Fix loading 2D spectra that were previously ignoring spectral WCS

### DIFF
--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -553,6 +553,8 @@ class ConfigHelper(HubListener):
         if not cls:
             if 'Trace' in data.meta:
                 cls = None
+            elif hasattr(data, '_native_data_cls'):
+                cls = data._native_data_cls
             elif data.ndim == 2 and self.app.config == "specviz2d":
                 cls = Spectrum1D
             elif data.ndim == 2:

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -162,6 +162,9 @@ class BaseImporterToDataCollection(BaseImporter):
         self.app.add_data(data, data_label=data_label)
         if show_in_viewer:
             self.load_into_viewer(data_label)
+        # store the original input class so that get_data can default to the
+        # same class as the input
+        self.app.data_collection[data_label]._native_data_cls = data.__class__
 
     def __call__(self):
         if self.data_label_invalid_msg:

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -131,12 +131,7 @@ class Spectrum2DImporter(BaseImporterToDataCollection):
         except Exception:
             data_unit = u.count
 
-        # FITS WCS is invalid, so ignore it.
-        if wcs.spectral.naxis == 0:
-            kw = {}
-        else:
-            kw = {'wcs': wcs}
-
+        kw = {'wcs': wcs}
         return Spectrum1D(flux=data * data_unit, meta=metadata, **kw)
 
     def __call__(self):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes some cases in the new loaders where a 2D spectrum's WCS was ignored and also ensures that `get_data` in the deconfigged app will default to the original type of the input data.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
