### PR TITLE
Fix Roman ASDF spectrum loading in Specviz

### DIFF
--- a/jdaviz/configs/specviz/plugins/__init__.py
+++ b/jdaviz/configs/specviz/plugins/__init__.py
@@ -3,3 +3,4 @@ from .parsers import *  # noqa
 from .tools import *  # noqa
 from .unit_conversion.unit_conversion import *  # noqa
 from .line_analysis.line_analysis import *  # noqa
+from .roman_asdf_importer import RomanAsdfImporter

--- a/jdaviz/configs/specviz/plugins/roman_asdf_importer.py
+++ b/jdaviz/configs/specviz/plugins/roman_asdf_importer.py
@@ -1,0 +1,61 @@
+import pathlib
+from specutils import Spectrum
+
+from jdaviz.core.registries import loader_importer_registry
+from jdaviz.core.loaders.importers import (BaseImporterToDataCollection,
+                                           _spectrum_assign_component_type)
+from .roman_helpers import is_roman_asdf, load_roman_asdf_spectrum
+
+
+@loader_importer_registry('roman-asdf-importer')
+class RomanAsdfImporter(BaseImporterToDataCollection):
+    """
+    Importer for Roman ASDF 1D Spectrum files.
+    """
+    label = "Roman ASDF 1D Spectrum"
+    resolver = "file"
+    format = "roman-asdf"
+    template_file = __file__, "../../../core/loaders/importers/to_dc_with_label.vue"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.default_data_label_from_resolver:
+            self.data_label_default = self.default_data_label_from_resolver
+        else:
+            self.data_label_default = 'Roman ASDF Spectrum'
+
+    @staticmethod
+    def _get_supported_viewers():
+        return [{'label': '1D Spectrum', 'reference': 'spectrum-1d-viewer'}]
+
+    @property
+    def target(self):
+        """Return the target dict for this importer."""
+        # Call parent to get viewer choices, similar to BaseImporterToDataCollection
+        if len(self.viewer.create_new.choices) > 0:
+            return {'type': 'viewer',
+                    'icon': 'mdi-window-maximize',
+                    'label': self.viewer.create_new.choices[0]}
+        else:
+            return {}
+
+    @property
+    def is_valid(self):
+        """Check if the input file is a valid Roman ASDF spectrum."""
+        # Only valid for file paths (strings/Paths), not Spectrum objects
+        if not isinstance(self.input, (str, pathlib.Path)):
+            return False
+        if not pathlib.Path(self.input).exists():
+            return False
+        return is_roman_asdf(str(self.input))
+
+    @property
+    def output(self):
+        """Load and return the spectrum."""
+        spec = load_roman_asdf_spectrum(str(self.input))
+        if not isinstance(spec, Spectrum):
+            raise ValueError("Roman ASDF importer did not produce a specutils.Spectrum")
+        return spec
+
+    def assign_component_type(self, comp_id, comp, units, physical_type):
+        return _spectrum_assign_component_type(comp_id, comp, units, physical_type)

--- a/jdaviz/configs/specviz/plugins/roman_helpers.py
+++ b/jdaviz/configs/specviz/plugins/roman_helpers.py
@@ -1,0 +1,73 @@
+import numpy as np
+import asdf
+from astropy import units as u
+from specutils import Spectrum
+
+def _to_unit(x):
+    """Coerce str/bytes/Unit to astropy.units.Unit."""
+    if isinstance(x, bytes):
+        x = x.decode()
+    return u.Unit(x)
+
+def is_roman_asdf(filename):
+    """
+    Check if the file is a Roman ASDF spectrum.
+    This version is robust against None inputs and malformed files.
+    """
+    # Immediately return False if the filename is None to avoid errors.
+    if filename is None:
+        return False
+
+    try:
+        with asdf.open(filename) as af:
+            # Use .get() with a default to prevent errors if 'roman' key is missing.
+            roman = af.tree.get("roman", {})
+            meta = roman.get("meta", {})
+            data = roman.get("data", {})
+
+            # Check for required keys and that 'data' is not empty in one step.
+            if not all(k in meta for k in ["unit_wl", "unit_flux"]) or not data:
+                return False
+
+            # Safely get the first spectrum entry and check for its required keys.
+            first_key = next(iter(data), None)
+            spec = data.get(first_key, {})
+            if not all(k in spec for k in ["wl", "flux"]):
+                return False
+
+            # If all checks pass, it's a valid file.
+            return True
+
+    except Exception:
+        # If any error occurs during file opening or parsing, it's not a valid file.
+        return False
+
+def load_roman_asdf_spectrum(filename):
+    """Load a Roman ASDF spectrum and convert it to Spectrum."""
+    with asdf.open(filename) as af:
+        roman = af["roman"]
+        meta = roman["meta"]
+        data = roman["data"]
+        first_spectrum_key = list(data.keys())[0]
+        spectrum = data[first_spectrum_key]
+        wavelength = np.asarray(spectrum["wl"])
+        flux = np.asarray(spectrum["flux"])
+        wl_unit = _to_unit(meta["unit_wl"])
+        flux_unit = _to_unit(meta["unit_flux"])
+
+        # optional uncertainty (uncomment/adjust if your files provide these fields)
+        # flux_error = spectrum.get("flux_error", None)
+        # variance = spectrum.get("var", None)
+        # uncertainty = None
+        # if flux_error is not None:
+        #     uncertainty = StdDevUncertainty(np.asarray(flux_error) * flux_unit)
+        # elif variance is not None:
+        #     var = np.asarray(variance) * (flux_unit ** 2)
+        #     var = np.where(np.asarray(var.value) < 0, np.nan, var.value) * var.unit
+        #     uncertainty = StdDevUncertainty(np.sqrt(var))
+        
+        spectrum1d = Spectrum(
+            flux=flux * flux_unit,
+            spectral_axis=wavelength * wl_unit
+        )
+        return spectrum1d

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -21,14 +21,17 @@ from jdaviz.core.linelists import load_preset_linelist, get_available_linelists
 from jdaviz.core.unit_conversion_utils import (spectral_axis_conversion,
                                                flux_conversion_general,
                                                all_flux_unit_conversion_equivs)
