### PR TITLE
updates to release docs

### DIFF
--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -284,7 +284,7 @@ instances of ``vX.Y.x`` with ``v3.5.x``.
    backport PRs intended for this release have been merged.
 
 3. Checkout the upstream ``vX.Y.x`` branch corresponding to the last feature release.
-   Alternativley you can create a new local branch from ``vX.Y.x`` and make sure
+   Alternatively you can create a new local branch from ``vX.Y.x`` and make sure
    it is up to date with the upstream ``vX.Y.x`` branch, in which case you will
    eventually open a PR to ``vX.Y.x`` with changes for the release from your fork 
    instead of pushing directly to upstream.
@@ -306,7 +306,7 @@ instances of ``vX.Y.x`` with ``v3.5.x``.
      git add CITATION.cff
      git commit -m "Preparing release vX.Y.Z"
 
-7. Push the ``vX.Y.x`` branch to upstream. Alternativley, you can open a PR to
+7. Push the ``vX.Y.x`` branch to upstream. Alternatively, you can open a PR to
    the ``vX.Y.x`` branch from your fork if you do not have direct push access or
    prefer to not push directly to upstream. Make sure the CI passes. If any of
    the CI fails, stop here; do not continue! Contact the maintainers for


### PR DESCRIPTION
Updating the release procedures:

- Remove references to auto backport label including the labels bookkeeping section. This has been replaced with updating the description in milestones to specific text to trigger auto backport of PRs milestoned to that branch, instructions for which are now included in the release procedures
- Clarify that you do not need to checkout an upstream branch and push directly to it when preparing for a release, and that you have the option to create a local branch and open a pull request. This is personally how I prefer to do it, and those without direct push access will need to do it this way. (I personally think this should be the only option because silly typos or erroneous change log entries do happen and its good to have eyes on it even though these are normally trivial changes, but I've left the direct push instructions in for now).
- Clarified that locking down the branch isn't a necessary step. Especially for bug fix releases, its sufficient to just give the team a heads up IMO, so i've included this option in the instructions 