### PR TITLE
Add test for multiple 2d spectra in deconfig

### DIFF
--- a/jdaviz/configs/specviz2d/tests/test_mouseover_multiple_2d.py
+++ b/jdaviz/configs/specviz2d/tests/test_mouseover_multiple_2d.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 from astropy import units as u
-from astropy.wcs import WCS
 from specutils import Spectrum
 from jdaviz.core.marks import PluginLine
 
@@ -29,46 +28,25 @@ def test_multiple_2d_spectra(deconfigged_helper, spectrum2d, mos_spectrum2d):
                 break
         return line_visible
 
-    header_wcs = {
-        'WCSAXES': 2,
-        'CRPIX1': 0.0, 'CRPIX2': 5.0,
-        'CDELT1': 1E-06, 'CDELT2': 1.0,
-        'CUNIT1': 'm', 'CUNIT2': 'pix',
-        'CTYPE1': 'WAVE', 'CTYPE2': 'PIXEL',
-        'CRVAL1': 1.0e-6, 'CRVAL2': 0.0,
-        'RADESYS': 'ICRS', 'SPECSYS': 'BARYCENT'
-    }
-    np.random.seed(42)
-    data_wcs = np.random.random((10, 20)) * u.Jy
-    wcs = WCS(header_wcs)
-
-    spectrum2d_with_wcs = Spectrum(data_wcs, wcs=wcs, meta=header_wcs)
-    deconfigged_helper.load(spectrum2d_with_wcs, data_label='2D Spectrum WCS',
-                            format='2D Spectrum')
-    deconfigged_helper.load(spectrum2d_with_wcs, data_label='2D Spectrum WCS 2',
+    deconfigged_helper.load(mos_spectrum2d, data_label='2D Spectrum WCS',
                             format='2D Spectrum')
 
     viewer_1d = deconfigged_helper.viewers['1D Spectrum']._obj.glue_viewer
     viewer_2d = deconfigged_helper.viewers['2D Spectrum']._obj.glue_viewer
 
     # Get the coordinates info object for mouseover
-    label_mouseover = viewer_2d.session.application._tools['g-coords-info']
+    label_mouseover = deconfigged_helper._coords_info
 
     # Test mouseover on 2D spectrum with WCS
-    assert _mouseover_and_check_line_visible(viewer_2d, label_mouseover, 10, 5)
+    assert _mouseover_and_check_line_visible(viewer_2d, label_mouseover, 5, 5)
     # Test mouseover on 1d spectrum linked to the 2D spectrum
-    assert _mouseover_and_check_line_visible(viewer_1d, label_mouseover, 10, 5)
+    assert _mouseover_and_check_line_visible(viewer_1d, label_mouseover, 5, 5)
 
-    # Create second 2D spectrum with simple spectral axis (no WCS)
-    data_spectral = np.zeros((8, 15))
-    data_spectral[4] = np.arange(15) * 0.5
-    spectral_axis = np.linspace(2.0, 5.0, 15) * u.um
-    spectrum2d_with_spectral_axis = Spectrum(flux=data_spectral*u.MJy, spectral_axis=spectral_axis)
-    deconfigged_helper.load(spectrum2d_with_spectral_axis, data_label='2D Spectrum Spectral Axis',
+    # Add a second 2D spectrum with simple spectral axis (no WCS)
+    deconfigged_helper.load(spectrum2d, data_label='2D Spectrum Spectral Axis',
                             format='2D Spectrum')
-
-    assert _mouseover_and_check_line_visible(viewer_2d, label_mouseover, 10, 5)
-    assert _mouseover_and_check_line_visible(viewer_1d, label_mouseover, 10, 5)
+    assert _mouseover_and_check_line_visible(viewer_2d, label_mouseover, 5, 5)
+    assert _mouseover_and_check_line_visible(viewer_1d, label_mouseover, 5, 5)
 
     data_no_wcs = np.ones((12, 18)) * 2.0
     data_no_wcs[6] = np.arange(18) * 0.3
@@ -79,5 +57,5 @@ def test_multiple_2d_spectra(deconfigged_helper, spectrum2d, mos_spectrum2d):
     #  are not convertible'
     deconfigged_helper.load(spectrum2d_no_wavelength, data_label='2D Spectrum No Wavelength',
                             format='2D Spectrum')
-    assert _mouseover_and_check_line_visible(viewer_2d, label_mouseover, 10, 5)
-    assert _mouseover_and_check_line_visible(viewer_1d, label_mouseover, 10, 5)
+    assert _mouseover_and_check_line_visible(viewer_2d, label_mouseover, 5, 5)
+    assert _mouseover_and_check_line_visible(viewer_1d, label_mouseover, 5, 5)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request adds a test which creates multiple 2d spectra, some with spectral axis mappings and one without, and plots them on the same viewer. The test also checks if lines are appearing when using the mouse over tool. Currently the test fails because of a unit conversion error when adding a spectrum without spectral axis mapping to a viewer which has a spectrum with WCS.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
