### PR TITLE
check link type to set catalog visibility in data menu

### DIFF
--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -194,8 +194,8 @@
                     </v-list-item-content>
                     <v-list-item-action>
                       <j-tooltip
-                        v-if="disabled_layers_due_to_pixel_link.includes(item.label)"
-                        tooltipcontent="Layer cannot be made visible when viewer is aligned by pixel coordinates."
+                        v-if="disabled_layers_due_to_pixel_sky_mismatch.includes(item.label)"
+                        tooltipcontent="Layer cannot be made visible when catalog does not contain coordinates (pixel or sky) that correspond to current alignment type."
                       >
                         <v-btn icon disabled>
                           <v-icon>mdi-eye-off</v-icon>

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -146,16 +146,20 @@ def test_zoom_center_radius_init(imviz_helper):
     assert imviz_helper.default_viewer._obj.glue_viewer.state.zoom_radius > 0
 
 
-def test_catalog_in_image_viewer(imviz_helper, image_2d_wcs, source_catalog):
+def test_catalog_in_image_viewer(imviz_helper, image_2d_wcs,
+                                 sky_coord_only_source_catalog):
     data = NDData(np.ones((128, 128)) * u.nJy, wcs=image_2d_wcs)
     imviz_helper.load_data(data, data_label='my_data')
-    imviz_helper.plugins['Orientation'].align_by = 'WCS'
 
     # TODO: remove once dev-flag no longer required
     imviz_helper.app.state.catalogs_in_dc = True
 
+    # change alignment to WCS to enable catalog visibility
+    imviz_helper.plugins['Orientation'].align_by = 'WCS'
+
     # Load the source catalog into the data collection, and into the image viewer
-    imviz_helper.load(source_catalog, format='Catalog', data_label='my_catalog')
+    imviz_helper.load(sky_coord_only_source_catalog, format='Catalog',
+                      data_label='my_catalog')
 
     iv = imviz_helper.viewers['imviz-0']
     dm = iv.data_menu

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -201,7 +201,7 @@ def image_2d_wcs():
 
 
 @pytest.fixture
