### PR TITLE
fix API hint in data-menu to access viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 New Features
 ------------
 
-- The Markers plugin now includes a Distance Tool to interactively measure and log pixel, on-sky, and axis-separated (dx, dy) 
+- The Markers plugin now includes a Distance Tool to interactively measure and log pixel, on-sky, and axis-separated (dx, dy)
   distances between points in any viewer. [#3609]
 
 - The Plot Options plugin now highlights the tab for the active (top-most) data layer
@@ -166,6 +166,8 @@ Bug Fixes
 - Fixed issue in ``compute_scale`` to handle the case when the wcs forward
   transform does not use units, which was previously causing issues when
   aligning by WCS. [#3658]
+
+- Fixed API hints for viewers in the data-menu. [#3695]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -62,7 +62,7 @@
             <v-list-item v-if="api_hints_enabled" style="min-height: 12px">
               <v-list-item-content>
                 <span class="api-hint">
-                  <b>dm = {{ api_hints_obj }}.viewers['{{viewer_id}}'].data_menu</b>
+                  <b>dm = {{ api_hints_obj }}.viewers['{{viewer_reference}}'].data_menu</b>
                 </span>
               </v-list-item-content>
             </v-list-item>
@@ -189,9 +189,9 @@
                   </span>
                 </v-list-item-content>
                 <v-list-item-action>
-                  <j-tooltip 
+                  <j-tooltip
                     :tooltipcontent="api_hints_enabled ? '' : item.is_sonified ? 'Toggle sonification' :'Toggle visibility'"
-                  > 
+                  >
                     <plugin-switch
                       :value="item.visible"
                       @click="(value) => {set_layer_visibility({layer: item.label, value: value})}"


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes the API hint in viewer data-menus to use the viewer reference instead of viewer ID.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
