### PR TITLE
Forbid polynomial order < 0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,6 +79,8 @@ Bug Fixes
 
 - Fixed issue in Rampviz where new loader infrastructure was unintentionally exposed. [#3740]
 
+- Restrict polynomial order value of Polynomial1D model component to be >= 0. [#3741]
+
 Cubeviz
 ^^^^^^^
 - Fixed issue with initial model components not using spectral y axis unit. [#3715]

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -226,8 +226,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         if self.config == "cubeviz":
             expose += ['cube_fit']
         expose += ['spectral_subset', 'model_component',
-                   'poly_order', 'poly_order_invalid_msg',
-                   'model_component_label', 'model_components',
+                   'poly_order', 'model_component_label', 'model_components',
                    'valid_model_components', 'create_model_component',
                    'remove_model_component', 'get_model_component',
                    'set_model_component', 'reestimate_model_parameters',

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -64,6 +64,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
     * ``spectral_subset`` (:class:`~jdaviz.core.template_mixin.SubsetSelect`)
     * ``model_component`` (:class:`~jdaviz.core.template_mixin.SelectPluginComponent`)
     * ``poly_order``
+    * ``poly_order_invalid_msg``
     * ``model_component_label`` (:class:`~jdaviz.core.template_mixin.AutoTextField`)
     * :meth:`create_model_component`
     * :meth:`remove_model_component`
@@ -225,7 +226,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         if self.config == "cubeviz":
             expose += ['cube_fit']
         expose += ['spectral_subset', 'model_component',
-                   'poly_order', 'poly_order_invalid_msg'
+                   'poly_order', 'poly_order_invalid_msg',
                    'model_component_label', 'model_components',
                    'valid_model_components', 'create_model_component',
                    'remove_model_component', 'get_model_component',

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -432,6 +432,26 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
     @observe('poly_order')
     def _check_poly_order(self, event={}, model_comp=None, poly_order=None):
+        """
+        Check that the polynomial order is valid if the model component is
+        Polynomial1D.  If not, set the invalid message and return None.
+
+        Parameters
+        ----------
+        event : dict
+            IPyWidget callback event object.
+        model_comp : str
+            Type of model component to check.  If not provided, will default
+            to the object attribute ``model_comp_selected``.
+        poly_order : int
+            Order of the polynomial to check.  If not provided, will default
+            to the object attribute ``poly_order``.
+
+        Returns
+        -------
+        int or None
+            The polynomial order if valid, otherwise None.
+        """
         self.poly_order_invalid_msg = ""
 
         model_comp = model_comp if model_comp is not None else self.model_comp_selected

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -425,6 +425,18 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         self.comp_label_default = self._default_comp_label(self.model_comp_selected,
                                                            self.poly_order)
 
+    @observe('poly_order')
+    def _check_poly_order(self, event={}, model_comp=None, poly_order=None):
+        model_comp = model_comp if model_comp is not None else self.model_comp_selected
+        if model_comp != 'Polynomial1D':
+            return None
+
+        poly_order = poly_order if poly_order is not None else self.poly_order
+        if not isinstance(poly_order, int) or poly_order <= 1:
+            raise ValueError("poly_order must be an integer > 1")
+
+        return poly_order
+
     @observe('comp_label')
     def _comp_label_changed(self, event={}):
         if not len(self.comp_label.strip()):
@@ -494,15 +506,6 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
         return temp_models
 
-    def _check_poly_order(self, poly_order=None):
-        poly_order = poly_order if poly_order is not None else self.poly_order
-
-        if poly_order <= 1 or not isinstance(poly_order, int):
-            raise ValueError("Polynomial order must be an integer > 1")
-
-        return poly_order
-
-
     def create_model_component(self, model_component=None, model_component_label=None,
                                poly_order=None):
         """
@@ -528,7 +531,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         if model_comp != "Polynomial1D" and poly_order is not None:
             raise ValueError("poly_order should only be passed if model_component is Polynomial1D")
 
-        poly_order = self._check_poly_order(poly_order)
+        poly_order = self._check_poly_order(model_comp=model_comp, poly_order=poly_order)
 
         # if model_component was passed and different than the one set in the traitlet, AND
         # model_component_label is not passed, AND the auto is enabled on the label, then

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -64,7 +64,6 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
     * ``spectral_subset`` (:class:`~jdaviz.core.template_mixin.SubsetSelect`)
     * ``model_component`` (:class:`~jdaviz.core.template_mixin.SelectPluginComponent`)
     * ``poly_order``
-    * ``poly_order_invalid_msg``
     * ``model_component_label`` (:class:`~jdaviz.core.template_mixin.AutoTextField`)
     * :meth:`create_model_component`
     * :meth:`remove_model_component`

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -431,14 +431,16 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
     @observe('poly_order')
     def _check_poly_order(self, event={}, model_comp=None, poly_order=None):
+        self.poly_order_invalid_msg = ""
+
         model_comp = model_comp if model_comp is not None else self.model_comp_selected
         if model_comp != 'Polynomial1D':
             return None
 
         poly_order = poly_order if poly_order is not None else self.poly_order
-        self.poly_order_invalid_msg = ""
         if not isinstance(poly_order, int) or poly_order <= 1:
             self.poly_order_invalid_msg = "Order must be an integer > 1"
+            return None
 
         return poly_order
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -494,6 +494,15 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
         return temp_models
 
+    def _check_poly_order(self, poly_order=None):
+        poly_order = poly_order if poly_order is not None else self.poly_order
+
+        if poly_order <= 1 or not isinstance(poly_order, int):
+            raise ValueError("Polynomial order must be an integer > 1")
+
+        return poly_order
+
+
     def create_model_component(self, model_component=None, model_component_label=None,
                                poly_order=None):
         """
@@ -518,7 +527,8 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
         if model_comp != "Polynomial1D" and poly_order is not None:
             raise ValueError("poly_order should only be passed if model_component is Polynomial1D")
-        poly_order = poly_order if poly_order is not None else self.poly_order
+
+        poly_order = self._check_poly_order(poly_order)
 
         # if model_component was passed and different than the one set in the traitlet, AND
         # model_component_label is not passed, AND the auto is enabled on the label, then

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -92,7 +92,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
     # model components:
     model_comp_items = List().tag(sync=True)
     model_comp_selected = Unicode().tag(sync=True)
-    poly_order = IntHandleEmpty(2).tag(sync=True)
+    poly_order = IntHandleEmpty(0).tag(sync=True)
     poly_order_invalid_msg = Unicode().tag(sync=True)
 
     comp_label = Unicode().tag(sync=True)
@@ -438,8 +438,8 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
             return None
 
         poly_order = poly_order if poly_order is not None else self.poly_order
-        if not isinstance(poly_order, int) or poly_order <= 1:
-            self.poly_order_invalid_msg = "Order must be an integer > 1"
+        if not isinstance(poly_order, int) or poly_order < 0:
+            self.poly_order_invalid_msg = "Order must be an integer >= 0"
             return None
 
         return poly_order

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -67,11 +67,7 @@
           v-model.number="poly_order"
           :label="api_hints_enabled ? 'plg.poly_order' : 'Order'"
           :class="api_hints_enabled ? 'api-hint' : null"
-          :rules="[
-            () => poly_order!=='' || 'This field is required',
-            () => Number.isInteger(poly_order) || 'Order must be an integer',
-            () => poly_order > 1 || 'Order must be greater than 1'
-          ]"
+          :error-messages="poly_order_invalid_msg"
           hint="Order of polynomial to fit."
           persistent-hint
         >

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -64,13 +64,13 @@
       <v-row v-if="display_order">
         <v-text-field
           type="number"
-          v-model.number="poly_order"
+          v-model.number="poly_order_input"
           :label="api_hints_enabled ? 'plg.poly_order' : 'Order'"
           :class="api_hints_enabled ? 'api-hint' : null"
           :rules="[
-            () => poly_order!=='' || 'This field is required',
-            () => Number.isInteger(poly_order) || 'Order must be an integer',
-            () => poly_order > 1 || 'Order must be greater than 1'
+            () => poly_order_input!=='' || 'This field is required',
+            () => Number.isInteger(poly_order_input) || 'Order must be an integer',
+            () => poly_order_input > 1 || 'Order must be greater than 1'
           ]"
           hint="Order of polynomial to fit."
           persistent-hint
@@ -384,6 +384,23 @@
       this.sanitizeCompLabel = (v) => {
         // strip non-word character entries
         this.comp_label = v.replace(/[\W]+/g, '');
+      }
+    },
+    data() {
+      return {
+        poly_order_input: this.poly_order,
+      }
+    },
+    watch: {
+      poly_order_input(newVal) {
+        if (
+          newVal !== '' &&
+          Number.isInteger(newVal) &&
+          newVal > 1
+        ) {
+          this.poly_order = newVal;
+        }
+        // If invalid, do not update poly_order
       }
     },
     methods: {

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -64,13 +64,13 @@
       <v-row v-if="display_order">
         <v-text-field
           type="number"
-          v-model.number="poly_order_input"
+          v-model.number="poly_order"
           :label="api_hints_enabled ? 'plg.poly_order' : 'Order'"
           :class="api_hints_enabled ? 'api-hint' : null"
           :rules="[
-            () => poly_order_input!=='' || 'This field is required',
-            () => Number.isInteger(poly_order_input) || 'Order must be an integer',
-            () => poly_order_input > 1 || 'Order must be greater than 1'
+            () => poly_order!=='' || 'This field is required',
+            () => Number.isInteger(poly_order) || 'Order must be an integer',
+            () => poly_order > 1 || 'Order must be greater than 1'
           ]"
           hint="Order of polynomial to fit."
           persistent-hint
@@ -384,23 +384,6 @@
       this.sanitizeCompLabel = (v) => {
         // strip non-word character entries
         this.comp_label = v.replace(/[\W]+/g, '');
-      }
-    },
-    data() {
-      return {
-        poly_order_input: this.poly_order,
-      }
-    },
-    watch: {
-      poly_order_input(newVal) {
-        if (
-          newVal !== '' &&
-          Number.isInteger(newVal) &&
-          newVal > 1
-        ) {
-          this.poly_order = newVal;
-        }
-        // If invalid, do not update poly_order
       }
     },
     methods: {

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.vue
@@ -67,7 +67,11 @@
           v-model.number="poly_order"
           :label="api_hints_enabled ? 'plg.poly_order' : 'Order'"
           :class="api_hints_enabled ? 'api-hint' : null"
-          :rules="[() => poly_order!=='' || 'This field is required']"
+          :rules="[
+            () => poly_order!=='' || 'This field is required',
+            () => Number.isInteger(poly_order) || 'Order must be an integer',
+            () => poly_order > 1 || 'Order must be greater than 1'
+          ]"
           hint="Order of polynomial to fit."
           persistent-hint
         >

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -78,7 +78,7 @@ def test_check_poly_order_function(specviz_helper, spectrum1d):
     assert plugin.poly_order_invalid_msg == ""
     assert result is None
 
-    poly_order_default = 2
+    poly_order_default = 0
     assert plugin.poly_order == poly_order_default  # stays default
 
     plugin.poly_order = poly_order_default
@@ -100,9 +100,9 @@ def test_check_poly_order_function(specviz_helper, spectrum1d):
     # doesn't change actual value of plugin.poly_order
     assert plugin.poly_order == poly_order_default
 
-    for poly_order in [-1, 0, 1, 2.5]:
+    for poly_order in [-2, -1, 2.5]:
         result = plugin._check_poly_order(poly_order=poly_order)
-        assert plugin.poly_order_invalid_msg == "Order must be an integer > 1"
+        assert plugin.poly_order_invalid_msg == "Order must be an integer >= 0"
         assert result is None
 
 
@@ -112,7 +112,7 @@ def test_check_poly_order_observer(specviz_helper, spectrum1d):
     plugin.dataset_selected = '1D Spectrum'
 
     # poly_order default
-    assert plugin.poly_order == 2
+    assert plugin.poly_order == 0
     # No model components added yet
     assert len(plugin.model_components) == 0
 
@@ -129,12 +129,12 @@ def test_check_poly_order_observer(specviz_helper, spectrum1d):
 
     plugin.model_comp_selected = "Polynomial1D"
 
-    vue_err_msg = "Order must be an integer > 1"
+    vue_err_msg = "Order must be an integer >= 0"
     err_msg = f"poly_{vue_err_msg.lower()}"
     with pytest.raises(ValueError, match=err_msg):
         plugin.vue_add_model({})
 
-    for poly_order in range(-1, 1):
+    for poly_order in range(-3, 0):
         plugin.poly_order = poly_order
         assert plugin.poly_order_invalid_msg == vue_err_msg
         with pytest.raises(ValueError, match=err_msg):

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -71,9 +71,11 @@ def test_check_poly_order_function(specviz_helper, spectrum1d):
     assert result is None
 
     result = plugin._check_poly_order(poly_order=-1.5)
+    assert plugin.poly_order_invalid_msg == ""
     assert result is None
 
     result = plugin._check_poly_order(model_comp='fake', poly_order=-1.5)
+    assert plugin.poly_order_invalid_msg == ""
     assert result is None
 
     poly_order_default = 2
@@ -99,8 +101,9 @@ def test_check_poly_order_function(specviz_helper, spectrum1d):
     assert plugin.poly_order == poly_order_default
 
     for poly_order in [-1, 0, 1, 2.5]:
-        plugin._check_poly_order(poly_order=poly_order)
+        result = plugin._check_poly_order(poly_order=poly_order)
         assert plugin.poly_order_invalid_msg == "Order must be an integer > 1"
+        assert result is None
 
 
 def test_check_poly_order_observer(specviz_helper, spectrum1d):

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -1,5 +1,4 @@
 import warnings
-import itertools
 import numpy as np
 import pytest
 from astropy import units as u


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address restricting the value of polynomial order in model fitting to >= 0 to avoid a traceback for negative numbers. 0 and 1 are redundant with constant and linear but for convenience, we (currently) allow those values.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
