### PR TITLE
Rename derived data for data renaming as well as subset renaming

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,10 @@ New Features
 
 - Top level access to datasets API dictionary, deprecating top-level access to data_labels list. [#4024]
 
+- Renaming data will now propagate the new label to derived data in the same way as renaming subsets. For example,
+  renaming 'Cube' to 'CubeFlux' will rename 'Cube (Subset 1, sum)' to 'CubeFlux (Subset 1, sum)'. [#4025]
+
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1953,7 +1953,7 @@ class Application(VuetifyTemplate, HubListener):
                     viewer.state.reference_data = data
 
             # Updated derived data if applicable
-            self._renamed_derived_data(old_label, new_label, 'data')
+            self._rename_derived_data(old_label, new_label, 'data')
 
         finally:
             # Reset the renaming flag after all callbacks have been processed
@@ -1961,14 +1961,14 @@ class Application(VuetifyTemplate, HubListener):
             # will skip resetting the selected value during the rename process
             self._renaming_data = False
 
-    def _renamed_derived_data(self, old_label, new_label, data_type):
+    def _rename_derived_data(self, old_label, new_label, data_type):
         for d in self.data_collection:
             data_renamed = False
             if data_type == 'subset':
                 # Extracted spectra are named, e.g., 'Data (Subset 1, sum)'
                 label_base = d.label.split('(')[-1].split(',')[0]
             else:
-                label_base = d.label.split(' (')[0].split('[')[0]
+                label_base = d.label.split('(')[0].split('[')[0].strip()
             # Extracted spectra are named, e.g., 'Data (Subset 1, sum)'
             if label_base == old_label:
                 old_data_label = d.label
@@ -2557,7 +2557,7 @@ class Application(VuetifyTemplate, HubListener):
             self._update_layer_icons(old_label, new_label)
 
             # Updated derived data if applicable
-            self._renamed_derived_data(old_label, new_label, 'subset')
+            self._rename_derived_data(old_label, new_label, 'subset')
 
         finally:
             self._renaming_subset = False

--- a/jdaviz/configs/default/plugins/data_tools/tests/test_rename_data.py
+++ b/jdaviz/configs/default/plugins/data_tools/tests/test_rename_data.py
@@ -178,7 +178,7 @@ def test_rename_data_no_auto_extraction_on_2d_spectrum(deconfigged_helper, spect
     # Verify rename (of 2d spectrum only) was successful
     assert '2d_spectrum' not in dcf_dc.labels
     assert '2d_spectrum_renamed' in dcf_dc.labels
-    assert '2d_spectrum (auto-ext)' in dcf_dc.labels
+    assert '2d_spectrum_renamed (auto-ext)' in dcf_dc.labels
 
     # Verify no new data was auto-extracted
     # The number of data items should remain the same (or only increase


### PR DESCRIPTION
I thought this was a bug, but it turns out we had only implemented propagating the new data label to derived data for renaming subsets, not for renaming data. This PR splits out that code to a separate function that gets triggered for both data and subset renames.

Closes #4013 