### PR TITLE
skip failing tests temporarily

### DIFF
--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -336,6 +336,7 @@ class TestMarkers(BaseImviz_WCS_NoWCS):
             self.viewer.add_markers(tbl, use_skycoord=True, marker_name='my_sky')
 
 
+@pytest.mark.skip(reason="now raising: File does not appear to be a VOTABLE")
 def test_markers_gwcs_lonlat(imviz_helper):
     """GWCS uses Lon/Lat for ICRS."""
     gw_file = get_pkg_data_filename('data/miri_i2d_lonlat_gwcs.asdf')

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -62,6 +62,7 @@ class TestCatalogs:
     # https://dr12.sdss.org/fields/runCamcolField?field=76&camcol=5&run=7674
     # the z-band FITS image was downloaded and used
     # NOTE: We mark "slow" so it only runs on the dev job that is allowed to fail.
+    @pytest.mark.skip(reason="now raising: File does not appear to be a VOTABLE")
     @pytest.mark.slow
     def test_plugin_image_with_result(self, imviz_helper, tmp_path):
         arr = np.ones((1489, 2048))
@@ -235,6 +236,7 @@ def test_from_file_parsing(imviz_helper, tmp_path):
         )
 
 
+@pytest.mark.skip(reason="now raising: File does not appear to be a VOTABLE")
 def test_catalog_reingestion(imviz_helper, tmp_path):
     # load data that we know has Gaia sources
     arr = np.ones((1489, 2048))


### PR DESCRIPTION
This PR temporarily skips two tests raising the following errors until they can be addressed:

```
FAILED jdaviz/configs/imviz/tests/test_catalogs.py::test_catalog_reingestion - astropy.io.votable.exceptions.E19: None:1:0: E19: File does not appear to be a VOTABLE
FAILED jdaviz/configs/imviz/tests/test_astrowidgets_api.py::test_markers_gwcs_lonlat - astropy.io.votable.exceptions.E19: None:1:0: E19: File does not appear to be a VOTABLE
```