### PR TITLE
Manual backport of PR 3695

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Bug Fixes
   transform does not use units, which was previously causing issues when
   aligning by WCS. [#3658]
 
+- Fixed API hints for viewers in the data-menu. [#3695]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -62,7 +62,7 @@
             <v-list-item v-if="api_hints_enabled" style="min-height: 12px"> 
               <v-list-item-content> 
                 <span class="api-hint"> 
-                  <b>dm = {{ config }}.viewers['{{viewer_id}}'].data_menu</b>
+                  <b>dm = {{ config }}.viewers['{{viewer_reference}}'].data_menu</b>
                 </span> 
               </v-list-item-content> 
             </v-list-item> 


### PR DESCRIPTION
This PR is a manual backport of PR #3695 (conflicts with `config` vs `api_hints_obj` and sonification added to the visibility switch addressed)