### PR TITLE
remove roman_datamodels.maker_utils usage

### DIFF
--- a/jdaviz/configs/imviz/tests/utils.py
+++ b/jdaviz/configs/imviz/tests/utils.py
@@ -270,11 +270,9 @@ def create_wfi_image_model(image_shape=(20, 10), **kwargs):
 
     """  # noqa: E501
     from roman_datamodels import datamodels as rdd
-    from roman_datamodels.maker_utils import mk_level2_image
 
-    wfi_image = mk_level2_image(shape=image_shape, **kwargs)
+    model = rdd.ImageModel.create_fake_data(shape=image_shape, defaults=kwargs)
 
     # introduce synthetic gwcs:
-    wfi_image["meta"]["wcs"] = create_example_gwcs(image_shape)
-
-    return rdd.ImageModel(wfi_image)
+    model.meta.wcs = create_example_gwcs(image_shape)
+    return model

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -65,12 +65,11 @@ def deconfigged_helper():
 
 @pytest.fixture
 def roman_level_1_ramp():
-    from roman_datamodels.maker_utils import mk_datamodel
     from roman_datamodels.datamodels import RampModel
     rng = np.random.default_rng(seed=42)
 
     shape = (10, 25, 25)
-    data_model = mk_datamodel(RampModel, shape=shape, dq=False)
+    data_model = RampModel.create_fake_data(shape=shape)
 
     data_model.data = 100 + 3 * np.cumsum(rng.uniform(size=shape), axis=0)
     return data_model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ docs = [
     "sphinx_design"
 ]
 roman = [
-    "roman_datamodels>=0.22.0",
+    "roman_datamodels>=0.26.0",
 ]
 strauss = [
     "strauss",


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
