### PR TITLE
Migrate plugin narrative documentation to deconfigged docs

### DIFF
--- a/docs/_templates/index.html
+++ b/docs/_templates/index.html
@@ -1504,7 +1504,7 @@
             <h2 class="announcement-header">Introducing the new generalized Jdaviz</h2>
             <p class="announcement-text">
                 Version 5.0 of Jdaviz introduces a new generalized Jdaviz capable of advanced mixed workflows.
-                No longer do you need to choose between the different configurations - just load the data
+                You no longer need to choose between the different configurations - just load the data
                 you want to analyze into jdaviz and the interface and tools will adjust accordingly.
             </p>
             <a href="{{ pathto('configs_deprecated') }}" class="announcement-button">View Deprecated Configuration-Specific Documentation</a>

--- a/docs/info/markers.rst
+++ b/docs/info/markers.rst
@@ -1,4 +1,4 @@
-.. _deconfigged-info-markers:
+.. _info-markers:
 .. rst-class:: section-icon-mdi-information-outline
 
 *******

--- a/docs/info/markers.rst
+++ b/docs/info/markers.rst
@@ -23,7 +23,7 @@ UI Access
 Details
 =======
 
-With the Markers tool open in the Information tab , mouse over any viewer and press the "m" key to log the information
+With the Markers tool open in the Information tab, mouse over any viewer and press the "m" key to log the information
 displayed in the app toolbar into the table.  The markers remain at that fixed pixel-position in
 the viewer they were created (regardless of changes to the underlying data or linking,
 see :ref:`dev_glue_linking`) and are only visible when the plugin is opened.

--- a/docs/info/markers.rst
+++ b/docs/info/markers.rst
@@ -1,12 +1,16 @@
-.. _info-markers:
+.. _deconfigged-info-markers:
 .. rst-class:: section-icon-mdi-information-outline
 
 *******
 Markers
 *******
 
-Documentation coming soon.
+Overview
+========
 
+This tool allows for interactively creating markers in any viewer and logging information about
+the location of that marker along with the applicable data and viewer labels into a table. It also
+allows the user to measure distances between points in a viewer.
 
 UI Access
 =========
@@ -15,3 +19,58 @@ UI Access
    :demo: info,info:select-tab=Markers
    :enable-only: info
    :demo-repeat: false
+
+Details
+=======
+
+With the Markers tool open in the Information tab , mouse over any viewer and press the "m" key to log the information
+displayed in the app toolbar into the table.  The markers remain at that fixed pixel-position in
+the viewer they were created (regardless of changes to the underlying data or linking,
+see :ref:`dev_glue_linking`) and are only visible when the plugin is opened.
+
+When images are WCS linked, the table also exposes columns labeled "pixel:unreliable", "world:unreliable",
+and "value:unreliable".  These will be logged as ``True`` in cases where the information is outside
+the bounds of the reference image's WCS (noted in the mouseover display by the information showing
+as grayed).
+
+.. _distance-tool:
+
+Distance Tool
+-------------
+
+The Markers plugin also includes a tool for measuring the distance and position angle between
+two points in a viewer. This functionality is available whenever the Markers plugin is open.
+
+
+1. Mouse over the desired start point in a viewer and press the ``d`` key. A ``...`` indicator
+   will appear in the :guilabel:`Last Measured Distance` field at the bottom of the plugin,
+   showing that the first point is set.
+2. Mouse over the desired end point and press the ``d`` key again.
+
+This will draw a line between the two points. A label showing the distance will appear,
+rotated to be parallel with the line, and offset to prevent intersecting the line.
+
+A new table, :guilabel:`Measurements`, will also appear below the main markers table. This
+table logs the start and end coordinates (both pixel and world, if available), the on-sky
+separation, the pixel distance, and the position angle for each measurement.
+
+**Additional Features:**
+
+* **Snapping**: To measure the distance from or to an existing marker, hold down the ``Alt`` key
+  (or ``Option`` on Mac) when you press ``d``. The tool will "snap" to the nearest marker
+  already in the main table.
+* **Clearing**: Pressing the ``r`` key will clear all markers from the main table *and* all
+  distance lines from the viewers.
+
+
+
+API Access
+==========
+
+To export the table into the notebook or clear the table via the API:
+
+.. code-block:: python
+
+    markersplugin = jd.plugins['Markers']
+    t = markersplugin.export_table()
+    markersplugin.clear_table()

--- a/docs/plugins/2d_spectral_extraction.rst
+++ b/docs/plugins/2d_spectral_extraction.rst
@@ -12,8 +12,8 @@ Extract 1D spectra from 2D spectroscopic data.
 Description
 ===========
 
-The 2D Spectral Extraction plugin extracts 1D spectra from 2D spectroscopic
-data by summing or averaging across the spatial direction.
+The 2D Spectral Extraction plugin exposes `specreduce <https://specreduce.readthedocs.io>`_
+methods for tracing, background subtraction, and spectral extraction from 2D spectra.
 
 **Key Features:**
 
@@ -22,6 +22,179 @@ data by summing or averaging across the spatial direction.
 * Background subtraction
 * Trace following
 * Uncertainty propagation
