### PR TITLE
Spectrum list default to using first source

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ Specviz
 
 - Added support for WFSS Level 3 data. [#3729]
 
+- Spectrum lists default to selecting the first available source. [#3771]
+
 Specviz2d
 ^^^^^^^^^
 

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -2,7 +2,6 @@ from zipfile import ZipFile
 
 import numpy as np
 import pytest
-import re
 from astropy import units as u
 from astropy.io import fits
 from astropy.tests.helper import assert_quantity_allclose

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -62,12 +62,6 @@ class TestSpecvizHelper:
          {'sources': [f"1D Spectrum at index: {i}" for i in (0, 1, 2)]},
          {'sources': '*'}))
     def test_load_spectrum_list_with_kwargs(self, kwargs):
-        error_msg = "No sources selected."
-        with pytest.raises(
-                ValueError,
-                match=re.escape(error_msg)):
-            self.spec_app.load_data(self.spec_list)
-
         # When loading via the ``data_label`` argument, the length of the
         # list must match the number of sources in the SpectrumList.
         self.spec_app.load_data(self.spec_list, **kwargs)

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -213,9 +213,7 @@ class ConfigHelper(HubListener):
             kwargs['viewer'] = '*' if kwargs.pop('show_in_viewer') else []
 
         importer = resolver.importer
-        for k, v in kwargs.items():
-            if hasattr(importer, k) and v is not None:
-                setattr(importer, k, v)
+        importer._obj._apply_kwargs(kwargs)
         return importer()
 
     @property

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -54,6 +54,16 @@ class BaseImporter(PluginTemplateMixin):
     def __repr__(self):
         return f"<{self.__class__.__name__}>"
 
+    def _apply_kwargs(self, kwargs):
+        user_api = self.user_api
+        applied_kwargs = []
+        for k, v in kwargs.items():
+            if hasattr(user_api, k) and v is not None:
+                setattr(user_api, k, v)
+                applied_kwargs.append(k)
+
+        return applied_kwargs
+
     @property
     def is_valid(self):
         # override by subclass

--- a/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
+++ b/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
@@ -43,7 +43,6 @@ class SpectrumListImporter(BaseImporterToDataCollection):
             self.data_label_default = '1D Spectrum'
 
         sources_options = []
-        self._sources_selected_default = True
 
         if isinstance(self.input, Spectrum):
             speclist_input = SpectrumList(self.input_to_list_of_spec(self.input))
@@ -84,8 +83,6 @@ class SpectrumListImporter(BaseImporterToDataCollection):
                                                     manual_options=sources_options)
 
         self.sources.selected = [self.sources.choices[0]]
-        # Make sure it's still set to true
-        self._sources_selected_default = True
         self._sources_items_helper = deepcopy(self.sources.items)
 
         # TODO: This observer will likely be removed in follow-up effort

--- a/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
+++ b/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
@@ -118,10 +118,13 @@ class SpectrumListImporter(BaseImporterToDataCollection):
         # Check to see if the user has changed the selection from the default
         # If so, we set this flag to False so that the snackbar message
         # in __call__() is not triggered.
-        if (self._sources_selected_default and
-                change.get('name') == 'sources_selected' and
-                change.get('new') != self.sources.choices[0]):
-            self._sources_selected_default = False
+        if self._sources_selected_default and change.get('name') == 'sources_selected':
+            # Normalize the new value to a list so we can compare consistently
+            # whether the change provides a single value or a list of values.
+            new = change.get('new')
+            new_list = new if isinstance(new, (list, tuple)) else [new]
+            if new_list != [self.sources.choices[0]]:
+                self._sources_selected_default = False
 
         if len(self.sources_selected) == 0:
             self.import_disabled = True

--- a/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
+++ b/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
@@ -241,8 +241,7 @@ class SpectrumListImporter(BaseImporterToDataCollection):
             msg_str = (f"The default source selection ({self.sources.selected}) will be used.\n"
                        f"To load additional sources, please specify them via dropdown or "
                        f"as follows:\n'{self.config}.load(filename, sources = [...]).")
-            msg = SnackbarMessage(msg_str,
-                color='warning', sender=self, timeout=10000)
+            msg = SnackbarMessage(msg_str, color='warning', sender=self, timeout=10000)
             self.app.hub.broadcast(msg)
             warnings.warn(msg_str)
 

--- a/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
+++ b/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
@@ -80,7 +80,7 @@ class SpectrumListImporter(BaseImporterToDataCollection):
                                                     multiselect='sources_multiselect',
                                                     manual_options=sources_options)
 
-        self.sources.selected = []
+        self.sources.selected = [self.sources.choices[0]]
         self._sources_items_helper = deepcopy(self.sources.items)
 
         # TODO: This observer will likely be removed in follow-up effort

--- a/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
+++ b/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
@@ -93,6 +93,17 @@ class SpectrumListImporter(BaseImporterToDataCollection):
         # only enable the import button if at least one spectrum is selected.
         self.resolver.observe(self._on_format_selected_change, names='format_selected')
 
