### PR TITLE
GH actions cache implementation for remote data on MAST

### DIFF
--- a/.github/workflows/cache-download.yml
+++ b/.github/workflows/cache-download.yml
@@ -1,0 +1,131 @@
+name: Download from Astroquery to Cache
+
+on:
+  workflow_dispatch:
+    inputs:
+      append_to_cache:
+        description: 'Append to latest cache?'
+        required: false
+        default: false
+        type: boolean
+      uris:
+        description: 'List of files to download (comma-separated in format mission:filename)'
+        required: false
+        default: 'HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst:hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits,
+                  hst:hst_17183_02_wfc3_uvis_g280_iexr02mt_flt.fits,
+                  hst:hst_16968_01_acs_wfc_f606w_jezz01l3_flt.fits,
+                  hst:jclj01010_drz.fits,
+                  jwst:jw01050-o003_t005_miri_ch1-medium_s3d.fits,
+                  jwst:jw01524-o003_t002_miri_ch1-medium_s3d.fits,
+                  jwst:jw01538-o161_s000000001_nirspec_f290lp-g395h-s1600a1_s2d.fits,
+                  jwst:jw01538160001_16101_00004_nrs1_s2d.fits,
+                  jwst:jw01895001004_07101_00001_nrca3_cal.fits,
+                  jwst:jw02123-o001_v000000353_nirspec_f170lp-g235h_s2d.fits,
+                  jwst:jw02727-o002_t062_nircam_clear-f090w_i2d.fits,
+                  jwst:jw02727-o002_t062_nircam_clear-f277w_i2d.fits,
+                  jwst:jw02732-c1001_t004_miri_ch1-short_s3d.fits,
+                  jwst:jw02732-c1001_t004_miri_ch1-short_x1d.fits,
+                  jwst:jw02732-o003_t002_nirspec_prism-clear_s3d.fits,
+                  jwst:jw02732004001_02103_00004_mirifushort_s3d.fits,
+                  jwst:jw02732004001_02103_00004_mirifushort_x1d.fits'
+        type: string
+  schedule:
+    - cron: '0 6 * * 0'  # Every Sunday at 6 AM UTC
+
+jobs:
+  download-astroquery:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install astroquery
+
+    - name: Get components for cache key
+      id: date
+      run: |
+        echo "year=$(date +'%Y')" >> $GITHUB_OUTPUT
+        echo "week=$(date +'%V')" >> $GITHUB_OUTPUT
+        echo "day=$(date +'%j')" >> $GITHUB_OUTPUT
+        if [ "${{ github.event_name }}" = "schedule" ]; then
+          echo "trigger=scheduled" >> $GITHUB_OUTPUT
+        else
+          echo "trigger=manual" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Create download script
+      run: |
+        cat > download_script.py << 'EOF'
+        import os
+        from astroquery.mast import MastMissions, Observations
+
+        # Get URIs from environment variable
+        uris_input = os.environ.get('URIS')
+        uris = [uri.strip() for uri in uris_input.split(',')]
+
+        # Initialize MAST missions
+        mast = MastMissions()
+
+        for i, uri in enumerate(uris):
+            mission, uri = uri.split(':')
+            mast.mission = mission
+
+            print(f'\nProcessing URI {i+1}/{len(uris)}: {uri} (mission={mission})')
+
+            if mission.upper().startswith('HLSP'):
+                # For HLSP, use Observations to download
+                # in this case, the "mission" should be the full string between "mast:" and the filename
+                observations_uri = f'mast:{mission}/{uri}'
+                print(f'Observations.download_file(\'{observations_uri}\')')
+                try:
+                    Observations.download_file(observations_uri, local_path='./', cache=True)
+                except Exception as e:
+                    print(f'Error downloading {observations_uri}: {e}')
+            else:
+                # For other missions, use MastMissions to download
+                missions_uri = '_'.join(uri.split('_')[:3])+'/'+uri
+                print(f"mast.download_file(\'{missions_uri}\')")
+                try:
+                    mast.download_file(missions_uri, local_path='./', cache=False)
+                except Exception as e:
+                    print(f'Error processing {uri}: {e}')
+
+        print('\nDownloads completed!')
+        EOF
+
+    - name: Restore existing cache
+      id: cache-restore
+      if: ${{ inputs.append_to_cache }}
+      uses: actions/cache/restore@v4
+      with:
+        path: ./
+        key: use-restore-keys-below-to-match-in-priority-order
+        restore-keys: |
+          mast-cache-${{ steps.date.outputs.year }}-${{ steps.date.outputs.week }}-${{ steps.date.outputs.day }}-
+          mast-cache-${{ steps.date.outputs.year }}-${{ steps.date.outputs.week }}-
+          mast-cache-${{ steps.date.outputs.year }}-
+          mast-cache-
+
+    - name: Run download script
+      run: |
+        python download_script.py
+      env:
+        URIS: ${{ inputs.uris }}
+
+    - name: List cached files
+      run: |
+        echo "All cached files:"
+        ls -ls *.fits || echo "No files found"
+
+    - name: Save updated cache (overwrite)
+      uses: actions/cache/save@v4
+      with:
+        key: mast-cache-${{ steps.date.outputs.year }}-${{ steps.date.outputs.week }}-${{ steps.date.outputs.day }}-${{ github.run_number }}-${{ steps.date.outputs.trigger }}
+        path: ./
+        enableCrossOsArchive: true