+
+Trace
+-----
+
+The first section of the plugin allows for creating and visualizing
+:py:class:`specreduce.tracing.Trace` objects.
+
+Once you interact with any of the inputs in the extract step or hover over that area
+of the plugin, the live visualization will change to show the trace as a solid line
+in the 2D spectrum viewer.
+
+To create a new trace in the plugin, choose the desired "Trace Type" and edit any input arguments.
+A preview of the trace will update in real time in the 2D spectrum viewer.
+
+To export the trace as a data object into the 2D spectrum viewer (to access via the API or to
+adjust plotting options), open the "Export Trace" panel, choose a label for the new data entry,
+and click "Create".  Note that this step is not required to create an extraction with simple
+workflows.
+
+Suppose you have 2D spectra of an extended source, and you have already created a trace that follows the
+bright central region of the source. It is possible to create a new trace, with the same 2D
+shape as the trace of the central region, but offset in the spatial direction. This might be useful
+for extracting spectra from the faint outer regions of the extended source, while using a trace computed from the
+brighter inner region. You can create a new trace based on the existing trace by clicking
+the "Trace" dropdown and selecting the existing trace. Then, offset it in the spatial direction by clicking or entering
+the spatial offset, and save it by creating a new trace or overwriting the existing trace entry.
+
+From the API
+^^^^^^^^^^^^
+
+Trace parameters can be set from the notebook by accessing the plugin.
+
+.. code-block:: python
+
+   sp_ext = jd.plugins['2D Spectral Extraction']
+    sp_ext.trace_type = 'Polynomial'
+    sp_ext.trace_order = 2
+    sp_ext.trace_window = 10
+    sp_ext.trace_peak_method = 'Gaussian'
+
+To export and access the :py:class:`specreduce.tracing.Trace` object defined in the plugin,
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_trace`:
+
+.. code-block:: python
+
+    trace = sp_ext.export_trace()
+
+
+Trace objects created outside of jdaviz can be loaded into the app
+via ``load``:
+
+.. code-block:: python
+
+    jd.load(my_trace, data_label="my trace")
+
+or directly into the plugin
+via :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.import_trace`
+
+.. code-block:: python
+
+    sp_ext.import_trace(my_trace)
+
+
+Background
+----------
+
+The background step of the plugin allows for creating background and background-subtracted
+images via :py:mod:`specreduce.background`.
+
+Once you interact with any of the inputs in the background step or hover over that area
+of the plugin, the live visualization in the 2D spectrum viewer will change to show the center
+(dotted line) and edges (solid lines) of the background region(s).  The 1D representation of the
+background will also be visualized in the 1D spectrum viewer (thin, solid line).
+
+Backgrounds can either be created around the trace defined in the earlier Trace section
+or around a new, flat trace by selecting "Manual" in the Background Type dropdown.
+
+To visualize the resulting background or background-subtracted image, click on the respective panel,
+and choose a label for the new data entry.  The exported images will now appear in the data dropdown
+menu in the 2D spectrum viewer.
+To refine the trace based on the background-subtracted image, return
+to the Trace step and select the exported background-subtracted image as input.
+
+From the API
+^^^^^^^^^^^^
+
+Background parameters can be set from the notebook by accessing the plugin.
+
+.. code-block:: python
+
+    sp_ext.bg_type = 'TwoSided'
+    sp_ext.bg_separation = 8
+    sp_ext.bg_width = 6
+
+To export and access the :py:class:`specreduce.background.Background` object defined in the plugin,
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_bg`:
+
+.. code-block:: python
+
+  bg = sp_ext.export_bg()
+
+To access the background image, background spectrum, or background-subtracted image as a
+:class:`~specutils.Spectrum` object,
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_bg_img`,
+:py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_bg_spectrum`,
+or :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_bg_sub`, respectively.
+
+To import the parameters from a :py:class:`specreduce.background.Background` object into the plugin,
+whether it's new or was exported and modified in the notebook,
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.import_bg`:
+
+.. code-block:: python
+
+  sp_ext.import_bg(bg)
+
+Extract
+-------
+
+The extraction step of the plugin extracts a 1D spectrum from an input 2D spectrum via
+:py:mod:`specreduce.extract`.
+
+Once you interact with any of the inputs in the extract step or hover over that area
+of the plugin, the live visualization will change to show the center (dotted line) and
+edges (solid lines) of the extraction region.
+
+The input 2D spectrum defaults to "From Plugin", which will use the settings defined in the
+Background step to create a background-subtracted image without needing to export it into the app
+itself. To use a different 2D spectrum loaded in the app (or exported from the Background step),
+choose that from the dropdown instead.  To skip background subtraction, choose the original 2D
+spectrum as input.
+
+To visualize or export the resulting 2D spectrum, provide a data label and click "Extract".
+The resulting spectrum object can be :ref:`accessed from the API <specviz2d-export-data-1d>`
+in the same way as any other data product in the spectrum viewer.
+
+From the API
+^^^^^^^^^^^^
+
+Extraction parameters can be set from the notebook by accessing the plugin.
+
+.. code-block:: python
+
+    sp_ext.ext_type = 'Boxcar'
+    sp_ext.ext_width = 8
+
+To export and access
+the :py:class:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D` object defined
+in the plugin,
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_extract`:
+
+.. code-block:: python
+
+  ext = sp_ext.export_extract()
+
+To access the extracted spectrum as a :class:`~specutils.Spectrum` object,
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_extract_spectrum`.
+
+To import the parameters from
+a :py:class:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D` object
+(either a new object, or an exported one modified in the notebook) into the plugin,
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.import_extract`:
+
+.. code-block:: python
+
+  sp_ext.import_extract(ext)
+
+
+.. note::
+
+    Horne extraction uses uncertainties on the input 2D spectrum. If the
+    spectrum uncertainties are not explicitly assigned a type, they are assumed
+    to be standard deviation uncertainties. If no uncertainty is provided,
+    it is assumed to be an array of ones.
 
 UI Access
 =========

