### PR TITLE
expose aperture photometry api

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,8 @@ New Features
 - Added subset_label keyword argument to ``import_region`` method of Subset Tools plugin
   to name the resulting subset(s). [#3616]
 
+- Aperture Photometry public API exposed, added API hints to plugin. [#3617]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
@@ -24,13 +24,13 @@ def test_cubeviz_aperphot_cube_orig_flux(cubeviz_helper, image_cube_hdu_obj_micr
     # Make sure MASK is not an option even when shown in viewer.
     cubeviz_helper.app.add_data_to_viewer("flux-viewer", "test[MASK]", visible=True)
 
-    plg = cubeviz_helper.plugins["Aperture Photometry"]._obj
+    plg = cubeviz_helper.plugins["Aperture Photometry"]
     assert plg.dataset.labels == ["test[FLUX]", "test[ERR]"]
-    assert plg.cube_slice == "4.894e+00 um"
+    assert plg._obj.cube_slice == "4.894e+00 um"
 
-    plg.dataset_selected = "test[FLUX]"
-    plg.aperture_selected = "Subset 1"
-    plg.vue_do_aper_phot()
+    plg.dataset.selected = "test[FLUX]"
+    plg.aperture.selected = "Subset 1"
+    plg._obj.vue_do_aper_phot()
     row = plg.export_table()[0]
 
     # Basically, we should recover the input rectangle here.
@@ -50,7 +50,7 @@ def test_cubeviz_aperphot_cube_orig_flux(cubeviz_helper, image_cube_hdu_obj_micr
     # Move slider and make sure it recomputes for a new slice automatically.
     cube_slice_plg = cubeviz_helper.plugins["Slice"]._obj
     cube_slice_plg.vue_goto_first()
-    plg.vue_do_aper_phot()
+    plg._obj.vue_do_aper_phot()
     row = plg.export_table()[1]
 
     # Same rectangle but different slice value.
@@ -75,10 +75,10 @@ def test_cubeviz_aperphot_cube_orig_flux(cubeviz_helper, image_cube_hdu_obj_micr
     # Need this to make it available for photometry data drop-down.
     cubeviz_helper.app.add_data_to_viewer("uncert-viewer", "test[FLUX] collapsed")
 
-    plg = cubeviz_helper.plugins["Aperture Photometry"]._obj
-    plg.dataset_selected = "test[FLUX] collapsed"
-    plg.aperture_selected = "Subset 1"
-    plg.vue_do_aper_phot()
+    plg = cubeviz_helper.plugins["Aperture Photometry"]
+    plg.dataset.selected = "test[FLUX] collapsed"
+    plg.aperture.selected = "Subset 1"
+    plg._obj.vue_do_aper_phot()
     row = plg.export_table()[2]
 
     # Basically, we should recover the input rectangle here.
@@ -97,8 +97,8 @@ def test_cubeviz_aperphot_cube_orig_flux(cubeviz_helper, image_cube_hdu_obj_micr
 
     # Invalid counts conversion factor
     plg.counts_factor = -1
-    plg.vue_do_aper_phot()
-    assert "cannot be negative" in plg.result_failed_msg
+    plg._obj.vue_do_aper_phot()
+    assert "cannot be negative" in plg._obj.result_failed_msg
 
 
 def test_cubeviz_aperphot_generated_3d_gaussian_smooth(cubeviz_helper, image_cube_hdu_obj_microns):
@@ -117,10 +117,10 @@ def test_cubeviz_aperphot_generated_3d_gaussian_smooth(cubeviz_helper, image_cub
     aper = RectanglePixelRegion(center=PixCoord(x=1, y=2), width=3, height=5)
     cubeviz_helper.plugins['Subset Tools'].import_region(aper)
 
-    plg = cubeviz_helper.plugins["Aperture Photometry"]._obj
-    plg.dataset_selected = "test[FLUX] spatial-smooth stddev-1.0"
-    plg.aperture_selected = "Subset 1"
-    plg.vue_do_aper_phot()
+    plg = cubeviz_helper.plugins["Aperture Photometry"]
+    plg.dataset.selected = "test[FLUX] spatial-smooth stddev-1.0"
+    plg.aperture.selected = "Subset 1"
+    plg._obj.vue_do_aper_phot()
     row = cubeviz_helper.plugins['Aperture Photometry'].export_table()[0]
 
     # Basically, we should recover the input rectangle here.
@@ -155,10 +155,10 @@ def test_cubeviz_aperphot_cube_sr_and_pix2(cubeviz_helper,
     cubeviz_helper.plugins['Subset Tools'].import_region(
         [aper, bg], combination_mode='new')
 
-    plg = cubeviz_helper.plugins["Aperture Photometry"]._obj
-    plg.dataset_selected = "test[FLUX]"
-    plg.aperture_selected = "Subset 1"
-    plg.background_selected = "Subset 2"
+    plg = cubeviz_helper.plugins["Aperture Photometry"]
+    plg.dataset.selected = "test[FLUX]"
+    plg.aperture.selected = "Subset 1"
+    plg.background.selected = "Subset 2"
 
     #  Check that the default flux scaling is present for MJy / sr cubes
     if cube_unit == (u.MJy / u.sr):
@@ -182,7 +182,7 @@ def test_cubeviz_aperphot_cube_sr_and_pix2(cubeviz_helper,
         solid_angle_unit = PIX2
         cube_unit = u.MJy / solid_angle_unit  # cube unit in app is now per pix2
 
-    plg.vue_do_aper_phot()
+    plg._obj.vue_do_aper_phot()
     row = cubeviz_helper.plugins['Aperture Photometry'].export_table()[0]
 
     # Basically, we should recover the input rectangle here, minus background.
@@ -218,16 +218,16 @@ def test_cubeviz_aperphot_cube_orig_flux_mjysr(cubeviz_helper,
     cubeviz_helper.plugins['Subset Tools'].import_region([aper, bg],
                                                          combination_mode='new')
 
-    plg = cubeviz_helper.plugins["Aperture Photometry"]._obj
-    plg.dataset_selected = "test[FLUX]"
-    plg.aperture_selected = "Subset 1"
-    plg.background_selected = "Subset 2"
+    plg = cubeviz_helper.plugins["Aperture Photometry"]
+    plg.dataset.selected = "test[FLUX]"
+    plg.aperture.selected = "Subset 1"
+    plg.background.selected = "Subset 2"
 
     # Make sure per steradian is handled properly.
     assert_allclose(plg.pixel_area, 0.01)
     assert_allclose(plg.flux_scaling, 0.003631)
 
-    plg.vue_do_aper_phot()
+    plg._obj.vue_do_aper_phot()
     row = cubeviz_helper.plugins['Aperture Photometry'].export_table()[0]
 
     # Basically, we should recover the input rectangle here, minus background.
@@ -311,7 +311,7 @@ def test_cubeviz_aperphot_unit_conversions(cubeviz_helper,
 
     # get plugins
     st = cubeviz_helper.plugins['Subset Tools']
-    ap = cubeviz_helper.plugins['Aperture Photometry']._obj
+    ap = cubeviz_helper.plugins['Aperture Photometry']
     uc = cubeviz_helper.plugins['Unit Conversion']
 
     # load aperture
@@ -319,43 +319,43 @@ def test_cubeviz_aperphot_unit_conversions(cubeviz_helper,
     st.import_region(aper, combination_mode='new')
 
     # select dataset and aperture in plugin
-    ap.dataset_selected = "test[FLUX]"
-    ap.aperture_selected = "Subset 1"
+    ap.dataset.selected = "test[FLUX]"
+    ap.aperture.selected = "Subset 1"
 
     # equivalencies for unit conversion, we only need u.spectral_density because
     # no flux<>sb conversions will occur in this plugin
-    equiv = u.spectral_density(ap._cube_wave)
+    equiv = u.spectral_density(ap._obj._cube_wave)
 
     # check initial unit traitlets are synced between ap. phot and unit conv. plugins
-    assert uc.flux_unit.selected == ap.flux_scaling_display_unit == flux_unit_str
+    assert uc.flux_unit.selected == ap._obj.flux_scaling_display_unit == flux_unit_str
     assert uc.angle_unit.selected == angle_unit_str
-    assert ap.display_unit == cube_unit_str
-    assert ap.flux_scaling_display_unit == flux_unit_str
+    assert ap._obj.display_unit == cube_unit_str
+    assert ap._obj.flux_scaling_display_unit == flux_unit_str
 
     # set background to manual and background/flux scaling to 1 to make it
     # easier to compare between unit conversions
-    ap.background_selected == 'Manual'
+    ap.background.selected == 'Manual'
     ap.background_value = 1.
     ap.flux_scaling = 1.
 
     # do aperture photometry with inital cube units to compare original results
     # to results after flux unit conversion
-    ap.vue_do_aper_phot()
-    orig_tab = Table(ap.results)
+    ap._obj.vue_do_aper_phot()
+    orig_tab = Table(ap._obj.results)
 
     # set to new unit
     uc.flux_unit.selected = new_flux_unit_str
 
     # make sure display units in aperture phot plugin reflect change
-    assert (u.Unit(ap.display_unit) * angle_unit).to_string() == new_flux_unit
-    assert ap.flux_scaling_display_unit == new_flux_unit_str
+    assert (u.Unit(ap._obj.display_unit) * angle_unit).to_string() == new_flux_unit
+    assert ap._obj.flux_scaling_display_unit == new_flux_unit_str
 
     # make sure background and flux scaling were converted to new unit
     assert_allclose((ap.background_value * new_flux_unit).to(flux_unit, equiv).value, 1.)
-    assert_allclose((ap.flux_scaling * new_flux_unit).to(flux_unit, equiv).value, 1.)
+    assert_allclose((ap._obj.flux_scaling * new_flux_unit).to(flux_unit, equiv).value, 1.)
 
-    ap.vue_do_aper_phot()
-    new_tab = Table(ap.results)
+    ap._obj.vue_do_aper_phot()
+    new_tab = Table(ap._obj.results)
 
     # if ap. phot silently fails, then 'new_tab' will just be the last
     # calculated one, so make sure this didn't happen

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -44,11 +44,37 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
     Only the following attributes and methods are available through the
     :ref:`public plugin API <plugin-apis>`:
 
-    * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.show`
-    * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.open_in_tray`
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.close_in_tray`
+    * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.open_in_tray`
+    * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.show`
+    * :meth:`~jdaviz.core.template_mixin.TableMixin.clear_table`
     * :meth:`~jdaviz.core.template_mixin.TableMixin.export_table`
+    * :meth:`calculate_batch_photometry`
+    * :meth:`calculate_photometry`
     * :meth:`fitted_models`
+    * :meth:`fit_radial_profile`
+    * :meth:`unpack_batch_options`
+    * ``aperture`` (:class:`~jdaviz.core.template_mixin.SubsetSelect`):
+    * ``background`` (:class:`~jdaviz.core.template_mixin.SubsetSelect`):
+    * ``background_value``
+      Fixed value to use as background level.
+    * ``counts_factor``
+      Factor to convert data unit to counts, in unit of flux/counts.
+    * ``current_plot_type``
+      Choice of Curve of Growth, Radial Profile, or Radial Profile (Raw).
+      Only applicable when ``multiselect=False``.
+    * ``dataset`` (:class:`~jdaviz.core.template_mixin.DatasetSelect`):
+    * ``flux_scaling``
+      Flux scaling factor for calculation of magnitudes in output table.
+    * ``multiselect``
+      Enable multiselect mode to select multiple datasets for aperture photometry.
+    * ``pixel_area``
+        In arcsec squared, only used if data is in units of surface brightness.
+    * ``plot`` (:class:`~jdaviz.core.template_mixin.Plot`):
+        Plot, based on selection of ``current_plot_type``. Only applicable when
+        ``multiselect=False``
+    * ``table`` (:class:`~jdaviz.core.template_mixin.Table`):
+        Table with photometry results.
     """
     template_file = __file__, "aper_phot_simple.vue"
     uses_active_status = Bool(True).tag(sync=True)
@@ -157,14 +183,14 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
     @property
     def user_api(self):
-        # TODO: expose public API once finalized
-        # expose=('multiselect', 'dataset', 'aperture',
-        #                                   'background', 'background_value',
-        #                                   'pixel_area', 'counts_factor', 'flux_scaling',
-        #                                   'calculate_photometry',
-        #                                   'unpack_batch_options', 'calculate_batch_photometry')
+        expose = ('multiselect', 'dataset', 'aperture', 'background',
+                  'background_value', 'pixel_area', 'counts_factor', 'flux_scaling',
+                  'calculate_photometry', 'unpack_batch_options',
+                  'calculate_batch_photometry', 'table', 'clear_table',
+                  'export_table', 'fitted_models', 'current_plot_type',
+                  'fit_radial_profile', 'plot')
 
-        return PluginUserApi(self, expose=('export_table', 'fitted_models'))
+        return PluginUserApi(self, expose=expose)
 
     @property
     def fitted_models(self):

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -3,6 +3,7 @@
     :description="docs_description"
     :link="docs_link || 'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#aperture-photometry'"
     :uses_active_status="uses_active_status"
+    :api_hints_enabled.sync="api_hints_enabled"
     @plugin-ping="plugin_ping($event)"
     :keep_active.sync="keep_active"
     :popout_button="popout_button"
@@ -22,6 +23,8 @@
       :show_if_single_entry="false"
       label="Data"
       hint="Select the data for photometry."
+      api_hint="plg.dataset = "
+      :api_hints_enabled="api_hints_enabled"
     />
 
     <div v-if='config == "cubeviz" && is_cube'>
@@ -46,6 +49,8 @@
         :show_if_single_entry="true"
         label="Aperture"
         hint="Select aperture region for photometry (cannot be an annulus or composite subset)."
+        api_hint="plg.aperture = "
+        :api_hints_enabled="api_hints_enabled"
       />
 
       <v-row v-if="aperture_selected.length && !aperture_selected_validity.is_aperture">
@@ -61,6 +66,8 @@
           :show_if_single_entry="true"
           label="Background"
           hint="Select subset region for background calculation (cannot be a composite subset)."
+          api_hint="plg.background = "
+          :api_hints_enabled="api_hints_enabled"
         />
 
         <v-row v-if="(multiselect && aperture_selected.includes(background_selected)) || aperture_selected === background_selected">
@@ -76,13 +83,14 @@
         </v-row>
         <v-row v-else>
           <v-text-field
-            label="Background value"
             v-model.number="background_value"
             type="number"
             hint="Background to subtract"
             :suffix="display_unit"
             :disabled="background_selected!='Manual'"
             persistent-hint
+            :label="api_hints_enabled ? 'plg.background_value =' : 'Background value'"
+            :class="api_hints_enabled ? 'api-hint' : null"
           >
           </v-text-field>
         </v-row>
@@ -98,7 +106,8 @@
         <v-row v-if="(!multiselect || !pixel_area_multi_auto) && display_solid_angle_unit!='pix2'">
 
           <v-text-field
-            label="Pixel area"
+            :label="api_hints_enabled ? 'plg.pixel_area =' : 'Pixel area'"
+            :class="api_hints_enabled ? 'api-hint' : null"
             v-model.number="pixel_area"
             type="number"
             hint="Pixel area in arcsec squared, only used if data is in units of surface brightness."
@@ -109,7 +118,8 @@
 
         <v-row>
           <v-text-field
-            label="Counts conversion factor"
+            :label="api_hints_enabled ? 'plg.counts_factor =' : 'Counts conversion factor'"
+            :class="api_hints_enabled ? 'api-hint' : null"
             v-model.number="counts_factor"
             type="number"
             hint="Factor to convert data unit to counts, in unit of flux/counts"
@@ -129,12 +139,13 @@
         </v-row>
         <v-row v-if="!multiselect || !flux_scaling_multi_auto">
           <v-text-field
-            label="Flux scaling"
             v-model.number="flux_scaling"
             type="number"
-            :suffix="flux_scaling_display_unit"
             hint="Used in -2.5 * log(flux / flux_scaling)"
+            :suffix="flux_scaling_display_unit"
             persistent-hint
+            :label="api_hints_enabled ? 'plg.flux_scaling =' : 'Flux scaling'"
+            :class="api_hints_enabled ? 'api-hint' : null"
           >
           </v-text-field>
         </v-row>
@@ -150,6 +161,8 @@
           :selected.sync="current_plot_type"
           label="Plot Type"
           hint="Aperture photometry plot type"
+          api_hint="plg.current_plot_type = "
+          :api_hints_enabled="api_hints_enabled"
         />
 
         <v-row v-if="!multiselect && current_plot_type==='Radial Profile (Raw)' && aperture_area > 5000">
@@ -161,10 +174,11 @@
         <v-row v-if="!multiselect && current_plot_type.indexOf('Radial Profile') != -1">
 
           <v-switch
-            label="Fit Gaussian"
             hint="Fit Gaussian1D to radial profile"
             v-model="fit_radial_profile"
-            persistent-hint>
+            persistent-hint
+            :label="api_hints_enabled ? 'plg.fit_radial_profile =' : 'Fit Gaussian'"
+            :class="api_hints_enabled ? 'api-hint' : null">
           </v-switch>
         </v-row>
 
@@ -173,9 +187,14 @@
             :results_isolated_to_plugin="true"
             @click="do_aper_phot"
             :spinner="spinner"
+            :api_hints_enabled="api_hints_enabled"
             :disabled="aperture_selected === background_selected || !aperture_selected_validity.is_aperture || counts_factor < 0"
           >
-            Calculate
+            {{ api_hints_enabled ?
+              'plg.calculate_photometry()'
+              :
+              'Calculate'
+            }}
           </plugin-action-button>
         </v-row>
       </div>


### PR DESCRIPTION
Exposes the Aperture Photometry public API. Updates tests and class docstring accordingly. There are no calls to aperture photometry in example notebooks, so no updates are needed there. Added API hints.