### PR TITLE
fix deconf model fitting when spectral subset is referenced

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -145,6 +145,9 @@ Bug Fixes
 
 - Improve performance when adding/removing subsets by avoiding circular callbacks. [#3628]
 
+- Fix model fitting bug in deconfigged app where selecting a spectral 
+  subset threw a traceback. [#3655]
+
 Cubeviz
 ^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -145,9 +145,6 @@ Bug Fixes
 
 - Improve performance when adding/removing subsets by avoiding circular callbacks. [#3628]
 
-- Fix model fitting bug in deconfigged app where selecting a spectral 
-  subset threw a traceback. [#3655]
-
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2416,6 +2416,8 @@ class SubsetSelect(SelectPluginComponent):
         elif 'is_spatial' in self.filters:
             get_data_kwargs['spatial_subset'] = subset
 
+        # uses jdaviz_helper's _get_data so we can pass subset args
+        # as, get_data from core helper doesn't support subset args
         subset = self.app._jdaviz_helper._get_data(**get_data_kwargs)
         return subset.mask
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2416,7 +2416,7 @@ class SubsetSelect(SelectPluginComponent):
         elif 'is_spatial' in self.filters:
             get_data_kwargs['spatial_subset'] = subset
 
-        subset = self.app._jdaviz_helper.get_data(**get_data_kwargs)
+        subset = self.app._jdaviz_helper._get_data(**get_data_kwargs)
         return subset.mask
 
     @cached_property


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address a bug in deconfigged model fitting where the plugin attempted to access a spectral subset, but was unable to.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
