### PR TITLE
fix: add PyInstaller hook for pythreejs JSON data files

### DIFF
--- a/standalone/hooks/hook-pythreejs.py
+++ b/standalone/hooks/hook-pythreejs.py
@@ -1,0 +1,10 @@
+"""PyInstaller hook for pythreejs.
+
+pythreejs requires JSON data files at runtime for shader definitions.
+This hook ensures those files are bundled with the application.
+"""
+
+from PyInstaller.utils.hooks import collect_data_files
+
+# Collect all JSON files from pythreejs package
+datas = collect_data_files('pythreejs', includes=['**/*.json'])


### PR DESCRIPTION
### Description
pythreejs loads JSON shader data files at import time (ShaderChunk, ShaderLib, and UniformsLib). PyInstaller doesn't automatically bundle these data files, causing runtime FileNotFoundError. This hook ensures the JSON files are included in the bundled application.



Fixes errors like:
https://github.com/spacetelescope/jdaviz/actions/runs/20140106864/job/57804784350?pr=3943


```
FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/work/jdaviz/jdaviz/standalone/dist/jdaviz/_internal/pythreejs/renderers/shaders/ShaderChunk.autogen.json'
[PYI-15690:ERROR] Failed to execute script 'jdaviz-cli-entrypoint' due to unhandled exception!
```

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
