### PR TITLE
Fix subset selects not showing when mode is undefined

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ New Features
 
 - AIDA methods setting and retrieving rotation of imviz viewer [#3834]
 
-- Added ability to delete subsets from the Subset Tools plugin UI and API. [#3853]
+- Added ability to delete subsets from the Subset Tools plugin UI and API. [#3853, #3870]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/components/plugin_subset_select.vue
+++ b/jdaviz/components/plugin_subset_select.vue
@@ -2,7 +2,7 @@
   <div>
   <v-row v-if="items.length > 1 || selected.length===0 || show_if_single_entry || api_hints_enabled">
     <v-select
-      v-if="mode=='select'"
+      v-if="mode=='select' || mode===undefined"
       :menu-props="{ left: true }"
       attach
       :items="items"


### PR DESCRIPTION
#3853 accidentally broke all the subset selects *outside* the Subset Tools plugin, because they were always punting to the `v-else` case in the vue file. 