### PR TITLE
fix bug in `_set_zoom_radius_center`

### DIFF
--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -151,11 +151,15 @@ class FreezableBqplotImageViewerState(BqplotImageViewerState, FreezableState):
         if self.linked_by_wcs:
             image, i_ref = get_reference_image_data(self._viewer.jdaviz_app, self._viewer.reference)
             ref_wcs = image.coords
-            cr = ref_wcs.world_to_pixel_values((self.zoom_center_x, self.zoom_center_x+abs(self.zoom_radius)),  # noqa
-                                               (self.zoom_center_y, self.zoom_center_y))
+            if ( self.zoom_center_y+abs(self.zoom_radius) < 0):
+                cr = ref_wcs.world_to_pixel_values((self.zoom_center_x, self.zoom_center_x),  # noqa: E501
+                                                   (self.zoom_center_y, self.zoom_center_y+abs(self.zoom_radius)))  # noqa: E501
+            else:
+                cr = ref_wcs.world_to_pixel_values((self.zoom_center_x, self.zoom_center_x),  # noqa: E501
+                                                   (self.zoom_center_y, self.zoom_center_y-abs(self.zoom_radius)))  # noqa: E501
             center_x, center_xr = cr[0]
-            center_y, _ = cr[1]
-            radius = abs(center_xr - center_x)
+            center_y, center_yr = cr[1]
+            radius = ((center_xr - center_x)**2 + (center_yr - center_y)**2)**(1/2)
         else:
             center_x, center_y = self.zoom_center_x, self.zoom_center_y
             radius = abs(self.zoom_radius)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
Previously, when the x/y min/max values were calculated in the `_set_zoom_radius_center` method, the radius used to calculate the values was only correct when the viewer wasn't rotated. This was due to how the `radius` was being calculated in the method. One point was defined at the center (x, y) and another was defined at (x+zoom_radius, y). The radius was the distance between these points along the x axis in pixels.

This had two issues, first when the viewer was rotated, the distance calculation between the x values was not accurately calculated as the outer point moved along the unit circle, such that at a 90 degree rotation, the radius was effectively 0. 
To fix this issue, we used the Pythagorean theorem to calculate the radius between the points, accounting for both the x and y distances. 

**Example:** 
<img width="591" height="271" alt="image" src="https://github.com/user-attachments/assets/67160f09-d6b6-4e47-88ea-f536509535bc" />

The other issue that was uncovered was that the `zoom_center_x` represents a right ascension, and as the viewer gets closer to the poles, calculating the radius by adding the `zoom_radius` to a right ascension value would skew the `zoom_level` applied to the `x/y_min/max` values. To fix this, we instead add to `zoom_center_y` which represents a declination which is a constant scale. The downside here is that declination is between `-90` and `+90`, so we need to ensure we are always subtracting or adding the `zoom_level` depending on which side of `0` the current declination is.


<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
