### PR TITLE
deconfigged: concept of current application

### DIFF
--- a/jdaviz/__init__.py
+++ b/jdaviz/__init__.py
@@ -26,7 +26,7 @@ _expose = ['show', 'load', 'batch_load',
            'viewers',
            'new_viewers',
            'get_data']
-_incl = ['App', 'enable_hot_reloading', '__version__', 'gca', 'get_all_apps', 'new']
+_incl = ['enable_hot_reloading', '__version__', 'gca', 'get_all_apps', 'new']
 _temporary_incl = ['open', 'Cubeviz', 'Imviz', 'Mosviz', 'Rampviz', 'Specviz', 'Specviz2d']
 __all__ = _expose + _incl + _temporary_incl
 

--- a/jdaviz/__init__.py
+++ b/jdaviz/__init__.py
@@ -26,14 +26,91 @@ _expose = ['show', 'load', 'batch_load',
            'viewers',
            'new_viewers',
            'get_data']
-_incl = ['App', 'enable_hot_reloading', '__version__']
+_incl = ['App', 'enable_hot_reloading', '__version__', 'gca', 'get_all_apps', 'new']
 _temporary_incl = ['open', 'Cubeviz', 'Imviz', 'Mosviz', 'Rampviz', 'Specviz', 'Specviz2d']
 __all__ = _expose + _incl + _temporary_incl
 
 
-global _ca
+global _apps
+global _current_index
 
-_ca = App(api_hints_obj='jd')
+_apps = []
+
+
+def new(replace=False, set_as_current=True):
+    """
+    Create a new jdaviz application instance and assign as the current instance.
+
+    Parameters
+    ----------
+    replace : bool, optional
+        If True, replaces the current application instance with the new one.
+        Default is False, which means a new instance is added to the list of applications.
+    set_as_current : bool, optional
+        If True, sets the newly created application instance as the current instance.
+        Default is True.
+
+    Returns
+    -------
+    App
+        A new instance of the App class.
+    """
+    global _apps
+    global _current_index
+    ca = App(api_hints_obj='jd')
+    if replace:
+        _apps[_current_index] = ca
+    else:
+        _apps += [ca]
+        if set_as_current:
+            _current_index = len(_apps) - 1
+    return ca
+
+
+new()
+
+
+def get_all_apps():
+    """
+    Get a list of all jdaviz application instances.
+
+    Returns
+    -------
+    list
+        A list of all jdaviz application instances.
+    """
+    return _apps
+
+
+def gca(index=None, set_as_current=True):
+    """
+    Get the current jdaviz application instance.
+
+    Parameters
+    ----------
+    index : int, optional
+        The index of the application instance to retrieve.
+        Default is the current instance.
+    set_as_current : bool, optional
+        If True, sets the application instance at the specified index as the current instance.
+        Default is True.
+
+    Returns
+    -------
+    App
+        The most jdaviz application instance.
+    """
+    global _current_index
+    if index is None:
+        index = _current_index
+    app = _apps[index]
+    if set_as_current:
+        if index < 0:
+            # make sure we have a positive index so
+            # this remains fixed when adding new entries
+            index = len(_apps) + index
+        _current_index = index
+    return app
 
 
 def __dir__():
@@ -42,7 +119,7 @@ def __dir__():
 
 def __getattr__(name):
     if name in _expose:
-        return getattr(_ca, name)
+        return getattr(gca(), name)
     if name in globals():
         return globals()[name]
     raise AttributeError()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements one option for a more advanced concept of the current application at the top-level of jdaviz for deconfigged instances.  Previously, top-level access was only for the _first created_ jdaviz instance, with all other instances having to be instantiated manually and tracked as objects.  Now, all created instances are stored, with the latest created or accessed being the "current"/"default" instance used for top-level methods.

On import, and instance is automatically created and considered the current application.  For most users, they can ignore everything else.

```
import jdaviz as jd
jd.show()
```

If users want additional instances, they can do so:

```
jd.new()
```

this creates a new deconfigged instance and sets it as the current application (additional calls to `.show()`, `.loaders`, etc, will go to this instance).

Because this returns the helper, it is also possible to create a new instance but not change the "current" instance

```
other_app = jd.new(set_as_current=default)
```

or it is possible to _replace_ the current instance in memory if it is no longer needed

```
jd.new(replace=True)
```

the current helper is available to access

```
jd.gca()
```

and so is the full list of all tracked instances

```
jd.get_all_apps()
```

To change the current instance, call

```
jd.gca(index, set_as_current=True)
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
