### PR TITLE
Add test coverage for importing flat and fit traces in Spectral Extraction

### DIFF
--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -38,6 +38,22 @@ def test_plugin(specviz2d_helper):
     assert pext.marks['trace'].marks_list[0].visible is True
     assert len(pext.marks['trace'].marks_list[0].x) > 0
 
+    # test importing traces
+    img = specviz2d_helper.get_data('Spectrum 2D')
+    flat_trace = tracing.FlatTrace(img, trace_pos=25)
+    fit_trace = tracing.FitTrace(img)
+
+    for imported_trace in [flat_trace, fit_trace]:
+        pext.import_trace(imported_trace)
+        exported_trace = pext.export_trace(add_data=False)
+        assert isinstance(exported_trace, type(imported_trace))
+
+    # # array trace needs to go through loader, uncomment after JDAT-5518
+    # array_trace = tracing.ArrayTrace(img, np.arange(len(img.spectral_axis)))
+    # specviz2d_helper.load(array_trace)
+    # exported_trace = pext.export_trace(add_data=False)
+    # assert isinstance(exported_trace, tracing.ArrayTrace)
+
     # create FlatTrace
     pext.trace_type_selected = 'Flat'
     pext.trace_pixel = 28


### PR DESCRIPTION
Adds some test coverage to test the 'import_trace' function in spectral extraction. Array Traces need to go though the loader, and are having issues with unit conversion at the moment, so i added in a commented out test that should pass once this is fixed in the follow up ticket (JDAT 5518)