### PR TITLE
Export JPG with AVM (WCS metadata)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,8 @@ New Features
 
 - 'Auto' parenting can now associate with data already loaded into the app without needing to specify the data label. [#4248]
 
+- Export image viewer screenshots to JPG with Astronomy Visualization Metadata (AVM). [#4065]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/default/aida.py
+++ b/jdaviz/configs/default/aida.py
@@ -173,11 +173,12 @@ class AID:
 
         if sky_or_pixel == 'pixel':
             return pixel_fov
-        if not any(c.strip() for c in wcs.wcs.ctype):
-            raise ValueError("The image must have valid WCS to return `fov` in `sky`.")
 
         if isinstance(wcs, GWCS):
             wcs = WCS(wcs.to_fits_sip())
+
+        if not any(c.strip() for c in wcs.wcs.ctype):
+            raise ValueError("The image must have valid WCS to return `fov` in `sky`.")
 
         # compute the mean of the height and width of the
         # viewer's FOV on ``data`` in world units:

--- a/jdaviz/configs/default/plugins/export/avm.py
+++ b/jdaviz/configs/default/plugins/export/avm.py
@@ -1,0 +1,77 @@
+
+import os
+import numpy as np
+from PIL import Image
+
+from astropy.wcs import WCS
+from astropy.wcs.utils import fit_wcs_from_points, pixel_to_pixel
+from pyavm import AVM
+
+
+def png_to_jpg_avm(viz, viewer, png_filename):
+    """Convert a PNG screenshot to JPG with Astronomy Visualization Metadata (AVM).
+
+    Parameters
+    ----------
+    viz : jdaviz.configs.imviz.helper.Imviz
+        Imviz helper.
+    viewer : jdaviz.configs.imviz.plugins.viewers.ImvizImageVew
+        Glue viewer exported in the PNG screenshot screenshot
+    png_filename : path-like, str
+        Path to PNG screenshot
+    """
+    # open temporary PNG
+    img = Image.open(png_filename)
+    png_shape = img.size
+
+    # get the viewer limits in refdata pixel coords
+    refdata_wcs = viewer.state.reference_data.coords
+    xy_ref = (
+        np.array([
+            viewer.state.x_min,
+            viewer.state.x_min,
+            viewer.state.x_max,
+            viewer.state.x_max,
+            0.5 * (viewer.state.x_min + viewer.state.x_max)]),
+        np.array([
+            viewer.state.y_min,
+            viewer.state.y_max,
+            viewer.state.y_min,
+            viewer.state.y_max,
+            0.5 * (viewer.state.y_min + viewer.state.y_max)]),
+    )
+    # pixel coordinates for the corners and center of the image
+    xy_png = (
+        np.array([0, 0, png_shape[0], png_shape[0], png_shape[0] / 2]),
+        np.array([0, png_shape[1], 0, png_shape[1], png_shape[1] / 2])
+    )
+
+    # convert observation pixel coords to world
+    world = refdata_wcs.pixel_to_world(*xy_ref)
+
+    # fit for WCS using these five points
+    png_wcs = fit_wcs_from_points(xy_png, world, proj_point=world[0])
+
+    # assemble AVM with this WCS:
+    png_avm = AVM().from_wcs(png_wcs, png_shape)
+
+    # add AVM tags required for the aladin-lite parser:
+    png_avm.Creator = 'jdaviz'
+    png_avm.Rights = ''
+    png_avm.Credit = ''
+    png_avm.ID = ''
+    png_avm.MetadataDate = ''
+
+    jpg_path = str(png_filename).replace('.png', '.jpg')
+
+    try:
+        jpg_path_tmp = str(png_filename).replace('.png', '_tmp.jpg')
+
+        # write out temporary JPG (drop alpha channel)
+        img.convert('RGB').save(jpg_path_tmp)
+
+        # embed AVM into final JPG
+        png_avm.embed(jpg_path_tmp, jpg_path, verify=True)
+    finally:
+        # ensure tmp file gets removed
+        os.remove(jpg_path_tmp)

--- a/jdaviz/configs/default/plugins/export/avm.py
+++ b/jdaviz/configs/default/plugins/export/avm.py
@@ -3,8 +3,7 @@ import os
 import numpy as np
 from PIL import Image
 
-from astropy.wcs import WCS
-from astropy.wcs.utils import fit_wcs_from_points, pixel_to_pixel
+from astropy.wcs.utils import fit_wcs_from_points
 from pyavm import AVM
 
 

--- a/jdaviz/configs/default/plugins/export/avm.py
+++ b/jdaviz/configs/default/plugins/export/avm.py
@@ -22,7 +22,6 @@ def png_embed_avm(viz, viewer, png_filename, format='jpg'):
         Write out the image with embedded AVM as type ``format``
     """
     # open temporary PNG
-    print(f"{png_filename=}")
     img = Image.open(png_filename)
     png_shape = img.size
 
@@ -61,26 +60,24 @@ def png_embed_avm(viz, viewer, png_filename, format='jpg'):
     png_avm.Creator = 'jdaviz'
     png_avm.Rights = ''
     png_avm.Credit = ''
-    # png_avm.ID = viewer.reference
-    # png_avm.MetadataDate = datetime.now().strftime("%Y-%m-%dT%H:%M")
+    png_avm.MetadataDate = datetime.now().strftime("%Y-%m-%dT%H:%M")
 
     dest_path = str(png_filename).replace('.png', f'.{format}')
     dest_path_tmp = str(png_filename).replace('.png', f'_tmp.{format}')
 
-    # try:
-    if True:
+    try:
         # write out temporary file
-
         if format == 'jpg':
             # drop alpha channel for JPG files
             img.convert('RGB').save(dest_path_tmp)
+
+            # embed AVM into final jpg/png
+            png_avm.embed(dest_path_tmp, dest_path, verify=True)
+
         elif format == 'png':
-            # PNG supports alpha channel, no conversion necessary
             img.save(dest_path_tmp)
+            png_avm.embed(dest_path_tmp, dest_path, verify=True)
 
-        # embed AVM into final JPG
-        png_avm.embed(dest_path_tmp, dest_path, verify=True)
-
-    # finally:
+    finally:
         # ensure tmp file gets removed
         os.remove(dest_path_tmp)

--- a/jdaviz/configs/default/plugins/export/avm.py
+++ b/jdaviz/configs/default/plugins/export/avm.py
@@ -2,12 +2,12 @@
 import os
 import numpy as np
 from PIL import Image
-
+from datetime import datetime
 from astropy.wcs.utils import fit_wcs_from_points
 from pyavm import AVM
 
 
-def png_to_jpg_avm(viz, viewer, png_filename):
+def png_embed_avm(viz, viewer, png_filename, format='jpg'):
     """Convert a PNG screenshot to JPG with Astronomy Visualization Metadata (AVM).
 
     Parameters
@@ -18,8 +18,11 @@ def png_to_jpg_avm(viz, viewer, png_filename):
         Glue viewer exported in the PNG screenshot screenshot
     png_filename : path-like, str
         Path to PNG screenshot
+    format : str {'jpg', 'png'}
+        Write out the image with embedded AVM as type ``format``
     """
     # open temporary PNG
+    print(f"{png_filename=}")
     img = Image.open(png_filename)
     png_shape = img.size
 
@@ -58,19 +61,26 @@ def png_to_jpg_avm(viz, viewer, png_filename):
     png_avm.Creator = 'jdaviz'
     png_avm.Rights = ''
     png_avm.Credit = ''
-    png_avm.ID = ''
-    png_avm.MetadataDate = ''
+    # png_avm.ID = viewer.reference
+    # png_avm.MetadataDate = datetime.now().strftime("%Y-%m-%dT%H:%M")
 
-    jpg_path = str(png_filename).replace('.png', '.jpg')
+    dest_path = str(png_filename).replace('.png', f'.{format}')
+    dest_path_tmp = str(png_filename).replace('.png', f'_tmp.{format}')
 
-    try:
-        jpg_path_tmp = str(png_filename).replace('.png', '_tmp.jpg')
+    # try:
+    if True:
+        # write out temporary file
 
-        # write out temporary JPG (drop alpha channel)
-        img.convert('RGB').save(jpg_path_tmp)
+        if format == 'jpg':
+            # drop alpha channel for JPG files
+            img.convert('RGB').save(dest_path_tmp)
+        elif format == 'png':
+            # PNG supports alpha channel, no conversion necessary
+            img.save(dest_path_tmp)
 
         # embed AVM into final JPG
-        png_avm.embed(jpg_path_tmp, jpg_path, verify=True)
-    finally:
+        png_avm.embed(dest_path_tmp, dest_path, verify=True)
+
+    # finally:
         # ensure tmp file gets removed
-        os.remove(jpg_path_tmp)
+        os.remove(dest_path_tmp)

--- a/jdaviz/configs/default/plugins/export/avm.py
+++ b/jdaviz/configs/default/plugins/export/avm.py
@@ -78,6 +78,14 @@ def png_embed_avm(viz, viewer, png_filename, format='jpg'):
             img.save(dest_path_tmp)
             png_avm.embed(dest_path_tmp, dest_path, verify=True)
 
+    except Exception as err:
+        raise ValueError(
+            f"While saving screenshot, encountered: {err}"
+        )
+
     finally:
+        if format == 'jpg':
+            os.remove(png_filename)
+
         # ensure tmp file gets removed
         os.remove(dest_path_tmp)

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -7,6 +7,7 @@ from astropy import units as u
 from astropy.nddata import CCDData
 from glue.core.message import SubsetCreateMessage, SubsetDeleteMessage, SubsetUpdateMessage
 from glue_jupyter.bqplot.image import BqplotImageView
+from pyavm import AVM
 from regions import CircleSkyRegion, EllipseSkyRegion
 from specutils import Spectrum
 from traitlets import Bool, List, Unicode, observe
@@ -446,7 +447,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
     @with_spinner()
     def export(self, filename=None, show_dialog=None, overwrite=False,
-               raise_error_for_overwrite=True):
+               raise_error_for_overwrite=True, embed_avm=False):
         """
         Export selected item(s)
 
@@ -465,6 +466,10 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             If `True`, raise exception when ``overwrite=False`` but
             output file already exists. Otherwise, a message will be sent
             to application snackbar instead.
+
+        embed_avm : bool
+            If `True` and the file type is PNG, embed
+            Astronomy Visualization Metadata (including WCS) using ``pyAVM``.
         """
         if self.multiselect:
             raise NotImplementedError("batch export not yet supported")
@@ -512,6 +517,10 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                 self.save_figure(viewer, filename, filetype, show_dialog=show_dialog,
                                  width=f"{self.image_width}px" if self.image_custom_size else None,
                                  height=f"{self.image_height}px" if self.image_custom_size else None)  # noqa
+
+                if embed_avm and filetype == "png":
+                    AVM.embed()
+
 
             # restore marks to their original state
             for restore, mark in zip(restores, viewer.figure.marks):

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -11,7 +11,7 @@ from regions import CircleSkyRegion, EllipseSkyRegion
 from specutils import Spectrum
 from traitlets import Bool, List, Unicode, observe
 
-from jdaviz.configs.default.plugins.export.avm import png_to_jpg_avm
+from jdaviz.configs.default.plugins.export.avm import png_embed_avm
 from jdaviz.core.custom_traitlets import FloatHandleEmpty, IntHandleEmpty
 from jdaviz.core.marks import ShadowMixin
 from jdaviz.core.registries import tray_registry
@@ -447,7 +447,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
     @with_spinner()
     def export(self, filename=None, show_dialog=None, overwrite=False,
-               raise_error_for_overwrite=True, embed_avm=False):
+               raise_error_for_overwrite=True, embed_avm=True):
         """
         Export selected item(s)
 
@@ -514,15 +514,24 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                                 width=f"{self.image_width}px" if self.image_custom_size else None,
                                 height=f"{self.image_height}px" if self.image_custom_size else None)
 
-            elif filetype == "jpg":
+            elif embed_avm and filetype in ('jpg', 'png'):
                 # export screenshot to JPG with AVM by:
                 #   (1) export a temporary PNG
                 #   (2) convert temporary PNG to a temporary JPG with PIL
                 #   (3) use pyAVM to embed AVM into a final copy of the temporary JPG
 
                 try:
-                    # export PNG
-                    tmp_filename = Path(str(Path(filename)).replace('.jpg', '.png'))
+                    # export as PNG, even if final filetype will be JPG
+                    # note: following `replace` assumes lower case extensions
+                    tmp_filename = Path(
+                        str(Path(filename)).replace('.jpg', '.png')
+                    )
+                    print(tmp_filename)
+
+                    # wait for PNG to be available before continuing
+                    while viewer.figure._upload_png_callback is not None:
+                        time.sleep(0.05)
+
                     self.save_figure(
                         viewer, tmp_filename, 'png', show_dialog=show_dialog,
                         width=f"{self.image_width}px" if self.image_custom_size else None,
@@ -531,16 +540,20 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
                     # wait for PNG to be available before continuing
                     while viewer.figure._upload_png_callback is not None:
-                        time.sleep(0.1)
+                        time.sleep(0.05)
 
                     # now convert to JPG with AVM
-                    png_to_jpg_avm(self.app._jdaviz_helper, viewer, tmp_filename)
+                    png_embed_avm(self.app._jdaviz_helper, viewer, tmp_filename, format=filetype)
+
+                except Exception as e:
+                    print(f"Could not complete {filetype} export, raised: {e}")
 
                 finally:
                     # remove temporary png file, even if there are exceptions
                     os.remove(tmp_filename)
 
             else:
+
                 self.save_figure(viewer, filename, filetype, show_dialog=show_dialog,
                                  width=f"{self.image_width}px" if self.image_custom_size else None,
                                  height=f"{self.image_height}px" if self.image_custom_size else None)  # noqa
@@ -671,6 +684,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                     f.write(data)
 
             except Exception as e:
+                print(e)
                 self.hub.broadcast(SnackbarMessage(
                     f"{self.viewer.selected} failed to export to {str(filename)}: {e}",
                     sender=self, color="error", traceback=e))
@@ -734,7 +748,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                 threading.Thread(target=wait_in_other_thread).start()
             _widget_after_first_display(cloned_viewer.figure, on_figure_displayed)
             _show_hidden(cloned_viewer.figure, width, height)
-        elif filetype == 'png':
+        elif filetype in ('png', 'jpg'):
             # NOTE: get_png already check if _upload_png_callback is not None
             get_png(viewer.figure)
 

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -1,6 +1,5 @@
 import os
 import time
-from functools import partial
 from pathlib import Path
 import threading
 
@@ -8,8 +7,6 @@ from astropy import units as u
 from astropy.nddata import CCDData
 from glue.core.message import SubsetCreateMessage, SubsetDeleteMessage, SubsetUpdateMessage
 from glue_jupyter.bqplot.image import BqplotImageView
-from PIL import Image
-from pyavm import AVM
 from regions import CircleSkyRegion, EllipseSkyRegion
 from specutils import Spectrum
 from traitlets import Bool, List, Unicode, observe
@@ -526,9 +523,11 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                 try:
                     # export PNG
                     tmp_filename = Path(str(Path(filename)).replace('.jpg', '.png'))
-                    self.save_figure(viewer, tmp_filename, 'png', show_dialog=show_dialog,
-                                    width=f"{self.image_width}px" if self.image_custom_size else None,
-                                    height=f"{self.image_height}px" if self.image_custom_size else None)  # noqa
+                    self.save_figure(
+                        viewer, tmp_filename, 'png', show_dialog=show_dialog,
+                        width=f"{self.image_width}px" if self.image_custom_size else None,
+                        height=f"{self.image_height}px" if self.image_custom_size else None
+                    )
 
                     # wait for PNG to be available before continuing
                     while viewer.figure._upload_png_callback is not None:

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -523,21 +523,23 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                 #   (2) convert temporary PNG to a temporary JPG with PIL
                 #   (3) use pyAVM to embed AVM into a final copy of the temporary JPG
 
-                # first export PNG
-                tmp_filename = Path(str(Path(filename)).replace('.jpg', '.png'))
-                self.save_figure(viewer, tmp_filename, 'png', show_dialog=show_dialog,
-                                 width=f"{self.image_width}px" if self.image_custom_size else None,
-                                 height=f"{self.image_height}px" if self.image_custom_size else None)  # noqa
+                try:
+                    # export PNG
+                    tmp_filename = Path(str(Path(filename)).replace('.jpg', '.png'))
+                    self.save_figure(viewer, tmp_filename, 'png', show_dialog=show_dialog,
+                                    width=f"{self.image_width}px" if self.image_custom_size else None,
+                                    height=f"{self.image_height}px" if self.image_custom_size else None)  # noqa
 
-                # wait for PNG to be available before continuing
-                while viewer.figure._upload_png_callback is not None:
-                    time.sleep(0.05)
+                    # wait for PNG to be available before continuing
+                    while viewer.figure._upload_png_callback is not None:
+                        time.sleep(0.1)
 
-                # now convert to JPG with AVM
-                png_to_jpg_avm(self.app._jdaviz_helper, viewer, tmp_filename)
+                    # now convert to JPG with AVM
+                    png_to_jpg_avm(self.app._jdaviz_helper, viewer, tmp_filename)
 
-                # remove temporary png file
-                os.remove(tmp_filename)
+                finally:
+                    # remove temporary png file, even if there are exceptions
+                    os.remove(tmp_filename)
 
             else:
                 self.save_figure(viewer, filename, filetype, show_dialog=show_dialog,
@@ -736,14 +738,6 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         elif filetype == 'png':
             # NOTE: get_png already check if _upload_png_callback is not None
             get_png(viewer.figure)
-        elif filetype == 'jpg':
-            # the expected filename at this point is a JPG, but we're going to
-            # produce a PNG first, and convert to JPG later:
-            tmp_filename = Path(str(filename).replace('.jpg', '.png'))
-
-            # below is equivalent to `get_png`
-            # viewer.figure.get_png_data(partial(on_img_received, filename=tmp_filename))
-            get_png(viewer.figure, partial(on_img_received, filename=tmp_filename))
 
         elif filetype == 'svg':
             if viewer.figure._upload_svg_callback is not None:

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -7,11 +7,13 @@ from astropy import units as u
 from astropy.nddata import CCDData
 from glue.core.message import SubsetCreateMessage, SubsetDeleteMessage, SubsetUpdateMessage
 from glue_jupyter.bqplot.image import BqplotImageView
+from PIL import Image
 from pyavm import AVM
 from regions import CircleSkyRegion, EllipseSkyRegion
 from specutils import Spectrum
 from traitlets import Bool, List, Unicode, observe
 
+from jdaviz.configs.default.plugins.export.avm import png_to_jpg_avm
 from jdaviz.core.custom_traitlets import FloatHandleEmpty, IntHandleEmpty
 from jdaviz.core.marks import ShadowMixin
 from jdaviz.core.registries import tray_registry
@@ -141,7 +143,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
         self.viewer.add_filter('is_not_empty')
 
-        viewer_format_options = ['png', 'svg']
+        viewer_format_options = ['png', 'svg', 'jpg']
         if self.config == 'cubeviz':
             if not self._app.state.settings.get('server_is_remote'):
                 viewer_format_options += ['mp4']
@@ -518,10 +520,6 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                                  width=f"{self.image_width}px" if self.image_custom_size else None,
                                  height=f"{self.image_height}px" if self.image_custom_size else None)  # noqa
 
-                if embed_avm and filetype == "png":
-                    AVM.embed()
-
-
             # restore marks to their original state
             for restore, mark in zip(restores, viewer.figure.marks):
                 for k, v in restore.items():
@@ -644,8 +642,14 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
         def on_img_received(data):
             try:
-                with filename.open(mode='bw') as f:
-                    f.write(data)
+                if filetype == 'jpg':
+                    print(f'{filename=}')
+                    with filename.open(mode='bw') as f:
+                        f.write(data)
+                else:
+                    with filename.open(mode='bw') as f:
+                        f.write(data)
+
             except Exception as e:
                 self.hub.broadcast(SnackbarMessage(
                     f"{self.viewer.selected} failed to export to {str(filename)}: {e}",
@@ -713,6 +717,15 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         elif filetype == 'png':
             # NOTE: get_png already check if _upload_png_callback is not None
             get_png(viewer.figure)
+        elif filetype == 'jpg':
+            # NOTE: get_png already check if _upload_png_callback is not None
+            get_png(viewer.figure)
+
+            viz = self.app._jdaviz_helper
+            viewer_name = 'imviz-0'
+            old_filename = str(filename)
+            png_to_jpg_avm(viz, viewer_name, filename)
+
         elif filetype == 'svg':
             if viewer.figure._upload_svg_callback is not None:
                 raise ValueError("previous svg export is still in progress. Wait to complete before making another call to save_figure") # noqa

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -509,51 +509,43 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                     mark.labels = [lbl.strip() for lbl in mark.labels]
                 restores.append(restore)
 
+            # avoid circular import:
+            from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
+
             if filetype == "mp4":
                 self.save_movie(viewer, filename, filetype,
                                 width=f"{self.image_width}px" if self.image_custom_size else None,
                                 height=f"{self.image_height}px" if self.image_custom_size else None)
 
-            elif embed_avm and filetype in ('jpg', 'png'):
+            elif (
+                    isinstance(self.viewer.selected_obj, ImvizImageView) and
+                    embed_avm and filetype in ('jpg', 'png')
+            ):
                 # export screenshot to JPG with AVM by:
                 #   (1) export a temporary PNG
                 #   (2) convert temporary PNG to a temporary JPG with PIL
                 #   (3) use pyAVM to embed AVM into a final copy of the temporary JPG
 
-                try:
-                    # export as PNG, even if final filetype will be JPG
-                    # note: following `replace` assumes lower case extensions
-                    tmp_filename = Path(
-                        str(Path(filename)).replace('.jpg', '.png')
-                    )
-                    print(tmp_filename)
+                # export as PNG, even if final filetype will be JPG
+                # note: following `replace` assumes lower case extensions
+                tmp_filename = Path(
+                    str(Path(filename)).replace('.jpg', '.png')
+                )
 
-                    # wait for PNG to be available before continuing
-                    while viewer.figure._upload_png_callback is not None:
-                        time.sleep(0.05)
+                self.save_figure(
+                    viewer, tmp_filename, 'png', show_dialog=show_dialog,
+                    width=f"{self.image_width}px" if self.image_custom_size else None,
+                    height=f"{self.image_height}px" if self.image_custom_size else None
+                )
 
-                    self.save_figure(
-                        viewer, tmp_filename, 'png', show_dialog=show_dialog,
-                        width=f"{self.image_width}px" if self.image_custom_size else None,
-                        height=f"{self.image_height}px" if self.image_custom_size else None
-                    )
+                # wait for PNG to be available before continuing
+                while viewer.figure._upload_png_callback is not None:
+                    time.sleep(0.05)
 
-                    # wait for PNG to be available before continuing
-                    while viewer.figure._upload_png_callback is not None:
-                        time.sleep(0.05)
-
-                    # now convert to JPG with AVM
-                    png_embed_avm(self.app._jdaviz_helper, viewer, tmp_filename, format=filetype)
-
-                except Exception as e:
-                    print(f"Could not complete {filetype} export, raised: {e}")
-
-                finally:
-                    # remove temporary png file, even if there are exceptions
-                    os.remove(tmp_filename)
+                # now convert to JPG with AVM
+                png_embed_avm(self.app._jdaviz_helper, viewer, tmp_filename, format=filetype)
 
             else:
-
                 self.save_figure(viewer, filename, filetype, show_dialog=show_dialog,
                                  width=f"{self.image_width}px" if self.image_custom_size else None,
                                  height=f"{self.image_height}px" if self.image_custom_size else None)  # noqa

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -1,5 +1,6 @@
 import os
 import time
+from functools import partial
 from pathlib import Path
 import threading
 
@@ -515,6 +516,29 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                 self.save_movie(viewer, filename, filetype,
                                 width=f"{self.image_width}px" if self.image_custom_size else None,
                                 height=f"{self.image_height}px" if self.image_custom_size else None)
+
+            elif filetype == "jpg":
+                # export screenshot to JPG with AVM by:
+                #   (1) export a temporary PNG
+                #   (2) convert temporary PNG to a temporary JPG with PIL
+                #   (3) use pyAVM to embed AVM into a final copy of the temporary JPG
+
+                # first export PNG
+                tmp_filename = Path(str(Path(filename)).replace('.jpg', '.png'))
+                self.save_figure(viewer, tmp_filename, 'png', show_dialog=show_dialog,
+                                 width=f"{self.image_width}px" if self.image_custom_size else None,
+                                 height=f"{self.image_height}px" if self.image_custom_size else None)  # noqa
+
+                # wait for PNG to be available before continuing
+                while viewer.figure._upload_png_callback is not None:
+                    time.sleep(0.05)
+
+                # now convert to JPG with AVM
+                png_to_jpg_avm(self.app._jdaviz_helper, viewer, tmp_filename)
+
+                # remove temporary png file
+                os.remove(tmp_filename)
+
             else:
                 self.save_figure(viewer, filename, filetype, show_dialog=show_dialog,
                                  width=f"{self.image_width}px" if self.image_custom_size else None,
@@ -640,15 +664,10 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         else:
             app = viewer.app
 
-        def on_img_received(data):
+        def on_img_received(data, filename=filename):
             try:
-                if filetype == 'jpg':
-                    print(f'{filename=}')
-                    with filename.open(mode='bw') as f:
-                        f.write(data)
-                else:
-                    with filename.open(mode='bw') as f:
-                        f.write(data)
+                with filename.open(mode='bw') as f:
+                    f.write(data)
 
             except Exception as e:
                 self.hub.broadcast(SnackbarMessage(
@@ -659,7 +678,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                     f"{self.viewer.selected} exported to {str(filename)}",
                     sender=self, color="success"))
 
-        def get_png(figure):
+        def get_png(figure, on_img_received=on_img_received):
             if figure._upload_png_callback is not None:
                 raise ValueError("previous png export is still in progress. Wait to complete before making another call to save_figure")  # noqa: E501 # pragma: no cover
 
@@ -718,13 +737,13 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
             # NOTE: get_png already check if _upload_png_callback is not None
             get_png(viewer.figure)
         elif filetype == 'jpg':
-            # NOTE: get_png already check if _upload_png_callback is not None
-            get_png(viewer.figure)
+            # the expected filename at this point is a JPG, but we're going to
+            # produce a PNG first, and convert to JPG later:
+            tmp_filename = Path(str(filename).replace('.jpg', '.png'))
 
-            viz = self.app._jdaviz_helper
-            viewer_name = 'imviz-0'
-            old_filename = str(filename)
-            png_to_jpg_avm(viz, viewer_name, filename)
+            # below is equivalent to `get_png`
+            # viewer.figure.get_png_data(partial(on_img_received, filename=tmp_filename))
+            get_png(viewer.figure, partial(on_img_received, filename=tmp_filename))
 
         elif filetype == 'svg':
             if viewer.figure._upload_svg_callback is not None:

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -443,6 +443,7 @@ class TestExportPluginPlots:
         # just check that it doesn't crash, since we can't download
         export_plugin.export()
 
+    @pytest.mark.usefixtures('_jail')
     def test_figure_export(self, imviz_helper):
 
         data = NDData(np.ones((500, 500)) * u.nJy)
@@ -451,11 +452,17 @@ class TestExportPluginPlots:
 
         export_plugin = imviz_helper.plugins['Export']._obj
 
-        export_plugin.export(filename=None)
+        export_plugin.filename_value = 'test_export_plugin_plot'
+
+        # when `embed_avm` is true (default), ``png_embed_avm`` will
+        # wait until the PNG upload callback has completed. that callback is
+        # never completed when running tests in headless CI envs, so we turn off
+        # AVM embedding here for testing:
+        export_plugin.export(filename=None, overwrite=True, embed_avm=False)
 
         # attempt to save a figure back to back
         try:
-            export_plugin.export(filename='img.png')
+            export_plugin.export(filename='img.png', embed_avm=False)
         except ValueError as e:
             assert str(e) == "previous png export is still in progress. Wait to complete before making another call to save_figure"  # noqa: E501
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "specutils>=2.0.0",
     "specreduce>=1.6.0",
     "photutils>=2.2",
+    "pyavm>=0.9",
     "glue-astronomy>=0.12.0",
     "asteval>=0.9.23",
     "idna",


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description

The main goal of this PR is to allow users to export a screenshot of their image viewer and load that screenshot into [aladin-lite](https://aladin.cds.unistra.fr/AladinLite/) or [mast-aladin](https://github.com/spacetelescope/mast-aladin). In order to overlay the screenshot on the correct sky coordinates in aladin-lite, the screenshot must contain AVM.

[AVM](https://www.virtualastronomy.org/avm_metadata.php) is a metadata standard for embedding WCS in common image formats, including PNG and JPG. The python module for embedding AVM from WCS is [pyavm](https://github.com/astrofrog/pyavm/) by @astrofrog, which is a new (and [extremely minimal](https://github.com/astrofrog/pyavm/blob/19b9e3999b3ee3166f1bc14d07cbc600767fd533/pyproject.toml#L42-L48)) dependency in this PR. 

This PR adds a supported image viewer screenshot filetype (`"jpg"`). When selected, the Export plugin:
1. exports a PNG as normal
2. assembles WCS for the screenshot
3. converts PNG to JPG using PIL, since PNG w/ AVM isn't yet supported by aladin-lite
4. embeds the WCS into the final JPG, and cleans up temporary files

The result is a JPG file with AVM. You can check this by calling:
> ```$ head imviz-0.jpg```
> ```����JFIF��^http://ns.adobe.com/xap/1.0/<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?> <x:xmpmeta xmlns:avm="http://www.communicatingastronomy.org/avm/1.0/" xmlns:photoshop="http://ns.adobe.com/photoshop/1.0/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:x="adobe:ns:meta/"><rdf:RDF><rdf:Description><avm:MetadataVersion>1.1000000000000001</avm:MetadataVersion><photoshop:Source>jdaviz</photoshop:Source<avm:Spatial.CoordinateFrame>FK5</avm:Spatial.CoordinateFrame><avm:Spatial.Equinox>2000.0013661202186</avm:Spatial.Equinox><avm:Spatial.ReferenceValue><rdf:Seq><rdf:li>201.7042659999999898</rdf:li>...```

See that madness? That's the WCS.

Now you can load the JPG with [aladin-lite](https://aladin.cds.unistra.fr/AladinLite/) in your browser, or in an instance of [mast-aladin](https://github.com/spacetelescope/mast-aladin). In either environment, right click* on the sky , select "Load a local file" > "FITS image"*, and select the `imviz-0.jpg` file (*see known issues below).

To try this out in a notebook with mast-aladin, run the following in one cell:
```python
from mast_aladin import AppSidecar
import astropy.units as u
from astropy.coordinates import SkyCoord

# open mast-aladin and jdaviz
ma, viz = AppSidecar.open(anchor=['split-bottom', 'split-right'])
target = SkyCoord(ra=201.704266 * u.deg, dec=-47.44637979 * u.deg)
fov = 36 * u.arcsec

# set up the mast-aladin viewport
ma.target = target
ma.fov = fov
ma.survey = 'HST/color'

viz.load('mast:jwst/products/jw01478-o014_t003_nircam_clear-f115w_i2d.fits', format='Image')
viz.link_data('wcs')
viz.default_viewer.reset_limits()

# configure the colormap
plot_opts = viz.plugins['Plot Options']
plot_opts.image_colormap = 'viridis'
plot_opts.stretch_vmin = 5
plot_opts.stretch_vmax  = 1000
plot_opts.stretch_function = 'Arcsinh'

# set the jdaviz viewport to match mast-aladin
viz.default_viewer._obj.glue_viewer.aid.set_viewport(
    center=target,
    fov=fov
)
```
and in a second cell:
```python
# export JPG with AVM
export = viz.plugins['Export']
export.viewer_format = 'jpg'
export.export(overwrite=True)
```

You will see this:

https://github.com/user-attachments/assets/bfeddfc8-ef17-47fa-af94-b4fd545b5b0a


### Known issues

* aladin-lite will happily load a JPG via the "load a local file > FITS image" button. This may be addressed by CDS soon: https://github.com/cds-astro/aladin-lite/issues/349#issuecomment-3999028470
* aladin-lite on OS X and in Chrome doesn't support ctrl+click to open the menu shown in this demo. This is a known issue that will be resolved shortly. Workaround: aladin-lite does recognize ctrl+click on OS X in Firefox. https://github.com/cds-astro/aladin-lite/issues/348#issuecomment-3999211669
* the WCS that I'm constructing for the screenshot underestimates the pixel scale. I haven't found the source of this yet.
* aladin-lite cannot read PNG with AVM yet, though the idea was received positively in https://github.com/cds-astro/aladin-lite/issues/349. If PNG+AVM support becomes available, I will replicate the AVM logic for exporting PNGs as well. One major advantage to PNG is that it supports transparency, so we could export screenshots where out-of-bounds portions of the image are transparent, rather than a black background.

### To do items before merge:

* [x] I haven't accounted for jdaviz users beginning in any orientation other than Default Orientation
* [x] should add logic to ensure that tmp files are removed if the export fails out early (prevent leaving tmp files)

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
