### PR TITLE
Fix flaky `test_rename_data_errors`

### DIFF
--- a/jdaviz/configs/default/plugins/data_tools/tests/test_rename_data.py
+++ b/jdaviz/configs/default/plugins/data_tools/tests/test_rename_data.py
@@ -97,8 +97,10 @@ def test_rename_data_errors(deconfigged_helper, image_hdu_wcs):
     with pytest.raises(ValueError):
         deconfigged_helper.app.rename_data('data1', 'data2')
 
-    # Try to rename with a reserved label
-    reserved_label = list(deconfigged_helper.app._reserved_labels)[0]
+    # Try to rename with a reserved label (exclude old_label from candidates
+    # to avoid picking the same name, which would skip the validation check)
+    reserved_label = next(label for label in deconfigged_helper.app._reserved_labels
+                          if label != 'data1')
     with pytest.raises(ValueError):
         deconfigged_helper.app.rename_data('data1', reserved_label)
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes the flaky test `jdaviz/configs/default/plugins/data_tools/tests/test_rename_data.py::test_rename_data_errors`. Was inspired to look into this after seeing CI failures in PR #4032 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
