### PR TITLE
Automatic (wcs) linking for source catalogs

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -297,6 +297,7 @@ class ApplicationState(State):
     # https://github.com/spacetelescope/jdaviz/pull/3761
     # https://github.com/spacetelescope/jdaviz/pull/3777
     # https://github.com/spacetelescope/jdaviz/pull/3799
+    # https://github.com/spacetelescope/jdaviz/pull/3814
     catalogs_in_dc = CallbackProperty(
         False, docstring="Whether to enable developer mode for adding catalogs to data collection.")
     loader_items = ListCallbackProperty(
@@ -757,6 +758,7 @@ class Application(VuetifyTemplate, HubListener):
                 viewer.center_on(sky_cen)
 
     def _link_new_data_by_component_type(self, new_data_label):
+
         new_data = self.data_collection[new_data_label]
 
         if (new_data.meta.get('_importer') in ('ImageImporter', 'CatalogImporter') and
@@ -2579,10 +2581,19 @@ class Application(VuetifyTemplate, HubListener):
         if self.config in CONFIGS_WITH_LOADERS:
             data_needing_relinking = []
             for link in self.data_collection.external_links:
-                if data_to_remove == link.data1:
-                    data_needing_relinking.append(link.data2)
-                elif data_to_remove == link.data2:
-                    data_needing_relinking.append(link.data1)
+                if hasattr(link, 'data1') and hasattr(link, 'data2'):
+                    if data_to_remove == link.data1:
+                        data_needing_relinking.append(link.data2)
+                    elif data_to_remove == link.data2:
+                        data_needing_relinking.append(link.data1)
+
+                # ComponentsLink has comp_from and comp_to instead of data1 and data2,
+                # and is currently used in linking for Source Catalog
+                elif hasattr(link, 'comp_from') and hasattr(link, 'comp_to'):
+                    if data_to_remove == link.comp_from.data:
+                        data_needing_relinking.append(link.comp_to.data)
+                    elif data_to_remove == link.comp_to.data:
+                        data_needing_relinking.append(link.comp_from.data)
 
         self.data_collection.remove(data_to_remove)
 

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -206,33 +206,19 @@ def source_catalog():
     Create a sample source catalog with sources positioned within the
     coordinate range of the image_2d_wcs fixture.
 
-    The catalog contains 5 sources spread across a 128x128 pixel image field.
+    The catalog contains 5 sources spread across a 128x128 pixel image field,
+    one roughly in the center and others towards the edges. In addition to RA
+    and Dec, the catalog includes magnitude, flux, and a unique source ID.
     """
-    # WCS parameters from image_2d_wcs fixture
-    ra_center = 337.5202808  # degrees
-    dec_center = -20.833333  # degrees
-    pixel_scale_deg = 0.0002777777778  # degrees per pixel
 
     # Create the catalog table
     catalog = Table()
 
-    # Define source positions spread across the image field
-    catalog['ra'] = [
-        ra_center - 30 * pixel_scale_deg,  # Left side of image
-        ra_center,                          # Center
-        ra_center + 25 * pixel_scale_deg,  # Right side
-        ra_center - 10 * pixel_scale_deg,  # Slightly left of center
-        ra_center + 15 * pixel_scale_deg   # Slightly right of center
-    ] * u.deg
+    # ra and dec columns, which are required to be loaded as a source catalog
+    catalog['ra'] = [337.50293, 337.52763, 337.52844, 337.47438, 337.47432] * u.deg
+    catalog['dec'] = [-20.81483, -20.80438, -20.82707, -20.82683, -20.80342] * u.deg
 
-    catalog['dec'] = [
-        dec_center + 20 * pixel_scale_deg,  # Top
-        dec_center - 25 * pixel_scale_deg,  # Bottom
-        dec_center + 10 * pixel_scale_deg,  # Upper right
-        dec_center,                         # Center row
-        dec_center - 15 * pixel_scale_deg   # Lower right
-    ] * u.deg
-
+    # additional columns
     catalog['magnitude'] = [12.5, 14.2, 13.8, 15.1, 16.3] * u.mag
     catalog['flux'] = [1.23e-12, 8.45e-13, 9.87e-13, 6.12e-13, 4.33e-13] * u.erg / (u.cm**2 * u.s)
     catalog['source_id'] = ['src_001', 'src_002', 'src_003', 'src_004', 'src_005']


### PR DESCRIPTION
This PR implements linking for source catalogs when loaded into an image viewer, when WCS linked (because source catalogs must have RA and Dec only, this will change once pixel coordinate columns are supported). The catalog is linked to the orientation layer via Component Links because a 2D WCS can not be assigned directly to the glue data table object.

This PR changes a test fixture as well to have better source positions, and modifies the test that uses it to not use manual linking anymore and now loads the catalog into the viewer when it is initially loaded into the data collection, rather than waiting for manual links to be set up and then adding it from the data menu. 