### PR TITLE
Remove label incrementing for user-specified label in Specviz 1/2D

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -134,9 +134,6 @@ Bug Fixes
 
 - Fixed WCS layer being pushed to incorrect viewer types in deconfigged when changing between pixel and WCS linking. [#4049]
 
-- Fixed an inconsistency with 1/2D Spectra when loading duplicate user-supplied labels. With those data types,
-user-supplied labels would auto-increment whereas with others, they would not. Now all user-supplied labels do not auto-increment. [#4055]
-
 - Avoid crashing Jdaviz if the PyVO vocabularies can't be downloaded. [#4059]
 
 Cubeviz
@@ -154,6 +151,9 @@ Mosviz
 
 Specviz
 ^^^^^^^
+
+- Fixed an inconsistency with 1/2D Spectra when loading duplicate user-supplied labels. With those data types,
+user-supplied labels would auto-increment whereas with others, they would not. Now all user-supplied labels do not auto-increment. [#4055]
 
 Specviz2d
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,10 @@ Mosviz
 Specviz
 ^^^^^^^
 
+- Fixed an inconsistency with 1/2D Spectra when loading duplicate user-supplied labels. With those data types,
+  user-supplied labels would auto-increment whereas with others, they would not.
+  Now all user-supplied labels do not auto-increment. [#4055]
+
 Specviz2d
 ^^^^^^^^^
 
@@ -152,9 +156,6 @@ Mosviz
 Specviz
 ^^^^^^^
 
-- Fixed an inconsistency with 1/2D Spectra when loading duplicate user-supplied labels. With those data types,
-  user-supplied labels would auto-increment whereas with others, they would not.
-  Now all user-supplied labels do not auto-increment. [#4055]
 
 Specviz2d
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -153,8 +153,8 @@ Specviz
 ^^^^^^^
 
 - Fixed an inconsistency with 1/2D Spectra when loading duplicate user-supplied labels. With those data types,
-user-supplied labels would auto-increment whereas with others, they would not.
-Now all user-supplied labels do not auto-increment. [#4055]
+  user-supplied labels would auto-increment whereas with others, they would not.
+  Now all user-supplied labels do not auto-increment. [#4055]
 
 Specviz2d
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ New Features
 - Add handles to subset to allow interactive resizing. [#3919]
 
 - Indicate in loaders whether the loaded entry/entries will overwrite existing data in the app. [#3997]
-  
+
 - Added ``enable_footprint_selection_tools()`` and ``disable_footprint_selection_tools()`` APIs
   to programmatically control footprint selection toolbar. [#4048]
 
@@ -133,6 +133,8 @@ Bug Fixes
 - Fix layer filtering logic for plot options to properly show/hide layers based on coordinate and link type. [#4046]
 
 - Fixed WCS layer being pushed to incorrect viewer types in deconfigged when changing between pixel and WCS linking. [#4049]
+
+- Fixed an inconsistency with loading duplicate user-supplied labels. [#4055]
 
 - Avoid crashing Jdaviz if the PyVO vocabularies can't be downloaded. [#4059]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -134,7 +134,8 @@ Bug Fixes
 
 - Fixed WCS layer being pushed to incorrect viewer types in deconfigged when changing between pixel and WCS linking. [#4049]
 
-- Fixed an inconsistency with loading duplicate user-supplied labels. [#4055]
+- Fixed an inconsistency with 1/2D Spectra when loading duplicate user-supplied labels. With those data types,
+user-supplied labels would auto-increment whereas with others, they would not. Now all user-supplied labels do not auto-increment. [#4055]
 
 - Avoid crashing Jdaviz if the PyVO vocabularies can't be downloaded. [#4059]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -153,7 +153,8 @@ Specviz
 ^^^^^^^
 
 - Fixed an inconsistency with 1/2D Spectra when loading duplicate user-supplied labels. With those data types,
-user-supplied labels would auto-increment whereas with others, they would not. Now all user-supplied labels do not auto-increment. [#4055]
+user-supplied labels would auto-increment whereas with others, they would not.
+Now all user-supplied labels do not auto-increment. [#4055]
 
 Specviz2d
 ^^^^^^^^^

--- a/jdaviz/configs/specviz/helper.py
+++ b/jdaviz/configs/specviz/helper.py
@@ -138,8 +138,6 @@ class Specviz(ConfigHelper, LineListMixin):
                 or (isinstance(data, Spectrum) and len(data.shape) == 2)):
             load_kwargs['concatenate'] = False
 
-        if data_label is not None:
-            data_label = self.app.return_unique_name(data_label)
         self.load(data, format='1D Spectrum',
                   data_label=data_label,
                   viewer='*' if show_in_viewer else [],

--- a/jdaviz/configs/specviz2d/helper.py
+++ b/jdaviz/configs/specviz2d/helper.py
@@ -120,8 +120,6 @@ class Specviz2d(Specviz):
             load_kwargs['local_path'] = local_path
 
         if spectrum_2d is not None:
-            if spectrum_2d_label is not None:
-                spectrum_2d_label = self.app.return_unique_name(spectrum_2d_label)
             if isinstance(spectrum_2d, Spectrum):
                 # don't pass ext if input is not a file
                 ext = None
@@ -133,8 +131,6 @@ class Specviz2d(Specviz):
                       extension=ext,
                       **load_kwargs)
         if spectrum_1d is not None:
-            if spectrum_1d_label is not None:
-                spectrum_1d_label = self.app.return_unique_name(spectrum_1d_label)
             self.load(spectrum_1d, format='1D Spectrum',
                       data_label=spectrum_1d_label,
                       viewer='*' if show_in_viewer else [],

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -217,13 +217,6 @@ class ConfigHelper(HubListener):
 
         importer = resolver.importer
         importer._obj._apply_kwargs(kwargs)
-        # When data_label is explicitly passed via API, ensure uniqueness
-        # so that loading the same label twice creates incremented labels
-        # (e.g. "test", "test (1)") rather than overwriting.
-        if 'data_label' in kwargs and hasattr(importer._obj, 'data_label'):
-            importer._obj.data_label.value = self.app.return_unique_name(
-                importer._obj.data_label.value
-            )
         out = resolver.load()
         # force cleanup before returning
         resolver._obj._cleanup()

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -217,6 +217,13 @@ class ConfigHelper(HubListener):
 
         importer = resolver.importer
         importer._obj._apply_kwargs(kwargs)
+        # When data_label is explicitly passed via API, ensure uniqueness
+        # so that loading the same label twice creates incremented labels
+        # (e.g. "test", "test (1)") rather than overwriting.
+        if 'data_label' in kwargs and hasattr(importer._obj, 'data_label'):
+            importer._obj.data_label.value = self.app.return_unique_name(
+                importer._obj.data_label.value
+            )
         out = resolver.load()
         # force cleanup before returning
         resolver._obj._cleanup()

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -78,10 +78,22 @@ def test_nonstandard_specviz_viewer_name(spectrum1d):
 ])
 def test_duplicate_data_labels(deconfigged_helper, input_data, input_format, request):
     input_data = request.getfixturevalue(input_data)
+    # Test duplicate auto-generated labels
+    deconfigged_helper.load(input_data, format=input_format)
+    deconfigged_helper.load(input_data, format=input_format)
+    dc = deconfigged_helper.app.data_collection
+
+    expected_label_base = input_format
+    if input_format == 'Image':
+        expected_label_base = 'Image[SCI,1]'
+
+    assert any([dc_entry.label == expected_label_base for dc_entry in dc])
+    assert any([dc_entry.label == f'{expected_label_base} (1)' for dc_entry in dc])
+
+    # Test duplicate custom labels
     deconfigged_helper.load(input_data, format=input_format, data_label="test")
     deconfigged_helper.load(input_data, format=input_format, data_label="test")
 
-    dc = deconfigged_helper.app.data_collection
     assert any([dc_entry.label == 'test' for dc_entry in dc])
     assert any([dc_entry.label == 'test (1)' for dc_entry in dc])
 

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -70,7 +70,6 @@ def test_nonstandard_specviz_viewer_name(spectrum1d):
         viz.datasets["non-existent label"]
 
 
-@pytest.mark.xfail(reason='Known issue with duplicate data labels when using API.')
 @pytest.mark.parametrize(('input_data', 'input_format'), [
     ('image_hdu_wcs', 'Image'),
     ('spectrum1d', '1D Spectrum'),

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -108,15 +108,6 @@ def test_duplicate_data_labels(deconfigged_helper, input_data, input_format, req
     assert any([dc_entry.label == 'test_1' for dc_entry in dc])
 
 
-def test_duplicate_data_labels_with_brackets(specviz_helper, spectrum1d):
-    specviz_helper.load_data(spectrum1d, data_label="test[test]")
-    specviz_helper.load_data(spectrum1d, data_label="test[test]")
-    dc = specviz_helper.app.data_collection
-    assert len(dc) == 2
-    assert dc[0].label == "test[test]"
-    assert dc[1].label == "test[test] (1)"
-
-
 def test_return_data_label_is_none(specviz_helper):
     data_label = specviz_helper.app.return_data_label(None)
     assert data_label == "Unknown"
@@ -159,26 +150,18 @@ def test_substring_in_label(specviz_helper, spectrum1d):
     assert data_label == "M"
 
 
-@pytest.mark.parametrize('data_label', ('111111', 'aaaaa', '///(#$@)',
-                                        'two  spaces  repeating',
-                                        'word42word42word  two  spaces'))
-def test_edge_cases(specviz_helper, spectrum1d, data_label):
-    dc = specviz_helper.app.data_collection
+def test_edge_cases(deconfigged_helper, spectrum1d):
+    data_labels = ['111111',
+                   'aaaaa',
+                   '///(#$@)',
+                   'two  spaces  repeating',
+                   'word42word42word  two  spaces']
 
-    specviz_helper.load_data(spectrum1d, data_label=data_label)
-    specviz_helper.load_data(spectrum1d, data_label=data_label)
-    assert dc[1].label == f"{data_label} (1)"
+    dc = deconfigged_helper.app.data_collection
 
-    specviz_helper.load_data(spectrum1d, data_label=data_label)
-    assert dc[2].label == f"{data_label} (2)"
-
-
-def test_case_that_used_to_break_return_label(specviz_helper, spectrum1d):
-    specviz_helper.load_data(spectrum1d, data_label="this used to break (1)")
-    specviz_helper.load_data(spectrum1d, data_label="this used to break")
-    dc = specviz_helper.app.data_collection
-    assert dc[0].label == "this used to break (1)"
-    assert dc[1].label == "this used to break (2)"
+    for dl in data_labels:
+        deconfigged_helper.load(spectrum1d, data_label=dl)
+        assert dl in dc
 
 
 def test_viewer_renaming_specviz(specviz_helper):

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -90,18 +90,22 @@ def test_duplicate_data_labels(deconfigged_helper, input_data, input_format, req
     assert any([dc_entry.label == expected_label_base for dc_entry in dc])
     assert any([dc_entry.label == f'{expected_label_base} (1)' for dc_entry in dc])
 
-    # Test duplicate custom labels
+    # Test overwrite when using custom labels
     deconfigged_helper.load(input_data, format=input_format, data_label="test")
     deconfigged_helper.load(input_data, format=input_format, data_label="test")
 
-    assert any([dc_entry.label == 'test' for dc_entry in dc])
-    assert any([dc_entry.label == 'test (1)' for dc_entry in dc])
+    test_labels = [dc_entry.label == 'test' for dc_entry in dc]
+    assert any(test_labels)
+    assert sum(test_labels) == 1
+    assert 'test (1)' not in dc
 
+    deconfigged_helper.load(input_data, format=input_format, data_label=expected_label_base)
     deconfigged_helper.load(input_data, format=input_format, data_label="test_1")
-    deconfigged_helper.load(input_data, format=input_format, data_label="test")
 
+    # Test second attempt at overwrite using custom label
+    # that matches the expected auto-generated label
+    assert f'{expected_label_base} (2)' not in dc
     assert any([dc_entry.label == 'test_1' for dc_entry in dc])
-    assert any([dc_entry.label == 'test (2)' for dc_entry in dc])
 
 
 def test_duplicate_data_labels_with_brackets(specviz_helper, spectrum1d):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This PR addresses an inconsistency in handling duplicate user-supplied data labels. Specviz1/2D API incremented user-supplied data labels while other configs did not. Rather than adding the ability for all configs/deconfigged to increment data labels, opt for overwrite as the default behavior to be consistent with the UI. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
