### PR TITLE
Manual backport of PR 3580

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Bug Fixes
 
 - Fixed bug on MOSVIZ where an exception was raised when loading JWST S2D file from a directory. 
 
+- Improved error messaging when passing invalid URL to ``load``. [#3580]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -43,12 +43,19 @@ class FormatSelect(SelectPluginComponent):
             self._apply_default_selection()
             return
 
+        all_resolvers = []
+        self._dbg_parsers = {}
+        self._dbg_importers = {}
+        self._invalid_importers = {}
+        self._importers = {}
+
         # check for valid parser > importer combinations given the current filters
         # and resolver inputs
         try:
             parser_input = self.plugin()
-        except Exception:
+        except Exception as e:
             self.items = []
+            self._invalid_importers = f'resolver exception: {e}'
             self._apply_default_selection()
             return
 
@@ -263,6 +270,10 @@ class BaseResolver(PluginTemplateMixin):
 def find_matching_resolver(app, inp=None, resolver=None, format=None, target=None, **kwargs):
     valid_resolvers = []
     for resolver_name, Resolver in loader_resolver_registry.members.items():
+        if resolver_name == 'file drop':
+            # no API input, so let's avoid always returning the confusing
+            # message that default_input is undefined
+            continue
         if resolver is not None and resolver != resolver_name:
             continue
         try:

--- a/jdaviz/core/loaders/test_loaders.py
+++ b/jdaviz/core/loaders/test_loaders.py
@@ -119,7 +119,7 @@ def test_resolver_url(specviz_helper):
     assert len(specviz_helper.app.data_collection) == 1
 
     with pytest.raises(ValueError, match="Failed query for URI"):
-        deconfigged_helper.load('mast:invalid')
+        specviz_helper.load_data('mast:invalid', cache=False)
 
 
 def test_invoke_from_plugin(specviz_helper, spectrum1d, tmp_path):

--- a/jdaviz/core/loaders/test_loaders.py
+++ b/jdaviz/core/loaders/test_loaders.py
@@ -118,6 +118,9 @@ def test_resolver_url(specviz_helper):
 
     assert len(specviz_helper.app.data_collection) == 1
 
+    with pytest.raises(ValueError, match="Failed query for URI"):
+        deconfigged_helper.load('mast:invalid')
+
 
 def test_invoke_from_plugin(specviz_helper, spectrum1d, tmp_path):
     s = SpectralRegion(5*u.um, 6*u.um)


### PR DESCRIPTION
Manual backport of #3580 (conflicts in changelog and `resolver.py`)