--- a/.github/workflows/cache-set-override.yml
+++ b/.github/workflows/cache-set-override.yml
@@ -1,0 +1,41 @@
+name: Use Older Cache as Override Until Deleted
+
+on:
+  workflow_dispatch:
+    inputs:
+      cache_key:
+        description: 'Existing cache-key to use in place of newer entries until deleted'
+        required: true
+        default: ''
+        type: string
+
+jobs:
+  copy-cache-to-override:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Get components for cache key
+      id: date
+      run: |
+        echo "year=$(date +'%Y')" >> $GITHUB_OUTPUT
+        echo "week=$(date +'%V')" >> $GITHUB_OUTPUT
+        echo "day=$(date +'%j')" >> $GITHUB_OUTPUT
+
+    - name: Restore existing cache
+      id: cache-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: ./
+        key: ${{ inputs.cache_key }}
+
+    - name: List cached files
+      run: |
+        echo "All cached files:"
+        ls -ls *.fits || echo "No files found"
+
+    - name: Save updated cache to override entry
+      uses: actions/cache/save@v4
+      with:
+        key: mast-cache-override-${{ steps.date.outputs.year }}-${{ steps.date.outputs.week }}-${{ steps.date.outputs.day }}-${{ github.run_number }}
+        path: ./
+        enableCrossOsArchive: true

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -101,6 +101,24 @@ jobs:
     - name: Get IP address for MAST debugging
       if: "contains(matrix.toxposargs, '--remote-data')"
       run: curl https://api.ipify.org
+    - name: Get components for cache key
+      id: date
+      run: |
+        echo "year=$(date +'%Y')" >> $GITHUB_OUTPUT
+        echo "week=$(date +'%V')" >> $GITHUB_OUTPUT
+        echo "day=$(date +'%j')" >> $GITHUB_OUTPUT
+    - name: Restore cache
+      id: cache-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: ./
+        key: use-restore-keys-below-to-match-in-priority-order
+        restore-keys: |
+          mast-cache-override-
+          mast-cache-${{ steps.date.outputs.year }}-${{ steps.date.outputs.week }}-${{ steps.date.outputs.day }}-
+          mast-cache-${{ steps.date.outputs.year }}-${{ steps.date.outputs.week }}-
+          mast-cache-${{ steps.date.outputs.year }}-
+          mast-cache-
     - name: Test/run with tox
       run: tox -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
     - name: Upload coverage to artifacts


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements a caching system for remote-data pulled into CI from MAST.

* `Download from Astroquery to Cache` will run weekly at 6am UTC to update the cache with any changed files from MAST
* `Download form Astroquery to Cache` can also be triggered manually from the `Actions` tab, with overrides to change the URIs and whether to build on top of the previous cache or start from scratch
* `Use Older Cache as Override Until Deleted` can be triggered manually to copy any existing cache and set it as the priority to use for workflows.  The intention of this is cases where the scheduled run results in breaks to CI that we choose to temporarily ignore.  If we find we never use this (or no one thinks there would be a use for this), we can get rid of it.  To revert to using the latest, delete the override cache from `Actions > Caches`.
* The existing CI workflows will apply existing caches based on the following priority:
  - "override" before non-override
  - the "latest" found match, where first it looks for _any_ created on the same day, then in the same week, then the same year, then any cache.  There is no clear way to take the "latest" created, so this is a rough workaround to try to get the most recent valid cache

As this is hard to test before merge, see https://github.com/kecnry/gh-action-cache-on-box/actions for a proof-of-concept (let me know if you need collaborator permission to view/run actions).

Note that this currently restores the cached files to the root directory.  Is this sufficient for the way we have astroquery look for cache in the workflows?