### PR TITLE
add dq to cube loaders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,8 @@ New Features
 
 Cubeviz
 ^^^^^^^
+- Added ability to load DQ extension in the cubeviz loader, which activates the
+  DQ plugin in cubeviz. [#4077]
 
 Imviz
 ^^^^^

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -453,7 +453,6 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
                                for child in self.app._get_assoc_data_children(data.label)}
 
             for layer in self._viewer.layers:
-                print(f"layer {layer.layer.label} with zorder {layer.zorder}")  # noqa
                 # Skip reordering scatter layers in image viewers.
                 if isinstance(self._viewer, BqplotImageView) and isinstance(layer.state, ScatterLayerState):  # noqa
                     continue
@@ -461,14 +460,15 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
                     new_zorder = len(label_order) - label_order.index(layer.layer.label)
                     if layer.layer.label not in data_and_children:
                         for x in children_blocks:
+
                             # skip empty blocks (still need to figure out why
                             # this is happening - without this, when you have a DQ
                             # layer in cubeviz, adding data to the spectrum 1D viewer
                             # results in an error because it is encountering an empty
                             # block here, but skipping seems to do the trick)
                             if not x:
-                                print(f"skipping empty block for layer {layer.layer.label}")  # noqa
                                 continue
+
                             # If the projected new_zorder falls within a block of
                             # data+children, adjust to be just above or below the block
                             # depending on if the layer came from below or above, respectively

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -453,6 +453,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
                                for child in self.app._get_assoc_data_children(data.label)}
 
             for layer in self._viewer.layers:
+                print(f"layer {layer.layer.label} with zorder {layer.zorder}")  # noqa
                 # Skip reordering scatter layers in image viewers.
                 if isinstance(self._viewer, BqplotImageView) and isinstance(layer.state, ScatterLayerState):  # noqa
                     continue
@@ -460,6 +461,14 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
                     new_zorder = len(label_order) - label_order.index(layer.layer.label)
                     if layer.layer.label not in data_and_children:
                         for x in children_blocks:
+                            # skip empty blocks (still need to figure out why
+                            # this is happening - without this, when you have a DQ
+                            # layer in cubeviz, adding data to the spectrum 1D viewer
+                            # results in an error because it is encountering an empty
+                            # block here, but skipping seems to do the trick)
+                            if not x:
+                                print(f"skipping empty block for layer {layer.layer.label}")  # noqa
+                                continue
                             # If the projected new_zorder falls within a block of
                             # data+children, adjust to be just above or below the block
                             # depending on if the layer came from below or above, respectively

--- a/jdaviz/configs/default/plugins/data_quality/dq_utils.py
+++ b/jdaviz/configs/default/plugins/data_quality/dq_utils.py
@@ -207,7 +207,6 @@ def generate_listed_colormap(n_flags=None, rgba_colors=None, seed=3):
     cmap = ListedColormap(rgba_colors)
 
     # setting `bad` alpha=0 will make NaNs transparent:
-    # cmap.with_extremes(bad='k', alpha=0)
     cmap = cmap.with_extremes(bad=to_rgba("k", alpha=0))
     return cmap, rgba_colors
 

--- a/jdaviz/configs/default/plugins/data_quality/dq_utils.py
+++ b/jdaviz/configs/default/plugins/data_quality/dq_utils.py
@@ -2,7 +2,7 @@ from importlib import resources
 from pathlib import Path
 
 import numpy as np
-from matplotlib.colors import ListedColormap, rgb2hex
+from matplotlib.colors import ListedColormap, rgb2hex, to_rgba
 from glue.config import stretches
 from astropy.table import Table
 
@@ -207,7 +207,8 @@ def generate_listed_colormap(n_flags=None, rgba_colors=None, seed=3):
     cmap = ListedColormap(rgba_colors)
 
     # setting `bad` alpha=0 will make NaNs transparent:
-    cmap.with_extremes(bad='k', alpha=0)
+    # cmap.with_extremes(bad='k', alpha=0)
+    cmap = cmap.with_extremes(bad=to_rgba("k", alpha=0))
     return cmap, rgba_colors
 
 

--- a/jdaviz/configs/default/plugins/data_quality/dq_utils.py
+++ b/jdaviz/configs/default/plugins/data_quality/dq_utils.py
@@ -207,7 +207,7 @@ def generate_listed_colormap(n_flags=None, rgba_colors=None, seed=3):
     cmap = ListedColormap(rgba_colors)
 
     # setting `bad` alpha=0 will make NaNs transparent:
-    cmap.set_bad(color='k', alpha=0)
+    cmap.with_extremes(bad='k', alpha=0)
     return cmap, rgba_colors
 
 

--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -220,6 +220,13 @@ def test_data_quality_plugin_hst_acs(imviz_helper):
 
 @pytest.mark.remote_data
 def test_cubeviz_layer_visibility_bug(cubeviz_helper):