--- a/docs/plugins/2d_spectral_extraction.rst
+++ b/docs/plugins/2d_spectral_extraction.rst
@@ -38,7 +38,7 @@ A preview of the trace will update in real time in the 2D spectrum viewer.
 
 To export the trace as a data object into the 2D spectrum viewer (to access via the API or to
 adjust plotting options), open the "Export Trace" panel, choose a label for the new data entry,
-and click "Create".  Note that this step is not required to create an extraction with simple
+and click "Create".  Note that this step is not required to create an extraction with simplex
 workflows.
 
 Suppose you have 2D spectra of an extended source, and you have already created a trace that follows the
@@ -157,45 +157,6 @@ To visualize or export the resulting 2D spectrum, provide a data label and click
 The resulting spectrum object can be :ref:`accessed from the API <specviz2d-export-data-1d>`
 in the same way as any other data product in the spectrum viewer.
 
-From the API
-^^^^^^^^^^^^
-
-Extraction parameters can be set from the notebook by accessing the plugin.
-
-.. code-block:: python
-
-    sp_ext.ext_type = 'Boxcar'
-    sp_ext.ext_width = 8
-
-To export and access
-the :py:class:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D` object defined
-in the plugin,
-call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_extract`:
-
-.. code-block:: python
-
-  ext = sp_ext.export_extract()
-
-To access the extracted spectrum as a :class:`~specutils.Spectrum` object,
-call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_extract_spectrum`.
-
-To import the parameters from
-a :py:class:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D` object
-(either a new object, or an exported one modified in the notebook) into the plugin,
-call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.import_extract`:
-
-.. code-block:: python
-
-  sp_ext.import_extract(ext)
-
-
-.. note::
-
-    Horne extraction uses uncertainties on the input 2D spectrum. If the
-    spectrum uncertainties are not explicitly assigned a type, they are assumed
-    to be standard deviation uncertainties. If no uncertainty is provided,
-    it is assumed to be an array of ones.
-
 UI Access
 =========
 
@@ -216,11 +177,44 @@ Click the :guilabel:`Spectral Extraction` icon in the plugin toolbar to:
 API Access
 ==========
 
+Extraction parameters can be set from the notebook by accessing the plugin.
+
 .. code-block:: python
 
-    plg = specviz2d.plugins['Spectral Extraction']
+    plg = jd.plugins['Spectral Extraction']
     plg.aperture_width = 5  # pixels
+    plg.ext_type = 'Boxcar'
+    plg.ext_width = 8
     plg.extract()
+
+To export and access
+the :py:class:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D` object defined
+in the plugin,
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_extract`:
+
+.. code-block:: python
+
+  ext = plg.export_extract()
+
+To access the extracted spectrum as a :class:`~specutils.Spectrum` object,
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.export_extract_spectrum`.
+
+To import the parameters from
+a :py:class:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D` object
+(either a new object, or an exported one modified in the notebook) into the plugin,
+call :py:meth:`~jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction.SpectralExtraction2D.import_extract`:
+
+.. code-block:: python
+
+  sp_ext.import_extract(ext)
+
+
+.. note::
+
+    Horne extraction uses uncertainties on the input 2D spectrum. If the
+    spectrum uncertainties are not explicitly assigned a type, they are assumed
+    to be standard deviation uncertainties. If no uncertainty is provided,
+    it is assumed to be an array of ones.
 
 .. plugin-api-refs::
    :module: jdaviz.configs.specviz2d.plugins.spectral_extraction.spectral_extraction

--- a/docs/plugins/2d_spectral_extraction.rst
+++ b/docs/plugins/2d_spectral_extraction.rst
@@ -38,7 +38,7 @@ A preview of the trace will update in real time in the 2D spectrum viewer.
 
 To export the trace as a data object into the 2D spectrum viewer (to access via the API or to
 adjust plotting options), open the "Export Trace" panel, choose a label for the new data entry,
-and click "Create".  Note that this step is not required to create an extraction with simplex
+and click "Create".  Note that this step is not required to create an extraction with simple
 workflows.
 
 Suppose you have 2D spectra of an extended source, and you have already created a trace that follows the

--- a/docs/plugins/3d_spectral_extraction.rst
+++ b/docs/plugins/3d_spectral_extraction.rst
@@ -267,5 +267,5 @@ Example Notebooks
 See Also
 ========
 
-* :ref:`plugin-collapse` - Create 2D images from cubes
-* :ref:`plugin-moment-maps` - Alternative spectral integration method
+* :ref:`plugins-collapse` - Create 2D images from cubes
+* :ref:`plugins-moment-maps` - Alternative spectral integration method

--- a/docs/plugins/3d_spectral_extraction.rst
+++ b/docs/plugins/3d_spectral_extraction.rst
@@ -268,4 +268,4 @@ See Also
 ========
 
 * :ref:`plugins-collapse` - Create 2D images from cubes
-* :ref:`plugins-moment-maps` - Alternative spectral integration method
+* :ref:`plugins-moment_maps` - Alternative spectral integration method

--- a/docs/plugins/3d_spectral_extraction.rst
+++ b/docs/plugins/3d_spectral_extraction.rst
@@ -156,9 +156,8 @@ Accessing the Plugin
 
 .. code-block:: python
 
-    import jdaviz
+    import jdaviz as jd
 
-    jd = Jdaviz()
     jd.show()
     jd.load('cube.fits', format='3D Spectrum')
 

--- a/docs/plugins/3d_spectral_extraction.rst
+++ b/docs/plugins/3d_spectral_extraction.rst
@@ -109,7 +109,7 @@ Opening the Plugin
 Workflow
 --------
 
-1. **Load cube** into Cubeviz
+1. **Load cube** into Jdaviz
 2. **(Optional) Draw spatial region** for aperture
 3. **Select dataset** from :guilabel:`Data` dropdown
 4. **Select function** from :guilabel:`Function` dropdown
@@ -156,14 +156,14 @@ Accessing the Plugin
 
 .. code-block:: python
 
-    from jdaviz import Cubeviz
+    import jdaviz
 
-    cubeviz = Cubeviz()
-    cubeviz.show()
-    cubeviz.load('cube.fits', format='3D Spectrum')
+    jd = Jdaviz()
+    jd.show()
+    jd.load('cube.fits', format='3D Spectrum')
 
     # Access plugin
-    plg = cubeviz.plugins['3D Spectral Extraction']
+    plg = jd.plugins['3D Spectral Extraction']
 
 Basic Extraction
 ----------------
@@ -267,6 +267,5 @@ Example Notebooks
 See Also
 ========
 
-* :ref:`spectral-extraction` - Detailed Cubeviz extraction documentation
-* :ref:`collapse` - Create 2D images from cubes
-* :ref:`moment-maps` - Alternative spectral integration method
+* :ref:`plugin-collapse` - Create 2D images from cubes
+* :ref:`plugin-moment-maps` - Alternative spectral integration method

--- a/docs/plugins/collapse.rst
+++ b/docs/plugins/collapse.rst
@@ -202,5 +202,5 @@ Example Notebooks
 See Also
 ========
 
-* :ref:`plugins-moment-maps` - Alternative method for creating integrated flux maps
+* :ref:`plugins-moment_maps` - Alternative method for creating integrated flux maps
 * :ref:`plugins-spectral_extraction_3d` - Extract 1D spectra from cubes

--- a/docs/plugins/collapse.rst
+++ b/docs/plugins/collapse.rst
@@ -120,9 +120,8 @@ Accessing the Plugin
 
 .. code-block:: python
 
-    import Jdaviz
+    import jdaviz as jd
 
-    jd = Jdaviz()
     jd.show()
     jd.load('cube.fits', format='3D Spectrum')
 

--- a/docs/plugins/collapse.rst
+++ b/docs/plugins/collapse.rst
@@ -85,16 +85,10 @@ UI Access
    :plugin-panel-opened: false
    :demo-repeat: false
 
-Opening the Plugin
-------------------
-
-**Cubeviz:**
-  Click the :guilabel:`Collapse` icon in the plugin toolbar.
-
 Workflow
 --------
 
-1. **Load data cube** into Cubeviz
+1. **Load data cube** into Jdaviz
 2. **Select dataset** from :guilabel:`Data` dropdown
 3. **Select collapse function** from :guilabel:`Function` dropdown
 4. **(Optional) Define spectral region**:
@@ -126,11 +120,11 @@ Accessing the Plugin
 
 .. code-block:: python
 
-    from jdaviz import Cubeviz
+    import Jdaviz
 
-    cubeviz = Cubeviz()
-    cubeviz.show()
-    cubeviz.load('cube.fits', format='3D Spectrum')
+    jd = Jdaviz()
+    jd.show()
+    jd.load('cube.fits', format='3D Spectrum')
 
     # Access plugin
     plg = cubeviz.plugins['Collapse']
@@ -208,6 +202,5 @@ Example Notebooks
 See Also
 ========
 
-* :ref:`collapse` - Detailed Cubeviz collapse documentation
-* :ref:`moment-maps` - Alternative method for creating integrated flux maps
-* :ref:`spectral-extraction` - Extract 1D spectra from cubes
+* :ref:`plugin-moment-maps` - Alternative method for creating integrated flux maps
+* :ref:`plugin-spectral-extraction_3d` - Extract 1D spectra from cubes

--- a/docs/plugins/collapse.rst
+++ b/docs/plugins/collapse.rst
@@ -202,5 +202,5 @@ Example Notebooks
 See Also
 ========
 
-* :ref:`plugin-moment-maps` - Alternative method for creating integrated flux maps
-* :ref:`plugin-spectral-extraction_3d` - Extract 1D spectra from cubes
+* :ref:`plugins-moment-maps` - Alternative method for creating integrated flux maps
+* :ref:`plugins-spectral_extraction_3d` - Extract 1D spectra from cubes

--- a/docs/plugins/data_quality.rst
+++ b/docs/plugins/data_quality.rst
@@ -11,9 +11,27 @@ Visualize and filter data quality flags.
 Description
 ===========
 
-The Data Quality plugin displays and manages data quality (DQ) flags from JWST
-and HST observations. It allows visualization of flagged pixels and filtering
-based on quality criteria.
+This plugin allows you to visualize data quality arrays for science data.
+The currently supported data quality flag mappings include JWST (all instruments)
+and Roman/WFI.
+
+Each science data layer can have one associated data quality layer.
+The visibility of the data quality layer can be toggled from the data
+dropdown menu, and toggling the science data visibility will do the
+same for the data quality layer. The mapping between bits and data quality
+flags is defined differently for each mission or instrument, and the
+plugin will infer the correct flag mapping from the file metadata.
+The opacity of the data quality layer can be changed relative to the
+opacity of the science data layer using the slider.
+
+The "Quality Flag" section contains a dropdown for applying a filter to the
+visualized bits. Select bits from the dropdown to visualize only flags
+containing those bits. The list of data quality flags beneath shows
+every flag in the data quality layer in bold, followed by the
+decomposed bits in that flag in parentheses. Clicking on a row
+will expand to flag to reveal the flag's short name and description,
+as well as a visibility toggle for that flag. Click on the color swatch
+to select a color for any flag.
 
 **Key Features:**
 
@@ -44,6 +62,7 @@ API Access
 .. code-block:: python
 
     plg = app.plugins['Data Quality']
+    plg.flags_filter = [0, 2]
 
 .. plugin-api-refs::
    :module: jdaviz.configs.default.plugins.data_quality.data_quality

--- a/docs/plugins/footprints.rst
+++ b/docs/plugins/footprints.rst
@@ -22,6 +22,20 @@ showing detector layouts and orientations for planning or analysis.
 * Multiple footprint overlays
 * Export footprint regions
 
+This plugin supports loading and overplotting instrument footprint overlays on the image viewers.
+Any number of overlays can be plotted simultaneously from any number of the available
+preset instruments (requires ``pysiaf`` to be installed), by loading an Astropy regions object from
+a file, or by passing an ``STC-S`` string.
+
+The top dropdown allows renaming, adding, and removing footprint overlays.  To modify the display
+and input parameters for a given overlay, select the overlay in the dropdown, and modify the choices
+in the plugin to change its color, opacity, visibilities in any image viewer in the app.
+You can also select between various preset instruments and change the input options
+(position on the sky, position angle, offsets, etc).
+
+To import a file, open the "Import" section at the top of the dropdown and select a valid file (must
+be able to be parsed by `regions.Regions.read`) from the applicable source.
+
 UI Access
 =========
 
@@ -44,14 +58,11 @@ API Access
 
 .. code-block:: python
 
-    plg = imviz.plugins['Footprints']
-    # Add and configure footprints programmatically
+    plg = jd.plugins['Footprints']
+    plg.open_in_tray()
+    plg.add_overlay('my imported overlay')  # or fp.rename_overlay to rename an existing entry
+    plg.import_region(region)
 
 .. plugin-api-refs::
    :module: jdaviz.configs.imviz.plugins.footprints.footprints
    :class: Footprints
-
-See Also
-========
-
-* :ref:`imviz-footprints` - Footprints documentation

--- a/docs/plugins/gaussian_smooth.rst
+++ b/docs/plugins/gaussian_smooth.rst
@@ -11,9 +11,16 @@ Smooth spectra or cubes using a Gaussian kernel.
 Description
 ===========
 
-The Gaussian Smooth plugin applies Gaussian smoothing to spectroscopic data,
-reducing noise while preserving overall spectral features. Smoothing can be applied
-along the spectral axis or spatial axes.
+Gaussian Smooth convolves a Gaussian function (kernel) with a Spectrum data object
+to smooth the data, reducing noise while preserving overall spectral features.
+The convolution requires a Gaussian standard deviation value
+(in pixels) which can be entered into the :guilabel:`Standard deviation`
+field in the plugin. Smoothing can be applied along the spectral axis or spatial axes
+(in the case of a spectral cube).
+
+A new Spectrum object is generated and can be added to any spectrum viewers.
+The object can also be selected and shown in the viewers via the
+viewer data menus.
 
 **Key Features:**
 
@@ -40,7 +47,7 @@ API Access
 
 .. code-block:: python
 
-    plg = app.plugins['Gaussian Smooth']
+    plg = jd.plugins['Gaussian Smooth']
     plg.dataset = 'spectrum'
     plg.stddev = 3.0  # Standard deviation in pixels
     plg.smooth()
@@ -48,8 +55,3 @@ API Access
 .. plugin-api-refs::
    :module: jdaviz.configs.default.plugins.gaussian_smooth.gaussian_smooth
    :class: GaussianSmooth
-
-See Also
-========
-
-* :ref:`gaussian-smooth` - Detailed Specviz documentation on Gaussian smoothing

--- a/docs/plugins/image_profiles.rst
+++ b/docs/plugins/image_profiles.rst
@@ -1,9 +1,9 @@
-.. _plugins-line-profiles:
+.. _plugins-image-profiles:
 .. rst-class:: section-icon-mdi-tune-variant
 
-*************
-Line Profiles
-*************
+*************************
+Image Profiles (X/Y cuts)
+*************************
 
 .. plugin-availability::
 
@@ -12,9 +12,15 @@ Extract and analyze spatial line profiles from images.
 Description
 ===========
 
-The Line Profiles (XY) plugin extracts pixel values along a line drawn on an image,
+This plugin extracts pixel values along a line drawn on an image,
 showing how flux varies spatially. This is useful for analyzing extended sources,
-edges, or gradients.
+edges, or gradients.. The line profiles in X and Y can be extracted by either:
+pressing ``l`` at the desired pixel location on the image viewer while the plugin is open,
+or by manually specifying the pixel coordinates X and Y, before selecting the :guilabel:`PLOT`
+button. The top visible image, the same one displayed under :ref:`imviz-compass`,
+will be used for these plots.
+
+This plugin only considers pixel locations, not sky coordinates.
 
 **Key Features:**
 
@@ -26,7 +32,7 @@ edges, or gradients.
 UI Access
 =========
 
-Click the :guilabel:`Line Profiles` icon in the plugin toolbar to:
+Click the :guilabel:`Image Profiles (XY)` icon in the plugin toolbar to:
 
 1. Draw a line on the image
 2. View the profile plot
@@ -37,7 +43,7 @@ API Access
 
 .. code-block:: python
 
-    plg = imviz.plugins['Line Profiles']
+    plg = jd.plugins['Image Profiles (XY)']
     # Access profile data programmatically
 
 .. plugin-api-refs::

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -21,7 +21,7 @@ Jdaviz provides a wide range of data analysis plugins for different types of ast
    3d_spectral_extraction
    ramp_extraction
    cross_dispersion_profile
-   line_profiles
+   image_profiles
    compass
    catalog_search
    data_quality
@@ -52,7 +52,7 @@ Plugins provide specialized analysis capabilities tailored to different data typ
 
 **Image Analysis (2D)**
   - Aperture Photometry
-  - Line Profiles (XY)
+  - Image Profiles (XY)
   - Compass
   - Orientation
   - Footprints

--- a/docs/plugins/line_analysis.rst
+++ b/docs/plugins/line_analysis.rst
@@ -7,7 +7,47 @@ Line Analysis
 
 .. plugin-availability::
 
-Analyze spectral line properties.
+The Line Analysis plugin returns
+`specutils analysis <https://specutils.readthedocs.io/en/stable/analysis.html>`_
+for a single spectral line.
+The line is selected via the :guilabel:`region` tool in
+the spectrum viewer to select a spectral subset. Note that you can have
+multiple subsets in Specviz, but the plugin will only show statistics for the
+selected subset.
+
+A linear continuum is fitted and subtracted (divided for the case of equivalenth width) before
+computing the line statistics.  By default, the continuum is fitted to a region surrounding
+the select line.  The width of this region can be adjusted, with a visual indicator shown
+in the spectrum plot while the plugin is open.  The thick line shows the linear fit which
+is then interpolated into the line region as shown by a thin line.  Alternatively, a custom
+secondary region can be created and selected as the region to fit the linear continuum.
+
+The properties returned include the line centroid, gaussian sigma width, gaussian FWHM,
+total flux, and equivalent width. Uncertainties on the derived properties are also
+returned. For more information on the algorithms used, refer to the `specutils documentation
+<https://specutils.readthedocs.io/en/stable/analysis.html>`_.
+
+The line flux results are automatically converted to Watts/meter2,
+when appropriate.
+
+From the API
+------------
+
+The Line Analysis plugin can be run from the API:
+
+.. code-block:: python
+
+    # Open line analysis plugin
+    plugin_la = specviz.plugins['Line Analysis']
+    plugin_la.open_in_tray()
+    # Input the appropriate spectrum and region
+    plugin_la.dataset = 'my spectrum'
+    plugin_la.spectral_subset = 'Subset 2'
+    # Input the values for the continuum
+    plugin_la.continuum = 'Subset 3'
+    # Return line analysis results
+    plugin_la.get_results()
+
 
 UI Access
 =========
