### PR TITLE
add model fitting test for linking bug

### DIFF
--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -713,3 +713,47 @@ def test_different_fitters(specviz_helper, spectrum1d, fitter):
     expected_result = [6000., 6222.22222222, 6444.44444444, 6666.66666667, 6888.88888889,
                        7111.11111111, 7333.33333333, 7555.55555556, 7777.77777778, 8000.] * u.AA
     assert_allclose(result.get_object().spectral_axis, expected_result)
+
+
+def test_specviz2d_linking(specviz2d_helper):
+    header = {
+              'WCSAXES': 2,
+              'CRPIX1': 0.0, 'CRPIX2': 8.5,
+              'CDELT1': 1E-06, 'CDELT2': 7.5E-05,
+              'CUNIT1': 'm', 'CUNIT2': 'deg',
+              'CTYPE1': 'WAVE', 'CTYPE2': 'OFFSET',
+              'CRVAL1': 0.0, 'CRVAL2': 5.0,
+              'RADESYS': 'ICRS', 'SPECSYS': 'BARYCENT'}
+    wcs = WCS(header)
+
+    x_values = np.linspace(0, 10, 128)
+    y_values = np.linspace(0, 5, 256)
+
+    # Create a continuous 2D
+    data = np.sin(x_values[:, np.newaxis]) * np.cos(y_values) * u.one
+    spectrum_data = Spectrum(data, wcs=wcs, meta=header)
+    specviz2d_helper.load_data(spectrum_2d=spectrum_data)
+
+    viewer_1d = specviz2d_helper.app.get_viewer(
+        specviz2d_helper._default_spectrum_viewer_reference_name)
+
+    mf = specviz2d_helper.plugins['Model Fitting']
+    mf.create_model_component('Const1D')
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', message='Model is linear in parameters.*')
+        mf.calculate_fit()
+
+    # testing to ensure a bug where the fit values create a vertical line along the
+    # x-axis (x=0). This test verifies that the x-range is of the fit is within the
+    # limits of the spectrum data used to produce the fit.
+    fit_marks_x = viewer_1d.native_marks[-1].x
+    fit_x_min = np.min(fit_marks_x)
+    fit_x_max = np.max(fit_marks_x)
+
+    data_marks_x = viewer_1d.native_marks[0].x
+    data_x_min = np.min(data_marks_x)
+    data_x_max = np.max(data_marks_x)
+
+    assert data_x_min <= fit_x_min <= fit_x_max <= data_x_max, (
+        f"Fit range [{fit_x_min},{fit_x_max}] isn't within data range [{data_x_min},{data_x_max}]"
+    )


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address a transient bug in specviz2d. The bug occurs when creating this simplest of fits, and the  model results created are a vertical line along the x-axis (x=0). While this bug is not currently present on main, this test ensures that if a change in behavior causes the bug to return, that we become aware of it through testing instead of by chance through utilizing model fitting in specviz2d.


Refer to the following PR and that linked comment:
https://github.com/spacetelescope/jdaviz/pull/3434#issuecomment-2659861178

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
