### PR TITLE
add successful sonified data snackbar message (#3647)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Cubeviz
 - Significantly improved the performance of Cubeviz when creating several subsets in the
   image viewer. [#3626]
 
+- Broadcast snackbar message to user when sonification of a data cube completes. [#3647]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -108,7 +108,7 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
         spec_at_spaxel_tool = self.flux_viewer.toolbar.tools['jdaviz:spectrumperspaxel']
         self.flux_viewer.toolbar.active_tool = spec_at_spaxel_tool
 
-        msg = SnackbarMessage(f"'{self.results_label}' sonified successfully.",
+        msg = SnackbarMessage(f"Data cube sonified successfully.",
                               color='success',
                               sender=self)
         self.app.hub.broadcast(msg)

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -108,7 +108,7 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
         spec_at_spaxel_tool = self.flux_viewer.toolbar.tools['jdaviz:spectrumperspaxel']
         self.flux_viewer.toolbar.active_tool = spec_at_spaxel_tool
 
-        msg = SnackbarMessage(f"Data cube sonified successfully.",
+        msg = SnackbarMessage("Data cube sonified successfully.",
                               color='success',
                               sender=self)
         self.app.hub.broadcast(msg)

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -6,6 +6,7 @@ from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin, DatasetSelectMixin,
                                         SpectralSubsetSelectMixin, with_spinner)
 from jdaviz.core.user_api import PluginUserApi
+from jdaviz.core.events import SnackbarMessage
 
 
 __all__ = ['SonifyData']
@@ -106,6 +107,11 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
         # Automatically select spectrum-at-spaxel tool
         spec_at_spaxel_tool = self.flux_viewer.toolbar.tools['jdaviz:spectrumperspaxel']
         self.flux_viewer.toolbar.active_tool = spec_at_spaxel_tool
+
+        msg = SnackbarMessage(f"'{self.results_label}' sonified successfully.",
+                              color='success',
+                              sender=self)
+        self.app.hub.broadcast(msg)
 
     def vue_start_stop_stream(self, *args):
         self.stream_active = not self.stream_active


### PR DESCRIPTION
Manual Backport of #3647 

* add successful sonified data snackbar message

* update change log, styling

* use results label in messasge

(cherry picked from commit 8973df4b47bf948ebe6075ab4f0f08623269e445)

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