@@ -18,5 +58,3 @@ UI Access
    :plugin-name: Line Analysis
    :plugin-panel-opened: false
    :demo-repeat: false
-
-See :doc:`../specviz/plugins` for detailed documentation.

--- a/docs/plugins/line_analysis.rst
+++ b/docs/plugins/line_analysis.rst
@@ -38,7 +38,7 @@ The Line Analysis plugin can be run from the API:
 .. code-block:: python
 
     # Open line analysis plugin
-    plugin_la = specviz.plugins['Line Analysis']
+    plugin_la = jd.plugins['Line Analysis']
     plugin_la.open_in_tray()
     # Input the appropriate spectrum and region
     plugin_la.dataset = 'my spectrum'

--- a/docs/plugins/line_lists.rst
+++ b/docs/plugins/line_lists.rst
@@ -44,15 +44,7 @@ Click the :guilabel:`Line Lists` icon in the plugin toolbar to:
 API Access
 ==========
 
-.. code-block:: python
-
-    plg = jd.plugins['Line Lists']
-
-    # Load a line list
-    plg.load_line_list('SDSS')
-
-    # Set redshift
-    plg.set_redshift(0.05)
+The public API for the this plugin is in development
 
 .. plugin-api-refs::
    :module: jdaviz.configs.default.plugins.line_lists.line_lists

