### PR TITLE
VO: don't update coords on change to align_by

### DIFF
--- a/jdaviz/configs/default/plugins/virtual_observatory/tests/test_vo_imviz.py
+++ b/jdaviz/configs/default/plugins/virtual_observatory/tests/test_vo_imviz.py
@@ -185,12 +185,18 @@ def test_link_type_autocoord(imviz_helper):
 
     imviz_helper.plugins["Orientation"].align_by = "WCS"
 
+    # coordinates have not updated to the new center
+    assert vo_plugin.coord_follow_viewer_pan is False
     ra_str, dec_str = vo_plugin.source.split()
+    np.testing.assert_allclose(float(ra_str), 284.2101962057667)
+    np.testing.assert_allclose(float(dec_str), 32.23616603681311)
 
-    # Large absolute tolerances due to WCS center coordinate bug (see issue 3225)
-    # Truth values may need to be reevaluated
-    np.testing.assert_allclose(float(ra_str), 326.7884142245305, atol=30)
-    np.testing.assert_allclose(float(dec_str), -9.905948925234416, atol=30)
+    vo_plugin.center_on_data()
+    ra_str, dec_str = vo_plugin.source.split()
+    # coordinates should now update based on the new alignment/zoom
+    np.testing.assert_allclose(float(ra_str), 239.18584957810944)
+    np.testing.assert_allclose(float(dec_str), 14.793145129887552)
+    assert vo_plugin.viewer_centered
 
 
 @pytest.mark.remote_data

--- a/jdaviz/configs/default/plugins/virtual_observatory/vo_plugin.py
+++ b/jdaviz/configs/default/plugins/virtual_observatory/vo_plugin.py
@@ -11,8 +11,7 @@ from traitlets import Bool, Unicode, Any, List, Float, observe
 from jdaviz.core.events import (
     SnackbarMessage,
     AddDataMessage,
-    RemoveDataMessage,
-    LinkUpdatedMessage,
+    RemoveDataMessage
 )
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (
@@ -106,7 +105,6 @@ class VoPlugin(PluginTemplateMixin, AddResultsMixin, TableMixin):
 
         self.hub.subscribe(self, AddDataMessage, handler=self.vue_center_on_data)
         self.hub.subscribe(self, RemoveDataMessage, handler=self.vue_center_on_data)
-        self.hub.subscribe(self, LinkUpdatedMessage, handler=self.vue_center_on_data)
 
     @observe("viewer_selected", type="change")
     def vue_viewer_changed(self, _=None):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request changes the behavior of the VO plugin to not update the coords when the link type changes (unless manually requested or the auto-switch is enabled).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
