### PR TITLE
use spectral y unit for non cube fit model fitting component  

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,7 @@ Bug Fixes
 
 Cubeviz
 ^^^^^^^
+- Fixed issue with initial model components not using spectral y axis unit. [#3715]
 
 Imviz
 ^^^^^

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -640,7 +640,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
             # The units have to be in surface brightness for a cube fit.
             uc = self.app._jdaviz_helper.plugins.get('Unit Conversion', None)
             if uc is None:
-                pass
+                return
             if not self.cube_fit:
                 # use spectrum viewer y axis units
                 if hasattr(uc, 'spectral_y_unit'):

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -641,12 +641,20 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
             uc = self.app._jdaviz_helper.plugins.get('Unit Conversion', None)
             if uc is None:
                 pass
-            elif self.cube_fit and unit != uc._obj.sb_unit_selected:
-                self._units[axis] = uc._obj.sb_unit_selected
-                self._check_model_component_compat([axis], [u.Unit(uc._obj.sb_unit_selected)])
-                return
-            elif msg.axis == 'flux' and uc._obj.has_sb:
-                unit = u.Unit(self.app._get_display_unit('sb'))
+            if not self.cube_fit:
+                # use spectrum viewer y axis units
+                if hasattr(uc, 'spectral_y_unit'):
+                    # NOTE, spectral_y_unit should probably be set and exposed
+                    # in the unit conversion plugin for specviz2d
+                    # and specviz so this check doesn't have to be done
+                    unit = u.Unit(uc.spectral_y_unit)
+            else:
+                if unit != uc._obj.sb_unit_selected:
+                    self._units[axis] = uc._obj.sb_unit_selected
+                    self._check_model_component_compat([axis], [u.Unit(uc._obj.sb_unit_selected)])
+                    return
+                elif msg.axis == 'flux' and uc._obj.has_sb:
+                    unit = u.Unit(self.app._get_display_unit('sb'))
 
         # update internal tracking of current units
         self._units[axis] = str(unit)

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -650,6 +650,9 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
                     unit = u.Unit(uc.spectral_y_unit)
                 elif msg.axis == 'flux' and uc._obj.has_sb:
                     unit = u.Unit(self.app._get_display_unit('sb'))
+                # JDAT 5586
+                # else:
+                #     unit = u.Unit(self.app._get_display_unit('spectral_y'))
 
             else:
                 if unit != uc._obj.sb_unit_selected:

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -648,6 +648,9 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
                     # in the unit conversion plugin for specviz2d
                     # and specviz so this check doesn't have to be done
                     unit = u.Unit(uc.spectral_y_unit)
+                elif msg.axis == 'flux' and uc._obj.has_sb:
+                    unit = u.Unit(self.app._get_display_unit('sb'))
+
             else:
                 if unit != uc._obj.sb_unit_selected:
                     self._units[axis] = uc._obj.sb_unit_selected

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -648,11 +648,8 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
                     # in the unit conversion plugin for specviz2d
                     # and specviz so this check doesn't have to be done
                     unit = u.Unit(uc.spectral_y_unit)
-                elif msg.axis == 'flux' and uc._obj.has_sb:
-                    unit = u.Unit(self.app._get_display_unit('sb'))
-                # JDAT 5586
-                # else:
-                #     unit = u.Unit(self.app._get_display_unit('spectral_y'))
+                else:
+                    unit = u.Unit(self.app._get_display_unit('spectral_y'))
 
             else:
                 if unit != uc._obj.sb_unit_selected:

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -429,6 +429,10 @@ class UnitConversion(PluginTemplateMixin):
 
         spectral_y_change = False
         for sv in self.spectrum_1d_viewers:
+
+            if self.spectral_unit.selected != yunit:
+                spectral_y_change = True
+
             if sv.state.y_display_unit == yunit:
                 sv.set_plot_axes()
                 continue


### PR DESCRIPTION
Fixes an issue where model components created in model fitting were not correctly using the spectral y unit when cube fit was not selected. 

This also fixes an issue where temporarily on load the unit conversion spectral_y_unit traitlet and the real spectrum y axis units are temporarily out of sync when data is being loaded. this was preventing reliable access to the spectrum y axis unit through the unit conversion plugin.