### PR TITLE
Write coverage for 2 2d spectral extractions in deconfigged

### DIFF
--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -324,3 +324,64 @@ def test_spectral_extraction_flux_unit_conversions(specviz2d_helper, mos_spectru
 
         exported_extract = pext.export_extract()
         assert exported_extract.image._unit == specviz2d_helper.app._get_display_unit('flux')
+
+
+@pytest.mark.parametrize('method', ['load', 'loader_infrastructure'])
+def test_spectral_extraction_two_spectra_deconfigged(method,
+        deconfigged_helper, spectrum2d, mos_spectrum2d):
+    sp_ext_plugin = config.plugins['2D Spectral Extraction']
+    sp_ext_plugin.trace_dataset = spectrum_2
+
+    sp_ext_plugin.bg_dataset = spectrum_2
+    # sp_ext_plugin.bg_trace = 'From Plugin'
+
+    sp_ext_plugin.ext_dataset = spectrum_2
+    sp_ext_plugin.ext_trace = 'From Plugin'
+
+    sp_ext_2 = sp_ext_plugin.export_extract_spectrum()
+    if method == 'load':
+        spec2d_label = '2D Spectrum'
+        deconfigged_helper.load(spectrum2d, format='2D Spectrum', label=spec2d_label)
+        assert spec2d_label in deconfigged_helper.data_collection.labels
+
+        mos_spec2d_label = 'Mos 2D Spectrum'
+        deconfigged_helper.load(mos_spectrum2d, format='2D Spectrum', label=mos_spec2d_label)
+        assert mos_spec2d_label in deconfigged_helper.data_collection.labels
+    elif method == 'loader_infrastructure':
+        ldr = deconfigged_helper.loaders['object']
+        ldr.object = mos_spectrum2d
+        ldr.format = '2D Spectrum'
+        ldr.importer.auto_extract = True
+        ldr.importer()
+
+        # Swapping these causes a different issue
+        ldr.object = spectrum2d
+        ldr.format = '2D Spectrum'
+        ldr.importer.auto_extract = True
+        ldr.importer()
+
+    # Test that Nans are linked correctly
+    # and match to markers is worked correctly
+
+    # sp_ext = deconfigged_helper.plugins['2D Spectral Extraction']
+    # print('first selection', sp_ext.bg_dataset.selected)
+    # extracted_spectrum1 = sp_ext.export_extract_spectrum()
+    # print('first spectrum', sp_ext.ext_dataset.get_selected_spectrum())
+
+    # Test that 2nd spectra can be loaded in and that the spectral extraction runs
+    # by virtue of auto_extract = True
+
+    # sp_ext = deconfigged_helper.plugins['2D Spectral Extraction']
+    print('first', deconfigged_helper.get_data('2D Spectrum (auto-ext)'))
+    print()
+    print('second', deconfigged_helper.get_data('2D Spectrum (1) (auto-ext)'))
+    # print('third?', deconfigged_helper.get_data('2D Spectrum (2) (auto-ext)'))
+
+    # print('second selection', sp_ext.bg_dataset.selected)
+    #sp_ext.dataset = mos_spectrum2d
+    #extracted_spectrum2 = sp_ext.export_extract_spectrum()
+    #print('second spectrum', sp_ext.ext_dataset.get_selected_spectrum())
+
+    # print(extracted_spectrum1, extracted_spectrum2)
+    # print(extracted_spectrum2)
+    # assert not np.array_equal(extracted_spectrum1.flux, extracted_spectrum2.flux)

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -333,7 +333,7 @@ def test_spectral_extraction_flux_unit_conversions(specviz2d_helper, mos_spectru
 
 
 @pytest.mark.xfail
-@pytest.mark.parametrize('method', ['load']) #, 'loader_infrastructure'])
+@pytest.mark.parametrize('method', ['load', 'loader_infrastructure'])
 def test_spectral_extraction_two_spectra_deconfigged(method, deconfigged_helper,
                                                      spectrum2d, mos_spectrum2d):
     # One resembling the default
@@ -464,19 +464,23 @@ def test_spectral_extraction_two_spectra_deconfigged(method, deconfigged_helper,
 
     # Now trying through the viewer ROI
     roi = XRangeROI(0, 2)
-    viewer_2d.toolbar.tools['bqplot:xrange'].activate()
-    viewer_2d.toolbar.tools['bqplot:xrange'].update_from_roi(roi)
-    viewer_2d.toolbar.tools['bqplot:xrange'].update_selection()
+    viewer_2d.toolbar.active_tool = viewer_2d.toolbar.tools['bqplot:xrange']
+    viewer_2d.toolbar.active_tool.activate()
+    viewer_2d.toolbar.active_tool.update_from_roi(roi)
+    viewer_2d.toolbar.active_tool.update_selection()
 
     # Check that the subset appears in both viewers
     subset_label = 'Subset 2'
     assert any(subset_label in str(layer) for layer in viewer_1d.layers)
     assert any(subset_label in str(layer) for layer in viewer_2d.layers)
 
+    # Not 100% sure why there is a difference of 1 in the number of marks
+    # but leaving this here for posterity.
+    assert len(viewer_2d.native_marks) == 7
+    assert len(viewer_2d.native_marks) == 6
+
     # Checking that panning one viewer pans the other
     viewer_2d.toolbar.active_tool = viewer_2d.toolbar.tools['jdaviz:panzoom_matchx']
-    assert len(viewer_2d.native_marks) == 5
-    assert len(viewer_1d.data()) == 4
 
     # Check before
     assert_allclose(viewer_1d.get_limits(), (x_min, x_max, y_min_1d, y_max_1d))

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -451,8 +451,8 @@ def test_spectral_extraction_two_spectra_deconfigged(method, deconfigged_helper,
 
     # now create a subset in the spectrum-viewer, and determine if
     # subset is linked correctly in spectrum2d-viewer
-    x_min_reg = 1
-    x_max_reg = 2
+    x_min_reg = x_min_2d + midway
+    x_max_reg = x_max_2d - midway
     spec_reg = SpectralRegion(x_min_reg * u.um, x_max_reg * u.um)
     st = deconfigged_helper.plugins['Subset Tools']
     st.import_region(spec_reg, edit_subset=subset_label)
@@ -471,7 +471,7 @@ def test_spectral_extraction_two_spectra_deconfigged(method, deconfigged_helper,
         assert_allclose(min_value_subset, x_min_reg, atol=atol)
         assert_allclose(max_value_subset, x_max_reg, atol=atol)
     except ValueError:
-        check.is_true(False, msg='Subset in 2D viewer has no non-zero values')
+        check.is_true(False, msg='Subset in mask calculation failed (no non-zero values).')
     except AssertionError:
         check.is_true(False, msg=f'Subset in 2D viewer has incorrect x range\n'
                                  f'Expected approx: {x_min_reg}, {x_max_reg}\n'

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -492,8 +492,8 @@ def test_spectral_extraction_two_spectra_deconfigged(method, deconfigged_helper,
     # Not 100% sure why there is a difference of 1 in the number of marks
     # but leaving this here for posterity.
     assert len(viewer_2d.native_marks) == 7
-    # assert len(viewer_1d.native_marks) == 3 or 6
-    check.is_true(len(viewer_1d.native_marks) == 3, msg='unexpected number of marks in 1D viewer')
+    check.is_true(len(viewer_1d.native_marks) == 6,
+                  msg='unexpected number of marks in 1D viewer (due to missing extracted spectra)')
 
     # Checking that panning one viewer pans the other
     viewer_2d.toolbar.active_tool = viewer_2d.toolbar.tools['jdaviz:panzoom_matchx']

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -329,16 +329,7 @@ def test_spectral_extraction_flux_unit_conversions(specviz2d_helper, mos_spectru
 @pytest.mark.parametrize('method', ['load', 'loader_infrastructure'])
 def test_spectral_extraction_two_spectra_deconfigged(method,
         deconfigged_helper, spectrum2d, mos_spectrum2d):
-    sp_ext_plugin = config.plugins['2D Spectral Extraction']
-    sp_ext_plugin.trace_dataset = spectrum_2
 
-    sp_ext_plugin.bg_dataset = spectrum_2
-    # sp_ext_plugin.bg_trace = 'From Plugin'
-
-    sp_ext_plugin.ext_dataset = spectrum_2
-    sp_ext_plugin.ext_trace = 'From Plugin'
-
-    sp_ext_2 = sp_ext_plugin.export_extract_spectrum()
     if method == 'load':
         spec2d_label = '2D Spectrum'
         deconfigged_helper.load(spectrum2d, format='2D Spectrum', label=spec2d_label)

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -477,7 +477,7 @@ def test_spectral_extraction_two_spectra_deconfigged(method, deconfigged_helper,
     # Not 100% sure why there is a difference of 1 in the number of marks
     # but leaving this here for posterity.
     assert len(viewer_2d.native_marks) == 7
-    assert len(viewer_2d.native_marks) == 6
+    assert len(viewer_1d.native_marks) == 6
 
     # Checking that panning one viewer pans the other
     viewer_2d.toolbar.active_tool = viewer_2d.toolbar.tools['jdaviz:panzoom_matchx']


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address missing coverage for (automatically) generating two 2d spectral extractions using deconfigged. As part of an investigate ticket, these tests are used to identify bugs in deconfigged with loading 2d spectra.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
