### PR TITLE
rename and deprecate Spectral Extraction plugins in specviz2d and cubeviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,12 +33,15 @@ New Features
 
 - Allow custom resolutions when exporting viewers to png or mp4. [#3478]
 
+
 Cubeviz
 ^^^^^^^
 
 - Ability to ingest and export ``SkyRegion`` objects. [#3502]
 
 - Add sonified layer for each cube created by the Sonify Data plugin. [#3430, #3660]
+
+- Renamed ``Spectral Extraction`` plugin to ``3D Spectral Extraction``. [#3691]
 
 Imviz
 ^^^^^
@@ -75,6 +78,8 @@ Specviz2d
   deprecated and will open the new sidebar.  [#3473]
 
 - New plugin to vizualize the cross-dispersion profile [#3552]
+
+- Renamed ``Spectral Extraction`` plugin to ``2D Spectral Extraction``. [#3691]
 
 API Changes
 -----------

--- a/docs/cubeviz/export_data.rst
+++ b/docs/cubeviz/export_data.rst
@@ -33,7 +33,7 @@ To extract all the subsets created in the viewers, call the Subset Tools plugin:
         Documentation on how to export data from the ``spectrum-viewer``.
 
 The following line of code can be used to extract 1D spectra.
-To use a ``function`` other than sum, use the :ref:`Spectral Extraction <spectral-extraction>` plugin
+To use a ``function`` other than sum, use the :ref:`3D Spectral Extraction <spectral-extraction>` plugin
 first to create a 1D spectrum and then refer to it by label in ``get_data``.
 
 .. code-block:: python

--- a/docs/cubeviz/plugins.rst
+++ b/docs/cubeviz/plugins.rst
@@ -288,7 +288,7 @@ spectral region of interest.
 .. _spectral-extraction:
 
 3D Spectral Extraction
-========================
+======================
 
 .. image:: ../img/cubeviz_spectral_extraction.png
 

--- a/docs/cubeviz/plugins.rst
+++ b/docs/cubeviz/plugins.rst
@@ -287,13 +287,13 @@ spectral region of interest.
 
 .. _spectral-extraction:
 
-Spectral Extraction
-===================
+3D Spectral Extraction
+========================
 
 .. image:: ../img/cubeviz_spectral_extraction.png
 
 
-The Spectral Extraction plugin produces a 1D spectrum from a spectral
+The 3D Spectral Extraction plugin produces a 1D spectrum from a spectral
 cube. The 1D spectrum can be computed via the sum, mean, minimum, or
 maximum of the spatial dimensions in the spectral cube. Select an
 extraction operation from the :guilabel:`Function` dropdown, and
@@ -304,6 +304,12 @@ from the spectral cube, which has uncertainties propagated by
 By default, if a mask was loaded with the cube, it will be applied to the
 cube when extracting in addition to any subsets chosen as an aperture. This
 is not currently done for Data Quality arrays, e.g. the DQ extension in JWST files.
+
+To interact with the plugin via the API in a notebook, access the plugin object via:
+
+.. code-block:: python
+
+  sp_ext = cubeviz.plugins['3D Spectral Extraction']
 
 If using a simple subset (currently only works for a circular subset applied to data
 with spatial axis units in wavelength) for the spatial aperture, an option to

--- a/docs/specviz2d/plugins.rst
+++ b/docs/specviz2d/plugins.rst
@@ -48,17 +48,17 @@ Markers
 
 .. _specviz2d-spectral-extraction:
 
-Spectral Extraction
-===================
+2D Spectral Extraction
+======================
 
-The Spectral Extraction plugin exposes `specreduce <https://specreduce.readthedocs.io>`_
+The 2D Spectral Extraction plugin exposes `specreduce <https://specreduce.readthedocs.io>`_
 methods for tracing, background subtraction, and spectral extraction from 2D spectra.
 
 To interact with the plugin via the API in a notebook, access the plugin object via:
 
 .. code-block:: python
 
-  sp_ext = specviz2d.plugins['Spectral Extraction']
+  sp_ext = specviz2d.plugins['2D Spectral Extraction']
 
 
 Trace
@@ -100,7 +100,7 @@ Trace parameters can be set from the notebook by accessing the plugin.
     sp_ext.trace_peak_method = 'Gaussian'
 
 To export and access the :py:class:`specreduce.tracing.Trace` object defined in the plugin,
-call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_trace`:
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_trace`:
 
 .. code-block:: python
 
@@ -115,7 +115,7 @@ via ``load``:
     specviz2d.load(my_trace, data_label="my trace")
 
 or directly into the plugin
-via :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.import_trace`
+via :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.import_trace`
 
 .. code-block:: python
 
@@ -154,7 +154,7 @@ Background parameters can be set from the notebook by accessing the plugin.
     sp_ext.bg_width = 6
 
 To export and access the :py:class:`specreduce.background.Background` object defined in the plugin,
-call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_bg`:
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_bg`:
 
 .. code-block:: python
 
@@ -162,13 +162,13 @@ call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_ex
 
 To access the background image, background spectrum, or background-subtracted image as a
 :class:`~specutils.Spectrum` object,
-call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_bg_img`,
-:py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_bg_spectrum`,
-or :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_bg_sub`, respectively.
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_bg_img`,
+:py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_bg_spectrum`,
+or :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_bg_sub`, respectively.
 
 To import the parameters from a :py:class:`specreduce.background.Background` object into the plugin,
 whether it's new or was exported and modified in the notebook,
-call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.import_bg`:
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.import_bg`:
 
 .. code-block:: python
 
@@ -205,21 +205,21 @@ Extraction parameters can be set from the notebook by accessing the plugin.
     sp_ext.ext_width = 8
 
 To export and access
-the :py:class:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction` object defined
+the :py:class:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D` object defined
 in the plugin,
-call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_extract`:
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_extract`:
 
 .. code-block:: python
 
   ext = sp_ext.export_extract()
 
 To access the extracted spectrum as a :class:`~specutils.Spectrum` object,
-call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.export_extract_spectrum`.
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_extract_spectrum`.
 
 To import the parameters from
-a :py:class:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction` object
+a :py:class:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D` object
 (either a new object, or an exported one modified in the notebook) into the plugin,
-call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction.import_extract`:
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.import_extract`:
 
 .. code-block:: python
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -824,7 +824,7 @@ class Application(VuetifyTemplate, HubListener):
             dc.add_link(LinkSame(ref_wavelength_component, linked_wavelength_component))
             return
 
-        elif (linked_data.meta.get('Plugin', None) == 'Spectral Extraction' or
+        elif (linked_data.meta.get('Plugin', None) == '3D Spectral Extraction' or
                 (linked_data.meta.get('Plugin', None) == ('Gaussian Smooth') and
                  linked_data.ndim < 3 and  # Cube linking requires special logic. See below
                  ref_data.ndim < 3)

--- a/jdaviz/configs/cubeviz/cubeviz.yaml
+++ b/jdaviz/configs/cubeviz/cubeviz.yaml
@@ -25,7 +25,7 @@ tray:
   - g-markers
   - cube-slice
   - g-unit-conversion
-  - cubeviz-spectral-extraction
+  - spectral-extraction-3d
   - g-gaussian-smooth
   - g-collapse
   - g-model-fitting

--- a/jdaviz/configs/cubeviz/helper.py
+++ b/jdaviz/configs/cubeviz/helper.py
@@ -88,23 +88,23 @@ class Cubeviz(CubeConfigHelper, LineListMixin):
 
         super().load_data(data, parser_reference="cubeviz-data-parser", **kwargs)
 
-        if 'Spectral Extraction' not in self.plugins:  # pragma: no cover
+        if '3D Spectral Extraction' not in self.plugins:  # pragma: no cover
             msg = SnackbarMessage(
-                "Automatic spectral extraction requires the Spectral Extraction plugin to be enabled",  # noqa
+                "Automatic spectral extraction requires the 3D Spectral Extraction plugin to be enabled",  # noqa
                 color='error', sender=self, timeout=10000)
             self.app.hub.broadcast(msg)
         else:
             try:
-                self.plugins['Spectral Extraction']._obj._extract_in_new_instance(auto_update=False, add_data=True)  # noqa
+                self.plugins['3D Spectral Extraction']._obj._extract_in_new_instance(auto_update=False, add_data=True)  # noqa
             except Exception:
                 msg = SnackbarMessage(
                     "Automatic spectrum extraction for the entire cube failed."
-                    " See the spectral extraction plugin to perform a custom extraction",
+                    " See the 3D Spectral Extraction plugin to perform a custom extraction",
                     color='error', sender=self, timeout=10000)
             else:
                 msg = SnackbarMessage(
                     "The extracted 1D spectrum was generated automatically for the entire cube."
-                    " See the spectral extraction plugin for details or to"
+                    " See the 3D Spectral Extraction plugin for details or to"
                     " perform a custom extraction.",
                     color='warning', sender=self, timeout=10000)
             self.app.hub.broadcast(msg)
@@ -137,22 +137,24 @@ class Cubeviz(CubeConfigHelper, LineListMixin):
     def get_data(self, data_label=None, spatial_subset=None, spectral_subset=None,
                  cls=None, use_display_units=False):
         """
-        Returns data with name equal to ``data_label`` of type ``cls`` with subsets applied from
-        ``spectral_subset``, if applicable.
+        Returns data with name equal to ``data_label`` of type ``cls`` with
+        subsets applied from ``spectral_subset``, if applicable.
 
         Parameters
         ----------
         data_label : str, optional
             Provide a label to retrieve a specific data set from data_collection.
         spatial_subset : str, optional
-            Spatial subset applied to data.  Only applicable if ``data_label`` points to a cube or
-            image.  To extract a spectrum from a cube, use the spectral extraction plugin instead.
+            Spatial subset applied to data.  Only applicable if ``data_label``
+            points to a cube or image.  To extract a spectrum from a cube, use
+            the 3D Spectral Extraction plugin instead.
         spectral_subset : str, optional
             Spectral subset applied to data.
         cls : `~specutils.Spectrum`, `~astropy.nddata.CCDData`, optional
             The type that data will be returned as.
         use_display_units : bool, optional
-            Specify whether the returned data is in native units or the current display units.
+            Specify whether the returned data is in native units or the current
+            display units.
 
         Returns
         -------

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -28,16 +28,17 @@ from jdaviz.configs.cubeviz.plugins.parsers import _return_spectrum_with_correct
 from jdaviz.configs.cubeviz.plugins.viewers import WithSliceIndicator
 
 
-__all__ = ['SpectralExtraction']
+__all__ = ['CubeSpectralExtraction']
 
 
 @tray_registry(
-    'cubeviz-spectral-extraction', label="Spectral Extraction"
+    'spectral-extraction-3d', label="3D Spectral Extraction"
 )
-class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
-                         DatasetSelectMixin, AddResultsMixin):
+class CubeSpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
+                             DatasetSelectMixin, AddResultsMixin):
     """
-    See the :ref:`Spectral Extraction Plugin Documentation <spectral-extraction>` for more details.
+    See the :ref:`3D Spectral Extraction Plugin Documentation <spectral-extraction>`
+    for more details.
 
     Only the following attributes and methods are available through the
     :ref:`public plugin API <plugin-apis>`:
@@ -279,8 +280,8 @@ class SpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
     def _extract_in_new_instance(self, dataset=None, function='Sum', subset_lbl=None,
                                  auto_update=False, add_data=False):
-        # create a new instance of the Spectral Extraction plugin (to not affect the instance in
-        # the tray) and extract the entire cube with defaults.
+        # create a new instance of the 3D Spectral Extraction plugin (to not
+        # affect the instance in the tray) and extract the entire cube with defaults.
         plg = self.new()
         plg.dataset.selected = self.dataset.selected if dataset is None else dataset
         if subset_lbl is not None:

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -28,14 +28,14 @@ from jdaviz.configs.cubeviz.plugins.parsers import _return_spectrum_with_correct
 from jdaviz.configs.cubeviz.plugins.viewers import WithSliceIndicator
 
 
-__all__ = ['CubeSpectralExtraction']
+__all__ = ['SpectralExtraction3D']
 
 
 @tray_registry(
     'spectral-extraction-3d', label="3D Spectral Extraction"
 )
-class CubeSpectralExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
-                             DatasetSelectMixin, AddResultsMixin):
+class SpectralExtraction3D(PluginTemplateMixin, ApertureSubsetSelectMixin,
+                           DatasetSelectMixin, AddResultsMixin):
     """
     See the :ref:`3D Spectral Extraction Plugin Documentation <spectral-extraction>`
     for more details.

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
@@ -1,7 +1,7 @@
 <template>
   <j-tray-plugin
     :config="config"
-    :plugin_key="plugin_key || 'Spectral Extraction'"
+    :plugin_key="plugin_key || '3D Spectral Extraction'"
     :api_hints_enabled.sync="api_hints_enabled"
     :description="docs_description"
     :link="docs_link || 'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#spectral-extraction'"

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -24,7 +24,7 @@ calspec_url = "https://archive.stsci.edu/hlsps/reference-atlases/cdbs/current_ca
 
 def test_version_after_nddata_update(cubeviz_helper, spectrum1d_cube_with_uncerts):
     # Also test that plugin is disabled before data is loaded.
-    plg = cubeviz_helper.plugins['Spectral Extraction']
+    plg = cubeviz_helper.plugins['3D Spectral Extraction']
     assert plg._obj.disabled_msg != ''
 
     cubeviz_helper.load_data(spectrum1d_cube_with_uncerts)
@@ -87,7 +87,7 @@ def test_gauss_smooth_before_spec_extract(cubeviz_helper, spectrum1d_cube_with_u
     ]
     cubeviz_helper.plugins['Subset Tools'].import_region(regions, combination_mode='new')
 
-    extract_plugin = cubeviz_helper.plugins['Spectral Extraction']
+    extract_plugin = cubeviz_helper.plugins['3D Spectral Extraction']
     extract_plugin.function = "Sum"
     expected_uncert = 2
 
@@ -127,7 +127,7 @@ def test_subset(
     cubeviz_helper.load_data(spectrum1d_cube_with_uncerts)
     cubeviz_helper.plugins['Subset Tools'].import_region(regions, combination_mode='new')
 
-    plg = cubeviz_helper.plugins['Spectral Extraction']
+    plg = cubeviz_helper.plugins['3D Spectral Extraction']
     plg.function = function
 
     # single pixel region:
@@ -150,7 +150,7 @@ def test_extracted_file_in_export_plugin(cubeviz_helper, spectrum1d_cube_with_un
 
     cubeviz_helper.load_data(spectrum1d_cube_with_uncerts)
 
-    extract_plugin = cubeviz_helper.plugins['Spectral Extraction']
+    extract_plugin = cubeviz_helper.plugins['3D Spectral Extraction']
 
     # make sure export enabled is true, and that before the collapse function
     # is run `extraction_available` is correctly set to False
@@ -179,7 +179,7 @@ def test_aperture_markers(cubeviz_helper, spectrum1d_cube):
     cubeviz_helper.plugins['Subset Tools'].import_region(
         [CirclePixelRegion(PixCoord(0.5, 0), radius=1.2)])
 
-    extract_plg = cubeviz_helper.plugins['Spectral Extraction']
+    extract_plg = cubeviz_helper.plugins['3D Spectral Extraction']
     slice_plg = cubeviz_helper.plugins['Slice']
 
     mark = extract_plg.aperture.marks[0]
@@ -234,7 +234,7 @@ def test_cone_aperture_with_different_methods(cubeviz_helper, spectrum1d_cube_la
     cubeviz_helper.plugins['Subset Tools'].import_region(
         EllipsePixelRegion(center, width=5, height=5), combination_mode='new')
 
-    extract_plg = cubeviz_helper.plugins['Spectral Extraction']
+    extract_plg = cubeviz_helper.plugins['3D Spectral Extraction']
 
     extract_plg.aperture = subset
     extract_plg.aperture_method.selected = aperture_method
@@ -266,7 +266,7 @@ def test_cylindrical_aperture_with_different_methods(cubeviz_helper, spectrum1d_
         CirclePixelRegion(center, radius=2.5),
         EllipsePixelRegion(center, width=5, height=5)], combination_mode='new')
 
-    extract_plg = cubeviz_helper.plugins['Spectral Extraction']
+    extract_plg = cubeviz_helper.plugins['3D Spectral Extraction']
 
     extract_plg.aperture = subset
     extract_plg.aperture_method.selected = aperture_method
@@ -289,7 +289,7 @@ def test_rectangle_aperture_with_exact(cubeviz_helper, spectrum1d_cube_largest):
     cubeviz_helper.plugins['Subset Tools'].import_region(
         RectanglePixelRegion(PixCoord(5, 10), width=4, height=4))
 
-    extract_plg = cubeviz_helper.plugins['Spectral Extraction']
+    extract_plg = cubeviz_helper.plugins['3D Spectral Extraction']
 
     extract_plg.aperture = "Subset 1"
     extract_plg.aperture_method.selected = "Exact"
@@ -318,7 +318,7 @@ def test_background_subtraction(cubeviz_helper, spectrum1d_cube_largest):
         CirclePixelRegion(PixCoord(5, 10), radius=2.5),
         EllipsePixelRegion(PixCoord(13, 10), width=3, height=5)], combination_mode='new')
 
-    extract_plg = cubeviz_helper.plugins['Spectral Extraction']
+    extract_plg = cubeviz_helper.plugins['3D Spectral Extraction']
     with extract_plg.as_active():
         extract_plg.aperture = 'Subset 1'
         spec_no_bg = extract_plg.extract()
@@ -371,7 +371,7 @@ def test_cone_and_cylinder_errors(cubeviz_helper, spectrum1d_cube_largest):
         CirclePixelRegion(center, radius=2.5),
         CircleAnnulusPixelRegion(center, inner_radius=2.5, outer_radius=4)], combination_mode='new')
 
-    extract_plg = cubeviz_helper.plugins['Spectral Extraction']
+    extract_plg = cubeviz_helper.plugins['3D Spectral Extraction']
 
     extract_plg.aperture = 'Subset 1'
     extract_plg.aperture_method.selected = 'Exact'
@@ -397,7 +397,7 @@ def test_cone_aperture_with_frequency_units(cubeviz_helper, spectral_cube_wcs):
     cubeviz_helper.plugins['Subset Tools'].import_region(
         [CirclePixelRegion(PixCoord(14, 15), radius=2.5)])
 
-    extract_plg = cubeviz_helper.plugins['Spectral Extraction']
+    extract_plg = cubeviz_helper.plugins['3D Spectral Extraction']
 
     extract_plg.aperture = 'Subset 1'
     extract_plg.aperture_method.selected = 'Exact'
@@ -411,7 +411,7 @@ def test_cone_aperture_with_frequency_units(cubeviz_helper, spectral_cube_wcs):
 def test_cube_extraction_with_nan(cubeviz_helper, image_cube_hdu_obj):
     image_cube_hdu_obj[1].data[:, :2, :2] = np.nan
     cubeviz_helper.load_data(image_cube_hdu_obj, data_label="with_nan")
-    extract_plg = cubeviz_helper.plugins['Spectral Extraction']
+    extract_plg = cubeviz_helper.plugins['3D Spectral Extraction']
     sp = extract_plg.extract()  # Default settings (sum)
     assert_allclose(sp.flux.value, 9.6E-16)  # (10 x 10) - 4
 
@@ -427,7 +427,7 @@ def test_autoupdate_results(cubeviz_helper, spectrum1d_cube_largest):
     cubeviz_helper.plugins['Subset Tools'].import_region(
         CircularROI(xc=5, yc=5, radius=2))
 
-    extract_plg = cubeviz_helper.plugins['Spectral Extraction']
+    extract_plg = cubeviz_helper.plugins['3D Spectral Extraction']
     extract_plg.aperture = 'Subset 1'
     extract_plg.add_results.label = 'extracted'
     extract_plg.add_results._obj.auto_update_result = True
@@ -452,7 +452,7 @@ def test_autoupdate_results(cubeviz_helper, spectrum1d_cube_largest):
 def test_aperture_composite_detection(cubeviz_helper, spectrum1d_cube):
     cubeviz_helper.load_data(spectrum1d_cube)
     subset_plugin = cubeviz_helper.plugins['Subset Tools']
-    spec_extr_plugin = cubeviz_helper.plugins['Spectral Extraction']._obj
+    spec_extr_plugin = cubeviz_helper.plugins['3D Spectral Extraction']._obj
 
     # create a rectangular subset with all spaxels:
     rectangle = RectangularROI(-0.5, 1.5, -0.5, 3.5)
@@ -475,7 +475,7 @@ def test_extraction_composite_subset(cubeviz_helper, spectrum1d_cube):
     cubeviz_helper.load_data(spectrum1d_cube)
 
     subset_plugin = cubeviz_helper.plugins['Subset Tools']
-    spec_extr_plugin = cubeviz_helper.plugins['Spectral Extraction']._obj
+    spec_extr_plugin = cubeviz_helper.plugins['3D Spectral Extraction']._obj
 
     lower_aperture = RectangularROI(-0.5, 0.5, -0.5, 1.5)
     upper_aperture = RectangularROI(2.5, 3.5, -0.5, 1.5)
@@ -514,7 +514,7 @@ def test_extraction_composite_subset(cubeviz_helper, spectrum1d_cube):
 def test_spectral_extraction_with_correct_sum_units(cubeviz_helper,
                                                     spectrum1d_cube_fluxunit_jy_per_steradian):
     cubeviz_helper.load_data(spectrum1d_cube_fluxunit_jy_per_steradian)
-    spec_extr_plugin = cubeviz_helper.plugins['Spectral Extraction']._obj
+    spec_extr_plugin = cubeviz_helper.plugins['3D Spectral Extraction']._obj
     collapsed = spec_extr_plugin.extract()
 
     assert '_pixel_scale_factor' in collapsed.meta
@@ -566,7 +566,7 @@ def test_spectral_extraction_unit_conv_one_spec(
     assert uc.flux_unit == "Jy"
     uc.flux_unit.selected = "MJy"
     assert spectrum_viewer.state.y_display_unit == "MJy"
-    spec_extr_plugin = cubeviz_helper.plugins['Spectral Extraction']
+    spec_extr_plugin = cubeviz_helper.plugins['3D Spectral Extraction']
     # Overwrite the one and only default extraction.
     collapsed = spec_extr_plugin.extract()
     # Actual values not in display unit but should not affect display unit.
@@ -635,7 +635,7 @@ def test_spectral_extraction_scientific_validation(
     slice_plugin.value = start_slice
 
     # run a conical spectral extraction
-    spectral_extraction = cubeviz_helper.plugins['Spectral Extraction']
+    spectral_extraction = cubeviz_helper.plugins['3D Spectral Extraction']
     spectral_extraction.aperture = 'Subset 1'
     spectral_extraction.wavelength_dependent = True
     spectral_extraction._obj.results_label = 'conical-extraction'
@@ -684,7 +684,7 @@ def test_spectral_extraction_flux_unit_conversions(cubeviz_helper,
         cubeviz_helper._default_spectrum_viewer_reference_name)
 
     uc = cubeviz_helper.plugins["Unit Conversion"]
-    se = cubeviz_helper.plugins['Spectral Extraction']
+    se = cubeviz_helper.plugins['3D Spectral Extraction']
     se.keep_active = True  # keep active for access to preview markers
 
     # equivalencies for unit conversion, for comparison of outputs

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -219,7 +219,7 @@ def test_loading_with_mask(cubeviz_helper):
     uc = cubeviz_helper.plugins['Unit Conversion']
     uc.spectral_y_type = "Surface Brightness"
 
-    se = cubeviz_helper.plugins['Spectral Extraction']
+    se = cubeviz_helper.plugins['3D Spectral Extraction']
     se.function = "Mean"
     se.extract()
     extracted = cubeviz_helper.get_data("Spectrum (mean)")
@@ -246,7 +246,7 @@ def test_manga_with_mask(cubeviz_helper, function, expected_value):
     uc = cubeviz_helper.plugins['Unit Conversion']
     uc.spectral_y_type = "Surface Brightness"
 
-    se = cubeviz_helper.plugins['Spectral Extraction']
+    se = cubeviz_helper.plugins['3D Spectral Extraction']
     se.function = function
     se.extract()
     extracted_max = cubeviz_helper.get_data(f"Spectrum ({function.lower()})").max()

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -26,7 +26,7 @@ from specreduce import tracing
 from specreduce import background
 from specreduce import extract
 
-__all__ = ['SpectralExtraction']
+__all__ = ['SpectralExtraction2D']
 
 _model_cls = {'Spline': models.Spline1D,
               'Polynomial': models.Polynomial1D,
@@ -34,13 +34,13 @@ _model_cls = {'Spline': models.Spline1D,
               'Chebyshev': models.Chebyshev1D}
 
 
-@tray_registry('spectral-extraction', label="Spectral Extraction",
+@tray_registry('spectral-extraction-2d', label="2D Spectral Extraction",
                category="data:reduction")
-class SpectralExtraction(PluginTemplateMixin):
+class SpectralExtraction2D(PluginTemplateMixin):
     """
-    The Spectral Extraction plugin exposes specreduce methods for tracing, background subtraction,
-    and spectral extraction from 2D spectra.
-    See the :ref:`Spectral Extraction Plugin Documentation <specviz2d-spectral-extraction>`
+    The Spectral Extraction 2D plugin exposes specreduce methods for tracing,
+    background subtraction, and spectral extraction from 2D spectra.
+    See the :ref:`2D Spectral Extraction Plugin Documentation <specviz2d-spectral-extraction>`
     for more details.
 
     Only the following attributes and methods are available through the
@@ -413,8 +413,8 @@ class SpectralExtraction(PluginTemplateMixin):
         self._clear_default_inputs()
 
     def _extract_in_new_instance(self, dataset=None, add_data=False):
-        # create a new instance of the Spectral Extraction plugin (to not affect the instance in
-        # the tray) and extract the entire cube with defaults.
+        # create a new instance of the 2D Spectral Extraction plugin (to not
+        # affect the instance in the tray) and extract the entire cube with defaults.
         plg = self.new()
         # all other settings remain at their plugin defaults
         plg._clear_default_inputs()

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -25,7 +25,7 @@ def test_plugin(specviz2d_helper):
 
     specviz2d_helper.load_data(spectrum_2d=fn)
 
-    pext = specviz2d_helper.app.get_tray_item_from_name('spectral-extraction')
+    pext = specviz2d_helper.app.get_tray_item_from_name('spectral-extraction-2d')
 
     # test trace marks - won't be created until after opening the plugin
     sp2dv = specviz2d_helper.app.get_viewer('spectrum-2d-viewer')
@@ -167,7 +167,7 @@ def test_user_api(specviz2d_helper):
 
     specviz2d_helper.load_data(spectrum_2d=fn)
 
-    pext = specviz2d_helper.plugins['Spectral Extraction']
+    pext = specviz2d_helper.plugins['2D Spectral Extraction']
     pext.keep_active = True
 
     # test that setting a string to an AddResults object redirects to the label
@@ -193,7 +193,7 @@ def test_background_extraction_and_display(specviz2d_helper):
                        cache=True)
 
     specviz2d_helper.load_data(spectrum_2d=fn)
-    pext = specviz2d_helper.app.get_tray_item_from_name('spectral-extraction')
+    pext = specviz2d_helper.app.get_tray_item_from_name('spectral-extraction-2d')
 
     # check that the background extraction method and parameters are as expected
     assert pext.bg_type_selected == 'TwoSided'
@@ -228,7 +228,7 @@ def test_horne_extract_self_profile(specviz2d_helper):
                           uncertainty=VarianceUncertainty(spec2dvar*u.Jy*u.Jy))
 
     specviz2d_helper.load_data(objectspec)
-    pext = specviz2d_helper.plugins['Spectral Extraction']._obj
+    pext = specviz2d_helper.plugins['2D Spectral Extraction']._obj
 
     trace_fit = tracing.FitTrace(objectspec,
                                  trace_model=models.Polynomial1D(degree=1),
@@ -287,7 +287,7 @@ def test_spectral_extraction_flux_unit_conversions(specviz2d_helper, mos_spectru
     specviz2d_helper.load_data(mos_spectrum2d)
 
     uc = specviz2d_helper.plugins["Unit Conversion"]
-    pext = specviz2d_helper.plugins['Spectral Extraction']
+    pext = specviz2d_helper.plugins['2D Spectral Extraction']
 
     for new_flux_unit in SPEC_PHOTON_FLUX_DENSITY_UNITS:
 

--- a/jdaviz/configs/specviz2d/specviz2d.yaml
+++ b/jdaviz/configs/specviz2d/specviz2d.yaml
@@ -20,7 +20,7 @@ tray:
   - g-subset-tools
   - g-markers
   - g-unit-conversion
-  - spectral-extraction
+  - spectral-extraction-2d
   - g-gaussian-smooth
   - g-model-fitting
   - g-line-list

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -65,7 +65,7 @@ def test_hlsp_goods_s2d_deconfigged(deconfigged_helper):
                             cache=True)
     dc_0 = deconfigged_helper.app.data_collection[0]
     assert dc_0.get_component('flux').shape == (27, 674)
-    assert isinstance(deconfigged_helper.plugins['Spectral Extraction'].trace_dataset.selected_obj, Spectrum)  # noqa
+    assert isinstance(deconfigged_helper.plugins['2D Spectral Extraction'].trace_dataset.selected_obj, Spectrum)  # noqa
     # TODO: store expected class in data itself so get_data doesn't need to pass cls
     assert isinstance(deconfigged_helper.get_data('2D Spectrum', cls=Spectrum), Spectrum)
 

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -212,11 +212,17 @@ class ConfigHelper(HubListener):
         plugins = {item['label']: widget_serialization['from_json'](item['widget'], None).user_api
                    for item in self.app.state.tray_items if item['is_relevant']}
 
+        msg_temp = "in the future, the formerly named \"{}\" plugin will only be available by its new name: \"{}\""  # noqa
+
+        old_new = (('Imviz Line Profiles (XY)', 'Image Profiles (XY)'),  # renamed in 4.0
+                   ('Spectral Extraction', '2D Spectral Extraction'),  # renamed in 4.3
+                   ('Spectral Extraction', '3D Spectral Extraction'))  # renamed in 4.3
+
         # handle renamed plugins during deprecation
-        if 'Image Profiles (XY)' in plugins:
-            # renamed in 4.0
-            plugins['Imviz Line Profiles (XY)'] = plugins['Image Profiles (XY)']._obj.user_api
-            plugins['Imviz Line Profiles (XY)']._deprecation_msg = 'in the future, the formerly named \"Imviz Line Profiles (XY)\" plugin will only be available by its new name: \"Image Profiles (XY)\".'  # noqa
+        for old, new in old_new:
+            if new in plugins:
+                plugins[old] = plugins[new]._obj.user_api
+                plugins[old]._deprecation_msg = msg_temp.format(old, new)
 
         return plugins
 

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -175,7 +175,7 @@ class Spectrum2DImporter(BaseImporterToDataCollection):
             return
 
         try:
-            spext = self.app.get_tray_item_from_name('spectral-extraction')
+            spext = self.app.get_tray_item_from_name('spectral-extraction-2d')
             ext = spext._extract_in_new_instance(dataset=data_label,
                                                  add_data=False)
         except Exception:

--- a/jdaviz/core/loaders/test_loaders.py
+++ b/jdaviz/core/loaders/test_loaders.py
@@ -52,7 +52,7 @@ def test_resolver_matching(specviz_helper):
 def test_trace_importer(specviz2d_helper, spectrum2d):
     specviz2d_helper._load(spectrum2d, format='2D Spectrum')
 
-    trace = specviz2d_helper.plugins['Spectral Extraction'].export_trace()
+    trace = specviz2d_helper.plugins['2D Spectral Extraction'].export_trace()
 
     res_sp = find_matching_resolver(specviz2d_helper.app, trace)
     assert res_sp._obj._registry_label == 'object'

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3867,11 +3867,11 @@ class DatasetSelect(SelectPluginComponent):
             shape = self.selected_obj.shape
         if len(shape) == 3:
             # then this is a cube, but we want the 1D spectrum,
-            # so we can pass through the Spectral Extraction plugin
+            # so we can pass through the 3D Spectral Extraction plugin
             if self.plugin.config != 'cubeviz':
                 raise ValueError("extracting a spectrum from a cube only supported in cubeviz")
             # we need to get the 1d extracted spectrum for the cube
-            spec_extract = self.app._jdaviz_helper.plugins['Spectral Extraction']._obj
+            spec_extract = self.app._jdaviz_helper.plugins['3D Spectral Extraction']._obj
             sp = spec_extract._extract_in_new_instance(self.selected,
                                                        function=self._spectral_extraction_function,
                                                        add_data=False)

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -213,8 +213,8 @@ def test_to_unit(cubeviz_helper):
     cube = Spectrum(flux=flux * (u.MJy / u.sr), wcs=w, meta=wcs_dict)
     cubeviz_helper.load_data(cube, data_label="test")
 
-    # this can be removed once spectra pass through spectral extraction
-    extract_plg = cubeviz_helper.plugins['Spectral Extraction']
+    # this can be removed once spectra pass through cube spectral extraction
+    extract_plg = cubeviz_helper.plugins['3D Spectral Extraction']
 
     extract_plg.aperture = extract_plg.aperture.choices[-1]
     extract_plg.aperture_method.selected = 'Exact'

--- a/notebooks/Specviz2dExample.ipynb
+++ b/notebooks/Specviz2dExample.ipynb
@@ -95,7 +95,7 @@
    "source": [
     "## Re-extract the spectrum\n",
     "\n",
-    "In cases where you wish to fine-tune the default extraction, you can opt to re-extract using \"Spectral Extraction\" plugin. If you prefer using its API, you can do it as follows. If your new inputs result in a successful extraction, a valid 1D spectrum would now appear in the bottom viewer."
+    "In cases where you wish to fine-tune the default extraction, you can opt to re-extract using \"2D Spectral Extraction\" plugin. If you prefer using its API, you can do it as follows. If your new inputs result in a successful extraction, a valid 1D spectrum would now appear in the bottom viewer."
    ]
   },
   {


### PR DESCRIPTION
To allow the deconfigged app to start using the new names without conflict, cubeviz Spectral Extraction is now 'Spectral Extraction 3D', and specviz2d Spectral Extraction is now 'Spectral Extraction 2D'. Access by the former name is still possible for now, with a deprecation message. Docs and notebooks updated.