### PR TITLE
Fix handling of nonfinite data in model fitting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,8 @@ Specviz2d
 Bug Fixes
 ---------
 
+- Fixes in model fitting plugin to work better with nonfinite data. [#3792]
+
 Cubeviz
 ^^^^^^^
 
@@ -85,6 +87,7 @@ Other Changes and Additions
 - Linking is now generalized to act based on physical type. [#3698]
 
 - Improve memory usage when loading large cubes in cubeviz. [#3788]
+
 
 4.3.2 (2025-09-15)
 ==================

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -381,33 +381,6 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
                 self.component_models[model_index]["compat_display_units"] = False
             self.send_state('component_models')
 
-    @observe("dataset_selected")
-    def _dataset_selected_changed(self, event=None):
-        """
-        Callback method for when the user has selected data from the drop down
-        in the front-end. It is here that we actually parse and create a new
-        data object from the selected data. From this data object, unit
-        information is scraped, and the selected spectrum is stored for later
-        use in fitting.
-
-        Parameters
-        ----------
-        event : str
-            IPyWidget callback event object. In this case, represents the data
-            label of the data collection object selected by the user.
-        """
-        if not hasattr(self, 'dataset') or self.app._jdaviz_helper is None or self.dataset_selected == '':  # noqa
-            # during initial init, this can trigger before the component is initialized
-            return
-
-        selected_spec = self.dataset.selected_obj
-        if selected_spec is None:
-            return
-
-        # Replace NaNs from collapsed Spectrum in Cubeviz
-        # (won't affect calculations because these locations are masked)
-        selected_spec.flux[np.isnan(selected_spec.flux)] = 0.0
-
     def _default_comp_label(self, model, poly_order=None):
         abbrevs = {'BlackBody': 'BB', 'PowerLaw': 'PL', 'Lorentz1D': 'Lo'}
         abbrev = abbrevs.get(model, model[0].upper())
@@ -653,7 +626,17 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
             masked_spectrum = self._apply_subset_masks(self.dataset.selected_spectrum,
                                                        self.spectral_subset)
 
-        mask = masked_spectrum.mask
+        # subset-masked spectrum, if aplicable
+        subset_mask = masked_spectrum.mask
+
+        # mask out non-finite values in flux array
+        flux_nan_mask = ~np.isfinite(masked_spectrum.flux)
+
+        if subset_mask is not None:
+            mask = subset_mask | flux_nan_mask
+        else:
+            mask = flux_nan_mask if np.any(flux_nan_mask) else None
+
         if mask is not None:
             if mask.ndim == 3:
                 if masked_spectrum.spectral_axis_index in [2, -1]:

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_fitting.py
@@ -539,6 +539,7 @@ def test_cube_fit_with_nans(cubeviz_helper):
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', message='Model is linear in parameters.*')
         mf.calculate_fit()
+
     result = cubeviz_helper.app.data_collection['model']
     assert np.all(result.get_component("flux").data == 1)
 

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -417,12 +417,13 @@ def test_invalid_subset(specviz_helper, spectrum1d):
     assert plugin._obj.spectral_subset_valid
 
 
-def test_fitting_with_nans(specviz_helper):
+@pytest.mark.parametrize('fill_val', [np.nan, np.inf])
+def test_fitting_with_nans(specviz_helper, fill_val):
     # test that model fitting works when there are nans in the flux array. these
     # nonfinite values should be filtered out both when computing the initial
     # guess for model parameters, and when fitting the model
 
-    spec = Spectrum(flux=np.array([0, 1, 2, np.nan, np.nan, np.nan, 6, 7, 8, 9]) * u.Jy,
+    spec = Spectrum(flux=np.array([0, 1, 2, fill_val, fill_val, fill_val, 6, 7, 8, 9]) * u.Jy,
                     spectral_axis=np.arange(10) * u.nm)
     specviz_helper.load_data(spec)
 
@@ -452,12 +453,13 @@ def test_fitting_with_nans(specviz_helper):
     assert plugin._obj.non_finite_uncertainty_mismatch is False
 
 
-def test_fitting_partial_overlap_subset(specviz_helper):
+@pytest.mark.parametrize('fill_val', [np.nan, np.inf])
+def test_fitting_partial_overlap_subset(specviz_helper, fill_val):
     # test that a partially out of bounds subset works correctly,
     # using a test dataset with nans to make sure the masking accounts for
     # out-of-bounds values as well as nonfinite values
 
-    spec = Spectrum(flux=np.array([0, 1, 2, np.nan, np.nan, np.nan, 6, 7, 8, 9]) * u.Jy,
+    spec = Spectrum(flux=np.array([0, 1, 2, fill_val, fill_val, fill_val, 6, 7, 8, 9]) * u.Jy,
                     spectral_axis=np.arange(10) * u.nm)
     specviz_helper.load_data(spec)
 

--- a/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
+++ b/jdaviz/configs/default/plugins/model_fitting/tests/test_plugin.py
@@ -417,6 +417,41 @@ def test_invalid_subset(specviz_helper, spectrum1d):
     assert plugin._obj.spectral_subset_valid
 
 
+def test_fitting_with_nans(specviz_helper):
+    # test that model fitting works when there are nans in the flux array. these
+    # nonfinite values should be filtered out both when computing the initial
+    # guess for model parameters, and when fitting the model
+
+    spec = Spectrum(flux=np.array([0, 1, 2, np.nan, np.nan, np.nan, 6, 7, 8, 9]) * u.Jy,
+                    spectral_axis=np.arange(10) * u.nm)
+    specviz_helper.load_data(spec)
+
+    plugin = specviz_helper.plugins['Model Fitting']
+    plugin.model_component = 'Linear1D'
+    plugin.create_model_component()
+
+    # check initial component value guesses
+    assert_allclose(plugin._obj.component_models[0]['parameters'][0]['value'], 4.5)  # slope
+    assert_allclose(plugin._obj.component_models[0]['parameters'][1]['value'], 4.5)  # intercept
+
+    with pytest.warns(AstropyUserWarning) as ws:
+        plugin.calculate_fit()
+
+    # should be two warnings, one for linear model, one for nans
+    assert len(ws) == 2
+    assert any('Model is linear in parameters' in str(w.message) for w in ws)
+    assert any('Non-Finite input data has been removed by the fitter' in str(w.message) for w in ws)
+
+    # check that slope and intercept are fit correctly
+    assert_allclose(plugin._obj.component_models[0]['parameters'][0]['value'], 1.0)  # slope
+    assert_allclose(plugin._obj.component_models[0]['parameters'][1]['value'],
+                    0.0, atol=1e-12)  # intercept
+
+    # and that this value is correctly set to false, since its only the data
+    # values that are non-finite, not the uncertainty values
+    assert plugin._obj.non_finite_uncertainty_mismatch is False
+
+
 def test_all_nan_uncert(specviz_helper):
 
     # test that if you have a fully finite data array, and a fully nan/inf


### PR DESCRIPTION
This PR makes a few changes to improve how nonfinite data in flux is handled by the model fitting plugin, and adds test coverage for a simple case of a flux array with NaNs as well as a partially overlapping subset, which was a case mentioned in the ticket.