+    """
+    This test covers two things (combined to reduce the number of remote data
+    tests). First, it has coverage for a (now fixed) bug in the Data Quality
+    plugin that attempted to apply array compositing logic to spatial subsets.
+    Second, it tests basic functionality of the data quality plugin in Cubeviz.
+    """
+
     # regression test for bug:
     uri = "mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_s3d.fits"
     with warnings.catch_warnings():
@@ -245,3 +252,9 @@ def test_cubeviz_layer_visibility_bug(cubeviz_helper):
     # toggle layer visibility, this used to trigger an AttributeError:
     cubeviz_helper.app.set_data_visibility('flux-viewer', dc[-1].label)
     cubeviz_helper.app.set_data_visibility('flux-viewer', dc[0].label)
+
+    # now test DQ specific things
+    assert len(cubeviz_helper.app.data_collection) == 2
+
+    # this assumption is made in the DQ plugin (for now)
+    assert cubeviz_helper.app.data_collection[-1].label.endswith('[DQ]')

--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -126,7 +126,6 @@ def test_data_quality_plugin(imviz_helper):
     assert dq_alpha == new_sci_opacity * dq_plugin.dq_layer_opacity
 
     # check that mouseover shows dq values on bad pixels (flag == 0):
-    # check that mouseover shows dq values on bad pixels (flag == 0):
     viewer = imviz_helper.default_viewer._obj.glue_viewer
     label_mouseover = imviz_helper._coords_info
     label_mouseover._viewer_mouse_event(viewer,
@@ -227,11 +226,65 @@ def test_cubeviz_dq_plugin_and_layer_visibility_bug(cubeviz_helper):
     Second, it tests basic functionality of the data quality plugin in Cubeviz.
     """
 
-    # regression test for bug:
     uri = "mast:JWST/product/jw02732-c1001_t004_miri_ch1-short_s3d.fits"
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         cubeviz_helper.load_data(cached_uri(uri), cache=True)
+
+    dq_plugin = cubeviz_helper.plugins['Data Quality']._obj
+
+    # in the data collection there should be flux, unc, extracted spectrum,
+    # and the DQ cube for a total of 4 items
+    assert len(cubeviz_helper.app.data_collection) == 4
+
+    # this assumption is made in the DQ plugin (for now)
+    assert cubeviz_helper.app.data_collection[-1].label.endswith('[DQ]')
+
+    # sci+dq layers are correctly identified
+    expected_science_data = cubeviz_helper.app.data_collection[0]
+    expected_dq_data = cubeviz_helper.app.data_collection[-1]
+    assert dq_plugin.science_layer_selected == expected_science_data.label
+    assert dq_plugin.dq_layer_selected == expected_dq_data.label
+
+    # JWST data product identified as such:
+    assert dq_plugin.flag_map_selected == 'JWST'
+
+    # check flag 0 is a bad pixel in the JWST flag map:
+    flag_map_selected = dq_plugin.flag_map_definitions_selected
+    assert flag_map_selected[0]['name'] == 'DO_NOT_USE'
+    assert flag_map_selected[0]['description'] == 'Bad pixel. Do not use.'
+
+    plot_opts = cubeviz_helper.plugins['Plot Options']._obj
+
+    # only the sci data appears in Plot Options when the flux viewer is selected
+    assert plot_opts.viewer_selected == 'flux-viewer'
+    assert len(plot_opts.layer_items) == 1
+
+    # check changes to sci opacity affect dq opacity
+    new_sci_opacity = 0.5
+    plot_opts.image_opacity_value = new_sci_opacity
+    dq_alpha = cubeviz_helper.default_viewer._obj.glue_viewer.layers[1].state.alpha
+    assert dq_alpha == new_sci_opacity * dq_plugin.dq_layer_opacity
+
+    # check that mouseover shows dq values on flagged pixels
+    viewer = cubeviz_helper.default_viewer._obj.glue_viewer
+    label_mouseover = cubeviz_helper._coords_info
+    label_mouseover._viewer_mouse_event(viewer,
+                                        {'event': 'mousemove', 'domain': {'x': 40, 'y': 34}})
+
+    # DQ features are labeled in the first line:
+    label_mouseover_text = label_mouseover.as_text()[0]
+    expected_flux_label = '+nan MJy / sr'
+    assert expected_flux_label in label_mouseover_text
+
+    # check that the decomposed DQ flag is at the end of the flux label's line:
+    flux_label_idx = label_mouseover_text.index(expected_flux_label)
+    associated_dq_layer = dq_plugin.get_dq_layers(viewer)[0]
+    dq_data = associated_dq_layer.layer.get_data(associated_dq_layer.state.attribute)
+    dq_val = dq_data[34, 40][0]
+    assert label_mouseover_text[flux_label_idx + len(expected_flux_label) + 1:] == f'(DQ: {dq_val:.0f})'  # noqa: E501
+
+    # Regression test for layer visibility bug
 
     # create a moment map:
     mm = cubeviz_helper.plugins['Moment Maps']
@@ -252,28 +305,3 @@ def test_cubeviz_dq_plugin_and_layer_visibility_bug(cubeviz_helper):
     # toggle layer visibility, this used to trigger an AttributeError:
     cubeviz_helper.app.set_data_visibility('flux-viewer', dc[-1].label)
     cubeviz_helper.app.set_data_visibility('flux-viewer', dc[0].label)
-
-    # now test DQ specific things
-
-    dq_plugin = cubeviz_helper.plugins['Data Quality']._obj
-
-    # in the data collection there should be flux, unc, extracted spectrum,
-    # moment map, a subset, and the DQ cube so a total of 6 items
-    assert len(cubeviz_helper.app.data_collection) == 6
-
-    # this assumption is made in the DQ plugin (for now)
-    assert cubeviz_helper.app.data_collection[3].label.endswith('[DQ]')
-
-    # sci+dq layers are correctly identified
-    expected_science_data = cubeviz_helper.app.data_collection[0]
-    expected_dq_data = cubeviz_helper.app.data_collection[3]
-    assert dq_plugin.science_layer_selected == expected_science_data.label
-    assert dq_plugin.dq_layer_selected == expected_dq_data.label
-
-    # JWST data product identified as such:
-    assert dq_plugin.flag_map_selected == 'JWST'
-
-    # check flag 0 is a bad pixel in the JWST flag map:
-    flag_map_selected = dq_plugin.flag_map_definitions_selected
-    assert flag_map_selected[0]['name'] == 'DO_NOT_USE'
-    assert flag_map_selected[0]['description'] == 'Bad pixel. Do not use.'

--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -219,7 +219,7 @@ def test_data_quality_plugin_hst_acs(imviz_helper):
 
 
 @pytest.mark.remote_data
-def test_cubeviz_layer_visibility_bug(cubeviz_helper):
+def test_cubeviz_dq_plugin_and_layer_visibility_bug(cubeviz_helper):
     """
     This test covers two things (combined to reduce the number of remote data
     tests). First, it has coverage for a (now fixed) bug in the Data Quality
@@ -254,7 +254,26 @@ def test_cubeviz_layer_visibility_bug(cubeviz_helper):
     cubeviz_helper.app.set_data_visibility('flux-viewer', dc[0].label)
 
     # now test DQ specific things
-    assert len(cubeviz_helper.app.data_collection) == 2
+
+    dq_plugin = cubeviz_helper.plugins['Data Quality']._obj
+
+    # in the data collection there should be flux, unc, extracted spectrum,
+    # moment map, a subset, and the DQ cube so a total of 6 items
+    assert len(cubeviz_helper.app.data_collection) == 6
 
     # this assumption is made in the DQ plugin (for now)
-    assert cubeviz_helper.app.data_collection[-1].label.endswith('[DQ]')
+    assert cubeviz_helper.app.data_collection[3].label.endswith('[DQ]')
+
+    # sci+dq layers are correctly identified
+    expected_science_data = cubeviz_helper.app.data_collection[0]
+    expected_dq_data = cubeviz_helper.app.data_collection[3]
+    assert dq_plugin.science_layer_selected == expected_science_data.label
+    assert dq_plugin.dq_layer_selected == expected_dq_data.label
+
+    # JWST data product identified as such:
+    assert dq_plugin.flag_map_selected == 'JWST'
+
+    # check flag 0 is a bad pixel in the JWST flag map:
+    flag_map_selected = dq_plugin.flag_map_definitions_selected
+    assert flag_map_selected[0]['name'] == 'DO_NOT_USE'
+    assert flag_map_selected[0]['description'] == 'Bad pixel. Do not use.'

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -1,4 +1,6 @@
 import os
+
+from astropy import units as u
 from traitlets import Any, Bool, List, Unicode, observe
 from glue.core.message import (DataCollectionAddMessage,
                                DataCollectionDeleteMessage)
@@ -16,6 +18,32 @@ from jdaviz.utils import (standardize_metadata,
                           create_data_hash)
 
 __all__ = ['BaseImporter', 'BaseImporterToDataCollection', 'BaseImporterToPlugin']
+
+
+def _physical_type_from_component(comp_id, comp):
+    """
+    Extract physical type (e.g., 'length', 'angle') from a component's units.
+
+    Parameters
+    ----------
+    comp_id : str
+        The component identifier.
+    comp : `~glue.core.component.Component`
+        The glue component to extract units from.
+
+    Returns
+    -------
+    tuple
+        (units, physical_type) where physical_type is a string like 'angle'
+        or None if units are empty/invalid.
+    """
+    try:
+        comp_units = comp.units
+        if comp_units is None or comp_units == '':
+            return comp_units, None
+        return comp_units, str(u.Unit(comp_units).physical_type)
+    except (ValueError, TypeError, AttributeError):
+        return comp_units, None
 
 
 class BaseImporter(PluginTemplateMixin):
@@ -280,7 +308,36 @@ class BaseImporterToDataCollection(BaseImporter):
                                parent=None,
                                viewer_select=None,
                                cls=None):