--- a/docs/plugins/line_lists.rst
+++ b/docs/plugins/line_lists.rst
@@ -46,7 +46,7 @@ API Access
 
 .. code-block:: python
 
-    plg = app.plugins['Line Lists']
+    plg = jd.plugins['Line Lists']
 
     # Load a line list
     plg.load_line_list('SDSS')

--- a/docs/plugins/model_fitting.rst
+++ b/docs/plugins/model_fitting.rst
@@ -25,4 +25,121 @@ UI Access
    :plugin-panel-opened: false
    :demo-repeat: false
 
-See :ref:`specviz-model-fitting` for detailed documentation.
+Details
+=======
+
+Astropy models can be fit to a spectrum via the Model Fitting plugin.
+Model components are selected via the :guilabel:`Model Component` pulldown menu.
+The :guilabel:`Add Component` button adds a Model Components block.
+
+Model Parameters are automatically initialized with a guess.
+These starting values can be edited by the user.
+They may also be fixed by selecting the checkbox,
+so that they are not fit or changed by the model fitting.
+
+A mathematical expression must be entered into the
+:guilabel:`Equation Editor` to specify the mathematical
+combination of models.
+This is also necessary even if there is only one model component.
+The model components are specified by their labels and the equation
+defaults to the sum of all created components, but can be modified to
+exclude some of components without needing to delete them entirely
+or to change to subtraction, for example. The user can also select
+a different fitter to use for the model and adjust the corresponding
+parameters that appear in the :guilabel:`Fitter Parameters`
+accordion menu. The default fitter used is
+`astropy.modeling.fitting.TRFLSQFitter <https://docs.astropy.org/en/latest/api/astropy.modeling.fitting.TRFLSQFitter.html#astropy.modeling.fitting.TRFLSQFitter>`_.
+The fitter can be changed to any of the available Astropy fitters,
+which can be found here `<https://docs.astropy.org/en/latest/modeling/reference_api.html#id6>`_.
+
+After fitting, the expandable menu for each component model will update to
+show the fitted value of each parameter rather than the initial value, and
+will additionally show the standard deviation uncertainty of the fitted
+parameter value if the parameter was not set to be fixed to the initial value
+and if the spectrum uncertainty was loaded.
+
+.. note::
+
+   When a `1D Spline Models <https://docs.astropy.org/en/stable/modeling/spline_models.html>`_. model is selected, the plugin uses
+   `astropy.modeling.spline.SplineSmoothingFitter <https://docs.astropy.org/en/stable/api/astropy.modeling.spline.SplineSmoothingFitter.html#astropy.modeling.spline.SplineSmoothingFitter>`_. to compute the fit.
+   The initial value of the smoothing factor is automatically set to:
+   (``len(data) * (standard_deviation(data))**2``).
+
+   Refer to the section of the Scipy spline modeling documentation explaining
+   the ``s`` parameter for advice on setting the smoothing factor/condition manually:
+   https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.UnivariateSpline.html#scipy.interpolate.UnivariateSpline
+
+
+From the API
+------------
+
+The model fitting plugin can be run from the API:
+
+.. code-block:: python
+
+    # Open model fitting plugin
+    plugin_mf = jd.plugins['Model Fitting']
+    plugin_mf.open_in_tray()
+    # Input the appropriate dataset and subset
+    plugin_mf.dataset = 'my spectrum'
+    plugin_mf.spectral_subset = 'Subset 1'
+    # Input the model components
+    plugin_mf.create_model_component(model_component='Linear1D',
+                                     model_component_label='L')
+    plugin_mf.create_model_component(model_component='Gaussian1D',
+                                     model_component_label='G')
+    # Set the initial guess of some model parameters
+    plugin_mf.set_model_component('G', 'stddev', 0.002)
+    plugin_mf.set_model_component('G', 'mean', 2.2729)
+    # Model equation gets populated automatically, but can be overwritten
+    plugin_mf.equation = 'L+G'
+    # Set fitter
+    plugin_mf.fitter.selected = 'TRFLSQFitter'
+    # Calculate fit
+    plugin_mf.calculate_fit()
+
+Customizing Fitter Parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The fitter parameters (such as maximum iterations, filtering non-finite values, etc.)
+can be accessed and modified programmatically using the
+:meth:`~jdaviz.configs.default.plugins.model_fitting.model_fitting.ModelFitting.get_fitter_parameter`
+and :meth:`~jdaviz.configs.default.plugins.model_fitting.model_fitting.ModelFitting.set_fitter_parameter`
+methods. The available parameters depend on the selected fitter.
+
+Common parameters include:
+
+* ``maxiter``: Maximum number of iterations (available for most fitters)
+* ``filter_non_finite``: Whether to filter non-finite values like NaNs (available for most fitters)
+* ``calc_uncertainties``: Whether to calculate parameter uncertainties (available for most fitters)
+
+.. code-block:: python
+
+    # Get the current value of a fitter parameter
+    max_iterations = plugin_mf.get_fitter_parameter('maxiter')
+    print(f"Current max iterations: {max_iterations}")
+
+    # Set a new value for a fitter parameter
+    plugin_mf.set_fitter_parameter('maxiter', 200)
+    plugin_mf.set_fitter_parameter('filter_non_finite', False)
+
+    # Verify the change
+    new_max_iterations = plugin_mf.get_fitter_parameter('maxiter')
+    print(f"New max iterations: {new_max_iterations}")
+
+Note that different fitters support different parameters. For example, ``LinearLSQFitter``
+does not support the ``maxiter`` parameter. If you attempt to get a parameter that doesn't
+exist for the selected fitter, the method will return ``None``.
+
+Exporting Fit Results
+^^^^^^^^^^^^^^^^^^^^^^
+
+Parameter values for each fitting run are stored in the plugin table.
+To export the table into the notebook, call
+:meth:`~jdaviz.core.template_mixin.TableMixin.export_table`
+(see :ref:`plugin-apis`).
+
+.. seealso::
+
+    :ref:`Export Models <specviz-export-model>`
+        Documentation on exporting model fitting results.

