### PR TITLE
enable imviz.load, deprecate load_data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,7 +49,7 @@ Imviz
 
 - ``load_data`` is deprecated in favor of ``load`` method and loaders infrastructure.  Default data-labels
   from ``load_data`` may change in some cases, with the actual extension name used in place of ``[DATA]``
-  and the version number included along with the extension.  [#3662, #3709]
+  and the version number included along with the extension.  [#3662, #3709, #3713]
 
 - Loading data is now done through the loaders menu in the right sidebar.  The "import data" button is
   deprecated and will open the new sidebar.  [#3662, #3709]

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -41,6 +41,10 @@ class Imviz(ImageConfigHelper):
         global _current_app
         _current_app = self
 
+        # Temporary during deconfig process
+        self.load = self._load
+        self.app.state.dev_loaders = True
+
     def create_image_viewer(self, viewer_name=None):
         """Create a new image viewer.
 
@@ -152,8 +156,6 @@ class Imviz(ImageConfigHelper):
         image as Numpy array and load the latter instead.
 
         """
-        self.app.state.dev_loaders = True
-
         extensions = kwargs.pop('ext', None)
 
         if isinstance(data, str) and "," in data:

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -96,6 +96,7 @@ class Imviz(ImageConfigHelper):
             raise ValueError(f"Default viewer '{viewer_id}' cannot be destroyed")
         self.app.vue_destroy_viewer_item(viewer_id)
 
+    @deprecated(since="4.3", alternative="load")
     def load_data(self, data, data_label=None, show_in_viewer=True,
                   gwcs_to_fits_sip=False, **kwargs):
         """Load data into Imviz.

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -618,8 +618,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
 
 
 def add_wcs_data_to_app(app, data, data_label=None):
-    app._jdaviz_helper._load(data, format='Image',
-                             data_label=data_label, show_in_viewer=False)
+    app._jdaviz_helper.load(data, format='Image',
+                            data_label=data_label, show_in_viewer=False)
     # TODO: refactor logic to avoid having to send an AddDataMessage just to update icons
     # ensure that icons are updated by forcing a call to app._on_layers_changed
     image_viewer = app.get_viewers_of_cls(ImvizImageView)[0]

--- a/notebooks/ImvizExample.ipynb
+++ b/notebooks/ImvizExample.ipynb
@@ -100,7 +100,7 @@
     "    warnings.simplefilter('ignore')\n",
     "    for fn in filenames:\n",
     "        uri = f\"mast:JWST/product/{fn}\"\n",
-    "        imviz.load_data(uri, cache=True)"
+    "        imviz.load(uri, cache=True)"
    ]
   },
   {

--- a/notebooks/Specviz2dExample.ipynb
+++ b/notebooks/Specviz2dExample.ipynb
@@ -77,7 +77,7 @@
    "source": [
     "uri = f\"mast:jwst/product/jw01538-o161_s000000001_nirspec_f290lp-g395h-s1600a1_s2d.fits\"\n",
     "\n",
-    "specviz2d.load_data(uri, cache=True)"
+    "specviz2d.load(uri, cache=True)"
    ]
   },
   {

--- a/notebooks/SpecvizExample.ipynb
+++ b/notebooks/SpecvizExample.ipynb
@@ -88,7 +88,7 @@
    },
    "outputs": [],
    "source": [
-    "specviz.load_data(\"mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_x1d.fits\", data_label=\"myfile\", cache=True)"
+    "specviz.load(\"mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_x1d.fits\", data_label=\"myfile\", cache=True)"
    ]
   },
   {


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request enables user-access to `imviz.load` and deprecates `imviz.load_data` to match what has been done for specviz and specviz 2d now that `load_data` relies entirely on `load` in #3662.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
