### PR TITLE
Fix catalog layer filter in plot options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -122,6 +122,8 @@ Bug Fixes
 
 - Avoid incorrectly showing "no viewer selected" warning when adding data from some plugins. [#4037]
 
+- Fix layer filtering logic for plot options to properly show/hide layers based on coordinate and link type. [#4046]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -493,7 +493,8 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
         self.layer = LayerSelect(self, 'layer_items', 'layer_selected',
                                  'viewer_selected', 'layer_multiselect')
 
-        self.layer.filters += [is_not_wcs_only, 'has_wcs_if_image_viewer_pixel_linked',
+        self.layer.filters += [is_not_wcs_only, 
+                               'catalog_has_correct_coords_based_on_link_type',
                                'not_in_table_viewer']
 
         self.swatches_palette = [

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -493,7 +493,7 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
         self.layer = LayerSelect(self, 'layer_items', 'layer_selected',
                                  'viewer_selected', 'layer_multiselect')
 
-        self.layer.filters += [is_not_wcs_only, 
+        self.layer.filters += [is_not_wcs_only,
                                'catalog_has_correct_coords_based_on_link_type',
                                'not_in_table_viewer']
 

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -595,10 +595,17 @@ def test_catalog_visibility(imviz_helper, image_2d_wcs):
     dm = imviz_helper.viewers['imviz-0'].data_menu
     assert dm.data_labels_visible == ['Image[DATA]']
 
+    # and it should not be available as a layer in plot options
+    po = imviz_helper.plugins['Plot Options']
+    po.viewer = 'imviz-0'
+    assert po.layer.choices == ['Image[DATA]']  # catalog layer not an option
+
     # but if we load the catalog with X, Y, it should be visible
     imviz_helper.load(table_x_y_only,
                       data_label='catalog1')
     assert dm.data_labels_visible == ['catalog1', 'Image[DATA]']
+
+    assert po.layer.choices == ['Image[DATA]', 'catalog1']  # catalog layer is now an option
 
     # now change to WCS linking
     imviz_helper.plugins['Orientation'].align_by = 'WCS'

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2274,16 +2274,28 @@ class LayerSelect(SelectPluginComponent):
             return getattr(getattr(lyr, 'data', None), 'meta', '').get('_extname', '') == 'DQ'
 
         def has_wcs_if_image_viewer_pixel_linked(lyr):
+            # this filter is only relevant for image viewers
             if not np.all([viewer.__class__.__name__ == 'ImvizImageView'
                            for viewer in self.viewer_objs]):
                 return True
+
+            # non-catalog layers should remain available regardless of link type
             if getattr(lyr, 'meta', {}).get('_importer', '') != 'CatalogImporter':
-                # for now, allow any non-catalog layers to reproduce
-                # expected behavior from tests
                 return True
+
+            comp_labels = [str(x) for x in lyr.component_ids()]
+
+            # if pixel linked, only show catalog layers if they have X and Y coords
             if self.app._align_by.lower() == 'pixels':
-                return getattr(lyr, 'coords', None) is not None
-            return True
+                x_col = lyr.meta.get('_jdaviz_loader_x_col')
+                y_col = lyr.meta.get('_jdaviz_loader_y_col')
+                return x_col in comp_labels and y_col in comp_labels
+
+            # if WCS linked, only show catalog layers if they have RA and Dec coords
+            elif self.app._align_by.lower() == 'wcs':
+                ra_col = lyr.meta.get('_jdaviz_loader_ra_col')
+                dec_col = lyr.meta.get('_jdaviz_loader_dec_col')
+                return ra_col in comp_labels and dec_col in comp_labels
 
         def not_in_table_viewer(lyr):
             # exclude layers when all selected viewers are table viewers

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2273,7 +2273,13 @@ class LayerSelect(SelectPluginComponent):
         def is_dq_layer(lyr):
             return getattr(getattr(lyr, 'data', None), 'meta', '').get('_extname', '') == 'DQ'
 
-        def has_wcs_if_image_viewer_pixel_linked(lyr):
+        def catalog_has_correct_coords_based_on_link_type(lyr):
+            """
+            For catalogs in image viewers, filter based on link type. Catalog
+            must have X+Y coordinate columns assigned if pixel linked, and RA+Dec
+            coordinate columns assigned if WCS linked.
+            """
+
             # this filter is only relevant for image viewers
             if not np.all([viewer.__class__.__name__ == 'ImvizImageView'
                            for viewer in self.viewer_objs]):

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2296,7 +2296,7 @@ class LayerSelect(SelectPluginComponent):
                 ra_col = lyr.meta.get('_jdaviz_loader_ra_col')
                 dec_col = lyr.meta.get('_jdaviz_loader_dec_col')
                 return ra_col in comp_labels and dec_col in comp_labels
-            
+
             # this should never be encountered, but just in case raise an error
             # instead of just returning None so we know something went wrong
             else:

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2296,6 +2296,11 @@ class LayerSelect(SelectPluginComponent):
                 ra_col = lyr.meta.get('_jdaviz_loader_ra_col')
                 dec_col = lyr.meta.get('_jdaviz_loader_dec_col')
                 return ra_col in comp_labels and dec_col in comp_labels
+            
+            # this should never be encountered, but just in case raise an error
+            # instead of just returning None so we know something went wrong
+            else:
+                raise ValueError("_align_by must be 'wcs' or 'pixels'")
 
         def not_in_table_viewer(lyr):
             # exclude layers when all selected viewers are table viewers


### PR DESCRIPTION
This PR fixes a bug where when a catalog and an image viewer are in an image viewer and are pixel linked, the catalog layer is not an option in plot options to adjust marker size etc. The solution was to modify the filter on layers in plot options, catalogs with only RA and Dec while pixel linked will be hidden but they won't be if they contain X and Y (and vice versa for WCS linked). 
