### PR TITLE
re-enabling spectral subset visibility from data menu

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,9 @@ Bug Fixes
 
 - Distance measurement marks now update properly upon unit conversion. [#3716]
 
+- Use validator on subset layer visibility and subset deletion to ensure toggling visibility and
+  deleting subsets from data menu and plot options updates accordingly. [#3708]
+
 Cubeviz
 ^^^^^^^
 - Fixed issue with initial model components not using spectral y axis unit. [#3715]
@@ -133,9 +136,6 @@ Cubeviz
 - Sonified data can now be added to any image viewer after initial sonification. [#3690]
 
 - Renamed ``Spectral Extraction`` plugin to ``3D Spectral Extraction``. [#3691]
-
-- Use validator on subset layer visibility to ensure toggling visibility from data menu
-  and plot options updates accordingly. [#3708]
 
 Imviz
 ^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -134,6 +134,9 @@ Cubeviz
 
 - Renamed ``Spectral Extraction`` plugin to ``3D Spectral Extraction``. [#3691]
 
+- Use validator on subset layer visibility to ensure toggling visibility from data menu
+  and plot options updates accordingly. [#3708]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -587,7 +587,8 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
         Remove the selected layers from the entire app and all viewers.
         """
         # future improvement: allow overriding layer.selected via *args, with pre-validation
-        for layer in self.layer.selected:
+        for layer in (self.layer.selected if isinstance(self.layer.selected,
+                                                        (list, tuple)) else [self.layer.selected]):
             if layer in self.existing_subset_labels:
                 for sg in self.app.data_collection.subset_groups:
                     if sg.label == layer:

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -8,6 +8,7 @@ from jdaviz.core.template_mixin import (TemplateMixin, LayerSelect,
 from jdaviz.core.user_api import UserApiWrapper
 from jdaviz.core.events import (IconsUpdatedMessage, AddDataMessage,
                                 ChangeRefDataMessage, ViewerRenamedMessage)
+from glue.core.message import SubsetDeleteMessage
 from jdaviz.core.sonified_layers import SonifiedLayerState, SonifiedDataLayerArtist
 from jdaviz.utils import cmap_samples, is_not_wcs_only
 
@@ -138,6 +139,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
         # set their initial state
         self.hub.subscribe(self, IconsUpdatedMessage, self._on_app_icons_updated)
         self.hub.subscribe(self, AddDataMessage, handler=lambda _: self._set_viewer_id())
+        self.hub.subscribe(self, SubsetDeleteMessage, handler=lambda msg: self._update_items(msg.subset))  # noqa
         self.hub.subscribe(self, ChangeRefDataMessage, handler=self._on_refdata_change)
         self.hub.subscribe(self, ViewerRenamedMessage, handler=self._on_viewer_renamed_message)
         self.viewer_icons = dict(self.app.state.viewer_icons)
@@ -195,6 +197,17 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
     @property
     def data_labels_unloaded(self):
         return self.dataset.choices
+
+    def _update_items(self, msg={}):
+        if not hasattr(self, 'layer'):
+            return
+
+        # on SubsetDeleteMessage, message is sent before self.layer is updated, so update
+        # layer visible to ensure icon is updated in data menu
+        if msg.label not in self.existing_subset_labels:
+            for layer in self._viewer.layers:
+                if layer.layer.label == msg.label:
+                    layer.visible = False
 
     def _set_viewer_id(self):
         # viewer_ids are not populated on the viewer at init, so we'll keep checking and set
@@ -395,7 +408,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
                 self.subset_edit_tooltip = "Select a single subset to edit"
         self.layer._update_items()
 
-    def set_layer_visibility(self, layer_label, visible=True):
+    def set_layer_visibility(self, layer_label, visible=False):
         """
         Set the visibility of a layer in the viewer.
 
@@ -424,11 +437,12 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
                 # so also hide the child-layer
                 layer.visible = False
 
+            if layer.state.visible != layer.visible:
+                layer.state.visible = layer.visible
+
         if visible and (parent_label := self.app._get_assoc_data_parent(layer_label)):
             # ensure the parent layer is also visible
             self.set_layer_visibility(parent_label, visible=True)
-
-        self.layer._update_items()
 
         return self.visible_layers
 

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -139,7 +139,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
         # set their initial state
         self.hub.subscribe(self, IconsUpdatedMessage, self._on_app_icons_updated)
         self.hub.subscribe(self, AddDataMessage, handler=lambda _: self._set_viewer_id())
-        self.hub.subscribe(self, SubsetDeleteMessage, handler=lambda msg: self._update_items(msg.subset))  # noqa
+        self.hub.subscribe(self, SubsetDeleteMessage, handler=lambda msg: self._remove_subset_from_layers(msg.subset))  # noqa
         self.hub.subscribe(self, ChangeRefDataMessage, handler=self._on_refdata_change)
         self.hub.subscribe(self, ViewerRenamedMessage, handler=self._on_viewer_renamed_message)
         self.viewer_icons = dict(self.app.state.viewer_icons)
@@ -198,7 +198,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
     def data_labels_unloaded(self):
         return self.dataset.choices
 
-    def _update_items(self, msg={}):
+    def _remove_subset_from_layers(self, msg={}):
         if not hasattr(self, 'layer'):
             return
 
@@ -207,7 +207,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
         if msg.label not in self.existing_subset_labels:
             for layer in self._viewer.layers:
                 if layer.layer.label == msg.label:
-                    layer.visible = False
+                    self.layer._update_items(remove_subset=msg.label)
 
     def _set_viewer_id(self):
         # viewer_ids are not populated on the viewer at init, so we'll keep checking and set
@@ -408,7 +408,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
                 self.subset_edit_tooltip = "Select a single subset to edit"
         self.layer._update_items()
 
-    def set_layer_visibility(self, layer_label, visible=False):
+    def set_layer_visibility(self, layer_label, visible=True):
         """
         Set the visibility of a layer in the viewer.
 

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -393,6 +393,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
                 self.subset_edit_tooltip = "Select a subset to edit"
             else:
                 self.subset_edit_tooltip = "Select a single subset to edit"
+        self.layer._update_items()
 
     def set_layer_visibility(self, layer_label, visible=True):
         """
@@ -426,6 +427,8 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
         if visible and (parent_label := self.app._get_assoc_data_parent(layer_label)):
             # ensure the parent layer is also visible
             self.set_layer_visibility(parent_label, visible=True)
+
+        self.layer._update_items()
 
         return self.visible_layers
 
@@ -573,6 +576,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
                 for sg in self.app.data_collection.subset_groups:
                     if sg.label == layer:
                         self.app.data_collection.remove_subset_group(sg)
+                        self.layer._update_items()
                         break
             else:
                 self.app.data_item_remove(layer)

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -440,6 +440,8 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
             if layer.state.visible != layer.visible:
                 layer.state.visible = layer.visible
 
+            self.layer._update_items()
+
         if visible and (parent_label := self.app._get_assoc_data_parent(layer_label)):
             # ensure the parent layer is also visible
             self.set_layer_visibility(parent_label, visible=True)

--- a/jdaviz/configs/default/plugins/subset_tools/tests/test_subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/tests/test_subset_tools.py
@@ -597,3 +597,47 @@ def test_update_subset(cubeviz_helper, spectrum1d_cube):
     assert plg._obj.subset_definitions[0][2]['value'] == 1
     # Check radius
     assert plg._obj.subset_definitions[0][3]['value'] == 1
+
+
+def test_data_menu_subset_delete(cubeviz_helper, spectrum1d_cube):
+    cubeviz_helper.load_data(spectrum1d_cube)
+    dm = cubeviz_helper.viewers['spectrum-viewer'].data_menu
+    plg = cubeviz_helper.plugins['Subset Tools']
+
+    dm.layer.multiselect = False
+
+    # load one spectral region
+    plg.import_region(SpectralRegion(1 * u.um, 1.5 * u.um))
+
+    # load a spatial region
+    spatial_reg = CirclePixelRegion(center=PixCoord(x=2, y=2), radius=2)
+    plg.import_region(spatial_reg, combination_mode='new')
+
+    # load a second spectral region after spatial region
+    plg.import_region(SpectralRegion(1.6 * u.um, 2 * u.um))
+
+    print(cubeviz_helper.app.data_collection)
+    expected_dm_layer_len = 4
+
+    assert (len(cubeviz_helper.viewers['spectrum-viewer'].data_menu.layer.choices) ==
+            expected_dm_layer_len)
+
+    # select the spectral subset created after the spatial subset
+    dm.layer = 'Subset 3'
+    dm.remove_from_app()
+    expected_dm_layer_len = 3
+
+    # ensure removing from app removes it from LayerSelect and is no longer a data label
+    # within the data menu
+    assert (len(cubeviz_helper.viewers['spectrum-viewer'].data_menu.layer.choices) ==
+            expected_dm_layer_len)
+    assert dm.layer not in cubeviz_helper.viewers['spectrum-viewer'].data_menu.data_labels_loaded
+
+    # select the spectral subset created before the spatial subset
+    dm.layer = 'Subset 1'
+    dm.remove_from_app()
+    expected_dm_layer_len = 2
+
+    assert (len(cubeviz_helper.viewers['spectrum-viewer'].data_menu.layer.choices) ==
+            expected_dm_layer_len)
+    assert dm.layer not in cubeviz_helper.viewers['spectrum-viewer'].data_menu.data_labels_loaded

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -287,17 +287,12 @@ class JdavizViewerMixin(WithCache):
             # whenever as_steps changes, we need to redraw the uncertainties (if enabled)
             layer_state.add_callback('as_steps', self._show_uncertainty_changed)
 
-        if (hasattr(layer_state, 'visible') and self.__class__.__name__ == 'CubevizImageView' and
-           get_subset_type(layer_state.layer) != 'spatial'):
+        # use echo-validator to ensure visible sets & updates properly in plot options & data menu
+        if (hasattr(layer_state, 'visible') and get_subset_type(layer_state.layer) != 'spatial'):
             layer_state.layer.visible = CallbackProperty()
-            self._spectral_overlay(layer_state)
             layer_state.add_callback('layer',
-                                     self._spectral_overlay,
-                                     validator=True,
-                                     echo_old=True)
-
-    def _spectral_overlay(self, layer_state):
-        layer_state.visible = False
+                                     self._expected_subset_layer_default,
+                                     validator=True)
 
     def _expected_subset_layer_default(self, layer_state):
         if self.__class__.__name__ == 'RampvizImageView':
@@ -313,7 +308,7 @@ class JdavizViewerMixin(WithCache):
         elif (self.__class__.__name__ == 'CubevizImageView' and
               get_subset_type(layer_state.layer) != 'spatial'):
             # set visibility of spectral subsets to false in Cubeviz image-viewers
-            return
+            layer_state.visible = False
         else:
             layer_state.visible = self._get_layer(layer_state.layer.data.label).visible
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2098,7 +2098,7 @@ class LayerSelect(SelectPluginComponent):
         self._update_items({'source': 'data_added'})
 
     @observe('filters', 'sort_by')
-    def _update_items(self, msg={}):
+    def _update_items(self, msg={}, remove_subset=None):
         # NOTE: _on_layers_changed is passed without a msg object during init
         # TODO: if the message is a SubsetUpdateMessage, only act on those that require
         # an update
@@ -2120,7 +2120,10 @@ class LayerSelect(SelectPluginComponent):
             if self.app.state.layer_icons.get(layer.layer.label) or
             self.only_wcs_layers
         ]
-        unique_layer_labels = list(set(layer_labels))
+
+        # if remove_subset provided, subset has already been removed, enforcing the removal here
+        # so data menu updates accordingly
+        unique_layer_labels = list(set(layer_labels) - {remove_subset})
         layer_items = [self._layer_to_dict(layer_label) for layer_label in unique_layer_labels]
 
         def _sort_by_icon(items_dict):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request modifies existing glue-validator logic to resolve subset visibility issues in spectrum-viewer data menu, while maintaining the same plot option functionality.


https://github.com/user-attachments/assets/ea97d7e4-5d16-4445-b9af-0fe2cbcc272d



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->



### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
