### PR TITLE
Filter PytestUnraisableExceptionWarning in tests that use GAIA

### DIFF
--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -337,6 +337,8 @@ class TestMarkers(BaseImviz_WCS_NoWCS):
 
 
 @pytest.mark.remote_data
+# TODO: remove this when GAIA archive issues are resolved
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_markers_gwcs_lonlat(imviz_helper, catch_validate_known_exceptions):
     """GWCS uses Lon/Lat for ICRS."""
     gw_file = get_pkg_data_filename('data/miri_i2d_lonlat_gwcs.asdf')

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -237,6 +237,8 @@ def test_from_file_parsing(imviz_helper, tmp_path):
 
 
 @pytest.mark.remote_data
+# TODO: remove this when GAIA archive issues are resolved
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_catalog_reingestion(imviz_helper, tmp_path, catch_validate_known_exceptions):
     # load data that we know has Gaia sources
     arr = np.ones((1489, 2048))

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -356,6 +356,8 @@ def test_load_catalog_skycoord(imviz_helper, tmp_path, from_file):
 
 
 @pytest.mark.remote_data
+# TODO: remove this when GAIA archive issues are resolved
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_astroquery_load_catalog_source(deconfigged_helper, catch_validate_known_exceptions):
     deconfigged_helper.app.state.catalogs_in_dc = True
 


### PR DESCRIPTION
GAIA archives are still having issues, this will allow three affected tests to pass despite SSLSocket problems due to that. To be reverted when GAIA handles their business.