### PR TITLE
improve default marker style for scatter layers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ New Features
 
 - Indicate in loaders whether the loaded entry/entries will overwrite existing data in the app. [#3997]
 
-
+- Improve default marker styling options (size and color cycler) for scatter layers. [#4044]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2765,7 +2765,13 @@ class Application(VuetifyTemplate, HubListener):
             # unless it is used
             color = data.meta.get('_default_color')
             if color is None:
-                color = viewer.color_cycler()
+                # check if this is a catalog/scatter layer and use scatter_color_cycler,
+                # which has brighter colors.
+                is_catalog = data.meta.get('_importer') == 'CatalogImporter'
+                if is_catalog and hasattr(viewer, 'scatter_color_cycler'):
+                    color = viewer.scatter_color_cycler()
+                else:
+                    color = viewer.color_cycler()
             viewer.add_data(data, percentile=95, color=color)
 
             # Specviz removes the data from collection in viewer.py if flux unit incompatible.

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -74,6 +74,20 @@ class JdavizViewerMixin(WithCache):
         # Allow each viewer to cycle through colors for each new addition to the viewer:
         self.color_cycler = ColorCycler()
 
+        # Separate color cycler for scatter layers (catalogs) that has brighter colors,
+        # starting with neon green
+        self.scatter_color_cycler = ColorCycler()
+        self.scatter_color_cycler.default_color_palette = [
+            '#00FF00',  # neon green
+            '#FF00FF',  # magenta
+            '#00FFFF',  # cyan
+            '#FF0000',  # red
+            '#FFFF00',  # yellow
+            '#FF8800',  # orange
+            '#8800FF',  # purple
+            '#0088FF',  # blue
+        ]
+
         self._data_menu = DataMenu(viewer=self, app=self.jdaviz_app)
 
     @property
@@ -295,6 +309,30 @@ class JdavizViewerMixin(WithCache):
                 layer_state.as_steps = False
             # whenever as_steps changes, we need to redraw the uncertainties (if enabled)
             layer_state.add_callback('as_steps', self._show_uncertainty_changed)
+
+        # set default size for scatter layers (e.g., catalog markers)
+        # based on 1% of the average viewer dimension
+        if isinstance(layer_state, BqplotScatterLayerState):
+
+            # set the marker default size to 1% of the size of the viewer (average
+            # x and y dimensions to account for viewer not being square), and
+            # fall back on a 10 pt marker size if we can't get the viewer
+            # dimensions for some reason (e.g., no image layers)
+            marker_size = 10  # default fallback default for marker size in points d
+            for layer in self.state.layers:
+                if (hasattr(layer, 'layer') and
+                        hasattr(layer.layer, 'data') and
+                        hasattr(layer.layer.data, 'shape') and
+                        len(layer.layer.data.shape) >= 2):
+                    shape = layer.layer.data.shape
+                    avg_dimension = (shape[-2] + shape[-1]) / 2
+                    marker_size = avg_dimension * 0.01
+                    # set a lower limit on marker size, which is the glue default
+                    # of three pixels.
+                    marker_size = max(marker_size, 3)
+                    break
+
+            layer_state.size = marker_size
 
         # use echo-validator to ensure visible sets & updates properly in plot options & data menu
         if (hasattr(layer_state, 'visible') and get_subset_type(layer_state.layer) != 'spatial'):

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -295,7 +295,7 @@ class TestMarkers(BaseImviz_WCS_NoWCS):
         assert data.label == 'my_sky'
         assert data.style.color in ((0, 1, 0), '#00ff00')
         assert data.style.marker == 'o'
-        assert_allclose(data.style.markersize, 3)  # Glue default
+        assert_allclose(data.style.markersize, 3)
         assert_allclose(data.style.alpha, 0.8)
         assert_allclose(data.get_component('ra').data, sky.ra.deg)
         assert_allclose(data.get_component('dec').data, sky.dec.deg)


### PR DESCRIPTION
This PR improves the default marker options for scatter layers. The points are now bigger (in most cases), set to ~1% of the size of the viewer (so 30 pix for a 3000x3000 pix image, but no smaller than 3 pixels), compared to always being 5 pixels previously. Scatter layers now have their own color cycler with brighter colors and the first loaded will be bright green (previously was a medium blue, which didn't stand out much on black and white).
New defaults:

<img width="978" height="544" alt="Screenshot 2026-02-19 at 2 46 48 PM" src="https://github.com/user-attachments/assets/2ef5972c-9457-453b-b6a5-8c4af7dfa067" />

Old: 

<img width="968" height="509" alt="Screenshot 2026-02-19 at 2 49 42 PM" src="https://github.com/user-attachments/assets/e4cc9972-41bf-4a9c-bd55-66538ee655ac" />
