### PR TITLE
Don't add actual subsets to CubevizProfileView

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -146,6 +146,9 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Significantly improved the performance of Cubeviz when creating several subsets in the
+  image viewer. [#3626]
+
 Imviz
 ^^^^^
 
@@ -173,9 +176,6 @@ Bug Fixes
 - Pinned specutils<2.0 until our compatibility fix is merged. [#3605]
 
 - Hide rename button in editable dropdowns in multiselect mode. [#3623]
-
-- Significantly improved the performance of Cubeviz when creating several subsets in the
-  image viewer. [#3626]
 
 Cubeviz
 ^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -174,6 +174,9 @@ Bug Fixes
 
 - Hide rename button in editable dropdowns in multiselect mode. [#3623]
 
+- Significantly improved the performance of Cubeviz when creating several subsets in the
+  image viewer. [#3626]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
@@ -83,8 +83,6 @@ class TestLoadRegions(BaseRegionHandler):
         with pytest.warns(UserWarning, match='Applying the value from the redshift slider'):
             spectral_subsets = self.cubeviz.specviz.get_spectra()
         assert list(spectral_subsets.keys()) == ['Spectrum (sum)',
-                                                 'Spectrum (sum) (Subset 2)',
-                                                 'Spectrum (Subset 1, sum)',
-                                                 'Spectrum (Subset 1, sum) (Subset 2)']
+                                                 'Spectrum (Subset 1, sum)']
         for sp in spectral_subsets.values():
             assert isinstance(sp, Spectrum1D)

--- a/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
@@ -83,6 +83,8 @@ class TestLoadRegions(BaseRegionHandler):
         with pytest.warns(UserWarning, match='Applying the value from the redshift slider'):
             spectral_subsets = self.cubeviz.specviz.get_spectra()
         assert list(spectral_subsets.keys()) == ['Spectrum (sum)',
-                                                 'Spectrum (Subset 1, sum)']
+                                                 'Spectrum (sum) (Subset 2)',
+                                                 'Spectrum (Subset 1, sum)',
+                                                 'Spectrum (Subset 1, sum) (Subset 2)']
         for sp in spectral_subsets.values():
             assert isinstance(sp, Spectrum1D)

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -356,7 +356,13 @@ class CubevizProfileView(Spectrum1DViewer, WithSliceIndicator):
     def _default_flux_viewer_reference_name(self):
         return self.jdaviz_helper._default_flux_viewer_reference_name
 
-    def add_subset(self, *args, **kwargs):
-        # The cubeviz profile viewer uses datasets to represent the subsets,
-        # so we can ignore actual glue subsets here
-        return False
+    def add_subset(self, subset, *args, **kwargs):
+        # The cubeviz profile viewer does not show the spectra/profiles based
+        # on the subsets of the cubes, but based on extracted datasets derived
+        # from those subsets. We can ignore all subsets that have a subset
+        # state that was defined from the image, and we recognize these by
+        # looking for subset states that are defined based on two attributes.
+        if len(subset.subset_state.attributes) == 2:
+            return False
+        else:
+            return super().add_subset(subset, *args, **kwargs)

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -355,3 +355,8 @@ class CubevizProfileView(Spectrum1DViewer, WithSliceIndicator):
     @property
     def _default_flux_viewer_reference_name(self):
         return self.jdaviz_helper._default_flux_viewer_reference_name
+
+    def add_subset(self, *args, **kwargs):
+        # The cubeviz profile viewer uses datasets to represent the subsets,
+        # so we can ignore actual glue subsets here
+        return False


### PR DESCRIPTION
### Description

While I don't understand the motivations behind this, it seems the cubeviz profile viewer doesn't actually use glue subsets and instead uses extracted datasets and pretends they are subsets. However, because of the way glue works, all subsets that are defined automatically get added to all datasets, and if a dataset is in a viewer, subsets will get added automatically. This means that if one had a cube loaded in cubeviz and had extracted say 10 subsets, there would be 11 datasets in the cubeviz profile viewer plus 110 subsets. The subsets were all set to be not visible, but having them in the viewer still slows things down a lot as they still all have a layer artist and state instantiated in case the visibility changes.

The simple fix is to simply not accept any subsets in the cubeviz profile viewer. This is valid usage - ``add_data`` and ``add_subset`` can just return without adding data or subsets.

With 10 subsets, this speeds up cubeviz by a factor of 9x (in addition to the new echo 0.11 release)

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
