### PR TITLE
Allow downloading from MastMissions instead of Observations

### DIFF
--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -93,7 +93,6 @@ class Specviz(ConfigHelper, LineListMixin):
         if mast_mission is not None:
             load_kwargs['mast_mission'] = mast_mission
 
-
         if isinstance(data, (SpectrumList, SpectrumCollection)) and isinstance(data_label, list):
             if len(data_label) != len(data):
                 raise ValueError(f"Length of data labels list ({len(data_label)}) is different"

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -46,7 +46,7 @@ class Specviz(ConfigHelper, LineListMixin):
     @deprecated(since="4.3", alternative="load")
     def load_data(self, data, data_label=None, format=None, show_in_viewer=True,
                   concat_by_file=False, cache=None, local_path=None, timeout=None,
-                  load_as_list=False):
+                  load_as_list=False, mast_mission=None):
         """
         Load data into Specviz.
 
@@ -90,6 +90,9 @@ class Specviz(ConfigHelper, LineListMixin):
             load_kwargs['timeout'] = timeout
         if local_path is not None:
             load_kwargs['local_path'] = local_path
+        if mast_mission is not None:
+            load_kwargs['mast_mission'] = mast_mission
+
 
         if isinstance(data, (SpectrumList, SpectrumCollection)) and isinstance(data_label, list):
             if len(data_label) != len(data):
@@ -114,6 +117,7 @@ class Specviz(ConfigHelper, LineListMixin):
             format = '1D Spectrum'
         if data_label is not None:
             data_label = self.app.return_unique_name(data_label)
+        print(load_kwargs)
         self.load(data, format=format,
                   data_label=data_label,
                   show_in_viewer=show_in_viewer,

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -173,6 +173,7 @@ class ConfigHelper(HubListener):
             Additional kwargs are passed on to both the loader and importer, as applicable.
             Any kwargs that do not match valid inputs are silently ignored.
         """
+        print(kwargs)
         resolver = find_matching_resolver(self.app, inp,
                                           resolver=loader,
                                           format=format,

--- a/jdaviz/core/launcher.py
+++ b/jdaviz/core/launcher.py
@@ -50,6 +50,9 @@ def open(filename, show=True, **kwargs):
         fn_dl_kw = {"local_path": kwargs["local_path"]}
     else:
         fn_dl_kw = {}
+    if "mast_mission" in kwargs:
+        fn_dl_kw["mast_mission"] = kwargs['mast_mission']
+
     filename = download_uri_to_path(filename, cache=True, **fn_dl_kw)
 
     # Identify the correct config
@@ -58,6 +61,8 @@ def open(filename, show=True, **kwargs):
         raise NotImplementedError(f"Multiple helpers provided: {compatible_helpers}."
                                   "Unsure which to launch")
     else:
+        if "mast_mission" in kwargs:
+            kwargs.pop('mast_mission')
         return _launch_config_with_data(compatible_helpers[0], hdul, filepath=filename,
                                         show=show, **kwargs)
 

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -225,8 +225,11 @@ class BaseResolver(PluginTemplateMixin):
             raise NotImplementedError("Resolver subclass must implement default_input")  # noqa pragma: nocover
         setattr(self, self.default_input, inp)
         user_api = self.user_api
+        print(kwargs)
         for k, v in kwargs.items():
+            print(f"checking {k}")
             if hasattr(user_api, k):
+                print(f"Setting {k} to {v}")
                 setattr(user_api, k, v)
         return self
 

--- a/jdaviz/core/loaders/resolvers/url/url.py
+++ b/jdaviz/core/loaders/resolvers/url/url.py
@@ -39,7 +39,7 @@ class URLResolver(BaseResolver):
     def is_valid(self):
         return urlparse(self.url.strip()).scheme in ['http', 'https', 'mast', 'ftp']
 
-    @observe('url', 'cache', 'timeout')
+    @observe('url', 'cache', 'timeout', 'mast_mission')
     def _on_url_changed(self, change):
         self._update_format_items()
 

--- a/jdaviz/core/loaders/resolvers/url/url.py
+++ b/jdaviz/core/loaders/resolvers/url/url.py
@@ -20,15 +20,18 @@ class URLResolver(BaseResolver):
     url = Unicode("").tag(sync=True)
     cache = Bool(True).tag(sync=True)
     local_path = Unicode("").tag(sync=True)
+    mast_mission = Unicode("").tag(sync=True)
     timeout = FloatHandleEmpty(10).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         self.local_path = os.curdir
+        self.mast_mission = kwargs.pop("mast_mission", "")
         super().__init__(*args, **kwargs)
 
     @property
     def user_api(self):
-        return LoaderUserApi(self, expose=['url', 'cache', 'local_path', 'timeout'])
+        return LoaderUserApi(self, expose=['url', 'cache', 'local_path',
+                                           'timeout', 'mast_mission'])
 
     @property
     def is_valid(self):
@@ -39,5 +42,7 @@ class URLResolver(BaseResolver):
         self._update_format_items()
 
     def __call__(self):
+        print(f"Calling with {self.mast_mission}")
         return download_uri_to_path(self.url.strip(), cache=self.cache,
-                                    local_path=self.local_path, timeout=self.timeout)
+                                    local_path=self.local_path, timeout=self.timeout,
+                                    mast_mission=self.mast_mission)

