### PR TITLE
Fix failing data format tests

### DIFF
--- a/jdaviz/core/data_formats.py
+++ b/jdaviz/core/data_formats.py
@@ -76,7 +76,9 @@ def get_valid_format(filename):
         The recommended application configuration
     """
 
-    valid_file_format = identify_spectrum_format(filename, SpectrumList)
+    valid_file_format = identify_spectrum_format(filename)
+    if valid_file_format == []:
+        valid_file_format = identify_spectrum_format(filename, SpectrumList)
     ndim = guess_dimensionality(filename)
 
     if valid_file_format:

--- a/jdaviz/tests/test_data_formats.py
+++ b/jdaviz/tests/test_data_formats.py
@@ -27,6 +27,7 @@ def create_manga(n_dim=None, **kwargs):
 def _create_bintable(name, ver=1):
     return fits.BinTableHDU.from_columns(
                 [fits.Column(name='target', format='20A', array=np.ones(3)),
+                 fits.Column(name='WAVELENGTH', format='E', array=np.arange(3)),
                  fits.Column(name='V_mag', format='E', array=np.ones(3))],
                 name=name, ver=ver
             )


### PR DESCRIPTION
This adds a `WAVELENGTH` column to the JWST test fixture (expected/checked by the new WFSS logic in specutils) and checks for valid `Spectrum` formats before checking valid `SpectrumList` formats. I'm still not 100% convinced that this is the correct fix, but it does work.