--- a/docs/plugins/moment_maps.rst
+++ b/docs/plugins/moment_maps.rst
@@ -244,4 +244,4 @@ See Also
 ========
 
 * :ref:`plugins-collapse` - Alternative collapse method
-* :ref:`plugins-spectral-extraction_3d` - Extract 1D spectra from cubes
+* :ref:`plugins-spectral_extraction_3d` - Extract 1D spectra from cubes

--- a/docs/plugins/moment_maps.rst
+++ b/docs/plugins/moment_maps.rst
@@ -134,9 +134,8 @@ Accessing the Plugin
 
 .. code-block:: python
 
-    import jdaviz
+    import jdaviz as jd
 
-    jd = Jdaviz()
     jd.show()
     jd.load('cube.fits', format='3D Spectrum')
 

--- a/docs/plugins/moment_maps.rst
+++ b/docs/plugins/moment_maps.rst
@@ -90,16 +90,10 @@ UI Access
    :plugin-panel-opened: false
    :demo-repeat: false
 
-Opening the Plugin
-------------------
-
-**Cubeviz:**
-  Click the :guilabel:`Moment Maps` icon in the plugin toolbar.
-
 Workflow
 --------
 
-1. **Load cube** into Cubeviz
+1. **Load cube** into Jdaviz
 2. **Select dataset** from :guilabel:`Data` dropdown
 3. **Set spectral region**:
 
