### PR TITLE
Ignore chararray deprecation warning from astropy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,8 @@ filterwarnings = [
     # This warning will not fail in CI, but causes issues running tests locally on Windows so test locally if considering
     # removing this in the future
     "ignore:Importing display from IPython.core.display is deprecated since IPython 7.14, please import from IPython.display",
+    # This is needed until https://github.com/astropy/astropy/issues/19216 is resolved
+    "ignore:The chararray class is deprecated and will be removed in a future release:DeprecationWarning",
 ]
 
 


### PR DESCRIPTION
Best we can do for now.