+        """
+        Add data to the data collection (and optionally to viewers).
 
+        This method handles adding a Glue Data object (or an object with a glue
+        data translator, e.g Spectrum or Astropy Table) to the data collection,
+        setting up parent-child relationships for associated data, standardizing
+        metadata, assigning component types, and adding the data to viewers.
+
+        Parameters
+        ----------
+        data
+            The object to add to the data collection.
+        data_label : str, optional
+            Label for the data in the collection. If not provided, uses
+            ``self.data_label_value``. If a data entry with this label already
+            exists, it will be overwritten.
+        data_hash : str, optional
+            Pre-computed hash for the data. If not provided, a hash will be
+            generated from the data.
+        parent : str, optional
+            Label of the parent data entry. If provided, establishes this data
+            as a child of the parent (e.g., DQ layer as child of SCI layer).
+            Used by the Data Quality plugin to associate layers.
+        viewer_select : `~jdaviz.core.template_mixin.ViewerSelect`, optional
+            Viewer selection component to determine which viewers to add the
+            data to. If not provided, uses ``self.viewer``.
+        cls : class, optional
+            The native data class to store in metadata for later export via
+            ``get_data``. If not provided, uses the class of the input data.
+        """
         if data_label is None:
             data_label = self.data_label_value.strip()
         else:
