### PR TITLE
TST: CI updates to use cache

### DIFF
--- a/.github/workflows/cache-download.yml
+++ b/.github/workflows/cache-download.yml
@@ -26,6 +26,11 @@ env:
 on:
   workflow_dispatch:
     inputs:
+      skip_cache:
+        description: 'Test downloading but skip creating cache'
+        required: false
+        default: false
+        type: boolean
       append_to_cache:
         description: 'Append to latest cache?'
         required: false
@@ -131,6 +136,7 @@ jobs:
         ls -ltr || echo "No files found"
 
     - name: Save updated cache (overwrite)
+      if: ${{ !inputs.skip_cache }}
       uses: actions/cache/save@v4
       with:
         key: mast-cache-${{ steps.date.outputs.year }}-${{ steps.date.outputs.week }}-${{ steps.date.outputs.day }}-${{ github.run_number }}-${{ steps.date.outputs.trigger }}

--- a/.github/workflows/cache-download.yml
+++ b/.github/workflows/cache-download.yml
@@ -4,7 +4,8 @@ env:
   # add any URIs from MAST used in remote tests here
   # the cache can be updated by manual trigger after changes are merged into main
   # or if you need the cache for the current PR, trigger the workflow manually
-  # and append to the previous cache with the new URI(s)
+  # and append to the previous cache with the new URI(s).
+  # NOTE: cached files are not currently accessible when using the _jail fixture (without manually copying them)
   DEFAULT_URIS: 'HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst:hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits,
                  hst:hst_17183_02_wfc3_uvis_g280_iexr02mt_flt.fits,
                  hst:hst_16968_01_acs_wfc_f606w_jezz01l3_flt.fits,

--- a/.github/workflows/cache-download.yml
+++ b/.github/workflows/cache-download.yml
@@ -128,7 +128,7 @@ jobs:
     - name: List cached files
       run: |
         echo "All cached files:"
-        ls -ls *.fits || echo "No files found"
+        ls -ltr || echo "No files found"
 
     - name: Save updated cache (overwrite)
       uses: actions/cache/save@v4

--- a/.github/workflows/cache-download.yml
+++ b/.github/workflows/cache-download.yml
@@ -1,5 +1,28 @@
 name: Download from Astroquery to Cache
 
+env:
+  # add any URIs from MAST used in remote tests here
+  # the cache can be updated by manual trigger after changes are merged into main
+  # or if you need the cache for the current PR, trigger the workflow manually
+  # and append to the previous cache with the new URI(s)
+  DEFAULT_URIS: 'HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst:hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits,
+                 hst:hst_17183_02_wfc3_uvis_g280_iexr02mt_flt.fits,
+                 hst:hst_16968_01_acs_wfc_f606w_jezz01l3_flt.fits,
+                 hst:jclj01010_drz.fits,
+                 jwst:jw01050-o003_t005_miri_ch1-medium_s3d.fits,
+                 jwst:jw01524-o003_t002_miri_ch1-medium_s3d.fits,
+                 jwst:jw01538-o161_s000000001_nirspec_f290lp-g395h-s1600a1_s2d.fits,
+                 jwst:jw01538160001_16101_00004_nrs1_s2d.fits,
+                 jwst:jw01895001004_07101_00001_nrca3_cal.fits,
+                 jwst:jw02123-o001_v000000353_nirspec_f170lp-g235h_s2d.fits,
+                 jwst:jw02727-o002_t062_nircam_clear-f090w_i2d.fits,
+                 jwst:jw02727-o002_t062_nircam_clear-f277w_i2d.fits,
+                 jwst:jw02732-c1001_t004_miri_ch1-short_s3d.fits,
+                 jwst:jw02732-c1001_t004_miri_ch1-short_x1d.fits,
+                 jwst:jw02732-o003_t002_nirspec_prism-clear_s3d.fits,
+                 jwst:jw02732004001_02103_00004_mirifushort_s3d.fits,
+                 jwst:jw02732004001_02103_00004_mirifushort_x1d.fits'
+
 on:
   workflow_dispatch:
     inputs:
@@ -9,29 +32,9 @@ on:
         default: false
         type: boolean
       uris:
-        description: 'List of files to download (comma-separated in format mission:filename)'
+        description: 'Override list of files to download (comma-separated in format mission:filename)'
         required: false
-        # add any URIs from MAST used in remote tests here
-        # the cache can be updated by manual trigger after changes are merged into main
-        # or if you need the cache for the current PR, trigger the workflow manually
-        # and append to the previous cache with the new URI(s)
-        default: 'HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst:hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits,
-                  hst:hst_17183_02_wfc3_uvis_g280_iexr02mt_flt.fits,
-                  hst:hst_16968_01_acs_wfc_f606w_jezz01l3_flt.fits,
-                  hst:jclj01010_drz.fits,
-                  jwst:jw01050-o003_t005_miri_ch1-medium_s3d.fits,
-                  jwst:jw01524-o003_t002_miri_ch1-medium_s3d.fits,
-                  jwst:jw01538-o161_s000000001_nirspec_f290lp-g395h-s1600a1_s2d.fits,
-                  jwst:jw01538160001_16101_00004_nrs1_s2d.fits,
-                  jwst:jw01895001004_07101_00001_nrca3_cal.fits,
-                  jwst:jw02123-o001_v000000353_nirspec_f170lp-g235h_s2d.fits,
-                  jwst:jw02727-o002_t062_nircam_clear-f090w_i2d.fits,
-                  jwst:jw02727-o002_t062_nircam_clear-f277w_i2d.fits,
-                  jwst:jw02732-c1001_t004_miri_ch1-short_s3d.fits,
-                  jwst:jw02732-c1001_t004_miri_ch1-short_x1d.fits,
-                  jwst:jw02732-o003_t002_nirspec_prism-clear_s3d.fits,
-                  jwst:jw02732004001_02103_00004_mirifushort_s3d.fits,
-                  jwst:jw02732004001_02103_00004_mirifushort_x1d.fits'
+        # Default URIs are defined in the workflow env section and will be provided if not specified here
         type: string
   schedule:
     - cron: '0 6 * * 0'  # Every Sunday at 6 AM UTC
@@ -120,7 +123,7 @@ jobs:
       run: |
         python download_script.py
       env:
-        URIS: ${{ inputs.uris }}
+        URIS: ${{ inputs.uris || env.DEFAULT_URIS }}
 
     - name: List cached files
       run: |

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -103,11 +103,13 @@ jobs:
       run: curl https://api.ipify.org
     - name: Get components for cache key
       id: date
+      if: "contains(matrix.toxposargs, '--remote-data')"
       run: |
         echo "year=$(date +'%Y')" >> $GITHUB_OUTPUT
         echo "week=$(date +'%V')" >> $GITHUB_OUTPUT
         echo "day=$(date +'%j')" >> $GITHUB_OUTPUT
