### PR TITLE
Backport PR #3876 on branch v4.4.x (Disable cloning viewers in specviz and specviz2d)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Bug Fixes
 - Fixes a bug in parser preference where sometimes an input would go through the specutils parser
   instead of the fits parser. [#3869]
 
+- Disable cloning viewers in Specviz, Specviz2d, Cubeviz, and Mosviz. [#3876]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -30,7 +30,7 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
                     ['bqplot:truecircle', 'bqplot:rectangle', 'bqplot:ellipse',
                      'bqplot:circannulus'],
                     ['jdaviz:spectrumperspaxel'],
-                    ['jdaviz:sidebar_plot', 'jdaviz:sidebar_export']
+                    ['jdaviz:viewer_clone', 'jdaviz:sidebar_plot', 'jdaviz:sidebar_export']
                 ]
 
     default_class = None

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -30,8 +30,8 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
                      'bqplot:circannulus'],
                     ['jdaviz:blinkonce', 'jdaviz:contrastbias',
                         'jdaviz:selectcatalog', 'jdaviz:selectfootprint'],
-                    ['jdaviz:sidebar_plot', 'jdaviz:sidebar_export', 'jdaviz:sidebar_compass']
-                ]
+                    ['jdaviz:viewer_clone', 'jdaviz:sidebar_plot',
+                     'jdaviz:sidebar_export', 'jdaviz:sidebar_compass']]
 
     default_class = None
     _state_cls = FreezableBqplotImageViewerState

--- a/jdaviz/core/tools.py
+++ b/jdaviz/core/tools.py
@@ -351,6 +351,9 @@ class ViewerClone(Tool):
     def activate(self):
         self.viewer.clone_viewer()
 
+    def is_visible(self):
+        return self.viewer.jdaviz_app.config not in ['specviz', 'specviz2d', 'cubeviz', 'mosviz']
+
 
 @viewer_tool
 class SelectLine(CheckableTool, HubListener):


### PR DESCRIPTION
…#3876)

* Remove ability to clone viewer from specviz and specviz2d
* To avoid issues with tab management since tabs are disabled.

* Update `CHANGES.rst`

* Revert `viewer_clone` changes to allow compatibility with deconfigged

* Add `is_visible` method to `ViewerClone`...
* ...to dynamically hide clone button depending on config

* Add clone viewer to cube viewers but disable for cubeviz

* Update change log

* Update change log

* Add clone viewer to imviz image viewers

(cherry picked from commit 964f372be83fa2ac15858cc1c803a074d89d7694)

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
