### PR TITLE
Fix export movie in cubeviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -178,6 +178,9 @@ Cubeviz
 
 - Broadcast snackbar message to user when sonification of a data cube completes. [#3647]
 
+- Fixes exporting an image viewer as a movie by starting the movie at the specified slice
+  and returning to the correct slice after exporting. [#3710]
+
 Imviz
 ^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
@@ -41,7 +41,6 @@ def test_export_movie_not_cubeviz(imviz_helper):
     assert 'mp4' not in plugin.viewer_format.choices
 
 
-@pytest.mark.skip("known failure")
 @pytest.mark.skipif(not HAS_OPENCV, reason="opencv-python is not installed")
 def test_export_movie_cubeviz_exceptions(cubeviz_helper, spectrum1d_cube):
     cubeviz_helper.load_data(spectrum1d_cube, data_label="test")

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -714,7 +714,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         temp_png_files = []
         i = i_start
         video = None
-        slice_plg._on_value_updated({'new': slice_plg.valid_values_sorted[i_start]})
+        slice_plg.value = slice_plg.valid_values_sorted[i_start]
 
         # TODO: Expose to users?
         i_step = 1  # Need n_frames check if we allow tweaking
@@ -751,7 +751,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             cv2.destroyAllWindows()
             if video:
                 video.release()
-            slice_plg._on_value_updated({'new': slice_plg.valid_values_sorted[orig_slice]})
+            slice_plg.value = slice_plg.valid_values_sorted[orig_slice]
 
         if rm_temp_files or self.movie_interrupt:
             for cur_pngfile in temp_png_files:

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -298,7 +298,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         # NOTE: This needs revising if we allow loading more than one cube.
         if isinstance(msg.viewer, BqplotImageView):
             if len(msg.data.shape) == 3:
-                self.i_end = msg.data.shape[-1] - 1
+                self.i_end = msg.data.shape[msg.data.meta['spectral_axis_index']] - 1
 
     @observe('multiselect', 'viewer_multiselect')
     def _sync_multiselect_traitlets(self, event):

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -714,6 +714,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         temp_png_files = []
         i = i_start
         video = None
+        slice_plg._on_value_updated({'new': slice_plg.valid_values_sorted[i_start]})
 
         # TODO: Expose to users?
         i_step = 1  # Need n_frames check if we allow tweaking
@@ -750,7 +751,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             cv2.destroyAllWindows()
             if video:
                 video.release()
-            slice_plg._on_slider_updated({'new': orig_slice})
+            slice_plg._on_value_updated({'new': slice_plg.valid_values_sorted[orig_slice]})
 
         if rm_temp_files or self.movie_interrupt:
             for cur_pngfile in temp_png_files:


### PR DESCRIPTION
Fixes getting an incorrect value for the default slice maximum as well as a bug where the movie was always starting from the current slice rather than the specified slice and returning to an incorrect slice after the movie.