### PR TITLE
Don't load other HDU types as catalogs

### DIFF
--- a/jdaviz/core/loaders/parsers/astropytable.py
+++ b/jdaviz/core/loaders/parsers/astropytable.py
@@ -36,7 +36,7 @@ class AstropyTableParser(BaseParser):
         # it as a catalog type if it opens sucessfully
         # eventually we may want to accept BinTableHDU/TableHDU
         # inside fits so this logic should be improved then
-        if isinstance(self.input, (fits.ImageHDU, fits.HDUList)):
+        if isinstance(self.input, (fits.ImageHDU, fits.HDUList, fits.PrimaryHDU, fits.CompImageHDU)):  # noqa
             return False
         try:
             f = fits.open(self.input)


### PR DESCRIPTION
If a primary HDU contains data, it can be loaded as a catalog since converting it to a table will not fail. Add a check for other possible HDU types that we would not want to pass through the catalog resolver.