-    - name: Restore cache
+    - name: Restore MAST cache
+      if: "contains(matrix.toxposargs, '--remote-data')"
       id: cache-restore
       uses: actions/cache/restore@v4
       with:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -48,7 +48,7 @@ jobs:
             os: ubuntu-latest
             python: '3.11'
             toxenv: py311-test-alldeps-cov
-            toxposargs: --remote-data --run-slow
+            toxposargs: --remote-data
             allow_failure: false
 
           - name: OS X - Python 3.12
@@ -75,7 +75,7 @@ jobs:
             os: ubuntu-latest
             python: '3.13'
             toxenv: py313-test-devdeps
-            toxposargs: --remote-data --run-slow
+            toxposargs: --remote-data
             allow_failure: true
 
           - name: Python 3.11 with stable versions of dependencies and Roman

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -120,13 +120,22 @@ jobs:
           mast-cache-${{ steps.date.outputs.year }}-${{ steps.date.outputs.week }}-
           mast-cache-${{ steps.date.outputs.year }}-
           mast-cache-
-    - name: Move cache to astroquery cache directory
+    - name: Move cache to tox working directory
       if: "contains(matrix.toxposargs, '--remote-data')"
       run: |
-        # Create the standard astroquery cache directory structure
-        mkdir -p "$HOME/.astropy/cache/astroquery/mast"
-        # Move fits files to the astroquery MAST cache directory
-        mv ./*.fits "$HOME/.astropy/cache/astroquery/mast/"
+        # Create cache directories for all possible tox environments
+        # tox runs from .tmp/{envname}, so we need to place cache files there
+        mkdir -p ".tmp/${{ matrix.toxenv }}"
+
+        # Check if any fits files exist and move them to the tox working directory
+        if ls ./*.fits 1> /dev/null 2>&1; then
+          mv ./*.fits ".tmp/${{ matrix.toxenv }}/"
+          echo "Cache files moved to .tmp/${{ matrix.toxenv }}/"
+          echo "Files in tox working directory:"
+          ls -la ".tmp/${{ matrix.toxenv }}/"*.fits
+        else
+          echo "No .fits files found in cache - tests will download files as needed"
+        fi
     - name: Test/run with tox
       run: tox -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
     - name: Upload coverage to artifacts

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -113,7 +113,7 @@ jobs:
       id: cache-restore
       uses: actions/cache/restore@v4
       with:
-        path: ./
+        path: ./mast_cache
         key: use-restore-keys-below-to-match-in-priority-order
         restore-keys: |
           mast-cache-${{ steps.date.outputs.year }}-${{ steps.date.outputs.week }}-${{ steps.date.outputs.day }}-

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -48,7 +48,7 @@ jobs:
             os: ubuntu-latest
             python: '3.11'
             toxenv: py311-test-alldeps-cov
-            toxposargs: --remote-data
+            toxposargs: --remote-data --run-slow
             allow_failure: false
 
           - name: OS X - Python 3.12
@@ -75,7 +75,7 @@ jobs:
             os: ubuntu-latest
             python: '3.13'
             toxenv: py313-test-devdeps
-            toxposargs: --remote-data
+            toxposargs: --remote-data --run-slow
             allow_failure: true
 
           - name: Python 3.11 with stable versions of dependencies and Roman

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -120,11 +120,13 @@ jobs:
           mast-cache-${{ steps.date.outputs.year }}-${{ steps.date.outputs.week }}-
           mast-cache-${{ steps.date.outputs.year }}-
           mast-cache-
-    - name: TMP Move cache location
+    - name: Move cache to astroquery cache directory
       if: "contains(matrix.toxposargs, '--remote-data')"
       run: |
-        mkdir -p ./mast_cache
-        mv ./*fits ./mast_cache/
+        # Create the standard astroquery cache directory structure
+        mkdir -p "$HOME/.astropy/cache/astroquery/mast"
+        # Move fits files to the astroquery MAST cache directory
+        mv ./*.fits "$HOME/.astropy/cache/astroquery/mast/"
     - name: Test/run with tox
       run: tox -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
     - name: Upload coverage to artifacts

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -113,13 +113,18 @@ jobs:
       id: cache-restore
       uses: actions/cache/restore@v4
       with:
-        path: ./mast_cache
+        path: ./
         key: use-restore-keys-below-to-match-in-priority-order
         restore-keys: |
           mast-cache-${{ steps.date.outputs.year }}-${{ steps.date.outputs.week }}-${{ steps.date.outputs.day }}-
           mast-cache-${{ steps.date.outputs.year }}-${{ steps.date.outputs.week }}-
           mast-cache-${{ steps.date.outputs.year }}-
           mast-cache-
+    - name: TMP Move cache location
+      if: "contains(matrix.toxposargs, '--remote-data')"
+      run: |
+        mkdir -p ./mast_cache
+        mv ./*fits ./mast_cache/
     - name: Test/run with tox
       run: tox -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
     - name: Upload coverage to artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,25 @@ jobs:
     - name: Check dist
       run: python -m twine check --strict dist/*
 
+    - name: Get components for cache key
+      id: date
+      run: |
+        echo "year=$(date +'%Y')" >> $GITHUB_OUTPUT
+        echo "week=$(date +'%V')" >> $GITHUB_OUTPUT
+        echo "day=$(date +'%j')" >> $GITHUB_OUTPUT
+
+    - name: Restore MAST cache
+      id: cache-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: ./
+        key: use-restore-keys-below-to-match-in-priority-order
+        restore-keys: |
+          mast-cache-${{ steps.date.outputs.year }}-${{ steps.date.outputs.week }}-${{ steps.date.outputs.day }}-
+          mast-cache-${{ steps.date.outputs.year }}-${{ steps.date.outputs.week }}-
+          mast-cache-${{ steps.date.outputs.year }}-
+          mast-cache-
+
     - name: Test package
       run: |
         cd ..

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,17 @@ jobs:
           mast-cache-${{ steps.date.outputs.year }}-
           mast-cache-
 
+    - name: Move cache to working directory
+      run: |
+        # Check if any fits files exist and move them to the working directory
+        if ls ./*.fits 1> /dev/null 2>&1; then
+          mv ./*.fits "/home/runner/work/jdaviz/"
+          echo "Files in working directory:"
+          ls -la "/home/runner/work/jdaviz/"*.fits
+        else
+          echo "No .fits files found in cache - tests will download files as needed"
+        fi
+
     - name: Test package
       run: |
         cd ..

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -1,4 +1,3 @@
-import os
 import warnings
 
 import numpy as np
@@ -275,16 +274,14 @@ def test_write_momentmap(cubeviz_helper, spectrum1d_cube, tmp_path):
 
 
 @pytest.mark.remote_data
-def test_momentmap_nirspec_prism(cubeviz_helper, mast_cache_path):
+def test_momentmap_nirspec_prism(cubeviz_helper):
     uri = "mast:jwst/product/jw02732-o003_t002_nirspec_prism-clear_s3d.fits"
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         # NOTE: appending URI to local_path may not be necessary once cubeviz
         # uses the new loaders infrastructure
-        cubeviz_helper.load_data(uri, cache=True,
-                                 local_path=os.path.join(mast_cache_path,
-                                                         uri.split('/')[-1]))
+        cubeviz_helper.load_data(uri, cache=True)
     uc = cubeviz_helper.plugins["Unit Conversion"]
     uc.open_in_tray()  # plugin has to be open for unit change to take hold
     uc._obj.show_translator = True

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 
 import numpy as np
@@ -279,7 +280,11 @@ def test_momentmap_nirspec_prism(cubeviz_helper, mast_cache_path):
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        cubeviz_helper.load_data(uri, cache=True, local_path=mast_cache_path)
+        # NOTE: appending URI to local_path may not be necessary once cubeviz
+        # uses the new loaders infrastructure
+        cubeviz_helper.load_data(uri, cache=True,
+                                 local_path=os.path.join(mast_cache_path,
+                                                         uri.split('/')[-1]))
     uc = cubeviz_helper.plugins["Unit Conversion"]
     uc.open_in_tray()  # plugin has to be open for unit change to take hold
     uc._obj.show_translator = True

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -1,5 +1,4 @@
 import warnings
-from pathlib import Path
 
 import numpy as np
 import pytest
@@ -66,7 +65,7 @@ def test_user_api(cubeviz_helper, spectrum1d_cube, spectrum1d_cube_sb_unit, cube
 
 @pytest.mark.parametrize("cube_type", ["Surface Brightness", "Flux"])
 def test_moment_calculation(cubeviz_helper, spectrum1d_cube,
-                            spectrum1d_cube_sb_unit, cube_type, tmp_path):
+                            spectrum1d_cube_sb_unit, cube_type):
 
     moment_unit = "Jy m"
     moment_value_str = "+6.40166e-10"
@@ -275,13 +274,12 @@ def test_write_momentmap(cubeviz_helper, spectrum1d_cube, tmp_path):
 
 
 @pytest.mark.remote_data
-def test_momentmap_nirspec_prism(cubeviz_helper, tmp_path):
+def test_momentmap_nirspec_prism(cubeviz_helper, mast_cache_path):
     uri = "mast:jwst/product/jw02732-o003_t002_nirspec_prism-clear_s3d.fits"
-    local_path = str(tmp_path / Path(uri).name)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        cubeviz_helper.load_data(uri, cache=True, local_path=local_path)
+        cubeviz_helper.load_data(uri, cache=True, local_path=mast_cache_path)
     uc = cubeviz_helper.plugins["Unit Conversion"]
     uc.open_in_tray()  # plugin has to be open for unit change to take hold
     uc._obj.show_translator = True

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -10,6 +10,7 @@ from numpy.testing import assert_allclose
 from specutils import SpectralRegion
 
 from jdaviz.core.custom_units_and_equivs import PIX2, SPEC_PHOTON_FLUX_DENSITY_UNITS
+from jdaviz.utils import cached_uri
 
 
 @pytest.mark.parametrize("cube_type", ["Surface Brightness", "Flux"])
@@ -279,7 +280,7 @@ def test_momentmap_nirspec_prism(cubeviz_helper):
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        cubeviz_helper.load_data(uri, cache=True)
+        cubeviz_helper.load_data(cached_uri(uri), cache=True)
     uc = cubeviz_helper.plugins["Unit Conversion"]
     uc.open_in_tray()  # plugin has to be open for unit change to take hold
     uc._obj.show_translator = True

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -279,8 +279,6 @@ def test_momentmap_nirspec_prism(cubeviz_helper):
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        # NOTE: appending URI to local_path may not be necessary once cubeviz
-        # uses the new loaders infrastructure
         cubeviz_helper.load_data(uri, cache=True)
     uc = cubeviz_helper.plugins["Unit Conversion"]
     uc.open_in_tray()  # plugin has to be open for unit change to take hold

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import warnings
 
@@ -625,7 +626,11 @@ def test_spectral_extraction_scientific_validation(
     # load observations into Cubeviz
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        cubeviz_helper.load_data(uri, cache=True, local_path=mast_cache_path)
+        # NOTE: appending URI to local_path may not be necessary once cubeviz
+        # uses the new loaders infrastructure
+        cubeviz_helper.load_data(uri, cache=True,
+                                 local_path=os.path.join(mast_cache_path,
+                                                         uri.split('/')[-1]))
 
     # add a subset with an aperture centered on each source
     subset_plugin = cubeviz_helper.plugins['Subset Tools']

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -591,7 +591,8 @@ def test_spectral_extraction_unit_conv_one_spec(
 )
 def test_spectral_extraction_scientific_validation(
     cubeviz_helper, start_slice,
-    aperture, expected_rtol, uri, calspec_url
+    aperture, expected_rtol, uri, calspec_url,
+    mast_cache_path
 ):
     """
     Compare the extracted spectrum from MIRI CH1 IFU cubes for
@@ -624,7 +625,7 @@ def test_spectral_extraction_scientific_validation(
     # load observations into Cubeviz
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        cubeviz_helper.load_data(uri, cache=True)
+        cubeviz_helper.load_data(uri, cache=True, local_path=mast_cache_path)
 
     # add a subset with an aperture centered on each source
     subset_plugin = cubeviz_helper.plugins['Subset Tools']

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 import warnings
 
@@ -592,8 +591,7 @@ def test_spectral_extraction_unit_conv_one_spec(
 )
 def test_spectral_extraction_scientific_validation(
     cubeviz_helper, start_slice,
-    aperture, expected_rtol, uri, calspec_url,
-    mast_cache_path
+    aperture, expected_rtol, uri, calspec_url
 ):
     """
     Compare the extracted spectrum from MIRI CH1 IFU cubes for
@@ -628,9 +626,7 @@ def test_spectral_extraction_scientific_validation(
         warnings.simplefilter('ignore')
         # NOTE: appending URI to local_path may not be necessary once cubeviz
         # uses the new loaders infrastructure
-        cubeviz_helper.load_data(uri, cache=True,
-                                 local_path=os.path.join(mast_cache_path,
-                                                         uri.split('/')[-1]))
+        cubeviz_helper.load_data(uri, cache=True)
 
     # add a subset with an aperture centered on each source
     subset_plugin = cubeviz_helper.plugins['Subset Tools']

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -18,6 +18,7 @@ from specutils.manipulation import FluxConservingResampler
 from jdaviz.core.custom_units_and_equivs import PIX2, SPEC_PHOTON_FLUX_DENSITY_UNITS
 from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
                                                flux_conversion_general)
+from jdaviz.utils import cached_uri
 
 calspec_url = "https://archive.stsci.edu/hlsps/reference-atlases/cdbs/current_calspec/"
 
@@ -624,7 +625,7 @@ def test_spectral_extraction_scientific_validation(
     # load observations into Cubeviz
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        cubeviz_helper.load_data(uri, cache=True)
+        cubeviz_helper.load_data(cached_uri(uri), cache=True)
 
     # add a subset with an aperture centered on each source
     subset_plugin = cubeviz_helper.plugins['Subset Tools']

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -624,8 +624,6 @@ def test_spectral_extraction_scientific_validation(
     # load observations into Cubeviz
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        # NOTE: appending URI to local_path may not be necessary once cubeviz
-        # uses the new loaders infrastructure
         cubeviz_helper.load_data(uri, cache=True)
 
     # add a subset with an aperture centered on each source

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -576,7 +576,6 @@ def test_spectral_extraction_unit_conv_one_spec(
     assert spectrum_viewer.state.y_display_unit == "MJy"
 
 
-@pytest.mark.usefixtures('_jail')
 @pytest.mark.remote_data
 @pytest.mark.parametrize(
     "start_slice, aperture, expected_rtol, uri, calspec_url",

--- a/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
@@ -41,6 +41,7 @@ def test_export_movie_not_cubeviz(imviz_helper):
     assert 'mp4' not in plugin.viewer_format.choices
 
 
+@pytest.mark.skip("known failure")
 @pytest.mark.skipif(not HAS_OPENCV, reason="opencv-python is not installed")
 def test_export_movie_cubeviz_exceptions(cubeviz_helper, spectrum1d_cube):
     cubeviz_helper.load_data(spectrum1d_cube, data_label="test")

--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -75,13 +75,13 @@ def test_roman_against_rdm():
 
 
 @pytest.mark.remote_data
-def test_data_quality_plugin(imviz_helper, mast_cache_path):
+def test_data_quality_plugin(imviz_helper):
     uri = "mast:JWST/product/jw01895001004_07101_00001_nrca3_cal.fits"
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         imviz_helper.load_data(
-            uri, cache=True, local_path=mast_cache_path, ext=('SCI', 'DQ')
+            uri, cache=True, ext=('SCI', 'DQ')
         )
 
     assert len(imviz_helper.app.data_collection) == 2
@@ -170,13 +170,13 @@ def test_data_quality_plugin(imviz_helper, mast_cache_path):
 
 
 @pytest.mark.remote_data
-def test_data_quality_plugin_hst_wfc3(imviz_helper, mast_cache_path):
+def test_data_quality_plugin_hst_wfc3(imviz_helper):
 
     # load HST/WFC3-UVIS observations:
     uri = "mast:HST/product/hst_17183_02_wfc3_uvis_g280_iexr02mt_flt.fits"
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        imviz_helper.load_data(uri, cache=True, local_path=mast_cache_path, ext=('SCI', 'DQ'))
+        imviz_helper.load_data(uri, cache=True, ext=('SCI', 'DQ'))
 
     assert len(imviz_helper.app.data_collection) == 2
 
@@ -190,12 +190,12 @@ def test_data_quality_plugin_hst_wfc3(imviz_helper, mast_cache_path):
 
 
 @pytest.mark.remote_data
-def test_data_quality_plugin_hst_acs(imviz_helper, mast_cache_path):
+def test_data_quality_plugin_hst_acs(imviz_helper):
     # load HST/ACS observations:
     uri = "mast:HST/product/hst_16968_01_acs_wfc_f606w_jezz01l3_flt.fits"
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        imviz_helper.load_data(uri, cache=True, local_path=mast_cache_path, ext=('SCI', 'DQ'))
+        imviz_helper.load_data(uri, cache=True, ext=('SCI', 'DQ'))
 
     assert len(imviz_helper.app.data_collection) == 2
 
@@ -212,12 +212,12 @@ def test_data_quality_plugin_hst_acs(imviz_helper, mast_cache_path):
 
 
 @pytest.mark.remote_data
-def test_cubeviz_layer_visibility_bug(cubeviz_helper, mast_cache_path):
+def test_cubeviz_layer_visibility_bug(cubeviz_helper):
     # regression test for bug:
     uri = "mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_s3d.fits"
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        cubeviz_helper.load_data(uri, cache=True, local_path=mast_cache_path)
+        cubeviz_helper.load_data(uri, cache=True)
 
     # create a moment map:
     mm = cubeviz_helper.plugins['Moment Maps']

--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -1,9 +1,7 @@
 import warnings
-from pathlib import Path
 import pytest
 
 import numpy as np
-from astroquery.mast import Observations
 from stdatamodels.jwst.datamodels.dqflags import pixel as pixel_jwst
 from glue.core.subset import RectangularROI
 
@@ -77,14 +75,13 @@ def test_roman_against_rdm():
 
 
 @pytest.mark.remote_data
-def test_data_quality_plugin(imviz_helper, tmp_path):
+def test_data_quality_plugin(imviz_helper, mast_cache_path):
     uri = "mast:JWST/product/jw01895001004_07101_00001_nrca3_cal.fits"
-    local_path = str(tmp_path / Path(uri).name)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         imviz_helper.load_data(
-            uri, cache=True, local_path=local_path, ext=('SCI', 'DQ')
+            uri, cache=True, local_path=mast_cache_path, ext=('SCI', 'DQ')
         )
 
     assert len(imviz_helper.app.data_collection) == 2
@@ -173,16 +170,13 @@ def test_data_quality_plugin(imviz_helper, tmp_path):
 
 
 @pytest.mark.remote_data
-def test_data_quality_plugin_hst_wfc3(imviz_helper, tmp_path):
+def test_data_quality_plugin_hst_wfc3(imviz_helper, mast_cache_path):
 
     # load HST/WFC3-UVIS observations:
     uri = "mast:HST/product/hst_17183_02_wfc3_uvis_g280_iexr02mt_flt.fits"
-    download_path = str(tmp_path / Path(uri).name)
-    Observations.download_file(uri, local_path=download_path)
-
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        imviz_helper.load_data(download_path, ext=('SCI', 'DQ'))
+        imviz_helper.load_data(uri, cache=True, local_path=mast_cache_path, ext=('SCI', 'DQ'))
 
     assert len(imviz_helper.app.data_collection) == 2
 
@@ -196,15 +190,12 @@ def test_data_quality_plugin_hst_wfc3(imviz_helper, tmp_path):
 
 
 @pytest.mark.remote_data
-def test_data_quality_plugin_hst_acs(imviz_helper, tmp_path):
+def test_data_quality_plugin_hst_acs(imviz_helper, mast_cache_path):
     # load HST/ACS observations:
     uri = "mast:HST/product/hst_16968_01_acs_wfc_f606w_jezz01l3_flt.fits"
-    download_path = str(tmp_path / Path(uri).name)
-    Observations.download_file(uri, local_path=download_path)
-
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        imviz_helper.load_data(download_path, ext=('SCI', 'DQ'))
+        imviz_helper.load_data(uri, cache=True, local_path=mast_cache_path, ext=('SCI', 'DQ'))
 
     assert len(imviz_helper.app.data_collection) == 2
 
@@ -221,15 +212,12 @@ def test_data_quality_plugin_hst_acs(imviz_helper, tmp_path):
 
 
 @pytest.mark.remote_data
-def test_cubeviz_layer_visibility_bug(cubeviz_helper, tmp_path):
+def test_cubeviz_layer_visibility_bug(cubeviz_helper, mast_cache_path):
     # regression test for bug:
     uri = "mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_s3d.fits"
-    download_path = str(tmp_path / Path(uri).name)
-    Observations.download_file(uri, local_path=download_path)
-
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        cubeviz_helper.load_data(download_path)
+        cubeviz_helper.load_data(uri, cache=True, local_path=mast_cache_path)
 
     # create a moment map:
     mm = cubeviz_helper.plugins['Moment Maps']

--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -9,6 +9,7 @@ from jdaviz.configs.imviz.plugins.parsers import HAS_ROMAN_DATAMODELS
 from jdaviz.configs.default.plugins.data_quality.dq_utils import (
     load_flag_map, write_flag_map
 )
+from jdaviz.utils import cached_uri
 
 
 @pytest.mark.parametrize(
@@ -81,7 +82,7 @@ def test_data_quality_plugin(imviz_helper):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         imviz_helper.load_data(
-            uri, cache=True, ext=('SCI', 'DQ')
+            cached_uri(uri), cache=True, ext=('SCI', 'DQ')
         )
 
     assert len(imviz_helper.app.data_collection) == 2
@@ -176,7 +177,7 @@ def test_data_quality_plugin_hst_wfc3(imviz_helper):
     uri = "mast:HST/product/hst_17183_02_wfc3_uvis_g280_iexr02mt_flt.fits"
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        imviz_helper.load_data(uri, cache=True, ext=('SCI', 'DQ'))
+        imviz_helper.load_data(cached_uri(uri), cache=True, ext=('SCI', 'DQ'))
 
     assert len(imviz_helper.app.data_collection) == 2
 
@@ -195,7 +196,7 @@ def test_data_quality_plugin_hst_acs(imviz_helper):
     uri = "mast:HST/product/hst_16968_01_acs_wfc_f606w_jezz01l3_flt.fits"
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        imviz_helper.load_data(uri, cache=True, ext=('SCI', 'DQ'))
+        imviz_helper.load_data(cached_uri(uri), cache=True, ext=('SCI', 'DQ'))
 
     assert len(imviz_helper.app.data_collection) == 2
 
@@ -217,7 +218,7 @@ def test_cubeviz_layer_visibility_bug(cubeviz_helper):
     uri = "mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_s3d.fits"
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        cubeviz_helper.load_data(uri, cache=True)
+        cubeviz_helper.load_data(cached_uri(uri), cache=True)
 
     # create a moment map:
     mm = cubeviz_helper.plugins['Moment Maps']

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -187,12 +187,9 @@ def test_user_api(specviz2d_helper):
 @pytest.mark.remote_data
 @pytest.mark.skipif(GWCS_LT_0_18_1, reason='Needs GWCS 0.18.1 or later')
 @pytest.mark.filterwarnings("ignore::astropy.wcs.wcs.FITSFixedWarning")
-def test_background_extraction_and_display(specviz2d_helper):
+def test_background_extraction_and_display(specviz2d_helper, mast_cache_path):
     uri = 'mast:jwst/product/jw01538-o161_s000000001_nirspec_f290lp-g395h-s1600a1_s2d.fits'
-    fn = download_file(f'https://mast.stsci.edu/api/v0.1/Download/file/?uri={uri}',
-                       cache=True)
-
-    specviz2d_helper.load_data(spectrum_2d=fn)
+    specviz2d_helper.load_data(spectrum2d=uri, cache=True, local_path=mast_cache_path)
     pext = specviz2d_helper.app.get_tray_item_from_name('spectral-extraction-2d')
 
     # check that the background extraction method and parameters are as expected

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -189,7 +189,7 @@ def test_user_api(specviz2d_helper):
 @pytest.mark.filterwarnings("ignore::astropy.wcs.wcs.FITSFixedWarning")
 def test_background_extraction_and_display(specviz2d_helper, mast_cache_path):
     uri = 'mast:jwst/product/jw01538-o161_s000000001_nirspec_f290lp-g395h-s1600a1_s2d.fits'
-    specviz2d_helper.load_data(spectrum2d=uri, cache=True, local_path=mast_cache_path)
+    specviz2d_helper.load_data(spectrum_2d=uri, cache=True, local_path=mast_cache_path)
     pext = specviz2d_helper.app.get_tray_item_from_name('spectral-extraction-2d')
 
     # check that the background extraction method and parameters are as expected

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -187,9 +187,9 @@ def test_user_api(specviz2d_helper):
 @pytest.mark.remote_data
 @pytest.mark.skipif(GWCS_LT_0_18_1, reason='Needs GWCS 0.18.1 or later')
 @pytest.mark.filterwarnings("ignore::astropy.wcs.wcs.FITSFixedWarning")
-def test_background_extraction_and_display(specviz2d_helper, mast_cache_path):
+def test_background_extraction_and_display(specviz2d_helper):
     uri = 'mast:jwst/product/jw01538-o161_s000000001_nirspec_f290lp-g395h-s1600a1_s2d.fits'
-    specviz2d_helper.load_data(spectrum_2d=uri, cache=True, local_path=mast_cache_path)
+    specviz2d_helper.load_data(spectrum_2d=uri, cache=True)
     pext = specviz2d_helper.app.get_tray_item_from_name('spectral-extraction-2d')
 
     # check that the background extraction method and parameters are as expected

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -11,6 +11,7 @@ from specreduce import tracing, background, extract
 from specutils import Spectrum
 
 from jdaviz.core.custom_units_and_equivs import SPEC_PHOTON_FLUX_DENSITY_UNITS
+from jdaviz.utils import cached_uri
 
 GWCS_LT_0_18_1 = Version(gwcs.__version__) < Version('0.18.1')
 
@@ -189,7 +190,7 @@ def test_user_api(specviz2d_helper):
 @pytest.mark.filterwarnings("ignore::astropy.wcs.wcs.FITSFixedWarning")
 def test_background_extraction_and_display(specviz2d_helper):
     uri = 'mast:jwst/product/jw01538-o161_s000000001_nirspec_f290lp-g395h-s1600a1_s2d.fits'
-    specviz2d_helper.load_data(spectrum_2d=uri, cache=True)
+    specviz2d_helper.load_data(spectrum_2d=cached_uri(uri), cache=True)
     pext = specviz2d_helper.app.get_tray_item_from_name('spectral-extraction-2d')
 
     # check that the background extraction method and parameters are as expected

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -50,19 +50,19 @@ def test_2d_parser_ext_hdulist(specviz2d_helper):
 
 
 @pytest.mark.remote_data
-def test_hlsp_goods_s2d(specviz2d_helper, mast_cache_path):
+def test_hlsp_goods_s2d(specviz2d_helper):
     specviz2d_helper.load('mast:HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst/hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits ',  # noqa
-                          cache=True, local_path=mast_cache_path)
+                          cache=True)
     dc_0 = specviz2d_helper.app.data_collection[0]
     assert dc_0.get_component('flux').shape == (27, 674)
 
 
 @pytest.mark.remote_data
-def test_hlsp_goods_s2d_deconfigged(deconfigged_helper, mast_cache_path):
+def test_hlsp_goods_s2d_deconfigged(deconfigged_helper):
     deconfigged_helper.load('mast:HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst/hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits ',  # noqa
                             format='2D Spectrum',
                             data_label='2D Spectrum',
-                            cache=True, local_path=mast_cache_path)
+                            cache=True)
     dc_0 = deconfigged_helper.app.data_collection[0]
     assert dc_0.get_component('flux').shape == (27, 674)
     assert isinstance(deconfigged_helper.plugins['2D Spectral Extraction'].trace_dataset.selected_obj, Spectrum)  # noqa

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -50,19 +50,19 @@ def test_2d_parser_ext_hdulist(specviz2d_helper):
 
 
 @pytest.mark.remote_data
-def test_hlsp_goods_s2d(specviz2d_helper):
+def test_hlsp_goods_s2d(specviz2d_helper, mast_cache_path):
     specviz2d_helper.load('mast:HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst/hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits ',  # noqa
-                          cache=True)
+                          cache=True, local_path=mast_cache_path)
     dc_0 = specviz2d_helper.app.data_collection[0]
     assert dc_0.get_component('flux').shape == (27, 674)
 
 
 @pytest.mark.remote_data
-def test_hlsp_goods_s2d_deconfigged(deconfigged_helper):
+def test_hlsp_goods_s2d_deconfigged(deconfigged_helper, mast_cache_path):
     deconfigged_helper.load('mast:HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst/hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits ',  # noqa
                             format='2D Spectrum',
                             data_label='2D Spectrum',
-                            cache=True)
+                            cache=True, local_path=mast_cache_path)
     dc_0 = deconfigged_helper.app.data_collection[0]
     assert dc_0.get_component('flux').shape == (27, 674)
     assert isinstance(deconfigged_helper.plugins['2D Spectral Extraction'].trace_dataset.selected_obj, Spectrum)  # noqa

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -6,7 +6,7 @@ from glue.core.edit_subset_mode import NewMode
 from glue.core.roi import XRangeROI
 from specutils import Spectrum
 
-from jdaviz.utils import PRIHDR_KEY
+from jdaviz.utils import PRIHDR_KEY, cached_uri
 from jdaviz.configs.imviz.tests.utils import create_example_gwcs
 
 
@@ -51,7 +51,8 @@ def test_2d_parser_ext_hdulist(specviz2d_helper):
 
 @pytest.mark.remote_data
 def test_hlsp_goods_s2d(specviz2d_helper):
-    specviz2d_helper.load('mast:HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst/hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits ',  # noqa
+    uri='mast:HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst/hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits'  # noqa
+    specviz2d_helper.load(cached_uri(uri),
                           cache=True)
     dc_0 = specviz2d_helper.app.data_collection[0]
     assert dc_0.get_component('flux').shape == (27, 674)
@@ -59,7 +60,8 @@ def test_hlsp_goods_s2d(specviz2d_helper):
 
 @pytest.mark.remote_data
 def test_hlsp_goods_s2d_deconfigged(deconfigged_helper):
-    deconfigged_helper.load('mast:HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst/hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits ',  # noqa
+    uri = 'mast:HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst/hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits'  # noqa
+    deconfigged_helper.load(cached_uri(uri),
                             format='2D Spectrum',
                             data_label='2D Spectrum',
                             cache=True)

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -64,6 +64,15 @@ def deconfigged_helper():
 
 
 @pytest.fixture
+def mast_cache_path():
+    """
+    Returns the path to the MAST cache directory.
+    This is used to ensure that tests can access cached data.
+    """
+    return './mast_cache/'
+
+
+@pytest.fixture
 def roman_level_1_ramp():
     from roman_datamodels.maker_utils import mk_datamodel
     from roman_datamodels.datamodels import RampModel

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -69,7 +69,7 @@ def mast_cache_path():
     Returns the path to the MAST cache directory.
     This is used to ensure that tests can access cached data.
     """
-    return './mast_cache/'
+    return './mast_cache'
 
 
 @pytest.fixture

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -64,15 +64,6 @@ def deconfigged_helper():
 
 
 @pytest.fixture
-def mast_cache_path():
-    """
-    Returns the path to the MAST cache directory.
-    This is used to ensure that tests can access cached data.
-    """
-    return './mast_cache'
-
-
-@pytest.fixture
 def roman_level_1_ramp():
     from roman_datamodels.maker_utils import mk_datamodel
     from roman_datamodels.datamodels import RampModel

--- a/jdaviz/core/loaders/test_loaders.py
+++ b/jdaviz/core/loaders/test_loaders.py
@@ -80,10 +80,9 @@ def test_markers_specviz2d_unit_conversion(specviz2d_helper, spectrum2d):
 
 @pytest.mark.remote_data
 @pytest.mark.filterwarnings(r"ignore::astropy.wcs.wcs.FITSFixedWarning")
-def test_fits_spectrum2d(deconfigged_helper, mast_cache_path):
+def test_fits_spectrum2d(deconfigged_helper):
     ldr = deconfigged_helper.loaders['url']
     ldr.cache = True
-    ldr.local_path = mast_cache_path
     ldr.url = 'mast:jwst/product/jw02123-o001_v000000353_nirspec_f170lp-g235h_s2d.fits'
 
     # Default is Image but the test switches to 2D Spectrum

--- a/jdaviz/core/loaders/test_loaders.py
+++ b/jdaviz/core/loaders/test_loaders.py
@@ -80,8 +80,10 @@ def test_markers_specviz2d_unit_conversion(specviz2d_helper, spectrum2d):
 
 @pytest.mark.remote_data
 @pytest.mark.filterwarnings(r"ignore::astropy.wcs.wcs.FITSFixedWarning")
-def test_fits_spectrum2d(deconfigged_helper):
+def test_fits_spectrum2d(deconfigged_helper, mast_cache_path):
     ldr = deconfigged_helper.loaders['url']
+    ldr.cache = True
+    ldr.local_path = mast_cache_path
     ldr.url = 'mast:jwst/product/jw02123-o001_v000000353_nirspec_f170lp-g235h_s2d.fits'
 
     # Default is Image but the test switches to 2D Spectrum

--- a/jdaviz/core/loaders/test_loaders.py
+++ b/jdaviz/core/loaders/test_loaders.py
@@ -4,6 +4,7 @@ from astropy import units as u
 from specutils import SpectralRegion, Spectrum
 from jdaviz.core.registries import loader_resolver_registry
 from jdaviz.core.loaders.resolvers import find_matching_resolver
+from jdaviz.utils import cached_uri
 
 
 def test_loaders_registry(specviz_helper):
@@ -81,9 +82,14 @@ def test_markers_specviz2d_unit_conversion(specviz2d_helper, spectrum2d):
 @pytest.mark.remote_data
 @pytest.mark.filterwarnings(r"ignore::astropy.wcs.wcs.FITSFixedWarning")
 def test_fits_spectrum2d(deconfigged_helper):
-    ldr = deconfigged_helper.loaders['url']
-    ldr.cache = True
-    ldr.url = 'mast:jwst/product/jw02123-o001_v000000353_nirspec_f170lp-g235h_s2d.fits'
+    uri = cached_uri('mast:jwst/product/jw02123-o001_v000000353_nirspec_f170lp-g235h_s2d.fits')
+    if 'mast' in uri:
+        ldr = deconfigged_helper.loaders['url']
+        ldr.cache = True
+        ldr.url = uri
+    else:
+        ldr = deconfigged_helper.loaders['file']
+        ldr.filepath = uri
 
     # Default is Image but the test switches to 2D Spectrum
     # since this file type is not yet supported by the image loader
@@ -142,6 +148,8 @@ def test_resolver_url(deconfigged_helper):
     assert len(deconfigged_helper.viewers) == 2
 
     with pytest.raises(ValueError, match="Failed query for URI"):
+        # NOTE: this test will attempt to reach out to MAST via astroquery
+        # even if cache is available.
         deconfigged_helper.load('mast:invalid')
 
 

--- a/jdaviz/core/tests/test_autoconfig.py
+++ b/jdaviz/core/tests/test_autoconfig.py
@@ -27,13 +27,11 @@ AUTOCONFIG_EXAMPLES = (
 @pytest.mark.slow
 @pytest.mark.filterwarnings('ignore')
 @pytest.mark.parametrize('uris', AUTOCONFIG_EXAMPLES)
-def test_autoconfig(uris, mast_cache_path):
+def test_autoconfig(uris):
     uri = uris[0]
     helper_class = uris[1]
 
     kwargs = dict(cache=True, show=False)
-    if uri.startswith('mast'):
-        kwargs['local_path'] = mast_cache_path
 
     viz_helper = jdaviz_open(uri, **kwargs)
     assert isinstance(viz_helper, helper_class)

--- a/jdaviz/core/tests/test_autoconfig.py
+++ b/jdaviz/core/tests/test_autoconfig.py
@@ -10,6 +10,7 @@ from jdaviz import open as jdaviz_open
 from jdaviz.cli import ALL_JDAVIZ_CONFIGS
 from jdaviz.configs import Specviz2d, Cubeviz, Imviz, Specviz
 from jdaviz.core.launcher import Launcher, STATUS_HINTS
+from jdaviz.utils import cached_uri
 
 
 AUTOCONFIG_EXAMPLES = (
@@ -33,7 +34,7 @@ def test_autoconfig(uris):
 
     kwargs = dict(cache=True, show=False)
 
-    viz_helper = jdaviz_open(uri, **kwargs)
+    viz_helper = jdaviz_open(cached_uri(uri), **kwargs)
     assert isinstance(viz_helper, helper_class)
     assert len(viz_helper.app.data_collection) > 0
 

--- a/jdaviz/core/tests/test_autoconfig.py
+++ b/jdaviz/core/tests/test_autoconfig.py
@@ -27,15 +27,13 @@ AUTOCONFIG_EXAMPLES = (
 @pytest.mark.slow
 @pytest.mark.filterwarnings('ignore')
 @pytest.mark.parametrize('uris', AUTOCONFIG_EXAMPLES)
-def test_autoconfig(uris, tmp_path):
+def test_autoconfig(uris, mast_cache_path):
     uri = uris[0]
     helper_class = uris[1]
 
-    local_path = str(tmp_path / Path(uri).name)
-
     kwargs = dict(cache=True, show=False)
     if uri.startswith('mast'):
-        kwargs['local_path'] = local_path
+        kwargs['local_path'] = mast_cache_path
 
     viz_helper = jdaviz_open(uri, **kwargs)
     assert isinstance(viz_helper, helper_class)

--- a/jdaviz/core/tests/test_config_detection.py
+++ b/jdaviz/core/tests/test_config_detection.py
@@ -2,6 +2,7 @@ import pytest
 from astropy.utils.data import download_file
 
 from jdaviz.core.data_formats import identify_helper
+from jdaviz.utils import cached_uri
 
 
 # URIs to example JWST/HST files on MAST, and their corresponding jdaviz helpers.
@@ -14,8 +15,12 @@ from jdaviz.core.data_formats import identify_helper
     ('mast:JWST/product/jw02727-o002_t062_nircam_clear-f277w_i2d.fits', 'imviz'),
     ('mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_s3d.fits', 'cubeviz')])
 def test_auto_config_detection(uri, expected_helper):
-    url = f'https://mast.stsci.edu/api/v0.1/Download/file/?uri={uri}'
-    fn = download_file(url, timeout=100)
+    uri = cached_uri(uri)
+    if 'mast' in uri:
+        url = f'https://mast.stsci.edu/api/v0.1/Download/file/?uri={uri}'
+        fn = download_file(url, timeout=100)
+    else:
+        fn = uri
     helper_name, hdul = identify_helper(fn)
     hdul.close()
     assert len(helper_name) == 1 and helper_name[0] == expected_helper

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from astropy.wcs import FITSFixedWarning
 
-from jdaviz.utils import alpha_index, download_uri_to_path, get_cloud_fits
+from jdaviz.utils import alpha_index, download_uri_to_path, get_cloud_fits, cached_uri
 from astropy.io import fits
 
 
@@ -31,6 +31,8 @@ def test_uri_to_download_nonexistent_mast_file(imviz_helper):
     # this validates as a mast uri but doesn't actually exist on mast:
     uri = "mast:JWST/product/jw00000-no-file-here.fits"
     with pytest.raises(ValueError, match='Failed query for URI'):
+        # NOTE: this test will attempt to reach out to MAST via astroquery
+        # even if cache is available.
         imviz_helper.load_data(uri, cache=False)
 
 
@@ -49,6 +51,7 @@ def test_url_to_download_imviz_local_path_warning(imviz_helper):
 
 
 def test_uri_to_download_specviz_local_path_check():
+    # NOTE: do not use cached_uri here since no download should occur
     uri = "mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_x1d.fits"
     local_path = download_uri_to_path(uri, cache=False, dryrun=True)  # No download
 
@@ -59,13 +62,13 @@ def test_uri_to_download_specviz_local_path_check():
 
 @pytest.mark.remote_data
 def test_uri_to_download_specviz(specviz_helper):
-    uri = "mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_x1d.fits"
+    uri = cached_uri("mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_x1d.fits")
     specviz_helper.load_data(uri, cache=True)
 
 
 @pytest.mark.remote_data
 def test_uri_to_download_specviz2d(specviz2d_helper):
-    uri = "mast:jwst/product/jw01538-o161_s000000001_nirspec_f290lp-g395h-s1600a1_s2d.fits"
+    uri = cached_uri("mast:jwst/product/jw01538-o161_s000000001_nirspec_f290lp-g395h-s1600a1_s2d.fits")  # noqa: E501
     specviz2d_helper.load_data(uri, cache=True)
 
 

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -58,17 +58,15 @@ def test_uri_to_download_specviz_local_path_check():
 
 
 @pytest.mark.remote_data
-def test_uri_to_download_specviz(specviz_helper, tmp_path):
+def test_uri_to_download_specviz(specviz_helper, mast_cache_path):
     uri = "mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_x1d.fits"
-    local_path = str(tmp_path / uri.split('/')[-1])
-    specviz_helper.load_data(uri, cache=True, local_path=local_path)
+    specviz_helper.load_data(uri, cache=True, local_path=mast_cache_path)
 
 
 @pytest.mark.remote_data
-def test_uri_to_download_specviz2d(specviz2d_helper, tmp_path):
+def test_uri_to_download_specviz2d(specviz2d_helper, mast_cache_path):
     uri = "mast:jwst/product/jw01538-o161_s000000001_nirspec_f290lp-g395h-s1600a1_s2d.fits"
-    local_path = str(tmp_path / uri.split('/')[-1])
-    specviz2d_helper.load_data(uri, cache=True, local_path=local_path)
+    specviz2d_helper.load_data(uri, cache=True, local_path=mast_cache_path)
 
 
 @pytest.mark.remote_data

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -58,15 +58,15 @@ def test_uri_to_download_specviz_local_path_check():
 
 
 @pytest.mark.remote_data
-def test_uri_to_download_specviz(specviz_helper, mast_cache_path):
+def test_uri_to_download_specviz(specviz_helper):
     uri = "mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_x1d.fits"
-    specviz_helper.load_data(uri, cache=True, local_path=mast_cache_path)
+    specviz_helper.load_data(uri, cache=True)
 
 
 @pytest.mark.remote_data
-def test_uri_to_download_specviz2d(specviz2d_helper, mast_cache_path):
+def test_uri_to_download_specviz2d(specviz2d_helper):
     uri = "mast:jwst/product/jw01538-o161_s000000001_nirspec_f290lp-g395h-s1600a1_s2d.fits"
-    specviz2d_helper.load_data(uri, cache=True, local_path=mast_cache_path)
+    specviz2d_helper.load_data(uri, cache=True)
 
 
 @pytest.mark.remote_data

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -621,7 +621,6 @@ def cached_uri(uri):
     fname = uri.split(':')[-1].split('/')[-1]
     if os.path.isfile(fname):
         return fname
-    raise ValueError(f"*** cached_uri not finding cached file: uri={uri}, fname={fname}, cwd={os.getcwd()}")  # noqa
     return uri
 
 
@@ -719,7 +718,6 @@ def download_uri_to_path(possible_uri, cache=None, local_path=os.curdir, timeout
             local_path = os.path.join(local_path, parsed_uri.path.split('/')[-1])
 
         if not dryrun:
-            raise ValueError(f"*** attempting download from MAST: {possible_uri}, cwd={os.getcwd()}")  # noqa
             with conf.set_temp('timeout', timeout):
                 (status, msg, url) = Observations.download_file(
                     possible_uri, cache=cache, local_path=local_path

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -621,6 +621,7 @@ def cached_uri(uri):
     fname = uri.split(':')[-1].split('/')[-1]
     if os.path.isfile(fname):
         return fname
+    raise ValueError(f"*** cached_uri not finding cached file: uri={uri}, fname={fname}, cwd={os.getcwd()}")  # noqa
     return uri
 
 
@@ -718,6 +719,7 @@ def download_uri_to_path(possible_uri, cache=None, local_path=os.curdir, timeout
             local_path = os.path.join(local_path, parsed_uri.path.split('/')[-1])
 
         if not dryrun:
+            raise ValueError(f"*** attempting download from MAST: {possible_uri}, cwd={os.getcwd()}")  # noqa
             with conf.set_temp('timeout', timeout):
                 (status, msg, url) = Observations.download_file(
                     possible_uri, cache=cache, local_path=local_path

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -32,7 +32,7 @@ from ipyvue import watch
 
 __all__ = ['SnackbarQueue', 'enable_hot_reloading', 'bqplot_clear_figure',
            'standardize_metadata', 'ColorCycler', 'alpha_index',
-           'get_subset_type', 'download_uri_to_path', 'layer_is_2d',
+           'get_subset_type', 'cached_uri', 'download_uri_to_path', 'layer_is_2d',
            'layer_is_2d_or_3d', 'layer_is_image_data', 'layer_is_wcs_only',
            'get_wcs_only_layer_labels', 'get_top_layer_index',
            'get_reference_image_data', 'standardize_roman_metadata',
@@ -612,6 +612,16 @@ def get_cloud_fits(possible_uri, ext=None, cache=None, local_path=os.curdir, tim
         return file_obj
     # not s3 resource, return string as is
     return possible_uri
+
+
+def cached_uri(uri):
+    # return a filename if it exists in the working directory, otherwise return the URI
+    # this is used in CI tests where the MAST files are downloaded by a separate workflow,
+    # cached, and restored in the tox working directory to avoid downloading them again
+    fname = uri.split(':')[-1].split('/')[-1]
+    if os.path.isfile(fname):
+        return fname
+    return uri
 
 
 def download_uri_to_path(possible_uri, cache=None, local_path=os.curdir, timeout=None,


### PR DESCRIPTION
This PR updates the CI workflow to make use of the caches implemented in #3689 by moving the cache to the top-level directory of the tox working directory, removing references to hardcoded local paths from the tests, and having tests call `cached_uri` to pass just the filename to `load`/`load_data` if it is found in the cache in the working directory and otherwise pass through the full URI.  This PR also fixes the weekly scheduled run in #3689 to default to the same set of URIs as when manually triggered.

Before #3689, remote/slow tests often took 2 hours and still failed due to timeouts.

Now they take ~45 mins, including with slow tests enabled.

Note that this PR does skip one remote test which is now failing - it likely slipped through the cracks among the remote data failures so should be fixed as a separate follow-up effort asap.