### PR TITLE
Disable subset export formats

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -147,6 +147,8 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Disable export and raise vue error message upon selection of unsupported subset format. [#3635]
+
 - Improve performance when adding/removing subsets by avoiding circular callbacks. [#3628]
 
 - Fixed issue in ``compute_scale`` to handle the case when the wcs forward

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -147,6 +147,8 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Improve performance when adding/removing subsets by avoiding circular callbacks. [#3628]
+
 - Disable export and raise vue error message upon selection of unsupported subset format. [#3635]
 
 - Improve performance when adding/removing subsets by avoiding circular callbacks. [#3628]
@@ -163,6 +165,9 @@ Cubeviz
 
 - Broadcast snackbar message to user when sonification of a data cube completes. [#3647]
 
+- Significantly improved the performance of Cubeviz when creating several subsets in the
+  image viewer. [#3626]
+
 Imviz
 ^^^^^
 
@@ -171,6 +176,10 @@ Imviz
 - Prevent image wrapping in Imviz with Roman L2 images with GWCS. [#2887]
 
 - Fix get_zoom_limits when WCS linked and out of image bounds. [#3654]
+
+- Fix dropdowns for overlay not showing in UI. [#3640]
+
+- Prevent image wrapping in Imviz with Roman L2 images with GWCS. [#2887]
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -151,8 +151,6 @@ Bug Fixes
 
 - Disable export and raise vue error message upon selection of unsupported subset format. [#3635]
 
-- Improve performance when adding/removing subsets by avoiding circular callbacks. [#3628]
-
 - Fixed issue in ``compute_scale`` to handle the case when the wcs forward
   transform does not use units, which was previously causing issues when
   aligning by WCS. [#3658]
@@ -165,9 +163,6 @@ Cubeviz
 
 - Broadcast snackbar message to user when sonification of a data cube completes. [#3647]
 
-- Significantly improved the performance of Cubeviz when creating several subsets in the
-  image viewer. [#3626]
-
 Imviz
 ^^^^^
 
@@ -176,10 +171,6 @@ Imviz
 - Prevent image wrapping in Imviz with Roman L2 images with GWCS. [#2887]
 
 - Fix get_zoom_limits when WCS linked and out of image bounds. [#3654]
-
-- Fix dropdowns for overlay not showing in UI. [#3640]
-
-- Prevent image wrapping in Imviz with Roman L2 images with GWCS. [#2887]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -305,9 +305,8 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     @observe('viewer_selected', 'dataset_selected', 'subset_selected',
              'plugin_table_selected', 'plugin_plot_selected')
     def _sync_singleselect(self, event):
-
         if not hasattr(self, 'dataset') or not hasattr(self, 'viewer'):
-            # plugin not fully intialized
+            # plugin not fully initialized
             return
         # if multiselect is not enabled, only allow a single selection across all select components
         if self.multiselect:
@@ -541,7 +540,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             filetype = self.subset_format.selected
             filename = self._normalize_filename(filename, filetype, overwrite=overwrite)
             if self.subset_invalid_msg != '':
-                raise NotImplementedError(f'Subset can not be exported - {self.subset_invalid_msg}')
+                raise NotImplementedError(f'Subset cannot be exported - {self.subset_invalid_msg}')
             elif self.subset_format_invalid_msg:
                 raise ValueError(self.subset_format_invalid_msg)
 

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -165,6 +165,9 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                                                    filters=[self._is_valid_item],
                                                    apply_filters_to_manual_options=True)
 
+        if 'specviz' in self.config:
+            self.subset_format.selected = 'ecsv'
+
         dataset_format_options = ['fits']
         self.dataset_format = SelectPluginComponent(self,
                                                     items='dataset_format_items',

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -240,7 +240,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
         # raise vue message
         if not is_supported:
-            self.subset_format_invalid_msg = (f"Export '{self.subset.selected}' "
+            self.subset_format_invalid_msg = (f"Export of '{self.subset.selected}' "
                                               f"in '{selected}' format is not supported.")
 
         return is_supported

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -243,8 +243,6 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             self.subset_format_invalid_msg = (f"Export of '{self.subset.selected}' "
                                               f"in '{selected}' format is not supported.")
 
-        return is_supported
-
     @observe('subset_selected')
     def _on_subset_selected(self, event):
         if hasattr(self, 'subset_format'):
@@ -377,6 +375,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             else:
                 if self.subset.selected == '':
                     self.subset_invalid_msg = ''
+                    self.subset_format_invalid_msg = ''
                 elif self.app._is_subset_spectral(subset[0]):
                     self.subset_invalid_msg = ''
                 elif len(subset) > 1:
@@ -385,6 +384,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                     self.subset_invalid_msg = ''
         else:  # no subset selected (can be '' instead of None if previous selection made)
             self.subset_invalid_msg = ''
+            self.subset_format_invalid_msg = ''
 
     def _set_dataset_not_supported_msg(self, msg=None):
         if self.dataset.selected_obj is not None:

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -93,7 +93,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     # if selected subset is spectral or composite, display message and disable export
     subset_invalid_msg = Unicode().tag(sync=True)
     data_invalid_msg = Unicode().tag(sync=True)
-    format_invalid_msg = Unicode().tag(sync=True)
+    subset_format_invalid_msg = Unicode().tag(sync=True)
 
     # We currently disable exporting spectrum-viewer in Cubeviz
     viewer_invalid_msg = Unicode().tag(sync=True)
@@ -218,6 +218,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     def _on_subset_selected(self, event):
         if hasattr(self, 'subset_format'):
             self.subset_format._update_items()
+            self.subset_format_invalid_msg = ''
 
     @observe('viewer_items', 'dataset_items', 'subset_items',
              'plugin_table_items', 'plugin_plot_items')
@@ -366,11 +367,11 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
         if bad_combo:
             # raise vue message
-            self.format_invalid_msg = (f"Cannot export '{self.subset.selected}' "
+            self.subset_format_invalid_msg = (f"Cannot export '{self.subset.selected}' "
                                        f"in '{event['new']}' format.")
-            raise ValueError(f"{self.format_invalid_msg}")
+            raise ValueError(f"{self.subset_format_invalid_msg}")
         else:
-            self.format_invalid_msg = ''
+            self.subset_format_invalid_msg = ''
 
     def _set_subset_not_supported_msg(self, msg=None):
         """
@@ -550,8 +551,8 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             filename = self._normalize_filename(filename, filetype, overwrite=overwrite)
             if self.subset_invalid_msg != '':
                 raise NotImplementedError(f'Subset can not be exported - {self.subset_invalid_msg}')
-            elif self.format_invalid_msg:
-                raise ValueError(self.format_invalid_msg)
+            elif self.subset_format_invalid_msg:
+                raise ValueError(self.subset_format_invalid_msg)
 
             if self.overwrite_warn and not overwrite:
                 if raise_error_for_overwrite:

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -550,10 +550,14 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             filename = self._normalize_filename(filename, filetype, overwrite=overwrite)
             if self.subset_invalid_msg != '':
                 raise NotImplementedError(f'Subset can not be exported - {self.subset_invalid_msg}')
+            elif self.format_invalid_msg:
+                raise ValueError(self.format_invalid_msg)
+
             if self.overwrite_warn and not overwrite:
                 if raise_error_for_overwrite:
                     raise FileExistsError(f"{filename} exists but overwrite=False")
                 return
+
             if self.subset_format.selected in ('fits', 'reg'):
                 self.save_subset_as_region(selected_subset_label, filename)
             elif self.subset_format.selected == 'ecsv':

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -366,8 +366,8 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
         if bad_combo:
             # raise vue message
-            self.format_invalid_msg = (f"Cannot export {self.subset.selected} "
-                                       f"in {event['new']} format.")
+            self.format_invalid_msg = (f"Cannot export '{self.subset.selected}' "
+                                       f"in '{event['new']}' format.")
             raise ValueError(f"{self.format_invalid_msg}")
         else:
             self.format_invalid_msg = ''

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -93,6 +93,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     # if selected subset is spectral or composite, display message and disable export
     subset_invalid_msg = Unicode().tag(sync=True)
     data_invalid_msg = Unicode().tag(sync=True)
+    format_invalid_msg = Unicode().tag(sync=True)
 
     # We currently disable exporting spectrum-viewer in Cubeviz
     viewer_invalid_msg = Unicode().tag(sync=True)
@@ -364,12 +365,14 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             bad_combo = True
 
         if bad_combo:
-            # Set back to a good value and raise error
+            # Set back to a good value and raise vue message
             good_format = [format["label"] for format in self.subset_format_items if
                            format["disabled"] is False][0]
             self.subset_format.selected = good_format
-            raise ValueError(f"Cannot export {self.subset.selected} in {event['new']}"
-                             f" format, reverting selection to {self.subset_format.selected}")
+            self.format_invalid_msg = f"Cannot export '{self.subset.selected}' in {event['new']}" \
+                f" format, reverting selection to {self.subset_format.selected}."
+        else:
+            self.format_invalid_msg = ''
 
     def _set_subset_not_supported_msg(self, msg=None):
         """

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -365,12 +365,8 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             bad_combo = True
 
         if bad_combo:
-            # Set back to a good value and raise vue message
-            good_format = [format["label"] for format in self.subset_format_items if
-                           format["disabled"] is False][0]
-            self.subset_format.selected = good_format
-            self.format_invalid_msg = f"Cannot export '{self.subset.selected}' in {event['new']}" \
-                f" format, reverting selection to {self.subset_format.selected}."
+            # raise vue message
+            self.format_invalid_msg = f"Cannot export '{self.subset.selected}' in {event['new']}."
         else:
             self.format_invalid_msg = ''
 

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -261,7 +261,6 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             else:
                 self.subset_format_dict['spatial'] = selected
 
-
     @observe('viewer_items', 'dataset_items', 'subset_items',
              'plugin_table_items', 'plugin_plot_items')
     def _set_relevant(self, *args):
@@ -387,16 +386,16 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                 return
             if self.app._is_subset_spectral(subset[0]):
                 subset_type = 'spectral'
-                good_formats = ["ecsv"]
+                good_formats = ['ecsv']
             else:
                 subset_type = 'spatial'
                 good_formats = ['fits', 'reg']
 
             for item in self.subset_format_items:
-                if item["label"] in good_formats:
-                    item["disabled"] = False
+                if item['label'] in good_formats:
+                    item['disabled'] = False
                 else:
-                    item["disabled"] = True
+                    item['disabled'] = True
 
                 new_items.append(item)
 

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -366,7 +366,9 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
         if bad_combo:
             # raise vue message
-            self.format_invalid_msg = f"Cannot export '{self.subset.selected}' in {event['new']}."
+            self.format_invalid_msg = (f"Cannot export {self.subset.selected} "
+                                       f"in {event['new']} format.")
+            raise ValueError(f"{self.format_invalid_msg}")
         else:
             self.format_invalid_msg = ''
 

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -165,9 +165,9 @@
         </div>
       </v-row>
 
-      <v-row v-if="format_invalid_msg.length > 0">
+      <v-row v-if="subset_format_invalid_msg.length > 0">
         <span class="category-content v-messages v-messages__message text--secondary" style="color: red !important">
-          {{format_invalid_msg}}
+          {{subset_format_invalid_msg}}
         </span>
       </v-row>
 
@@ -281,7 +281,7 @@
                    movie_recording ||
                    subset_invalid_msg.length > 0 ||
                    data_invalid_msg.length > 0 ||
-                   format_invalid_msg.length > 0 ||
+                   subset_format_invalid_msg.length > 0 ||
                    viewer_invalid_msg.length > 0 ||
                    (viewer_selected.length > 0 && viewer_format_selected == 'mp4' && !movie_enabled)"
       >

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -164,6 +164,13 @@
           />
         </div>
       </v-row>
+
+      <v-row v-if="format_invalid_msg.length > 0">
+        <span class="category-content v-messages v-messages__message text--secondary" style="color: red !important">
+          {{format_invalid_msg}}
+        </span>
+      </v-row>
+
     </div>
 
     <div v-if="plugin_table_items.length > 0 && serverside_enabled">

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -279,7 +279,9 @@
         :api_hints_enabled="api_hints_enabled"
         :disabled="filename_value.length === 0 ||
                    movie_recording ||
-                   subset_invalid_msg.length > 0 || data_invalid_msg.length > 0 ||
+                   subset_invalid_msg.length > 0 ||
+                   data_invalid_msg.length > 0 ||
+                   format_invalid_msg.length > 0 ||
                    viewer_invalid_msg.length > 0 ||
                    (viewer_selected.length > 0 && viewer_format_selected == 'mp4' && !movie_enabled)"
       >

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -45,7 +45,7 @@ class TestExportSubsets:
         for current_format in spatial_valid_formats:
             export_plugin.subset_format.selected = current_format
             assert export_plugin.subset_format.selected == current_format
-            assert export_plugin.subset_invalid_msg == '' # for non-composite spatial
+            assert export_plugin.subset_invalid_msg == ''  # for non-composite spatial
             assert export_plugin.subset_format_invalid_msg == ''
 
             assert export_plugin.filename.value.endswith(f".{current_format}")

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -66,7 +66,7 @@ class TestExportSubsets:
 
         # test that invalid file extension raises an error
         with pytest.raises(ValueError,
-                           match=re.escape("'x' not one of ['fits', 'reg', 'ecsv']")):  # noqa
+                           match=re.escape("'x' not one of ['fits', 'reg', 'ecsv'], reverting selection to 'reg'")):  # noqa
             export_plugin.subset_format.selected = 'x'
 
     def test_not_implemented(self, cubeviz_helper, spectral_cube_wcs):
@@ -181,11 +181,11 @@ class TestExportSubsets:
 
         # test that invalid file extension raises an error
         with pytest.raises(ValueError,
-                           match=re.escape("'x' not one of ['fits', 'reg', 'ecsv']")):  # noqa
+                           match=re.escape("'x' not one of ['fits', 'reg', 'ecsv'], reverting selection to 'reg'")):  # noqa
             export_plugin.subset_format.selected = 'x'
 
         # Test that selecting disabled option raises an error
-        with pytest.raises(ValueError, match="Cannot export Subset 1 in ecsv format."):  # noqa
+        with pytest.raises(ValueError, match="Cannot export 'Subset 1' in 'ecsv' format."):  # noqa
             export_plugin.subset_format.selected = 'ecsv'
 
         # test that attempting to save a composite subset raises an error

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -193,13 +193,13 @@ class TestExportSubsets:
 
         # test that invalid file extension raises an error
         with pytest.raises(ValueError,
-                           match = re.escape(
+                           match=re.escape(
                                "'x' not one of ['fits', 'reg', 'ecsv'], reverting selection to 'reg'")):  # noqa
             export_plugin.subset_format.selected = 'x'
 
         # Test that selecting disabled option raises an error
         with pytest.raises(ValueError,
-                           match = "Cannot export 'Subset 1' in 'ecsv' format."):  # noqa
+                           match="Cannot export 'Subset 1' in 'ecsv' format."):  # noqa
             export_plugin.subset_format.selected = 'ecsv'
 
         # test that attempting to save a composite subset raises an error

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -196,7 +196,7 @@ class TestExportSubsets:
             # Finally, attempt to export with Spectral subset
             export_plugin.subset.selected = spectral_subset
             with pytest.raises(ValueError,
-                               match = f"Export of '{spectral_subset}' "
+                               match=f"Export of '{spectral_subset}' "
                                        f"in '{current_format}' format is not supported."):  # noqa
                 export_plugin.export()
 
@@ -254,8 +254,7 @@ class TestExportSubsets:
         export_plugin.subset.selected = spectral_subset
         export_plugin.filename_value = "test_spectral_region"
         export_plugin.export()
-        assert os.path.isfile(f'test_spectral_region.ecsv')
-
+        assert os.path.isfile('test_spectral_region.ecsv')
 
     def test_export_stcs_circle_ellipse(self, imviz_helper):
         wcs = WCS({'CTYPE1': 'RA---TAN', 'CUNIT1': 'deg', 'CDELT1': -0.0002777777778,

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -66,7 +66,7 @@ class TestExportSubsets:
 
         # test that invalid file extension raises an error
         with pytest.raises(ValueError,
-                           match=re.escape("'x' not one of ['fits', 'reg', 'ecsv'], reverting selection to 'reg'")):  # noqa
+                           match=re.escape("'x' not one of ['fits', 'reg', 'ecsv']")):  # noqa
             export_plugin.subset_format.selected = 'x'
 
     def test_not_implemented(self, cubeviz_helper, spectral_cube_wcs):
@@ -181,11 +181,11 @@ class TestExportSubsets:
 
         # test that invalid file extension raises an error
         with pytest.raises(ValueError,
-                           match=re.escape("'x' not one of ['fits', 'reg', 'ecsv'], reverting selection to 'reg'")):  # noqa
+                           match=re.escape("'x' not one of ['fits', 'reg', 'ecsv']")):  # noqa
             export_plugin.subset_format.selected = 'x'
 
         # Test that selecting disabled option raises an error
-        with pytest.raises(ValueError, match="Cannot export Subset 1 in ecsv format, reverting selection to fits"):  # noqa
+        with pytest.raises(ValueError, match="Cannot export Subset 1 in ecsv format."):  # noqa
             export_plugin.subset_format.selected = 'ecsv'
 
         # test that attempting to save a composite subset raises an error

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -31,38 +31,45 @@ class TestExportSubsets:
         export_plugin = imviz_helper.plugins['Export']._obj
         export_plugin.subset.selected = 'Subset 1'
 
-        assert export_plugin.subset_format.selected == 'fits'  # default format
-        assert export_plugin.subset_invalid_msg == ''  # for non-composite spatial
+        # Make no assumptions on default since the 'default' is now
+        # set by the first option in the list of available formats
+        # (but it's *almost* 100% likely to be fits)
+        spatial_valid_formats = ['fits', 'reg']
+        assert export_plugin.subset_format.selected in spatial_valid_formats
 
-        assert export_plugin.filename.value.endswith('.fits')
-        export_plugin.export()
-        assert os.path.isfile(export_plugin.filename.value)
+        for current_format in spatial_valid_formats:
+            export_plugin.subset_format.selected = current_format
+            assert export_plugin.subset_format.selected == current_format
+            assert export_plugin.subset_invalid_msg == ''  # for non-composite spatial
 
-        # read exported file back in
-        with fits.open(export_plugin.filename.value) as hdu:
-            fits_region = hdu[1].data[0]
+            assert export_plugin.filename.value.endswith(f".{current_format}")
+            export_plugin.export()
+            assert os.path.isfile(export_plugin.filename.value)
 
-        assert fits_region[0] == 'circle'
-        assert fits_region[1] == fits_region[2] == 250.0
-        assert fits_region[3] == 100.0
-        assert fits_region[4] == 0.0
+            # changing file name and catching the result (the new filename/path)
+            # for checking the file
+            new_filename = 'test'
+            export_plugin.filename.value = new_filename
+            output_filename = export_plugin.export()
+            assert os.path.isfile(f'{new_filename}.{current_format}')
+            assert os.path.isfile(output_filename)
 
-        # now test changing file format
-        export_plugin.subset_format.selected = 'reg'
-        assert export_plugin.filename.value.endswith('.reg')
-        export_plugin.export()
-        assert os.path.isfile(export_plugin.filename.value)
+            if current_format == 'fits':
+                # read exported file back in
+                with fits.open(output_filename) as hdu:
+                    fits_region = hdu[1].data[0]
 
-        # read exported file back in
-        region = Regions.read(export_plugin.filename.value)[0]
-        assert region.center.x == 250.0
-        assert region.center.y == 250.0
-        assert region.radius == 100.0
+                assert fits_region[0] == 'circle'
+                assert fits_region[1] == fits_region[2] == 250.0
+                assert fits_region[3] == 100.0
+                assert fits_region[4] == 0.0
 
-        # changing file name
-        export_plugin.filename_value = 'test'
-        export_plugin.export()
-        assert os.path.isfile('test.reg')
+            elif current_format == 'reg':
+                # read exported file back in
+                region = Regions.read(output_filename)[0]
+                assert region.center.x == 250.0
+                assert region.center.y == 250.0
+                assert region.radius == 100.0
 
         # test that invalid file extension raises an error
         with pytest.raises(ValueError,
@@ -129,36 +136,41 @@ class TestExportSubsets:
         export_plugin = cubeviz_helper.plugins['Export']._obj
         export_plugin.subset.selected = 'Subset 1'
 
-        assert export_plugin.subset_format.selected == 'fits'  # default format
+        # Again no assumptions here on default
+        spatial_valid_formats = ['fits', 'reg']
+        assert export_plugin.subset_format.selected in spatial_valid_formats
 
-        assert export_plugin.filename.value.endswith('.fits')
-        export_plugin.export()
-        assert os.path.isfile(export_plugin.filename.value)
+        for current_format in spatial_valid_formats:
+            export_plugin.subset_format.selected = current_format
+            assert export_plugin.subset_format.selected == current_format  # default format
+            assert export_plugin.filename.value.endswith(current_format)
+            export_plugin.export()
+            assert os.path.isfile(export_plugin.filename.value)
 
-        # read exported file back in
-        with fits.open(export_plugin.filename.value) as hdu:
-            fits_region = hdu[1].data[0]
+            # changing file name and catching the result (the new filename/path)
+            # for checking the file
+            new_filename = 'test'
+            export_plugin.filename.value = new_filename
+            output_filename = export_plugin.export()
+            assert os.path.isfile(f'{new_filename}.{current_format}')
+            assert os.path.isfile(output_filename)
 
-        assert fits_region[0] == 'circle'
-        assert fits_region[1] == fits_region[2] == 50.0
-        assert fits_region[3] == 10.0
-        assert fits_region[4] == 0.0
+            if current_format == 'fits':
+                # read exported file back in
+                with fits.open(output_filename) as hdu:
+                    fits_region = hdu[1].data[0]
 
-        # now test changing file format
-        export_plugin.subset_format.selected = 'reg'
-        export_plugin.export()
-        assert os.path.isfile(export_plugin.filename.value)
+                assert fits_region[0] == 'circle'
+                assert fits_region[1] == fits_region[2] == 50.0
+                assert fits_region[3] == 10.0
+                assert fits_region[4] == 0.0
 
-        # read exported file back in
-        region = Regions.read(export_plugin.filename.value)[0]
-        assert region.center.x == 50.0
-        assert region.center.y == 50.0
-        assert region.radius == 10.0
-
-        # changing file name
-        export_plugin.filename_value = 'test'
-        export_plugin.export()
-        assert os.path.isfile('test.reg')
+            elif current_format == 'reg':
+                # read exported file back in
+                region = Regions.read(output_filename)[0]
+                assert region.center.x == 50.0
+                assert region.center.y == 50.0
+                assert region.radius == 10.0
 
         # Overwrite not enable, so no-op with warning.
         export_plugin.export(raise_error_for_overwrite=False)
@@ -181,11 +193,13 @@ class TestExportSubsets:
 
         # test that invalid file extension raises an error
         with pytest.raises(ValueError,
-                           match=re.escape("'x' not one of ['fits', 'reg', 'ecsv'], reverting selection to 'reg'")):  # noqa
+                           match = re.escape(
+                               "'x' not one of ['fits', 'reg', 'ecsv'], reverting selection to 'reg'")):  # noqa
             export_plugin.subset_format.selected = 'x'
 
         # Test that selecting disabled option raises an error
-        with pytest.raises(ValueError, match="Cannot export 'Subset 1' in 'ecsv' format."):  # noqa
+        with pytest.raises(ValueError,
+                           match = "Cannot export 'Subset 1' in 'ecsv' format."):  # noqa
             export_plugin.subset_format.selected = 'ecsv'
 
         # test that attempting to save a composite subset raises an error
@@ -194,7 +208,11 @@ class TestExportSubsets:
         subset_plugin.import_region(CircularROI(xc=20, yc=25, radius=5), edit_subset='Subset 1',
                                     combination_mode='and')
 
+        old_format = 'reg'
         export_plugin.subset.selected = 'Subset 1'
+        # This needs to be set again otherwise we'll raise an error because the selected format
+        # is still 'ecsv' from the ValueError test above.
+        export_plugin.subset_format.selected = old_format
         assert export_plugin.subset_invalid_msg == 'Export for composite subsets not yet supported.'
         with pytest.raises(NotImplementedError,
                            match='Subset can not be exported - Export for composite subsets not yet supported.'):  # noqa
@@ -206,18 +224,24 @@ class TestExportSubsets:
         subset_plugin.import_region(SpectralRegion(5 * spectral_axis_unit,
                                                    15.5 * spectral_axis_unit))
         export_plugin.subset.selected = 'Subset 2'
+        current_format = 'ecsv'
 
         # Format should auto-update to first non-disabled entry
-        assert export_plugin.subset_format.selected == 'ecsv'
+        assert export_plugin.subset_format.selected == current_format
         for format in export_plugin.subset_format.items:
-            if format['label'] != 'ecsv':
+            if format['label'] != current_format:
                 assert format['disabled']
             else:
                 assert format['disabled'] is False
 
         export_plugin.filename_value = "test_spectral_region"
         export_plugin.export()
-        assert os.path.isfile('test_spectral_region.ecsv')
+        assert os.path.isfile(f'test_spectral_region.{current_format}')
+
+        # Confirm that flipping back to 'Subset 1' returns the format to 'reg'
+        # not the default 'fits'
+        export_plugin.subset.selected = 'Subset 1'
+        assert export_plugin.subset_format.selected == old_format
 
     def test_export_stcs_circle_ellipse(self, imviz_helper):
         wcs = WCS({'CTYPE1': 'RA---TAN', 'CUNIT1': 'deg', 'CDELT1': -0.0002777777778,


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address API behavior that raised an error message and
automatically reverted bad subset formats to an allowed default format. 
* In the UI, a vue message is displayed while also raising an error (necessary for users
working solely in code). 
* The export button is also now disabled when a bad format
is selected.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes [JDAT-5374](https://jira.stsci.edu/browse/JDAT-5374)

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