@@ -299,6 +356,7 @@ class BaseImporterToDataCollection(BaseImporter):
                         self.app.remove_data_from_viewer(viewer.reference_id, data_label)
             self.app.data_collection.remove(self.app.data_collection[data_label])
 
+        # Standardize metadata if possible
         if hasattr(data, 'meta'):
             try:
                 data.meta = standardize_metadata(data.meta)
@@ -315,24 +373,19 @@ class BaseImporterToDataCollection(BaseImporter):
             data.meta = dict(data.meta)
         data.meta['_native_data_cls'] = cls
         data.meta['_importer'] = self.__class__.__name__
-
         # Create a hashed representation of the data if not already present
         data.meta['_data_hash'] = data_hash if data_hash is not None else create_data_hash(data)
 
+        # Add the data to data collection.
         self.app.add_data(data, data_label=data_label)
+
+        # Set up parent-child relationship if specified
         if parent is not None:
             self.app._set_assoc_data_as_child(data_label, parent)
 
-        def _physical_type_from_component(comp_id, comp):
-            import astropy.units as u
-            try:
-                comp_units = comp.units
-                if comp_units is None or comp_units == '':
-                    return comp_units, None
-                return comp_units, str(u.Unit(comp_units).physical_type)
-            except (ValueError, TypeError, AttributeError):
-                return comp_units, None
-
+        # Assign component types (e.g., 'RA:angle', 'DEC:angle', 'pixel') to each
+        # component in the data. These types are used for automatic data linking
+        # and determining which components can be plotted together.
         new_dc_entry = self.app.data_collection[data_label]
         for comp_id in new_dc_entry.components:
             comp_units, physical_type = _physical_type_from_component(str(comp_id),
@@ -341,14 +394,20 @@ class BaseImporterToDataCollection(BaseImporter):
                                                                  new_dc_entry.get_component(comp_id),  # noqa
                                                                  comp_units, physical_type)
 
+        # link the new data to existing data in the collection based on matching
+        # component types
         if self.app.config in CONFIGS_WITH_LOADERS:
             self.app._link_new_data_by_component_type(data_label)
 
+        # Determine which viewer(s) to add the data to.
         viewer_select = viewer_select if viewer_select is not None else self.viewer
+
+        # user requested creating a new viewer for this data.
         if viewer_select.create_new.selected:
             viewer_reference = viewer_select.create_new.selected_item.get('reference')
             viewer_label = viewer_select.new_label.value.strip()
 
