### PR TITLE
User API tweaks for viewer select create new

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ New Features
 - Enable unix style wildcard matching for searches in UI dropdown menus and
   API objects that support multiselect. [#3744, #3752]
 
-- Loaders now allow selecting which viewer(s) to show the data or whether to create a new viewer. [#3739]
+- Loaders now allow selecting which viewer(s) to show the data or whether to create a new viewer. [#3739, #3766]
 
 - Ability to change the logger levels and clear the logger history from the UI. [#3745]
 

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -207,6 +207,13 @@ class BaseImporterToDataCollection(BaseImporter):
             viewer_select.create_new.selected = ''
             viewer_select.selected = [viewer_label]
 
+        elif len(viewer_select.selected) == 0:
+            # just send a snackbar as feedback
+            if len(self.app._jdaviz_helper.viewers):
+                msg = f"{data_label} loaded without any viewers selected - add manually from viewer data-menu"  # noqa
+            else:
+                msg = f"{data_label} loaded but no viewers were created.  Create viewers manually and add data from data-menu"  # noqa
+            self.app.hub.broadcast(SnackbarMessage(msg, sender=self, color='warning'))
         else:
             failed_viewers = []
             for viewer_label in viewer_select.selected:

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3918,9 +3918,11 @@ class ViewerSelectCreateNew(ViewerSelect):
         if self.create_new.selected == '':
             return
         self.new_label.default = self.create_new.selected_item.get('label')
+        # may also affect new_label.invalid_msg
+        self._on_viewer_label_changed()
 
     def _on_viewer_label_changed(self, msg={}):
-        if not len(self.new_label.value.strip()):
+        if not len(self.new_label.value.strip()) and self.create_new.selected != '':
             self.new_label.invalid_msg = 'new_label must be provided'
             return
 

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -67,7 +67,17 @@ class UserApiWrapper:
                                                 SelectFileExtensionComponent,
                                                 PlotOptionsSyncState,
                                                 AddResults,
-                                                AutoTextField)
+                                                AutoTextField,
+                                                ViewerSelectCreateNew)
+        if isinstance(exp_obj, ViewerSelectCreateNew):
+            if value in exp_obj.choices + ['', []]:
+                exp_obj.create_new.selected = ''
+                exp_obj.selected = value
+                return
+            elif len(exp_obj.create_new.choices) > 0:
+                exp_obj.create_new.selected = exp_obj.create_new.choices[0]
+                exp_obj.new_label.value = value
+                return
 
         if isinstance(exp_obj, SelectPluginComponent):
             # this allows setting the selection directly without needing to access the underlying

--- a/jdaviz/tests/test_user_api.py
+++ b/jdaviz/tests/test_user_api.py
@@ -144,6 +144,34 @@ def test_wildcard_match_extension(imviz_helper, multi_extension_image_hdu_wcs):
     assert selection_obj.multiselect is True
 
 
+def test_viewer_create_new(deconfigged_helper, spectrum1d):
+    assert len(deconfigged_helper.new_viewers.keys()) == 0
+    # passing [] should not load into a new viewer nor should it create a new viewer
+    deconfigged_helper.load(spectrum1d, format='1D Spectrum', viewer=[], data_label='data1')
+    assert len(deconfigged_helper.app.data_collection) == 1
+    assert len(deconfigged_helper.viewers) == 0
+    assert len(deconfigged_helper.new_viewers.keys()) > 0
+
+    # passing nothing when there are no viewers should create a new viewer
+    deconfigged_helper.load(spectrum1d, format='1D Spectrum', data_label='data2')
+    assert len(deconfigged_helper.app.data_collection) == 2
+    assert len(deconfigged_helper.viewers) == 1
+    assert len(deconfigged_helper.viewers['1D Spectrum'].data_menu.layer.choices) == 1
+
+    # passing nothing when there is a viewer should default to loading into that viewer
+    deconfigged_helper.load(spectrum1d, format='1D Spectrum', data_label='data3')
+    assert len(deconfigged_helper.app.data_collection) == 3
+    assert len(deconfigged_helper.viewers) == 1
+    assert len(deconfigged_helper.viewers['1D Spectrum'].data_menu.layer.choices) == 2
+
+    # passing a string of a viewer that does not exist should create a viewer with that label
+    deconfigged_helper.load(spectrum1d, format='1D Spectrum', viewer='user-defined-viewer', data_label='data4')  # noqa
+    assert len(deconfigged_helper.app.data_collection) == 4
+    assert len(deconfigged_helper.viewers) == 2
+    assert len(deconfigged_helper.viewers['1D Spectrum'].data_menu.layer.choices) == 2
+    assert len(deconfigged_helper.viewers['user-defined-viewer'].data_menu.layer.choices) == 1
+
+
 @pytest.mark.parametrize(
     ("selection", "matches"), [
         ('*', (0, 1, 2, 3)),


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request adds user API convenience setting to the `ViewerSelectCreateNew` component introduced in #3739 (not yet released).  The main motivation for this is to allow access via the kwarg from `.load()`, for example: `jd.load(..., viewer=[])` to be equivalent to the previous `show_in_viewer=False` but also `jd.load(..., viewer='my-new-viewer')` to create a new viewer.  See added test coverage for details.

This also fixes the case where the import button was disabled when a viewer already existed as it was considering the empty `new_label` as invalid even if `create_new` was off.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
