### PR TITLE
continue-on-error PR label support

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -22,7 +22,7 @@ jobs:
   ci_tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allow_failure }}
+    continue-on-error: ${{ matrix.allow_failure || contains(github.event.pull_request.labels.*.name, 'continue-on-error') }}
     strategy:
       matrix:
         include:


### PR DESCRIPTION
This PR implements CI-workflow support for a `continue-on-error` PR label which disables stopping workflows when another fails.  This is useful if you want to run CI on devdeps or remote data while other workflows have known failures, etc.

This can be seen in action in #3698 (I'll remove that commit from there if/when this is merged).