### PR TITLE
Fix broken photutils links

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.vue
@@ -223,7 +223,7 @@
         />
         <v-row>
           <j-docs-link>
-              See the <j-external-link link='https://photutils.readthedocs.io/en/stable/aperture.html#aperture-and-pixel-overlap'
+              See the <j-external-link link='https://photutils.readthedocs.io/en/stable/user_guide/aperture.html#aperture-and-pixel-overlap'
               linktext='photutils docs'></j-external-link> for more details on aperture masking methods.
           </j-docs-link>
         </v-row>

--- a/notebooks/concepts/mosviz_generate_photometry.ipynb
+++ b/notebooks/concepts/mosviz_generate_photometry.ipynb
@@ -148,7 +148,7 @@
    "source": [
     "### Generate analytical galaxy cutouts\n",
     "\n",
-    "Whether or not the image comes with a catalog, we can use the methods imported from `photutils` to make our own `SourceCatalog`. We follow a workflow modified from `photuils`' [documentation on segmentation](https://photutils.readthedocs.io/en/stable/segmentation.html)."
+    "Whether or not the image comes with a catalog, we can use the methods imported from `photutils` to make our own `SourceCatalog`. We follow a workflow modified from `photuils`' [documentation on segmentation](https://photutils.readthedocs.io/en/stable/user_guide/segmentation.html)."
    ]
   },
   {


### PR DESCRIPTION
Turns out there was a new `user_guide` subheading needed in the URL.