### PR TITLE
allow creation of image viewer for moment maps, hide option for 'align by' in image importer in specific cases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,9 @@ New Features
 
 - Allow ingesting tables in plugins back into the app. [#4021]
 
+- Allow creating new image viewers from moment map plugin. Remove option to select 'align by' in image
+  importer unless orientation plugin exists, or new viewer creation selection is Image. [#4054]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -131,7 +131,10 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
 
     def _get_supported_viewers(self):
         """Return viewer types that can display moment map 2D image."""
-        return [{'label': '3D Spectrum', 'reference': 'cubeviz-image-viewer'}]
+        return [
+            {'label': '3D Spectrum', 'reference': 'cubeviz-image-viewer'},
+            {'label': 'Image', 'reference': 'cubeviz-image-viewer'}
+        ]
 
     @property
     def _default_image_viewer_reference_name(self):

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -255,6 +255,41 @@ def test_moment_frequency_unit_conversion(cubeviz_helper, spectrum1d_cube_larger
     assert_quantity_allclose(moment_0_data, -2.9607526e+09*u.Unit("Hz Jy / pix2"))
 
 
+def test_moment_create_new_image_viewer_deconfigged(deconfigged_helper, image_cube_hdu_obj):
+    """
+    Make sure you can create a new Image viewer (not just 3D Spectrum viewer)
+    from the moment map plugin and add the moment map to that viewer.
+    """
+    deconfigged_helper.load(image_cube_hdu_obj, format='3D Spectrum', data_label='test')
+
+    mm = deconfigged_helper.plugins['Moment Maps']._obj
+    mm.dataset.selected = mm.dataset.labels[0]
+    mm.n_moment = 0
+
+    assert 'Image' in mm.add_results.viewer.create_new.choices
+    mm.add_results.viewer.create_new.selected = 'Image'
+
+    mm.calculate_moment()
+
+    # make sure that the new 'Image' viewer exists and that the moment map is in it
+    all_viewers = deconfigged_helper.viewers.keys()
+    assert 'Image' in all_viewers
+    image_viewer = deconfigged_helper.viewers['Image']
+    assert 'moment 0' in image_viewer.data_menu.data_labels_visible
+
+    # currently blocked by issue with units in JDAT-5951, uncomment this
+    # portion of the test once that ticket is resolved
+
+    # # now calculate another moment map and add it to the existing Image viewer
+    # # and make sure it is added
+    # mm.add_results.label = 'moment 00'
+    # mm.add_results.viewer.selected = 'Image'
+    # mm.calculate_moment()
+
+    # image_viewer = deconfigged_helper.app.get_viewer('Image')
+    # assert 'moment 00' in image_viewer.data_menu.layer.choices
+
+
 def test_write_momentmap(cubeviz_helper, spectrum1d_cube, tmp_path):
     ''' Test writing a moment map out to a FITS file on disk '''
 

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -13,7 +13,6 @@ from specutils import Spectrum
 from stdatamodels import asdf_in_fits
 from traitlets import Bool, List, Any, Unicode, observe
 
-from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.template_mixin import (SelectFileExtensionComponent,
                                         DatasetSelect,
                                         SelectPluginComponent)
@@ -82,6 +81,10 @@ class ImageImporter(BaseImporterToDataCollection):
     # suffices that will be applied to the prefix (read-only)
     data_label_suffices = List().tag(sync=True)
 
+    # if orientation plugin exists or create new viewer selection is an Image
+    # viewer, expose options to align by pixels or WCS.
+    expose_align_by_options = Bool(True).tag(sync=True)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -94,11 +97,17 @@ class ImageImporter(BaseImporterToDataCollection):
                                               items='align_by_items',
                                               selected='align_by_selected',
                                               manual_options=['Pixels', 'WCS'])
+
         align_plg = self.app._jdaviz_helper.plugins.get('Orientation', None)
         if align_plg is not None:
+            self.expose_align_by_options = True
             self.align_by.selected = align_plg.align_by.selected
         else:
-            self.align_by.selected = 'Pixels'
+            if self.viewer_create_new_selected == 'Image':
+                self.expose_align_by_options = True
+            else:
+                self.expose_align_by_options = False
+                self.align_by.selected = 'Pixels'
 
         input = self.input
         if isinstance(input, fits.hdu.image.ImageHDU):
@@ -216,6 +225,19 @@ class ImageImporter(BaseImporterToDataCollection):
                 # that pass the FITS/NDData condition
                 return False
             return True
+
+    @observe('viewer_create_new_selected')
+    def _on_create_new_viewer_selected(self, msg):
+        """
+        If the orientation plugin does not exist but the new selected viewer to
+        create is an image viewer, expose the option to align by pixels or WCS
+        because the creation of the app's first image viewer will cause the
+        Orientation plugin relevancy to change.
+        """
+
+        align_plg = self.app._jdaviz_helper.plugins.get('Orientation', None)
+        if align_plg is None:
+            self.expose_align_by_options = (msg['new'] == 'Image')
 
     def _glue_data_wcs_to_fits(self, glue_data):
         """
@@ -406,9 +428,6 @@ class ImageImporter(BaseImporterToDataCollection):
         align_plg = self.app._jdaviz_helper.plugins.get('Orientation', None)
         if align_plg is not None:
             align_plg.align_by.selected = self.align_by.selected
-        else:
-            msg = f"could not change align_by to {self.align_by.selected}"
-            self.app.hub.broadcast(SnackbarMessage(msg, sender=self, color='warning'))
 
     def assign_component_type(self, comp_id, comp, units, physical_type):
         return _spatial_assign_component_type(comp_id, comp, units, physical_type)

--- a/jdaviz/core/loaders/importers/image/image.vue
+++ b/jdaviz/core/loaders/importers/image/image.vue
@@ -55,7 +55,7 @@
         hint="If GWCS exists, try to convert into FITS SIP for better performance aligning images (typical precision <0.1 pixels)."
       />
     </v-row>
-    <v-row>
+    <v-row v-if="expose_align_by_options">
       <v-radio-group
         :label="api_hints_enabled ? 'ldr.importer.align_by = ' : 'Align by'"
         :class="api_hints_enabled ? 'api-hint' : null"

--- a/jdaviz/core/loaders/importers/test_importer.py
+++ b/jdaviz/core/loaders/importers/test_importer.py
@@ -197,6 +197,30 @@ def test_reject_2d_spectrum_as_image(deconfigged_helper, spectrum2d, mos_spectru
     assert len(deconfigged_helper.app.data_collection) > 0
 
 
+def test_image_importer_expose_align_by_options(deconfigged_helper, image_hdu_wcs):
+    """
+    Verify that the logic for expose_align_by_options, the traitlet in the image
+    importer that determines whether or not to expose option to align by pixels
+    or WCS, is correct. It should be True (to show options) if there is an
+    Orientation plugin or if the selection for the new viewer creation is 'Image',
+    and False otherwise.
+    """
+
+    ldr = deconfigged_helper.loaders['object']
+    ldr.object = image_hdu_wcs
+    ldr.format = 'Image'
+
+    importer = ldr.importer._obj
+
+    # selecting Image viewer for create new should expose options
+    importer.viewer.create_new.selected = 'Image'
+    assert importer.expose_align_by_options is True
+
+    # clearing create new Image viewer selection should hide options again
+    importer.viewer.create_new.selected = ''
+    assert importer.expose_align_by_options is False
+
+
 class TestDataLabelOverwrite:
     """Tests for the data_label_overwrite functionality in loaders."""
 


### PR DESCRIPTION
Allow moment map plugin to create a new image viewer in deconfigged, when previously you could only create a new 3D Spectrum viewer. Also allow moment maps to be added to existing image viewers (currently blocked by another issue, but this PR enables that option and adds test coverage that can be un-commented once that blocking issue is fixed). 

This also hides a warning that pops up from the image importer when there is no orientation plugin. Moment maps go through the image loader when added to a viewer, but in cubeviz or in deconfigged when there is no image viewer there won't be an orientation plugin, so this warning will always be raised. Instead, the option for 'align by' is removed from the image importer unless the orientation plugin exists, or the create new viewer selected is an image viewer, which will create the orientation plugin. 