### PR TITLE
Avoid making object arrays for mask in cubeviz to speed up loading large cubes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,14 @@ Other Changes and Additions
 
 - Linking is now generalized to act based on physical type. [#3698]
 
+4.3.3 (unreleased)
+==================
+
+Bug Fixes
+---------
+
+- Speed up loading of large cubes into cubeviz. [#3787]
+
 4.3.2 (2025-09-15)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,8 @@ Bug Fixes
 Cubeviz
 ^^^^^^^
 
+- Speed up loading of large cubes into cubeviz. [#3787]
+
 Imviz
 ^^^^^
 
@@ -79,14 +81,6 @@ Other Changes and Additions
 - When importing a 2D spectrum file into a SpectrumList, surface brightness units are automatically converted to flux units. [#3729]
 
 - Linking is now generalized to act based on physical type. [#3698]
-
-4.3.3 (unreleased)
-==================
-
-Bug Fixes
----------
-
-- Speed up loading of large cubes into cubeviz. [#3787]
 
 4.3.2 (2025-09-15)
 ==================

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -454,6 +454,7 @@ class SpectralExtraction3D(PluginTemplateMixin, ApertureSubsetSelectMixin,
     def _extract_from_aperture(self, cube, uncert_cube, mask_cube, aperture,
                                weight_mask, wavelength_dependent,
                                selected_func, **kwargs):
+
         # This plugin collapses over the *spatial axes* (optionally over a spatial subset,
         # defaults to ``No Subset``). Since the Cubeviz parser puts the fluxes
         # and uncertainties in different glue Data objects, we translate the spectral
@@ -505,7 +506,10 @@ class SpectralExtraction3D(PluginTemplateMixin, ApertureSubsetSelectMixin,
             wcs = cube.coords
 
         # Filter out NaNs (False = good)
-        mask = np.logical_or(mask, np.isnan(flux))
+        if mask is None:
+            mask = np.isnan(flux)
+        else:
+            mask = np.logical_or(mask, np.isnan(flux))
 
         # Also apply the cube's original mask array
         if mask_cube:

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -454,7 +454,6 @@ class SpectralExtraction3D(PluginTemplateMixin, ApertureSubsetSelectMixin,
     def _extract_from_aperture(self, cube, uncert_cube, mask_cube, aperture,
                                weight_mask, wavelength_dependent,
                                selected_func, **kwargs):
-
         # This plugin collapses over the *spatial axes* (optionally over a spatial subset,
         # defaults to ``No Subset``). Since the Cubeviz parser puts the fluxes
         # and uncertainties in different glue Data objects, we translate the spectral


### PR DESCRIPTION
### Description

Before this PR, if the mask was None as returned by the ``NDData``'s ``.mask`` attribute, ``np.logical_or`` was returning object arrays:

```
In [2]: np.logical_or(None, np.array([1, 0, 1], dtype=bool))
Out[2]: array([True, False, True], dtype=object)
```

Object arrays are very memory and CPU inefficient. This PR avoids this by only doing a logical OR if the original mask is not None. This speeds up the initial loading of large cubes into cubeviz by a factor of 3x on my machine (I tested this for a 3.4GB cube).

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
