### PR TITLE
Update data URI in Cubeviz and Specviz example notebooks

### DIFF
--- a/notebooks/CubevizExample.ipynb
+++ b/notebooks/CubevizExample.ipynb
@@ -71,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "uri = \"mast:JWST/product/jw02732-o004_t004_miri_ch1-short_s3d.fits\"\n",
+    "uri = \"mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_s3d.fits\"\n",
     "\n",
     "with warnings.catch_warnings():\n",
     "    warnings.simplefilter('ignore')\n",

--- a/notebooks/SpecvizExample.ipynb
+++ b/notebooks/SpecvizExample.ipynb
@@ -88,7 +88,7 @@
    },
    "outputs": [],
    "source": [
-    "specviz.load_data(\"mast:JWST/product/jw02732-o004_t004_miri_ch1-short_x1d.fits\", data_label=\"myfile\", cache=True)"
+    "specviz.load_data(\"mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_x1d.fits\", data_label=\"myfile\", cache=True)"
    ]
   },
   {
@@ -244,7 +244,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I missed these when I updated the links in the remote data tests.