### PR TITLE
Fix WCS bug and 3D WCS = None for 2D spectra

### DIFF
--- a/jdaviz/core/loaders/importers/spectrum_common.py
+++ b/jdaviz/core/loaders/importers/spectrum_common.py
@@ -485,14 +485,11 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
                         if len(wcs.forward_transform.inputs) == 5:
                             wcs = None
                         # TODO: This is a temporary fix until handled upstream in glue
-                        # For 2D spectra, disable GWCS with multiple world dimensions
-                        # (e.g., composite frame with celestial + wavelength).
+                        # For 2D spectra, disable 3D GWCS
                         # This prevents glue-astronomy from misidentifying component
                         # units (setting Wavelength to 'deg' instead of wavelength unit).
-                        # 2D spectra don't use celestial coordinates anyway.
                         elif (self.supported_flux_ndim == 2 and
-                              hasattr(wcs, 'world_n_dim') and
-                              wcs.world_n_dim > 1):  # noqa
+                              getattr(wcs, 'world_n_dim', 0) > self.supported_flux_ndim):
                             wcs = None
                     else:
                         wcs = None


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request addresses two bugs, an index error that was getting repressed, and an issue where glue mishandles 3D WCS components for a 2D spectra. The fix for the latter is temporary given that work has started on the issue upstream. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