-from jdaviz.utils import SPECTRAL_AXIS_COMP_LABELS
+# from jdaviz.utils import SPECTRAL_AXIS_COMP_LABELS
+# from jdaviz.core.spectral_axes import SPECTRAL_AXIS_COMP_LABELS
 from jdaviz.core.freezable_state import FreezableProfileViewerState
 from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin, JdavizProfileView
+
+SPECTRAL_AXIS_COMP_LABELS = ('spectral_axis', 'World 0')
 
 __all__ = ['Spectrum1DViewer', 'Spectrum2DViewer']
 
 
-@viewer_registry("spectrum-1d-viewer", label="1D Spectrum")
+@viewer_registry("spectrum-1d-viewer", label="1D Spectrum", overwrite=True)
 class Spectrum1DViewer(JdavizProfileView):
     # categories: zoom resets, zoom, pan, subset, select tools, shortcuts
     tools_nested = [
@@ -296,7 +299,7 @@ class Spectrum1DViewer(JdavizProfileView):
         self.figure.axes[1].num_ticks = 5
 
 
-@viewer_registry('spectrum-2d-viewer', label="2D Spectrum")
+@viewer_registry('spectrum-2d-viewer', label="2D Spectrum", overwrite=True)
 class Spectrum2DViewer(JdavizViewerMixin, BqplotImageView):
     # Due to limitations in CCDData and 2D data that has spectral and spatial
     #  axes, the default conversion class must handle cubes

--- a/jdaviz/configs/specviz/specviz.ipynb
+++ b/jdaviz/configs/specviz/specviz.ipynb
@@ -12,14 +12,14 @@
     "specviz = Specviz(verbosity='JDAVIZ_VERBOSITY', history_verbosity='JDAVIZ_HISTORY_VERBOSITY')\n",
     "data_path = 'DATA_FILENAME'\n",
     "if data_path:\n",
-    "    specviz.load_data(data_path)\n",
+    "    specviz.load(data_path)\n",
     "specviz.app"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -33,9 +33,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6-final"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -266,10 +266,10 @@ class BaseResolver(PluginTemplateMixin):
         if self.default_input is None:
             raise NotImplementedError("Resolver subclass must implement default_input")  # noqa pragma: nocover
         with self.defer_update_format_items():
-            setattr(self, self.default_input,
-                    self.default_input_cast(inp) if self.default_input_cast else inp)
+            setattr(self, self.default_input, self.default_input_cast(inp) if self.default_input_cast else inp)
             user_api = self.user_api
             for k, v in kwargs.items():
+                print("Got this far into the from_input function")
                 if hasattr(user_api, k):
                     setattr(user_api, k, v)
         return self
@@ -420,10 +420,10 @@ def find_matching_resolver(app, inp=None, resolver=None, format=None, target=Non
 
         for fmt_item in this_resolver.format.items:
             if (format is not None
-                and not any([format in (fmt_item['label'],
-                                        fmt_item['parser'],
-                                        fmt_item['importer'])
-                             for format in formats])):
+                and not any([fmt in (fmt_item['label'],
+                                     fmt_item['parser'],
+                                     fmt_item['importer'])
+                             for fmt in formats])):
                 invalid_resolvers[resolver_name] = this_resolver.format._invalid_importers
                 continue
             this_resolver.format.selected = fmt_item['label']


### PR DESCRIPTION
## Summary
Made specviz compatible with Roman ASDF, specifically "wfi_spec_individual_1d_r0000201001001001001_0002_WFI01.asdf"

- Fixed bug in find_matching_resolver() where format filtering was not working due to a loop variable reusing the same name as a function parameter
- Added support for loading Roman ASDF files
- Updated viewer registration and notebook loading method
- Added RomanAsdfImporter class and helper functions
- Updated parsers to handle Roman ASDF files
- Enabled viewer overwrite in viewers.py