### PR TITLE
Support to export via serverside or clientside

### DIFF
--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -118,9 +118,6 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
     overwrite_warn = Bool(False).tag(sync=True)
 
-    # Controls which expansion panels are open (first panel open by default)
-    expansion_panels_opened = Any([0]).tag(sync=True)
-
     # This is a temporary measure to allow server-installations to disable saving server-side until
     # saving client-side is supported for all exports.
     serverside_enabled = Bool(True).tag(sync=True)

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -9,7 +9,7 @@ from glue.core.message import SubsetCreateMessage, SubsetDeleteMessage, SubsetUp
 from glue_jupyter.bqplot.image import BqplotImageView
 from regions import CircleSkyRegion, EllipseSkyRegion
 from specutils import Spectrum
-from traitlets import Bool, List, Unicode, observe
+from traitlets import Any, Bool, List, Unicode, observe
 
 from jdaviz.core.custom_traitlets import FloatHandleEmpty, IntHandleEmpty
 from jdaviz.core.marks import ShadowMixin
@@ -114,6 +114,9 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     movie_interrupt = Bool(False).tag(sync=True)
 
     overwrite_warn = Bool(False).tag(sync=True)
+
+    # Controls which expansion panels are open (first panel open by default)
+    expansion_panels_opened = Any([0]).tag(sync=True)
 
     # This is a temporary measure to allow server-installations to disable saving server-side until
     # saving client-side is supported for all exports.

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -597,7 +597,9 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                 if raise_error_for_overwrite:
                     raise FileExistsError(f"{filename} exists but overwrite=False")
                 return
-            self.dataset.selected_obj.write(Path(filename) if isinstance(filename, str) else filename, overwrite=True, format=filetype)
+            self.dataset.selected_obj.write(Path(filename)
+                                            if isinstance(filename, str) else filename,
+                                            overwrite=True, format=filetype)
         else:
             raise ValueError("nothing selected for export")
 

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -582,7 +582,10 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                 return
 
             if self.subset_format.selected in ('fits', 'reg'):
-                self.save_subset_as_region(selected_subset_label, filename)
+                # TODO: what format should be passed for .reg?
+                # I'm getting errors for a spatial subset
+                self.save_subset_as_region(selected_subset_label, filename,
+                                           format=self.subset_format.selected)
             elif self.subset_format.selected == 'ecsv':
                 self.save_subset_as_table(filename)
             elif self.subset_format.selected == 'stcs':
@@ -903,7 +906,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         with open(filename, 'w') as f:
             f.write(stcs_str)
 
