### PR TITLE
Add APIs to enable/disable footprint selection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ New Features
 - Indicate in loaders whether the loaded entry/entries will overwrite existing data in the app. [#3997]
   
 - Added ``enable_footprint_selection_tools()`` and ``disable_footprint_selection_tools()`` APIs
-  to programmatically control footprint selection toolbar in Imviz. [#4048]
+  to programmatically control footprint selection toolbar. [#4048]
 
 - Improve default marker styling options (size and color cycler) for scatter layers. [#4044]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ New Features
 - Add handles to subset to allow interactive resizing. [#3919]
 
 - Indicate in loaders whether the loaded entry/entries will overwrite existing data in the app. [#3997]
+  
+- Added ``enable_footprint_selection_tools()`` and ``disable_footprint_selection_tools()`` APIs
+  to programmatically control footprint selection toolbar in Imviz. [#4048]
 
 - Improve default marker styling options (size and color cycler) for scatter layers. [#4044]
 

--- a/jdaviz/components/custom_toolbar_toggle.vue
+++ b/jdaviz/components/custom_toolbar_toggle.vue
@@ -7,7 +7,7 @@
         @click="$emit('toggle-custom-toolbar')"
       >
         <slot></slot>
-        <span v-if="api_hints_enabled && api_hint_enable" class="api-hint">
+        <span v-if="api_hints_enabled && api_hint_enable" class="api-hint" :style="enabled ? 'color: white !important' : ''">
           {{ enabled ? api_hint_disable : api_hint_enable }}
         </span>
         <span v-else>

--- a/jdaviz/components/custom_toolbar_toggle.vue
+++ b/jdaviz/components/custom_toolbar_toggle.vue
@@ -7,7 +7,7 @@
         @click="$emit('toggle-custom-toolbar')"
       >
         <slot></slot>
-        <span v-if="api_hints_enabled && api_hint_enable" class="api-hint" :style="enabled ? 'color: white !important' : ''">
+        <span v-if="api_hints_enabled && api_hint_enable" :class="enabled ? 'api-hint api-hint-invert-color' : 'api-hint'">
           {{ enabled ? api_hint_disable : api_hint_enable }}
         </span>
         <span v-else>

--- a/jdaviz/components/custom_toolbar_toggle.vue
+++ b/jdaviz/components/custom_toolbar_toggle.vue
@@ -7,7 +7,12 @@
         @click="$emit('toggle-custom-toolbar')"
       >
         <slot></slot>
-        {{ enabled ? 'Disable' : 'Enable' }} {{ text }}
+        <span v-if="api_hints_enabled && api_hint_enable" class="api-hint">
+          {{ enabled ? api_hint_disable : api_hint_enable }}
+        </span>
+        <span v-else>
+          {{ (enabled ? 'Disable' : 'Enable') + ' ' + text }}
+        </span>
       </v-btn>
     </j-tooltip>
   </v-row>
@@ -15,6 +20,6 @@
 
 <script>
   module.exports = {
-    props: ['enabled', 'text']
+    props: ['enabled', 'text', 'api_hints_enabled', 'api_hint_enable', 'api_hint_disable']
   };
 </script>

--- a/jdaviz/components/loader.vue
+++ b/jdaviz/components/loader.vue
@@ -43,6 +43,9 @@
             v-if="footprint_select_icon && treat_table_as_query && is_wcs_linked && observation_table_populated"
             :enabled="custom_toolbar_enabled"
             text="footprint selection tools"
+            :api_hints_enabled="api_hints_enabled"
+            api_hint_enable="ldr.enable_footprint_selection_tools()"
+            api_hint_disable="ldr.disable_footprint_selection_tools()"
             @toggle-custom-toolbar="$emit('toggle-custom-toolbar')"
             style="margin-bottom: 16px"
           >

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -165,6 +165,10 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin,
         Additional V3 offset in telescope coordinates to apply to instrument center, as from a
         dither pattern.
     * :meth:`overlay_regions`
+    * :meth:`enable_footprint_selection_tools`
+        enable footprint selection tools in the viewer toolbar
+    * :meth:`disable_footprint_selection_tools`
+        disable footprint selection tools in the viewer toolbar
     """
     template_file = __file__, "footprints.vue"
     uses_active_status = Bool(True).tag(sync=True)
@@ -299,6 +303,22 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin,
         self.overlay_selected = closest_overlay_label
         self._highlight_overlay(closest_overlay_label, viewers=self.viewer.selected_obj)
 
+    def enable_footprint_selection_tools(self):
+        """
+        Enable footprint selection tools in the viewer toolbar.
+
+        This allows clicking on footprints to select them.
+        """
+        if not self.custom_toolbar_enabled:
+            self.toggle_custom_toolbar()
+
+    def disable_footprint_selection_tools(self):
+        """
+        Disable footprint selection tools in the viewer toolbar.
+        """
+        if self.custom_toolbar_enabled:
+            self.toggle_custom_toolbar()
+
     @property
     def user_api(self):
         return PluginUserApi(self, expose=('overlay',
@@ -307,7 +327,9 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin,
                                            'preset_obs', 'preset', 'import_region',
                                            'center_on_viewer', 'ra', 'dec', 'pa',
                                            'v2_offset', 'v3_offset',
-                                           'overlay_regions'))
+                                           'overlay_regions',
+                                           'enable_footprint_selection_tools',
+                                           'disable_footprint_selection_tools'))
 
     def _get_marks(self, viewer, overlay=None):
         matches = [mark for mark in viewer.figure.marks

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.vue
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.vue
@@ -23,6 +23,9 @@
       v-if="overlay_items.length > 1"
       :enabled="custom_toolbar_enabled"
       text="footprint selection tools"
+      :api_hints_enabled="api_hints_enabled"
+      api_hint_enable="plg.enable_footprint_selection_tools()"
+      api_hint_disable="plg.disable_footprint_selection_tools()"
       @toggle-custom-toolbar="toggle_custom_toolbar"
     >
       <img class="invert-if-dark" :src="footprint_select_icon" width="20"/>

--- a/jdaviz/configs/imviz/tests/test_footprints.py
+++ b/jdaviz/configs/imviz/tests/test_footprints.py
@@ -365,12 +365,12 @@ def test_footprint_enable_disable_api(imviz_helper, image_2d_wcs):
         plugin.add_overlay('second')
 
         # Initially disabled
-        assert plugin._obj.custom_toolbar_enabled is False
+        assert not plugin._obj.custom_toolbar_enabled
 
         # Enable using API
         plugin.enable_footprint_selection_tools()
-        assert plugin._obj.custom_toolbar_enabled is True
+        assert plugin._obj.custom_toolbar_enabled
 
         # Disable using API
         plugin.disable_footprint_selection_tools()
-        assert plugin._obj.custom_toolbar_enabled is False
+        assert not plugin._obj.custom_toolbar_enabled

--- a/jdaviz/configs/imviz/tests/test_footprints.py
+++ b/jdaviz/configs/imviz/tests/test_footprints.py
@@ -348,3 +348,29 @@ def test_footprint_loaders(imviz_helper, image_2d_wcs):
     ldr.load()
 
     assert 'imported from STCS' in plg.overlay.choices
+
+
+def test_footprint_enable_disable_api(imviz_helper, image_2d_wcs):
+    """Test enable/disable footprint selection tools API on Footprints plugin."""
+    arr = np.ones((10, 10))
+    ndd = NDData(arr, wcs=image_2d_wcs)
+    imviz_helper.load_data(ndd)
+    imviz_helper.load_data(ndd)
+
+    plugin = imviz_helper.plugins['Footprints']
+    plugin._obj.vue_link_by_wcs()
+
+    with plugin.as_active():
+        # Add a second overlay to make toolbar button available
+        plugin.add_overlay('second')
+
+        # Initially disabled
+        assert plugin._obj.custom_toolbar_enabled is False
+
+        # Enable using API
+        plugin.enable_footprint_selection_tools()
+        assert plugin._obj.custom_toolbar_enabled is True
+
+        # Disable using API
+        plugin.disable_footprint_selection_tools()
+        assert plugin._obj.custom_toolbar_enabled is False

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -755,9 +755,6 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
         Only available when loading observation tables with s_region data
         and images are linked by WCS.
 
-        Note: Images must be linked by WCS before enabling footprint selection.
-        Use ``imviz.link_data(align_by='wcs')`` to link images by WCS.
-
         Raises
         ------
         ValueError
@@ -771,8 +768,7 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
 
         if not self.is_wcs_linked:
             raise ValueError(
-                "Images must be linked by WCS before enabling footprint selection tools. "
-                "Use imviz.link_data(align_by='wcs') to link images by WCS."
+                "Images must be linked by WCS before enabling footprint selection tools."
             )
 
         if not self.custom_toolbar_enabled:

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -761,7 +761,7 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
         Raises
         ------
         ValueError
-            If images are not linked by WCS or if no observation table with 
+            If images are not linked by WCS or if no observation table with
             s_region data has been loaded.
         """
         if not (self.parsed_input_is_query and self.treat_table_as_query):

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -747,6 +747,44 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
         else:
             return self.parsed_input
 
+    def enable_footprint_selection_tools(self):
+        """
+        Enable footprint selection tools in the viewer toolbar.
+
+        This allows clicking on observation footprints to select them.
+        Only available when loading observation tables with s_region data
+        and images are linked by WCS.
+
+        Note: Images must be linked by WCS before enabling footprint selection.
+        Use ``imviz.link_data(align_by='wcs')`` to link images by WCS.
+
+        Raises
+        ------
+        ValueError
+            If images are not linked by WCS or if no observation table with 
+            s_region data has been loaded.
+        """
+        if not (self.parsed_input_is_query and self.treat_table_as_query):
+            raise ValueError(
+                "Footprint selection tools require an observation table with s_region data."
+            )
+
+        if not self.is_wcs_linked:
+            raise ValueError(
+                "Images must be linked by WCS before enabling footprint selection tools. "
+                "Use imviz.link_data(align_by='wcs') to link images by WCS."
+            )
+
+        if not self.custom_toolbar_enabled:
+            self.toggle_custom_toolbar()
+
+    def disable_footprint_selection_tools(self):
+        """
+        Disable footprint selection tools in the viewer toolbar.
+        """
+        if self.custom_toolbar_enabled:
+            self.toggle_custom_toolbar()
+
     @property
     def user_api(self):
         return LoaderUserApi(self)

--- a/jdaviz/core/loaders/resolvers/test_resolver.py
+++ b/jdaviz/core/loaders/resolvers/test_resolver.py
@@ -507,7 +507,7 @@ def test_disable_footprint_selection_tools_api(deconfigged_helper, image_nddata_
 
     # Now disable
     ldr.disable_footprint_selection_tools()
-    assert ldr._obj.custom_toolbar_enabled is False
+    assert not ldr._obj.custom_toolbar_enabled
 
     # Verify footprints are removed
     footprints = [m for m in viewer.figure.marks if isinstance(m, RegionOverlay)]

--- a/jdaviz/core/loaders/resolvers/test_resolver.py
+++ b/jdaviz/core/loaders/resolvers/test_resolver.py
@@ -472,9 +472,9 @@ def test_enable_footprint_selection_tools_api(deconfigged_helper, image_nddata_w
     # Link by WCS
     ldr._obj.vue_link_by_wcs()
 
-    assert ldr._obj.custom_toolbar_enabled is False
+    assert not ldr._obj.custom_toolbar_enabled
     ldr.enable_footprint_selection_tools()
-    assert ldr._obj.custom_toolbar_enabled is True
+    assert ldr._obj.custom_toolbar_enabled
 
     # Verify footprints are displayed
     viewer = list(deconfigged_helper.app._viewer_store.values())[0]
@@ -499,7 +499,7 @@ def test_disable_footprint_selection_tools_api(deconfigged_helper, image_nddata_
 
     # Enable first
     ldr.enable_footprint_selection_tools()
-    assert ldr._obj.custom_toolbar_enabled is True
+    assert ldr._obj.custom_toolbar_enabled
 
     viewer = list(deconfigged_helper.app._viewer_store.values())[0]
     footprints = [m for m in viewer.figure.marks if isinstance(m, RegionOverlay)]

--- a/jdaviz/core/loaders/resolvers/test_resolver.py
+++ b/jdaviz/core/loaders/resolvers/test_resolver.py
@@ -4,6 +4,7 @@ from jdaviz.core.marks import RegionOverlay
 from jdaviz.utils import find_polygon_mark_with_skewer
 
 import numpy as np
+import pytest
 from astropy.table import Table
 
 
@@ -448,3 +449,76 @@ def test_skewer_selection_with_empty_region(deconfigged_helper, image_nddata_wcs
     # Should still work with the single valid footprint
     indices = find_polygon_mark_with_skewer(center_x, center_y, viewer, footprints)
     assert indices == [0]
+
+
+def test_enable_footprint_selection_tools_api(deconfigged_helper, image_nddata_wcs):
+    """Test the enable_footprint_selection_tools API method."""
+    deconfigged_helper.load(image_nddata_wcs, format='Image', data_label='test_image')
+
+    table = Table()
+    table['Dataset'] = ['obs1']
+    table['s_region'] = [
+        'POLYGON 337.499 -20.831 337.501 -20.831 337.501 -20.829 337.499 -20.829'
+    ]
+
+    ldr = deconfigged_helper.loaders['object']
+    ldr.object = table
+    ldr.treat_table_as_query = True
+
+    # Should fail without WCS linking
+    with pytest.raises(ValueError, match="Images must be linked by WCS"):
+        ldr.enable_footprint_selection_tools()
+
+    # Link by WCS
+    ldr._obj.vue_link_by_wcs()
+
+    assert ldr._obj.custom_toolbar_enabled is False
+    ldr.enable_footprint_selection_tools()
+    assert ldr._obj.custom_toolbar_enabled is True
+
+    # Verify footprints are displayed
+    viewer = list(deconfigged_helper.app._viewer_store.values())[0]
+    footprints = [m for m in viewer.figure.marks if isinstance(m, RegionOverlay)]
+    assert len(footprints) == 1
+
+
+def test_disable_footprint_selection_tools_api(deconfigged_helper, image_nddata_wcs):
+    """Test the disable_footprint_selection_tools API method."""
+    deconfigged_helper.load(image_nddata_wcs, format='Image', data_label='test_image')
+
+    table = Table()
+    table['Dataset'] = ['obs1']
+    table['s_region'] = [
+        'POLYGON 337.499 -20.831 337.501 -20.831 337.501 -20.829 337.499 -20.829'
+    ]
+
+    ldr = deconfigged_helper.loaders['object']
+    ldr.object = table
+    ldr.treat_table_as_query = True
+    ldr._obj.vue_link_by_wcs()
+
+    # Enable first
+    ldr.enable_footprint_selection_tools()
+    assert ldr._obj.custom_toolbar_enabled is True
+
+    viewer = list(deconfigged_helper.app._viewer_store.values())[0]
+    footprints = [m for m in viewer.figure.marks if isinstance(m, RegionOverlay)]
+    assert len(footprints) == 1
+
+    # Now disable
+    ldr.disable_footprint_selection_tools()
+    assert ldr._obj.custom_toolbar_enabled is False
+
+    # Verify footprints are removed
+    footprints = [m for m in viewer.figure.marks if isinstance(m, RegionOverlay)]
+    assert len(footprints) == 0
+
+
+def test_enable_without_observation_table(deconfigged_helper, image_nddata_wcs):
+    deconfigged_helper.load(image_nddata_wcs, format='Image', data_label='test_image')
+
+    ldr = deconfigged_helper.loaders['object']
+
+    # Try to enable without loading any observation table
+    with pytest.raises(ValueError, match="observation table with s_region data"):
+        ldr.enable_footprint_selection_tools()

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -380,7 +380,9 @@ class LoaderUserApi(UserApiWrapper):
                                           'observation_table', 'file_table',
                                           'file_cache',
                                           'file_timeout',
-                                          'file_local_path']))
+                                          'file_local_path',
+                                          'enable_footprint_selection_tools',
+                                          'disable_footprint_selection_tools']))
         super().__init__(loader, expose, readonly, excl_from_dict, deprecated)
 
     def __repr__(self):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This PR adds programmatic APIs to enable and disable footprint selection tools in Imviz. The APIs are available on both the object loader (for MAST observation tables) and the Footprints plugin.

**Usage examples:**

For observation tables loaded via the object loader:
```python
ldr = imviz.loaders['object']
ldr.object = observation_table  # MAST query results with s_region
imviz.link_data(align_by='wcs')  # Required before enabling
ldr.enable_footprint_selection_tools()
ldr.disable_footprint_selection_tools()
```
For the Footprints plugin:
```python
plg = imviz.plugins['Footprints']
plg.enable_footprint_selection_tools()
plg.disable_footprint_selection_tools()
```

API Hints: 
<img width="328" height="502" alt="image" src="https://github.com/user-attachments/assets/6b346c9a-ae57-44c8-bb8f-50334526fb67" /> <img width="340" height="502" alt="image" src="https://github.com/user-attachments/assets/e0d5e3ea-25c7-407f-a017-b48dfa77f57f" />

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