+    def _apply_kwargs(self, kwargs):
+        applied_kwargs = super()._apply_kwargs(kwargs)
+        if 'sources' not in applied_kwargs:
+            msg_str = (f"The default source selection ({self.sources.selected}) will be used.\n"
+                       f"To load additional sources, please specify them via dropdown or "
+                       f"as follows:\n'{self.config}.load(filename, sources = [...]).")
+            msg = SnackbarMessage(msg_str, color='warning', sender=self, timeout=10000)
+            self.app.hub.broadcast(msg)
+            warnings.warn(msg_str)
+        return applied_kwargs
+
     @staticmethod
     def _get_supported_viewers():
         return [{'label': '1D Spectrum', 'reference': 'spectrum-1d-viewer'}]

--- a/jdaviz/core/loaders/importers/spectrum_list/test_spectrum_list.py
+++ b/jdaviz/core/loaders/importers/spectrum_list/test_spectrum_list.py
@@ -478,9 +478,10 @@ class TestSpectrumListConcatenatedImporter:
         spec = self.setup_combined_spectrum(with_uncertainty)
 
         importer_obj = self.setup_importer_obj(deconfigged_helper, SpectrumList([spec]))
-        importer_obj.sources.select_all()
+        with pytest.warns(UserWarning):
+            # Catch the warning about default selection
+            result = importer_obj.output
 
-        result = importer_obj.output
         assert np.all(result.flux == spec.flux)
         assert np.all(result.spectral_axis == spec.spectral_axis)
         if with_uncertainty:
@@ -527,8 +528,9 @@ class TestSpectrumListConcatenatedImporter:
         spec = self.setup_combined_spectrum(with_uncertainty=True)
 
         importer_obj = self.setup_importer_obj(deconfigged_helper, SpectrumList([spec]))
-        importer_obj.sources.select_all()
-        importer_obj.__call__()
+        with pytest.warns(UserWarning):
+            # Catch the warning about default selection
+            importer_obj.__call__()
 
         dc = deconfigged_helper.app.data_collection
         assert len(dc) == 1  # 1 concatenated spectrum loaded

--- a/jdaviz/core/loaders/importers/spectrum_list/test_spectrum_list.py
+++ b/jdaviz/core/loaders/importers/spectrum_list/test_spectrum_list.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import re
+from unittest.mock import patch
 
 from astropy import units as u
 from astropy.nddata import StdDevUncertainty
@@ -59,7 +60,7 @@ class TestSpectrumListImporter:
         assert hasattr(importer_obj, 'sources')
 
         assert importer_obj.sources.selected == [importer_obj.sources.choices[0]]
-
+        assert importer_obj._sources_selected_default is True
         assert importer_obj._sources_items_helper == importer_obj.sources.items
 
     # Parameterize to test both single and multiple selection
@@ -140,10 +141,17 @@ class TestSpectrumListImporter:
     def test_on_sources_selected(self, deconfigged_helper, premade_spectrum_list):
         importer_obj = self.setup_importer_obj(deconfigged_helper, premade_spectrum_list)
         # Baseline, default first source selected
-        assert importer_obj.import_disabled is False
         assert importer_obj.sources.selected == [importer_obj.sources.choices[0]]
+        assert importer_obj._sources_selected_default is True
+        assert importer_obj.import_disabled is False
+
+        # Selecting the same thing shouldn't turn off the default flag
+        importer_obj.sources.selected = [importer_obj.sources.choices[0]]
+        assert importer_obj._sources_selected_default is True
+        assert importer_obj.import_disabled is False
 
         importer_obj.sources.selected = []
+        assert importer_obj._sources_selected_default is False
         assert importer_obj.import_disabled is True
 
     def test_on_format_selected(self, deconfigged_helper, premade_spectrum_list):
@@ -152,12 +160,15 @@ class TestSpectrumListImporter:
         # Baseline, default first source selected
         assert importer_obj.import_disabled is False
         assert importer_obj.sources.selected == [importer_obj.sources.choices[0]]
+        assert importer_obj._sources_selected_default is True
         importer_obj._on_format_selected_change(change={'new': '1D Spectrum List'})
         # No change
         assert importer_obj.import_disabled is False
+        assert importer_obj._sources_selected_default is True
 
         # Set new selection to empty to ensure it doesn't change on format change
         importer_obj.sources.selected = []
+        assert importer_obj._sources_selected_default is False
         importer_obj._on_format_selected_change(change={'new': '1D Spectrum List'})
         # No selection
         assert importer_obj.import_disabled is True
@@ -300,6 +311,29 @@ class TestSpectrumListImporter:
         assert np.all(result.uncertainty.array == spec.uncertainty[~mask].array)
         assert np.all(result.mask == mask[~mask])
 