--- a/jdaviz/core/loaders/resolvers/url/url.py
+++ b/jdaviz/core/loaders/resolvers/url/url.py
@@ -25,7 +25,9 @@ class URLResolver(BaseResolver):
 
     def __init__(self, *args, **kwargs):
         self.local_path = os.curdir
-        self.mast_mission = kwargs.pop("mast_mission", "")
+        if "mast_mission" in kwargs:
+            self.mast_mission = kwargs['mast_mission']
+            kwargs.pop('mast_mission')
         super().__init__(*args, **kwargs)
 
     @property

--- a/jdaviz/core/tests/test_autoconfig.py
+++ b/jdaviz/core/tests/test_autoconfig.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 import pytest
-from astroquery.mast import Observations
+from astroquery.mast import MastMissions
 from astropy.utils.data import download_file
 
 from jdaviz import open as jdaviz_open
@@ -13,10 +13,10 @@ from jdaviz.core.launcher import Launcher, STATUS_HINTS
 
 
 AUTOCONFIG_EXAMPLES = (
-    ("mast:JWST/product/jw02732004001_02103_00004_mirifushort_x1d.fits", Specviz),
-    ("mast:JWST/product/jw01538160001_16101_00004_nrs1_s2d.fits", Specviz2d),
-    ("mast:JWST/product/jw02727-o002_t062_nircam_clear-f090w_i2d.fits", Imviz),
-    ("mast:JWST/product/jw02732004001_02103_00004_mirifushort_s3d.fits", Cubeviz),
+    ("mast:jw02732004001_02103_00004/jw02732004001_02103_00004_mirifushort_x1d.fits", Specviz),
+    ("mast:jw01538160001_16101_00004/jw01538160001_16101_00004_nrs1_s2d.fits", Specviz2d),
+    ("mast:jw02727002001_02101_00001/jw02727-o002_t062_nircam_clear-f090w_i2d.fits", Imviz),
+    ("mast:jw02732004001_02103_00004/jw02732004001_02103_00004_mirifushort_s3d.fits", Cubeviz),
     ("https://stsci.box.com/shared/static/28a88k1qfipo4yxc4p4d40v4axtlal8y.fits", Cubeviz)
     # Check that MaNGA cubes go to cubeviz. This file is originally from:
     # https://data.sdss.org/sas/dr14/manga/spectro/redux/v2_1_2/7495/stack/manga-7495-12704-LOGCUBE.fits.gz)
@@ -36,6 +36,7 @@ def test_autoconfig(uris, tmp_path):
     kwargs = dict(cache=True, show=False)
     if uri.startswith('mast'):
         kwargs['local_path'] = local_path
+        kwargs['mast_mission'] = 'jwst'
 
     viz_helper = jdaviz_open(uri, **kwargs)
     assert isinstance(viz_helper, helper_class)
@@ -65,7 +66,10 @@ def test_launcher(tmp_path):
     for uri, config in AUTOCONFIG_EXAMPLES:
         if uri.startswith("mast:"):
             download_path = str(tmp_path / Path(uri).name)
-            Observations.download_file(uri, local_path=download_path)
+            m = MastMissions()
+            m.mission = 'jwst'
+            print(uri.split(':')[1])
+            m.download_file(uri.split(':')[1], local_path=download_path)
         elif uri.startswith("http"):
             download_path = download_file(uri, cache=True, timeout=100)
         launcher.filepath = download_path

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -50,7 +50,7 @@ def test_url_to_download_imviz_local_path_warning(imviz_helper):
 
 def test_uri_to_download_specviz_local_path_check():
     uri = "mast:jw02732-c1001_t004_miri/jw02732-c1001_t004_miri_ch1-short_x1d.fits"
-    local_path = download_uri_to_path(uri, cache=False, dryrun=True, mast_mission="jwst")  # No download
+    local_path = download_uri_to_path(uri, cache=False, dryrun=True)  # No download
 
     # Wrong: '.\\JWST/product/jw02732-c1001_t004_miri_ch1-short_x1d.fits'
     # Correct:  '.\\jw02732-c1001_t004_miri_ch1-short_x1d.fits'

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -49,8 +49,8 @@ def test_url_to_download_imviz_local_path_warning(imviz_helper):
 
 
 def test_uri_to_download_specviz_local_path_check():
-    uri = "mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_x1d.fits"
-    local_path = download_uri_to_path(uri, cache=False, dryrun=True)  # No download
+    uri = "mast:jw02732-c1001_t004_miri/jw02732-c1001_t004_miri_ch1-short_x1d.fits"
+    local_path = download_uri_to_path(uri, cache=False, dryrun=True, mast_mission="jwst")  # No download
 
     # Wrong: '.\\JWST/product/jw02732-c1001_t004_miri_ch1-short_x1d.fits'
     # Correct:  '.\\jw02732-c1001_t004_miri_ch1-short_x1d.fits'
@@ -59,9 +59,9 @@ def test_uri_to_download_specviz_local_path_check():
 
 @pytest.mark.remote_data
 def test_uri_to_download_specviz(specviz_helper, tmp_path):
-    uri = "mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_x1d.fits"
+    uri = "mast:jw02732-c1001_t004_miri/jw02732-c1001_t004_miri_ch1-short_x1d.fits"
     local_path = str(tmp_path / uri.split('/')[-1])
-    specviz_helper.load_data(uri, cache=True, local_path=local_path)
+    specviz_helper.load_data(uri, cache=True, local_path=local_path, mast_mission='jwst')
 
 
 @pytest.mark.remote_data

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -695,7 +695,7 @@ def download_uri_to_path(possible_uri, cache=None, local_path=os.curdir, timeout
 
         if not dryrun:
             with conf.set_temp('timeout', timeout):
-                if mast_mission is None:
+                if mast_mission in (None, ""):
                     (status, msg, url) = Observations.download_file(
                         possible_uri, cache=cache, local_path=local_path
                     )

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -12,7 +12,7 @@ from astropy.io import fits
 from astropy.utils import minversion
 from astropy.utils.data import download_file
 from astropy.wcs.wcsapi import BaseHighLevelWCS
-from astroquery.mast import Observations, conf
+from astroquery.mast import MastMissions, Observations, conf
 from matplotlib import colors as mpl_colors
 import matplotlib.cm as cm
 from photutils.utils import make_random_cmap
@@ -601,7 +601,7 @@ def get_cloud_fits(possible_uri, ext=None, cache=None, local_path=os.curdir, tim
 
 
 def download_uri_to_path(possible_uri, cache=None, local_path=os.curdir, timeout=None,
-                         dryrun=False):
+                         dryrun=False, mast_mission=None):
     """
     Retrieve data from a URI (or a URL). Return the input if it
     cannot be parsed as a URI.
@@ -695,9 +695,16 @@ def download_uri_to_path(possible_uri, cache=None, local_path=os.curdir, timeout
 
         if not dryrun:
             with conf.set_temp('timeout', timeout):
-                (status, msg, url) = Observations.download_file(
-                    possible_uri, cache=cache, local_path=local_path
-                )
+                if mast_mission is None:
+                    (status, msg, url) = Observations.download_file(
+                        possible_uri, cache=cache, local_path=local_path
+                    )
+                else:
+                    m = MastMissions()
+                    m.mission = mast_mission
+                    (status, msg, url) = m.download_file(parsed_uri.path,
+                                                         cache=cache,
+                                                         local_path=local_path)
         else:
             status = "COMPLETE"
 


### PR DESCRIPTION
I'll need to figure out the right paths for the other downloads, but this is an initial test.