### PR TITLE
add gwcs sip switch to image loader, remove from orientation plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,7 +64,7 @@ Imviz
 - The Export plugin now supports saving spatial subsets as STC-S strings, including CircleSkyRegion and EllipseSkyRegion,
   which are exported as ``CIRCLE`` and ``ELLIPSE`` STC-S shapes, respectively. [#3591, #3595]
 
-- Improve performance by using FITS WCS for reference data layers when linked by WCS, rather than GWCS. [#3483, #3535, #3540]
+- Improve performance by using FITS WCS for reference data layers when linked by WCS, rather than GWCS. [#3483, #3535, #3540, #3687]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -92,7 +92,8 @@ class Imviz(ImageConfigHelper):
             raise ValueError(f"Default viewer '{viewer_id}' cannot be destroyed")
         self.app.vue_destroy_viewer_item(viewer_id)
 
-    def load_data(self, data, data_label=None, show_in_viewer=True, **kwargs):
+    def load_data(self, data, data_label=None, show_in_viewer=True,
+                  gwcs_to_fits_sip=False, **kwargs):
         """Load data into Imviz.
 
         Parameters
@@ -134,8 +135,7 @@ class Imviz(ImageConfigHelper):
             Try to convert GWCS coordinates into an approximate FITS SIP solution. Typical
             precision loss due to this approximation is of order 0.1 pixels. This may
             improve image rendering performance for images with expensive GWCS
-            transformations. If this keyword argument isn't specified, the choice
-            will be taken from the Orientation plugin's ``gwcs_to_fits_sip`` traitlet.
+            transformations. (Default: False)
 
         kwargs : dict
             Extra keywords to be passed into app-level parser.
@@ -156,9 +156,6 @@ class Imviz(ImageConfigHelper):
 
         extensions = kwargs.pop('ext', None)
 
-        if 'gwcs_to_fits_sip' not in kwargs and 'Orientation' in self.plugins.keys():
-            kwargs['gwcs_to_fits_sip'] = self.plugins['Orientation'].gwcs_to_fits_sip
-
         if isinstance(data, str) and "," in data:
             data = data.split(',')
 
@@ -172,6 +169,7 @@ class Imviz(ImageConfigHelper):
                     self.load_data(data_i,
                                    data_label=data_label,
                                    show_in_viewer=show_in_viewer,
+                                   gwcs_to_fits_sip=gwcs_to_fits_sip,
                                    **kw)
             return
 
@@ -194,14 +192,16 @@ class Imviz(ImageConfigHelper):
                            data_label=data_label,
                            extension=extensions,
                            parent=kwargs.pop('parent', None),
-                           show_in_viewer=show_in_viewer)
+                           show_in_viewer=show_in_viewer,
+                           gwcs_to_fits_sip=gwcs_to_fits_sip)
         elif isinstance(data, str) and data.endswith('.reg'):
             self._load(data,
                        format='Subset',
                        data_label=data_label,
                        extension=extensions,
                        parent=kwargs.pop('parent', None),
-                       show_in_viewer=show_in_viewer)
+                       show_in_viewer=show_in_viewer,
+                       gwcs_to_fits_sip=gwcs_to_fits_sip)
         else:
             # if the data-label is provided but without an
             # extension in the label, maintain previous behavior of appending
@@ -227,7 +227,8 @@ class Imviz(ImageConfigHelper):
                        data_label_as_prefix=data_label_as_prefix,
                        extension=extensions,
                        parent=kwargs.pop('parent', None),
-                       show_in_viewer=show_in_viewer)
+                       show_in_viewer=show_in_viewer,
+                       gwcs_to_fits_sip=gwcs_to_fits_sip)
 
     def link_data(self, align_by='pixels', wcs_fallback_scheme=None, wcs_fast_approximation=True):
         """(Re)link loaded data in Imviz with the desired link type.

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -74,7 +74,6 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
     wcs_use_fallback = Bool(True).tag(sync=True)
     wcs_fast_approximation = Bool(True).tag(sync=True)
     wcs_linking_available = Bool(False).tag(sync=True)
-    gwcs_to_fits_sip = Bool(False).tag(sync=True)
 
     need_clear_astrowidget_markers = Bool(False).tag(sync=True)
     plugin_markers_exist = Bool(False).tag(sync=True)
@@ -155,8 +154,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
                 'align_by', 'wcs_fast_approximation',
                 'delete_subsets', 'viewer', 'orientation',
                 'rotation_angle', 'east_left', 'add_orientation',
-                'set_north_up_east_left', 'set_north_up_east_right',
-                'gwcs_to_fits_sip'
+                'set_north_up_east_left', 'set_north_up_east_right'
             )
         )
 

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.vue
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.vue
@@ -91,17 +91,6 @@
           />
         </v-row>
 
-        <v-row>
-          <plugin-switch
-            v-if="align_by_selected == 'WCS'"
-            :value.sync="gwcs_to_fits_sip"
-            label="Approximate GWCS with FITS SIP"
-            api_hint="plg.gwcs_to_fits_sip = "
-            :api_hints_enabled="api_hints_enabled"
-            hint="On future data loads, try to convert GWCS into FITS SIP for better performance (typical precision <0.1 pixels)."
-          />
-        </v-row>
-
         <v-row v-if="false">
           <plugin-switch
             :value.sync="wcs_use_fallback"

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -237,12 +237,9 @@ class TestParseImage:
 
     @pytest.mark.remote_data
     def test_parse_jwst_nircam_level2(self, imviz_helper):
-        # use non-default GWCS rather than FITS SIP (not the default),
-        # to test the GWCS compatibility:
-        imviz_helper.plugins['Orientation'].gwcs_to_fits_sip = False
 
         # Default behavior: Science image
-        imviz_helper.load_data(self.jwst_asdf_url_1, timeout=100)
+        imviz_helper.load_data(self.jwst_asdf_url_1, timeout=100, gwcs_to_fits_sip=False)
 
         data = imviz_helper.app.data_collection[0]
         comp = data.get_component('data')
@@ -525,26 +522,17 @@ class TestParseImage:
             parse_data(imviz_helper.app, filename, ext='DOES_NOT_EXIST', data_label='foo')
 
     @pytest.mark.remote_data
+    @pytest.mark.filterwarnings("ignore:Some non-standard WCS keywords were excluded")
     @pytest.mark.parametrize(
         ('gwcs_to_fits_sip', 'expected_cls'),
-        ((True, WCS),
-         (False, GWCS),)
-    )
+        ((True, WCS), (False, GWCS),), ids=('True-WCS', 'False-GWCS'))
     def test_gwcs_to_fits_sip(self, gwcs_to_fits_sip, expected_cls, imviz_helper):
