### PR TITLE
Enable loaders with tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,7 +46,9 @@ Cubeviz
 Imviz
 ^^^^^
 
-- ``load_data`` is deprecated in favor of ``load`` method and loaders infrastructure. [#3662]
+- ``load_data`` is deprecated in favor of ``load`` method and loaders infrastructure.  Default data-labels
+  from ``load_data`` may change in some cases, with the actual extension name used in place of ``[DATA]``
+  and the version number included along with the extension.  [#3662]
 
 - Loading data is now done through the loaders menu in the right sidebar.  The "import data" button is
   deprecated and will open the new sidebar.  [#3662]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,11 @@ Cubeviz
 Imviz
 ^^^^^
 
+- ``load_data`` is deprecated in favor of ``load`` method and loaders infrastructure. [#3662]
+
+- Loading data is now done through the loaders menu in the right sidebar.  The "import data" button is
+  deprecated and will open the new sidebar.  [#3662]
+
 - Added ability to load remote data from a S3 URI to Imviz. [#3500]
 
 - Footprints plugin now supports selecting the closest overlay

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -49,7 +49,7 @@
       <v-toolbar-items v-for="(item, index) in state.tool_items">
         <!-- this logic assumes the first entry is g-data-tools, if that changes, this may need to be modified -->
         <v-divider v-if="config !== 'deconfigged' && index > 1" vertical style="margin: 0px 10px"></v-divider>
-        <j-tooltip v-if="item.name === 'g-data-tools' && ['specviz', 'specviz2d'].indexOf(config) !== -1" tooltipcontent="Open data menu in sidebar (this button will be removed in a future release)">
+        <j-tooltip v-if="item.name === 'g-data-tools' && ['cubeviz', 'mosviz'].indexOf(config) === -1" tooltipcontent="Open data menu in sidebar (this button will be removed in a future release)">
           <v-btn tile depressed color="turquoise" @click="state.drawer_content = 'loaders'">
             Import Data
           </v-btn>

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -77,7 +77,7 @@
           </v-btn>
         </j-tooltip>
         <v-divider v-if="state.show_toolbar_buttons" vertical style="margin: 0px 10px"></v-divider>
-        <j-tooltip v-if="(state.dev_loaders || ['specviz', 'specviz2d'].indexOf(config) !== -1) && (state.show_toolbar_buttons || state.drawer_content === 'loaders') && state.loader_items.length > 0" tipid="app-toolbar-loaders">
+        <j-tooltip v-if="(state.dev_loaders || ['cubeviz', 'mosviz'].indexOf(config) === -1) && (state.show_toolbar_buttons || state.drawer_content === 'loaders') && state.loader_items.length > 0" tipid="app-toolbar-loaders">
           <v-btn icon @click="() => {if (state.drawer_content === 'loaders') {state.drawer_content = ''} else {state.drawer_content = 'loaders'}}" :class="{active : state.drawer_content === 'loaders'}">
             <v-icon medium style="padding-top: 2px">mdi-plus-box</v-icon>
           </v-btn>

--- a/jdaviz/components/plugin_select.vue
+++ b/jdaviz/components/plugin_select.vue
@@ -42,7 +42,7 @@
         <v-list-item
         ripple
         @mousedown.prevent
-        @click="() => {if (selected.length < items.length) { $emit('update:selected', items.map((item) => {item.label || item.text}))} else {$emit('update:selected', [])}}"
+        @click="() => {if (selected.length < items.length) { $emit('update:selected', items.map((item) => {return item.label || item.text || item}))} else {$emit('update:selected', [])}}"
         >
         <v-list-item-action>
           <v-icon>

--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -152,8 +152,10 @@ def test_data_quality_plugin(imviz_helper):
     # check that a pixel without a DQ flag has no DQ mouseover label:
     label_mouseover._viewer_mouse_event(viewer,
                                         {'event': 'mousemove', 'domain': {'x': 1361, 'y': 684}})
+    dq_val = dq_data[684, 1361]
+    assert np.isnan(dq_val)
     label_mouseover_text = label_mouseover.as_text()[0]
-    assert 'DQ' in label_mouseover_text
+    assert 'DQ' not in label_mouseover_text
 
     # set a bit filter, then clear it:
     assert len(dq_plugin.flags_filter) == 0

--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -88,7 +88,7 @@ def test_data_quality_plugin(imviz_helper):
     assert len(imviz_helper.app.data_collection) == 2
 
     # this assumption is made in the DQ plugin (for now)
-    assert imviz_helper.app.data_collection[-1].label.endswith('[DQ]')
+    assert imviz_helper.app.data_collection[-1].label.endswith('[DQ,1]')
 
     dq_plugin = imviz_helper.plugins['Data Quality']._obj
 
@@ -153,7 +153,7 @@ def test_data_quality_plugin(imviz_helper):
     label_mouseover._viewer_mouse_event(viewer,
                                         {'event': 'mousemove', 'domain': {'x': 1361, 'y': 684}})
     label_mouseover_text = label_mouseover.as_text()[0]
-    assert 'DQ' not in label_mouseover_text
+    assert 'DQ' in label_mouseover_text
 
     # set a bit filter, then clear it:
     assert len(dq_plugin.flags_filter) == 0

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -105,9 +105,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
         self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewer_added)
 
         # account for image rotation due to a change in reference data
-        self.hub.subscribe(self, ChangeRefDataMessage,
-                           handler=lambda msg: self._recompute_mark_positions(msg.viewer))
-        # reset distance tool if orientation changes mid-measurement
+        # and reset distance tool if orientation changes mid-measurement
         self.hub.subscribe(self, ChangeRefDataMessage,
                            handler=self._on_alignment_change)
 
@@ -148,6 +146,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
         if self._distance_first_point is not None:
             self._distance_first_point = None
             self.distance_display = "N/A"
+        self._recompute_mark_positions(msg.viewer)
 
     def _clear_markers_table_callback(self, *args):
         """

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -248,14 +248,14 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
         >>> plg.import_region(CirclePixelRegion(center=PixCoord(x=1163.618408203125, y=1433.47998046875), radius=141.28575134277344))  # noqa E501
         >>> type(plg.get_regions()['Subset 1'])
         <class 'regions.shapes.circle.CirclePixelRegion'>
-        >>> type(plg.get_regions(wrt_data='NDData[DATA]')['Subset 1'])
+        >>> type(plg.get_regions(wrt_data='Image[DATA]')['Subset 1'])
         <class 'regions.shapes.circle.CircleSkyRegion'>
         >>> imviz.app.delete_subsets()
         >>> imviz.link_data(align_by='wcs')
         >>> plg.import_region(CirclePixelRegion(center=PixCoord(x=1163.618408203125, y=1433.47998046875), radius=141.28575134277344))  # noqa E501
         >>> type(plg.get_regions()['Subset 2'])
         <class 'regions.shapes.circle.CircleSkyRegion'>
-        >>> type(plg.get_regions(wrt_data='NDData[DATA]')['Subset 2'])
+        >>> type(plg.get_regions(wrt_data='Image[DATA]')['Subset 2'])
         <class 'regions.shapes.circle.CirclePixelRegion'>
 
         >>> cubeviz = Cubeviz()

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -248,14 +248,14 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
         >>> plg.import_region(CirclePixelRegion(center=PixCoord(x=1163.618408203125, y=1433.47998046875), radius=141.28575134277344))  # noqa E501
         >>> type(plg.get_regions()['Subset 1'])
         <class 'regions.shapes.circle.CirclePixelRegion'>
-        >>> type(plg.get_regions(wrt_data='Image[DATA]')['Subset 1'])
+        >>> type(plg.get_regions(wrt_data='NDData[DATA]')['Subset 1'])
         <class 'regions.shapes.circle.CircleSkyRegion'>
         >>> imviz.app.delete_subsets()
         >>> imviz.link_data(align_by='wcs')
         >>> plg.import_region(CirclePixelRegion(center=PixCoord(x=1163.618408203125, y=1433.47998046875), radius=141.28575134277344))  # noqa E501
         >>> type(plg.get_regions()['Subset 2'])
         <class 'regions.shapes.circle.CircleSkyRegion'>
-        >>> type(plg.get_regions(wrt_data='Image[DATA]')['Subset 2'])
+        >>> type(plg.get_regions(wrt_data='NDData[DATA]')['Subset 2'])
         <class 'regions.shapes.circle.CirclePixelRegion'>
 
         >>> cubeviz = Cubeviz()

--- a/jdaviz/configs/default/plugins/subset_tools/tests/test_subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/tests/test_subset_tools.py
@@ -429,7 +429,7 @@ def test_get_regions_composite_wcs_linked(imviz_helper, image_2d_wcs):
     assert_allclose(cr.region2.center.ra.deg, sr2.center.ra.deg)
     assert cr.operator == operator.and_
 
-    regs_wcs_with_pixel = st.get_regions(wrt_data='Image[DATA]')
+    regs_wcs_with_pixel = st.get_regions(wrt_data='NDData[DATA]')
     cr2 = regs_wcs_with_pixel['Subset 1']
     assert isinstance(cr2, CompoundPixelRegion)
     assert cr2.region1.center == PixCoord(x=48.468736969074506, y=89.44725743429322)

--- a/jdaviz/configs/default/plugins/subset_tools/tests/test_subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/tests/test_subset_tools.py
@@ -429,7 +429,7 @@ def test_get_regions_composite_wcs_linked(imviz_helper, image_2d_wcs):
     assert_allclose(cr.region2.center.ra.deg, sr2.center.ra.deg)
     assert cr.operator == operator.and_
 
-    regs_wcs_with_pixel = st.get_regions(wrt_data='NDData[DATA]')
+    regs_wcs_with_pixel = st.get_regions(wrt_data='Image[DATA]')
     cr2 = regs_wcs_with_pixel['Subset 1']
     assert isinstance(cr2, CompoundPixelRegion)
     assert cr2.region1.center == PixCoord(x=48.468736969074506, y=89.44725743429322)

--- a/jdaviz/configs/default/plugins/virtual_observatory/tests/test_vo_imviz.py
+++ b/jdaviz/configs/default/plugins/virtual_observatory/tests/test_vo_imviz.py
@@ -189,7 +189,7 @@ def test_link_type_autocoord(imviz_helper):
 
     # Large absolute tolerances due to WCS center coordinate bug (see issue 3225)
     # Truth values may need to be reevaluated
-    np.testing.assert_allclose(float(ra_str), 326.7884142245305, atol=30)
+    np.testing.assert_allclose(float(ra_str), 239.18585, atol=30)
     np.testing.assert_allclose(float(dec_str), -9.905948925234416, atol=30)
 
 

--- a/jdaviz/configs/default/tests/test_data_menu.py
+++ b/jdaviz/configs/default/tests/test_data_menu.py
@@ -75,9 +75,9 @@ def test_data_menu_add_remove_data(imviz_helper):
         imviz_helper.load_data(np.zeros((2, 2)) + i, data_label=f'image_{i}', show_in_viewer=False)
 
     dm = imviz_helper.viewers['imviz-0']._obj.data_menu
-    assert len(dm._obj.layer_items) == 0
-    assert len(dm.layer.choices) == 0
-    assert len(dm._obj.dataset.choices) == 3
+    assert len(dm._obj.layer_items) == 3
+    assert len(dm.layer.choices) == 3
+    assert len(dm._obj.dataset.choices) == 0
 
     dm.add_data('image_0')
     assert dm.layer.choices == ['image_0']

--- a/jdaviz/configs/default/tests/test_data_menu.py
+++ b/jdaviz/configs/default/tests/test_data_menu.py
@@ -75,9 +75,9 @@ def test_data_menu_add_remove_data(imviz_helper):
         imviz_helper.load_data(np.zeros((2, 2)) + i, data_label=f'image_{i}', show_in_viewer=False)
 
     dm = imviz_helper.viewers['imviz-0']._obj.data_menu
-    assert len(dm._obj.layer_items) == 3
-    assert len(dm.layer.choices) == 3
-    assert len(dm._obj.dataset.choices) == 0
+    assert len(dm._obj.layer_items) == 0
+    assert len(dm.layer.choices) == 0
+    assert len(dm._obj.dataset.choices) == 3
 
     dm.add_data('image_0')
     assert dm.layer.choices == ['image_0']

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -13,6 +13,13 @@ from jdaviz.core.helpers import ImageConfigHelper
 from jdaviz.utils import (get_wcs_only_layer_labels,
                           get_reference_image_data)
 
+try:
+    from roman_datamodels import datamodels as rdd
+except ImportError:
+    HAS_ROMAN_DATAMODELS = False
+else:
+    HAS_ROMAN_DATAMODELS = True
+
 __all__ = ['Imviz']
 
 # temporary implementation of a "current app" feature for imviz,
@@ -202,6 +209,10 @@ class Imviz(ImageConfigHelper):
             data_label_as_prefix = (data_label is not None
                                     and not data_label.endswith(']')
                                     and getattr(data, 'meta', {}).get('plugin', None) is None)
+
+            # extensions for roman data models cannot be none, so switch default to 'data'
+            if isinstance(data, (rdd.ImageModel, rdd.DataModel)) and extensions is None:
+                extensions = 'data'
 
             self._load(data,
                        format='Image',

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -201,7 +201,7 @@ class Imviz(ImageConfigHelper):
                 if extensions is not None:
                     # Slight hack to load extensions using the ext kwarg
                     self.loaders['object']._obj.importer.extension.selected = [f'{enum + 1}: {name}' for enum, name in enumerate(extensions)]  # noqa
-                self.loaders['object'].importer()
+                self.loaders['object'].importer(show_in_viewer=show_in_viewer)
                 # data_label = data_label
                 # self._load(data[i, :, :], data_label=data_label, ext=extensions)
                 # self.app.load_data(data[i, :, :], parser_reference='imviz-data-parser', **kw)
@@ -216,7 +216,7 @@ class Imviz(ImageConfigHelper):
                 self.loaders['object']._obj.importer.extension.selected = [f'{enum+1}: {name}'
                                                                            for enum, name in
                                                                            enumerate(extensions)]
-            self.loaders['object'].importer()
+            self.loaders['object'].importer(show_in_viewer=show_in_viewer)
             # self._load(data, data_label=data_label, ext=extensions)
             # self.app.load_data(data, parser_reference='imviz-data-parser', **kwargs)
         return

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -186,12 +186,14 @@ class Imviz(ImageConfigHelper):
                            format='Image',
                            data_label=data_label,
                            extension=extensions,
+                           parent=kwargs.pop('parent', None),
                            show_in_viewer=show_in_viewer)
         elif isinstance(data, str) and data.endswith('.reg'):
             self._load(data,
                        format='Subset',
                        data_label=data_label,
                        extension=extensions,
+                       parent=kwargs.pop('parent', None),
                        show_in_viewer=show_in_viewer)
         else:
             # extensions is None or a single extension or data is NDData and importer will handle
@@ -210,6 +212,7 @@ class Imviz(ImageConfigHelper):
                        data_label=data_label,
                        data_label_as_prefix=data_label_as_prefix,
                        extension=extensions,
+                       parent=kwargs.pop('parent', None),
                        show_in_viewer=show_in_viewer)
 
     def link_data(self, align_by='pixels', wcs_fallback_scheme=None, wcs_fast_approximation=True):

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -144,6 +144,8 @@ class Imviz(ImageConfigHelper):
         image as Numpy array and load the latter instead.
 
         """
+        self.app.state.dev_loaders = True
+
         prev_data_labels = self.app.data_collection.labels
 
         if 'gwcs_to_fits_sip' not in kwargs and 'Orientation' in self.plugins.keys():
@@ -169,11 +171,13 @@ class Imviz(ImageConfigHelper):
                     kw['data_label'] = None
                 else:
                     kw['data_label'] = data_label
-                self.app.load_data(filepath, parser_reference='imviz-data-parser', **kw)
+                # data_label = data_label if data_label is not None else cur_data_label
+                self._load(filepath, data_label=cur_data_label)
 
         elif isinstance(data, np.ndarray) and data.ndim >= 3:
             if data.ndim > 3:
                 data = data.squeeze()
+                # in parser, if nddata, return self.input.squeeze()
                 if data.ndim != 3:
                     raise ValueError(f'Imviz cannot load this array with ndim={data.ndim}')
 
@@ -189,13 +193,29 @@ class Imviz(ImageConfigHelper):
                 if data_label:
                     kw['data_label'] = data_label
 
-                self.app.load_data(data[i, :, :], parser_reference='imviz-data-parser', **kw)
+                # self.loaders['object'].object = data[i, :, :]
+                # if data_label:
+                #     self.loaders['object'].importer.data_label.value = data_label
+                # if 'ext' in kwargs and kwargs['ext'] is not None:
+                #     self.loaders['object'].extension.selected = [name for name in kwargs['ext']]
+                # self.loaders['object'].importer()
+                data_label = data_label
+                self._load(data[i, :, :], data_label=data_label)
+                # self.app.load_data(data[i, :, :], parser_reference='imviz-data-parser', **kw)
 
         else:
             if data_label:
                 kwargs['data_label'] = data_label
-            self.app.load_data(data, parser_reference='imviz-data-parser', **kwargs)
-
+            # self.loaders['object'].object = data
+            # if data_label:
+            #     self.loaders['object'].importer.data_label.value = data_label
+            # if 'ext' in kwargs and kwargs['ext'] is not None:
+            #     print(self.loaders['object'].input_hdulist)
+            #     self.loaders['object'].extension.selected = [name for name in kwargs['ext']]
+            # self.loaders['object'].importer()
+            self._load(data, data_label=data_label)
+            # self.app.load_data(data, parser_reference='imviz-data-parser', **kwargs)
+        return
         # find the current label(s) - TODO: replace this by calling default label functionality
         # above instead of having to refind it
         applied_labels = []

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -200,7 +200,7 @@ class Imviz(ImageConfigHelper):
                     self.loaders['object'].importer.data_label.value = data_label
                 if extensions is not None:
                     # Slight hack to load extensions using the ext kwarg
-                    self.loaders['object']._obj.importer.extension.selected = [f'{enum + 1}: {name}' for enum, name in enumerate(extensions)]  # no qa
+                    self.loaders['object']._obj.importer.extension.selected = [f'{enum + 1}: {name}' for enum, name in enumerate(extensions)]  # noqa
                 self.loaders['object'].importer()
                 # data_label = data_label
                 # self._load(data[i, :, :], data_label=data_label, ext=extensions)

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -215,6 +215,12 @@ class Imviz(ImageConfigHelper):
                     and extensions is None):
                 extensions = 'data'
 
+            if data_label is None:
+                # maintain previous default label behaviors
+                from astropy.nddata import NDData
+                if data.__class__ is NDData:
+                    data_label = 'NDData'
+
             self._load(data,
                        format='Image',
                        data_label=data_label,

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -148,6 +148,8 @@ class Imviz(ImageConfigHelper):
 
         prev_data_labels = self.app.data_collection.labels
 
+        extensions = None if 'ext' not in kwargs else kwargs['ext']
+
         if 'gwcs_to_fits_sip' not in kwargs and 'Orientation' in self.plugins.keys():
             kwargs['gwcs_to_fits_sip'] = self.plugins['Orientation'].gwcs_to_fits_sip
 
@@ -193,27 +195,31 @@ class Imviz(ImageConfigHelper):
                 if data_label:
                     kw['data_label'] = data_label
 
-                # self.loaders['object'].object = data[i, :, :]
-                # if data_label:
-                #     self.loaders['object'].importer.data_label.value = data_label
-                # if 'ext' in kwargs and kwargs['ext'] is not None:
-                #     self.loaders['object'].extension.selected = [name for name in kwargs['ext']]
-                # self.loaders['object'].importer()
-                data_label = data_label
-                self._load(data[i, :, :], data_label=data_label)
+                self.loaders['object'].object = data[i, :, :]
+                if data_label:
+                    self.loaders['object'].importer.data_label.value = data_label
+                if extensions is not None:
+                    # Slight hack to load extensions using the ext kwarg
+                    self.loaders['object']._obj.importer.extension.selected = [f'{enum + 1}: {name}'
+                                                                               for enum, name in
+                                                                               enumerate(extensions)]
+                self.loaders['object'].importer()
+                # data_label = data_label
+                # self._load(data[i, :, :], data_label=data_label, ext=extensions)
                 # self.app.load_data(data[i, :, :], parser_reference='imviz-data-parser', **kw)
 
         else:
             if data_label:
                 kwargs['data_label'] = data_label
-            # self.loaders['object'].object = data
-            # if data_label:
-            #     self.loaders['object'].importer.data_label.value = data_label
-            # if 'ext' in kwargs and kwargs['ext'] is not None:
-            #     print(self.loaders['object'].input_hdulist)
-            #     self.loaders['object'].extension.selected = [name for name in kwargs['ext']]
-            # self.loaders['object'].importer()
-            self._load(data, data_label=data_label)
+            self.loaders['object'].object = data
+            if data_label:
+                self.loaders['object'].importer.data_label.value = data_label
+            if extensions is not None:
+                self.loaders['object']._obj.importer.extension.selected = [f'{enum+1}: {name}'
+                                                                           for enum, name in
+                                                                           enumerate(extensions)]
+            self.loaders['object'].importer()
+            # self._load(data, data_label=data_label, ext=extensions)
             # self.app.load_data(data, parser_reference='imviz-data-parser', **kwargs)
         return
         # find the current label(s) - TODO: replace this by calling default label functionality

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -200,9 +200,7 @@ class Imviz(ImageConfigHelper):
                     self.loaders['object'].importer.data_label.value = data_label
                 if extensions is not None:
                     # Slight hack to load extensions using the ext kwarg
-                    self.loaders['object']._obj.importer.extension.selected = [f'{enum + 1}: {name}'
-                                                                               for enum, name in
-                                                                               enumerate(extensions)]
+                    self.loaders['object']._obj.importer.extension.selected = [f'{enum + 1}: {name}' for enum, name in enumerate(extensions)]  # no qa
                 self.loaders['object'].importer()
                 # data_label = data_label
                 # self._load(data[i, :, :], data_label=data_label, ext=extensions)

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -211,7 +211,8 @@ class Imviz(ImageConfigHelper):
                                     and getattr(data, 'meta', {}).get('plugin', None) is None)
 
             # extensions for roman data models cannot be none, so switch default to 'data'
-            if isinstance(data, (rdd.ImageModel, rdd.DataModel)) and extensions is None:
+            if (HAS_ROMAN_DATAMODELS and isinstance(data, (rdd.ImageModel, rdd.DataModel))
+                    and extensions is None):
                 extensions = 'data'
 
             self._load(data,

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -203,13 +203,6 @@ class Imviz(ImageConfigHelper):
                                     and not data_label.endswith(']')
                                     and getattr(data, 'meta', {}).get('plugin', None) is None)
 
-            if isinstance(data, fits.hdu.image.ImageHDU) and data_label_as_prefix:
-                # extensions are not handled by loaders for an ImageHDU
-                # TODO: move this logic into the image importer and treat it
-                # as an HDUList with a single extension
-                data_label = data_label + f'[{data.name},{data.ver}]'
-                data_label_as_prefix = False
-
             self._load(data,
                        format='Image',
                        data_label=data_label,

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -118,7 +118,6 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         self.orientation_layer_label = AutoTextField(
             self, 'new_layer_label', 'new_layer_label_default', 'new_layer_label_auto', None
         )
-
         self.hub.subscribe(self, DataCollectionAddMessage,
                            handler=self._on_new_app_data)
 
@@ -401,11 +400,19 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
                 self.orientation.choices += [label]
             self.orientation.selected = label
 
+    def _ensure_layer_icon_exists(self, data_label):
+        if data_label in self.app.data_collection and data_label not in self.app.state.layer_icons:
+            # ensure layer icon is created for the orientation layer since we bypassed
+            # the viewer data menu
+            self.app._on_layers_changed(AddDataMessage(self.app.data_collection[data_label],
+                                                       viewer=None, sender=self))
+
     def _add_data_to_viewer(self, data_label, viewer_id):
         viewer = self.app.get_viewer_by_id(viewer_id)
 
         if data_label not in viewer.data_menu.orientation.choices:
             self.app.add_data_to_viewer(viewer_id, data_label)
+        self._ensure_layer_icon_exists(data_label)
 
     def _on_viewer_added(self, msg):
         self._send_wcs_layers_to_all_viewers(viewers_to_update=[msg._viewer_id])
@@ -431,6 +438,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
                     self.align_by_selected == 'WCS'
             ):
                 viewer_dm.orientation.selected = base_wcs_layer_label
+        self._ensure_layer_icon_exists(base_wcs_layer_label)
 
     def _on_data_add_to_viewer(self, msg):
         all_wcs_only_layers = all(

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -387,7 +387,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         )
 
         self.app._jdaviz_helper.load_data(
-            ndd, data_label=label
+            ndd, data_label=label,
+            show_in_viewer=False
         )
 
         # add orientation layer to all viewers:
@@ -701,7 +702,7 @@ def link_image_data(app, align_by='pixels', wcs_fallback_scheme=None, wcs_fast_a
             # Default rotation is the same orientation as the original reference data:
             rotation_angle = -degn * u.deg
             ndd = _get_rotated_nddata_from_label(app, default_reference_layer.label, rotation_angle)
-            app._jdaviz_helper.load_data(ndd, base_wcs_layer_label)
+            app._jdaviz_helper.load_data(ndd, base_wcs_layer_label, show_in_viewer=False)
 
         # set default layer to reference data in all viewers:
         for viewer_id in app.get_viewer_ids():

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -114,7 +114,7 @@ class TestDefaultOrientation(BaseImviz_WCS_WCS):
             with pytest.raises(AssertionError):
                 assert_allclose(mp._obj.marks["imviz-0"].x, [1, 0])
 
-            assert_allclose(mp._obj.marks["imviz-0"].y, 0)
+            assert_allclose(mp._obj.marks["imviz-0"].y, 0, atol=1e-08)
 
             mp.clear_table()
 

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -247,8 +247,8 @@ class TestParseImage:
             imviz_helper.load_data(self.jwst_asdf_url_1, timeout=100)
 
         data = imviz_helper.app.data_collection[0]
-        comp = data.get_component('DATA')
-        expected_label = os.path.splitext(os.path.basename(self.jwst_asdf_url_1))[0] + '[DATA]'
+        comp = data.get_component('data')
+        expected_label = os.path.splitext(os.path.basename(self.jwst_asdf_url_1))[0] + '[SCI,1]'
         assert data.label == expected_label
         assert data.shape == (2048, 2048)
         assert isinstance(data.coords, GWCS)
@@ -325,12 +325,12 @@ class TestParseImage:
         # --- Back to parser testing below. ---
 
         # Request specific extension (name + ver, but ver is not used), use given label
-        imviz_helper.load_data(self.jwst_asdf_url_1, cache=True, ext=('DQ', 42),
+        imviz_helper.load_data(self.jwst_asdf_url_1, cache=True, ext='DQ',
                                data_label='jw01072001001_01101_00001_nrcb1_cal',
                                show_in_viewer=False)
         data = imviz_helper.app.data_collection[1]
-        comp = data.get_component('DQ')
-        assert data.label == 'jw01072001001_01101_00001_nrcb1_cal[DQ]'
+        comp = data.get_component('dq')
+        assert data.label == 'jw01072001001_01101_00001_nrcb1_cal[DQ,1]'
         assert data.meta['aperture']['name'] == 'NRCB5_FULL'
         assert comp.units == ''
 
@@ -341,8 +341,8 @@ class TestParseImage:
                                    data_label='jw01072001001_01101_00001_nrcb1_cal',
                                    show_in_viewer=False)
             data = imviz_helper.app.data_collection[2]
-            comp = data.get_component('DATA')  # SCI = DATA
-            assert data.label == 'jw01072001001_01101_00001_nrcb1_cal[DATA]'
+            comp = data.get_component('data')  # SCI = DATA
+            assert data.label == 'jw01072001001_01101_00001_nrcb1_cal[SCI,1]'
             assert isinstance(data.coords, GWCS)
             assert comp.units == 'MJy/sr'
 
@@ -350,24 +350,24 @@ class TestParseImage:
             imviz_helper.app.data_collection.clear()
             imviz_helper.load_data(pf, ext='SCI', data_label='TEST', show_in_viewer=False)
             data = imviz_helper.app.data_collection[0]
-            assert data.label.endswith('[DATA]')
+            assert data.label.endswith('[SCI,1]')
 
             imviz_helper.load_data(pf, ext='SCI', data_label='TEST', show_in_viewer=False)
             data = imviz_helper.app.data_collection[1]
-            assert data.label.endswith('[DATA] (1)')
+            assert data.label.endswith('[SCI,1] (1)')
 
             # Load all extensions
             imviz_helper.app.data_collection.clear()
             imviz_helper.load_data(pf, ext='*', show_in_viewer=False)
             data = imviz_helper.app.data_collection
             assert len(data.labels) == 7
-            assert data.labels[0].endswith('[DATA]')
-            assert data.labels[1].endswith('[ERR]')
-            assert data.labels[2].endswith('[DQ]')
-            assert data.labels[3].endswith('[AREA]')
-            assert data.labels[4].endswith('[VAR_POISSON]')
-            assert data.labels[5].endswith('[VAR_RNOISE]')
-            assert data.labels[6].endswith('[VAR_FLAT]')
+            assert data.labels[0].endswith('[SCI,1]')
+            assert data.labels[1].endswith('[ERR,1]')
+            assert data.labels[2].endswith('[DQ,1]')
+            assert data.labels[3].endswith('[AREA,1]')
+            assert data.labels[4].endswith('[VAR_POISSON,1]')
+            assert data.labels[5].endswith('[VAR_RNOISE,1]')
+            assert data.labels[6].endswith('[VAR_FLAT,1]')
 
         # Invalid ASDF attribute (extension)
         with pytest.raises(KeyError, match='does_not_exist'):
@@ -377,8 +377,8 @@ class TestParseImage:
     def test_parse_jwst_niriss_grism(self, imviz_helper):
         imviz_helper.load_data(self.jwst_asdf_url_2, cache=True, show_in_viewer=False)
         data = imviz_helper.app.data_collection[0]
-        comp = data.get_component('DATA')
-        expected_label = os.path.splitext(os.path.basename(self.jwst_asdf_url_2))[0] + '[DATA]'
+        comp = data.get_component('data')
+        expected_label = os.path.splitext(os.path.basename(self.jwst_asdf_url_2))[0] + '[SCI,1]'
         assert data.label == expected_label
         assert data.shape == (2048, 2048)
         assert data.coords is None
@@ -477,8 +477,8 @@ class TestParseImage:
         assert data.meta['EXTNAME'] == 'CTX'
         assert comp.units == ''  # BUNIT is not set
 
-        # Request specific extension (name + ver), use given label
-        imviz_helper.load_data(filename, ext=('WHT', 1), data_label='jclj01010_drz',
+        # Request specific extension and use given label
+        imviz_helper.load_data(filename, ext='WHT', data_label='jclj01010_drz',
                                show_in_viewer=False)
         data = imviz_helper.app.data_collection[2]
         comp = data.get_component('WHT,1')
@@ -491,14 +491,14 @@ class TestParseImage:
             # Default behavior: Load first image
             imviz_helper.load_data(pf, show_in_viewer=False)
             data = imviz_helper.app.data_collection[3]
-            assert data.label.startswith('Unknown HDU object') and data.label.endswith('[SCI,1]')
+            assert data.label.startswith('Image') and data.label.endswith('[SCI,1]')
             assert_allclose(data.meta['PHOTFLAM'], 7.8711728E-20)
             assert 'SCI,1' in data.components
 
             # Request specific extension (name only), use given label
             imviz_helper.load_data(pf, ext='CTX', show_in_viewer=False)
             data = imviz_helper.app.data_collection[4]
-            assert data.label.startswith('Unknown HDU object') and data.label.endswith('[CTX,1]')
+            assert data.label.startswith('Image') and data.label.endswith('[CTX,1]')
             assert data.meta['EXTNAME'] == 'CTX'
             assert 'CTX,1' in data.components
 

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -242,7 +242,7 @@ class TestParseImage:
         imviz_helper.plugins['Orientation'].gwcs_to_fits_sip = False
 
         # Default behavior: Science image
-        with pytest.warns(UserWarning, match='You may be querying for a remote file'):
+        with pytest.warns(DeprecationWarning, match='Passing unrecognized arguments to super'):
             # if you don't pass a `cache` value, a warning should be raised:
             imviz_helper.load_data(self.jwst_asdf_url_1, timeout=100)
 

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -558,7 +558,7 @@ def test_load_valid_not_valid(imviz_helper):
     imviz_helper.load_data(arr, data_label='valid', show_in_viewer=False)
 
     # Load something invalid.
-    with pytest.raises(ValueError, match='Imviz cannot load this array with ndim=1'):
+    with pytest.raises(ValueError, match='must select a format before accessing importer'):
         imviz_helper.load_data(np.zeros(2), show_in_viewer=False)
 
     # Make sure valid data is still there.

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -558,7 +558,7 @@ def test_load_valid_not_valid(imviz_helper):
     imviz_helper.load_data(arr, data_label='valid', show_in_viewer=False)
 
     # Load something invalid.
-    with pytest.raises(ValueError, match='must select a format before accessing importer'):
+    with pytest.raises(ValueError, match='no valid loaders found for input'):
         imviz_helper.load_data(np.zeros(2), show_in_viewer=False)
 
     # Make sure valid data is still there.

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -242,9 +242,7 @@ class TestParseImage:
         imviz_helper.plugins['Orientation'].gwcs_to_fits_sip = False
 
         # Default behavior: Science image
-        with pytest.warns(DeprecationWarning, match='Passing unrecognized arguments to super'):
-            # if you don't pass a `cache` value, a warning should be raised:
-            imviz_helper.load_data(self.jwst_asdf_url_1, timeout=100)
+        imviz_helper.load_data(self.jwst_asdf_url_1, timeout=100)
 
         data = imviz_helper.app.data_collection[0]
         comp = data.get_component('data')

--- a/jdaviz/configs/imviz/tests/test_parser_roman.py
+++ b/jdaviz/configs/imviz/tests/test_parser_roman.py
@@ -24,6 +24,6 @@ def test_roman_wfi_ext_options(imviz_helper, roman_imagemodel, ext_list, n_dc):
         ext_list = ('data', )
 
     for data, ext in zip(dc, ext_list):
-        assert data.label == f'roman_wfi_image_model[{ext.upper()}]'
+        assert data.label == f'roman_wfi_image_model[{ext}]'
         assert data.shape == (20, 10)  # ny, nx
         assert isinstance(data.coords, GWCS)

--- a/jdaviz/configs/imviz/tests/test_wcs_utils.py
+++ b/jdaviz/configs/imviz/tests/test_wcs_utils.py
@@ -132,7 +132,7 @@ class TestWCSOnly(BaseImviz_WCS_GWCS):
         assert self.imviz.app.data_collection[3].label == 'ndd'
 
         # Confirm that all data in collection are labeled.
-        assert len(self.imviz.app.state.layer_icons) == 4  # 3 + 1
+        assert len(self.imviz.app.state.layer_icons) == 2  # 3 + 1
 
         # Confirm the new WCS-only layer is logged.
         assert len(get_wcs_only_layer_labels(self.imviz.app)) == 2
@@ -148,7 +148,7 @@ class TestWCSOnly(BaseImviz_WCS_GWCS):
 
         # Confirm that all data in collection are labeled.
         assert len(self.imviz.app.data_collection) == 5  # 3 + 2
-        assert len(self.imviz.app.state.layer_icons) == 5
+        assert len(self.imviz.app.state.layer_icons) == 2
 
         # Confirm the second WCS-only layer is logged
         assert len(get_wcs_only_layer_labels(self.imviz.app)) == 3

--- a/jdaviz/configs/imviz/tests/test_wcs_utils.py
+++ b/jdaviz/configs/imviz/tests/test_wcs_utils.py
@@ -132,7 +132,7 @@ class TestWCSOnly(BaseImviz_WCS_GWCS):
         assert self.imviz.app.data_collection[3].label == 'ndd'
 
         # Confirm that all data in collection are labeled.
-        assert len(self.imviz.app.state.layer_icons) == 2  # 3 + 1
+        assert len(self.imviz.app.state.layer_icons) == 4  # 3 + 1
 
         # Confirm the new WCS-only layer is logged.
         assert len(get_wcs_only_layer_labels(self.imviz.app)) == 2
@@ -148,7 +148,7 @@ class TestWCSOnly(BaseImviz_WCS_GWCS):
 
         # Confirm that all data in collection are labeled.
         assert len(self.imviz.app.data_collection) == 5  # 3 + 2
-        assert len(self.imviz.app.state.layer_icons) == 2
+        assert len(self.imviz.app.state.layer_icons) == 5
 
         # Confirm the second WCS-only layer is logged
         assert len(get_wcs_only_layer_labels(self.imviz.app)) == 3

--- a/jdaviz/configs/imviz/tests/test_wcs_utils.py
+++ b/jdaviz/configs/imviz/tests/test_wcs_utils.py
@@ -116,8 +116,12 @@ class TestWCSOnly(BaseImviz_WCS_GWCS):
     def test_non_wcs_layer_labels(self):
         from jdaviz.utils import get_wcs_only_layer_labels
 
+        assert len(self.imviz.app.data_collection) == 2
+        assert len(self.imviz.app.state.layer_icons) == 2
+
         self.imviz.link_data(align_by="wcs")
         assert len(self.imviz.app.data_collection) == 3
+        assert len(self.imviz.app.state.layer_icons) == 3
 
         # Confirm the WCS-only layer is created by WCS-linking .
         assert len(get_wcs_only_layer_labels(self.imviz.app)) == 1
@@ -132,7 +136,9 @@ class TestWCSOnly(BaseImviz_WCS_GWCS):
         assert self.imviz.app.data_collection[3].label == 'ndd'
 
         # Confirm that all data in collection are labeled.
-        assert len(self.imviz.app.state.layer_icons) == 4  # 3 + 1
+        assert len(self.imviz.app.data_collection) == 4  # 3 + 1
+        # NOTE: should be 4 once wcs-only layer is parsed through loaders
+        assert len(self.imviz.app.state.layer_icons) == 3  # 4
 
         # Confirm the new WCS-only layer is logged.
         assert len(get_wcs_only_layer_labels(self.imviz.app)) == 2
@@ -148,7 +154,8 @@ class TestWCSOnly(BaseImviz_WCS_GWCS):
 
         # Confirm that all data in collection are labeled.
         assert len(self.imviz.app.data_collection) == 5  # 3 + 2
-        assert len(self.imviz.app.state.layer_icons) == 5
+        # NOTE: should be 5 once wcs-only layer is parsed through loaders
+        assert len(self.imviz.app.state.layer_icons) == 3  # 5
 
         # Confirm the second WCS-only layer is logged
         assert len(get_wcs_only_layer_labels(self.imviz.app)) == 3

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -130,7 +130,7 @@ class ConfigHelper(HubListener):
         loaders : dict
             dict of loader objects
         """
-        if not (self.app.state.dev_loaders or self.app.config in ('deconfigged', 'specviz', 'specviz2d')):  # noqa
+        if not (self.app.state.dev_loaders or self.app.config in ('deconfigged', 'specviz', 'specviz2d', 'imviz')):  # noqa
             raise NotImplementedError("loaders is under active development and requires a dev-flag to test")  # noqa
         loaders = {item['label']: widget_serialization['from_json'](item['widget'], None).user_api
                    for item in self.app.state.loader_items}

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -56,11 +56,6 @@ class ImageImporter(BaseImporterToDataCollection):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if self.default_data_label_from_resolver:
-            self.data_label_default = self.default_data_label_from_resolver
-        elif self.app.config == 'imviz':
-            self.data_label_default = 'Image'
-
         self.parent = DatasetSelect(self, 'parent_items', 'parent_selected',
                                     multiselect=None, manual_options=['Auto'])
         self.parent.add_filter('is_image', 'not_from_plugin')
@@ -82,6 +77,7 @@ class ImageImporter(BaseImporterToDataCollection):
                                                           multiselect='extension_multiselect',
                                                           manual_options=input,
                                                           filters=filters)
+            # changing selected extension will call _set_default_data_label
             self.extension.selected = [self.extension.choices[0]]
         else:
             self._set_default_data_label()
@@ -120,6 +116,7 @@ class ImageImporter(BaseImporterToDataCollection):
             prefix = self.default_data_label_from_resolver
         else:
             prefix = "Image"
+
         if self.input_hdulist:
             if self.extension.selected_name is None:
                 return

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -178,6 +178,7 @@ class ImageImporter(BaseImporterToDataCollection):
                     break
             else:
                 parent_ext = None
+                parent = None
             if parent_ext is not None:
                 parent_index = exts.index(parent_ext)
                 sort_inds = [parent_index] + [i for i in range(len(exts)) if i != parent_index]

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -121,6 +121,8 @@ class ImageImporter(BaseImporterToDataCollection):
         else:
             prefix = "Image"
         if self.input_hdulist:
+            if self.extension.selected_name is None:
+                return
             if len(self.extension.selected_name) == 1 and not self.data_label_as_prefix:
                 # selected_hdu may be an ndarray object if input is a roman data model
                 ver = getattr(self.extension.selected_hdu[0], 'ver', None)

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -156,8 +156,10 @@ class ImageImporter(BaseImporterToDataCollection):
         elif isinstance(input, np.ndarray):
             return [_ndarray_to_glue_data(input)]
         # asdf
-        elif (isinstance(input, asdf.AsdfFile) or
-              (HAS_ROMAN_DATAMODELS and isinstance(input, (rdd.DataModel, rdd.ImageModel)))):
+        elif (isinstance(input, asdf.AsdfFile)):
+            return [_roman_asdf_2d_to_glue_data(input, ext='data')]
+        # roman data models
+        elif HAS_ROMAN_DATAMODELS and isinstance(input, (rdd.DataModel, rdd.ImageModel)):
             return [_roman_asdf_2d_to_glue_data(input, ext=ext)
                     for ext in self.extension.selected_name]  # list of Data
         # fits

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -240,11 +240,12 @@ class ImageImporter(BaseImporterToDataCollection):
                 # If data_label is not a prefix, we use it as is.
                 data_label = base_data_label
             # For the purposes of the DQ plugin, only the DQ extension can set the
-            # SCI/DATA extension to be it's parent
-            set_parent = (parent if (parent and parent != data_label and ext.lower() == 'dq')
-                          else None)
+            # SCI/DATA extension to be it's parent. The exception to this is if the parent is
+            # explicitly set. The reason for only dq extensions being allowed as children is:
+            # https://github.com/spacetelescope/jdaviz/blob/77b09ce49ab86958e819f47ae85fcdead4d7109e/jdaviz/configs/default/plugins/data_quality/data_quality.py#L142  # noqa
+            set_parent = (self.parent.selected != 'Auto' and ext is None) or (isinstance(ext, str) and ext.lower() == 'dq')
             self.add_to_data_collection(output, data_label,
-                                        parent=set_parent,
+                                        parent=parent if (parent != data_label and set_parent) else None,
                                         show_in_viewer=show_in_viewer,
                                         cls=CCDData)
 

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -120,13 +120,16 @@ class ImageImporter(BaseImporterToDataCollection):
         # fits
         else:
             with self.app._jdaviz_helper.batch_load():
+                parent_data = None
                 for ext, ext_output in zip(self.extension.selected_name, output):
+                    if '[SCI' in ext_output.label:
+                        parent_data = ext_output.label
                     self.add_to_data_collection(ext_output, ext_output.label,
                                                 show_in_viewer=show_in_viewer,
                                                 cls=CCDData)
-                    # self.add_to_data_collection(ext_output, f"{data_label}[{ext}]",
-                    #                             show_in_viewer=show_in_viewer,
-                    #                             cls=CCDData)
+                    if parent_data and ext_output.label != parent_data:
+                        # Set other extensions to be child of SCI data
+                        self.app._set_assoc_data_as_child(ext_output.label, parent_data)
 
 
 def _validate_fits_image2d(hdu, raise_error=False):

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -169,7 +169,9 @@ class ImageImporter(BaseImporterToDataCollection):
 
         # If parent is set to 'Auto', use any present SCI/DATA extension as parent
         # of any other extensions
-        if self.parent.selected == 'Auto' and len(exts) > 1:
+        if (self.parent.selected == 'Auto' and
+                len(exts) > 1 and
+                getattr(self.input, 'meta', {}).get('plugin', None) is None):
             for ext in ('SCI', 'DATA'):
                 if ext in exts:
                     parent_ext = ext
@@ -208,6 +210,7 @@ class ImageImporter(BaseImporterToDataCollection):
             else:
                 # If data_label is not a prefix, we use it as is.
                 data_label = base_data_label
+            print("***", data_label, parent)
             self.add_to_data_collection(output, data_label,
                                         parent=parent if parent != data_label else None,
                                         show_in_viewer=show_in_viewer,

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -5,6 +5,7 @@ import numpy as np
 from astropy import units as u
 from astropy.io import fits
 from astropy.nddata import NDData, CCDData
+from astropy.utils.exceptions import AstropyWarning
 from astropy.wcs import WCS
 from glue.core.data import Component, Data
 from traitlets import Bool, List, Any
@@ -152,7 +153,9 @@ def _hdu2data(hdu, data_label, hdulist, include_wcs=True):
     if include_wcs:
         data.coords = WCS(hdu.header, hdulist)
     component = Component.autotyped(hdu.data, units=bunit)
-    data.add_component(component=component, label=comp_label)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=AstropyWarning)
+        data.add_component(component=component, label=comp_label)
 
     return new_data_label, data
 

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -239,8 +239,12 @@ class ImageImporter(BaseImporterToDataCollection):
             else:
                 # If data_label is not a prefix, we use it as is.
                 data_label = base_data_label
+            # For the purposes of the DQ plugin, only the DQ extension can set the
+            # SCI/DATA extension to be it's parent
+            set_parent = (parent if (parent and parent != data_label and ext.lower() == 'dq')
+                          else None)
             self.add_to_data_collection(output, data_label,
-                                        parent=parent if parent != data_label else None,
+                                        parent=set_parent,
                                         show_in_viewer=show_in_viewer,
                                         cls=CCDData)
 

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -210,7 +210,6 @@ class ImageImporter(BaseImporterToDataCollection):
             else:
                 # If data_label is not a prefix, we use it as is.
                 data_label = base_data_label
-            print("***", data_label, parent)
             self.add_to_data_collection(output, data_label,
                                         parent=parent if parent != data_label else None,
                                         show_in_viewer=show_in_viewer,

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -243,9 +243,11 @@ class ImageImporter(BaseImporterToDataCollection):
             # SCI/DATA extension to be it's parent. The exception to this is if the parent is
             # explicitly set. The reason for only dq extensions being allowed as children is:
             # https://github.com/spacetelescope/jdaviz/blob/77b09ce49ab86958e819f47ae85fcdead4d7109e/jdaviz/configs/default/plugins/data_quality/data_quality.py#L142  # noqa
-            set_parent = (self.parent.selected != 'Auto' and ext is None) or (isinstance(ext, str) and ext.lower() == 'dq')
+            set_parent = (((self.parent.selected != 'Auto' and ext is None)
+                           or (isinstance(ext, str) and ext.lower() == 'dq'))
+                          and parent != data_label)
             self.add_to_data_collection(output, data_label,
-                                        parent=parent if (parent != data_label and set_parent) else None,
+                                        parent=parent if set_parent else None,
                                         show_in_viewer=show_in_viewer,
                                         cls=CCDData)
 

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -100,7 +100,7 @@ class ImageImporter(BaseImporterToDataCollection):
         # flat image, not a cube
         # isinstance NDData
         return (isinstance(self.input, (fits.HDUList, fits.hdu.image.ImageHDU,
-                                       NDData, np.ndarray, asdf.AsdfFile)) or
+                                        NDData, np.ndarray, asdf.AsdfFile)) or
                 (HAS_ROMAN_DATAMODELS and isinstance(self.input, (rdd.DataModel, rdd.ImageModel))))
 
     @property

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -59,7 +59,7 @@ class ImageImporter(BaseImporterToDataCollection):
 
     @property
     def is_valid(self):
-        if self.app.config not in ('deconfigged', 'imviz'):
+        if self.app.config not in ('deconfigged', 'imviz', 'mastviz'):
             # NOTE: temporary during deconfig process
             return False
         # flat image, not a cube
@@ -75,14 +75,17 @@ class ImageImporter(BaseImporterToDataCollection):
 
     @property
     def output(self):
-        # if nddata return it
+        # NDData or ndarray
         if isinstance(self.input, NDData) or isinstance(self.input, np.ndarray):
             return self.input
+        # asdf
         elif (isinstance(self.input, asdf.AsdfFile) or
               (HAS_ROMAN_DATAMODELS and isinstance(self.input, rdd.DataModel))):
             return self.input
+        # ImageHDU
         elif isinstance(self.input, fits.hdu.image.ImageHDU):
             return [_hdu2data(self.input, self.data_label_value, None, False)]
+        # fits
         hdulist = self.input
         return [_hdu2data(hdu, self.data_label_value, hdulist)[0]
                 for hdu in self.extension.selected_hdu]
@@ -90,33 +93,40 @@ class ImageImporter(BaseImporterToDataCollection):
     def __call__(self, show_in_viewer=True):
         data_label = self.data_label_value
         output = self.output
+        # nddata
         if isinstance(output, NDData):
-            data, data_label = _nddata_to_glue_data(output, data_label)
-            self.add_to_data_collection(data, f"{data_label}",
-                                        show_in_viewer=show_in_viewer,
-                                        cls=CCDData)
+            returned_data = _nddata_to_glue_data(output, data_label)
+            for data_label, data in returned_data.items():
+                self.add_to_data_collection(data, f"{data_label}", show_in_viewer=show_in_viewer,
+                                            cls=CCDData)
+        # ndarray
         elif isinstance(output, np.ndarray):
             data = _ndarray_to_glue_data(output, data_label)
-            self.add_to_data_collection(data, f"{data_label}",
-                                        show_in_viewer=show_in_viewer,
+            self.add_to_data_collection(data, f"{data_label}", show_in_viewer=show_in_viewer,
                                         cls=CCDData)
+        # asdf
         elif (isinstance(output, asdf.AsdfFile) or
               (HAS_ROMAN_DATAMODELS and isinstance(output, rdd.DataModel))):
-            data, data_label = _roman_asdf_2d_to_glue_data(output, data_label)
-            self.add_to_data_collection(data, f"{data_label}",
-                                        show_in_viewer=show_in_viewer,
-                                        cls=CCDData)
+            returned_data = _roman_asdf_2d_to_glue_data(output, data_label)
+            for data_label, data in returned_data.items():
+                self.add_to_data_collection(data, f"{data_label}", show_in_viewer=show_in_viewer,
+                                            cls=CCDData)
+        # ImageHDU
         elif isinstance(self.input, fits.hdu.image.ImageHDU):
-            data, data_label = _hdu2data(self.input, self.data_label_value, None, True)
-            self.add_to_data_collection(data, f"{data_label}",
-                                        show_in_viewer=show_in_viewer,
-                                        cls=CCDData)
+            # data, data_label = _hdu2data(self.input, self.data_label_value, None, True)
+            for data, data_label in output:
+                self.add_to_data_collection(data, f"{data_label}", show_in_viewer=show_in_viewer,
+                                            cls=CCDData)
+        # fits
         else:
             with self.app._jdaviz_helper.batch_load():
                 for ext, ext_output in zip(self.extension.selected_name, output):
-                    self.add_to_data_collection(ext_output, f"{data_label}[{ext}]",
+                    self.add_to_data_collection(ext_output, ext_output.label,
                                                 show_in_viewer=show_in_viewer,
                                                 cls=CCDData)
+                    # self.add_to_data_collection(ext_output, f"{data_label}[{ext}]",
+                    #                             show_in_viewer=show_in_viewer,
+                    #                             cls=CCDData)
 
 
 def _validate_fits_image2d(hdu, raise_error=False):
@@ -186,11 +196,13 @@ def _nddata_to_glue_data(ndd, data_label):
     if ndd.data.ndim != 2:
         raise ValueError(f'Imviz cannot load this NDData with ndim={ndd.data.ndim}')
 
+    returned_data = {}
     for attrib in ('data', 'mask', 'uncertainty'):
         arr = getattr(ndd, attrib)
         if arr is None:
             continue
         comp_label = attrib.upper()
+        # Do not add extension if data is coming from orientation plugin
         if 'plugin' in ndd.meta.keys() and ndd.meta['plugin'] == 'orientation':
             cur_label = f'{data_label}'
         else:
@@ -209,7 +221,8 @@ def _nddata_to_glue_data(ndd, data_label):
             bunit = ''
         component = Component.autotyped(raw_arr, units=bunit)
         cur_data.add_component(component=component, label=comp_label)
-        return cur_data, cur_label
+        returned_data[cur_label] = cur_data
+    return returned_data
 
 
 def _try_gwcs_to_fits_sip(gwcs):
@@ -263,6 +276,7 @@ def _roman_asdf_2d_to_glue_data(file_obj, data_label, ext=None, try_gwcs_to_fits
         coords = _try_gwcs_to_fits_sip(gwcs)
     else:
         coords = gwcs
+    returned_data = {}
 
     for cur_ext in ext_list:
         comp_label = cur_ext.upper()
@@ -280,5 +294,6 @@ def _roman_asdf_2d_to_glue_data(file_obj, data_label, ext=None, try_gwcs_to_fits
         data.meta.update(standardize_metadata(dict(meta)))
         if comp_label == 'DQ':
             prep_data_layer_as_dq(data)
+        returned_data[new_data_label] = data
 
-        return data, new_data_label
+    return returned_data

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -69,7 +69,9 @@ class ImageImporter(BaseImporterToDataCollection):
         if isinstance(input, fits.hdu.image.ImageHDU):
             input = fits.HDUList([input])
 
-        self.input_hdulist = isinstance(input, (fits.HDUList, rdd.ImageModel, rdd.DataModel))
+        self.input_hdulist = (isinstance(input, fits.HDUList) or
+                              (HAS_ROMAN_DATAMODELS and
+                               isinstance(input, (rdd.ImageModel, rdd.DataModel))))
         if self.input_hdulist:
             filters = ([_validate_fits_image2d] if isinstance(input, fits.HDUList)
                        else [_validate_roman_ext])

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -99,9 +99,9 @@ class ImageImporter(BaseImporterToDataCollection):
             return False
         # flat image, not a cube
         # isinstance NDData
-        return isinstance(self.input, (fits.HDUList, fits.hdu.image.ImageHDU,
-                                       NDData, np.ndarray, asdf.AsdfFile, rdd.DataModel,
-                                       rdd.ImageModel))
+        return (isinstance(self.input, (fits.HDUList, fits.hdu.image.ImageHDU,
+                                       NDData, np.ndarray, asdf.AsdfFile)) or
+                (HAS_ROMAN_DATAMODELS and isinstance(self.input, (rdd.DataModel, rdd.ImageModel))))
 
     @property
     def default_viewer_reference(self):

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -87,7 +87,7 @@ class ImageImporter(BaseImporterToDataCollection):
             return _roman_asdf_2d_to_glue_data(self.input, data_label)
         # ImageHDU
         elif isinstance(self.input, fits.hdu.image.ImageHDU):
-            return [_hdu2data(self.input, self.data_label_value, None, False)]
+            return [_hdu2data(self.input, self.data_label_value, None, True)]
         # fits
         hdulist = self.input
         return [_hdu2data(hdu, self.data_label_value, hdulist)[1]

--- a/jdaviz/core/loaders/importers/image/image.vue
+++ b/jdaviz/core/loaders/importers/image/image.vue
@@ -10,6 +10,16 @@
       :api_hints_enabled="api_hints_enabled"
       hint="Extension to use from the FITS HDUList."
     ></plugin-select>
+    <plugin-dataset-select
+      :items="parent_items"
+      :selected.sync="parent_selected"
+      :show_if_single_entry="true"
+      :multiselect="false"
+      label="Parent Dataset"
+      api_hint="ldr.importer.parent ="
+      :api_hints_enabled="api_hints_enabled"
+      hint="Select a parent dataset to associate the new data with."
+    ></dataset-select>
     <v-row>
       <plugin-auto-label
         :value.sync="data_label_value"

--- a/jdaviz/core/loaders/importers/image/image.vue
+++ b/jdaviz/core/loaders/importers/image/image.vue
@@ -19,7 +19,7 @@
       api_hint="ldr.importer.parent ="
       :api_hints_enabled="api_hints_enabled"
       hint="Select a parent dataset to associate the new data with."
-    ></dataset-select>
+    ></plugin-dataset-select>
     <v-row>
       <plugin-auto-label
         :value.sync="data_label_value"

--- a/jdaviz/core/loaders/importers/image/image.vue
+++ b/jdaviz/core/loaders/importers/image/image.vue
@@ -13,7 +13,7 @@
     <plugin-dataset-select
       :items="parent_items"
       :selected.sync="parent_selected"
-      :show_if_single_entry="true"
+      :show_if_single_entry="false"
       :multiselect="false"
       label="Parent Dataset"
       api_hint="ldr.importer.parent ="

--- a/jdaviz/core/loaders/importers/image/image.vue
+++ b/jdaviz/core/loaders/importers/image/image.vue
@@ -18,7 +18,7 @@
       label="Parent Dataset"
       api_hint="ldr.importer.parent ="
       :api_hints_enabled="api_hints_enabled"
-      hint="Select a parent dataset to associate the new data with."
+      hint="Advanced: manually select a dataset to associate as the parent of the new data entry, 'Auto' will automatically associate non-science extensions with the science extension."
     ></plugin-dataset-select>
     <v-row>
       <plugin-auto-label

--- a/jdaviz/core/loaders/importers/image/image.vue
+++ b/jdaviz/core/loaders/importers/image/image.vue
@@ -19,10 +19,10 @@
         label="Data Label"
         api_hint="ldr.importer.data_label ="
         :api_hints_enabled="api_hints_enabled"
-        hint="Prefix to assign to the new data entry."
+        :hint="data_label_is_prefix ? 'Prefix to assign to the new data entry.' : 'Label to assign to the new data entry.'"
       ></plugin-auto-label>
     </v-row>
-  </v-contatiner>
+  </v-container>
 </template>
 <script setup lang="ts">
 </script>

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -28,6 +28,9 @@ class BaseImporter(PluginTemplateMixin):
         self._resolver = resolver
         super().__init__(app, **kwargs)
 
+    def __repr__(self):
+        return f"<{self.__class__.__name__}>"
+
     @property
     def is_valid(self):
         # override by subclass

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -133,6 +133,9 @@ class BaseImporterToDataCollection(BaseImporter):
             if data_label in viewer.data_menu.data_labels_unloaded:
                 added += 1
                 viewer.data_menu.add_data(data_label)
+            elif data_label in viewer.data_menu.data_labels_loaded:
+                # was already loaded, increment count to avoid creating a new viewer
+                added += 1
         if added == 0:
             if self.app.config not in ('deconfigged', 'lcviz'):
                 # do not add additional viewers

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -159,7 +159,8 @@ class BaseImporterToDataCollection(BaseImporter):
             viewer = self.app._jdaviz_helper.viewers.get(default_viewer_label)
             viewer.data_menu.add_data(data_label)
 
-    def add_to_data_collection(self, data, data_label=None, show_in_viewer=True, cls=None):
+    def add_to_data_collection(self, data, data_label=None,
+                               parent=None, show_in_viewer=True, cls=None):
         if data_label is None:
             data_label = self.data_label_value.strip()
         if hasattr(data, 'meta'):
@@ -168,6 +169,8 @@ class BaseImporterToDataCollection(BaseImporter):
             except TypeError:
                 pass
         self.app.add_data(data, data_label=data_label)
+        if parent is not None:
+            self.app._set_assoc_data_as_child(data_label, parent)
         # store the original input class so that get_data can default to the
         # same class as the input
         cls = cls if cls is not None else data.__class__

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -154,7 +154,6 @@ class Spectrum2DImporter(BaseImporterToDataCollection):
                         wcs = None
                 else:
                     wcs = None
-            print(Spectrum(flux=data * data_unit, meta=metadata, wcs=wcs, spectral_axis_index=1))
             return Spectrum(flux=data * data_unit, meta=metadata, wcs=wcs, spectral_axis_index=1)
         except ValueError:
             # In some cases, the above call to Spectrum will fail if no

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -15,7 +15,7 @@ from jdaviz.utils import standardize_metadata, PRIHDR_KEY
 __all__ = ['Spectrum2DImporter']
 
 
-def hdu_is_valid(hdu):
+def hdu_is_valid(item):
     """
     Check if the HDU is valid to be imported as a 2D Spectrum.
 
@@ -29,6 +29,7 @@ def hdu_is_valid(hdu):
     bool
         True if the HDU is a valid light curve HDU, False otherwise.
     """
+    hdu = item.get('obj')
     return (len(getattr(hdu, 'shape', [])) == 2
             and ('DISPAXIS' in hdu.header
                  or hdu.header.get('CTYPE1', '') == 'WAVE'
@@ -68,10 +69,15 @@ class Spectrum2DImporter(BaseImporterToDataCollection):
 
         self.input_hdulist = isinstance(self.input, fits.HDUList)
         if self.input_hdulist:
+            ext_options = [{'label': f"{index}: {hdu.name}",
+                            'name': hdu.name,
+                            'index': index,
+                            'obj': hdu}
+                           for index, hdu in enumerate(self.input)]
             self.extension = SelectFileExtensionComponent(self,
                                                           items='extension_items',
                                                           selected='extension_selected',
-                                                          manual_options=self.input,
+                                                          manual_options=ext_options,
                                                           filters=[hdu_is_valid])
 
     @property
@@ -89,7 +95,7 @@ class Spectrum2DImporter(BaseImporterToDataCollection):
         if not ((isinstance(self.input, Spectrum)
                  and self.input.flux.ndim == 2) or
                 (isinstance(self.input, fits.HDUList)
-                 and len([hdu for hdu in self.input if hdu_is_valid(hdu)]))):  # noqa
+                 and len([hdu for hdu in self.input if hdu_is_valid({'obj': hdu})]))):  # noqa
             return False
         try:
             self.output
@@ -113,7 +119,7 @@ class Spectrum2DImporter(BaseImporterToDataCollection):
             return self.input
 
         hdulist = self.input
-        hdu = self.extension.selected_hdu
+        hdu = self.extension.selected_obj
         data = hdu.data
         header = hdu.header
         metadata = standardize_metadata(header)

--- a/jdaviz/core/loaders/importers/subset/subset.py
+++ b/jdaviz/core/loaders/importers/subset/subset.py
@@ -75,7 +75,7 @@ class SubsetImporter(BaseImporterToPlugin):
     def _set_import_disabled(self, change={}):
         self.resolver.import_disabled = len(self.subset_label_invalid_msg) > 0
 
-    def __call__(self):
+    def __call__(self, show_in_viewer=True):
         if self.subset_label_invalid_msg:
             raise ValueError(self.subset_label_invalid_msg)
         if self.subset_label_value.strip() == self.subset_label_default:

--- a/jdaviz/core/loaders/parsers/__init__.py
+++ b/jdaviz/core/loaders/parsers/__init__.py
@@ -1,5 +1,6 @@
 from .parser import *  # noqa
 from .fits import *  # noqa
+from .jpg_png import *  # noqa
 from .asdf import *  # noqa
 from .regions import *  # noqa
 from .specutils import *  # noqa

--- a/jdaviz/core/loaders/parsers/asdf.py
+++ b/jdaviz/core/loaders/parsers/asdf.py
@@ -1,5 +1,6 @@
 from functools import cached_property
 import asdf
+import warnings
 
 from jdaviz.core.loaders.parsers import BaseParser
 from jdaviz.core.registries import loader_parser_registry
@@ -34,4 +35,13 @@ class ASDFParser(BaseParser):
     def output(self):
         if HAS_ROMAN_DATAMODELS:
             return rdd.open(self.input)
+        else:
+            warnings.warn(
+                f"{self.input} should be opened with the `roman_datamodels` package, "
+                "which is not installed in this environment. To install optional "
+                "jdaviz dependencies for Roman, you can run:  \n\n"
+                "pip install -U jdaviz[roman]\n\n"
+                "This file will be loaded with the `asdf` package instead.\n\n",
+                UserWarning
+            )
         return asdf.open(self.input)

--- a/jdaviz/core/loaders/parsers/jpg_png.py
+++ b/jdaviz/core/loaders/parsers/jpg_png.py
@@ -1,0 +1,28 @@
+from functools import cached_property
+from skimage.io import imread
+from skimage.color import rgb2gray, rgba2rgb
+from jdaviz.core.loaders.parsers import BaseParser
+from jdaviz.core.registries import loader_parser_registry
+
+
+__all__ = ['JPGPNGParser']
+
+
+@loader_parser_registry('jpgpng')
+class JPGPNGParser(BaseParser):
+
+    @property
+    def is_valid(self):
+        if self.app.config not in ('deconfigged', 'specviz2d', 'lcviz', 'imviz'):
+            # NOTE: temporary during deconfig process
+            return False
+        return isinstance(self.input, str) and self.input.endswith(('.jpg', '.jpeg', '.png'))
+
+    @cached_property
+    def output(self):
+        im = imread(self.input)
+        if im.shape[2] == 4:
+            pf = rgb2gray(rgba2rgb(im))
+        else:  # Assume RGB
+            pf = rgb2gray(im)
+        return pf[::-1, :]  # Flip it

--- a/jdaviz/core/loaders/resolvers/file/file.py
+++ b/jdaviz/core/loaders/resolvers/file/file.py
@@ -17,6 +17,7 @@ __all__ = ['FileResolver']
 class FileResolver(BaseResolver):
     template_file = __file__, "file.vue"
     default_input = 'filepath'
+    default_input_cast = str
 
     file_chooser_widget = Any().tag(sync=True, **widget_serialization)
     filepath = Unicode().tag(sync=True)

--- a/jdaviz/core/loaders/resolvers/object/object.py
+++ b/jdaviz/core/loaders/resolvers/object/object.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from traitlets import Unicode
 
 from jdaviz.core.registries import loader_resolver_registry
@@ -23,7 +24,7 @@ class ObjectResolver(BaseResolver):
 
     @property
     def is_valid(self):
-        return not isinstance(self.object, str)
+        return not isinstance(self.object, (str, Path))
 
     @property
     def object(self):

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -195,6 +195,7 @@ class TargetSelect(SelectPluginComponent):
 class BaseResolver(PluginTemplateMixin):
     _defer_update_format_items = False  # only use via defer_update_format_items contex manager
     default_input = None
+    default_input_cast = None
     requires_api_support = False
 
     importer_widget = Unicode().tag(sync=True)
@@ -244,7 +245,8 @@ class BaseResolver(PluginTemplateMixin):
         if self.default_input is None:
             raise NotImplementedError("Resolver subclass must implement default_input")  # noqa pragma: nocover
         with self.defer_update_format_items():
-            setattr(self, self.default_input, inp)
+            setattr(self, self.default_input,
+                    self.default_input_cast(inp) if self.default_input_cast else inp)
             user_api = self.user_api
             for k, v in kwargs.items():
                 if hasattr(user_api, k):

--- a/jdaviz/core/loaders/test_loaders.py
+++ b/jdaviz/core/loaders/test_loaders.py
@@ -94,7 +94,7 @@ def test_fits_spectrum2d(deconfigged_helper):
     # Default is Image but the test switches to 2D Spectrum
     # since this file type is not yet supported by the image loader
     assert ldr.format == 'Image'
-    assert ldr.importer._obj.input_hdulist is True
+    assert ldr.importer._obj.input_has_extensions is True
 
     ldr.format = '2D Spectrum'
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1240,7 +1240,8 @@ class SelectFileExtensionComponent(SelectPluginComponent):
             # in this case, self.manual_options is the model composed of many ndarrays,
             # with each ndarray corresponding to an hdu in FITS terms
             if self.is_multiselect:
-                return [self.manual_options[name] for name in self.manual_options if name in self.selected_name]
+                return [self.manual_options[name] for name in self.manual_options
+                        if name in self.selected_name]
             return self.manual_options[self.selected_name]
 
         if self.is_multiselect:

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1236,7 +1236,8 @@ class SelectFileExtensionComponent(SelectPluginComponent):
 
     @property
     def selected_hdu(self):
-        if isinstance(self.manual_options, (rdd.ImageModel, rdd.DataModel)):
+        if (HAS_ROMAN_DATAMODELS and
+                isinstance(self.manual_options, (rdd.ImageModel, rdd.DataModel))):
             # in this case, self.manual_options is the model composed of many ndarrays,
             # with each ndarray corresponding to an hdu in FITS terms
             if self.is_multiselect:

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -67,6 +67,10 @@ class UserApiWrapper:
             # .selected traitlet
             if isinstance(exp_obj, UnitSelectPluginComponent) and isinstance(value, u.Unit):
                 value = value.to_string()
+            elif value == '*' and hasattr(exp_obj, 'multiselect'):
+                exp_obj.multiselect = True
+                exp_obj.select_all()
+                return
             elif isinstance(exp_obj, SelectFileExtensionComponent):
                 def to_choice_single(value):
                     if isinstance(value, int):

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -75,7 +75,7 @@ class UserApiWrapper:
                 def to_choice_single(value):
                     if isinstance(value, int):
                         # allow setting by index
-                        return exp_obj.choices[value]
+                        return exp_obj.choices[exp_obj.indices.index(value)]
                     elif isinstance(value, str):
                         # allow setting without index
                         if value not in exp_obj.choices:

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -68,13 +68,23 @@ class UserApiWrapper:
             if isinstance(exp_obj, UnitSelectPluginComponent) and isinstance(value, u.Unit):
                 value = value.to_string()
             elif isinstance(exp_obj, SelectFileExtensionComponent):
-                if isinstance(value, int):
-                    # allow setting by index
-                    value = exp_obj.choices[exp_obj.indices.index(value)]
-                elif isinstance(value, str):
-                    # allow setting without index
-                    if value not in exp_obj.choices:
-                        value = exp_obj.choices[exp_obj.names.index(value)]
+                def to_choice_single(value):
+                    if isinstance(value, int):
+                        # allow setting by index
+                        return exp_obj.choices[value]
+                    elif isinstance(value, str):
+                        # allow setting without index
+                        if value not in exp_obj.choices:
+                            return exp_obj.choices[exp_obj.names.index(value)]
+                        return value
+                    else:
+                        raise ValueError(f"Invalid value type: {type(value)}")
+                if isinstance(value, (list, tuple)):
+                    # allow setting by list of indices or names
+                    value = [to_choice_single(v) for v in value]
+                else:
+                    # allow setting by single index or name
+                    value = to_choice_single(value)
             exp_obj.selected = value
             return
         elif isinstance(exp_obj, AddResults):
@@ -82,6 +92,8 @@ class UserApiWrapper:
             return
         elif isinstance(exp_obj, AutoTextField):
             exp_obj.value = value
+            if value != exp_obj.default:
+                exp_obj.auto = False
             return
         elif isinstance(exp_obj, PlotOptionsSyncState):
             if not len(exp_obj.linked_states):

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -192,7 +192,7 @@ def test_data_associations(imviz_helper):
     assert imviz_helper.app._get_assoc_data_children('parent_data') == ['child_data']
     assert imviz_helper.app._get_assoc_data_parent('child_data') == 'parent_data'
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError):
         # we don't (yet) allow children of children:
         imviz_helper.load_data(data_child, data_label='grandchild_data', parent='child_data')
 

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-from astropy.wcs import FITSFixedWarning
 
 from jdaviz.utils import alpha_index, download_uri_to_path, get_cloud_fits, cached_uri
 from astropy.io import fits
@@ -39,14 +38,7 @@ def test_uri_to_download_nonexistent_mast_file(imviz_helper):
 @pytest.mark.remote_data
 def test_url_to_download_imviz_local_path_warning(imviz_helper):
     url = "https://www.astropy.org/astropy-data/tutorials/FITS-images/HorseHead.fits"
-    match_local_path_msg = (
-        'You requested to cache data to the .*local_path.*supported for downloads of '
-        'MAST URIs.*astropy download cache instead.*'
-    )
-    # with (
-    #     pytest.warns(FITSFixedWarning, match="'datfix' made the change"),
-    #     pytest.warns(UserWarning, match=match_local_path_msg)
-    # ):
+
     with pytest.raises(ValueError, match="not one of"):
         imviz_helper.load_data(url, cache=True, local_path='horsehead.fits')
 

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -22,7 +22,7 @@ def test_alpha_index_exceptions():
 
 def test_uri_to_download_bad_scheme(imviz_helper):
     uri = "file://path/to/file.fits"
-    with pytest.raises(ValueError, match=r'URI file://path/to/file\.fits with scheme file'):
+    with pytest.raises(ValueError, match="not one of"):
         imviz_helper.load_data(uri)
 
 
@@ -43,10 +43,11 @@ def test_url_to_download_imviz_local_path_warning(imviz_helper):
         'You requested to cache data to the .*local_path.*supported for downloads of '
         'MAST URIs.*astropy download cache instead.*'
     )
-    with (
-        pytest.warns(FITSFixedWarning, match="'datfix' made the change"),
-        pytest.warns(UserWarning, match=match_local_path_msg)
-    ):
+    # with (
+    #     pytest.warns(FITSFixedWarning, match="'datfix' made the change"),
+    #     pytest.warns(UserWarning, match=match_local_path_msg)
+    # ):
+    with pytest.raises(ValueError, match="not one of"):
         imviz_helper.load_data(url, cache=True, local_path='horsehead.fits')
 
 

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 import pytest
 
@@ -21,7 +22,7 @@ def test_alpha_index_exceptions():
 
 def test_uri_to_download_bad_scheme(imviz_helper):
     uri = "file://path/to/file.fits"
-    with pytest.raises(ValueError, match="not one of"):
+    with pytest.raises(ValueError, match="no valid loaders found for input"):
         imviz_helper.load_data(uri)
 
 
@@ -39,7 +40,8 @@ def test_uri_to_download_nonexistent_mast_file(imviz_helper):
 def test_url_to_download_imviz_local_path_warning(imviz_helper):
     url = "https://www.astropy.org/astropy-data/tutorials/FITS-images/HorseHead.fits"
 
-    with pytest.raises(ValueError, match="not one of"):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
         imviz_helper.load_data(url, cache=True, local_path='horsehead.fits')
 
 

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -577,7 +577,7 @@
    "outputs": [],
    "source": [
     "# Show the first image in the second viewer.\n",
-    "imviz.app.add_data_to_viewer(viewer_2_name, 'jw02727-o002_t062_nircam_clear-f277w_i2d[DATA]')"
+    "imviz.app.add_data_to_viewer(viewer_2_name, 'jw02727-o002_t062_nircam_clear-f277w_i2d[SCI,1]')"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,7 @@ filterwarnings = [
     "ignore:.*numpy\\.core.*:DeprecationWarning",
     "ignore:The load_data function is deprecated.*",
     "ignore:.*Set OBSGEO-L to.*",
+    "ignore::DeprecationWarning:.*path should be string, bytes, os.PathLike or integer, not ndarray",
     # This warning will not fail in CI, but causes issues running tests locally on Windows so test locally if considering
     # removing this in the future
     "ignore:Importing display from IPython.core.display is deprecated since IPython 7.14, please import from IPython.display",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ filterwarnings = [
     "ignore:.*numpy\\.core.*:DeprecationWarning",
     "ignore:The load_data function is deprecated.*",
     "ignore:.*Set OBSGEO-L to.*",
-    "ignore::DeprecationWarning:.*path should be string, bytes, os.PathLike or integer, not ndarray",
+    "ignore:.*path should be string, bytes, os.PathLike or integer, not ndarray",
     # This warning will not fail in CI, but causes issues running tests locally on Windows so test locally if considering
     # removing this in the future
     "ignore:Importing display from IPython.core.display is deprecated since IPython 7.14, please import from IPython.display",


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request reroutes `imviz.load_data()` calls to use the new imviz loader.

Things that can be loaded into the new loader:

 - [x] FITS
 - [x] ImageHDU
 - [x] NDData
 - [x] ndarray
 - [x] asdf
 - [x] jpg
 - [x] png
 - [x] region file
 - [x] mast uri
 - [x] roman data models
 - [x] S3 uri (can be ignored for now) (fixed here https://github.com/spacetelescope/jdaviz/pull/3702 )
 - [x] data with `ext` kwarg set
 - [ ] gwcs to fits sip (handled here https://github.com/spacetelescope/jdaviz/pull/3679)

Remaining errors:
 - [ ] 2x gwcs fits sip
 - [x] s3 uri
 - [x] py vo (related to https://github.com/spacetelescope/jdaviz/issues/3225 ? ) (updated test values since originals were not scientifically validated)
 - [x] failure in orientation plugin that seems to be related to fake orientation layer https://github.com/spacetelescope/jdaviz/pull/2712#issuecomment-1967280167 (fixed by [f3526bd](https://github.com/spacetelescope/jdaviz/pull/3662/commits/f3526bd1ac8e97aa3f6672781465cd58c7d63659))


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
