### PR TITLE
Pin specutils<2.0 until #2922 is merged

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "ipywidgets>=8.0.6",
     "solara>=1.40.0",
     "pyyaml>=5.4.1",
-    "specutils>=1.18",
+    "specutils>=1.18,<2.0",
     "specreduce>=1.4.1,!=1.5.0,!=1.5.1",
     "photutils>=2.2",
     "glue-astronomy>=0.10",


### PR DESCRIPTION
Simple enough, we need #2922 to handle specutils 2.0.