### PR TITLE
Auto-update default sonification label

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -137,6 +137,8 @@ Other Changes and Additions
   dependencies installed with the ``[all]`` extra dependencies flag
   (i.e., ``pip install jdaviz[all]``). [#3556]
 
+- Auto-update sonification label upon adding sonification to viewer. [#3656]
+
 4.2.4 (unreleased)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -137,7 +137,7 @@ Other Changes and Additions
   dependencies installed with the ``[all]`` extra dependencies flag
   (i.e., ``pip install jdaviz[all]``). [#3556]
 
-- Auto-update sonification label upon adding sonification to viewer. [#3656]
+- Auto-update sonification label upon adding sonification to viewer. [#3430, #3656]
 
 4.2.4 (unreleased)
 ==================

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -80,25 +80,20 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
 
         self.add_to_viewer_selected = 'flux-viewer'
 
-        self.results_label_default = 'Sonified data'
-        self.results_label_static = self.results_label_default
-
-        self.hub.subscribe(self, DataCollectionAddMessage,
-                           handler=self._update_label_default)
+        self._update_label_default(None)
 
     @property
     def user_api(self):
         expose = ['sonify_cube']
         return PluginUserApi(self, expose)
 
-    def _update_label_default(self, msg):
+    @observe('results_label_invalid_msg')
+    def _update_label_default(self, event):
         """
         Update default label when a new sonification is added to the viewer.
         """
-        self.results_label_auto = True
         # Modify default label to avoid vue error from re-using label
-        self.results_label_default = self.app.return_unique_name(
-            self.results_label_static, typ='data')
+        self.results_label_default = self.app.return_unique_name('Sonified data', typ='data')
 
     def sonify_cube(self):
         """

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -82,7 +82,7 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
         self.results_label_static = self.results_label_default
 
         self.hub.subscribe(self, DataCollectionAddMessage,
-                           handler = self._on_new_sonification)
+                           handler=self._on_new_sonification)
 
     @property
     def user_api(self):

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -9,8 +9,6 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin, DatasetSelectMixin,
 from jdaviz.core.user_api import PluginUserApi
 from jdaviz.core.events import SnackbarMessage
 
-from glue.core.message import DataCollectionAddMessage
-
 
 __all__ = ['SonifyData']
 

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -78,29 +78,27 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
             self.sound_device_indexes = None
             self.refresh_device_list()
 
+        self.add_to_viewer_selected = 'flux-viewer'
+
         self.results_label_default = 'Sonified data'
         self.results_label_static = self.results_label_default
 
         self.hub.subscribe(self, DataCollectionAddMessage,
-                           handler=self._on_new_sonification)
+                           handler=self._update_label_default)
 
     @property
     def user_api(self):
         expose = ['sonify_cube']
         return PluginUserApi(self, expose)
 
-    def _on_new_sonification(self, msg):
+    def _update_label_default(self, msg):
         """
-        Update default label when a new sonification is added to the viewer to avoid
-        an unsightly vue error.
+        Update default label when a new sonification is added to the viewer.
         """
         self.results_label_auto = True
-        # Count number of default labels in the viewer via substring matching.
-        counter = len([True for i in self.app.data_collection
-                       if self.results_label_static in i.label])
-
-        if counter:
-            self.results_label_default = f"{self.results_label_static} ({counter})"
+        # Modify default label to avoid vue error from re-using label
+        self.results_label_default = self.app.return_unique_name(
+            self.results_label_static, typ='data')
 
     def sonify_cube(self):
         """


### PR DESCRIPTION
* Added an observer to avoid a vue error (that checks for an existing label) since relabeling cannot be done 'simultaneously' with the sonification being added to the viewer. If the relabeling is done after sonification, the vue error disappears but this is not ideal.
* If the label is updated just before sonificiation (instead of with the observer), then there is a risk of confusing the user.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address updating the default output label provided the user upon sonification.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
