### PR TITLE
Avoid circular calls to _on_layers_update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -179,6 +179,8 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Improve performance when adding/removing subsets by avoiding circular callbacks. [#3628]
+
 - Use validator on spectral subset layer visibility in flux/uncertainty viewers when slice indicator
   is within the spectral subset bounds. [#3571]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -143,6 +143,8 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Improve performance when adding/removing subsets by avoiding circular callbacks. [#3628]
+
 Cubeviz
 ^^^^^^^
 
@@ -178,8 +180,6 @@ Bug Fixes
 
 Cubeviz
 ^^^^^^^
-
-- Improve performance when adding/removing subsets by avoiding circular callbacks. [#3628]
 
 - Use validator on spectral subset layer visibility in flux/uncertainty viewers when slice indicator
   is within the spectral subset bounds. [#3571]

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -8,6 +8,7 @@ from glue.core.exceptions import IncompatibleAttribute
 from glue.core.subset import Subset
 from glue.core.subset_group import GroupedSubset
 from glue.viewers.scatter.state import ScatterLayerState as BqplotScatterLayerState
+from glue.utils import avoid_circular
 
 from glue_astronomy.spectral_coordinates import SpectralCoordinates
 from glue_jupyter.bqplot.profile import BqplotProfileView
@@ -354,6 +355,7 @@ class JdavizViewerMixin(WithCache):
 
         self._data_menu.visible_layers = visible_layers
 
+    @avoid_circular
     def _on_layers_update(self, layers=None):
         if self.__class__.__name__ == 'MosvizTableViewer':
             # MosvizTableViewer uses this as a mixin, but we do not need any of this layer


### PR DESCRIPTION
### Description

While debugging cubeviz performance issues, I noticed that sometimes there are ciruclar calls to _on_layers_update - that is, if an update to any of the layers is made inside the method it will then call _on_layers_update again.

Avoiding this speeds things up by a factor of 2x when 10 subsets are present.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
