### PR TITLE
file loader: prevent UI jump when selecting directory

### DIFF
--- a/jdaviz/core/loaders/resolvers/file/file.py
+++ b/jdaviz/core/loaders/resolvers/file/file.py
@@ -59,6 +59,9 @@ class FileResolver(BaseResolver):
             return
         self.filepath_reactive.value = Path(self.filepath)
         self._resolver_input_updated()
+        if not os.path.exists(self.filepath) or not os.path.isfile(self.filepath):
+            # consider empty if a directory or non-existent file is selected
+            self.parsed_input_is_empty = True
 
     @property
     def is_valid(self):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->



<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request removes the UI jump when selecting a directory in the file loader (which has the annoying consequence of entering the wrong directory on a double click):

https://github.com/user-attachments/assets/5fae5b08-3614-49a9-8932-730ca7065041

It does so by considering a directory selection as still an empty input, and leaves the warning banner in place.

The "input is empty" warning was introduced in #3906 and never released, so this doesn't need a changelog or backport.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [x] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
