### PR TITLE
Fix reestimating cube fit parameters in some cases

### DIFF
--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -1365,7 +1365,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
             if subset_mask.ndim < spectrum.flux.ndim:
                 # correct the shape of spectral/spatial axes when they're different:
                 if spectrum.spectral_axis_index == 0:
-                    subset_mask = np.expand_dims(subset_mask, (1,2))
+                    subset_mask = np.expand_dims(subset_mask, (1, 2))
                 subset_mask = np.broadcast_to(subset_mask, spectrum.flux.shape)
 
             elif (subset_mask.ndim == spectrum.flux.ndim and

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -574,14 +574,6 @@ def test_cube_fit_after_unit_change(cubeviz_helper, solid_angle_unit):
     assert model_flux.units == expected_unit_string
 
 
-def test_reestimate_with_spectral_first_cube(cubeviz_helper, image_cube_hdu_obj_microns):
-    cubeviz_helper.load_data(image_cube_hdu_obj_microns, data_label="test")
-    mf = cubeviz_helper.plugins['Model Fitting']
-    mf.create_model_component('Linear1D')
-    mf.cube_fit = True
-    mf.reestimate_model_parameters()
-
-
 def test_deconf_mf_with_subset(deconfigged_helper):
     flux = np.ones(9) * u.Jy
     flux[7] = 10 * u.Jy

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -326,6 +326,20 @@ def test_reestimate_parameters(specviz_helper, spectrum1d):
     assert mc['parameters']['stddev']['fixed'] is True
 
 
+def test_reestimate_with_spectral_first_cube(cubeviz_helper, image_cube_hdu_obj_microns):
+    cubeviz_helper.load_data(image_cube_hdu_obj_microns, data_label="test")
+
+    subset = cubeviz_helper.plugins['Subset Tools']
+    subset.import_region(SpectralRegion(4 * u.Unit('um'), 6 * u.Unit('um')))
+
+    mf = cubeviz_helper.plugins['Model Fitting']
+    mf.spectral_subset.selected = 'Subset 1'
+    mf.create_model_component('Linear1D')
+    mf.cube_fit = True
+    # This call used to error due to a broadcasting failure
+    mf.reestimate_model_parameters()
+
+
 def test_subset_masks(cubeviz_helper, spectrum1d_cube_larger):
     cubeviz_helper.load_data(spectrum1d_cube_larger)
     assert spectrum1d_cube_larger.mask is None


### PR DESCRIPTION
Re-estimating model fit parameters was failing if a spectral subset was selected and the cube was one with spectral axis first rather than last. This fixes the issue and adds a test that fails on main.