### PR TITLE
Remove TestRunner ignore post spectral_cube release.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,8 +148,6 @@ filterwarnings = [
     "ignore:((.|\n)*)Sentinel is not a public part of the traitlets API((.|\n)*)",
     "ignore:'audioop' is deprecated and slated for removal in Python 3.13",
     "ignore::DeprecationWarning:glue",
-    "ignore:.*The TestRunner class.*:astropy.utils.exceptions.AstropyDeprecationWarning",
-    "ignore:.*The TestRunnerBase class.*:astropy.utils.exceptions.AstropyDeprecationWarning",
     "ignore:The load_data function is deprecated.*",
     # This warning will not fail in CI, but causes issues running tests locally on Windows so test locally if considering
     # removing this in the future


### PR DESCRIPTION
This should no longer be needed now that `spectral-cube` released with their upstream fix.