@@ -140,14 +134,14 @@ Accessing the Plugin
 
 .. code-block:: python
 
-    from jdaviz import Cubeviz
+    import jdaviz
 
-    cubeviz = Cubeviz()
-    cubeviz.show()
-    cubeviz.load('cube.fits', format='3D Spectrum')
+    jd = Jdaviz()
+    jd.show()
+    jd.load('cube.fits', format='3D Spectrum')
 
     # Access plugin
-    plg = cubeviz.plugins['Moment Maps']
+    plg = jd.plugins['Moment Maps']
 
 Moment 0 Map (Line Flux)
 ------------------------
@@ -249,6 +243,5 @@ Example Notebooks
 See Also
 ========
 
-* :ref:`moment-maps` - Detailed Cubeviz moment maps documentation
-* :ref:`collapse` - Alternative collapse method
-* :ref:`spectral-extraction` - Extract 1D spectra
+* :ref:`plugins-collapse` - Alternative collapse method
+* :ref:`plugins-spectral-extraction_3d` - Extract 1D spectra from cubes

--- a/docs/plugins/orientation.rst
+++ b/docs/plugins/orientation.rst
@@ -9,11 +9,34 @@ Orientation
 
 Control image display orientation and alignment.
 
+.. note::
+
+    This plugin was previous called "Links Control".
+
 Description
 ===========
 
