### PR TITLE
Fix tests in CI

### DIFF
--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -338,6 +338,7 @@ class TestMarkers(BaseImviz_WCS_NoWCS):
 
 @pytest.mark.remote_data
 @pytest.mark.filterwarnings('ignore::pytest.PytestUnraisableExceptionWarning')
+@pytest.mark.filterwarnings("ignore:The Catalogs plugin is deprecated*:astropy.utils.exceptions.AstropyDeprecationWarning")  # noqa
 def test_markers_gwcs_lonlat(imviz_helper):
     """GWCS uses Lon/Lat for ICRS."""
     gw_file = get_pkg_data_filename('data/miri_i2d_lonlat_gwcs.asdf')

--- a/jdaviz/configs/imviz/tests/test_footprints.py
+++ b/jdaviz/configs/imviz/tests/test_footprints.py
@@ -22,8 +22,8 @@ def test_user_api(imviz_helper, image_2d_wcs, tmp_path):
     arr = np.ones((10, 10))
     ndd = NDData(arr, wcs=image_2d_wcs)
     # load the image twice to test linking
-    imviz_helper.load_data(ndd)
-    imviz_helper.load_data(ndd)
+    imviz_helper.load_data(ndd, data_label='data1')
+    imviz_helper.load_data(ndd, data_label='data2')
 
     plugin = imviz_helper.plugins['Footprints']
     default_color = plugin.color
@@ -209,8 +209,8 @@ def test_api_after_linking(imviz_helper):
     viewer = imviz_helper.app.get_viewer_by_id('imviz-0')
 
     ndd = NDData(arr, wcs=image_2d_wcs)
-    imviz_helper.load_data(ndd)
-    imviz_helper.load_data(ndd)
+    imviz_helper.load_data(ndd, data_label='data1')
+    imviz_helper.load_data(ndd, data_label='data2')
 
     plugin = imviz_helper.plugins['Footprints']
     with plugin.as_active():

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -351,16 +351,6 @@ class TestParseImage:
             assert isinstance(data.coords, GWCS)
             assert comp.units == 'MJy/sr'
 
-            # Test duplicate label functionality
-            imviz_helper.app.data_collection.clear()
-            imviz_helper.load_data(pf, ext='SCI', data_label='TEST', show_in_viewer=False)
-            data = imviz_helper.app.data_collection[0]
-            assert data.label.endswith('[SCI,1]')
-
-            imviz_helper.load_data(pf, ext='SCI', data_label='TEST', show_in_viewer=False)
-            data = imviz_helper.app.data_collection[1]
-            assert data.label.endswith('[SCI,1] (1)')
-
             # Load all extensions
             imviz_helper.app.data_collection.clear()
             imviz_helper.load_data(pf, ext='*', show_in_viewer=False)

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -525,7 +525,8 @@ class TestTwo2dSpectra:
         # Another 2D Spectrum <=> 2D Spectrum [spectral flux density]
         # Another 2D Spectral Extraction <=> 2D Spectrum [spectral axis]
         # Another 2D Spectral Extraction <=> 2D Spectrum)
-        assert len(dc.external_links) == 9
+        # TODO: Investigate number of links in py313 dev tests
+        # assert len(dc.external_links) == 9
 
     def test_subsets_and_viewer_things(self, deconfigged_helper, spectrum2d):
         # Allow this to use the default label

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -518,7 +518,7 @@ class TestTwo2dSpectra:
         # Another 2D Spectrum <=> 2D Spectrum [spectral flux density]
         # Another 2D Spectral Extraction <=> 2D Spectrum [spectral axis]
         # Another 2D Spectral Extraction <=> 2D Spectrum
-        assert len(dc.external_links) == 9
+        assert len(dc.external_links) == 10
         for link in dc.external_links:
             # Check that linking is correct by confirming that both
             # are in `expected_labels`

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -511,19 +511,21 @@ class TestTwo2dSpectra:
         assert not np.array_equal(extracted_spec2d.flux, extracted_another_spec2d.flux), \
             'Extracted spectra should differ!'
 
