### PR TITLE
audit warnings in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,9 +142,7 @@ filterwarnings = [
     "ignore:.*With traitlets 4\\.1, metadata should be set using the \\.tag\\(\\) method:DeprecationWarning",
     "ignore:The unit 'Angstrom' has been deprecated in the VOUnit standard\\. Suggested.* 0\\.1nm\\.",
     "ignore:((.|\n)*)Sentinel is not a public part of the traitlets API((.|\n)*)",
-    "ignore:datetime\\.datetime\\.utcfromtimestamp:DeprecationWarning",  # asdf + dateutil<=2.8.2 + Python 3.12
     "ignore:'audioop' is deprecated and slated for removal in Python 3.13",
-    "ignore:Importing display from IPython.core.display is deprecated since IPython 7.14, please import from IPython.display",
     "ignore:Parsing dates involving a day of month without a year:DeprecationWarning",  # ipykernel<7
     "ignore::DeprecationWarning:glue",
     "ignore::DeprecationWarning:asteval",
@@ -154,9 +152,6 @@ filterwarnings = [
     # and https://github.com/scipy/scipy/pull/19275
     "ignore:.*numpy\\.core.*:DeprecationWarning",
     "ignore:The load_data function is deprecated.*",
-    "ignore:.*use_side_effect is deprecated.*",
-    "ignore:.*The WCS transformation has more axes.*",
-    "ignore:.*from MJD-BEG.*",
     "ignore:.*Set OBSGEO-L to.*",
 ]
 


### PR DESCRIPTION
Removes several ignored warnings from pyproject.toml that no longer come up as failures/errors in CI