-The Orientation plugin controls how images are displayed, including rotation,
-flipping, and alignment to celestial coordinates.
+This plugin is used to align image layers by pixels or sky (WCS).
+All images are automatically linked by pixels on load but you can use
+it to re-link by pixels or WCS as needed.
+
+For WCS linking, the "fast approximation" option uses an affine transform
+to represent the offset between images, if possible. This method, although less accurate,
+is much more performant and should still be accurate to within a pixel for most cases.
+If approximation fails, WCS linking will fall back to the full transformation.
+
+Since Jdaviz v3.9, when linking by WCS, a hidden reference data layer
+without distortion (labeled "Default orientation") will be created and all the data would be linked to
+it instead of the first loaded data. As a result, working in pixel
+space when linked by WCS is not recommended. Additionally, any data
+with distorted WCS would show as distorted on the display. Furthermore,
+any data without WCS can no longer be shown in WCS linking mode.
+
+For the best experience, it is recommended that you decide what kind of
+link you want and set it at the beginning of your Imviz session,
+rather than later.
+
+For more details on linking, see :ref:`dev_glue_linking`.
 
 **Key Features:**
 
@@ -21,6 +44,19 @@ flipping, and alignment to celestial coordinates.
 * Flip horizontally/vertically
 * Align North up, East left
 * Apply to single or all viewers
+
+Image Rotation
+==============
+
+When linked by WCS, sky rotation is also possible. You can choose from
+presets (N-up, E-left/right) or provide your own sky angle.
+
+.. warning::
+
+    Each rotation request creates a new reference data layer in the background.
+    Just as in :ref:`imviz-import-data`, the performance would be impacted by
+    the number of active rotation layers you have; only keep the desired rotation layer.
+    Note that the "default orientation" layer cannot be removed.
 
 UI Access
 =========

--- a/docs/plugins/spectral_slice.rst
+++ b/docs/plugins/spectral_slice.rst
@@ -22,6 +22,27 @@ slices in spectral cubes and managing slice display.
 * Slice animation
 * Synchronize across viewers
 
+To choose a specific slice, enter an approximate wavelength (in which case the nearest slice will
+be selected and the wavelength entry will "span" to the exact value of that slice).  The snapping
+behavior can be disabled in the plugin settings to allow for smooth scrubbing, in which case the
+closest slice will still be displayed in any relevant cube viewers.
+
+Spectrum viewers also contains a tool to allow clicking and
+dragging in the spectrum plot to choose the currently selected slice.
+When the slice tool is active, clicking anywhere on the spectrum viewer
+will select the nearest slice across all viewers, even if the indicator
+is off-screen.
+
+For your convenience, there are also player-style buttons with
+the following functionality:
+
+* Jump to first
+* Previous slice
+* Play/Pause
+* Next slice
+* Jump to last
+
+
 UI Access
 =========
 
@@ -33,7 +54,7 @@ API Access
 
 .. code-block:: python
 
-    plg = cubeviz.plugins['Spectral Slice']
+    plg = jdaviz.plugins['Spectral Slice']
     plg.slice = 50  # Go to slice 50
 
 .. plugin-api-refs::

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -120,12 +120,12 @@ Some shortcuts require a specific plugin to be open.
    * - ``b``
      - Blink to next image
      - 2+ images loaded
-   * - ``B`` 
+   * - ``B``
      - Blink to previous image
      - 2+ images loaded
    * - ``l``
      - Plot line profiles at cursor position
-     - :ref:`Line Profile (XY) <plugins-line-profiles>` plugin open
+     - :ref:`Line Profile (XY) <plugins-image-profiles>` plugin open
    * - ``m``
      - Add marker at cursor position
      - :ref:`Markers <info-markers>` plugin open


### PR DESCRIPTION
Does what it says on the tin. Haven't finished all plugins yet.

Rendered docs: https://jdaviz--4064.org.readthedocs.build/en/4064/ 