### PR TITLE
Update Roman L1 file to most recent version

### DIFF
--- a/notebooks/concepts/RampvizExample.ipynb
+++ b/notebooks/concepts/RampvizExample.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "force_download = False\n",
     "\n",
-    "url_L1 = \"https://stsci.box.com/shared/static/80vahj27t3y02itfohc22p999snkcocw.asdf\"\n",
+    "url_L1 = \"https://stsci.box.com/shared/static/vklnig8f7fflyfwrfa9t6vpl5vnoi5mb.asdf\"\n",
     "local_path = \"L1.asdf\"\n",
     "\n",
     "if not os.path.exists(local_path) or force_download:\n",
@@ -200,7 +200,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The file downloaded in RampvizExample no longer loaded due to asdf schema validation errors, this updates the file URL to the most recent version. 

Should we also move `RampvizExample.ipynb` out of the "concepts" folder and into the main notebook directory, now that Rampviz works/is released?