+            # Create the new viewer instance
             viewer_dict = viewer_registry.members.get(viewer_reference)
             viewer_cls = viewer_dict.get('cls')
             self.app._on_new_viewer(NewViewerMessage(viewer_cls, data=None, sender=self.app),
@@ -362,14 +421,18 @@ class BaseImporterToDataCollection(BaseImporter):
             viewer_select.create_new.selected = ''
             viewer_select.selected = [viewer_label]
 
+        # if no viewers selected, just notify user that data was loaded
+        # but not displayed anywhere.
         elif len(viewer_select.selected) == 0:
-            # just send a snackbar as feedback
             if len(self.app._jdaviz_helper.viewers):
                 msg = f"{data_label} loaded without any viewers selected - add manually from viewer data-menu"  # noqa
             else:
                 msg = f"{data_label} loaded but no viewers were created.  Create viewers manually and add data from data-menu"  # noqa
+            # Don't warn for WCS-only layers (orientation reference layers)
             if not new_dc_entry.meta.get(_wcs_only_label, False):
                 self.app.hub.broadcast(SnackbarMessage(msg, sender=self, color='warning'))
+
+        # otherwise, add data to all selected viewers.
         else:
             failed_viewers = []
             exceptions = []
@@ -380,6 +443,7 @@ class BaseImporterToDataCollection(BaseImporter):
                 except Exception as e:
                     failed_viewers.append(viewer_label)
                     exceptions.append(str(e))
+            # Report any failures (e.g., incompatible data types for the viewer)
             if len(failed_viewers) > 0:
                 msg = f"Failed to add {data_label} to viewers: {', '.join(failed_viewers)}"
                 self.app.hub.broadcast(SnackbarMessage(msg, sender=self, color='error',

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
@@ -76,6 +76,19 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
     dq_data_label_auto = Bool(True).tag(sync=True)
     dq_data_label_invalid_msg = Unicode().tag(sync=True)
 
+    # DQ Viewer
+    dq_viewer_create_new_items = List([]).tag(sync=True)
+    dq_viewer_create_new_selected = Unicode().tag(sync=True)
+
+    dq_viewer_items = List([]).tag(sync=True)
+    dq_viewer_selected = Any([]).tag(sync=True)
+    dq_viewer_multiselect = Bool(True).tag(sync=True)
+
+    dq_viewer_label_value = Unicode().tag(sync=True)
+    dq_viewer_label_default = Unicode().tag(sync=True)
+    dq_viewer_label_auto = Bool(True).tag(sync=True)
+    dq_viewer_label_invalid_msg = Unicode().tag(sync=True)
+
     # Extraction Options
     auto_extract = Bool(True).tag(sync=True)
     function_items = List().tag(sync=True)
@@ -205,6 +218,28 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
                                            'dq_data_label_auto',
                                            'dq_data_label_invalid_msg')
 
+        self.dq_viewer = ViewerSelectCreateNew(self,
+                                               'dq_viewer_items',
+                                               'dq_viewer_selected',
+                                               'dq_viewer_create_new_items',
+                                               'dq_viewer_create_new_selected',
+                                               'dq_viewer_label_value',
+                                               'dq_viewer_label_default',
+                                               'dq_viewer_label_auto',
+                                               'dq_viewer_label_invalid_msg',
+                                               multiselect='dq_viewer_multiselect',
+                                               default_mode='empty')
+        supported_viewers = [{'label': '3D Spectrum',
+                              'reference': 'cubeviz-image-viewer'}]
+        if self.app.config == 'deconfigged':
+            self.dq_viewer_create_new_items = supported_viewers
+
+        self.dq_viewer.add_filter(viewer_in_registry_names(supported_viewers))
+        if self.config == 'cubeviz':
+            self.dq_viewer.selected = ['flux-viewer']
+        else:
+            self.dq_viewer.select_default()
+
         # AUTO-EXTRACTION
         self.function = SelectPluginComponent(
             self,
@@ -298,7 +333,7 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
         if self.has_mask:
             expose += ['mask_data_label', 'mask_viewer']
         if self.has_dq:
-            expose += ['dq_data_label']
+            expose += ['dq_data_label', 'dq_viewer']
         expose += ['extension']
         if self.has_unc:
             expose += ['unc_extension']
@@ -458,7 +493,7 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
             self.add_to_data_collection(dq_cube,
                                         dq_data_label,
                                         parent=data_label,
-                                        viewer_select=self.viewer)
+                                        viewer_select=self.dq_viewer)
 
             self.app._jdaviz_helper._loaded_dq_cube = self.app.data_collection[dq_data_label]
 

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
@@ -69,6 +69,13 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
     mask_viewer_label_auto = Bool(True).tag(sync=True)
     mask_viewer_label_invalid_msg = Unicode().tag(sync=True)
 
+    # DQ (Data Quality) Cube
+    has_dq = Bool(False).tag(sync=True)
+    dq_data_label_value = Unicode().tag(sync=True)
+    dq_data_label_default = Unicode().tag(sync=True)
+    dq_data_label_auto = Bool(True).tag(sync=True)
+    dq_data_label_invalid_msg = Unicode().tag(sync=True)
+
     # Extraction Options
     auto_extract = Bool(True).tag(sync=True)
     function_items = List().tag(sync=True)
@@ -190,6 +197,14 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
         else:
             self.mask_viewer.selected = []
 
+        # DQ (DATA QUALITY) CUBE
+        self.has_dq = len(self.dq_extension_items) > 0
+        self.dq_data_label = AutoTextField(self,
+                                           'dq_data_label_value',
+                                           'dq_data_label_default',
+                                           'dq_data_label_auto',
+                                           'dq_data_label_invalid_msg')
+
         # AUTO-EXTRACTION
         self.function = SelectPluginComponent(
             self,
@@ -276,17 +291,21 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
 
     @property
     def user_api(self):
-        # TODO: remove flux_only and just have plugins set the extensions for mask/unc
+        # TODO: remove flux_only and just have plugins set the extensions for mask/unc/dq
         expose = ['auto_extract', 'ext_data_label', 'ext_viewer', 'flux_only']
         if self.has_unc:
             expose += ['unc_data_label', 'unc_viewer']
         if self.has_mask:
             expose += ['mask_data_label', 'mask_viewer']
+        if self.has_dq:
+            expose += ['dq_data_label']
         expose += ['extension']
         if self.has_unc:
             expose += ['unc_extension']
         if self.has_mask:
             expose += ['mask_extension']
+        if self.has_dq:
+            expose += ['dq_extension']
         return ImporterUserApi(self, expose)
 
     @property
@@ -312,6 +331,7 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
         self.ext_data_label_default = f"{base} ({self.function_selected.lower()})"
         self.unc_data_label_default = f"{base} [UNC]"
         self.mask_data_label_default = f"{base} [MASK]"
+        self.dq_data_label_default = f"{base} [DQ]"
 
     @property
     def supported_flux_ndim(self):
@@ -355,6 +375,7 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
         data_label = self.data_label_value
         unc_data_label = self.unc_data_label_value
         mask_data_label = self.mask_data_label_value
+        dq_data_label = self.dq_data_label_value
         ext_data_label = self.ext_data_label_value
 
         super().__call__()
@@ -415,6 +436,31 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
 
         if ext is not None:
             self.add_to_data_collection(ext, ext_data_label, viewer_select=self.ext_viewer)
+
+            if self.has_dq and not self.flux_only:
+                dq_hdu = self.dq_extension.selected_obj
+
+            # for DQ components, map zeros to nans
+            # so that they are not displayed in the DQ colormap
+            dq_data = np.float32(dq_hdu.data)
+            dq_data[dq_data == 0] = np.nan
+
+            # Set _extname so the DQ plugin can identify this as a DQ layer
+            dq_meta = dict(self.output.meta)
+            dq_meta['_extname'] = 'DQ'
+
+            dq_cube = Spectrum(spectral_axis=self.output.spectral_axis,
+                               flux=dq_data * u.dimensionless_unscaled,
+                               wcs=self.output.wcs,
+                               meta=dq_meta,
+                               spectral_axis_index=self.output.spectral_axis_index)
+
+            self.add_to_data_collection(dq_cube,
+                                        dq_data_label,
+                                        parent=data_label,
+                                        viewer_select=self.viewer)
+
+            self.app._jdaviz_helper._loaded_dq_cube = self.app.data_collection[dq_data_label]
 
     def assign_component_type(self, comp_id, comp, units, physical_type):
         comp_type = _spatial_assign_component_type(comp_id, comp, units, physical_type)

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
@@ -233,6 +233,9 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
             supported_viewers = [{'label': '3D Spectrum',
                                   'reference': 'cubeviz-image-viewer'}]
             self.dq_viewer.add_filter(viewer_in_registry_names(supported_viewers))
+            # put DQ layer in the same viewer as flux by default
+            # fine to hard code flux-viewer for cubeviz, but this will need to
+            # be generalized once DQ is supported in deconfigged
             self.dq_viewer.selected = ['flux-viewer']
 
         # AUTO-EXTRACTION

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
@@ -211,34 +211,29 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
             self.mask_viewer.selected = []
 
         # DQ (DATA QUALITY) CUBE
-        self.has_dq = len(self.dq_extension_items) > 0
+        self.has_dq = self.config == 'cubeviz' and len(self.dq_extension_items) > 0
         self.dq_data_label = AutoTextField(self,
                                            'dq_data_label_value',
                                            'dq_data_label_default',
                                            'dq_data_label_auto',
                                            'dq_data_label_invalid_msg')
 
-        self.dq_viewer = ViewerSelectCreateNew(self,
-                                               'dq_viewer_items',
-                                               'dq_viewer_selected',
-                                               'dq_viewer_create_new_items',
-                                               'dq_viewer_create_new_selected',
-                                               'dq_viewer_label_value',
-                                               'dq_viewer_label_default',
-                                               'dq_viewer_label_auto',
-                                               'dq_viewer_label_invalid_msg',
-                                               multiselect='dq_viewer_multiselect',
-                                               default_mode='empty')
-        supported_viewers = [{'label': '3D Spectrum',
-                              'reference': 'cubeviz-image-viewer'}]
-        if self.app.config == 'deconfigged':
-            self.dq_viewer_create_new_items = supported_viewers
-
-        self.dq_viewer.add_filter(viewer_in_registry_names(supported_viewers))
         if self.config == 'cubeviz':
+            self.dq_viewer = ViewerSelectCreateNew(self,
+                                                   'dq_viewer_items',
+                                                   'dq_viewer_selected',
+                                                   'dq_viewer_create_new_items',
+                                                   'dq_viewer_create_new_selected',
+                                                   'dq_viewer_label_value',
+                                                   'dq_viewer_label_default',
+                                                   'dq_viewer_label_auto',
+                                                   'dq_viewer_label_invalid_msg',
+                                                   multiselect='dq_viewer_multiselect',
+                                                   default_mode='empty')
+            supported_viewers = [{'label': '3D Spectrum',
+                                  'reference': 'cubeviz-image-viewer'}]
+            self.dq_viewer.add_filter(viewer_in_registry_names(supported_viewers))
             self.dq_viewer.selected = ['flux-viewer']
-        else:
-            self.dq_viewer.select_default()
 
         # AUTO-EXTRACTION
         self.function = SelectPluginComponent(
@@ -475,27 +470,27 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
             if self.has_dq and not self.flux_only:
                 dq_hdu = self.dq_extension.selected_obj
 
-            # for DQ components, map zeros to nans
-            # so that they are not displayed in the DQ colormap
-            dq_data = np.float32(dq_hdu.data)
-            dq_data[dq_data == 0] = np.nan
+                # for DQ components, map zeros to nans
+                # so that they are not displayed in the DQ colormap
+                dq_data = np.float32(dq_hdu.data)
+                dq_data[dq_data == 0] = np.nan
 
-            # Set _extname so the DQ plugin can identify this as a DQ layer
-            dq_meta = dict(self.output.meta)
-            dq_meta['_extname'] = 'DQ'
+                # Set _extname so the DQ plugin can identify this as a DQ layer
+                dq_meta = dict(self.output.meta)
+                dq_meta['_extname'] = 'DQ'
 
-            dq_cube = Spectrum(spectral_axis=self.output.spectral_axis,
-                               flux=dq_data * u.dimensionless_unscaled,
-                               wcs=self.output.wcs,
-                               meta=dq_meta,
-                               spectral_axis_index=self.output.spectral_axis_index)
+                dq_cube = Spectrum(spectral_axis=self.output.spectral_axis,
+                                   flux=dq_data * u.dimensionless_unscaled,
+                                   wcs=self.output.wcs,
+                                   meta=dq_meta,
+                                   spectral_axis_index=self.output.spectral_axis_index)
 
-            self.add_to_data_collection(dq_cube,
-                                        dq_data_label,
-                                        parent=data_label,
-                                        viewer_select=self.dq_viewer)
+                self.add_to_data_collection(dq_cube,
+                                            dq_data_label,
+                                            parent=data_label,
+                                            viewer_select=self.dq_viewer)
 
-            self.app._jdaviz_helper._loaded_dq_cube = self.app.data_collection[dq_data_label]
+                self.app._jdaviz_helper._loaded_dq_cube = self.app.data_collection[dq_data_label]
 
     def assign_component_type(self, comp_id, comp, units, physical_type):
         comp_type = _spatial_assign_component_type(comp_id, comp, units, physical_type)

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.vue
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.vue
@@ -158,6 +158,24 @@
           :api_hints_enabled="api_hints_enabled"
           hint="Label to assign to the new DQ cube data entry."
         ></plugin-auto-label>
+
+        <plugin-viewer-create-new
+          :items="dq_viewer_items"
+          :selected.sync="dq_viewer_selected"
+          :create_new_items="dq_viewer_create_new_items"
+          :create_new_selected.sync="dq_viewer_create_new_selected"
+          :new_label_value.sync="dq_viewer_label_value"
+          :new_label_default="dq_viewer_label_default"
+          :new_label_auto.sync="dq_viewer_label_auto"
+          :new_label_invalid_msg="dq_viewer_label_invalid_msg"
+          :multiselect="dq_viewer_multiselect"
+          :show_multiselect_toggle="false"
+          label="Viewer for DQ Cube"
+          api_hint="ldr.importer.dq_viewer ="
+          :api_hints_enabled="api_hints_enabled"
+          :show_if_single_entry="true"
+          hint="Select the viewer to use for the imported DQ cube."
+        ></plugin-viewer-create-new>
       </div>
     </div>
 

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.vue
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.vue
@@ -133,7 +133,7 @@
       </div>
     </div>
 
-    <div v-if="dq_extension_items.length >= 1">
+    <div v-if="config == 'cubeviz' && dq_extension_items.length >= 1">
       <j-plugin-section-header>DQ (Data Quality) Cube</j-plugin-section-header>
       <plugin-select
         :items="dq_extension_items"

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.vue
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.vue
@@ -133,6 +133,34 @@
       </div>
     </div>
 
+    <div v-if="dq_extension_items.length >= 1">
+      <j-plugin-section-header>DQ (Data Quality) Cube</j-plugin-section-header>
+      <plugin-select
+        :items="dq_extension_items"
+        :selected.sync="dq_extension_selected"
+        :show_if_single_entry="true"
+        :multiselect="multiselect"
+        :nonmultiselect_allow_clear="true"
+        :exists_in_dc="existing_data_in_dc"
+        label="DQ Extension"
+        api_hint="ldr.importer.dq_extension ="
+        :api_hints_enabled="api_hints_enabled"
+        hint="Extension from the FITS HDUList to use for the data quality cube."
+      />
+      <div v-if="dq_extension_selected.length > 0">
+        <plugin-auto-label
+          :value.sync="dq_data_label_value"
+          :default="dq_data_label_default"
+          :auto.sync="dq_data_label_auto"
+          :invalid_msg="dq_data_label_invalid_msg"
+          label="Data Label for the DQ Cube"
+          api_hint="ldr.importer.dq_data_label ="
+          :api_hints_enabled="api_hints_enabled"
+          hint="Label to assign to the new DQ cube data entry."
+        ></plugin-auto-label>
+      </div>
+    </div>
+
     <j-plugin-section-header>Extracted Spectrum</j-plugin-section-header>
     <plugin-switch
       :value.sync="auto_extract"

--- a/jdaviz/core/loaders/importers/spectrum_common.py
+++ b/jdaviz/core/loaders/importers/spectrum_common.py
@@ -63,6 +63,9 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
     mask_extension_items = List().tag(sync=True)
     mask_extension_selected = Any().tag(sync=True)
 
+    dq_extension_items = List().tag(sync=True)
+    dq_extension_selected = Any().tag(sync=True)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if isinstance(self.input, fits.HDUList):
@@ -177,12 +180,20 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
                                                            filters=[self.is_valid_mask],
                                                            default_mode='first')
         self.mask_extension.select_default()
+        self.dq_extension = SelectFileExtensionComponent(self,
+                                                         items='dq_extension_items',
+                                                         selected='dq_extension_selected',
+                                                         multiselect='multiselect',
+                                                         manual_options=ext_options,
+                                                         filters=[self.is_valid_dq],
+                                                         default_mode='first')
+        self.dq_extension.select_default()
 
         # set default data-label
         self._on_extension_change()
 
     def _cleanup(self):
-        for attr in ('extension', 'unc_extension', 'mask_extension'):
+        for attr in ('extension', 'unc_extension', 'mask_extension', 'dq_extension'):
             if not hasattr(self, attr):
                 continue
 
@@ -376,10 +387,46 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
         # include and pull from the flux extension?
         return False
 
+    def is_valid_dq(self, item):
+        if item.get('label') == 'None':
+            return True
+        if self.input_type == 'fits:hdulist':
+            return self.hdu_is_valid_dq(item)
+        if self.input_type == 'asdf:roman':
+            return self.asdf_roman_is_valid_dq(item)
+        if self.input_type == 'specutils:spectrum':
+            return False  # Spectrum doesn't have a dq attribute
+        if self.input_type == 'specutils:spectrumlist':
+            return False  # TODO: replace this
+        raise NotImplementedError("Unknown input type")
+
+    def hdu_is_valid_dq(self, item):
+        """
+        Check if the HDU is valid to be imported for the data quality in a Spectrum.
+
+        Parameters
+        ----------
+        hdu : `astropy.io.fits.hdu.base.HDUBase`
+            The HDU to check.
+
+        Returns
+        -------
+        bool
+            True if the HDU is a valid DQ HDU, False otherwise.
+        """
+        hdu = item.get('obj')
+        return (len(getattr(hdu, 'shape', [])) == self.supported_flux_ndim
+                and hdu.header.get('EXTNAME', '') == 'DQ')
+
+    def asdf_roman_is_valid_dq(self, item):
+        name = item.get('name')
+        return name == 'dq'
+
     @observe('extension_items',
              'extension_selected',
              'unc_extension_selected',
-             'mask_extension_selected')
+             'mask_extension_selected',
+             'dq_extension_selected')
     def _on_extension_change(self, change={}):
         self._clear_cache('spectra')
 


### PR DESCRIPTION
Restores previous behavior to enable loading DQ cubes into cubeviz. If a DQ extension is present in a fits file, it will be loaded by default (which was the pre-jdaviz 4.3 behavior). The DQ extension will be loaded into the flux viewer as a child of the flux cube, and the DQ plugin is now available in the plugin tray.

This is limited to cubeviz, followup work will generalize this to deconfigged, but the purpose of this PR was only to restore the original functionality to the cubeviz loader.

This also does a bit of clean up work specifically in add_to_data_collection, just some doc strings and in line comments that I added while I was trying to debug this. I also moved a nested function and import to the top level for readability and to avoid repeated imports of astropy units.  