-def source_catalog():
+def sky_coord_only_source_catalog():
     """
     Create a sample source catalog with sources positioned within the
     coordinate range of the image_2d_wcs fixture.

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -5,7 +5,7 @@ from glue.core.message import Message
 
 __all__ = ['NewViewerMessage', 'ViewerAddedMessage', 'ViewerRemovedMessage', 'LoadDataMessage',
            'AddDataMessage', 'SnackbarMessage', 'RemoveDataMessage', 'SubsetRenameMessage',
-           'ViewerVisibleLayersChangedMessage',
+           'ViewerVisibleLayersChangedMessage', 'LayersFinalizedMessage',
            'AddLineListMessage', 'RowLockMessage',
            'SliceSelectSliceMessage', 'SliceValueUpdatedMessage',
            'SliceToolStateMessage',
@@ -93,6 +93,35 @@ class LoadDataMessage(Message):
     @property
     def path(self):
         return self._path
+
+
+class LayersFinalizedMessage(Message):
+    """
+    This event type is a temporary solution to AddDataMessage ordering issues.
+    In app.py after the AddDataMessage is broadcast, modifications are made to
+    the viewer layers (e.g. setting visibility). This message is broadcast after
+    those modifications are made so that plugins can also set layer visiblity
+    after data is added to a viewer without the visibility being modified by the
+    code in app.py that runs after the AddDataMessage is broadcast."""
+
+    def __init__(self, data, viewer, viewer_id=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._data = data
+        self._viewer = viewer
+        self._viewer_id = viewer_id
+
+    @property
+    def data(self):
+        return self._data
+
+    @property
+    def viewer(self):
+        return self._viewer
+
+    @property
+    def viewer_id(self):
+        return self._viewer_id
 
 
 class AddDataMessage(Message):

--- a/jdaviz/core/loaders/importers/test_importer.py
+++ b/jdaviz/core/loaders/importers/test_importer.py
@@ -136,14 +136,15 @@ class TestResetAndCheckExistingDataInDC:
 
     def test_reset_and_check_all_importers(self, deconfigged_helper,
                                            image_hdu_wcs, spectrum1d, spectrum2d,
-                                           premade_spectrum_list, source_catalog):
+                                           premade_spectrum_list,
+                                           sky_coord_only_source_catalog):
 
         input_data = {'Image': image_hdu_wcs,
                       '1D Spectrum': spectrum1d,
                       '2D Spectrum': spectrum2d,
                       '1D Spectrum List': premade_spectrum_list,
                       '1D Spectrum Concatenated': premade_spectrum_list,
-                      'Catalog': source_catalog}
+                      'Catalog': sky_coord_only_source_catalog}
 
         # TODO: Remove when this dev flag is no longer needed
         deconfigged_helper.app.state.catalogs_in_dc = True

--- a/jdaviz/core/tests/test_template_mixin.py
+++ b/jdaviz/core/tests/test_template_mixin.py
@@ -369,8 +369,11 @@ def test_export_table_special_cases():
 
 
 @pytest.mark.parametrize('valid_format', astropy_table_write_formats())
-def test_export_table(deconfigged_helper, source_catalog, tmp_path, valid_format):
-    table_obj = FakeTable(deconfigged_helper.app.session, source_catalog)
+def test_export_table(deconfigged_helper, sky_coord_only_source_catalog,
+                      tmp_path, valid_format):
+
+    table_obj = FakeTable(deconfigged_helper.app.session,
+                          sky_coord_only_source_catalog)
 
     tmp_filename = tmp_path / 'temp_table'
     filename = f"{tmp_filename}_{valid_format}"

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -64,10 +64,12 @@ SPECTRAL_AXIS_COMP_LABELS = ('Wavelength', 'Wave', 'Frequency', 'Energy',
                              'Pixel Axis 0 [x]', 'Pixel Axis 1 [x]')
 RA_COMPS = ['rightascension', 'ra', 'radeg', 'radeg',
             'radegrees', 'rightascensiondegrees', 'rightascensiondeg',
-            'raobj', 'objra', 'sourcera', 'rasource', 'raj2000', 'ra2000']
+            'raobj', 'objra', 'sourcera', 'rasource', 'raj2000', 'ra2000',
+            'worldra']
 DEC_COMPS = ['declination', 'dec', 'decdeg', 'decdeg',
              'decdegrees', 'declinationdegrees', 'declinationdeg',
-             'decobj', 'objdec', 'decsource', 'sourcedec', 'decj2000', 'dec2000']
+             'decobj', 'objdec', 'decsource', 'sourcedec', 'decj2000', 'dec2000',
+             'worlddec']
 
 
 class SnackbarQueue:


### PR DESCRIPTION
This PR sets the default visibility of source catalogs based on link type and presence of sky/pixel coordinates. When a catalog with no pixel coordinates is loaded when pixel linked, the visibility is toggled off by default and a snackbar message indicating this is emitted. The same is true for catalogs with no world coordinates when pixel linked. This also applies the same logic to catalog visibility when toggling pixel>world (previously only world>pixel was handled), and also handles the case when theres an orientation change without a reference data change which handles setting visibility correctly when there is only one image loaded.

There was a (hopefully temporary) workaround used here. When i was initially trying to respond to AddDataMessage, the layer visibility was getting reset because there is some additional logic in app.py after AddDataMessage is broadcast, that would override any plugin trying to set visibility after data is added. This new event is called 'LayerFinalizedMessage', and there is a follow up ticket to see if we can clean this up because it would be ideal to have AddDataMessage sent only when data is fully added to the viewer, including the visibility logic, but to fit in the scope of this ticket the workaround described was used.

Follow up tickets:
JDAT-5774 (actually fixed by this PR now, archived)
JDAT-5775