### PR TITLE
Fix failing dev test due to specutils

### DIFF
--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -53,7 +53,7 @@ class Spectrum1DViewer(JdavizProfileView):
 
             # If we load, e.g.,  one spectrum in Frequency and one in Wavelength,
             # the viewer state x_att won't match the component of the second spectrum since
-            # they're no longer both the non-specific "World 0"
+            # (as of Specutils 2.X) they're no longer both the non-specific "World 0"
             if str(self.state.x_att) in data.component_ids():
                 data_xunit = data.get_component(str(self.state.x_att)).units
             else:


### PR DESCRIPTION
Dev specutils adds axis names to GWCS generated by creating a `Spectrum` with a `spectral_axis`, which means these spectra loaded into Glue will now have named components rather than the default/generic "World 0". This handles that new case in the Specviz viewer compatible unit check. I don't think this needs a changelog since nothing has been released yet.