-        imviz_helper.load_data(self.jwst_asdf_url_1, cache=True, gwcs_to_fits_sip=gwcs_to_fits_sip)
-
-        data = imviz_helper.app.data_collection[0]
-        assert isinstance(data.coords, expected_cls)
-
-    @pytest.mark.remote_data
-    @pytest.mark.parametrize(
-        ('gwcs_to_fits_sip', 'expected_cls'),
-        ((True, WCS),
-         (False, GWCS),)
-    )
-    def test_orientation_gwcs_to_fits_sip(self, gwcs_to_fits_sip, expected_cls, imviz_helper):
-        imviz_helper.plugins['Orientation'].gwcs_to_fits_sip = gwcs_to_fits_sip
-        imviz_helper.load_data(self.jwst_asdf_url_1, cache=True)
+        """
+        Test gwcs_to_fits_sip as an argument to load_data until it is
+        fully deprecated.
+        """
+        imviz_helper.load_data(self.jwst_asdf_url_1, cache=True,
+                               gwcs_to_fits_sip=gwcs_to_fits_sip)
 
         data = imviz_helper.app.data_collection[0]
         assert isinstance(data.coords, expected_cls)

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -182,6 +182,7 @@ class ConfigHelper(HubListener):
         # TODO: deprecate show_in_viewer?
         show_in_viewer = kwargs.pop('show_in_viewer', True)
         importer = resolver.importer
+
         for k, v in kwargs.items():
             if hasattr(importer, k) and v is not None:
                 setattr(importer, k, v)

--- a/jdaviz/core/loaders/importers/image/image.vue
+++ b/jdaviz/core/loaders/importers/image/image.vue
@@ -32,6 +32,15 @@
         :hint="data_label_is_prefix ? 'Prefix to assign to the new data entry.' : 'Label to assign to the new data entry.'"
       ></plugin-auto-label>
     </v-row>
+    <v-row>
+      <plugin-switch
+        :value.sync="gwcs_to_fits_sip"
+        label="Approximate GWCS with FITS SIP"
+        api_hint="ldr.importer.gwcs_to_fits_sip = "
+        :api_hints_enabled="api_hints_enabled"
+        hint="If GWCS exists, try to convert into FITS SIP for better performance aligning images (typical precision <0.1 pixels)."
+      />
+    </v-row>
   </v-container>
 </template>
 <script setup lang="ts">


### PR DESCRIPTION
This PR removes the toggle to enable FITS SIP approximation from the Orientation plugin and adds it to the image loader. 

To use the gwcs_to_fits_sip option from the API, 'gwcs_to_fits_sip' is now a keyword argument in imviz.load_data (previously it was advertised in the docstring of load_data, but obtained from kwargs). Within load_data it as added to kwargs to pass to the parser.

I did not deprecate this in the Orientation plugin because it was not in 4.3.2.

I also fixed a few instances where _roman_asdf_2d_to_glue_data was being called but not being passed the gwcs_to_fits_sip argument (I'm not sure this was intentional in the first place, if it was I will revert this change).