### PR TITLE
Only run 3.13 devdeps remote data test after other tests complete

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -69,15 +69,6 @@ jobs:
             toxenv: py313-test
             allow_failure: false
 
-          # This also runs on cron but we want to make sure new changes
-          # won't break this job at the PR stage.
-          - name: Python 3.13 with latest dev versions of key dependencies, and remote data
-            os: ubuntu-latest
-            python: '3.13'
-            toxenv: py313-test-devdeps
-            toxposargs: --remote-data --run-slow
-            allow_failure: true
-
           - name: Python 3.11 with stable versions of dependencies and Roman
             os: ubuntu-latest
             python: '3.11'
@@ -110,6 +101,29 @@ jobs:
         name: coverage_${{ matrix.toxenv }}.xml
         path: coverage.xml
         if-no-files-found: error
+
+  # This job depends on the successful completion of ci_tests,
+  # so that it will run after the other remote data test succeeds
+  ci_test_py313_devdeps:
+    name: Python 3.13 with latest dev versions of key dependencies, and remote data
+    runs-on: ubuntu-latest
+    needs: ci_tests
+    continue-on-error: true
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.13
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      with:
+        python-version: '3.13'
+    - name: Install base dependencies
+      run: python -m pip install --upgrade pip tox
+    - name: Get IP address for MAST debugging
+      run: curl https://api.ipify.org
+    - name: Test/run with tox
+      run: tox -e py313-test-devdeps -- --remote-data --run-slow
 
   upload-codecov:
     needs: [ ci_tests ]


### PR DESCRIPTION
This is a test to see if this helps with our remote data timeouts, at Scott/Cami's request.