### PR TITLE
importers to handle mapping SB>flux units for 2D spectrum > 1D

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,8 @@ Specviz2d
 Other Changes and Additions
 ---------------------------
 
+- When importing a 2D spectrum file into a SpectrumList, surface brightness units are automatically converted to flux units. [#3732]
+
 4.3.1 (unreleased)
 ==================
 

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -19,7 +19,7 @@ from jdaviz.core.unit_conversion_utils import (create_equivalent_spectral_axis_u
                                                create_equivalent_flux_units_list,
                                                check_if_unit_is_per_solid_angle,
                                                create_equivalent_angle_units_list,
-                                               supported_sq_angle_units)
+                                               flux_to_sb_unit)
 
 __all__ = ['UnitConversion']
 
@@ -40,16 +40,6 @@ def _valid_glue_display_unit(unit_str, viewer, axis='x'):
         raise ValueError(f"{unit_str} could not find match in valid {axis} display units {choices_str}")  # noqa
     ind = choices_u.index(unit_u)
     return choices_str[ind]
-
-
-def _flux_to_sb_unit(flux_unit, angle_unit):
-    if angle_unit not in supported_sq_angle_units(as_strings=True):
-        sb_unit = flux_unit
-    else:
-        # str > unit > str to remove formatting inconsistencies with
-        # parentheses/order of units/etc
-        sb_unit = (u.Unit(flux_unit) / u.Unit(angle_unit)).to_string()
-    return sb_unit
 
 
 @tray_registry('g-unit-conversion', label="Unit Conversion",
@@ -383,8 +373,8 @@ class UnitConversion(PluginTemplateMixin):
                 # which in turn will call _handle_attribute_display_unit,
                 # _handle_spectral_y_unit (if spectral_y_type_selected == 'Surface Brightness'),
                 #  and send a second GlobalDisplayUnitChanged message for sb
-                self.sb_unit_selected = _flux_to_sb_unit(self.flux_unit.selected,
-                                                         self.angle_unit.selected)
+                self.sb_unit_selected = flux_to_sb_unit(self.flux_unit.selected,
+                                                        self.angle_unit.selected)
 
         elif axis == 'angle':
             if len(self.flux_unit_selected):
@@ -392,8 +382,8 @@ class UnitConversion(PluginTemplateMixin):
                 # which in turn will call _handle_attribute_display_unit,
                 # _handle_spectral_y_unit (if spectral_y_type_selected == 'Surface Brightness'),
                 #  and send a second GlobalDisplayUnitChanged message for sb
-                self.sb_unit_selected = _flux_to_sb_unit(self.flux_unit.selected,
-                                                         self.angle_unit.selected)
+                self.sb_unit_selected = flux_to_sb_unit(self.flux_unit.selected,
+                                                        self.angle_unit.selected)
 
         elif axis == 'sb':
             # handle spectral y-unit first since that is a more apparent change to the user

--- a/jdaviz/core/unit_conversion_utils.py
+++ b/jdaviz/core/unit_conversion_utils.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 import itertools
 
 from astropy import units as u
+from specutils import Spectrum
 import numpy as np
 
 from jdaviz.core.custom_units_and_equivs import (PIX2,
@@ -17,7 +18,8 @@ __all__ = ["all_flux_unit_conversion_equivs", "check_if_unit_is_per_solid_angle"
            "create_equivalent_spectral_axis_units_list",
            "flux_conversion_general", "handle_squared_flux_unit_conversions",
            "supported_sq_angle_units", "spectral_axis_conversion",
-           "units_to_strings"]
+           "units_to_strings", "flux_to_sb_unit", "sb_to_flux_unit",
+           "spectrum_ensure_sb_unit", "spectrum_ensure_flux_unit"]
 
 
 def all_flux_unit_conversion_equivs(pixar_sr=None, cube_wave=None):
@@ -534,3 +536,83 @@ def convert_integrated_sb_unit(u1, spectral_axis_unit, desired_freq_unit, desire
         return u1  # units are compatible, return input
 
     return uu * spec_axis_conversion_scale_factor
+
+
+def flux_to_sb_unit(flux_unit, angle_unit):
+    if angle_unit not in supported_sq_angle_units(as_strings=True):
+        sb_unit = flux_unit
+    else:
+        # str > unit > str to remove formatting inconsistencies with
+        # parentheses/order of units/etc
+        sb_unit = (u.Unit(flux_unit) / u.Unit(angle_unit)).to_string()
+    return sb_unit
+
+
+def sb_to_flux_unit(sb_unit, pixar_sr=1.0):
+    if sb_unit.physical_type == 'flux':
+        return sb_unit
+
+    # Extract the angle/pixel unit from the surface brightness unit
+    angle_unit = check_if_unit_is_per_solid_angle(sb_unit, return_unit=True)
+
+    # Default behavior: extract angle unit or fallback to steradian
+    if angle_unit is None:
+        angle_unit = u.sr
+    return sb_unit * pixar_sr * angle_unit
+
+
+def spectrum_ensure_sb_unit(spectrum, angle_unit):
+    if spectrum.flux.unit.physical_type == 'surface brightness':
+        return spectrum
+
+    sb_unit = u.Unit(flux_to_sb_unit(spectrum.flux.unit, angle_unit))
+
+    # Handle uncertainty conversion based on type
+    if spectrum.uncertainty is not None:
+        if hasattr(spectrum.uncertainty, 'quantity'):
+            # StdDevUncertainty or similar - use quantity for proper unit handling
+            # Preserve the original uncertainty class
+            uncertainty_class = spectrum.uncertainty.__class__
+            new_uncertainty = uncertainty_class(spectrum.uncertainty.quantity.value * sb_unit)
+        else:
+            # Simple array-like uncertainty
+            new_uncertainty = spectrum.uncertainty.value * sb_unit
+    else:
+        new_uncertainty = None
+
+    return Spectrum(
+        spectral_axis=spectrum.spectral_axis,
+        flux=spectrum.flux.value * sb_unit,
+        uncertainty=new_uncertainty,
+        mask=spectrum.mask,
+        meta=spectrum.meta
+    )
+
+
+def spectrum_ensure_flux_unit(spectrum):
+    if spectrum.flux.unit.physical_type == 'flux':
+        return spectrum
+
+    pixar_sr = getattr(spectrum, 'meta', {}).get('PIXAR_SR', 1.0)
+    flux_unit = u.Unit(sb_to_flux_unit(spectrum.flux.unit, pixar_sr))
+
+    # Handle uncertainty conversion based on type
+    if spectrum.uncertainty is not None:
+        if hasattr(spectrum.uncertainty, 'quantity'):
+            # StdDevUncertainty or similar - use quantity for proper unit handling
+            # Preserve the original uncertainty class
+            uncertainty_class = spectrum.uncertainty.__class__
+            new_uncertainty = uncertainty_class(spectrum.uncertainty.quantity.value * flux_unit)
+        else:
+            # Simple array-like uncertainty
+            new_uncertainty = spectrum.uncertainty.value * flux_unit
+    else:
+        new_uncertainty = None
+
+    return Spectrum(
+        spectral_axis=spectrum.spectral_axis,
+        flux=spectrum.flux.value * flux_unit,
+        uncertainty=new_uncertainty,
+        mask=spectrum.mask,
+        meta=spectrum.meta
+    )


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements flux to SB conversion when importing spectra via the new loaders infrastructure BEFORE unit conflicts can occur when attempting to load into viewers.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
