### PR TITLE
Avoid unecessary float conversion in mask

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,8 @@ Other Changes and Additions
 
 - Linking is now generalized to act based on physical type. [#3698]
 
+- Improve memory usage when loading large cubes in cubeviz. [#3788]
+
 4.3.2 (2025-09-15)
 ==================
 

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -403,7 +403,7 @@ class SpectralExtraction3D(PluginTemplateMixin, ApertureSubsetSelectMixin,
         if self.mask_cube is not None:
             mask_non_science = np.logical_or(self.mask_cube.get_component('flux').data,
                                              mask_non_science)
-        return np.logical_not(mask_non_science).astype(float)
+        return np.logical_not(mask_non_science)
 
     @property
     def aperture_weight_mask(self):


### PR DESCRIPTION
### Description

This improves the memory usage of cubeviz a bit when using large cubes. Before this change, the casting to float would cause an array to be created that would be as big as the original data, but in fact this casting is unecessary, numpy deals fine with it as a boolean even when used in e.g. multiplications. This shaved off 10-20% of memory usage in my case.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
