### PR TITLE
fix: occasionally not all viewers visible

### DIFF
--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -498,6 +498,20 @@ export default {
     }).observe(this.$refs.mainapp.$el);
     this.outputCellHasHeight = this.$refs.mainapp.$el.offsetHeight > 0
 
+    /* Workaround for Lab 4.5: cells outside the viewport get the style "contentVisibility: auto" which causes wrong
+     * size calculations of golden layout from which it doesn't recover.    
+     */
+    const jpCell = this.$el.closest('.jp-Cell.jp-CodeCell');
+    if (jpCell) {
+      const observer = new MutationObserver((mutationsList) => {
+        if (jpCell.style.contentVisibility !== 'visible') {
+          jpCell.style.contentVisibility = 'visible';
+        }
+      });
+      observer.observe(jpCell, { attributes: true, attributeFilter: ['style'] });
+      jpCell.style.contentVisibility = 'visible';
+    }
+
     /* workaround: when initializing with an existing golden_layout state, the layout doesn't show. rendering it a
      * second time the layout does show.
      */


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request addresses an issue where viewers occasionally fail to appear. This is  caused by a new windowing mode in Jupyter Lab 4.5.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
