### PR TITLE
Add relevancy check code to PluginMixin

### DIFF
--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -213,12 +213,12 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             self.serverside_enabled = False
 
         if self.config == 'deconfigged':
-            self.observe_relevant_traitlets(non_empty_traitlets=['viewer_items',
-                                                                 'dataset_items',
-                                                                 'subset_items',
-                                                                 'plugin_table_items',
-                                                                 'plugin_plot_items'],
-                                            check_all_for_relevance=True)
+            self.observe_traitlets_for_relevancy(non_empty_traitlets=['viewer_items',
+                                                                      'dataset_items',
+                                                                      'subset_items',
+                                                                      'plugin_table_items',
+                                                                      'plugin_plot_items'],
+                                                 check_all_for_relevance=True)
 
     def _is_valid_item(self, item):
         return self._is_not_stcs(item) or self._is_stcs_region_supported(item)

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -213,10 +213,12 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             self.serverside_enabled = False
 
         if self.config == 'deconfigged':
-            self.setup_relevance(non_empty_traitlets=['viewer_items', 'dataset_items',
-                                                      'subset_items', 'plugin_table_items',
-                                                      'plugin_plot_items'],
-                                 set_relevant=self._set_relevant)
+            self.observe_relevant_traitlets(non_empty_traitlets=['viewer_items',
+                                                                 'dataset_items',
+                                                                 'subset_items',
+                                                                 'plugin_table_items',
+                                                                 'plugin_plot_items'],
+                                            set_relevant=self._set_relevant)
 
     def _set_relevant(self, *args):
         if not (len(self.viewer_items) or len(self.dataset_items) or len(self.subset_items)

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -218,14 +218,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                                                                  'subset_items',
                                                                  'plugin_table_items',
                                                                  'plugin_plot_items'],
-                                            set_relevant=self._set_relevant)
-
-    def _set_relevant(self, *args):
-        if not (len(self.viewer_items) or len(self.dataset_items) or len(self.subset_items)
-                or len(self.plugin_table_items) or len(self.plugin_plot_items)):
-            self.irrelevant_msg = 'Nothing to export'
-        else:
-            self.irrelevant_msg = ''
+                                            check_all_for_relevance=True)
 
     def _is_valid_item(self, item):
         return self._is_not_stcs(item) or self._is_stcs_region_supported(item)

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -213,8 +213,22 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             self.serverside_enabled = False
 
         if self.config == 'deconfigged':
-            self.setup_relevance(['viewer_items', 'dataset_items', 'subset_items',
-                                  'plugin_table_items', 'plugin_plot_items'])
+            self.setup_relevance(non_empty_traitlets=['viewer_items', 'dataset_items',
+                                                      'subset_items', 'plugin_table_items',
+                                                      'plugin_plot_items'],
+                                 set_relevant=self._set_relevant)
+
+    # Keep this _set_relevant because in the mixing, we use an implicit ANY
+    # i.e. if ANY of the non_empty_traitlets are in fact empty, the plugin is irrelevant
+    # whereas this uses ALL
+    def _set_relevant(self, *args):
+        if self.app.config != 'deconfigged':
+            return
+        if not (len(self.viewer_items) or len(self.dataset_items) or len(self.subset_items)
+                or len(self.plugin_table_items) or len(self.plugin_plot_items)):
+            self.irrelevant_msg = 'Nothing to export'
+        else:
+            self.irrelevant_msg = ''
 
     def _is_valid_item(self, item):
         return self._is_not_stcs(item) or self._is_stcs_region_supported(item)

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -213,12 +213,13 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             self.serverside_enabled = False
 
         if self.config == 'deconfigged':
-            self.observe_traitlets_for_relevancy(non_empty_traitlets=['viewer_items',
-                                                                      'dataset_items',
-                                                                      'subset_items',
-                                                                      'plugin_table_items',
-                                                                      'plugin_plot_items'],
-                                                 check_all_for_relevance=True)
+            self.observe_traitlets_for_relevancy(
+                traitlets_to_observe=['viewer_items',
+                                      'dataset_items',
+                                      'subset_items',
+                                      'plugin_table_items',
+                                      'plugin_plot_items'],
+                irrelevant_msg_callback=self.relevant_if_any_truthy)
 
     def _is_valid_item(self, item):
         return self._is_not_stcs(item) or self._is_stcs_region_supported(item)

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -214,7 +214,15 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
         if self.config == 'deconfigged':
             self.setup_relevance(['viewer_items', 'dataset_items', 'subset_items',
-                                  'plugin_table_items', 'plugin_plot_items'])
+                                  'plugin_table_items', 'plugin_plot_items'],
+                                 set_relevant=self._set_relevant)
+
+    def _set_relevant(self, *args):
+        if not (len(self.viewer_items) or len(self.dataset_items) or len(self.subset_items)
+                or len(self.plugin_table_items) or len(self.plugin_plot_items)):
+            self.irrelevant_msg = 'Nothing to export'
+        else:
+            self.irrelevant_msg = ''
 
     def _is_valid_item(self, item):
         return self._is_not_stcs(item) or self._is_stcs_region_supported(item)

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -212,7 +212,9 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             # on the user's machine, so export support in cubeviz should be disabled
             self.serverside_enabled = False
 
-        self._set_relevant()
+        if self.config == 'deconfigged':
+            self.setup_relevance(['viewer_items', 'dataset_items', 'subset_items',
+                                  'plugin_table_items', 'plugin_plot_items'])
 
     def _is_valid_item(self, item):
         return self._is_not_stcs(item) or self._is_stcs_region_supported(item)
@@ -265,17 +267,6 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     @observe('subset_format_selected')
     def _on_subset_format_selected(self, event):
         self._is_subset_format_supported()
-
-    @observe('viewer_items', 'dataset_items', 'subset_items',
-             'plugin_table_items', 'plugin_plot_items')
-    def _set_relevant(self, *args):
-        if self.app.config != 'deconfigged':
-            return
-        if not (len(self.viewer_items) or len(self.dataset_items) or len(self.subset_items)
-                or len(self.plugin_table_items) or len(self.plugin_plot_items)):
-            self.irrelevant_msg = 'Nothing to export'
-        else:
-            self.irrelevant_msg = ''
 
     @property
     def user_api(self):

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -213,8 +213,9 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             self.serverside_enabled = False
 
         if self.config == 'deconfigged':
