### PR TITLE
Max pin GWCS for now so tests pass

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "vispy>=0.6.5",
     "asdf>=2.14.3",
     "stdatamodels>=1.3",
-    "gwcs>=0.16.1",
+    "gwcs>=0.16.1,<1.0.3",
     "regions>=0.6",
     "scikit-image",
     "sidecar>=0.5.2",


### PR DESCRIPTION
Emergency pin since their 1.0.3 release broke our tests.