### PR TITLE
re-add windows specific warning to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,9 @@ filterwarnings = [
     "ignore:.*numpy\\.core.*:DeprecationWarning",
     "ignore:The load_data function is deprecated.*",
     "ignore:.*Set OBSGEO-L to.*",
-    "ignore:Importing display from IPython.core.display is deprecated since IPython 7.14, please import from IPython.display",  # windows
+    # This warning will not fail in CI, but causes issues running tests locally on Windows so test locally if considering
+    # removing this in the future
+    "ignore:Importing display from IPython.core.display is deprecated since IPython 7.14, please import from IPython.display",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ filterwarnings = [
     "ignore:.*numpy\\.core.*:DeprecationWarning",
     "ignore:The load_data function is deprecated.*",
     "ignore:.*Set OBSGEO-L to.*",
+    "ignore:Importing display from IPython.core.display is deprecated since IPython 7.14, please import from IPython.display",  # windows
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
The warning 'ignore:Importing display from IPython.core.display is deprecated since IPython 7.14, please import from IPython.display' was removed because it was not causing any errors in CI, but pops up when running tests locally on Windows machines. Re-add this warning to pyproject.toml and add a note about testing it on windows before removing in the future. 