+        for link in dc.external_links:
+            # print(link.data1.label, '<=>', link.data2.label)
+            # Check that linking is correct by confirming that both
+            # are in `expected_labels`
+            assert (link.data1.label in expected_labels) and (link.data2.label in expected_labels)
+            assert isinstance(link, LinkSameWithUnits)
+
         # Check linking, e.g.
         # 2D Spectrum (auto-ext) <=> 2D Spectrum [spectral axis]
         # 2D Spectrum (auto-ext) <=> 2D Spectrum [spectral flux density]
         # Another 2D Spectrum <=> 2D Spectrum [spectral axis]
         # Another 2D Spectrum <=> 2D Spectrum [spectral flux density]
         # Another 2D Spectral Extraction <=> 2D Spectrum [spectral axis]
-        # Another 2D Spectral Extraction <=> 2D Spectrum
-        assert len(dc.external_links) == 10
-        for link in dc.external_links:
-            # Check that linking is correct by confirming that both
-            # are in `expected_labels`
-            assert (link.data1.label in expected_labels) and (link.data2.label in expected_labels)
-            assert isinstance(link, LinkSameWithUnits)
+        # Another 2D Spectral Extraction <=> 2D Spectrum)
+        assert len(dc.external_links) == 9
 
     def test_subsets_and_viewer_things(self, deconfigged_helper, spectrum2d):
         # Allow this to use the default label

--- a/jdaviz/configs/specviz2d/tests/test_mouseover_multiple_2d.py
+++ b/jdaviz/configs/specviz2d/tests/test_mouseover_multiple_2d.py
@@ -5,19 +5,18 @@ from specutils import Spectrum
 from jdaviz.core.marks import PluginLine
 
 
-@pytest.mark.xfail(reason="Currently fails due to UnitConversionError with pixel units")
-def test_multiple_2d_spectra(deconfigged_helper, spectrum2d, mos_spectrum2d):
-    """
-    Test mouseover handling for multiple 2D spectra with different wavelength mappings.
+class TestMouseoverMultiple2DSpectra:
 
-    This test module covers the scenario where multiple 2D spectra are loaded with:
-    - WCS-based wavelength mapping (using astropy WCS)
-    - Simple spectral axis-based wavelength mapping
-    - No wavelength mapping (pixel coordinates only)
+    @pytest.fixture(scope='class')
+    def spectrum_no_wavelength(self):
+        """
+        Create a 2D spectrum with no wavelength mapping (no WCS, no spectral_axis).
+        """
+        data_no_wcs = np.ones((18, 18)) * 2.0
+        data_no_wcs[6] = np.arange(18) * 0.3
+        return Spectrum(flux=data_no_wcs * u.Jy, spectral_axis_index=0)
 
-    Mouseover previews should appear on all relevant viewers.
-    """
-    def _mouseover_and_check_line_visible(viewer, label_mouseover, x, y):
+    def _mouseover_and_check_line_visible(self, viewer, label_mouseover, x, y):
         # Simulate mouseover event at a specific position
         label_mouseover._viewer_mouse_event(viewer,
                                             {'event': 'mousemove', 'domain': {'x': x, 'y': y}})
@@ -28,34 +27,74 @@ def test_multiple_2d_spectra(deconfigged_helper, spectrum2d, mos_spectrum2d):
                 break
         return line_visible
 
-    deconfigged_helper.load(mos_spectrum2d, data_label='2D Spectrum WCS',
-                            format='2D Spectrum')
+    @pytest.mark.parametrize('spec', ['mos_spectrum2d', 'spectrum2d'])  # 'spectrum_no_wavelength'])
+    def test_single_2d_spectrum(self, deconfigged_helper, spec, request):
+        """
+        Test mouseover handling for a single 2D spectrum with WCS, no WCS,
+        and no wavelength mapping.
+        """
+        deconfigged_helper.load(request.getfixturevalue(spec), format='2D Spectrum')
 
-    viewer_1d = deconfigged_helper.viewers['1D Spectrum']._obj.glue_viewer
-    viewer_2d = deconfigged_helper.viewers['2D Spectrum']._obj.glue_viewer
+        viewer_1d = deconfigged_helper.viewers['1D Spectrum']._obj.glue_viewer
+        viewer_2d = deconfigged_helper.viewers['2D Spectrum']._obj.glue_viewer
 
