### PR TITLE
Update roman test for new version of roman_datamodels

### DIFF
--- a/jdaviz/configs/imviz/tests/test_parser_roman.py
+++ b/jdaviz/configs/imviz/tests/test_parser_roman.py
@@ -10,7 +10,7 @@ from gwcs import WCS as GWCS
     ('ext_list', 'n_dc'),
     [(None, 1),
      ('data', 1),
-     (['data', 'var_rnoise'], 2)])
+     (['data', 'var_poisson'], 2)])
 def test_roman_wfi_ext_options(imviz_helper, roman_imagemodel, ext_list, n_dc):
     imviz_helper.load_data(roman_imagemodel, data_label='roman_wfi_image_model', ext=ext_list)
     dc = imviz_helper.app.data_collection


### PR DESCRIPTION
It looks like there is no longer a `var_rnoise` extension, so I replaced it with `var_poisson` in this check. The `create_fake_data` method now returns a model that looks like:

```
>>> model.info()
root (AsdfObject)
└─roman (WfiImage) # Level 2 (L2) Calibrated Roman Wide Field Instrument (WFI) Rate  (truncated)
  ├─meta (dict)
  │ ├─calibration_software_name (str): RomanCAL # Calibration Software Name
  │ ├─calibration_software_version (str): ? # Calibration Software Version Number
  │ ├─product_type (str): ? # Product Type Descriptor
  │ ├─filename (str): ? # File Name
  │ └─21 not shown
  ├─data (ndarray) # Science Data (DN/s) or (MJy/sr) ...
  ├─dq (ndarray) # Data Quality ...
  ├─err (ndarray) # Error (DN / s) or (MJy / sr) ...
  ├─var_poisson (ndarray) # Poisson Variance (DN^2/s^2) or (MJy^2/sr^2) ...
  ├─chisq (ndarray) # Chi-squared of Ramp Fit ...
  ├─dumo (ndarray) # Difference Uniform Minus Optimal (DN / s) or (MJy / sr) ...
  ├─amp33 (ndarray) # Amplifier 33 Reference Pixel Data (DN) ...
  ├─border_ref_pix_left (ndarray) # Left-Edge Border Reference Pixels (DN) ...
  ├─border_ref_pix_right (ndarray) # Right-Edge Border Reference Pixels (DN) ...
  ├─border_ref_pix_top (ndarray) # Border Reference Pixels on the Top of the Detecto (truncated)
  ├─border_ref_pix_bottom (ndarray) # Bottom-Edge Border Reference Pixels (DN) (truncated)
  ├─dq_border_ref_pix_left (ndarray) # Left-Edge Border Reference Pixel Data Quality (truncated)
  ├─dq_border_ref_pix_right (ndarray) # Right-Edge Border Reference Pixel Data Quali (truncated)
  ├─dq_border_ref_pix_top (ndarray) # Border Reference Pixel Data Quality on the Top (truncated)
  └─dq_border_ref_pix_bottom (ndarray) # Bottom-Edge Border Reference Pixel Data Qua (truncated)
```