-    def save_subset_as_region(self, selected_subset_label, filename):
+    def save_subset_as_region(self, selected_subset_label, filename, format):
         """
         Save a subset to file as a Region object in the working directory.
         Currently only enabled for non-composite spatial subsets. Can be saved
@@ -921,7 +924,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
         region = region[0][f'{"sky_" if align_by == "wcs" else ""}region']
 
-        region.write(str(filename), overwrite=True)
+        region.write(str(filename), format=format, overwrite=True)
 
     def save_subset_as_table(self, filename):
         region = self.app.get_subsets(subset_name=self.subset.selected)

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -273,124 +273,117 @@
       </v-row>
     </div>
 
-    <v-row>
-      <v-expansion-panels popout multiple v-model="expansion_panels_opened">
-        <v-expansion-panel v-if="serverside_enabled">
-          <v-expansion-panel-header v-slot="{ open }">
-            <span style="padding: 6px">Save via Kernel</span>
-          </v-expansion-panel-header>
-          <v-expansion-panel-content class="plugin-expansion-panel-content">
-            <div style="display: grid; position: relative"> <!-- overlay container -->
-              <div style="grid-area: 1/1">
-
-                <v-row class="row-no-outside-padding row-min-bottom-padding">
-                  <v-col>
-                    <v-text-field
-                      :value="default_filepath"
-                      label="Filepath"
-                      hint="Filepath export location."
-                      persistent-hint
-                      disabled
-                    ></v-text-field>
-                  </v-col>
-                </v-row>
-
-                <plugin-auto-label
-                  :value.sync="filename_value"
-                  :default="filename_default"
-                  :auto.sync="filename_auto"
-                  :invalid_msg="filename_invalid_msg"
-                  label="Filename"
-                  :api_hint="'plg.filename = \''+filename_value+'\''"
-                  :api_hints_enabled="api_hints_enabled"
-                  hint="Export to a file on disk."
-                ></plugin-auto-label>
-
-                <v-row justify="end">
-                  <j-tooltip v-if="movie_recording" tooltipcontent="Interrupt recording and delete movie file">
-                      <plugin-action-button
-                        :results_isolated_to_plugin="true"
-                        @click="interrupt_recording"
-                        :disabled="!movie_recording"
-                      >
-                        <v-icon>stop</v-icon>
-                      </plugin-action-button>
-                  </j-tooltip>
-
-                  <plugin-action-button
-                    :results_isolated_to_plugin="true"
-                    @click="export_from_ui"
-                    :spinner="spinner"
-                    :api_hints_enabled="api_hints_enabled"
-                    :disabled="filename_value.length === 0 ||
-                              movie_recording ||
-                              subset_invalid_msg.length > 0 ||
-                              data_invalid_msg.length > 0 ||
-                              subset_format_invalid_msg.length > 0 ||
-                              viewer_invalid_msg.length > 0 ||
-                              (viewer_selected.length > 0 && viewer_format_selected == 'mp4' && !movie_enabled)"
-                  >
-                    {{ api_hints_enabled ?
-                      'plg.export()'
-                      :
-                      'Export'
-                    }}
-                  </plugin-action-button>
-                </v-row>
-              </div>
-
-              <v-overlay
-                absolute
-                opacity=0.5
-                :value="overwrite_warn"
-                :zIndex=3
-                style="grid-area: 1/1;
-                      margin-left: -24px;
-                      margin-right: -24px"
-              >
-                <v-card color="transparent" elevation=0 >
-                  <v-card-text width="100%">
-                    <div class="white--text">
-                      A file with this name is already on disk. Overwrite?
-                    </div>
-                  </v-card-text>
-
-                  <v-card-actions>
-                    <v-row justify="end">
-                      <v-btn tile small color="primary" class="mr-2" @click="overwrite_warn=false">Cancel</v-btn>
-                      <v-btn tile small color="accent" class="mr-4" @click="overwrite_from_ui">Overwrite</v-btn>
-                    </v-row>
-                  </v-card-actions>
-                </v-card>
-              </v-overlay>
-            </div>
-
-          </v-expansion-panel-content>
-        </v-expansion-panel>
-        <v-expansion-panel>
-          <v-expansion-panel-header v-slot="{ open }">
-            <span style="padding: 6px">Save via Browser</span>
-          </v-expansion-panel-header>
-          <v-expansion-panel-content class="plugin-expansion-panel-content">
-            <plugin-auto-label
-              :value.sync="filename_value"
-              :default="filename_default"
-              :auto.sync="filename_auto"
-              :invalid_msg="filename_invalid_msg"
-              label="Filename"
-              :api_hint="'plg.filename = \''+filename_value+'\''"
-              :api_hints_enabled="api_hints_enabled"
-              hint="Filename for download."
-            ></plugin-auto-label>
-            <v-row>
-              <jupyter-widget :widget="file_download"></jupyter-widget>
-            </v-row>
-          </v-expansion-panel-content>
-        </v-expansion-panel>
-      </v-expansion-panels>
+    <j-plugin-section-header>Save via Browser</j-plugin-section-header>
+    <plugin-auto-label
+      :value.sync="filename_value"
+      :default="filename_default"
+      :auto.sync="filename_auto"
+      :invalid_msg="filename_invalid_msg"
+      label="Filename"
+      :api_hint="'plg.filename = \''+filename_value+'\''"
+      :api_hints_enabled="api_hints_enabled"
+      hint="Filename for download."
+    ></plugin-auto-label>
+    <v-row justify="end">
+      <span
+        v-if="filename_value.length === 0 ||
+              movie_recording ||
+              subset_invalid_msg.length > 0 ||
+              data_invalid_msg.length > 0 ||
+              subset_format_invalid_msg.length > 0 ||
+              viewer_invalid_msg.length > 0 ||
+              (viewer_selected.length > 0 && viewer_format_selected == 'mp4' && !movie_enabled)"
+      >export disabled</span>
+      <jupyter-widget v-else :widget="file_download"></jupyter-widget>
     </v-row>
 
+    <div v-if="serverside_enabled">
+      <j-plugin-section-header v-if="serverside_enabled">Save via Kernel</j-plugin-section-header>
+      <div style="display: grid; position: relative"> <!-- overlay container -->
+        <div style="grid-area: 1/1">
 
+          <v-row class="row-no-outside-padding row-min-bottom-padding">
+            <v-col>
+              <v-text-field
+                :value="default_filepath"
+                label="Filepath"
+                hint="Filepath export location."
+                persistent-hint
+                disabled
+              ></v-text-field>
+            </v-col>
+          </v-row>
+
+          <plugin-auto-label
+            :value.sync="filename_value"
+            :default="filename_default"
+            :auto.sync="filename_auto"
+            :invalid_msg="filename_invalid_msg"
+            label="Filename"
+            :api_hint="'plg.filename = \''+filename_value+'\''"
+            :api_hints_enabled="api_hints_enabled"
+            hint="Export to a file on disk."
+          ></plugin-auto-label>
+
+          <v-row justify="end">
+            <j-tooltip v-if="movie_recording" tooltipcontent="Interrupt recording and delete movie file">
+                <plugin-action-button
+                  :results_isolated_to_plugin="true"
+                  @click="interrupt_recording"
+                  :disabled="!movie_recording"
+                >
+                  <v-icon>stop</v-icon>
+                </plugin-action-button>
+            </j-tooltip>
+
+            <plugin-action-button
+              :results_isolated_to_plugin="true"
+              @click="export_from_ui"
+              :spinner="spinner"
+              :api_hints_enabled="api_hints_enabled"
+              :disabled="filename_value.length === 0 ||
+                        movie_recording ||
+                        subset_invalid_msg.length > 0 ||
+                        data_invalid_msg.length > 0 ||
+                        subset_format_invalid_msg.length > 0 ||
+                        viewer_invalid_msg.length > 0 ||
+                        (viewer_selected.length > 0 && viewer_format_selected == 'mp4' && !movie_enabled)"
+            >
+              {{ api_hints_enabled ?
+                'plg.export()'
+                :
+                'Export'
+              }}
+            </plugin-action-button>
+          </v-row>
+        </div>
+
+        <v-overlay
+          absolute
+          opacity=0.5
+          :value="overwrite_warn"
+          :zIndex=3
+          style="grid-area: 1/1;
+                margin-left: -24px;
+                margin-right: -24px"
+        >
+          <v-card color="transparent" elevation=0 >
+            <v-card-text width="100%">
+              <div class="white--text">
+                A file with this name is already on disk. Overwrite?
+              </div>
+            </v-card-text>
+
+            <v-card-actions>
+              <v-row justify="end">
+                <v-btn tile small color="primary" class="mr-2" @click="overwrite_warn=false">Cancel</v-btn>
+                <v-btn tile small color="accent" class="mr-4" @click="overwrite_from_ui">Overwrite</v-btn>
+              </v-row>
+            </v-card-actions>
+          </v-card>
+        </v-overlay>
+      </div>
+    </div>
 
   </j-tray-plugin>
 </template>

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -372,8 +372,18 @@
             <span style="padding: 6px">Save via Browser</span>
           </v-expansion-panel-header>
           <v-expansion-panel-content class="plugin-expansion-panel-content">
+            <plugin-auto-label
+              :value.sync="filename_value"
+              :default="filename_default"
+              :auto.sync="filename_auto"
+              :invalid_msg="filename_invalid_msg"
+              label="Filename"
+              :api_hint="'plg.filename = \''+filename_value+'\''"
+              :api_hints_enabled="api_hints_enabled"
+              hint="Filename for download."
+            ></plugin-auto-label>
             <v-row>
-              <span>COMING SOON</span>
+              <jupyter-widget :widget="file_download"></jupyter-widget>
             </v-row>
           </v-expansion-panel-content>
         </v-expansion-panel>

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -273,92 +273,114 @@
       </v-row>
     </div>
 
-    <v-row v-if="serverside_enabled" class="row-no-outside-padding row-min-bottom-padding">
-      <v-col>
-        <v-text-field
-          :value="default_filepath"
-          label="Filepath"
-          hint="Filepath export location."
-          persistent-hint
-          disabled
-        ></v-text-field>
-      </v-col>
+    <v-row>
+      <v-expansion-panels popout multiple v-model="expansion_panels_opened">
+        <v-expansion-panel v-if="serverside_enabled">
+          <v-expansion-panel-header v-slot="{ open }">
+            <span style="padding: 6px">Save via Kernel</span>
+          </v-expansion-panel-header>
+          <v-expansion-panel-content class="plugin-expansion-panel-content">
+            <div style="display: grid; position: relative"> <!-- overlay container -->
+              <div style="grid-area: 1/1">
+
+                <v-row class="row-no-outside-padding row-min-bottom-padding">
+                  <v-col>
+                    <v-text-field
+                      :value="default_filepath"
+                      label="Filepath"
+                      hint="Filepath export location."
+                      persistent-hint
+                      disabled
+                    ></v-text-field>
+                  </v-col>
+                </v-row>
+
+                <plugin-auto-label
+                  :value.sync="filename_value"
+                  :default="filename_default"
+                  :auto.sync="filename_auto"
+                  :invalid_msg="filename_invalid_msg"
+                  label="Filename"
+                  :api_hint="'plg.filename = \''+filename_value+'\''"
+                  :api_hints_enabled="api_hints_enabled"
+                  hint="Export to a file on disk."
+                ></plugin-auto-label>
+
+                <v-row justify="end">
+                  <j-tooltip v-if="movie_recording" tooltipcontent="Interrupt recording and delete movie file">
+                      <plugin-action-button
+                        :results_isolated_to_plugin="true"
+                        @click="interrupt_recording"
+                        :disabled="!movie_recording"
+                      >
+                        <v-icon>stop</v-icon>
+                      </plugin-action-button>
+                  </j-tooltip>
+
+                  <plugin-action-button
+                    :results_isolated_to_plugin="true"
+                    @click="export_from_ui"
+                    :spinner="spinner"
+                    :api_hints_enabled="api_hints_enabled"
+                    :disabled="filename_value.length === 0 ||
+                              movie_recording ||
+                              subset_invalid_msg.length > 0 ||
+                              data_invalid_msg.length > 0 ||
+                              subset_format_invalid_msg.length > 0 ||
+                              viewer_invalid_msg.length > 0 ||
+                              (viewer_selected.length > 0 && viewer_format_selected == 'mp4' && !movie_enabled)"
+                  >
+                    {{ api_hints_enabled ?
+                      'plg.export()'
+                      :
+                      'Export'
+                    }}
+                  </plugin-action-button>
+                </v-row>
+              </div>
+
+              <v-overlay
+                absolute
+                opacity=0.5
+                :value="overwrite_warn"
+                :zIndex=3
+                style="grid-area: 1/1;
+                      margin-left: -24px;
+                      margin-right: -24px"
+              >
+                <v-card color="transparent" elevation=0 >
+                  <v-card-text width="100%">
+                    <div class="white--text">
+                      A file with this name is already on disk. Overwrite?
+                    </div>
+                  </v-card-text>
+
+                  <v-card-actions>
+                    <v-row justify="end">
+                      <v-btn tile small color="primary" class="mr-2" @click="overwrite_warn=false">Cancel</v-btn>
+                      <v-btn tile small color="accent" class="mr-4" @click="overwrite_from_ui">Overwrite</v-btn>
+                    </v-row>
+                  </v-card-actions>
+                </v-card>
+              </v-overlay>
+            </div>
+
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+        <v-expansion-panel>
+          <v-expansion-panel-header v-slot="{ open }">
+            <span style="padding: 6px">Save via Browser</span>
+          </v-expansion-panel-header>
+          <v-expansion-panel-content class="plugin-expansion-panel-content">
+            <v-row>
+              <span>COMING SOON</span>
+            </v-row>
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
     </v-row>
 
-    <div style="display: grid; position: relative"> <!-- overlay container -->
-    <div style="grid-area: 1/1">
 
-    <plugin-auto-label
-      :value.sync="filename_value"
-      :default="filename_default"
-      :auto.sync="filename_auto"
-      :invalid_msg="filename_invalid_msg"
-      label="Filename"
-      :api_hint="'plg.filename = \''+filename_value+'\''"
-      :api_hints_enabled="api_hints_enabled"
-      hint="Export to a file on disk."
-    ></plugin-auto-label>
-
-    <v-row justify="end">
-      <j-tooltip v-if="movie_recording" tooltipcontent="Interrupt recording and delete movie file">
-          <plugin-action-button
-             :results_isolated_to_plugin="true"
-             @click="interrupt_recording"
-             :disabled="!movie_recording"
-          >
-            <v-icon>stop</v-icon>
-          </plugin-action-button>
-      </j-tooltip>
-
-      <plugin-action-button
-        :results_isolated_to_plugin="true"
-        @click="export_from_ui"
-        :spinner="spinner"
-        :api_hints_enabled="api_hints_enabled"
-        :disabled="filename_value.length === 0 ||
-                   movie_recording ||
-                   subset_invalid_msg.length > 0 ||
-                   data_invalid_msg.length > 0 ||
-                   subset_format_invalid_msg.length > 0 ||
-                   viewer_invalid_msg.length > 0 ||
-                   (viewer_selected.length > 0 && viewer_format_selected == 'mp4' && !movie_enabled)"
-      >
-        {{ api_hints_enabled ?
-          'plg.export()'
-          :
-          'Export'
-        }}
-      </plugin-action-button>
-    </div>
-
-      <v-overlay
-        absolute
-        opacity=0.5
-        :value="overwrite_warn"
-        :zIndex=3
-        style="grid-area: 1/1;
-               margin-left: -24px;
-               margin-right: -24px">
-
-      <v-card color="transparent" elevation=0 >
-        <v-card-text width="100%">
-          <div class="white--text">
-            A file with this name is already on disk. Overwrite?
-          </div>
-        </v-card-text>
-
-        <v-card-actions>
-          <v-row justify="end">
-            <v-btn tile small color="primary" class="mr-2" @click="overwrite_warn=false">Cancel</v-btn>
-            <v-btn tile small color="accent" class="mr-4" @click="overwrite_from_ui">Overwrite</v-btn>
-          </v-row>
-        </v-card-actions>
-      </v-card>
-
-      </v-overlay>
-    </div>
-
-    </v-row>
 
   </j-tray-plugin>
 </template>


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request integrates the solara `FileDownload` widget to support saving any exported file via the browsers Save dialog _in addition to_ the existing support to save python/server-side.  In doing so, this removes the previous `show_dialog` kwarg which was only supported for png files.  

Deployments in which the server is private should continue to set `serverside_enabled = False` to disable access to saving files on that machine, in which case only the new widget will be shown.

This is currently a WIP as there are still some bugs, including a double file-dialog when downloading images from viewers and some issues in saving subsets as regions, etc.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