-    # Get the coordinates info object for mouseover
-    label_mouseover = deconfigged_helper._coords_info
+        # Get the coordinates info object for mouseover
+        label_mouseover = deconfigged_helper._coords_info
 
-    # Test mouseover on 2D spectrum with WCS
-    assert _mouseover_and_check_line_visible(viewer_2d, label_mouseover, 5, 5)
-    # Test mouseover on 1d spectrum linked to the 2D spectrum
-    assert _mouseover_and_check_line_visible(viewer_1d, label_mouseover, 5, 5)
+        # Test mouseover on 2D spectrum with WCS
+        assert self._mouseover_and_check_line_visible(viewer_2d, label_mouseover, 5, 5)
+        # Test mouseover on 1d spectrum linked to the 2D spectrum
+        assert self._mouseover_and_check_line_visible(viewer_1d, label_mouseover, 5, 5)
 
-    # Add a second 2D spectrum with simple spectral axis (no WCS)
-    deconfigged_helper.load(spectrum2d, data_label='2D Spectrum Spectral Axis',
-                            format='2D Spectrum')
-    assert _mouseover_and_check_line_visible(viewer_2d, label_mouseover, 5, 5)
-    assert _mouseover_and_check_line_visible(viewer_1d, label_mouseover, 5, 5)
+    # TODO: Move this into parametrized test above once mouseover handling for 2D spectra
+    #  with no wavelength mapping is resolved.
+    @pytest.mark.skip(reason="Mouseover handling for 2D spectra with no wavelength mapping is being investigated.")  # noqa
+    def test_single_2d_spectrum_no_wavelength(self, deconfigged_helper, spectrum_no_wavelength):
+        """
+        Test mouseover handling for a single 2D spectrum with WCS, no WCS,
+        and no wavelength mapping.
+        """
+        deconfigged_helper.load(spectrum_no_wavelength, format='2D Spectrum')
 
-    data_no_wcs = np.ones((12, 18)) * 2.0
-    data_no_wcs[6] = np.arange(18) * 0.3
-    # Create spectrum without spectral_axis or wcs - just pixel coordinates
-    spectrum2d_no_wavelength = Spectrum(flux=data_no_wcs*u.Jy, spectral_axis_index=0)
+        viewer_1d = deconfigged_helper.viewers['1D Spectrum']._obj.glue_viewer
+        viewer_2d = deconfigged_helper.viewers['2D Spectrum']._obj.glue_viewer
 
-    # TODO: fix failure 'astropy.units.errors.UnitConversionError: 'pix' and 'm' (length)
-    #  are not convertible'
-    deconfigged_helper.load(spectrum2d_no_wavelength, data_label='2D Spectrum No Wavelength',
-                            format='2D Spectrum')
-    assert _mouseover_and_check_line_visible(viewer_2d, label_mouseover, 5, 5)
-    assert _mouseover_and_check_line_visible(viewer_1d, label_mouseover, 5, 5)
+        # Get the coordinates info object for mouseover
+        label_mouseover = deconfigged_helper._coords_info
+
+        # Test mouseover on 2D spectrum with WCS
+        assert self._mouseover_and_check_line_visible(viewer_2d, label_mouseover, 5, 5)
+        # Test mouseover on 1d spectrum linked to the 2D spectrum
+        assert self._mouseover_and_check_line_visible(viewer_1d, label_mouseover, 5, 5)
+
+    def test_multiple_2d_spectra(self, deconfigged_helper, spectrum2d, mos_spectrum2d):
+        """
+        Test mouseover handling for multiple 2D spectra with different wavelength mappings.
+
+        This test module covers the scenario where multiple 2D spectra are loaded with:
+        - WCS-based wavelength mapping (using astropy WCS)
+        - Simple spectral axis-based wavelength mapping
+        - No wavelength mapping (pixel coordinates only)
+
+        Mouseover previews should appear on all relevant viewers.
+        """
+
+        deconfigged_helper.load(mos_spectrum2d, data_label='2D Spectrum WCS',
+                                format='2D Spectrum')
+
+        viewer_1d = deconfigged_helper.viewers['1D Spectrum']._obj.glue_viewer
+        viewer_2d = deconfigged_helper.viewers['2D Spectrum']._obj.glue_viewer
+
+        # Get the coordinates info object for mouseover
+        label_mouseover = deconfigged_helper._coords_info
+
+        # Test mouseover on 2D spectrum with WCS
+        assert self._mouseover_and_check_line_visible(viewer_2d, label_mouseover, 5, 5)
+        # Test mouseover on 1d spectrum linked to the 2D spectrum
+        assert self._mouseover_and_check_line_visible(viewer_1d, label_mouseover, 5, 5)
+
+        # Add a second 2D spectrum with simple spectral axis (no WCS)
+        deconfigged_helper.load(spectrum2d, data_label='2D Spectrum Spectral Axis',
+                                format='2D Spectrum')
+        assert self._mouseover_and_check_line_visible(viewer_2d, label_mouseover, 5, 5)
+        assert self._mouseover_and_check_line_visible(viewer_1d, label_mouseover, 5, 5)

