### PR TITLE
Fix wildcard bug and update test

### DIFF
--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -297,6 +297,11 @@ def test_select_plugin_component_map_value(imviz_helper, multi_extension_image_h
     assert selection_obj.selected == selection_obj.choices
     choices_before = selection_obj.choices
 
+    # Check set selected directly via ? wildcard
+    selection_obj.selected = '*MASK,?]'
+    assert selection_obj.selected == [selection_obj.choices[1]]
+    choices_before = selection_obj.choices
+
     selection_obj.fake_attribute = 'item1'
     # Check that a different attribute *does not* trigger the wildcard logic
     # i.e. it gets set as-is and doesn't go through `choices`

--- a/jdaviz/tests/test_user_api.py
+++ b/jdaviz/tests/test_user_api.py
@@ -150,7 +150,11 @@ def test_wildcard_match_extension(imviz_helper, multi_extension_image_hdu_wcs):
         (('*', '*:*'), (0, 1, 2, 3)),
         ('1:*', (0,)),
         ('*S*', (0, 1)),
-        (('*ERR*', '*DQ*'), (2, 3))])
+        (('*ERR*', '*DQ*'), (2, 3)),
+        # Brackets should be sanitized, if not this will fail
+        ('?: [SCI,1]', (0,)),
+        ('?:*', (0, 1, 2, 3)),
+    ])
 def test_wildcard_match_through_load(imviz_helper, multi_extension_image_hdu_wcs,
                                      selection, matches):
     data_labels = ['Image[SCI,1]',

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -158,9 +158,9 @@ def test_wildcard_match_basic(deconfigged_helper, premade_spectrum_list):
         # Test repeats
         ('*', '*:*'): test_obj.choices,
         # Test single selection
-        '1D Spectrum at index:*': test_obj.choices[:2],
+        '1D Spectrum at index: ?': test_obj.choices[:2],
         # Test multi-wildcard
-        '*Exposure*': test_obj.choices[2:],
+        '*Expo[sure]*': test_obj.choices[2:],
         # Test multi-selection
         ('*at index: 1', 'Exposure 0*'): test_obj.choices[1:-1]}
 

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -4,7 +4,8 @@ import warnings
 import pytest
 
 from jdaviz.utils import (alpha_index, download_uri_to_path,
-                          get_cloud_fits, cached_uri, wildcard_match)
+                          get_cloud_fits, cached_uri, escape_brackets,
+                          has_wildcard, wildcard_match)
 from astropy.io import fits
 
 from jdaviz.conftest import FakeSpectrumListImporter
@@ -94,6 +95,27 @@ def test_get_cloud_fits_ext():
 class FakeObject:
     def __init__(self):
         pass
+
+
+def test_escape_brackets():
+    # Test that wildcard_match escapes brackets properly
+    assert escape_brackets("") == ""
+    assert escape_brackets("no brackets") == "no brackets"
+    assert escape_brackets("some [brackets]") == "some [[]brackets[]]"
+    assert escape_brackets("s[o]me [br]a[]ckets]") == "s[[]o[]]me [[]br[]]a[[][]]ckets[]]"
+
+
+def test_has_wildcard():
+    assert has_wildcard("") is False
+    assert has_wildcard("no wildcards") is False
+    assert has_wildcard("some * wildcard") is True
+    assert has_wildcard("some ? wildcard") is True
+    # Don't check for brackets anymore, just * and ?
+    assert has_wildcard("some [brackets] wildcard") is False
+    assert has_wildcard("some [brackets] and * wildcard") is True
+    assert has_wildcard("some [brackets] and ? wildcard") is True
+    assert has_wildcard("*") is True
+    assert has_wildcard("?") is True
 
 
 def test_wildcard_match_basic(deconfigged_helper, premade_spectrum_list):

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -160,7 +160,7 @@ def test_wildcard_match_basic(deconfigged_helper, premade_spectrum_list):
         # Test single selection
         '1D Spectrum at index: ?': test_obj.choices[:2],
         # Test multi-wildcard
-        '*Expo[sure]*': test_obj.choices[2:],
+        '*Exposure*': test_obj.choices[2:],
         # Test multi-selection
         ('*at index: 1', 'Exposure 0*'): test_obj.choices[1:-1]}
 

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -900,7 +900,7 @@ def wildcard_match(obj, value, choices=None):
     def wildcard_match_list_of_str(internal_choices, internal_value):
         matched = []
         for v in internal_value:
-            if isinstance(v, str) and any(has_wildcard(v) for v in value if isinstance(v, str)):
+            if isinstance(v, str) and any(has_wildcard(v) for v in value):
                 # Check for wildcard matches
                 matched.extend(wildcard_match_str(internal_choices, v))
             else:

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -856,9 +856,14 @@ def get_reference_image_data(app, viewer_id=None):
     return None, -1
 
 
+def escape_brackets(s):
+    # Replace [ with [[] and ] with []]
+    return re.sub(r'([\[\]])', r'[\1]', s)
+
+
 def has_wildcard(s):
-    """Check if the string contains any shell-style wildcards: *, ?, [seq], [!seq], [^seq]."""
-    return bool(re.search(r'[\*\?]|\[[!^]?[^\]]+\]', s))
+    """Check if the string contains any shell-style wildcards: * or ?."""
+    return bool(re.search(r'[\*\?]', s))
 
 
 def wildcard_match(obj, value, choices=None):
@@ -869,9 +874,9 @@ def wildcard_match(obj, value, choices=None):
     in ``value``. If no matches are found, returns a list containing ``value`` itself.
 
     .. note::
-       ``fnmatch`` provides support for all Unix style wildcards including ``*``, ``?``,
-       ``[seq]``, and ``[!seq]``. If you want to exclude those and only allow ``*``,
-       you must sanitize ``value`` yourself.
+       ``fnmatch`` provides support for all Unix style wildcards including ``*``, ``?``.
+       We do not check for '[seq]`` and '[!seq]' because image extensions as we handle them
+       contain brackets.
 
     Parameters
     ----------
@@ -892,6 +897,8 @@ def wildcard_match(obj, value, choices=None):
         A list of matched strings or ``value``/``[value]`` if no matches found.
     """
     def wildcard_match_str(internal_choices, internal_value):
+        # Assume we want to escape brackets as in the case of images with
+        # multiple extensions
         matched = fnmatch.filter(internal_choices, internal_value)
         if len(matched) == 0:
             matched = [internal_value]

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -899,6 +899,7 @@ def wildcard_match(obj, value, choices=None):
     def wildcard_match_str(internal_choices, internal_value):
         # Assume we want to escape brackets as in the case of images with
         # multiple extensions
+        internal_value = escape_brackets(internal_value)
         matched = fnmatch.filter(internal_choices, internal_value)
         if len(matched) == 0:
             matched = [internal_value]


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address a bug in wildcard matching in which '?' and other wildcards weren't checked for
and therefore errored out. I have since realized an issue without our implementation which is that brackets are
used as UNIX wildcards but we also use brackets to denote image extension. I have therefore removed the ability
for our code to check for brackets, escaping any brackets on the premise that they're meant for image extensions. 

I have also added some tests and updated the old tests to be a bit more comprehensive. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
