### PR TITLE
Allow loading new BSUB file in Specviz2D

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,8 @@ Specviz
 Specviz2d
 ^^^^^^^^^
 
+- Allow loading intermediate ``_bsub`` pipeline step files for JWST WFSS. [#3786]
+
 API Changes
 -----------
 

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -185,9 +185,7 @@ class Spectrum2DImporter(BaseImporterToDataCollection):
                         from stdatamodels import asdf_in_fits
                         tree = asdf_in_fits.open(hdulist).tree
                         if 'meta' in tree and 'wcs' in tree['meta']:
-                            wcs = tree["meta"]["wcs"]
-                            if isinstance(wcs, (list, tuple)):
-                                wcs = wcs[0]
+                            wcs = tree["meta"]["wcs"][0]
                         else:
                             wcs = None
                     except ValueError:
@@ -205,6 +203,7 @@ class Spectrum2DImporter(BaseImporterToDataCollection):
                         if isinstance(wcs, (list, tuple)):
                             wcs = wcs[0]
                         if len(wcs.forward_transform.inputs) == 5:
+                            print("Setting WCS to None")
                             wcs = None
 
             return Spectrum(flux=data * data_unit, meta=metadata, wcs=wcs, spectral_axis_index=1)

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -197,7 +197,15 @@ class Spectrum2DImporter(BaseImporterToDataCollection):
             elif hasattr(wcs, 'spectral') and wcs.spectral.naxis == 0:
                 # This is the case for WFSS BSUB files, which we want to allow in Specviz2D
                 # without worrying about the wavelength solution for now.
-                wcs = None
+                if 'ASDF' in hdulist:
+                    from stdatamodels import asdf_in_fits
+                    tree = asdf_in_fits.open(hdulist).tree
+                    if 'meta' in tree and 'wcs' in tree['meta']:
+                        wcs = tree["meta"]["wcs"]
+                        if isinstance(wcs, (list, tuple)):
+                            wcs = wcs[0]
+                        if len(wcs.forward_transform.inputs) == 5:
+                            wcs = None
 
             return Spectrum(flux=data * data_unit, meta=metadata, wcs=wcs, spectral_axis_index=1)
         except ValueError:

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -203,7 +203,6 @@ class Spectrum2DImporter(BaseImporterToDataCollection):
                         if isinstance(wcs, (list, tuple)):
                             wcs = wcs[0]
                         if len(wcs.forward_transform.inputs) == 5:
-                            print("Setting WCS to None")
                             wcs = None
 
             return Spectrum(flux=data * data_unit, meta=metadata, wcs=wcs, spectral_axis_index=1)

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -185,13 +185,20 @@ class Spectrum2DImporter(BaseImporterToDataCollection):
                         from stdatamodels import asdf_in_fits
                         tree = asdf_in_fits.open(hdulist).tree
                         if 'meta' in tree and 'wcs' in tree['meta']:
-                            wcs = tree["meta"]["wcs"][0]
+                            wcs = tree["meta"]["wcs"]
+                            if isinstance(wcs, (list, tuple)):
+                                wcs = wcs[0]
                         else:
                             wcs = None
                     except ValueError:
                         wcs = None
                 else:
                     wcs = None
+            elif hasattr(wcs, 'spectral') and wcs.spectral.naxis == 0:
+                # This is the case for WFSS BSUB files, which we want to allow in Specviz2D
+                # without worrying about the wavelength solution for now.
+                wcs = None
+
             return Spectrum(flux=data * data_unit, meta=metadata, wcs=wcs, spectral_axis_index=1)
         except ValueError:
             # In some cases, the above call to Spectrum will fail if no

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -146,6 +146,24 @@ def test_fits_spectrum2d(deconfigged_helper):
     assert str(sp1d.spectral_axis.unit) == 'um'
 
 
+@pytest.mark.remote_data
+@pytest.mark.filterwarnings(r"ignore::astropy.wcs.wcs.FITSFixedWarning")
+@pytest.mark.filterwarnings(r"ignore::asdf.exceptions.AsdfPackageVersionWarning")
+def test_jwst_wfss_bsub(deconfigged_helper):
+    uri = 'https://stsci.box.com/shared/static/k5l446jid348jk343m8r4vvbkzk4syom.fits'
+    ldr = deconfigged_helper.loaders['url']
+    ldr.cache = True
+    ldr.url = uri
+
+    assert ldr.format == '2D Spectrum'
+
+    ldr.importer()
+
+    sp1d = deconfigged_helper.get_data('k5l446jid348jk343m8r4vvbkzk4syom (auto-ext)')  # noqa
+    assert isinstance(sp1d, Spectrum)
+    assert str(sp1d.spectral_axis.unit) == 'pix'
+
+
 # TODO: Skip until file is uploaded to box
 @pytest.mark.skip
 def test_fits_spectrum_list_L3_wfss(deconfigged_helper):

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -129,10 +129,7 @@ def test_fits_spectrum2d(deconfigged_helper):
         ldr = deconfigged_helper.loaders['file']
         ldr.filepath = uri
 
-    # Default format is Image, manually set to 2D Spectrum
-    assert ldr.format == 'Image'
-    assert ldr.importer._obj.input_has_extensions is True
-    ldr.format = '2D Spectrum'
+    assert ldr.format == '2D Spectrum'
 
     ldr.importer()
 

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -129,6 +129,7 @@ def test_fits_spectrum2d(deconfigged_helper):
         ldr = deconfigged_helper.loaders['file']
         ldr.filepath = uri
 
+    # Default format is Image, manually set to 2D Spectrum
     assert ldr.format == 'Image'
     assert ldr.importer._obj.input_has_extensions is True
     ldr.format = '2D Spectrum'

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -129,7 +129,9 @@ def test_fits_spectrum2d(deconfigged_helper):
         ldr = deconfigged_helper.loaders['file']
         ldr.filepath = uri
 
-    assert ldr.format == '2D Spectrum'
+    assert ldr.format == 'Image'
+    assert ldr.importer._obj.input_has_extensions is True
+    ldr.format = '2D Spectrum'
 
     ldr.importer()
 


### PR DESCRIPTION
This catches the case where the FITS WCS has a `spectral` attribute, but it's empty, as is the case for the new JWST WFSS* BSUB** files. We don't actually handle real WFSS spectral extraction, this just enables a simple preview in pixel space.

* wide field slitless spectroscopy
**  "background subtracted", this is an intermediate pipeline step that is being made available