### PR TITLE
Hard code waveband choices in VO loader

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -125,6 +125,8 @@ Bug Fixes
 
 - Fix layer filtering logic for plot options to properly show/hide layers based on coordinate and link type. [#4046]
 
+- Avoid crashing Jdaviz if the PyVO vocabularies can't be downloaded. [#4059]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
@@ -4,6 +4,7 @@ from astropy import units as u
 from pyvo.utils import vocabularies  # noqa: F401
 from pyvo import registry
 from pyvo.dal.exceptions import DALFormatError, DALQueryError
+from pyvo.utils.vocabularies import VocabularyError
 from requests.exceptions import ConnectionError as RequestConnectionError
 from traitlets import Bool, Any, List, observe
 
@@ -39,7 +40,12 @@ class VOResolver(BaseConeSearchResolver):
         )
 
         self.waveband.choices = (
-            w.lower() for w in vocabularies.get_vocabulary("messenger")["terms"]
+                    try:
+                        self.waveband.choices = (
+                            w.lower() for w in vocabularies.get_vocabulary("messenger")["terms"]
+                        )
+                    except VocabularyError:
+                        self.waveband.choices = []
         )
 
         self.waveband_selected = ""

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
@@ -3,7 +3,6 @@ from astropy import units as u
 
 from pyvo import registry
 from pyvo.dal.exceptions import DALFormatError, DALQueryError
-from pyvo.utils.vocabularies import VocabularyError
 from requests.exceptions import ConnectionError as RequestConnectionError
 from traitlets import Bool, Any, List, observe
 

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
@@ -39,14 +39,12 @@ class VOResolver(BaseConeSearchResolver):
             self, items="waveband_items", selected="waveband_selected"
         )
 
-        self.waveband.choices = (
-                    try:
-                        self.waveband.choices = (
-                            w.lower() for w in vocabularies.get_vocabulary("messenger")["terms"]
-                        )
-                    except VocabularyError:
-                        self.waveband.choices = []
-        )
+        try:
+            self.waveband.choices = (
+                w.lower() for w in vocabularies.get_vocabulary("messenger")["terms"]
+            )
+        except VocabularyError:
+            self.waveband.choices = []
 
         self.waveband_selected = ""
 

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
@@ -1,7 +1,6 @@
 from astropy.coordinates import SkyCoord
 from astropy import units as u
 
-from pyvo.utils import vocabularies  # noqa: F401
 from pyvo import registry
 from pyvo.dal.exceptions import DALFormatError, DALQueryError
 from pyvo.utils.vocabularies import VocabularyError
@@ -40,7 +39,8 @@ class VOResolver(BaseConeSearchResolver):
             self, items="waveband_items", selected="waveband_selected"
         )
 
-        # How often are we really discovering a new astronomical messenger? I think we can hard code this.
+        # How often are we really discovering a new astronomical messenger?
+        # I think we can hard code this.
         self.waveband.choices = ['photon', 'radio', 'millimeter', 'infrared', 'optical',
                                  'uv', 'euv', 'x-ray', 'gamma-ray', 'neutrino']
 

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
@@ -16,7 +16,6 @@ from jdaviz.core.template_mixin import (
 )
 from jdaviz.core.loaders.resolvers import BaseConeSearchResolver
 from jdaviz.core.user_api import LoaderUserApi
-from jdaviz.pytest_utilities.pytest_socket_management import cleanup_leaked_sockets
 
 
 __all__ = ["VOResolver"]
@@ -46,8 +45,7 @@ class VOResolver(BaseConeSearchResolver):
                 w.lower() for w in vocabularies.get_vocabulary("messenger")["terms"]
             )
         except VocabularyError:
-            self.waveband.choices = []
-            cleanup_leaked_sockets()
+            self.waveband.choices = ["",]
 
         self.waveband_selected = ""
 

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
@@ -16,6 +16,8 @@ from jdaviz.core.template_mixin import (
 )
 from jdaviz.core.loaders.resolvers import BaseConeSearchResolver
 from jdaviz.core.user_api import LoaderUserApi
+from jdaviz.pytest_utilities.pytest_socket_management import cleanup_leaked_sockets
+
 
 __all__ = ["VOResolver"]
 
@@ -45,6 +47,7 @@ class VOResolver(BaseConeSearchResolver):
             )
         except VocabularyError:
             self.waveband.choices = []
+            cleanup_leaked_sockets()
 
         self.waveband_selected = ""
 

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
@@ -40,12 +40,9 @@ class VOResolver(BaseConeSearchResolver):
             self, items="waveband_items", selected="waveband_selected"
         )
 
-        try:
-            self.waveband.choices = (
-                w.lower() for w in vocabularies.get_vocabulary("messenger")["terms"]
-            )
-        except VocabularyError:
-            self.waveband.choices = ["",]
+        # How often are we really discovering a new astronomical messenger? I think we can hard code this.
+        self.waveband.choices = ['photon', 'radio', 'millimeter', 'infrared', 'optical',
+                                 'uv', 'euv', 'x-ray', 'gamma-ray', 'neutrino']
 
         self.waveband_selected = ""
 


### PR DESCRIPTION
IVOA servers are down again and this hit us in a demo (the error stops you from starting a Jdaviz instance), this will let Jdaviz run even when it can't retrieve the vocabularies.

I looked into this and it turns out this is just retrieving a list that should realistically never change, I think we can hard code this and not query the IVOA servers at all.