### PR TITLE
Bugfixes for astroquery loader

### DIFF
--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -4,11 +4,10 @@ import threading
 import warnings
 from contextlib import contextmanager
 from functools import cached_property
-from traitlets import Bool, Float, Instance, List, Unicode, observe, default
+from traitlets import Bool, Instance, List, Unicode, observe, default
 from ipywidgets import widget_serialization
 
 from glue_jupyter.common.toolbar_vuetify import read_icon
-from astropy.coordinates import SkyCoord
 from astropy.coordinates.builtin_frames import __all__ as all_astropy_frames
 from astropy.table import Table as astropyTable
 from astroquery.mast import MastMissions
@@ -1084,7 +1083,7 @@ class BaseConeSearchResolver(BaseResolver):
     viewer_centered = Bool(False).tag(sync=True)
     coordframe_choices = List([]).tag(sync=True)
     coordframe_selected = Unicode("icrs").tag(sync=True)
-    radius = Float(1).tag(sync=True)
+    radius = FloatHandleEmpty(1).tag(sync=True)
     radius_unit_items = List().tag(sync=True)
     radius_unit_selected = Unicode("deg").tag(sync=True)
 

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -8,6 +8,7 @@ from traitlets import Bool, Instance, List, Unicode, observe, default
 from ipywidgets import widget_serialization
 
 from glue_jupyter.common.toolbar_vuetify import read_icon
+from astropy.coordinates import SkyCoord
 from astropy.coordinates.builtin_frames import __all__ as all_astropy_frames
 from astropy.table import Table as astropyTable
 from astroquery.mast import MastMissions
@@ -1210,9 +1211,14 @@ class BaseConeSearchResolver(BaseResolver):
             return
 
         # Obtain center point of the current image and convert into sky coordinates
-        skycoord_center = ref_data.coords.pixel_to_world(
-            viewer.state.zoom_center_x, viewer.state.zoom_center_y
-        )
+        if self._app._jdaviz_helper.plugins["Orientation"].align_by == "WCS":
+            skycoord_center = SkyCoord(
+                viewer.state.zoom_center_x, viewer.state.zoom_center_y, unit="deg"
+            )
+        else:
+            skycoord_center = viewer.state.reference_data.coords.pixel_to_world(
+                viewer.state.zoom_center_x, viewer.state.zoom_center_y
+            )
 
         # Extract SkyCoord values as strings for plugin display
         ra_deg = skycoord_center.ra.deg

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -1197,26 +1197,23 @@ class BaseConeSearchResolver(BaseResolver):
 
         # gets the current viewer
         viewer = self.viewer.selected_obj
+        ref_data = viewer.state.reference_data
 
         # nothing happens in the case there is no image in the viewer
         # additionally if the data does not have WCS
         if (
-            len(self._app._jdaviz_helper.datasets) < 1
-            or viewer.state.reference_data is None
-            or viewer.state.reference_data.coords is None
+
+            len(self.app._jdaviz_helper.datasets) < 1
+            or ref_data is None
+            or ref_data.coords is None
         ):
             self.source = ""
             return
 
         # Obtain center point of the current image and convert into sky coordinates
-        if self._app._jdaviz_helper.plugins["Orientation"].align_by == "WCS":
-            skycoord_center = SkyCoord(
-                viewer.state.zoom_center_x, viewer.state.zoom_center_y, unit="deg"
-            )
-        else:
-            skycoord_center = viewer.state.reference_data.coords.pixel_to_world(
-                viewer.state.zoom_center_x, viewer.state.zoom_center_y
-            )
+        skycoord_center = ref_data.coords.pixel_to_world(
+            viewer.state.zoom_center_x, viewer.state.zoom_center_y
+        )
 
         # Extract SkyCoord values as strings for plugin display
         ra_deg = skycoord_center.ra.deg

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -930,10 +930,10 @@ def test_load_image_align_by(deconfigged_helper, image_nddata_wcs):
 
 
 @pytest.mark.parametrize(
-    ('align_by', ), ('WCS', 'Pixel')
+    ('align_by', ), (('WCS', ), ('Pixel', ))
 )
 def test_load_image_align_by_and_astroquery_loader(deconfigged_helper, image_nddata_wcs, align_by):
-
+    deconfigged_helper.load(image_nddata_wcs, format='image')
     astroquery_loader = deconfigged_helper.loaders['astroquery']
     astroquery_loader.viewer = 'Image'
 

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -930,10 +930,15 @@ def test_load_image_align_by(deconfigged_helper, image_nddata_wcs):
 
 
 @pytest.mark.parametrize(
-    ('align_by', ), (('WCS', ), ('Pixel', ))
+    ('align_by', ), (('WCS', ), ('Pixels', ))
 )
 def test_load_image_align_by_and_astroquery_loader(deconfigged_helper, image_nddata_wcs, align_by):
-    deconfigged_helper.load(image_nddata_wcs, format='image')
+
+    ldr = deconfigged_helper.loaders['object']
+    ldr.object = image_nddata_wcs
+    ldr.format = 'Image'
+    ldr.load()
+
     astroquery_loader = deconfigged_helper.loaders['astroquery']
     astroquery_loader.viewer = 'Image'
 

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -929,6 +929,18 @@ def test_load_image_align_by(deconfigged_helper, image_nddata_wcs):
     assert deconfigged_helper.plugins['Orientation'].align_by.selected == 'WCS'
 
 
+@pytest.mark.parametrize(
+    ('align_by', ), ('WCS', 'Pixel')
+)
+def test_load_image_align_by_and_astroquery_loader(deconfigged_helper, image_nddata_wcs, align_by):
+
+    astroquery_loader = deconfigged_helper.loaders['astroquery']
+    astroquery_loader.viewer = 'Image'
+
+    deconfigged_helper.plugins['Orientation'].align_by = align_by
+    assert len(astroquery_loader.source)
+
+
 @pytest.mark.remote_data
 @pytest.mark.parametrize(
     ('gwcs_to_fits_sip', 'expected_cls'),


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description

While reviewing https://github.com/spacetelescope/jdaviz/pull/3962, I had trouble reproducing the demo if I first loaded an image, then made a query in the astroquery loader, and clicked the link by WCS button. 

To reproduce:
```python
import jdaviz as jd

jd.load('mast:JWST/product/jw06557001002_02101_00002_nrcb3_cal.fits')
jd.show()


jd.loaders['astroquery'].open_in_tray()
jd.loaders['astroquery'].viewer = 'Image'

jd.plugins['Orientation'].align_by = 'WCS'
```

I got an error where the loader's source selection tries to get the viewer's center coordinates: while WCS linking is processing, the `BaseConeSearchResolver.center_on_data` method tries to build a center sky coordinate from the `zoom_center_x/y` which at this point are in pixel units, and fails.

This PR simplifies the central coordinate logic to work in this case. 

I also switched the `radius` traitlet from `Float` to `FloatHandleEmpty` for convenience.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