+    def test_check_sources_selected_default(self, deconfigged_helper, premade_spectrum_list):
+        importer_obj = self.setup_importer_obj(deconfigged_helper, premade_spectrum_list)
+
+        warning_msg = (
+            f"The default source selection ({importer_obj.sources.selected}) will be used.\n"
+            f"To load additional sources, please specify them via dropdown or "
+            f"as follows:\n'{importer_obj.config}.load(filename, sources = [...]).")
+
+        # Mock the broadcast method to catch the snackbar messages
+        with patch.object(deconfigged_helper.app.hub, 'broadcast') as mock_broadcast:
+            with pytest.warns(UserWarning, match=re.escape(warning_msg)):
+                importer_obj._check_sources_selected_default()
+
+            broadcast_msgs = [arg[0][0].text for arg in mock_broadcast.call_args_list
+                              if hasattr(arg[0][0], 'text')]
+            assert warning_msg in broadcast_msgs
+
+        importer_obj._sources_selected_default = False
+        # No warning this time
+        with patch.object(deconfigged_helper.app.hub, 'broadcast') as mock_broadcast:
+            importer_obj._check_sources_selected_default()
+            assert mock_broadcast.call_count == 0
+
     def test_output(self, deconfigged_helper, premade_spectrum_list, spectrum1d):
         importer_obj = self.setup_importer_obj(deconfigged_helper, premade_spectrum_list)
         # Must make a selection for output to work
@@ -315,12 +349,11 @@ class TestSpectrumListImporter:
         assert importer_obj.output is None
 
     @pytest.mark.parametrize('selection', [[],
+                                           '1D Spectrum at index: *',
                                            ['1D Spectrum at index: 0',
                                             '1D Spectrum at index: 1',
                                             'Exposure 0, Source ID: 1111',
                                             'Exposure 1, Source ID: 1111']])
-    # TODO: Uncomment when generalized wild card matching is implemented:
-    #  '1D Spectrum at index: *']) # noqa
     def test_call_method_basic(self, deconfigged_helper, premade_spectrum_list, selection):
         importer_obj = self.setup_importer_obj(deconfigged_helper, premade_spectrum_list)
         sources_data_labels = self.sources_data_labels
@@ -459,6 +492,28 @@ class TestSpectrumListConcatenatedImporter:
         importer_obj = self.setup_importer_obj(deconfigged_helper, SpectrumList([spec]))
         importer_obj.sources.selected = []
         assert len(importer_obj.output) == 0
+
+    def test_spectrum_list_concatenated_importer_output_default(self, deconfigged_helper):
+        spec = self.setup_combined_spectrum(with_uncertainty=True)
+
+        importer_obj = self.setup_importer_obj(deconfigged_helper, SpectrumList([spec]))
+        warning_msg = (
+            f"The default source selection ({importer_obj.sources.selected}) will be used.\n"
+            f"To load additional sources, please specify them via dropdown or "
+            f"as follows:\n'{importer_obj.config}.load(filename, sources = [...]).")
+
+        # Mock the broadcast method to catch the snackbar messages
+        with patch.object(deconfigged_helper.app.hub, 'broadcast') as mock_broadcast:
+            with pytest.warns(UserWarning, match=re.escape(warning_msg)):
+                result = importer_obj.output
+
+            broadcast_msgs = [arg[0][0].text for arg in mock_broadcast.call_args_list
+                              if hasattr(arg[0][0], 'text')]
+            assert warning_msg in broadcast_msgs
+
+        assert np.all(result.flux == spec.flux)
+        assert np.all(result.spectral_axis == spec.spectral_axis)
+        assert np.all(result.uncertainty.array == spec.uncertainty.array)
 
     def test_spectrum_list_concatenated_importer_output_2d(self, deconfigged_helper, spectrum2d):
         importer_obj = self.setup_importer_obj(deconfigged_helper, spectrum2d)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1328,7 +1328,7 @@ class SelectPluginComponent(BasePluginComponent, HasTraits):
         self._clear_cache()
         if self.is_multiselect:
             self.selected = [self.selected] if self.selected != '' else []
-        elif isinstance(self.selected, list) and len(self.selected):
+        elif isinstance(self.selected, list) and len(self.selected) > 1:
             self.selected = self.selected[0]
         else:
             self._apply_default_selection()

--- a/jdaviz/tests/test_user_api.py
+++ b/jdaviz/tests/test_user_api.py
@@ -67,8 +67,10 @@ def test_wildcard_match_sources(specviz_helper, premade_spectrum_list):
     ldr = specviz_helper.loaders['object']
     ldr.object = premade_spectrum_list
     selection_obj = ldr.importer.sources
-    assert selection_obj.selected == []
+    assert selection_obj.selected == [default_choices[0]]
     assert selection_obj.choices == default_choices
+    # Resetting to empty
+    selection_obj.selected = []
 
     err_str1 = "not all items in"
     err_str2 = f"are one of {selection_obj.choices}, reverting selection to []"

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -152,7 +152,7 @@ def test_wildcard_match_basic(deconfigged_helper, premade_spectrum_list):
         ('some*', 'good*'): default_choices[:-1]}
 
     for selection, expected in test_selections.items():
-        # Reset
+        # Set and reset
         test_obj.multiselect = False
         match_result = wildcard_match(test_obj, selection)
         assert test_obj.multiselect is True


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

Previously, the spectrum list loader would default to using no selection to allow the user to 
choose the sources they wished to import. This led to scenarios where the viewer would be blank
and this was deemed confusing. We now default to loading in the first source and notify the user
via snackbar *and* warning (just in case they don't have the viewer open) that we will be doing so
and advise on how to load more. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
