### PR TITLE
Fix importing array trace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -196,6 +196,8 @@ Specviz2d
 - Fixed an issue with default angle unit being set in unit conversion plugin, which fixed
   a bug when background data from the spectral extraction plugin is added to the viewer. [#3661]
 
+- Fixed a bug loading array traces into Specviz2d. [#3697]
+
 4.2.3 (2025-06-16)
 ==================
 

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -304,7 +304,7 @@ class UnitConversion(PluginTemplateMixin):
             # NOTE: this assumes that all image data is coerced to surface brightness units
             layers = [lyr for lyr in msg.viewer.layers if lyr.layer.data.label == msg.data.label]
 
-            if not isinstance(data_obj, tracing.FlatTrace):
+            if not isinstance(data_obj, tracing.Trace):
 
                 if not len(self.spectral_unit_selected) and hasattr(data_obj, 'spectral_axis'):
                     try:

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -39,22 +39,6 @@ def test_plugin(specviz2d_helper):
     assert pext.marks['trace'].marks_list[0].visible is True
     assert len(pext.marks['trace'].marks_list[0].x) > 0
 
-    # test importing traces
-    img = specviz2d_helper.get_data('Spectrum 2D')
-    flat_trace = tracing.FlatTrace(img, trace_pos=25)
-    fit_trace = tracing.FitTrace(img)
-
-    for imported_trace in [flat_trace, fit_trace]:
-        pext.import_trace(imported_trace)
-        exported_trace = pext.export_trace(add_data=False)
-        assert isinstance(exported_trace, type(imported_trace))
-
-    # # array trace needs to go through loader, uncomment after JDAT-5518
-    # array_trace = tracing.ArrayTrace(img, np.arange(len(img.spectral_axis)))
-    # specviz2d_helper.load(array_trace)
-    # exported_trace = pext.export_trace(add_data=False)
-    # assert isinstance(exported_trace, tracing.ArrayTrace)
-
     # create FlatTrace
     pext.trace_type_selected = 'Flat'
     pext.trace_pixel = 28
@@ -175,6 +159,23 @@ def test_plugin(specviz2d_helper):
 
     with pytest.raises(ValueError):
         pext.export_extract(invalid_kwarg=5)
+
+    # test importing traces
+    img = specviz2d_helper.get_data('Spectrum 2D')
+    flat_trace = tracing.FlatTrace(img, trace_pos=25)
+    fit_trace = tracing.FitTrace(img)
+
+    for imported_trace in [flat_trace, fit_trace]:
+        pext.import_trace(imported_trace)
+        exported_trace = pext.export_trace(add_data=False)
+        assert isinstance(exported_trace, type(imported_trace))
+
+    # array trace needs to go through loader, uncomment after JDAT-5518
+    array_trace = tracing.ArrayTrace(img, np.arange(len(img.spectral_axis)))
+    specviz2d_helper.load(array_trace, data_label='array_trace')
+    pext.trace_trace.selected = 'array_trace'
+    exported_trace = pext.export_trace(add_data=False)
+    assert isinstance(exported_trace, tracing.ArrayTrace)
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
This fixes a bug when importing array traces, which must go through loaders instead of spectral_extraction.import_trace. 

The issue is related to unit conversion, in the method that handles when data is added to the viewer. A quick fix for this is to just skip this when the data being added is a trace, because the defaults and dropdown items should be set when non-trace data is added to the viewer. I think that refactoring this code in Unit Conversion at some point is necessary. I started to do that for this ticket on another branch but decided to just get in the quick fix for now. 
