### PR TITLE
fix get_zoom_limits when wcs linked and out of image bounds

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -160,6 +160,8 @@ Imviz
 
 - Prevent image wrapping in Imviz with Roman L2 images with GWCS. [#2887]
 
+- Fix get_zoom_limits when WCS linked and out of image bounds. [#3654]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
+++ b/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
@@ -124,12 +124,16 @@ class LineProfileXY(PluginTemplateMixin, ViewerSelectMixin):
             y_label = 'Value'
 
         xy_limits = viewer._get_zoom_limits(data)
+
+        # if any zoom limits are nan, that means that they fall outside the GWCS
+        # bounding box, so
         x_limits = xy_limits[:, 0]
         y_limits = xy_limits[:, 1]
-        x_min = max(int(x_limits.min()), 0)
-        x_max = min(int(x_limits.max()), nx)
-        y_min = max(int(y_limits.min()), 0)
-        y_max = min(int(y_limits.max()), ny)
+
+        x_min = max(int(np.nan_to_num(x_limits.min(), nan=0)), 0)
+        x_max = min(int(np.nan_to_num(x_limits.max(), nan=nx)), nx)
+        y_min = max(int(np.nan_to_num(y_limits.min(), nan=0)), 0)
+        y_max = min(int(np.nan_to_num(y_limits.max(), nan=ny)), ny)
 
         self.plot_across_x.figure.title = f'X={x}'
         self.plot_across_x._update_data('line', x=range(comp.data.shape[0]), y=comp.data[:, x],

--- a/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
+++ b/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
@@ -126,7 +126,7 @@ class LineProfileXY(PluginTemplateMixin, ViewerSelectMixin):
         xy_limits = viewer._get_zoom_limits(data)
 
         # if any zoom limits are nan, that means that they fall outside the GWCS
-        # bounding box, so
+        # bounding box, so use image size for limits in that case
         x_limits = xy_limits[:, 0]
         y_limits = xy_limits[:, 1]
 

--- a/jdaviz/configs/imviz/tests/test_line_profile_xy.py
+++ b/jdaviz/configs/imviz/tests/test_line_profile_xy.py
@@ -12,8 +12,7 @@ class TestLineProfileXYPixelLinked(BaseImviz_WCS_NoWCS):
     def test_plugin(self):
         """Go through plugin logic but does not check plot contents."""
         lp_plugin = self.imviz.plugins['Image Profiles (XY)']._obj
-        lp_plugin.open_in_tray()
-        assert lp_plugin.plugin_opened == True
+        lp_plugin.plugin_opened = True
 
         assert lp_plugin.viewer.labels == ['imviz-0']
         assert lp_plugin.viewer_selected == 'imviz-0'
@@ -70,6 +69,7 @@ class TestLineProfileXYPixelLinked(BaseImviz_WCS_NoWCS):
         assert len(lp_plugin.plot_across_y.layers['line'].layer.data['x']) > 0
         assert lp_plugin.plot_available
 
+        # JDAT-5465
         # # Nothing should update on "l" when plugin closed.
         # lp_plugin.plugin_opened = False
         # lp_plugin._on_viewer_key_event(self.viewer,
@@ -135,6 +135,7 @@ class TestLineProfileXYWCSLinked(BaseImviz_WCS_WCS):
         assert 'line' not in lp_plugin.plot_across_x.layers
         assert not lp_plugin.plot_available
 
+        # JDAT-5465
         # # Nothing should update on "l" when plugin closed.
         # lp_plugin.plugin_opened = False
         # lp_plugin._on_viewer_key_event(self.viewer,

--- a/jdaviz/configs/imviz/tests/test_line_profile_xy.py
+++ b/jdaviz/configs/imviz/tests/test_line_profile_xy.py
@@ -1,13 +1,15 @@
 import numpy as np
 from astropy import units as u
 from astropy.nddata import NDData
+from astropy.wcs.utils import pixel_to_pixel
 from numpy.testing import assert_allclose, assert_array_equal
 
-from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_NoWCS
+from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_NoWCS, BaseImviz_WCS_WCS
+from jdaviz.utils import get_top_layer_index
 
 
-class TestLineProfileXY(BaseImviz_WCS_NoWCS):
-    def test_plugin_linked_by_pixel(self):
+class TestLineProfileXYPixelLinked(BaseImviz_WCS_NoWCS):
+    def test_plugin(self):
         """Go through plugin logic but does not check plot contents."""
         lp_plugin = self.imviz.plugins['Image Profiles (XY)']._obj
         lp_plugin.plugin_opened = True
@@ -64,6 +66,71 @@ class TestLineProfileXY(BaseImviz_WCS_NoWCS):
         assert len(lp_plugin.plot_across_x.layers['line'].layer.data['x']) > 0
         assert len(lp_plugin.plot_across_y.layers['line'].layer.data['x']) > 0
         assert lp_plugin.plot_available
+
+        # Nothing should update on "l" when plugin closed.
+        lp_plugin.plugin_opened = False
+        lp_plugin._on_viewer_key_event(self.viewer,
+                                       {'event': 'keydown', 'key': 'l',
+                                        'domain': {'x': 5.1, 'y': 5}})
+        lp_plugin.selected_x = 1.1
+        lp_plugin.selected_y = 9
+
+
+class TestLineProfileXYWCSLinked(BaseImviz_WCS_WCS):
+    def test_plugin(self):
+
+        lp_plugin = self.imviz.plugins['Image Profiles (XY)']._obj
+        lp_plugin.plugin_opened = True
+
+        # link by WCS
+        self.imviz.link_data(align_by='wcs')
+
+        # the API input is pixels in the orientation layer, which will then
+        # be translated in the plugin to pixels in the selected layer image.
+        x_orig = 5.1
+        y_orig = 5
+
+        i = get_top_layer_index(self.viewer)
+        top_wcs = self.viewer.state.layers[i].layer.coords
+        ref_wcs = self.viewer.state.reference_data.coords
+        x_conv, y_conv = pixel_to_pixel(ref_wcs, top_wcs, x_orig, y_orig)
+
+        # Mimic "l" key pressed.
+        lp_plugin._on_viewer_key_event(self.viewer,
+                                       {'event': 'keydown', 'key': 'l',
+                                        'domain': {'x': x_orig, 'y': y_orig}})
+        assert_allclose(lp_plugin.selected_x, x_conv)
+        assert_allclose(lp_plugin.selected_y, y_conv)
+
+        assert len(lp_plugin.plot_across_x.layers['line'].layer.data['x']) > 0
+        assert len(lp_plugin.plot_across_y.layers['line'].layer.data['x']) > 0
+        assert lp_plugin.plot_available
+
+        # Add data with unit
+        ndd = NDData(np.ones((10, 10)), unit=u.nJy)
+        self.imviz.load_data(ndd, data_label='ndd', show_in_viewer=False)
+
+        viewer_2 = self.imviz.create_image_viewer()
+        self.imviz.app.add_data_to_viewer(viewer_2.reference_id, 'has_wcs_1[SCI,1]')
+        self.imviz.app.add_data_to_viewer(viewer_2.reference_id, 'ndd[DATA]')
+
+        # Blink also triggers viewer takeover and line profile redraw,
+        # similar to the "l" key but without touching X and Y.
+        viewer_2.blink_once()
+        assert lp_plugin.viewer.labels == ['imviz-0', 'imviz-1']
+        assert lp_plugin.viewer_selected == 'imviz-1'
+        assert_allclose(lp_plugin.selected_x, x_conv)
+        assert_allclose(lp_plugin.selected_y, y_conv)
+        assert lp_plugin.plot_across_x.layers['line'].visible
+        assert len(lp_plugin.plot_across_x.layers['line'].layer.data['x']) > 0
+        assert len(lp_plugin.plot_across_y.layers['line'].layer.data['x']) > 0
+        assert lp_plugin.plot_available
+
+        # Wrong input resets plots without error.
+        lp_plugin.selected_x = -1
+        lp_plugin.vue_draw_plot()
+        assert 'line' not in lp_plugin.plot_across_x.layers
+        assert not lp_plugin.plot_available
 
         # Nothing should update on "l" when plugin closed.
         lp_plugin.plugin_opened = False

--- a/jdaviz/configs/imviz/tests/test_line_profile_xy.py
+++ b/jdaviz/configs/imviz/tests/test_line_profile_xy.py
@@ -12,7 +12,8 @@ class TestLineProfileXYPixelLinked(BaseImviz_WCS_NoWCS):
     def test_plugin(self):
         """Go through plugin logic but does not check plot contents."""
         lp_plugin = self.imviz.plugins['Image Profiles (XY)']._obj
-        lp_plugin.plugin_opened = True
+        lp_plugin.open_in_tray()
+        assert lp_plugin.plugin_opened == True
 
         assert lp_plugin.viewer.labels == ['imviz-0']
         assert lp_plugin.viewer_selected == 'imviz-0'
@@ -61,19 +62,21 @@ class TestLineProfileXYPixelLinked(BaseImviz_WCS_NoWCS):
         # Mimic manual GUI inputs.
         lp_plugin.selected_x = 1.1
         lp_plugin.selected_y = 9
+        assert lp_plugin.selected_x == 1.1
+        assert lp_plugin.selected_y == 9
         lp_plugin.viewer_selected = 'imviz-0'
         assert lp_plugin.plot_across_x.layers['line'].visible
         assert len(lp_plugin.plot_across_x.layers['line'].layer.data['x']) > 0
         assert len(lp_plugin.plot_across_y.layers['line'].layer.data['x']) > 0
         assert lp_plugin.plot_available
 
-        # Nothing should update on "l" when plugin closed.
-        lp_plugin.plugin_opened = False
-        lp_plugin._on_viewer_key_event(self.viewer,
-                                       {'event': 'keydown', 'key': 'l',
-                                        'domain': {'x': 5.1, 'y': 5}})
-        lp_plugin.selected_x = 1.1
-        lp_plugin.selected_y = 9
+        # # Nothing should update on "l" when plugin closed.
+        # lp_plugin.plugin_opened = False
+        # lp_plugin._on_viewer_key_event(self.viewer,
+        #                                {'event': 'keydown', 'key': 'l',
+        #                                 'domain': {'x': 5.1, 'y': 5}})
+        # assert lp_plugin.selected_x == 1.1
+        # assert lp_plugin.selected_y == 9
 
 
 class TestLineProfileXYWCSLinked(BaseImviz_WCS_WCS):
@@ -132,13 +135,13 @@ class TestLineProfileXYWCSLinked(BaseImviz_WCS_WCS):
         assert 'line' not in lp_plugin.plot_across_x.layers
         assert not lp_plugin.plot_available
 
-        # Nothing should update on "l" when plugin closed.
-        lp_plugin.plugin_opened = False
-        lp_plugin._on_viewer_key_event(self.viewer,
-                                       {'event': 'keydown', 'key': 'l',
-                                        'domain': {'x': 5.1, 'y': 5}})
-        lp_plugin.selected_x = 1.1
-        lp_plugin.selected_y = 9
+        # # Nothing should update on "l" when plugin closed.
+        # lp_plugin.plugin_opened = False
+        # lp_plugin._on_viewer_key_event(self.viewer,
+        #                                {'event': 'keydown', 'key': 'l',
+        #                                 'domain': {'x': 5.1, 'y': 5}})
+        # assert lp_plugin.selected_x == 1.1
+        # assert lp_plugin.selected_y == 9
 
 
 def test_line_profile_with_nan(imviz_helper):


### PR DESCRIPTION
This PR fixes an issue when line profiles in imviz when WCS linked, when the zoom limits fall outside of the gwcs bounding box, and adds a test for this case.

Fixes #3641 