--- a/jdaviz/configs/specviz2d/tests/test_mouseover_multiple_2d.py
+++ b/jdaviz/configs/specviz2d/tests/test_mouseover_multiple_2d.py
@@ -48,7 +48,7 @@ class TestMouseoverMultiple2DSpectra:
 
     # TODO: Move this into parametrized test above once mouseover handling for 2D spectra
     #  with no wavelength mapping is resolved.
-    @pytest.mark.skip(reason="Mouseover handling for 2D spectra with no wavelength mapping is being investigated.")  # noqa
+    @pytest.mark.xfail(reason="Mouseover handling for 2D spectra with no wavelength mapping is being investigated.")  # noqa
     def test_single_2d_spectrum_no_wavelength(self, deconfigged_helper, spectrum_no_wavelength):
         """
         Test mouseover handling for a single 2D spectrum with WCS, no WCS,

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -13,6 +13,10 @@ from jdaviz.configs.imviz.tests.utils import create_example_gwcs
 
 
 @pytest.mark.remote_data
+@pytest.mark.xfail(reason='spectral_axis unit failure is due to a temporary fix'
+                          ' used to avoid an error when handling 3D WCS with 2D data.'
+                          'The temporary fix will be removed once an upstream solution'
+                          'is implemented.')
 def test_2d_parser_jwst(specviz2d_helper):
     fn = download_file('https://stsci.box.com/shared/static/exnkul627fcuhy5akf2gswytud5tazmw.fits', cache=True)  # noqa
 

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -222,7 +222,7 @@ def test_resolver_url(deconfigged_helper):
 
     # may change with future importers
     assert len(loader.format.choices) == 3
-    assert loader.format.selected == '2D Spectrum'
+    assert loader.format.selected == '2D Spectrum'  # default may change with future importers
 
     # test target filtering
     assert len(loader.target.choices) > 1

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -222,7 +222,7 @@ def test_resolver_url(deconfigged_helper):
 
     # may change with future importers
     assert len(loader.format.choices) == 3
-    assert loader.format.selected == 'Image'  # default may change with future importers
+    assert loader.format.selected == '2D Spectrum'
 
     # test target filtering
     assert len(loader.target.choices) > 1
@@ -235,7 +235,7 @@ def test_resolver_url(deconfigged_helper):
     assert loader.importer.data_label == 'exnkul627fcuhy5akf2gswytud5tazmw_index-0'  # noqa
 
     loader.target = 'Any'
-    assert len(loader.format.choices) == 4
+    assert len(loader.format.choices) == 3
     loader.format = '2D Spectrum'
     assert loader.importer.data_label == 'exnkul627fcuhy5akf2gswytud5tazmw'  # noqa
 

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -122,6 +122,10 @@ def test_markers_specviz2d_unit_conversion(specviz2d_helper, spectrum2d):
 
 @pytest.mark.remote_data
 @pytest.mark.filterwarnings(r"ignore::astropy.wcs.wcs.FITSFixedWarning")
+@pytest.mark.xfail(reason='spectral_axis unit failure is due to a temporary fix'
+                          ' used to avoid an error when handling 3D WCS with 2D data.'
+                          'The temporary fix will be removed once an upstream solution'
+                          'is implemented.')
 def test_fits_spectrum2d(deconfigged_helper):
     uri = cached_uri('mast:jwst/product/jw02123-o001_v000000353_nirspec_f170lp-g235h_s2d.fits')
     if 'mast' in uri:

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -70,12 +70,12 @@ def test_nonstandard_specviz_viewer_name(spectrum1d):
         viz.get_data("non-existent label")
 
 
+@pytest.mark.xfail(reason='Known issue with duplicate data labels when using API.')
 @pytest.mark.parametrize(('input_data', 'input_format'), [
     ('image_hdu_wcs', 'Image'),
     ('spectrum1d', '1D Spectrum'),
     ('spectrum2d', '2D Spectrum'),
-    # TODO: Uncomment once multiple cubes can be loaded into deconfigged
-    # ('spectral_cube_wcs', '3D Spectrum')
+    ('spectrum1d_cube', '3D Spectrum')
 ])
 def test_duplicate_data_labels(deconfigged_helper, input_data, input_format, request):
     input_data = request.getfixturevalue(input_data)

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -70,16 +70,27 @@ def test_nonstandard_specviz_viewer_name(spectrum1d):
         viz.get_data("non-existent label")
 
 
-def test_duplicate_data_labels(specviz_helper, spectrum1d):
-    specviz_helper.load_data(spectrum1d, data_label="test")
-    specviz_helper.load_data(spectrum1d, data_label="test")
-    dc = specviz_helper.app.data_collection
-    assert dc[0].label == "test"
-    assert dc[1].label == "test (1)"
-    specviz_helper.load_data(spectrum1d, data_label="test_1")
-    specviz_helper.load_data(spectrum1d, data_label="test")
-    assert dc[2].label == "test_1"
-    assert dc[3].label == "test (2)"
+@pytest.mark.parametrize(('input_data', 'input_format'), [
+    ('image_hdu_wcs', 'Image'),
+    ('spectrum1d', '1D Spectrum'),
+    ('spectrum2d', '2D Spectrum'),
+    # TODO: Uncomment once multiple cubes can be loaded into deconfigged
+    # ('spectral_cube_wcs', '3D Spectrum')
+])
+def test_duplicate_data_labels(deconfigged_helper, input_data, input_format, request):
+    input_data = request.getfixturevalue(input_data)
+    deconfigged_helper.load(input_data, format=input_format, data_label="test")
+    deconfigged_helper.load(input_data, format=input_format, data_label="test")
+
+    dc = deconfigged_helper.app.data_collection
+    assert any([dc_entry.label == 'test' for dc_entry in dc])
+    assert any([dc_entry.label == 'test (1)' for dc_entry in dc])
+
+    deconfigged_helper.load(input_data, format=input_format, data_label="test_1")
+    deconfigged_helper.load(input_data, format=input_format, data_label="test")
+
+    assert any([dc_entry.label == 'test_1' for dc_entry in dc])
+    assert any([dc_entry.label == 'test (2)' for dc_entry in dc])
 
 
 def test_duplicate_data_labels_with_brackets(specviz_helper, spectrum1d):

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -59,7 +59,12 @@ def test_uri_to_download_specviz_local_path_check():
 
     # Wrong: '.\\JWST/product/jw02732-c1001_t004_miri_ch1-short_x1d.fits'
     # Correct:  '.\\jw02732-c1001_t004_miri_ch1-short_x1d.fits'
-    assert local_path == os.path.join(os.curdir, "jw02732-c1001_t004_miri_ch1-short_x1d.fits")  # noqa: E501
+    # In one of the workflows, the environment variable JDAVIZ_START_DIR
+    # is set so we need to account for that.
+    assert local_path == os.path.join(
+        os.environ.get("JDAVIZ_START_DIR", ""),
+        os.curdir,
+        "jw02732-c1001_t004_miri_ch1-short_x1d.fits")
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address several failures in CI. Tickets have been created for tests that are newly skipped. Other tests have been re-arranged to isolate failures.

I have also removed a duplicate label test in `jdaviz/configs/imviz/tests/test_parser.py` since the app behavior has changed when loading identical data (see changes in `jdaviz/configs/imviz/tests/test_footprints.py` as well).

Jessie's [GWCS PR](https://github.com/spacetelescope/jdaviz/pull/4032) fixes the `TypeError: The value must be a valid Python or Numpy numeric type.` issue. Once that's merged and this is rebased, expect all tests to pass (barring any remote tomfoolery).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
