### PR TITLE
Warning for loading Roman ASDF without roman_datamodels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,9 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Improved warnings when loading Roman observations without `roman_datamodels` [#3598]
+
+
 Mosviz
 ^^^^^^
 
@@ -274,8 +277,6 @@ Cubeviz
 
 - Use validator on spectral subset layer visibility in flux/uncertainty viewers when slice indicator
   is within the spectral subset bounds. [#3571]
-
-- Broadcast snackbar message to user when Collapse plugin fails to perform the collapse. [#3604]
 
 Other changes and Additions
 ---------------------------

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -135,20 +135,19 @@ def parse_data(app, file_obj, ext=None, data_label=None,
             _parse_image(app, pf, data_label, ext=ext, parent=parent)
 
         elif file_obj_lower.endswith('.asdf'):
-            try:
-                if HAS_ROMAN_DATAMODELS:
-                    with rdd.open(file_obj) as pf:
-                        _parse_image(
-                            app, pf, data_label, ext=ext, parent=parent,
-                            try_gwcs_to_fits_sip=gwcs_to_fits_sip
-                        )
-            except TypeError:
-                # if roman_datamodels cannot parse the file, load it with asdf:
-                with asdf.open(file_obj) as af:
-                    _parse_image(
-                        app, af, data_label, ext=ext, parent=parent,
-                        try_gwcs_to_fits_sip=gwcs_to_fits_sip
-                    )
+
+            if HAS_ROMAN_DATAMODELS:
+                with rdd.open(file_obj) as pf:
+                    _parse_image(app, pf, data_label, ext=ext, parent=parent)
+            else:
+                warnings.warn(
+                    f"{file_obj} should be opened with the `roman_datamodels` package, "
+                    "which is not installed in this environment. To install optional "
+                    "jdaviz dependencies for Roman, you can run:  \n\n"
+                    "pip install -U jdaviz[roman]\n\n"
+                    "This file will be loaded with the `asdf` package instead.\n\n",
+                    UserWarning
+                )
 
         elif file_obj_lower.endswith('.reg'):
             # This will load DS9 regions as Subset but only if there is already data.

--- a/jdaviz/configs/imviz/tests/test_parser_roman.py
+++ b/jdaviz/configs/imviz/tests/test_parser_roman.py
@@ -1,11 +1,12 @@
 import pytest
+import shutil
 
-# NOTE: Since this is optional dependency, codecov coverage does not include this test module.
-roman_datamodels = pytest.importorskip("roman_datamodels")
-
+from astropy.utils.data import download_file
 from gwcs import WCS as GWCS
+from jdaviz.configs.imviz.plugins.parsers import HAS_ROMAN_DATAMODELS
 
 
+@pytest.mark.skipif(not HAS_ROMAN_DATAMODELS, reason="requires optional roman deps")
 @pytest.mark.parametrize(
     ('ext_list', 'n_dc'),
     [(None, 1),
@@ -27,3 +28,28 @@ def test_roman_wfi_ext_options(imviz_helper, roman_imagemodel, ext_list, n_dc):
         assert data.label == f'roman_wfi_image_model[{ext}]'
         assert data.shape == (20, 10)  # ny, nx
         assert isinstance(data.coords, GWCS)
+
+
+@pytest.mark.remote_data
+@pytest.mark.usefixtures('_jail')
+@pytest.mark.skipif(HAS_ROMAN_DATAMODELS,
+                    reason="requires asdf, but assumes roman_datamodels not installed")
+def test_roman_wfi_ext_no_rdm(imviz_helper):
+    # check how the file is loaded with roman_datamodels
+
+    # this is a Level 2 image for SCA01 from B17.
+    file_name = '9l76vqikqfrkv2ssr8za2bo8gi4ghc8t.asdf'
+    url = f'https://stsci.box.com/shared/static/{file_name}'
+    path = download_file(url)
+
+    # copy the file out of the astropy cache to test the parser:
+    shutil.copyfile(path, file_name)
+
+    with (
+        # helpful warning for the user:
+        pytest.raises(UserWarning, match="should be opened with the `roman_datamodels` package"),
+
+        # this will ultimately fail on an import if the binary is compressed with lz4:
+        pytest.raises(ImportError, match="lz4 library in not installed")
+    ):
+        imviz_helper.load_data(file_name, data_label='roman_wfi_image_model')


### PR DESCRIPTION
### Description

Mark Kyprianou pointed out that if a user tries to load Roman ASDF images into imviz without having the optional Roman dependencies (`roman_datamodels`) installed, no visible warning is raised. 

While investigating, I realized that the imviz parser doesn't open Roman ASDF files with the `asdf` package when `roman_datamodels` isn't installed, even though it could. 

This PR:
1. updates the imviz parser to fall back on `asdf` (required dep) when `roman_datamodels` is unavailable
2. adds a test on envs without `roman_datamodels` to check that the file is opened with `asdf` instead, and gives a helpful warning message about installing optional deps.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
