### PR TITLE
fix gwcs units issue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -147,6 +147,10 @@ Bug Fixes
 
 - Improve performance when adding/removing subsets by avoiding circular callbacks. [#3628]
 
+- Fixed issue in ``compute_scale`` to handle the case when the wcs forward
+  transform does not use units, which was previously causing issues when
+  aligning by WCS. [#3658]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/imviz/tests/test_wcs_utils.py
+++ b/jdaviz/configs/imviz/tests/test_wcs_utils.py
@@ -175,3 +175,7 @@ def test_compute_scale():
 
     pixscale = wcs_utils.compute_scale(image_gwcs, fiducial, None, pscale_ratio=1e+5)
     assert_allclose(pixscale, 3.0555555555555554)
+
+    # test with units
+    pixscale = wcs_utils.compute_scale(image_gwcs, fiducial * u.deg, None)
+    assert_allclose(pixscale, 3.0555555555555554e-05)

--- a/jdaviz/configs/imviz/wcs_utils.py
+++ b/jdaviz/configs/imviz/wcs_utils.py
@@ -552,6 +552,12 @@ def compute_scale(wcs, fiducial, disp_axis, pscale_ratio=1):
     if spectral and disp_axis is None:  # pragma: no cover
         raise ValueError('If input WCS is spectral, a disp_axis must be given')
 
+    # gwcs will not interally strip units off input if the forward transform
+    # does not use quantities, so they must be removed before checking if points
+    # are in image and computing the inverse
+    if not wcs.forward_transform.uses_quantity and hasattr(fiducial, 'value'):
+        fiducial = fiducial.value
+
     if wcs.in_image(*fiducial):
         crpix = np.array(wcs.invert(*fiducial))
     else:


### PR DESCRIPTION
This resolves an issue in which computing the inverse of a WCS (which is done in wcs.in_image) requires removing input units if the forward transform does not use units.