### PR TITLE
Debug remote test failures due to unclosed sockets

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -75,8 +75,8 @@ extras =
 commands =
     jupyter --paths
     pip freeze
-    !cov: pytest --dist loadfile --pyargs jdaviz {toxinidir}/docs --ignore=jdaviz/qt.py {posargs} --durations=30
-    cov: pytest --dist loadfile --pyargs jdaviz {toxinidir}/docs --cov jdaviz --cov-config={toxinidir}/pyproject.toml --ignore=jdaviz/qt.py {posargs} --durations=30
+    !cov: pytest --pyargs jdaviz {toxinidir}/docs --ignore=jdaviz/qt.py {posargs} --durations=30
+    cov: pytest --pyargs jdaviz {toxinidir}/docs --cov jdaviz --cov-config={toxinidir}/pyproject.toml --ignore=jdaviz/qt.py {posargs} --durations=30
     cov: coverage xml -o {toxinidir}/coverage.xml
 
 pip_pre =


### PR DESCRIPTION
This may be due to pytest-xdist rather than the GAIA servers, opening as draft to test some things on CI.