### PR TITLE
Fix for catalogs with string coordinate units, prevent arrays from being loaded as tables

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -301,6 +301,7 @@ class ApplicationState(State):
     # https://github.com/spacetelescope/jdaviz/pull/3799
     # https://github.com/spacetelescope/jdaviz/pull/3814
     # https://github.com/spacetelescope/jdaviz/pull/3835
+    # https://github.com/spacetelescope/jdaviz/pull/3854
     catalogs_in_dc = CallbackProperty(
         False, docstring="Whether to enable developer mode for adding catalogs to data collection.")
     loader_items = ListCallbackProperty(

--- a/jdaviz/core/loaders/parsers/astropytable.py
+++ b/jdaviz/core/loaders/parsers/astropytable.py
@@ -2,6 +2,7 @@ from functools import cached_property
 from astropy.io import fits
 from astropy.io.fits import VerifyError
 from astropy.table import Table, QTable
+import numpy as np
 
 from jdaviz.core.loaders.parsers import BaseParser
 from jdaviz.core.registries import loader_parser_registry
@@ -37,6 +38,10 @@ class AstropyTableParser(BaseParser):
         # eventually we may want to accept BinTableHDU/TableHDU
         # inside fits so this logic should be improved then
         if isinstance(self.input, (fits.ImageHDU, fits.HDUList, fits.PrimaryHDU, fits.CompImageHDU)):  # noqa
+            return False
+        elif isinstance(self.input, np.ndarray):
+            # arrays can be loaded as tables, skip these so images/spectra
+            # aren't mis-identified as catalogs
             return False
         try:
             f = fits.open(self.input)


### PR DESCRIPTION
This PR includes some additional logic to handle tables that have strings for input coordinate columns that are valid lon/lat/x/y units. In particular, units like '5° 55′ 55″. To do this, columns are temporarily converted to SkyCoords which has the machinery to handle this. I could not find anything standalone in the units package that didn't involve iterating through possible unit types to see if it is a valid unit, so going through SkyCoord seems like a clean way to handle this. Coordinates as strings like '1deg' are also handled this way.

This also adds a check to prevent arrays from being validated as tables - turns out Table(array) works sometimes. 