-            self.setup_relevance(['viewer_items', 'dataset_items', 'subset_items',
-                                  'plugin_table_items', 'plugin_plot_items'],
+            self.setup_relevance(non_empty_traitlets=['viewer_items', 'dataset_items',
+                                                      'subset_items', 'plugin_table_items',
+                                                      'plugin_plot_items'],
                                  set_relevant=self._set_relevant)
 
     def _set_relevant(self, *args):

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -213,22 +213,8 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             self.serverside_enabled = False
 
         if self.config == 'deconfigged':
-            self.setup_relevance(non_empty_traitlets=['viewer_items', 'dataset_items',
-                                                      'subset_items', 'plugin_table_items',
-                                                      'plugin_plot_items'],
-                                 set_relevant=self._set_relevant)
-
-    # Keep this _set_relevant because in the mixing, we use an implicit ANY
-    # i.e. if ANY of the non_empty_traitlets are in fact empty, the plugin is irrelevant
-    # whereas this uses ALL
-    def _set_relevant(self, *args):
-        if self.app.config != 'deconfigged':
-            return
-        if not (len(self.viewer_items) or len(self.dataset_items) or len(self.subset_items)
-                or len(self.plugin_table_items) or len(self.plugin_plot_items)):
-            self.irrelevant_msg = 'Nothing to export'
-        else:
-            self.irrelevant_msg = ''
+            self.setup_relevance(['viewer_items', 'dataset_items', 'subset_items',
+                                  'plugin_table_items', 'plugin_plot_items'])
 
     def _is_valid_item(self, item):
         return self._is_not_stcs(item) or self._is_stcs_region_supported(item)

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -73,7 +73,7 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
         self._plugin_description = 'Smooth data with a Gaussian kernel.'
 
         if self.app.config == 'deconfigged':
-            self.observe_traitlets_for_relevancy(non_empty_traitlets=['dataset_items'])
+            self.observe_traitlets_for_relevancy(traitlets_to_observe=['dataset_items'])
 
     @property
     def _default_spectrum_viewer_reference_name(self):

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -73,7 +73,7 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
         self._plugin_description = 'Smooth data with a Gaussian kernel.'
 
         if self.app.config == 'deconfigged':
-            self.observe_relevant_traitlets(non_empty_traitlets=['dataset_items'])
+            self.observe_traitlets_for_relevancy(non_empty_traitlets=['dataset_items'])
 
     @property
     def _default_spectrum_viewer_reference_name(self):

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -73,7 +73,7 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
         self._plugin_description = 'Smooth data with a Gaussian kernel.'
 
         if self.app.config == 'deconfigged':
-            self.setup_relevance(non_empty_traitlets=['dataset_items'])
+            self.observe_relevant_traitlets(non_empty_traitlets=['dataset_items'])
 
     @property
     def _default_spectrum_viewer_reference_name(self):

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -72,16 +72,8 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
         # description displayed under plugin title in tray
         self._plugin_description = 'Smooth data with a Gaussian kernel.'
 
-        self._set_relevant()
-
-    @observe('dataset_items')
-    def _set_relevant(self, *args):
-        if self.app.config != 'deconfigged':
-            return
-        if not len(self.dataset_items):
-            self.irrelevant_msg = 'No valid datasets loaded'
-        else:
-            self.irrelevant_msg = ''
+        if self.app.config == 'deconfigged':
+            self.setup_relevance(non_empty_traitlets=['dataset_items'])
 
     @property
     def _default_spectrum_viewer_reference_name(self):

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -120,30 +120,32 @@ class LineListTool(PluginTemplateMixin, ViewerSelectMixin):
             sv.state.add_callback("x_max",
                                   lambda x_max: self._on_spectrum_viewer_limits_changed())
 
-        self.observe_traitlets_for_relevancy(non_empty_traitlets=['viewer_items'],
-                                             set_relevant=self._set_relevant)
+        self.observe_traitlets_for_relevancy(traitlets_to_observe=['viewer_items'],
+                                             irrelevant_msg_callback=self._irrelevant_msg_callback)
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Plot spectral lines from preset or custom line lists.'
 
-    def _set_relevant(self, *args):
+    def _irrelevant_msg_callback(self, *args):
         if not hasattr(self, 'viewer'):
-            return
+            return None
         if not len(self.viewer_items) or self.viewer.selected_obj is None:
-            self.irrelevant_msg = 'Line Lists unavailable without spectrum viewer'
+            irrelevant_msg = 'Line Lists unavailable without spectrum viewer'
         elif not len(self.viewer.selected_obj.layers):
             if self.app.config == 'deconfigged':
-                self.irrelevant_msg = 'No data in spectrum viewer'
+                irrelevant_msg = 'No data in spectrum viewer'
             else:
-                self.irrelevant_msg = ''
+                irrelevant_msg = ''
             self.disabled_msg = 'Line Lists unavailable without data loaded in spectrum viewer'
         else:
-            self.irrelevant_msg = ''
+            irrelevant_msg = ''
             self.disabled_msg = ''
 
             if not len(self.available_lists):
                 # TODO: move this logic within the plugin itself and out of the viewer
                 self.available_lists = self.viewer.selected_obj.available_linelists()
+
+        return irrelevant_msg
 
     @observe('viewer_selected')
     def _on_viewer_selected_changed(self, event):

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -120,12 +120,12 @@ class LineListTool(PluginTemplateMixin, ViewerSelectMixin):
             sv.state.add_callback("x_max",
                                   lambda x_max: self._on_spectrum_viewer_limits_changed())
 
-        self._set_relevant()
+        self.setup_relevance(non_empty_traitlets=['viewer_items'],
+                             set_relevant=self._set_relevant)
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Plot spectral lines from preset or custom line lists.'
 
-    @observe('viewer_items')
     def _set_relevant(self, *args):
         if not hasattr(self, 'viewer'):
             return

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -120,8 +120,8 @@ class LineListTool(PluginTemplateMixin, ViewerSelectMixin):
             sv.state.add_callback("x_max",
                                   lambda x_max: self._on_spectrum_viewer_limits_changed())
 
-        self.setup_relevance(non_empty_traitlets=['viewer_items'],
-                             set_relevant=self._set_relevant)
+        self.observe_relevant_traitlets(non_empty_traitlets=['viewer_items'],
+                                        set_relevant=self._set_relevant)
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Plot spectral lines from preset or custom line lists.'

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -120,8 +120,8 @@ class LineListTool(PluginTemplateMixin, ViewerSelectMixin):
             sv.state.add_callback("x_max",
                                   lambda x_max: self._on_spectrum_viewer_limits_changed())
 
-        self.observe_relevant_traitlets(non_empty_traitlets=['viewer_items'],
-                                        set_relevant=self._set_relevant)
+        self.observe_traitlets_for_relevancy(non_empty_traitlets=['viewer_items'],
+                                             set_relevant=self._set_relevant)
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Plot spectral lines from preset or custom line lists.'

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -47,7 +47,7 @@ class MetadataViewer(PluginTemplateMixin, DatasetSelectMixin):
         self._plugin_description = 'View metadata.'
 
         if self.config == "deconfigged":
-            self.setup_relevance(non_empty_traitlets=['dataset_items'])
+            self.observe_relevant_traitlets(non_empty_traitlets=['dataset_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -47,7 +47,7 @@ class MetadataViewer(PluginTemplateMixin, DatasetSelectMixin):
         self._plugin_description = 'View metadata.'
 
         if self.config == "deconfigged":
-            self.observe_relevant_traitlets(non_empty_traitlets=['dataset_items'])
+            self.observe_traitlets_for_relevancy(non_empty_traitlets=['dataset_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -47,7 +47,7 @@ class MetadataViewer(PluginTemplateMixin, DatasetSelectMixin):
         self._plugin_description = 'View metadata.'
 
         if self.config == "deconfigged":
-            self.observe_traitlets_for_relevancy(non_empty_traitlets=['dataset_items'])
+            self.observe_traitlets_for_relevancy(traitlets_to_observe=['dataset_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -46,16 +46,8 @@ class MetadataViewer(PluginTemplateMixin, DatasetSelectMixin):
         # description displayed under plugin title in tray
         self._plugin_description = 'View metadata.'
 
-        self._set_relevant()
-
-    @observe('dataset_items')
-    def _set_relevant(self, *args):
-        if self.app.config != 'deconfigged':
-            return
-        if not len(self.dataset_items):
-            self.irrelevant_msg = 'No data loaded'
-        else:
-            self.irrelevant_msg = ''
+        if self.config == "deconfigged":
+            self.setup_relevance(non_empty_traitlets=['dataset_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -170,7 +170,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
         self.parallel_n_cpu = None
         if self.config == "deconfigged":
-            self.observe_relevant_traitlets(non_empty_traitlets=['dataset_items'])
+            self.observe_traitlets_for_relevancy(non_empty_traitlets=['dataset_items'])
 
     @property
     def _default_spectrum_viewer_reference_name(self):

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -169,16 +169,8 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
                            handler=self._on_global_display_unit_changed)
 
         self.parallel_n_cpu = None
-        self._set_relevant()
-
-    @observe('dataset_items')
-    def _set_relevant(self, *args):
-        if self.app.config != 'deconfigged':
-            return
-        if not len(self.dataset_items):
-            self.irrelevant_msg = 'No valid datasets loaded'
-        else:
-            self.irrelevant_msg = ''
+        if self.config == "deconfigged":
+            self.setup_relevance(non_empty_traitlets=['dataset_items'])
 
     @property
     def _default_spectrum_viewer_reference_name(self):

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -170,7 +170,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
         self.parallel_n_cpu = None
         if self.config == "deconfigged":
-            self.setup_relevance(non_empty_traitlets=['dataset_items'])
+            self.observe_relevant_traitlets(non_empty_traitlets=['dataset_items'])
 
     @property
     def _default_spectrum_viewer_reference_name(self):

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -170,7 +170,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
         self.parallel_n_cpu = None
         if self.config == "deconfigged":
-            self.observe_traitlets_for_relevancy(non_empty_traitlets=['dataset_items'])
+            self.observe_traitlets_for_relevancy(traitlets_to_observe=['dataset_items'])
 
     @property
     def _default_spectrum_viewer_reference_name(self):

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -632,7 +632,7 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
                            handler=self._on_refdata_change)
 
         if self.config == 'deconfigged':
-            self.observe_relevant_traitlets(non_empty_traitlets=['viewer_items'])
+            self.observe_traitlets_for_relevancy(non_empty_traitlets=['viewer_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -631,16 +631,8 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
         self.hub.subscribe(self, ChangeRefDataMessage,
                            handler=self._on_refdata_change)
 
-        self._set_relevant()
-
-    @observe('viewer_items')
-    def _set_relevant(self, *args):
-        if self.app.config != 'deconfigged':
-            return
-        if not len(self.viewer_items):
-            self.irrelevant_msg = 'No viewers'
-        else:
-            self.irrelevant_msg = ''
+        if self.config == 'deconfigged':
+            self.setup_relevance(non_empty_traitlets=['viewer_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -632,7 +632,7 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
                            handler=self._on_refdata_change)
 
         if self.config == 'deconfigged':
-            self.setup_relevance(non_empty_traitlets=['viewer_items'])
+            self.observe_relevant_traitlets(non_empty_traitlets=['viewer_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -632,7 +632,7 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
                            handler=self._on_refdata_change)
 
         if self.config == 'deconfigged':
-            self.observe_traitlets_for_relevancy(non_empty_traitlets=['viewer_items'])
+            self.observe_traitlets_for_relevancy(traitlets_to_observe=['viewer_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -185,7 +185,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
                                handler=self._on_display_units_changed)
 
         if self.config == "deconfigged":
-            self.observe_relevant_traitlets(non_empty_traitlets=['dataset_items'])
+            self.observe_traitlets_for_relevancy(non_empty_traitlets=['dataset_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -185,7 +185,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
                                handler=self._on_display_units_changed)
 
         if self.config == "deconfigged":
-            self.setup_relevance(non_empty_traitlets=['dataset_items'])
+            self.observe_relevant_traitlets(non_empty_traitlets=['dataset_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -184,16 +184,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             self.hub.subscribe(self, GlobalDisplayUnitChanged,
                                handler=self._on_display_units_changed)
 
-        self._set_relevant()
-
-    @observe('dataset_items')
-    def _set_relevant(self, *args):
-        if self.config != "deconfigged":
-            return
-        if not len(self.dataset_items):
-            self.irrelevant_msg = 'No image layers'
-        else:
-            self.irrelevant_msg = ''
+        if self.config == "deconfigged":
+            self.setup_relevance(non_empty_traitlets=['dataset_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -185,7 +185,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
                                handler=self._on_display_units_changed)
 
         if self.config == "deconfigged":
-            self.observe_traitlets_for_relevancy(non_empty_traitlets=['dataset_items'])
+            self.observe_traitlets_for_relevancy(traitlets_to_observe=['dataset_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -128,14 +128,7 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
         self.session.hub.subscribe(self, CatalogSelectClickEventMessage,
                                    self._on_catalog_select_click_event)
 
-        self._set_relevant()
-
-    @observe('viewer_items')
-    def _set_relevant(self, *args):
-        if not len(self.viewer_items):
-            self.irrelevant_msg = 'No image viewers'
-        else:
-            self.irrelevant_msg = ''
+        self.setup_relevance(non_empty_traitlets=['viewer_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -128,7 +128,7 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
         self.session.hub.subscribe(self, CatalogSelectClickEventMessage,
                                    self._on_catalog_select_click_event)
 
-        self.setup_relevance(non_empty_traitlets=['viewer_items'])
+        self.observe_relevant_traitlets(non_empty_traitlets=['viewer_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -128,7 +128,7 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
         self.session.hub.subscribe(self, CatalogSelectClickEventMessage,
                                    self._on_catalog_select_click_event)
 
-        self.observe_relevant_traitlets(non_empty_traitlets=['viewer_items'])
+        self.observe_traitlets_for_relevancy(non_empty_traitlets=['viewer_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -128,7 +128,7 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect, Tabl
         self.session.hub.subscribe(self, CatalogSelectClickEventMessage,
                                    self._on_catalog_select_click_event)
 
-        self.observe_traitlets_for_relevancy(non_empty_traitlets=['viewer_items'])
+        self.observe_traitlets_for_relevancy(traitlets_to_observe=['viewer_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/imviz/plugins/compass/compass.py
+++ b/jdaviz/configs/imviz/plugins/compass/compass.py
@@ -43,7 +43,7 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
         self.hub.subscribe(self, AddDataMessage, handler=self._on_viewer_data_changed)
         self.hub.subscribe(self, RemoveDataMessage, handler=self._on_viewer_data_changed)
 
-        self.setup_relevance(non_empty_traitlets=['viewer_items'])
+        self.observe_relevant_traitlets(non_empty_traitlets=['viewer_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/imviz/plugins/compass/compass.py
+++ b/jdaviz/configs/imviz/plugins/compass/compass.py
@@ -43,14 +43,7 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
         self.hub.subscribe(self, AddDataMessage, handler=self._on_viewer_data_changed)
         self.hub.subscribe(self, RemoveDataMessage, handler=self._on_viewer_data_changed)
 
-        self._set_relevant()
-
-    @observe('viewer_items')
-    def _set_relevant(self, *args):
-        if not len(self.viewer_items):
-            self.irrelevant_msg = 'No image viewers'
-        else:
-            self.irrelevant_msg = ''
+        self.setup_relevance(non_empty_traitlets=['viewer_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/imviz/plugins/compass/compass.py
+++ b/jdaviz/configs/imviz/plugins/compass/compass.py
@@ -43,7 +43,7 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
         self.hub.subscribe(self, AddDataMessage, handler=self._on_viewer_data_changed)
         self.hub.subscribe(self, RemoveDataMessage, handler=self._on_viewer_data_changed)
 
-        self.observe_relevant_traitlets(non_empty_traitlets=['viewer_items'])
+        self.observe_traitlets_for_relevancy(non_empty_traitlets=['viewer_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/imviz/plugins/compass/compass.py
+++ b/jdaviz/configs/imviz/plugins/compass/compass.py
@@ -43,7 +43,7 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
         self.hub.subscribe(self, AddDataMessage, handler=self._on_viewer_data_changed)
         self.hub.subscribe(self, RemoveDataMessage, handler=self._on_viewer_data_changed)
 
-        self.observe_traitlets_for_relevancy(non_empty_traitlets=['viewer_items'])
+        self.observe_traitlets_for_relevancy(traitlets_to_observe=['viewer_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -255,8 +255,8 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
                            handler=self._on_select_footprint_overlay)
         self._on_link_type_updated()
 
-        self.observe_relevant_traitlets(non_empty_traitlets=['viewer_items'],
-                                        irrelevant_msg='No WCS-linked image viewers')
+        self.observe_traitlets_for_relevancy(non_empty_traitlets=['viewer_items'],
+                                             irrelevant_msg='No WCS-linked image viewers')
 
     def _highlight_overlay(self, overlay_label, viewers=None):
         """

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -255,8 +255,7 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
                            handler=self._on_select_footprint_overlay)
         self._on_link_type_updated()
 
-        self.observe_traitlets_for_relevancy(traitlets_to_observe=['viewer_items'],
-                                             custom_irrelevant_msg='No WCS-linked image viewers')
+        self.observe_traitlets_for_relevancy(traitlets_to_observe=['viewer_items'])
 
     def _highlight_overlay(self, overlay_label, viewers=None):
         """

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -256,7 +256,7 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
         self._on_link_type_updated()
 
         self.observe_traitlets_for_relevancy(traitlets_to_observe=['viewer_items'],
-                                             irrelevant_msg='No WCS-linked image viewers')
+                                             custom_irrelevant_msg='No WCS-linked image viewers')
 
     def _highlight_overlay(self, overlay_label, viewers=None):
         """

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -255,7 +255,7 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
                            handler=self._on_select_footprint_overlay)
         self._on_link_type_updated()
 
-        self.observe_traitlets_for_relevancy(non_empty_traitlets=['viewer_items'],
+        self.observe_traitlets_for_relevancy(traitlets_to_observe=['viewer_items'],
                                              irrelevant_msg='No WCS-linked image viewers')
 
     def _highlight_overlay(self, overlay_label, viewers=None):

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -255,14 +255,8 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
                            handler=self._on_select_footprint_overlay)
         self._on_link_type_updated()
 
-        self._set_relevant()
-
-    @observe('viewer_items')
-    def _set_relevant(self, *args):
-        if not len(self.viewer_items):
-            self.irrelevant_msg = 'No WCS-linked image viewers'
-        else:
-            self.irrelevant_msg = ''
+        self.setup_relevance(non_empty_traitlets=['viewer_items'],
+                             irrelevant_msg='No WCS-linked image viewers')
 
     def _highlight_overlay(self, overlay_label, viewers=None):
         """

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -255,8 +255,8 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin, HasFileImportSelect):
                            handler=self._on_select_footprint_overlay)
         self._on_link_type_updated()
 
-        self.setup_relevance(non_empty_traitlets=['viewer_items'],
-                             irrelevant_msg='No WCS-linked image viewers')
+        self.observe_relevant_traitlets(non_empty_traitlets=['viewer_items'],
+                                        irrelevant_msg='No WCS-linked image viewers')
 
     def _highlight_overlay(self, overlay_label, viewers=None):
         """

--- a/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
+++ b/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
@@ -51,7 +51,7 @@ class LineProfileXY(PluginTemplateMixin, ViewerSelectMixin):
 
         self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewer_added)
 
-        self.setup_relevance(non_empty_traitlets=['viewer_items'])
+        self.observe_relevant_traitlets(non_empty_traitlets=['viewer_items'])
 
     def reset_results(self):
         self.plot_available = False

--- a/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
+++ b/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
@@ -51,14 +51,7 @@ class LineProfileXY(PluginTemplateMixin, ViewerSelectMixin):
 
         self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewer_added)
 
-        self._set_relevant()
-
-    @observe('viewer_items')
-    def _set_relevant(self, *args):
-        if not len(self.viewer_items):
-            self.irrelevant_msg = 'No image viewers'
-        else:
-            self.irrelevant_msg = ''
+        self.setup_relevance(non_empty_traitlets=['viewer_items'])
 
     def reset_results(self):
         self.plot_available = False

--- a/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
+++ b/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
@@ -51,7 +51,7 @@ class LineProfileXY(PluginTemplateMixin, ViewerSelectMixin):
 
         self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewer_added)
 
-        self.observe_relevant_traitlets(non_empty_traitlets=['viewer_items'])
+        self.observe_traitlets_for_relevancy(non_empty_traitlets=['viewer_items'])
 
     def reset_results(self):
         self.plot_available = False

--- a/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
+++ b/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
@@ -51,7 +51,7 @@ class LineProfileXY(PluginTemplateMixin, ViewerSelectMixin):
 
         self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewer_added)
 
-        self.observe_traitlets_for_relevancy(non_empty_traitlets=['viewer_items'])
+        self.observe_traitlets_for_relevancy(traitlets_to_observe=['viewer_items'])
 
     def reset_results(self):
         self.plot_available = False

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -154,15 +154,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
 
         if self.app.config == 'deconfigged':
             self.disabled_msg = 'Orientation plugin not available in deconfigged until generalized linking is implemented'  # noqa
-
-    @observe('viewer_items')
-    def _set_relevant(self, *args):
-        if self.app.config != 'deconfigged':
-            return
-        if not len(self.viewer_items):
-            self.irrelevant_msg = 'No image viewers with WCS'
-        else:
-            self.irrelevant_msg = ''
+            self.observe_traitlets_for_relevancy(traitlets_to_observe=['viewer_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -150,8 +150,6 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
 
         self._update_layer_label_default()
 
-        self._set_relevant()
-
         if self.app.config == 'deconfigged':
             self.disabled_msg = 'Orientation plugin not available in deconfigged until generalized linking is implemented'  # noqa
             self.observe_traitlets_for_relevancy(traitlets_to_observe=['viewer_items'])

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -151,25 +151,27 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, TableMixin,
         self.table.headers_avail = headers
         self.table.headers_visible = [h for h in headers if ':' not in h]
 
-        self.observe_traitlets_for_relevancy(non_empty_traitlets=['dataset_items'],
-                                             set_relevant=self._set_relevant)
+        self.observe_traitlets_for_relevancy(traitlets_to_observe=['dataset_items'],
+                                             irrelevant_msg_callback=self._irrelevant_msg_callback)
 
-    def _set_relevant(self, *args):
+    def _irrelevant_msg_callback(self, *args):
         if self.app.config == 'deconfigged':
             if not len(self.dataset_items):
-                self.irrelevant_msg = 'Line Analysis unavailable without data loaded in spectrum viewer'  # noqa
+                irrelevant_msg = 'Line Analysis unavailable without data loaded in spectrum viewer'  # noqa
             else:
-                self.irrelevant_msg = ''
+                irrelevant_msg = ''
         else:
             sv = self.spectrum_viewer
             if sv is None:
-                self.irrelevant_msg = 'Line Analysis unavailable without spectrum viewer'
+                irrelevant_msg = 'Line Analysis unavailable without spectrum viewer'
             elif not len(sv.layers):
-                self.irrelevant_msg = ''
+                irrelevant_msg = ''
                 self.disabled_msg = 'Line Analysis unavailable without data loaded in spectrum viewer'  # noqa
             else:
-                self.irrelevant_msg = ''
+                irrelevant_msg = ''
                 self.disabled_msg = ''
+
+        return irrelevant_msg
 
     @property
     def user_api(self):

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -151,8 +151,8 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, TableMixin,
         self.table.headers_avail = headers
         self.table.headers_visible = [h for h in headers if ':' not in h]
 
-        self.observe_relevant_traitlets(non_empty_traitlets=['dataset_items'],
-                                        set_relevant=self._set_relevant)
+        self.observe_traitlets_for_relevancy(non_empty_traitlets=['dataset_items'],
+                                             set_relevant=self._set_relevant)
 
     def _set_relevant(self, *args):
         if self.app.config == 'deconfigged':

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -151,9 +151,9 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, TableMixin,
         self.table.headers_avail = headers
         self.table.headers_visible = [h for h in headers if ':' not in h]
 
-        self._set_relevant()
+        self.setup_relevance(non_empty_traitlets=['dataset_items'],
+                             set_relevant=self._set_relevant)
 
-    @observe('dataset_items')
     def _set_relevant(self, *args):
         if self.app.config == 'deconfigged':
             if not len(self.dataset_items):

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -151,8 +151,8 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, TableMixin,
         self.table.headers_avail = headers
         self.table.headers_visible = [h for h in headers if ':' not in h]
 
-        self.setup_relevance(non_empty_traitlets=['dataset_items'],
-                             set_relevant=self._set_relevant)
+        self.observe_relevant_traitlets(non_empty_traitlets=['dataset_items'],
+                                        set_relevant=self._set_relevant)
 
     def _set_relevant(self, *args):
         if self.app.config == 'deconfigged':

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -171,19 +171,7 @@ class UnitConversion(PluginTemplateMixin):
                                                                  'angle_unit_selected',
                                                                  'time_unit_selected'],
                                             irrelevant_msg='No datasets with valid units loaded',
-                                            set_relevant=self._set_relevant)
-
-    # Keep this _set_relevant because in the mixing, we use an implicit ANY
-    # i.e. if ANY of the non_empty_traitlets are in fact empty, the plugin is irrelevant
-    # whereas this uses ALL
-    def _set_relevant(self, *args):
-        if self.app.config != 'deconfigged':
-            return
-        if (not self.spectral_unit_selected and not self.flux_unit_selected
-                and not self.angle_unit_selected and not self.time_unit_selected):
-            self.irrelevant_msg = 'No datasets with valid units loaded'
-        else:
-            self.irrelevant_msg = ''
+                                            check_all_for_relevance=True)
 
     @property
     def user_api(self):

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -165,10 +165,17 @@ class UnitConversion(PluginTemplateMixin):
                                                      items='spectral_y_type_items',
                                                      selected='spectral_y_type_selected')
 
-        self._set_relevant()
+        if self.app.config == 'deconfigged':
+            self.setup_relevance(non_empty_traitlets=['spectral_unit_selected',
+                                                      'flux_unit_selected',
+                                                      'angle_unit_selected',
+                                                      'time_unit_selected'],
+                                 irrelevant_msg='No datasets with valid units loaded',
+                                 set_relevant=self._set_relevant)
 
-    @observe('spectral_unit_selected', 'flux_unit_selected',
-             'angle_unit_selected', 'time_unit_selected')
+    # Keep this _set_relevant because in the mixing, we use an implicit ANY
+    # i.e. if ANY of the non_empty_traitlets are in fact empty, the plugin is irrelevant
+    # whereas this uses ALL
     def _set_relevant(self, *args):
         if self.app.config != 'deconfigged':
             return

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -167,12 +167,12 @@ class UnitConversion(PluginTemplateMixin):
 
         if self.app.config == 'deconfigged':
             self.observe_traitlets_for_relevancy(
-                non_empty_traitlets=['spectral_unit_selected',
-                                     'flux_unit_selected',
-                                     'angle_unit_selected',
-                                     'time_unit_selected'],
+                traitlets_to_observe=['spectral_unit_selected',
+                                      'flux_unit_selected',
+                                      'angle_unit_selected',
+                                      'time_unit_selected'],
                 irrelevant_msg='No datasets with valid units loaded',
-                check_all_for_relevance=True)
+                irrelevant_msg_callback=self.relevant_if_any_truthy)
 
     @property
     def user_api(self):

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -166,12 +166,12 @@ class UnitConversion(PluginTemplateMixin):
                                                      selected='spectral_y_type_selected')
 
         if self.app.config == 'deconfigged':
-            self.setup_relevance(non_empty_traitlets=['spectral_unit_selected',
-                                                      'flux_unit_selected',
-                                                      'angle_unit_selected',
-                                                      'time_unit_selected'],
-                                 irrelevant_msg='No datasets with valid units loaded',
-                                 set_relevant=self._set_relevant)
+            self.observe_relevant_traitlets(non_empty_traitlets=['spectral_unit_selected',
+                                                                 'flux_unit_selected',
+                                                                 'angle_unit_selected',
+                                                                 'time_unit_selected'],
+                                            irrelevant_msg='No datasets with valid units loaded',
+                                            set_relevant=self._set_relevant)
 
     # Keep this _set_relevant because in the mixing, we use an implicit ANY
     # i.e. if ANY of the non_empty_traitlets are in fact empty, the plugin is irrelevant

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -166,12 +166,13 @@ class UnitConversion(PluginTemplateMixin):
                                                      selected='spectral_y_type_selected')
 
         if self.app.config == 'deconfigged':
-            self.observe_relevant_traitlets(non_empty_traitlets=['spectral_unit_selected',
-                                                                 'flux_unit_selected',
-                                                                 'angle_unit_selected',
-                                                                 'time_unit_selected'],
-                                            irrelevant_msg='No datasets with valid units loaded',
-                                            check_all_for_relevance=True)
+            self.observe_traitlets_for_relevancy(
+                non_empty_traitlets=['spectral_unit_selected',
+                                     'flux_unit_selected',
+                                     'angle_unit_selected',
+                                     'time_unit_selected'],
+                irrelevant_msg='No datasets with valid units loaded',
+                check_all_for_relevance=True)
 
     @property
     def user_api(self):

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -171,7 +171,6 @@ class UnitConversion(PluginTemplateMixin):
                                       'flux_unit_selected',
                                       'angle_unit_selected',
                                       'time_unit_selected'],
-                custom_irrelevant_msg='No datasets with valid units loaded',
                 irrelevant_msg_callback=self.relevant_if_any_truthy)
 
     @property

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -171,7 +171,7 @@ class UnitConversion(PluginTemplateMixin):
                                       'flux_unit_selected',
                                       'angle_unit_selected',
                                       'time_unit_selected'],
-                irrelevant_msg='No datasets with valid units loaded',
+                custom_irrelevant_msg='No datasets with valid units loaded',
                 irrelevant_msg_callback=self.relevant_if_any_truthy)
 
     @property

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -360,7 +360,9 @@ class SpectralExtraction2D(PluginTemplateMixin):
         self.app.hub.subscribe(self, ViewerVisibleLayersChangedMessage,
                                lambda _: self._update_plugin_marks())
 
-        self._set_relevant()
+        if self.config == "deconfigged":
+            self.setup_relevance(non_empty_traitlets=['trace_dataset_items'],
+                                 irrelevant_msg='Requires at least one 2D spectrum')
 
     @property
     def user_api(self):
@@ -387,14 +389,6 @@ class SpectralExtraction2D(PluginTemplateMixin):
                                            'import_extract',
                                            'export_extract', 'export_extract_spectrum'))
 
-    @observe('trace_dataset_items')
-    def _set_relevant(self, *args):
-        if self.app.config != 'deconfigged':
-            return
-        if len(self.trace_dataset_items) < 1:
-            self.irrelevant_msg = 'Requires at least one 2D spectrum'
-        else:
-            self.irrelevant_msg = ''
 
     def _clear_default_inputs(self):
         self.trace_pixel = 0

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -361,7 +361,7 @@ class SpectralExtraction2D(PluginTemplateMixin):
                                lambda _: self._update_plugin_marks())
 
         if self.config == "deconfigged":
-            self.observe_traitlets_for_relevancy(non_empty_traitlets=['trace_dataset_items'],
+            self.observe_traitlets_for_relevancy(traitlets_to_observe=['trace_dataset_items'],
                                                  irrelevant_msg='Requires at least one 2D spectrum')
 
     @property

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -361,8 +361,8 @@ class SpectralExtraction2D(PluginTemplateMixin):
                                lambda _: self._update_plugin_marks())
 
         if self.config == "deconfigged":
-            self.setup_relevance(non_empty_traitlets=['trace_dataset_items'],
-                                 irrelevant_msg='Requires at least one 2D spectrum')
+            self.observe_relevant_traitlets(non_empty_traitlets=['trace_dataset_items'],
+                                            irrelevant_msg='Requires at least one 2D spectrum')
 
     @property
     def user_api(self):

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -362,8 +362,7 @@ class SpectralExtraction2D(PluginTemplateMixin):
 
         if self.config == "deconfigged":
             self.observe_traitlets_for_relevancy(
-                traitlets_to_observe=['trace_dataset_items'],
-                custom_irrelevant_msg='Requires at least one 2D spectrum')
+                traitlets_to_observe=['trace_dataset_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -389,7 +389,6 @@ class SpectralExtraction2D(PluginTemplateMixin):
                                            'import_extract',
                                            'export_extract', 'export_extract_spectrum'))
 
-
     def _clear_default_inputs(self):
         self.trace_pixel = 0
         self.trace_window = 0

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -361,8 +361,9 @@ class SpectralExtraction2D(PluginTemplateMixin):
                                lambda _: self._update_plugin_marks())
 
         if self.config == "deconfigged":
-            self.observe_traitlets_for_relevancy(traitlets_to_observe=['trace_dataset_items'],
-                                                 irrelevant_msg='Requires at least one 2D spectrum')
+            self.observe_traitlets_for_relevancy(
+                traitlets_to_observe=['trace_dataset_items'],
+                custom_irrelevant_msg='Requires at least one 2D spectrum')
 
     @property
     def user_api(self):

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -361,8 +361,8 @@ class SpectralExtraction2D(PluginTemplateMixin):
                                lambda _: self._update_plugin_marks())
 
         if self.config == "deconfigged":
-            self.observe_relevant_traitlets(non_empty_traitlets=['trace_dataset_items'],
-                                            irrelevant_msg='Requires at least one 2D spectrum')
+            self.observe_traitlets_for_relevancy(non_empty_traitlets=['trace_dataset_items'],
+                                                 irrelevant_msg='Requires at least one 2D spectrum')
 
     @property
     def user_api(self):

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -361,8 +361,7 @@ class SpectralExtraction2D(PluginTemplateMixin):
                                lambda _: self._update_plugin_marks())
 
         if self.config == "deconfigged":
-            self.observe_traitlets_for_relevancy(
-                traitlets_to_observe=['trace_dataset_items'])
+            self.observe_traitlets_for_relevancy(traitlets_to_observe=['trace_dataset_items'])
 
     @property
     def user_api(self):

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -63,14 +63,6 @@ def deconfigged_helper():
     return App()
 
 
-# # For dynamic generation of plugins from deconfigged
-# def pytest_generate_tests(metafunc):
-#     if "deconfigged_plugin" in metafunc.fixturenames:
-#         plugin_dict = App().plugins
-#         names, plugins = zip(*plugin_dict.items())
-#         metafunc.parametrize("deconfigged_plugin", plugins, ids=names)
-
-
 @pytest.fixture
 def roman_level_1_ramp():
     from roman_datamodels.datamodels import RampModel

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -63,6 +63,14 @@ def deconfigged_helper():
     return App()
 
 
+# For dynamic generation of plugins from deconfigged
+def pytest_generate_tests(metafunc):
+    if "deconfigged_plugin" in metafunc.fixturenames:
+        plugin_dict = App().plugins
+        names, plugins = zip(*plugin_dict.items())
+        metafunc.parametrize("deconfigged_plugin", plugins, ids=names)
+
+
 @pytest.fixture
 def roman_level_1_ramp():
     from roman_datamodels.datamodels import RampModel

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -63,12 +63,12 @@ def deconfigged_helper():
     return App()
 
 
-# For dynamic generation of plugins from deconfigged
-def pytest_generate_tests(metafunc):
-    if "deconfigged_plugin" in metafunc.fixturenames:
-        plugin_dict = App().plugins
-        names, plugins = zip(*plugin_dict.items())
-        metafunc.parametrize("deconfigged_plugin", plugins, ids=names)
+# # For dynamic generation of plugins from deconfigged
+# def pytest_generate_tests(metafunc):
+#     if "deconfigged_plugin" in metafunc.fixturenames:
+#         plugin_dict = App().plugins
+#         names, plugins = zip(*plugin_dict.items())
+#         metafunc.parametrize("deconfigged_plugin", plugins, ids=names)
 
 
 @pytest.fixture

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -679,18 +679,18 @@ class PluginTemplateMixin(TemplateMixin):
                 len(is_not_relevant) <= len(self._non_empty_traitlets)):
             self.irrelevant_msg = ''
 
-    def observe_relevant_traitlets(self,
-                                   non_empty_traitlets: (list, tuple), irrelevant_msg='',
-                                   check_all_for_relevance=False, set_relevant=None):
+    def observe_traitlets_for_relevancy(self,
+                                        non_empty_traitlets: (list, tuple), irrelevant_msg='',
+                                        check_all_for_relevance=False, set_relevant=None):
         """
-        `observe_relevant_traitlets` enables the app to observe traitlets
+        `observe_traitlets_for_relevancy` enables the app to observe traitlets
         necessary to determine configuration relevance for the plugins
         that require it. It sets up the observe method and calls either
         the user provided ``set_relevant`` method or the private method
         `_set_relevant` provided here.
 
         If a user does not provide the ``set_relevant`` kwarg or otherwise
-        sets it to ``None``, `observe_relevant_traitlets` will call the private
+        sets it to ``None``, `observe_traitlets_for_relevancy` will call the private
         `_set_relevant` method.
         """
         self._non_empty_traitlets = non_empty_traitlets

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -715,7 +715,7 @@ class PluginTemplateMixin(TemplateMixin):
             self.irrelevant_msg = irrelevant_msg
 
     def observe_traitlets_for_relevancy(self,
-                                        traitlets_to_observe: (list, tuple),
+                                        traitlets_to_observe,
                                         irrelevant_msg_callback=None,
                                         custom_irrelevant_msg=None):
         """
@@ -725,7 +725,23 @@ class PluginTemplateMixin(TemplateMixin):
         method `_set_relevant` which relies on either a user-provided
         ``irrelevant_msg_callback`` method or defaults to the
         `relevant_if_all_truthy` method.
+
+        Parameters
+        ----------
+        traitlets_to_observe : list or tuple
+            A list of the traitlets to be observed.
+
+        irrelevant_msg_callback : function or None
+            A function that takes a list of traitlets and returns a msg to be set
+            as the ``irrelevant_msg`` attribute.
+
+        custom_irrelevant_msg : string
+            A custom message to be set as the irrelevant msg attribute.
+
         """
+        if not isinstance(traitlets_to_observe, (list, tuple)):
+            raise TypeError(f"`traitlets_to_observe` must be a list or tuple.")
+
         self._traitlets_to_observe = traitlets_to_observe
 
         # Set the irrelevant message to user-provided if given (and not invalid)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -740,7 +740,7 @@ class PluginTemplateMixin(TemplateMixin):
 
         """
         if not isinstance(traitlets_to_observe, (list, tuple)):
-            raise TypeError(f"`traitlets_to_observe` must be a list or tuple.")
+            raise TypeError('`traitlets_to_observe` must be a list or tuple.')
 
         self._traitlets_to_observe = traitlets_to_observe
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -679,7 +679,7 @@ class PluginTemplateMixin(TemplateMixin):
             # irrelevant
             return irrelevant_msg
 
-    def relevant_if_any_truthy(self, traitlets=None, _custom_msg=None):
+    def relevant_if_any_truthy(self, traitlets=None):
         """
         Set relevance (via empty/non-empty string) if *any* traitlet is truthy.
         """

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -664,13 +664,13 @@ class PluginTemplateMixin(TemplateMixin):
                             for traitlet_name in traitlets
                             if getattr(self, traitlet_name, None)]
 
-        return truthy_traitlets, irrelevant_msg
+        return traitlets, truthy_traitlets, irrelevant_msg
 
     def relevant_if_all_truthy(self, traitlets=None):
         """
         Set relevance (via empty/non-empty string) if *all* traitlets are truthy.
         """
-        truthy_traitlets, irrelevant_msg = self._setup_relevant_if_truthy(traitlets)
+        traitlets, truthy_traitlets, irrelevant_msg = self._setup_relevant_if_truthy(traitlets)
 
         if len(truthy_traitlets) == len(traitlets):
             # relevant
@@ -683,7 +683,7 @@ class PluginTemplateMixin(TemplateMixin):
         """
         Set relevance (via empty/non-empty string) if *any* traitlet is truthy.
         """
-        truthy_traitlets, irrelevant_msg = self._setup_relevant_if_truthy(traitlets)
+        traitlets, truthy_traitlets, irrelevant_msg = self._setup_relevant_if_truthy(traitlets)
 
         if len(truthy_traitlets):
             # relevant
@@ -727,11 +727,13 @@ class PluginTemplateMixin(TemplateMixin):
         `_set_relevant` method.
         """
         self._traitlets_to_observe = traitlets_to_observe
-        if self.irrelevant_msg is None:
+
+        if custom_irrelevant_msg == '':
+            # Just in case!
+            raise ValueError('The custom_irrelevant_msg cannot be set to the empty string, '
+                             'doing so would invalidate the checking process.')
+        elif custom_irrelevant_msg is not None:
             self._custom_irrelevant_msg = custom_irrelevant_msg
-        elif custom_irrelevant_msg == '':
-            raise ValueError('The custom_irrelevant_msg cannot be set to the empty string, doing so'
-                             'would invalidate the checking process.')
 
         self._irrelevant_msg_callback = irrelevant_msg_callback
         if irrelevant_msg_callback is None:

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -644,6 +644,19 @@ class PluginTemplateMixin(TemplateMixin):
         # can even be dependent on config, etc.
         return PluginUserApi(self, expose=[])
 
+    def _set_relevant(self):
+        for traitlet_name in self._non_empty_traitlets:
+            if not len(getattr(self, traitlet_name, [])):
+                self.irrelevant_msg = f'No {traitlet_name} available'
+                return
+        self.irrelevant_msg = ''
+
+    def setup_relevance(self, non_empty_traitlets: (list, tuple)):
+        self._non_empty_traitlets = non_empty_traitlets
+        _ = [self.observe(self._set_relevant, traitlet_name)
+             for traitlet_name in self._non_empty_traitlets]
+        self._set_relevant()
+
     @observe('irrelevant_msg')
     def _irrelevant_msg_changed(self, *args):
         labels = [ti['label'] for ti in self.app.state.tray_items]

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -645,7 +645,9 @@ class PluginTemplateMixin(TemplateMixin):
         return PluginUserApi(self, expose=[])
 
     def _setup_relevant_if_truthy(self, traitlets):
-        # Setup traitlets to check
+        """
+        Sets up and returns some things used in both ``relevant_if_any/all_truthy`` methods.
+        """
         if traitlets is None:
             if hasattr(self, '_traitlets_to_observe'):
                 traitlets = self._traitlets_to_observe
@@ -698,10 +700,10 @@ class PluginTemplateMixin(TemplateMixin):
         `_set_relevant` sets `irrelevant_msg` attribute used to determine
         if relevance for a specific plugin in a configuration is required.
         The default behavior is for traitlets to evaluate to False
-        (e.g. None, '', False) in which case  `irrelevant_msg` will indicate
-        the failure via the first traitlet found.
+        (e.g. None, '', False) in which case `irrelevant_msg` will indicate
+        that the traitlet set to be observed are not available.
 
-        This method observes the traitlets in the `_non_empty_traitlets` iterable
+        This method observes the traitlets in the `_traitlets_to_observe` iterable
         and so updates the `irrelevant_msg` attribute whenever they are modified.
         """
         irrelevant_msg = self._irrelevant_msg_callback(self._traitlets_to_observe)
@@ -718,13 +720,10 @@ class PluginTemplateMixin(TemplateMixin):
         """
         `observe_traitlets_for_relevancy` enables the app to observe traitlets
         necessary to determine configuration relevance for the plugins
-        that require it. It sets up the observe method and calls either
-        the user provided ``set_relevant`` method or the private method
-        `_set_relevant` provided here.
-
-        If a user does not provide the ``set_relevant`` kwarg or otherwise
-        sets it to ``None``, `observe_traitlets_for_relevancy` will call the private
-        `_set_relevant` method.
+        that require it. It sets up the observe method and calls the private
+        method `_set_relevant` which relies on either a user-provided
+        ``irrelevant_msg_callback`` method or defaults to the
+        `relevant_if_all_truthy` method.
         """
         self._traitlets_to_observe = traitlets_to_observe
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -730,7 +730,6 @@ class PluginTemplateMixin(TemplateMixin):
         irrelevant_msg_callback : function or None
             A function that takes a list of traitlets and returns a msg to be set
             as the ``irrelevant_msg`` attribute.
-
         """
         if not isinstance(traitlets_to_observe, (list, tuple)):
             raise TypeError('`traitlets_to_observe` must be a list or tuple.')

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -657,20 +657,22 @@ class PluginTemplateMixin(TemplateMixin):
         and so updates the `irrelevant_msg` attribute whenever they are modified.
         """
 
+        self.irrelevant_msg = ''
+
         is_not_relevant = [''] + [self._custom_irrelevant_msg
                                   if self._custom_irrelevant_msg
                                   else f'No {traitlet_name} available'
                                   for traitlet_name in self._non_empty_traitlets
-                                  if getattr(self, traitlet_name, None)]
-
-        self.irrelevant_msg = is_not_relevant[-1]
+                                  if not getattr(self, traitlet_name, None)]
 
         # For multiple `_non_empty_traitlets` (see `export.py` or `unit_conversion.py`),
         # we assume that ALL traitlets must be unavailable in order to set
         # `irrelevant_msg`. So we reset the message if there are fewer messages
         # than traitlets.
-        if len(is_not_relevant[1:]) != len(self._non_empty_traitlets):
-            self.irrelevant_msg = ''
+        if (len(self._non_empty_traitlets) == 1 or
+                len(is_not_relevant) > len(self._non_empty_traitlets)):
+            self.irrelevant_msg = is_not_relevant[-1]
+
 
     def observe_relevant_traitlets(self, non_empty_traitlets: (list, tuple), irrelevant_msg='',
                                    set_relevant=None):

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -648,6 +648,7 @@ class PluginTemplateMixin(TemplateMixin):
         """
         Sets up and returns some things used in both ``relevant_if_any/all_truthy`` methods.
         """
+        # Setup traitlets to check
         if traitlets is None:
             if hasattr(self, '_traitlets_to_observe'):
                 traitlets = self._traitlets_to_observe
@@ -727,20 +728,24 @@ class PluginTemplateMixin(TemplateMixin):
         """
         self._traitlets_to_observe = traitlets_to_observe
 
+        # Set the irrelevant message to user-provided if given (and not invalid)
         if custom_irrelevant_msg == '':
-            # Just in case!
+            # Just in case! 
             raise ValueError('The custom_irrelevant_msg cannot be set to the empty string, '
                              'doing so would invalidate the checking process.')
         elif custom_irrelevant_msg is not None:
             self._custom_irrelevant_msg = custom_irrelevant_msg
 
+        # Set the callback function to the user-provided or default.
         self._irrelevant_msg_callback = irrelevant_msg_callback
         if irrelevant_msg_callback is None:
             self._irrelevant_msg_callback = self.relevant_if_all_truthy
 
+        # Set up the traitlets to be observed
         _ = [self.observe(self._set_relevant, traitlet_name)
              for traitlet_name in self._traitlets_to_observe]
 
+        # Perform an initial set_relevant
         self._set_relevant()
 
     @observe('irrelevant_msg')

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -654,13 +654,10 @@ class PluginTemplateMixin(TemplateMixin):
                 traitlets = self._traitlets_to_observe
             else:
                 raise AttributeError('_traitlets_to_observe has not been set yet '
-                                     '(by observe_traitlets_for_relevancy).')
+                                     '(by `observe_traitlets_for_relevancy`).')
 
         # Setup irrelevant message
-        if hasattr(self, '_custom_irrelevant_msg') and self._custom_irrelevant_msg:
-            irrelevant_msg = self._custom_irrelevant_msg
-        else:
-            irrelevant_msg = f"At least one of or all of {', '.join(traitlets)} are not available"
+        irrelevant_msg = f"At least one of or all of {', '.join(traitlets)} are not available"
 
         # Prepare the list for the check
         truthy_traitlets = [traitlet_name
@@ -716,8 +713,7 @@ class PluginTemplateMixin(TemplateMixin):
 
     def observe_traitlets_for_relevancy(self,
                                         traitlets_to_observe,
-                                        irrelevant_msg_callback=None,
-                                        custom_irrelevant_msg=None):
+                                        irrelevant_msg_callback=None):
         """
         `observe_traitlets_for_relevancy` enables the app to observe traitlets
         necessary to determine configuration relevance for the plugins
@@ -735,22 +731,11 @@ class PluginTemplateMixin(TemplateMixin):
             A function that takes a list of traitlets and returns a msg to be set
             as the ``irrelevant_msg`` attribute.
 
-        custom_irrelevant_msg : string
-            A custom message to be set as the irrelevant msg attribute.
-
         """
         if not isinstance(traitlets_to_observe, (list, tuple)):
             raise TypeError('`traitlets_to_observe` must be a list or tuple.')
 
         self._traitlets_to_observe = traitlets_to_observe
-
-        # Set the irrelevant message to user-provided if given (and not invalid)
-        if custom_irrelevant_msg == '':
-            # Just in case!
-            raise ValueError('The custom_irrelevant_msg cannot be set to the empty string, '
-                             'doing so would invalidate the checking process.')
-        elif custom_irrelevant_msg is not None:
-            self._custom_irrelevant_msg = custom_irrelevant_msg
 
         # Set the callback function to the user-provided or default.
         self._irrelevant_msg_callback = irrelevant_msg_callback

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -679,7 +679,6 @@ class PluginTemplateMixin(TemplateMixin):
                 len(is_not_relevant) <= len(self._non_empty_traitlets)):
             self.irrelevant_msg = ''
 
-
     def observe_relevant_traitlets(self,
                                    non_empty_traitlets: (list, tuple), irrelevant_msg='',
                                    check_all_for_relevance=False, set_relevant=None):

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -660,7 +660,7 @@ class PluginTemplateMixin(TemplateMixin):
         if hasattr(self, '_custom_irrelevant_msg') and self._custom_irrelevant_msg:
             irrelevant_msg = self._custom_irrelevant_msg
         else:
-            irrelevant_msg = f'At least one of or all of {', '.join(traitlets)} are not available'
+            irrelevant_msg = f"At least one of or all of {', '.join(traitlets)} are not available"
 
         # Prepare the list for the check
         truthy_traitlets = [traitlet_name

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -657,25 +657,25 @@ class PluginTemplateMixin(TemplateMixin):
         and so updates the `irrelevant_msg` attribute whenever they are modified.
         """
 
-        self.irrelevant_msg = ''
-
         is_not_relevant = [''] + [self._custom_irrelevant_msg
                                   if self._custom_irrelevant_msg
                                   else f'No {traitlet_name} available'
                                   for traitlet_name in self._non_empty_traitlets
                                   if not getattr(self, traitlet_name, None)]
 
+        self.irrelevant_msg = is_not_relevant[-1]
+
         # For multiple `_non_empty_traitlets` (see `export.py` or `unit_conversion.py`),
         # we assume that ALL traitlets must be unavailable in order to set
         # `irrelevant_msg`. So we reset the message if there are fewer messages
-        # than traitlets.
-        if (len(self._non_empty_traitlets) == 1 or
-                len(is_not_relevant) > len(self._non_empty_traitlets)):
-            self.irrelevant_msg = is_not_relevant[-1]
+        # than traitlets (since we initialize the list with an empty string).
+        if self._check_all_for_relevance and len(is_not_relevant) <= len(self._non_empty_traitlets):
+            self.irrelevant_msg = is_not_relevant[0]
 
 
-    def observe_relevant_traitlets(self, non_empty_traitlets: (list, tuple), irrelevant_msg='',
-                                   set_relevant=None):
+    def observe_relevant_traitlets(self,
+                                   non_empty_traitlets: (list, tuple), irrelevant_msg='',
+                                   check_all_for_relevance=False, set_relevant=None):
         """
         `observe_relevant_traitlets` enables the app to observe traitlets
         necessary to determine configuration relevance for the plugins
@@ -689,6 +689,7 @@ class PluginTemplateMixin(TemplateMixin):
         """
         self._non_empty_traitlets = non_empty_traitlets
         self._custom_irrelevant_msg = irrelevant_msg
+        self._check_all_for_relevance = check_all_for_relevance
 
         # NOTE: taking set_relevant in as a kwarg isn't STRICTLY necessary,
         # a plugin class could use its own _set_relevant and have it override

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -648,8 +648,8 @@ class PluginTemplateMixin(TemplateMixin):
     def _set_relevant(self, *args):
         for traitlet_name in self._non_empty_traitlets:
             if not getattr(self, traitlet_name, None):
-                self.irrelevant_msg = self.custom_irrelevant_message \
-                    if self.custom_irrelevant_message \
+                self.irrelevant_msg = self._custom_irrelevant_msg \
+                    if self._custom_irrelevant_msg \
                     else f'No {traitlet_name} available'
                 return
 
@@ -658,7 +658,7 @@ class PluginTemplateMixin(TemplateMixin):
     def setup_relevance(self, non_empty_traitlets: (list, tuple), irrelevant_msg='',
                         set_relevant=None):
         self._non_empty_traitlets = non_empty_traitlets
-        self.custom_irrelevant_message = irrelevant_msg
+        self._custom_irrelevant_msg = irrelevant_msg
 
         # NOTE: taking set_relevant in as a kwarg isn't STRICTLY necessary,
         # a plugin class could use its own _set_relevant and have it override

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -655,8 +655,8 @@ class PluginTemplateMixin(TemplateMixin):
 
         self.irrelevant_msg = ''
 
-    def setup_relevance(self, non_empty_traitlets: (list, tuple), irrelevant_msg = '',
-                        set_relevant = None):
+    def setup_relevance(self, non_empty_traitlets: (list, tuple), irrelevant_msg='',
+                        set_relevant=None):
         self._non_empty_traitlets = non_empty_traitlets
         self.custom_irrelevant_message = irrelevant_msg
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -659,18 +659,25 @@ class PluginTemplateMixin(TemplateMixin):
 
         is_not_relevant = [''] + [self._custom_irrelevant_msg
                                   if self._custom_irrelevant_msg
-                                  else f'No {traitlet_name} available'
+                                  else traitlet_name
                                   for traitlet_name in self._non_empty_traitlets
                                   if not getattr(self, traitlet_name, None)]
 
         self.irrelevant_msg = is_not_relevant[-1]
 
+        # If is_not_relevant is just the empty string then
+        # join will return an empty string
+        if not self._custom_irrelevant_msg and len(is_not_relevant) > 1:
+            all_irrelevant = ', '.join(is_not_relevant[1:])
+            self.irrelevant_msg = f'Traitlets {all_irrelevant} are not available.'
+
         # For multiple `_non_empty_traitlets` (see `export.py` or `unit_conversion.py`),
         # we assume that ALL traitlets must be unavailable in order to set
         # `irrelevant_msg`. So we reset the message if there are fewer messages
         # than traitlets (since we initialize the list with an empty string).
-        if self._check_all_for_relevance and len(is_not_relevant) <= len(self._non_empty_traitlets):
-            self.irrelevant_msg = is_not_relevant[0]
+        if (self._check_all_for_relevance and
+                len(is_not_relevant) <= len(self._non_empty_traitlets)):
+            self.irrelevant_msg = ''
 
 
     def observe_relevant_traitlets(self,

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -686,11 +686,11 @@ class PluginTemplateMixin(TemplateMixin):
         `observe_relevant_traitlets` enables the app to observe traitlets
         necessary to determine configuration relevance for the plugins
         that require it. It sets up the observe method and calls either
-        the user provided `set_relevant` method or the private method
+        the user provided ``set_relevant`` method or the private method
         `_set_relevant` provided here.
 
-        If a user does not provide the `set_relevant` kwarg or otherwise
-        sets it to None, `observe_relevant_traitlets` will call the private
+        If a user does not provide the ``set_relevant`` kwarg or otherwise
+        sets it to ``None``, `observe_relevant_traitlets` will call the private
         `_set_relevant` method.
         """
         self._non_empty_traitlets = non_empty_traitlets

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -730,7 +730,7 @@ class PluginTemplateMixin(TemplateMixin):
 
         # Set the irrelevant message to user-provided if given (and not invalid)
         if custom_irrelevant_msg == '':
-            # Just in case! 
+            # Just in case!
             raise ValueError('The custom_irrelevant_msg cannot be set to the empty string, '
                              'doing so would invalidate the checking process.')
         elif custom_irrelevant_msg is not None:

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -88,7 +88,7 @@ class FakePlugin(PluginTemplateMixin):
         super().__init__(*args, **kwargs)
 
 
-class TestObserveRelevantTraitlets:
+class TestObserveTraitletsForRelevancy:
 
     fake_traitlet1 = 'fake_traitlet1'
     fake_traitlet2 = 'fake_traitlet2'
@@ -110,12 +110,12 @@ class TestObserveRelevantTraitlets:
                             if getattr(plugin_obj, trait_name, False)]
 
     @pytest.mark.parametrize('check_all', [True, False])
-    def test_observe_relevant_traitlets_with_real_traitlets(self, deconfigged_helper, check_all):
+    def test_observe_traitlets_for_relevancy_real_traitlets(self, deconfigged_helper, check_all):
         deconfigged_plugin_obj, traitlets = self.setup_plugin_obj_and_traitlets(deconfigged_helper)
 
         # Testing basic functionality
-        deconfigged_plugin_obj.observe_relevant_traitlets(non_empty_traitlets=traitlets,
-                                                          check_all_for_relevance=check_all)
+        deconfigged_plugin_obj.observe_traitlets_for_relevancy(non_empty_traitlets=traitlets,
+                                                               check_all_for_relevance=check_all)
 
         assert deconfigged_plugin_obj._non_empty_traitlets == traitlets
         assert deconfigged_plugin_obj._custom_irrelevant_msg == ''
@@ -157,7 +157,7 @@ class TestObserveRelevantTraitlets:
             ('irrelevant message', '', True),
             ('testing check_all', 'testing check_all', True),
         ])
-    def test_observe_relevant_traitlets_with_fake_traitlets(self,
+    def test_observe_traitlets_for_relevancy_fake_traitlets(self,
                                                             deconfigged_helper,
                                                             irrelevant_msg,
                                                             result_msg,
@@ -172,9 +172,9 @@ class TestObserveRelevantTraitlets:
         if irrelevant_msg == 'testing check_all':
             traitlets = traitlets[-2:]
 
-        deconfigged_plugin_obj.observe_relevant_traitlets(non_empty_traitlets=traitlets,
-                                                          irrelevant_msg=irrelevant_msg,
-                                                          check_all_for_relevance=check_all)
+        deconfigged_plugin_obj.observe_traitlets_for_relevancy(non_empty_traitlets=traitlets,
+                                                               irrelevant_msg=irrelevant_msg,
+                                                               check_all_for_relevance=check_all)
 
         # Check that the fake traitlet is the only thing that triggers the irrelevant message
         assert deconfigged_plugin_obj._non_empty_traitlets == traitlets
@@ -199,11 +199,11 @@ class TestObserveRelevantTraitlets:
             assert deconfigged_plugin_obj.irrelevant_msg == result_msg
             assert deconfigged_plugin_obj._set_relevant() in all_results
 
-    def test_observe_relevant_traitlets_with_custom_function(self, deconfigged_helper):
+    def test_observe_traitlets_for_relevancy_custom_function(self, deconfigged_helper):
         deconfigged_plugin_obj, traitlets = self.setup_plugin_obj_and_traitlets(deconfigged_helper)
         # Now using our own set_relevant function
-        deconfigged_plugin_obj.observe_relevant_traitlets(non_empty_traitlets=traitlets,
-                                                          set_relevant=self.fake_set_relevant)
+        deconfigged_plugin_obj.observe_traitlets_for_relevancy(non_empty_traitlets=traitlets,
+                                                               set_relevant=self.fake_set_relevant)
 
         assert deconfigged_plugin_obj._non_empty_traitlets == traitlets
         assert deconfigged_plugin_obj._custom_irrelevant_msg == ''

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -2,6 +2,12 @@ import pytest
 import numpy as np
 import astropy.units as u
 from specutils import SpectralRegion
+from jdaviz.core.template_mixin import PluginTemplateMixin
+from jdaviz.core.registries import tray_registry
+from jdaviz.core.config import get_configuration
+from jdaviz.app import Application
+from jdaviz import App
+
 
 
 def test_spectralsubsetselect(specviz_helper, spectrum1d):
@@ -78,7 +84,21 @@ def test_viewer_select(cubeviz_helper, spectrum1d_cube):
     assert p.viewer.selected == p.viewer.labels[0]
 
 
-class TestSetupRelevance:
+@tray_registry('test-fake-plugin', label='Test Fake Plugin')
+class FakePlugin(PluginTemplateMixin):
+    template = ''
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    # @property
+    # def user_api(self):
+    #     return PluginUserApi(
+    #         self,
+    #         expose = ['disabled_msg', 'irrelevant_msg', 'is_active'])
+
+
+class TestObserveRelevantTraitlets:
 
     fake_traitlet = 'fake_traitlet'
     set_relevant_msg = 'stale message'
@@ -94,10 +114,17 @@ class TestSetupRelevance:
         return [trait_name for trait_name in plugin_obj.traits()
                 if getattr(plugin_obj, trait_name, False)]
 
-    # NOTE: deconfigged_plugin *is* a custom parametrization (see conftest.py)
+    # NOTE: deconfigged_plugin *is* a custom parametrization (see `conftest.py`)
     # so these will run with all the plugins available at initialization.
-    def test_observe_relevant_traitlets_with_real_traitlets(self, deconfigged_plugin):
-        deconfigged_plugin_obj = deconfigged_plugin._obj
+    def test_observe_relevant_traitlets_with_real_traitlets(self):
+        config = get_configuration('deconfigged')
+        config['tray'] = ['test-fake-plugin']
+
+        deconfigged_app = Application(config)
+        deconfigged_helper = App(deconfigged_app)
+        print(deconfigged_helper.plugins)
+
+        deconfigged_plugin_obj = deconfigged_helper.plugins['Test Fake Plugin']._obj
         traitlets = self.setup_traitlets(deconfigged_plugin_obj)
 
         # Testing basic functionality

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -84,7 +84,7 @@ def test_setup_relevance_basic(deconfigged_helper):
                                    irrelevant_msg='irrelevant_msg')
 
         assert p_obj._obj._non_empty_traitlets == traitlet_list
-        assert p_obj._obj.custom_irrelevant_msg == 'irrelevant_msg'
+        assert p_obj._obj._custom_irrelevant_msg == 'irrelevant_msg'
         assert p_obj._obj._set_relevant() is None
 
 
@@ -99,5 +99,5 @@ def test_setup_relevance_function(deconfigged_helper):
                                    set_relevant=fake_set_relevant)
 
         assert p_obj._obj._non_empty_traitlets == traitlet_list
-        assert p_obj._obj.custom_irrelevant_msg == 'irrelevant_msg'
+        assert p_obj._obj._custom_irrelevant_msg == 'irrelevant_msg'
         assert p_obj._obj.set_relevant() == 'useless return'

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -168,7 +168,7 @@ class TestObserveRelevantTraitlets:
         deconfigged_plugin_obj, traitlets = self.setup_plugin_obj_and_traitlets(deconfigged_helper)
         traitlets += [self.fake_traitlet1, self.fake_traitlet2]
 
-        # Sneaking another test in here because everything in a separate test
+        # Sneaking another test in here because a separate test
         # would be identical
         if irrelevant_msg == 'testing check_all':
             traitlets = traitlets[-2:]

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -2,7 +2,6 @@ import pytest
 import numpy as np
 import astropy.units as u
 from specutils import SpectralRegion
-from traitlets import Any, Instance
 
 
 def test_spectralsubsetselect(specviz_helper, spectrum1d):

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -96,12 +96,12 @@ class TestSetupRelevance:
 
     # NOTE: deconfigged_plugin *is* a custom parametrization (see conftest.py)
     # so these will run with all the plugins available at initialization.
-    def test_setup_relevance_with_real_traitlets(self, deconfigged_plugin):
+    def test_observe_relevant_traitlets_with_real_traitlets(self, deconfigged_plugin):
         deconfigged_plugin_obj = deconfigged_plugin._obj
         traitlets = self.setup_traitlets(deconfigged_plugin_obj)
 
         # Testing basic functionality
-        deconfigged_plugin_obj.setup_relevance(non_empty_traitlets=traitlets)
+        deconfigged_plugin_obj.observe_relevant_traitlets(non_empty_traitlets=traitlets)
 
         assert deconfigged_plugin_obj._non_empty_traitlets == traitlets
         assert deconfigged_plugin_obj._custom_irrelevant_msg == ''
@@ -141,15 +141,15 @@ class TestSetupRelevance:
             ('', f'No {fake_traitlet} available'),
             ('irrelevant message', 'irrelevant message')
         ])
-    def test_setup_relevance_with_fake_traitlets(self,
+    def test_observe_relevant_traitlets_with_fake_traitlets(self,
                                                  deconfigged_plugin, irrelevant_msg, result_msg):
         # Starting with at least one fake traitlet to make sure the irrelevant message
         # is set correctly when it can't find the attribute
         deconfigged_plugin_obj = deconfigged_plugin._obj
         traitlets = self.setup_traitlets(deconfigged_plugin_obj) + [self.fake_traitlet]
 
-        deconfigged_plugin_obj.setup_relevance(non_empty_traitlets=traitlets,
-                                               irrelevant_msg=irrelevant_msg)
+        deconfigged_plugin_obj.observe_relevant_traitlets(non_empty_traitlets=traitlets,
+                                                          irrelevant_msg=irrelevant_msg)
 
         # Check that the fake traitlet is the only thing that triggers the irrelevant message
         assert deconfigged_plugin_obj._non_empty_traitlets == traitlets
@@ -174,14 +174,14 @@ class TestSetupRelevance:
             assert deconfigged_plugin_obj.irrelevant_msg == result_msg
             assert deconfigged_plugin_obj._set_relevant() in all_results
 
-    def test_setup_relevance_with_custom_function(self, deconfigged_plugin):
+    def test_observe_relevant_traitlets_with_custom_function(self, deconfigged_plugin):
 
         deconfigged_plugin_obj = deconfigged_plugin._obj
         traitlets = self.setup_traitlets(deconfigged_plugin_obj)
 
         # Now using our own set_relevant function
-        deconfigged_plugin_obj.setup_relevance(non_empty_traitlets=traitlets,
-                                               set_relevant=self.fake_set_relevant)
+        deconfigged_plugin_obj.observe_relevant_traitlets(non_empty_traitlets=traitlets,
+                                                          set_relevant=self.fake_set_relevant)
 
         assert deconfigged_plugin_obj._non_empty_traitlets == traitlets
         assert deconfigged_plugin_obj._custom_irrelevant_msg == ''

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -3,6 +3,7 @@ import numpy as np
 import astropy.units as u
 from specutils import SpectralRegion
 
+
 def test_spectralsubsetselect(specviz_helper, spectrum1d):
     # apply mask to spectrum to check selected subset is masked:
     mask = spectrum1d.flux < spectrum1d.flux.mean()

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -6,7 +6,6 @@ from jdaviz.core.template_mixin import PluginTemplateMixin
 from jdaviz.core.registries import tray_registry
 
 
-
 def test_spectralsubsetselect(specviz_helper, spectrum1d):
     # apply mask to spectrum to check selected subset is masked:
     mask = spectrum1d.flux < spectrum1d.flux.mean()

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -134,7 +134,8 @@ class TestObserveTraitletsForRelevancy:
                                      for trait_name in traitlets}
 
         # Check to see if fake_set_relevant is available and runs
-        # when accessing the observed quantity
+        # when accessing the observed quantity.
+        # Using .items() for convenient debugging if necessary.
         for _, observe_methods in observed_traitlet_methods.items():
             deconfigged_plugin_obj.irrelevant_msg = self.sad_msg
 

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -116,8 +116,8 @@ class TestObserveTraitletsForRelevancy:
         deconfigged_plugin_obj, traitlets = self.setup_plugin_obj_and_traitlets(
             deconfigged_helper)
 
-        default_irrelevant_msg = (f'At least one of or all of {', '.join(traitlets)} '
-                                  f'are not available')
+        default_irrelevant_msg = (f"At least one of or all of {', '.join(traitlets)} "
+                                  f"are not available")
 
         # Covers no _traitlets_to_observe set
         with pytest.raises(AttributeError,
@@ -167,8 +167,8 @@ class TestObserveTraitletsForRelevancy:
 
         # Check that irrelevant message is set correctly for irrelevant traitlets
         result = deconfigged_plugin_obj.relevant_if_any_truthy(self.fake_traitlets)
-        assert result == (f'At least one of or all of {', '.join(self.fake_traitlets)} '
-                          f'are not available')
+        assert result == (f"At least one of or all of {', '.join(self.fake_traitlets)} "
+                          f"are not available")
 
         # Check that irrelevant message is set correctly for relevant + irrelevant traitlets
         traitlets += self.fake_traitlets
@@ -180,8 +180,8 @@ class TestObserveTraitletsForRelevancy:
         # Check that irrelevant message is set correctly for relevant + irrelevant traitlets and
         # a custom message.
         if method_type == 'all':
-            assert result_default_msg == (f'At least one of or all of {', '.join(traitlets)} '
-                                          f'are not available')
+            assert result_default_msg == (f"At least one of or all of {', '.join(traitlets)} "
+                                          f"are not available")
             assert result_custom_msg == self.sad_msg
         elif method_type == 'any':
             assert result_default_msg == ''
@@ -213,9 +213,9 @@ class TestObserveTraitletsForRelevancy:
 
         else:
             if method_type == 'all':
-                assert deconfigged_plugin_obj.irrelevant_msg == (f'At least one of or all of '
-                                                                 f'{', '.join(traitlets)} '
-                                                                 f'are not available')
+                assert deconfigged_plugin_obj.irrelevant_msg == (f"At least one of or all of "
+                                                                 f"{', '.join(traitlets)} "
+                                                                 f"are not available")
             elif method_type == 'any':
                 assert deconfigged_plugin_obj.irrelevant_msg == ''
 
@@ -231,7 +231,7 @@ class TestObserveTraitletsForRelevancy:
             expected_msg = ''
         else:
             # Real + fake so the default (if_all_truthy) is the observer
-            expected_msg = f'At least one of or all of {', '.join(traitlets)} are not available'
+            expected_msg = f"At least one of or all of {', '.join(traitlets)} are not available"
 
         # Testing default functionality
         deconfigged_plugin_obj.observe_traitlets_for_relevancy(traitlets)

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -156,8 +156,9 @@ class TestObserveTraitletsForRelevancy:
         method = getattr(self, f'if_{method_type}_truthy')
 
         # Checking the default argument (None) when nothing is observed yet
-        with pytest.raises(AttributeError, match=re.escape('_traitlets_to_observe has not been set yet '
-                                                 '(by observe_traitlets_for_relevancy).')):
+        with pytest.raises(AttributeError,
+                           match=re.escape('_traitlets_to_observe has not been set yet '
+                                           '(by observe_traitlets_for_relevancy).')):
             method()
 
         # Check that irrelevant message is set correctly for relevant traitlets
@@ -279,8 +280,8 @@ class TestObserveTraitletsForRelevancy:
         assert deconfigged_plugin_obj._custom_irrelevant_msg == self.set_relevant_msg
 
     @pytest.mark.parametrize('additional_traitlets', [[], fake_traitlets])
-    def test_observe_traitlets_for_relevancy_with_fake_callback(self,
-                                             deconfigged_helper, additional_traitlets):
+    def test_observe_traitlets_for_relevancy_with_fake_callback(
+            self, deconfigged_helper, additional_traitlets):
         deconfigged_plugin_obj, traitlets = self.setup_plugin_obj_and_traitlets(
             deconfigged_helper)
         traitlets += additional_traitlets
@@ -315,7 +316,7 @@ class TestObserveTraitletsForRelevancy:
             # traits may be observed by more than one method
             # traitlet ObserverHandlers don't have __name__ so we use getattr
             _ = [method() for method in observe_methods
-                           if getattr(method, '__name__', None) == '_set_relevant']
+                 if getattr(method, '__name__', None) == '_set_relevant']
 
             # Check that self.set_relevant_msg is overwritten by our if_fake_truthy
             # behind the scenes

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -80,6 +80,7 @@ def test_viewer_select(cubeviz_helper, spectrum1d_cube):
 
 class TestSetupRelevance:
 
+    fake_traitlet = 'fake_traitlet'
     set_relevant_msg = 'stale message'
     new_set_relevant_msg = 'fresh message'
     sad_msg = "I don't want to be made irrelevant"
@@ -137,7 +138,7 @@ class TestSetupRelevance:
     # Alternatively, a custom function could be used (but that's [currently] a separate test!)
     @pytest.mark.parametrize(
         ('irrelevant_msg', 'result_msg'), [
-            ('', f'No fake_traitlet available'),
+            ('', f'No {fake_traitlet} available'),
             ('irrelevant message', 'irrelevant message')
         ])
     def test_setup_relevance_with_fake_traitlets(self,
@@ -145,7 +146,7 @@ class TestSetupRelevance:
         # Starting with at least one fake traitlet to make sure the irrelevant message
         # is set correctly when it can't find the attribute
         deconfigged_plugin_obj = deconfigged_plugin._obj
-        traitlets = self.setup_traitlets(deconfigged_plugin_obj) + ['fake_traitlet']
+        traitlets = self.setup_traitlets(deconfigged_plugin_obj) + [self.fake_traitlet]
 
         deconfigged_plugin_obj.setup_relevance(non_empty_traitlets=traitlets,
                                                irrelevant_msg=irrelevant_msg)

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -3,7 +3,6 @@ import numpy as np
 import astropy.units as u
 from specutils import SpectralRegion
 
-
 def test_spectralsubsetselect(specviz_helper, spectrum1d):
     # apply mask to spectrum to check selected subset is masked:
     mask = spectrum1d.flux < spectrum1d.flux.mean()
@@ -76,3 +75,29 @@ def test_viewer_select(cubeviz_helper, spectrum1d_cube):
     # try setting based on id instead of reference
     p.viewer = p.viewer.ids[0]
     assert p.viewer.selected == p.viewer.labels[0]
+
+def test_setup_relevance_basic(deconfigged_helper):
+    traitlet_list = ['traitlet_1', 'traitlet_2', 'traitlet_3']
+
+    for p_name, p_obj in deconfigged_helper.plugins.items():
+        p_obj._obj.setup_relevance(non_empty_traitlets=traitlet_list,
+                                   irrelevant_msg='irrelevant_msg')
+
+        assert p_obj._obj._non_empty_traitlets == traitlet_list
+        assert p_obj._obj.custom_irrelevant_msg == 'irrelevant_msg'
+        assert p_obj._obj._set_relevant() is None
+
+
+def test_setup_relevance_function(deconfigged_helper):
+    traitlet_list = ['traitlet_1', 'traitlet_2', 'traitlet_3']
+    def fake_set_relevant():
+        return 'useless return'
+
+    for p_name, p_obj in deconfigged_helper.plugins.items():
+        p_obj._obj.setup_relevance(non_empty_traitlets=traitlet_list,
+                                   irrelevant_msg='irrelevant_msg',
+                                   set_relevant=fake_set_relevant)
+
+        assert p_obj._obj._non_empty_traitlets == traitlet_list
+        assert p_obj._obj.custom_irrelevant_msg == 'irrelevant_msg'
+        assert p_obj._obj.set_relevant() == 'useless return'


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address the use of a repeated structure, `set_relevant`, in plugins. The code to do so has been generalized and is now housed in `template_mixins.py`. Those that couldn't be neatly generalized were left in. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
