### PR TITLE
add gwcs sip switch to image loader, remove from orientation plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,7 +48,8 @@ Imviz
 - The Export plugin now supports saving spatial subsets as STC-S strings, including CircleSkyRegion and EllipseSkyRegion,
   which are exported as ``CIRCLE`` and ``ELLIPSE`` STC-S shapes, respectively. [#3591, #3595]
 
-- Improve performance by using FITS WCS for reference data layers when linked by WCS, rather than GWCS. [#3483, #3535, #3540]
+- Improve performance by using FITS WCS for reference data layers when linked by WCS, rather than GWCS. [#3483, #3535, #3540, #3679]
+
 
 Mosviz
 ^^^^^^

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -84,7 +84,8 @@ class Imviz(ImageConfigHelper):
             raise ValueError(f"Default viewer '{viewer_id}' cannot be destroyed")
         self.app.vue_destroy_viewer_item(viewer_id)
 
-    def load_data(self, data, data_label=None, show_in_viewer=True, **kwargs):
+    def load_data(self, data, data_label=None, show_in_viewer=True,
+                  gwcs_to_fits_sip=False, **kwargs):
         """Load data into Imviz.
 
         Parameters
@@ -146,8 +147,8 @@ class Imviz(ImageConfigHelper):
         """
         prev_data_labels = self.app.data_collection.labels
 
-        if 'gwcs_to_fits_sip' not in kwargs and 'Orientation' in self.plugins.keys():
-            kwargs['gwcs_to_fits_sip'] = self.plugins['Orientation'].gwcs_to_fits_sip
+        # to pass to parser
+        kwargs['gwcs_to_fits_sip'] = gwcs_to_fits_sip
 
         if isinstance(data, str):
             filelist = data.split(',')

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -74,7 +74,6 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
     wcs_use_fallback = Bool(True).tag(sync=True)
     wcs_fast_approximation = Bool(True).tag(sync=True)
     wcs_linking_available = Bool(False).tag(sync=True)
-    gwcs_to_fits_sip = Bool(False).tag(sync=True)
 
     need_clear_astrowidget_markers = Bool(False).tag(sync=True)
     plugin_markers_exist = Bool(False).tag(sync=True)
@@ -156,8 +155,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
                 'align_by', 'wcs_fast_approximation',
                 'delete_subsets', 'viewer', 'orientation',
                 'rotation_angle', 'east_left', 'add_orientation',
-                'set_north_up_east_left', 'set_north_up_east_right',
-                'gwcs_to_fits_sip'
+                'set_north_up_east_left', 'set_north_up_east_right'
             )
         )
 

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.vue
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.vue
@@ -91,17 +91,6 @@
           />
         </v-row>
 
-        <v-row>
-          <plugin-switch
-            v-if="align_by_selected == 'WCS'"
-            :value.sync="gwcs_to_fits_sip"
-            label="Approximate GWCS with FITS SIP"
-            api_hint="plg.gwcs_to_fits_sip = "
-            :api_hints_enabled="api_hints_enabled"
-            hint="On future data loads, try to convert GWCS into FITS SIP for better performance (typical precision <0.1 pixels)."
-          />
-        </v-row>
-
         <v-row v-if="false">
           <plugin-switch
             :value.sync="wcs_use_fallback"

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -13,6 +13,7 @@ from glue.core.data import Component, Data
 from gwcs.wcs import WCS as GWCS
 from stdatamodels import asdf_in_fits
 
+from jdaviz.utils import _try_gwcs_to_fits_sip
 from jdaviz.core.registries import data_parser_registry
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.utils import (
@@ -31,27 +32,6 @@ __all__ = ['parse_data']
 
 INFO_MSG = ("The file contains more viewable extensions. Add the '[*]' suffix"
             " to the file name to load all of them.")
-
-
-def _try_gwcs_to_fits_sip(gwcs):
-    """
-    Try to convert this GWCS to FITS SIP. Some GWCS models
-    cannot be converted to FITS SIP. In that case, a warning
-    is raised and the GWCS is used, as is.
-    """
-    try:
-        result = WCS(gwcs.to_fits_sip(), relax=True)
-
-    except ValueError as err:
-        warnings.warn(
-            "The GWCS coordinates could not be simplified to "
-            "a SIP-based FITS WCS, the following error was "
-            f"raised: {err}",
-            UserWarning
-        )
-        result = gwcs
-
-    return result
 
 
 def prep_data_layer_as_dq(data):
@@ -264,7 +244,8 @@ def get_image_data_iterator(app, file_obj, data_label, ext=None, try_gwcs_to_fit
 
     # load Roman 2D datamodels:
     elif HAS_ROMAN_DATAMODELS and isinstance(file_obj, rdd.DataModel):
-        data_iter = _roman_asdf_2d_to_glue_data(file_obj, data_label, ext=ext)
+        data_iter = _roman_asdf_2d_to_glue_data(file_obj, data_label, ext=ext,
+                                                try_gwcs_to_fits_sip=try_gwcs_to_fits_sip)
 
     # load ASDF files that may not validate as Roman datamodels:
     elif isinstance(file_obj, asdf.AsdfFile):

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -237,14 +237,11 @@ class TestParseImage:
 
     @pytest.mark.remote_data
     def test_parse_jwst_nircam_level2(self, imviz_helper):
-        # use non-default GWCS rather than FITS SIP (not the default),
-        # to test the GWCS compatibility:
-        imviz_helper.plugins['Orientation'].gwcs_to_fits_sip = False
 
         # Default behavior: Science image
         with pytest.warns(UserWarning, match='You may be querying for a remote file'):
             # if you don't pass a `cache` value, a warning should be raised:
-            imviz_helper.load_data(self.jwst_asdf_url_1, timeout=100)
+            imviz_helper.load_data(self.jwst_asdf_url_1, timeout=100, gwcs_to_fits_sip=False)
 
         data = imviz_helper.app.data_collection[0]
         comp = data.get_component('DATA')
@@ -533,20 +530,8 @@ class TestParseImage:
          (False, GWCS),)
     )
     def test_gwcs_to_fits_sip(self, gwcs_to_fits_sip, expected_cls, imviz_helper):
-        imviz_helper.load_data(self.jwst_asdf_url_1, cache=True, gwcs_to_fits_sip=gwcs_to_fits_sip)
-
-        data = imviz_helper.app.data_collection[0]
-        assert isinstance(data.coords, expected_cls)
-
-    @pytest.mark.remote_data
-    @pytest.mark.parametrize(
-        ('gwcs_to_fits_sip', 'expected_cls'),
-        ((True, WCS),
-         (False, GWCS),)
-    )
-    def test_orientation_gwcs_to_fits_sip(self, gwcs_to_fits_sip, expected_cls, imviz_helper):
-        imviz_helper.plugins['Orientation'].gwcs_to_fits_sip = gwcs_to_fits_sip
-        imviz_helper.load_data(self.jwst_asdf_url_1, cache=True)
+        imviz_helper.load_data(self.jwst_asdf_url_1, cache=True,
+                               gwcs_to_fits_sip=gwcs_to_fits_sip)
 
         data = imviz_helper.app.data_collection[0]
         assert isinstance(data.coords, expected_cls)

--- a/jdaviz/core/loaders/importers/image/image.vue
+++ b/jdaviz/core/loaders/importers/image/image.vue
@@ -22,6 +22,15 @@
         hint="Prefix to assign to the new data entry."
       ></plugin-auto-label>
     </v-row>
+    <v-row>
+      <plugin-switch v-if="has_gwcs"
+        :value.sync="gwcs_to_fits_sip"
+        label="Approximate GWCS with FITS SIP"
+        api_hint="ldr.importer.gwcs_to_fits_sip = "
+        :api_hints_enabled="api_hints_enabled"
+        hint="Try to convert GWCS into FITS SIP for better performance aligning images (typical precision <0.1 pixels)."
+      />
+    </v-row>
   </v-contatiner>
 </template>
 <script setup lang="ts">

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -11,6 +11,7 @@ import numpy as np
 from astropy.io import fits
 from astropy.utils import minversion
 from astropy.utils.data import download_file
+from astropy.wcs import WCS
 from astropy.wcs.wcsapi import BaseHighLevelWCS
 from astroquery.mast import Observations, conf
 from matplotlib import colors as mpl_colors
@@ -853,3 +854,24 @@ def _hex_for_cmap(cmap):
 
 
 cmap_samples = {cmap[1].name: _hex_for_cmap(cmap[1]) for cmap in glue_colormaps.members}
+
+
+def _try_gwcs_to_fits_sip(gwcs):
+    """
+    Try to convert this GWCS to FITS SIP. Some GWCS models
+    cannot be converted to FITS SIP. In that case, a warning
+    is raised and the GWCS is used, as is.
+    """
+    try:
+        result = WCS(gwcs.to_fits_sip(), relax=True)
+
+    except ValueError as err:
+        warnings.warn(
+            "The GWCS coordinates could not be simplified to "
+            "a SIP-based FITS WCS, the following error was "
+            f"raised: {err}",
+            UserWarning
+        )
+        result = gwcs
+
+    return result


### PR DESCRIPTION
This PR removes the toggle to enable FITS SIP approximation from the Orientation plugin and adds it to the image loader. It will be visible in the UI after https://github.com/spacetelescope/jdaviz/pull/3662 is merged. 

To use the gwcs_to_fits_sip option from the API, 'gwcs_to_fits_sip' is now a keyword argument in imviz.load_data (previously it was advertised in the docstring of load_data, but obtained from kwargs). Within load_data it as added to kwargs to pass to the parser. 

I did not deprecate this in the Orientation plugin because it was not in 4.3.2.

I also fixed a few instances where _roman_asdf_2d_to_glue_data was being called but not being passed the gwcs_to_fits_sip argument (I'm not sure this was intentional in the first place, if it was I will revert this change). 