### PR TITLE
add temporary current app implementation for Cobalt dev

### DIFF
--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -14,11 +14,24 @@ from jdaviz.utils import (data_has_valid_wcs, get_wcs_only_layer_labels,
 
 __all__ = ['Imviz']
 
+# temporary implementation of a "current app" feature for imviz,
+# useful for Cobalt dev work until imviz is fully superceded by
+# the current app feature in deconfigged. see:
+# https://github.com/spacetelescope/jdaviz/pull/3632
+global _current_app
+_current_app = None
+
 
 class Imviz(ImageConfigHelper):
     """Imviz Helper class."""
     _default_configuration = 'imviz'
     _default_viewer_reference_name = "image-viewer"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        global _current_app
+        _current_app = self
 
     def create_image_viewer(self, viewer_name=None):
         """Create a new image viewer.

--- a/jdaviz/configs/imviz/tests/test_helper.py
+++ b/jdaviz/configs/imviz/tests/test_helper.py
@@ -37,3 +37,8 @@ def test_create_new_viewer(imviz_helper, image_2d_wcs):
     # remove data from the new viewer, check that it was removed
     imviz_helper.app.remove_data_from_viewer(viewer_name, data_label)
     assert len(imviz_helper.app.get_viewer(viewer_name).data()) == 0
+
+
+def test_temporary_imviz_current_app(imviz_helper):
+    from jdaviz.configs.imviz.helper import _current_app
+    assert _current_app == imviz_helper


### PR DESCRIPTION
### Description

This PR unblocks some dev work on Cobalt by giving us access to a `gca` feature in Imviz. 

`gca()` for `deconfig` is being developed in https://github.com/spacetelescope/jdaviz/pull/3632. `deconfig` does not yet support all imviz functionality, and that work is in progress this sprint. 

This PR adds a very minimal implementation of the `gca` feature to Imviz. We can use this private implementation in the MAST upscope work until the more general version in #3632 supports our workflows.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
