### PR TITLE
Fix for GWCS 1.0.3, switching from zip strict = True to zip_longest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -99,7 +99,6 @@ Bug Fixes
 - Fixed bug when initializing relevant 2D Spectrum plugins when there are viewers
   with mixed pixel / wavelength spectral axis units. [#3982]
 
-
 - Fixed API hint styling for viewer labels. [#4003]
 
 Cubeviz
@@ -120,6 +119,7 @@ Specviz
 
 Specviz2d
 ^^^^^^^^^
+- Fixed an issue with GWCS 1.0.3 by updating the ``try/except`` to an if check against ``pixel_n_dim``. [#4032]
 
 4.5 (2025-12-15)
 ================

--- a/jdaviz/configs/default/plugins/data_tools/tests/test_rename_data.py
+++ b/jdaviz/configs/default/plugins/data_tools/tests/test_rename_data.py
@@ -97,8 +97,10 @@ def test_rename_data_errors(deconfigged_helper, image_hdu_wcs):
     with pytest.raises(ValueError):
         deconfigged_helper.app.rename_data('data1', 'data2')
 
-    # Try to rename with a reserved label
-    reserved_label = list(deconfigged_helper.app._reserved_labels)[0]
+    # Try to rename with a reserved label (exclude old_label from candidates
+    # to avoid picking the same name, which would skip the validation check)
+    reserved_label = next(label for label in deconfigged_helper.app._reserved_labels
+                          if label != 'data1')
     with pytest.raises(ValueError):
         deconfigged_helper.app.rename_data('data1', reserved_label)
 

--- a/jdaviz/configs/specviz2d/plugins/cross_dispersion_profile/cross_dispersion_profile.py
+++ b/jdaviz/configs/specviz2d/plugins/cross_dispersion_profile/cross_dispersion_profile.py
@@ -187,7 +187,8 @@ class CrossDispersionProfile(PluginTemplateMixin, PlotMixin):
                             # It's 2D, so this is the only option
                             wav = wcs.pixel_to_world(self.pixel, 0)[0]
                 else:
-                    raise ValueError("WCS with more than 2 dimensions is not supported")
+                    self.disabled_msg = "WCS with more than 2 pixel dimensions is not supported."
+                    raise ValueError(self.disabled_msg)
                 # if the resulting wcs transformation gave us a unit that is still
                 # in pixels, do not attempt to convert units and set wav to None.
                 if wav.unit == u.pix:

--- a/jdaviz/configs/specviz2d/plugins/cross_dispersion_profile/cross_dispersion_profile.py
+++ b/jdaviz/configs/specviz2d/plugins/cross_dispersion_profile/cross_dispersion_profile.py
@@ -171,12 +171,12 @@ class CrossDispersionProfile(PluginTemplateMixin, PlotMixin):
         data = self.dataset.selected_obj
         if data is not None:
             if hasattr(data, 'wcs') and self.sa_display_unit not in ('', u.pix):
+                # APE 14 WCS objects should have a `pixel_n_dim` attribute which
+                # indicates its input dimensionality
                 wcs = self.dataset.selected_obj.wcs
-                # wcs / gwcs don't necessarily have ndim attribute, so try
-                # to detect 2d/1d wcs with try / except
-                try:  # dataset selected wcs is 1d
+                if wcs.pixel_n_dim == 1:
                     wav = wcs.pixel_to_world(self.pixel)
-                except ValueError:  # dataset selected wcs is 2d
+                elif wcs.pixel_n_dim == 2:
                     wav = [c for c in wcs.pixel_to_world(self.pixel, 0) if isinstance(c, SpectralCoord)]  # noqa
                     if len(wav):
                         wav = wav[0]
@@ -186,7 +186,8 @@ class CrossDispersionProfile(PluginTemplateMixin, PlotMixin):
                         else:
                             # It's 2D, so this is the only option
                             wav = wcs.pixel_to_world(self.pixel, 0)[0]
-
+                else:
+                    raise ValueError("WCS with more than 2 dimensions is not supported")
                 # if the resulting wcs transformation gave us a unit that is still
                 # in pixels, do not attempt to convert units and set wav to None.
                 if wav.unit == u.pix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "vispy>=0.6.5",
     "asdf>=2.14.3",
     "stdatamodels>=1.3",
-    "gwcs>=0.16.1,<1.0.3",
+    "gwcs>=0.16.1",
     "regions>=0.6",
     "scikit-image",
     "sidecar>=0.5.2",


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

GWCS 1.0.3 switched from using `zip(..., strict=True)` to `zip_longest`. Jdaviz assumed it could use a `try/except` to determine dimensionality of the WCS because `ndim` was not available; however, APE 14 compliant WCS (`astropy.wcs` and `gwcs`) define `pixel_n_dim` to state the dimensionality of the WCS.

This PR fixes the issue with GWCS 1.0.3 by updating the `try/except` to an `if` check against `pixel_n_dim`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #4030 
Closes #4042 

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
