### PR TITLE
MAST settings

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -3576,14 +3576,14 @@ class Application(VuetifyTemplate, HubListener):
 
         if resolver not in preset_resolver_map:
             raise ValueError(f"Unknown resolver type '{resolver}'. "
-                           f"Must be one of: {', '.join(preset_resolver_map.keys())}")
+                             f"Must be one of: {', '.join(preset_resolver_map.keys())}")
 
         PresetResolverClass = preset_resolver_map[resolver]
 
         # Ensure unique name
         existing_names = [item['name'] for item in self.state.loader_items]
         if name in existing_names:
-            raise ValueError(f"Loader name must be unique. A loader with the name '{name}' already exists.")
+            raise ValueError(f"Loader name must be unique. A loader with the name '{name}' already exists.")  # noqa
 
         # Define callbacks (same as in initialization)
         def open():

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -3533,7 +3533,8 @@ class Application(VuetifyTemplate, HubListener):
         for loader in self._jdaviz_helper.loaders.values():
             loader.format._update_items()
 
-    def _add_custom_loader(self, resolver, input, name, open_in_tray=False, load=False):
+    def _add_custom_loader(self, resolver, input, name, open_in_tray=False, load=False,
+                           format=None):
         """
         Private method to programmatically add a custom loader with preset input.
 
@@ -3553,6 +3554,9 @@ class Application(VuetifyTemplate, HubListener):
             Whether to set this as the selected loader in the tray.
         load : bool, optional
             Whether to immediately load the data after adding the loader.
+        format : str or list of str, optional
+            If provided, restrict the format dropdown to only include the specified
+            format(s). Other formats will not be attempted or shown.
 
         Returns
         -------
@@ -3595,7 +3599,8 @@ class Application(VuetifyTemplate, HubListener):
             app=self,
             open_callback=open,
             close_callback=close,
-            set_active_loader_callback=set_active_loader
+            set_active_loader_callback=set_active_loader,
+            format=format
         )
 
         # Set the registry label to match the name for open_in_tray to work

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -49,6 +49,8 @@ from jdaviz.core.events import (LoadDataMessage, NewViewerMessage, AddDataMessag
                                 ViewerRemovedMessage, ViewerRenamedMessage, ChangeRefDataMessage,
                                 IconsUpdatedMessage, LayersFinalizedMessage)
 from jdaviz.core.loaders.resolvers.file.file import PresetFileResolver
+from jdaviz.core.loaders.resolvers.object.object import PresetObjectResolver
+from jdaviz.core.loaders.resolvers.url.url import PresetURLResolver
 from jdaviz.core.registries import (tool_registry, tray_registry,
                                     viewer_registry, viewer_creator_registry,
                                     data_parser_registry, loader_resolver_registry)
@@ -3531,49 +3533,57 @@ class Application(VuetifyTemplate, HubListener):
         for loader in self._jdaviz_helper.loaders.values():
             loader.format._update_items()
 
-    def _add_file_loader(self, filepath, name=None, open_in_tray=False, load=False):
+    def _add_custom_loader(self, resolver, input, name, open_in_tray=False, load=False):
         """
-        Private method to programmatically add a file loader with a preset path.
+        Private method to programmatically add a custom loader with preset input.
 
         This creates a loader entry that appears in the source dropdown but doesn't
-        show the file browser UI (similar to server_is_remote behavior).
+        show the input UI (similar to server_is_remote behavior).
 
         Parameters
         ----------
-        filepath : str
-            Absolute path to the file to load.
-        name : str, optional
-            Custom name for this loader. If None, uses the filename without extension.
+        resolver : str
+            Resolver type ('file', 'object', or 'url').
+        input : str or object
+            Input for the resolver. For 'file', an absolute path to the file.
+            For 'object', any Python object. For 'url', a URL string.
+        name : str
+            Name for this loader.
         open_in_tray : bool, optional
             Whether to set this as the selected loader in the tray.
         load : bool, optional
-            Whether to immediately load the file after adding the loader.
+            Whether to immediately load the data after adding the loader.
 
         Returns
         -------
-        str
-            The name of the added loader.
+        The new loader.
 
         Examples
         --------
-        >>> app._add_file_loader(filepath='/path/to/data.fits', name='my_special_file')
-        'my_special_file'
+        >>> app._add_custom_loader('file', '/path/to/data.fits', name='my_file')
+        'my_file'
+        >>> app._add_custom_loader('object', mytable, name='mytable')
+        'mytable'
+        >>> app._add_custom_loader('url', 'https://example.com/data.fits', name='remote_data')
+        'remote_data'
         """
-        # Validate filepath (PresetFileResolver will also validate, but check early)
-        if not os.path.exists(filepath) or not os.path.isfile(filepath):
-            raise ValueError(f"'{filepath}' is not a valid file path.")
+        # Map resolver names to preset classes
+        preset_resolver_map = {
+            'file': PresetFileResolver,
+            'object': PresetObjectResolver,
+            'url': PresetURLResolver
+        }
 
-        # Generate name if not provided
-        if name is None:
-            name = os.path.splitext(os.path.basename(filepath))[0]
+        if resolver not in preset_resolver_map:
+            raise ValueError(f"Unknown resolver type '{resolver}'. "
+                           f"Must be one of: {', '.join(preset_resolver_map.keys())}")
+
+        PresetResolverClass = preset_resolver_map[resolver]
 
         # Ensure unique name
         existing_names = [item['name'] for item in self.state.loader_items]
-        original_name = name
-        counter = 1
-        while name in existing_names:
-            name = f"{original_name}_{counter}"
-            counter += 1
+        if name in existing_names:
+            raise ValueError(f"Loader name must be unique. A loader with the name '{name}' already exists.")
 
         # Define callbacks (same as in initialization)
         def open():
@@ -3583,12 +3593,12 @@ class Application(VuetifyTemplate, HubListener):
         def close():
             self.state.loader_selected = ''
 
-        def set_active_loader(resolver):
-            self.state.loader_selected = resolver
+        def set_active_loader(res):
+            self.state.loader_selected = res
 
         # Create the preset resolver instance
-        loader = PresetFileResolver(
-            filepath=filepath,
+        loader = PresetResolverClass(
+            input,
             title=name,
             app=self,
             open_callback=open,
@@ -3603,17 +3613,18 @@ class Application(VuetifyTemplate, HubListener):
         self.state.loader_items.append({
             'name': name,
             'label': name,
-            'requires_api_support': False,
+            'requires_api_support': loader.requires_api_support,
             'widget': "IPY_MODEL_" + loader.model_id,
             'api_methods': loader.api_methods,
         })
 
+        ldr = self._jdaviz_helper.loaders[name]
         if open_in_tray:
-            self._jdaviz_helper.loaders[name].open_in_tray()
+            ldr.open_in_tray()
         if load:
-            self._jdaviz_helper.loaders[name].load()
+            ldr.load()
 
-        return name
+        return ldr
 
     def update_tray_items_from_registry(self):
         if self.config != 'deconfigged':

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -48,6 +48,7 @@ from jdaviz.core.events import (LoadDataMessage, NewViewerMessage, AddDataMessag
                                 RemoveDataFromViewerMessage, ViewerAddedMessage,
                                 ViewerRemovedMessage, ViewerRenamedMessage, ChangeRefDataMessage,
                                 IconsUpdatedMessage, LayersFinalizedMessage)
+from jdaviz.core.loaders.resolvers.file.file import PresetFileResolver
 from jdaviz.core.registries import (tool_registry, tray_registry,
                                     viewer_registry, viewer_creator_registry,
                                     data_parser_registry, loader_resolver_registry)
@@ -265,15 +266,17 @@ class ApplicationState(State):
             'tab_headers': True,
         },
         'dense_toolbar': True,
-        # In the context of a remote server, allow/disallow showing the loader
-        # server_is_remote == False -> Usual behavior, show loader, etc.
-        # server_is_remote + remote_enable_importers==False -> hide loader panel completely,
-        #   prepopulate the data
-        # server_is_remote + remote_enable_importers==True -> hide the loader,
-        #   but allow selecting and loading items from the file. This is used for
-        #   Spectrum Lists or multi-extension images.
+        # In the context of a remote server, set default values for loader visibility
+        # server_is_remote == False -> Usual behavior, show all loaders
+        # server_is_remote == True -> Sets default disabled_loaders to exclude loaders
+        #   that require local file access or external APIs
         'server_is_remote': False,  # sets some defaults, should be set before loading the config
-        'remote_enable_importers': True,  # Depends on server_is_remote, see above
+        'remote_enable_importers': True,  # Legacy setting, kept for backward compatibility
+        # List of loader names to exclude from the loaders panel source dropdown.
+        # If not provided (None), defaults to excluding loaders that typically require
+        # local file access or API support when server_is_remote is True.
+        # Set to [] to enable all loaders regardless of server_is_remote.
+        'disabled_loaders': None,
         'context': {
             'notebook': {
                 'max_height': '600px'
@@ -3410,7 +3413,18 @@ class Application(VuetifyTemplate, HubListener):
         # registry will be populated at import
         if self.config in CONFIGS_WITH_LOADERS:
             import jdaviz.core.loaders  # noqa
+            # Determine which loaders to disable
+            disabled_loaders = self.state.settings.get('disabled_loaders')
+            if disabled_loaders is None:
+                # Default: disable loaders based on server_is_remote setting
+                if self.state.settings.get('server_is_remote', False):
+                    disabled_loaders = ['file', 'file drop', 'url', 'object',
+                                        'astroquery', 'virtual observatory']
+                else:
+                    disabled_loaders = []
             for name, Resolver in loader_resolver_registry.members.items():
+                if name in disabled_loaders:
+                    continue
                 loader = Resolver(app=self,
                                   open_callback=open,
                                   close_callback=close,
@@ -3442,6 +3456,87 @@ class Application(VuetifyTemplate, HubListener):
                                       "implemented for the deconfigged app")
         for loader in self._jdaviz_helper.loaders.values():
             loader.format._update_items()
+
+    def _add_file_loader(self, filepath, name=None, open_in_tray=False, load=False):
+        """
+        Private method to programmatically add a file loader with a preset path.
+
+        This creates a loader entry that appears in the source dropdown but doesn't
+        show the file browser UI (similar to server_is_remote behavior).
+
+        Parameters
+        ----------
+        filepath : str
+            Absolute path to the file to load.
+        name : str, optional
+            Custom name for this loader. If None, uses the filename without extension.
+        open_in_tray : bool, optional
+            Whether to set this as the selected loader in the tray.
+        load : bool, optional
+            Whether to immediately load the file after adding the loader.
+
+        Returns
+        -------
+        str
+            The name of the added loader.
+
+        Examples
+        --------
+        >>> app._add_file_loader(filepath='/path/to/data.fits', name='my_special_file')
+        'my_special_file'
+        """
+        # Validate filepath (PresetFileResolver will also validate, but check early)
+        if not os.path.exists(filepath) or not os.path.isfile(filepath):
+            raise ValueError(f"'{filepath}' is not a valid file path.")
+
+        # Generate name if not provided
+        if name is None:
+            name = os.path.splitext(os.path.basename(filepath))[0]
+
+        # Ensure unique name
+        existing_names = [item['name'] for item in self.state.loader_items]
+        original_name = name
+        counter = 1
+        while name in existing_names:
+            name = f"{original_name}_{counter}"
+            counter += 1
+
+        # Define callbacks (same as in initialization)
+        def open():
+            self.state.drawer_content = 'loaders'
+            self.state.add_subtab = 0
+
+        def close():
+            self.state.loader_selected = ''
+
+        def set_active_loader(resolver):
+            self.state.loader_selected = resolver
+
+        # Create the preset resolver instance
+        loader = PresetFileResolver(
+            filepath=filepath,
+            title=name,
+            app=self,
+            open_callback=open,
+            close_callback=close,
+            set_active_loader_callback=set_active_loader
+        )
+
+        # Add to loader_items
+        self.state.loader_items.append({
+            'name': name,
+            'label': name,
+            'requires_api_support': False,
+            'widget': "IPY_MODEL_" + loader.model_id,
+            'api_methods': loader.api_methods,
+        })
+
+        if open_in_tray:
+            self._jdaviz_helper.loaders[name].open_in_tray()
+        if load:
+            self._jdaviz_helper.loaders[name].load()
+
+        return name
 
     def update_tray_items_from_registry(self):
         if self.config != 'deconfigged':

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -3556,16 +3556,8 @@ class Application(VuetifyTemplate, HubListener):
 
         Returns
         -------
-        The new loader.
-
-        Examples
-        --------
-        >>> app._add_custom_loader('file', '/path/to/data.fits', name='my_file')
-        'my_file'
-        >>> app._add_custom_loader('object', mytable, name='mytable')
-        'mytable'
-        >>> app._add_custom_loader('url', 'https://example.com/data.fits', name='remote_data')
-        'remote_data'
+        loader
+            The new loader user API object.
         """
         # Map resolver names to preset classes
         preset_resolver_map = {

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -3522,6 +3522,9 @@ class Application(VuetifyTemplate, HubListener):
             set_active_loader_callback=set_active_loader
         )
 
+        # Set the registry label to match the name for open_in_tray to work
+        loader._registry_label = name
+
         # Add to loader_items
         self.state.loader_items.append({
             'name': name,

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -277,6 +277,15 @@ class ApplicationState(State):
         # local file access or API support when server_is_remote is True.
         # Set to [] to enable all loaders regardless of server_is_remote.
         'disabled_loaders': None,
+        # List of telescope names to exclude from the astroquery loader telescope dropdown.
+        # Available telescopes: 'JWST', 'HST', 'SDSS', 'Gaia'
+        # Set to [] (default) to enable all telescopes.
+        'disabled_astroquery_telescopes': [],
+        # List of URL prefixes to allow in the URL loader.
+        # If None (default), any valid URL is allowed.
+        # If set to a list, only URLs starting with one of the prefixes will be accepted.
+        # Example: ['https://data.example.com/', 'https://archive.science.org/']
+        'url_prefix_whitelist': None,
         'context': {
             'notebook': {
                 'max_height': '600px'

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -288,6 +288,10 @@ class ApplicationState(State):
         # If set to a list, only URLs starting with one of the prefixes will be accepted.
         # Example: ['https://data.example.com/', 'https://archive.science.org/']
         'url_prefix_whitelist': None,
+        # Hide the 'url' column in file tables from resolver queries.
+        # When True, the url column is kept in the table data (for downloading)
+        # but is not shown in the UI and cannot be made visible by the user.
+        'hide_file_table_url_column': False,
         'context': {
             'notebook': {
                 'max_height': '600px'

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -12,7 +12,7 @@
             <img :src="state.icons['plus-box']" width="24" class="color-to-white"/>
           </v-btn>
         </j-tooltip>
-        <j-tooltip tipid="app-toolbar-save">
+        <j-tooltip v-if="!state.settings.server_is_remote" tipid="app-toolbar-save">
           <v-btn icon @click="() => {if (state.drawer_content === 'save') {state.drawer_content = ''} else {state.drawer_content = 'save'}}" :class="{active : state.drawer_content === 'save'}" :disabled="!state.tray_items[state.tray_items.map(ti => ti.label).indexOf('Export')].is_relevant">
             <img :src="state.icons['content-save']" width="24" class="color-to-white"/>
           </v-btn>
@@ -239,7 +239,7 @@
                 </v-tab-item>
               </v-tabs-items>
             </v-card>
-            <v-card v-if="state.drawer_content === 'save'" flat tile class="overflow-y-auto fill-height" style="overflow-x: hidden" color="gray">
+            <v-card v-if="state.drawer_content === 'save' && !state.settings.server_is_remote" flat tile class="overflow-y-auto fill-height" style="overflow-x: hidden" color="gray">
               <span v-if="state.show_api_hints" class="api-hint" style="font-weight: bold">plg = {{  api_hints_obj || config }}.plugins['Export']</span>
               <jupyter-widget :widget="state.tray_items[state.tray_items.map(ti => ti.label).indexOf('Export')].widget"></jupyter-widget>
             </v-card>

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -114,7 +114,7 @@
               </template>
               <v-card style="min-width: 350px; max-height: 500px; overflow-y: scroll">
                 <v-container>
-                  <div v-for="ldrItem in state.loader_items" :key="ldrItem.label">
+                  <div v-for="ldrItem in loader_items_filtered" :key="ldrItem.label">
                     <v-row v-if="trayItemVisible(ldrItem, state.global_search)">
                       <v-list-item style="display: grid; min-height: 6px; cursor: pointer" @click="(e) => {search_item_clicked({attr: 'loaders', label: ldrItem.label})}">
                         <v-list-item-title>
@@ -226,6 +226,7 @@
                     :api_hints_enabled="state.show_api_hints"
                     :api_hints_obj="api_hints_obj || config"
                     :server_is_remote="state.settings.server_is_remote"
+                    :disabled_loaders="state.settings.disabled_loaders"
                   ></j-loader-panel>
                 </v-tab-item>
                 <v-tab-item style="padding-bottom: 40px">
@@ -361,6 +362,7 @@
                 :api_hints_enabled="state.show_api_hints"
                 :api_hints_obj="api_hints_obj || config"
                 :server_is_remote="state.settings.server_is_remote"
+                :disabled_loaders="state.settings.disabled_loaders"
               ></j-loader-panel>
             </v-card>
 
@@ -450,6 +452,24 @@ export default {
       showGoldenLayout: true,
     };
   },
+  computed: {
+    loader_items_filtered() {
+      // Determine which loaders to disable
+      var disabled_loaders = this.state.settings.disabled_loaders;
+      if (disabled_loaders === null || disabled_loaders === undefined) {
+        // Default: disable loaders based on server_is_remote setting
+        if (this.state.settings.server_is_remote) {
+          disabled_loaders = ['file', 'file drop', 'url', 'object',
+                              'astroquery', 'virtual observatory'];
+        } else {
+          disabled_loaders = [];
+        }
+      }
+      return this.state.loader_items.filter(item => {
+        return !disabled_loaders.includes(item.name);
+      });
+    },
+  },
   methods: {
     checkNotebookContext() {
       this.notebook_context = document.getElementById("ipython-main-app")
@@ -497,7 +517,7 @@ export default {
     this.outputCellHasHeight = this.$refs.mainapp.$el.offsetHeight > 0
 
     /* Workaround for Lab 4.5: cells outside the viewport get the style "contentVisibility: auto" which causes wrong
-     * size calculations of golden layout from which it doesn't recover.    
+     * size calculations of golden layout from which it doesn't recover.
      */
     const jpCell = this.$el.closest('.jp-Cell.jp-CodeCell');
     if (jpCell) {

--- a/jdaviz/components/loader.vue
+++ b/jdaviz/components/loader.vue
@@ -20,7 +20,7 @@
         </span>
       </v-card-title>
       <v-card-text>
-        <v-container v-if="!hide_resolver" style="padding: 4px">
+        <v-container v-if="!hide_resolver && !hide_resolver_inputs" style="padding: 4px">
           <slot/>
         </v-container>
 
@@ -173,7 +173,7 @@ module.exports = {
           'file_cache', 'file_timeout',
           'target_items', 'target_selected',
           'format_items', 'format_selected',
-          'importer_widget', 'server_is_remote', 'hide_resolver',
+          'importer_widget', 'server_is_remote', 'hide_resolver', 'hide_resolver_inputs',
           'api_hints_enabled', 'valid_import_formats',
           'is_wcs_linked', 'footprint_select_icon', 'custom_toolbar_enabled','image_data_loaded'],
 

--- a/jdaviz/components/loader.vue
+++ b/jdaviz/components/loader.vue
@@ -13,14 +13,14 @@
     </div>
 
     <v-card flat>
-      <v-card-title v-if="!server_is_remote" class="headline" color="primary" primary-title style="display: block; width: 100%">
+      <v-card-title class="headline" color="primary" primary-title style="display: block; width: 100%">
         {{title}}
         <span style="float: right">
           <j-plugin-popout :popout_button="popout_button"></j-plugin-popout>
         </span>
       </v-card-title>
       <v-card-text>
-        <v-container v-if="!server_is_remote" style="padding: 4px">
+        <v-container style="padding: 4px">
           <slot/>
         </v-container>
 

--- a/jdaviz/components/loader_panel.vue
+++ b/jdaviz/components/loader_panel.vue
@@ -48,6 +48,21 @@ module.exports = {
       });
     },
   },
+  watch: {
+    loader_items_filtered: {
+      handler(newFiltered) {
+        // If the currently selected loader is not in the filtered list,
+        // select the first available item
+        if (newFiltered.length > 0) {
+          const isCurrentInFiltered = newFiltered.some(item => item.name === this.loader_selected);
+          if (!isCurrentInFiltered) {
+            this.$emit('update:loader_selected', newFiltered[0].name);
+          }
+        }
+      },
+      immediate: true
+    }
+  },
   methods: {
     checkNotebookContext() {
       this.notebook_context = document.getElementById("ipython-main-app")

--- a/jdaviz/components/loader_panel.vue
+++ b/jdaviz/components/loader_panel.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <v-select
-      v-if="!server_is_remote"
       :menu-props="{ left: true }"
       attach
       :items="loader_items_filtered"
@@ -27,11 +26,25 @@
 
 <script>
 module.exports = {
-  props: ['loader_items', 'loader_selected', 'api_hints_enabled', 'api_hints_obj', 'server_is_remote'],
+  props: ['loader_items', 'loader_selected', 'api_hints_enabled', 'api_hints_obj', 'server_is_remote', 'disabled_loaders'],
   computed: {
     loader_items_filtered() {
       var has_api_support = this.checkNotebookContext();
-      return this.loader_items.filter(item => {return !item.requires_api_support || has_api_support});
+      // Determine which loaders to disable
+      var disabled_loaders = this.disabled_loaders;
+      if (disabled_loaders === null || disabled_loaders === undefined) {
+        // Default: disable loaders based on server_is_remote setting
+        if (this.server_is_remote) {
+          disabled_loaders = ['file', 'file drop', 'url', 'object',
+                              'astroquery', 'virtual observatory'];
+        } else {
+          disabled_loaders = [];
+        }
+      }
+      return this.loader_items.filter(item => {
+        return (!item.requires_api_support || has_api_support) &&
+               !disabled_loaders.includes(item.name);
+      });
     },
   },
   methods: {

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -200,7 +200,8 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
         """
         Update server_is_remote when settings change.
         """
-        self.server_is_remote = new_settings_dict.get('server_is_remote', False)
+        if 'server_is_remote' in new_settings_dict:
+            self.server_is_remote = new_settings_dict.get('server_is_remote')
 
     @property
     def user_api(self):

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -120,6 +120,7 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
     is_centerable = Bool(False).tag(sync=True)
     can_simplify = Bool(False).tag(sync=True)
     can_freeze = Bool(False).tag(sync=True)
+    server_is_remote = Bool(False).tag(sync=True)
 
     icon_replace = Unicode(read_icon(os.path.join(icon_path("glue_replace", icon_format="svg")), 'svg+xml')).tag(sync=True)  # noqa
     icon_or = Unicode(read_icon(os.path.join(icon_path("glue_or", icon_format="svg")), 'svg+xml')).tag(sync=True)  # noqa
@@ -135,6 +136,12 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        # Initialize server_is_remote from settings
+        self.server_is_remote = self.app.state.settings.get('server_is_remote', False)
+
+        # Listen for changes to app.state.settings
+        self.app.state.add_callback('settings', self._on_app_settings_changed)
 
         # description displayed under plugin title in tray
         config = self.app.config
@@ -188,6 +195,12 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
                                                       items='combination_mode_items',
                                                       selected='combination_mode_selected',
                                                       manual_options=COMBO_OPTIONS)
+
+    def _on_app_settings_changed(self, new_settings_dict):
+        """
+        Update server_is_remote when settings change.
+        """
+        self.server_is_remote = new_settings_dict.get('server_is_remote', False)
 
     @property
     def user_api(self):

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.vue
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.vue
@@ -9,6 +9,7 @@
     :scroll_to.sync="scroll_to">
 
     <plugin-loaders-panel
+      v-if="!server_is_remote"
       :loader_panel_ind.sync="loader_panel_ind"
       :loader_items="loader_items"
       :loader_selected.sync="loader_selected"

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -197,6 +197,8 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin,
     v3_offset = FloatHandleEmpty().tag(sync=True)
     # TODO: dithering/mosaic options?
 
+    server_is_remote = Bool(False).tag(sync=True)
+
     footprint_select_icon = Unicode(read_icon(os.path.join(ICON_DIR, 'footprint_select.svg'), 'svg+xml')).tag(sync=True)  # noqa
 
     def __init__(self, *args, **kwargs):
@@ -204,6 +206,12 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin,
         self._overlays = {}
 
         super().__init__(*args, **kwargs)
+
+        # Initialize server_is_remote from settings
+        self.server_is_remote = self.app.state.settings.get('server_is_remote', False)
+
+        # Listen for changes to app.state.settings
+        self.app.state.add_callback('settings', self._on_app_settings_changed)
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Show instrument footprints as overlays on image viewers.'
@@ -271,6 +279,12 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin,
         self._on_link_type_updated()
 
         self.observe_traitlets_for_relevancy(traitlets_to_observe=['viewer_items'])
+
+    def _on_app_settings_changed(self, new_settings_dict):
+        """
+        Update server_is_remote when settings change.
+        """
+        self.server_is_remote = new_settings_dict.get('server_is_remote', False)
 
     def _highlight_overlay(self, overlay_label, viewers=None):
         """

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.vue
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.vue
@@ -13,6 +13,7 @@
     :scroll_to.sync="scroll_to">
 
     <plugin-loaders-panel
+      v-if="!server_is_remote"
       :loader_panel_ind.sync="loader_panel_ind"
       :loader_items="loader_items"
       :loader_selected.sync="loader_selected"

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -453,7 +453,8 @@ class ConfigHelper(HubListener):
                                              model_label=model_label,
                                              x=x, y=y)
 
-    def show(self, loc="inline", title=None, height=None):  # pragma: no cover
+    def show(self, loc="inline", title=None, height=None,
+             tray=None):  # pragma: no cover
         """Display the Jdaviz application.
 
         Parameters
@@ -500,6 +501,10 @@ class ConfigHelper(HubListener):
             The height of the top-level application widget, in pixels. Applies to all
             instances of the same application in the notebook.
 
+        tray: str, optional
+            Override the default open sidebar in the tray.  If not provided, will default to
+            loaders if no data is loaded, or plugins if data is loaded.
+
         Notes
         -----
         If "sidecar" is requested in the "classic" Jupyter notebook, the app will appear inline,
@@ -512,7 +517,9 @@ class ConfigHelper(HubListener):
             self.app.layout.height = height
             self.app.state.settings['context']['notebook']['max_height'] = height
 
-        if self.app.config in CONFIGS_WITH_LOADERS or self.app.state.dev_loaders:  # noqa
+        if tray is not None:
+            self.app.state.drawer_content = tray
+        elif self.app.config in CONFIGS_WITH_LOADERS or self.app.state.dev_loaders:  # noqa
             if not len(self.viewers) and not len(self.app.state.drawer_content):
                 self.app.state.drawer_content = 'loaders'
             else:

--- a/jdaviz/core/loaders/resolvers/astroquery/astroquery.py
+++ b/jdaviz/core/loaders/resolvers/astroquery/astroquery.py
@@ -43,7 +43,7 @@ class AstroqueryResolver(BaseConeSearchResolver):
         """
         Update telescope options when settings change.
         """
-        # Check if disabled_astroquery_telescopes changed
+        # Recalculate available telescopes based on new settings
         all_telescopes = ['JWST', 'HST', 'SDSS', 'Gaia']
         disabled_telescopes = new_settings_dict.get('disabled_astroquery_telescopes', [])
         available_telescopes = [t for t in all_telescopes if t not in disabled_telescopes]
@@ -51,7 +51,15 @@ class AstroqueryResolver(BaseConeSearchResolver):
         # Update the manual options and refresh items
         if self.telescope._manual_options != available_telescopes:
             self.telescope._manual_options = available_telescopes
-            self.telescope._update_items()
+            # Directly update the items list to ensure sync
+            manual_options_dicts = [self.telescope._to_item(opt) for opt in available_telescopes]
+            self.telescope.items = manual_options_dicts
+            # Reset selection if current selection is no longer valid
+            if self.telescope_selected and self.telescope_selected not in available_telescopes:
+                if len(available_telescopes) > 0:
+                    self.telescope_selected = available_telescopes[0]
+                else:
+                    self.telescope_selected = ''
 
     @property
     def user_api(self):

--- a/jdaviz/core/loaders/resolvers/astroquery/astroquery.py
+++ b/jdaviz/core/loaders/resolvers/astroquery/astroquery.py
@@ -43,6 +43,9 @@ class AstroqueryResolver(BaseConeSearchResolver):
         """
         Update telescope options when settings change.
         """
+        # Call parent's method to handle server_is_remote and other settings
+        super()._on_app_settings_changed(new_settings_dict)
+
         # Recalculate available telescopes based on new settings
         all_telescopes = ['JWST', 'HST', 'SDSS', 'Gaia']
         disabled_telescopes = new_settings_dict.get('disabled_astroquery_telescopes', [])

--- a/jdaviz/core/loaders/resolvers/astroquery/astroquery.py
+++ b/jdaviz/core/loaders/resolvers/astroquery/astroquery.py
@@ -25,10 +25,33 @@ class AstroqueryResolver(BaseConeSearchResolver):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        # Get list of available telescopes, filtering out disabled ones
+        all_telescopes = ['JWST', 'HST', 'SDSS', 'Gaia']
+        disabled_telescopes = self.app.state.settings.get('disabled_astroquery_telescopes', [])
+        available_telescopes = [t for t in all_telescopes if t not in disabled_telescopes]
+
         self.telescope = SelectPluginComponent(
             self, items="telescope_items", selected="telescope_selected",
-            manual_options=['JWST', 'HST', 'SDSS', 'Gaia']
+            manual_options=available_telescopes
         )
+
+        # Listen for changes to app.state.settings
+        self.app.state.add_callback('settings', self._on_app_settings_changed)
+
+    def _on_app_settings_changed(self, new_settings_dict):
+        """
+        Update telescope options when settings change.
+        """
+        # Check if disabled_astroquery_telescopes changed
+        all_telescopes = ['JWST', 'HST', 'SDSS', 'Gaia']
+        disabled_telescopes = new_settings_dict.get('disabled_astroquery_telescopes', [])
+        available_telescopes = [t for t in all_telescopes if t not in disabled_telescopes]
+
+        # Update the manual options and refresh items
+        if self.telescope._manual_options != available_telescopes:
+            self.telescope._manual_options = available_telescopes
+            self.telescope._update_items()
 
     @property
     def user_api(self):

--- a/jdaviz/core/loaders/resolvers/file/file.py
+++ b/jdaviz/core/loaders/resolvers/file/file.py
@@ -10,7 +10,7 @@ from jdaviz.core.loaders.resolvers import BaseResolver
 from jdaviz.core.user_api import LoaderUserApi
 
 
-__all__ = ['FileResolver']
+__all__ = ['FileResolver', 'PresetFileResolver']
 
 
 @loader_resolver_registry('file')
@@ -19,6 +19,7 @@ class FileResolver(BaseResolver):
     default_input = 'filepath'
     default_input_cast = str
 
+    title = Unicode("Load Local File").tag(sync=True)
     file_chooser_widget = Any().tag(sync=True, **widget_serialization)
     filepath = Unicode().tag(sync=True)
 
@@ -73,3 +74,55 @@ class FileResolver(BaseResolver):
 
     def parse_input(self):
         return self.filepath
+
+
+class PresetFileResolver(FileResolver):
+    """
+    A FileResolver variant with a pre-set filepath that doesn't show
+    the file browser widget. Used for programmatically adding files.
+
+    This resolver behaves like the file resolver but hides the file browser
+    UI, similar to when server_is_remote is True.
+    """
+
+    def __init__(self, filepath, title=None, *args, **kwargs):
+        # Validate filepath before initialization
+        if not os.path.exists(filepath) or not os.path.isfile(filepath):
+            raise ValueError(f"'{filepath}' is not a valid file path.")
+
+        # Skip the FileBrowser widget initialization
+        # Set these to None to avoid parent's __init__ trying to create them
+        self.file_chooser_widget = None
+        self.file_chooser_widget_el = None
+        self.file_chooser_dir = None
+        self.filepath_reactive = None
+
+        # Store filepath and title before calling BaseResolver's __init__
+        _preset_filepath = filepath
+        _preset_title = title
+
+        # Call grandparent (BaseResolver) init directly to skip FileResolver's init
+        BaseResolver.__init__(self, *args, **kwargs)
+
+        # Set the filepath after initialization
+        self.filepath = _preset_filepath
+
+        # Set custom title if provided
+        if _preset_title is not None:
+            self.title = _preset_title
+
+        # Override to hide file browser in UI (similar to server_is_remote behavior)
+        self.server_is_remote = True
+
+    def _on_file_chooser_path_changed(self, path):
+        # Override to prevent errors when file_chooser doesn't exist
+        pass
+
+    @observe('filepath')
+    def _on_filepath_changed(self, change):
+        # Simplified version that doesn't update UI widgets
+        if self.filepath == '':
+            return
+        self._resolver_input_updated()
+        if not os.path.exists(self.filepath) or not os.path.isfile(self.filepath):
+            self.parsed_input_is_empty = True

--- a/jdaviz/core/loaders/resolvers/file/file.py
+++ b/jdaviz/core/loaders/resolvers/file/file.py
@@ -98,19 +98,14 @@ class PresetFileResolver(FileResolver):
         self.file_chooser_dir = None
         self.filepath_reactive = None
 
-        # Store filepath and title before calling BaseResolver's __init__
-        _preset_filepath = filepath
-        _preset_title = title
-
         # Call grandparent (BaseResolver) init directly to skip FileResolver's init
         BaseResolver.__init__(self, *args, **kwargs)
 
-        # Set the filepath after initialization
-        self.filepath = _preset_filepath
+        self.filepath = filepath
 
         # Set custom title if provided
-        if _preset_title is not None:
-            self.title = _preset_title
+        if title is not None:
+            self.title = title
 
         # Override to hide file browser inputs
         self.hide_resolver_inputs = True

--- a/jdaviz/core/loaders/resolvers/file/file.py
+++ b/jdaviz/core/loaders/resolvers/file/file.py
@@ -82,7 +82,8 @@ class PresetFileResolver(FileResolver):
     the file browser widget. Used for programmatically adding files.
 
     This resolver behaves like the file resolver but hides the file browser
-    UI, similar to when server_is_remote is True.
+    inputs by setting hide_resolver_inputs=True, while still showing
+    query results and importer selection.
     """
 
     def __init__(self, filepath, title=None, *args, **kwargs):
@@ -111,8 +112,8 @@ class PresetFileResolver(FileResolver):
         if _preset_title is not None:
             self.title = _preset_title
 
-        # Override to hide file browser in UI (similar to server_is_remote behavior)
-        self.server_is_remote = True
+        # Override to hide file browser inputs
+        self.hide_resolver_inputs = True
 
     def _on_file_chooser_path_changed(self, path):
         # Override to prevent errors when file_chooser doesn't exist

--- a/jdaviz/core/loaders/resolvers/file/file.vue
+++ b/jdaviz/core/loaders/resolvers/file/file.vue
@@ -21,12 +21,14 @@
     :api_hints_enabled="api_hints_enabled"
     :valid_import_formats="valid_import_formats"
     :server_is_remote="server_is_remote"
+    :hide_resolver="hide_resolver"
+    :hide_resolver_inputs="hide_resolver_inputs"
     :is_wcs_linked="is_wcs_linked"
     :image_data_loaded="image_data_loaded"
     :footprint_select_icon="footprint_select_icon"
     :custom_toolbar_enabled="custom_toolbar_enabled"
   >
-    <v-row v-if="!server_is_remote" style="padding-left: 12px; margin-bottom: 16px">
+    <v-row v-if="!server_is_remote && !hide_resolver_inputs" style="padding-left: 12px; margin-bottom: 16px">
       Select a file with data you want to load into this instance of Jdaviz.
     </v-row>
     <v-row v-if="api_hints_enabled">
@@ -34,6 +36,6 @@
         ldr.filepath = '{{ filepath }}'
       </span>
     </v-row>
-    <jupyter-widget v-if="file_chooser_widget && !server_is_remote" :widget="file_chooser_widget"></jupyter-widget>
+    <jupyter-widget v-if="file_chooser_widget && !server_is_remote && !hide_resolver_inputs" :widget="file_chooser_widget"></jupyter-widget>
   </j-loader>
 </template>

--- a/jdaviz/core/loaders/resolvers/file/file.vue
+++ b/jdaviz/core/loaders/resolvers/file/file.vue
@@ -1,6 +1,6 @@
 <template>
   <j-loader
-    title="Load Local File"
+    :title="title"
     :popout_button="popout_button"
     :spinner="spinner"
     :parsed_input_is_empty="parsed_input_is_empty"
@@ -25,7 +25,7 @@
     :footprint_select_icon="footprint_select_icon"
     :custom_toolbar_enabled="custom_toolbar_enabled"
   >
-    <v-row style="padding-left: 12px; margin-bottom: 16px">
+    <v-row v-if="!server_is_remote" style="padding-left: 12px; margin-bottom: 16px">
       Select a file with data you want to load into this instance of Jdaviz.
     </v-row>
     <v-row v-if="api_hints_enabled">
@@ -33,6 +33,6 @@
         ldr.filepath = '{{ filepath }}'
       </span>
     </v-row>
-    <jupyter-widget :widget="file_chooser_widget"></jupyter-widget>
+    <jupyter-widget v-if="file_chooser_widget && !server_is_remote" :widget="file_chooser_widget"></jupyter-widget>
   </j-loader>
 </template>

--- a/jdaviz/core/loaders/resolvers/object/object.py
+++ b/jdaviz/core/loaders/resolvers/object/object.py
@@ -7,6 +7,9 @@ from jdaviz.core.loaders.resolvers import BaseResolver
 from jdaviz.core.user_api import LoaderUserApi
 
 
+__all__ = ['ObjectResolver', 'PresetObjectResolver']
+
+
 @loader_resolver_registry('object')
 class ObjectResolver(BaseResolver):
     template_file = __file__, "object.vue"
@@ -47,3 +50,32 @@ class ObjectResolver(BaseResolver):
 
     def parse_input(self):
         return self.object
+
+
+class PresetObjectResolver(ObjectResolver):
+    """
+    An ObjectResolver variant with a pre-set object that doesn't show
+    input widgets. Used for programmatically adding objects.
+
+    This resolver behaves like the object resolver but hides the input fields
+    by setting hide_resolver_inputs=True, while still showing query results
+    and importer selection.
+    """
+
+    def __init__(self, object, title=None, *args, **kwargs):
+        # Store object and title before calling parent's init
+        _preset_object = object
+        _preset_title = title
+
+        # Call parent (ObjectResolver) init
+        super().__init__(*args, **kwargs)
+
+        # Set the object after initialization
+        self.object = _preset_object
+
+        # Set custom title if provided
+        if _preset_title is not None:
+            self.title = _preset_title
+
+        # Override to hide input fields
+        self.hide_resolver_inputs = True

--- a/jdaviz/core/loaders/resolvers/object/object.py
+++ b/jdaviz/core/loaders/resolvers/object/object.py
@@ -16,6 +16,7 @@ class ObjectResolver(BaseResolver):
     default_input = 'object'
     requires_api_support = True
 
+    title = Unicode("Python Object (from API)").tag(sync=True)
     object_repr = Unicode("").tag(sync=True)
 
     def __init__(self, *args, **kwargs):

--- a/jdaviz/core/loaders/resolvers/object/object.py
+++ b/jdaviz/core/loaders/resolvers/object/object.py
@@ -64,19 +64,9 @@ class PresetObjectResolver(ObjectResolver):
     """
 
     def __init__(self, object, title=None, *args, **kwargs):
-        # Store object and title before calling parent's init
-        _preset_object = object
-        _preset_title = title
-
-        # Call parent (ObjectResolver) init
         super().__init__(*args, **kwargs)
 
-        # Set the object after initialization
-        self.object = _preset_object
-
-        # Set custom title if provided
-        if _preset_title is not None:
-            self.title = _preset_title
-
-        # Override to hide input fields
+        self.object = object
+        if title is not None:
+            self.title = title
         self.hide_resolver_inputs = True

--- a/jdaviz/core/loaders/resolvers/object/object.vue
+++ b/jdaviz/core/loaders/resolvers/object/object.vue
@@ -1,6 +1,6 @@
 <template>
   <j-loader
-    title="Python Object (from API)"
+    :title="title"
     :popout_button="popout_button"
     :spinner="spinner"
     :parsed_input_is_empty="parsed_input_is_empty"

--- a/jdaviz/core/loaders/resolvers/object/object.vue
+++ b/jdaviz/core/loaders/resolvers/object/object.vue
@@ -21,6 +21,7 @@
     :api_hints_enabled="api_hints_enabled"
     :server_is_remote="server_is_remote"
     :hide_resolver="hide_resolver"
+    :hide_resolver_inputs="hide_resolver_inputs"
     :is_wcs_linked="is_wcs_linked"
     :footprint_select_icon="footprint_select_icon"
     :custom_toolbar_enabled="custom_toolbar_enabled"
@@ -28,17 +29,19 @@
     @link-by-wcs="link_by_wcs"
     @toggle-custom-toolbar="toggle_custom_toolbar"
   >
-    <v-alert type="info">
-      Access the user API in a notebook cell to import a python object.
-    </v-alert>
-    <v-text-field
-      v-model='object_repr'
-      prepend-icon='mdi-language-python'
-      style="padding: 0px 8px"
-      :disabled="true"
-      label="ldr.object ="
-      class="api-hint"
-      :error-messages="parsed_input_is_resolvable ? [parsed_input_is_resolvable] : []"
-    ></v-text-field>
+    <div v-if="!hide_resolver_inputs">
+      <v-alert type="info">
+        Access the user API in a notebook cell to import a python object.
+      </v-alert>
+      <v-text-field
+        v-model='object_repr'
+        prepend-icon='mdi-language-python'
+        style="padding: 0px 8px"
+        :disabled="true"
+        label="ldr.object ="
+        class="api-hint"
+        :error-messages="parsed_input_is_resolvable ? [parsed_input_is_resolvable] : []"
+      ></v-text-field>
+    </div>
   </j-loader>
 </template>

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -303,7 +303,7 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
         self.file_table.enable_clear = False
         self.file_table.show_if_empty = False
         self.file_table.show_rowselect = True
-        self.file_table.item_key = "url"
+        self.file_table.item_key = "location"
         self.file_table.multiselect = False
         self.file_table._selected_rows_changed_callback = self.on_file_select_changed
 
@@ -375,8 +375,8 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
         bool
             True if the column should be visible, False otherwise.
         """
-        hide_url = self.app.state.settings.get('hide_file_table_url_column', False)
-        if colname == 'url' and hide_url:
+        hide_location = self.app.state.settings.get('hide_file_table_location_column', False)
+        if colname == 'location' and hide_location:
             return False
         return True
 
@@ -393,14 +393,14 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
 
     @observe('file_table_populated')
     def _on_file_table_populated(self, change={}):
-        """Remove url from headers_avail if hiding is enabled."""
+        """Remove location from headers_avail if hiding is enabled."""
         if not change.get('new', False):
             return
-        hide_url = self.app.state.settings.get('hide_file_table_url_column', False)
-        if hide_url and 'url' in self.file_table.headers_avail:
-            # Remove url from headers_avail (dropdown) but keep in data
+        hide_location = self.app.state.settings.get('hide_file_table_location_column', False)
+        if hide_location and 'location' in self.file_table.headers_avail:
+            # Remove location from headers_avail (dropdown) but keep in data
             self.file_table.headers_avail = [
-                h for h in self.file_table.headers_avail if h != 'url'
+                h for h in self.file_table.headers_avail if h != 'location'
             ]
 
     def _on_app_settings_changed(self, new_settings_dict):
@@ -414,34 +414,34 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
         """
         self.server_is_remote = new_settings_dict.get('server_is_remote', False)
 
-        # Update file table URL column visibility if the setting changed
-        hide_url = new_settings_dict.get('hide_file_table_url_column', False)
+        # Update file table location column visibility if the setting changed
+        hide_location = new_settings_dict.get('hide_file_table_location_column', False)
 
         # Update the _new_col_visible function with current settings
         self.file_table._new_col_visible = self._file_table_col_visible
 
-        # Check if url column exists in the actual data
-        url_in_data = (self.file_table._qtable is not None and
-                       'url' in self.file_table._qtable.colnames)
+        # Check if location column exists in the actual data
+        location_in_data = (self.file_table._qtable is not None and
+                            'location' in self.file_table._qtable.colnames)
 
-        if url_in_data:
-            if hide_url:
-                # Remove url from both available and visible headers
+        if location_in_data:
+            if hide_location:
+                # Remove location from both available and visible headers
                 self.file_table.headers_avail = [
-                    h for h in self.file_table.headers_avail if h != 'url'
+                    h for h in self.file_table.headers_avail if h != 'location'
                 ]
                 self.file_table.headers_visible = [
-                    h for h in self.file_table.headers_visible if h != 'url'
+                    h for h in self.file_table.headers_visible if h != 'location'
                 ]
             else:
-                # URL should be available - add it back if missing
-                if 'url' not in self.file_table.headers_avail:
+                # location should be available - add it back if missing
+                if 'location' not in self.file_table.headers_avail:
                     self.file_table.headers_avail = (
-                        self.file_table.headers_avail + ['url']
+                        self.file_table.headers_avail + ['location']
                     )
-                if 'url' not in self.file_table.headers_visible:
+                if 'location' not in self.file_table.headers_visible:
                     self.file_table.headers_visible = (
-                        self.file_table.headers_visible + ['url']
+                        self.file_table.headers_visible + ['location']
                     )
 
     def _on_collection_data_added(self, msg):
@@ -559,11 +559,11 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
         return None
 
     def _parsed_input_to_file_table(self, parsed_input_table):
-        if 'url' in parsed_input_table.colnames:
+        if 'location' in parsed_input_table.colnames:
             return parsed_input_table
-        for map_to_url in ('URL', 'uri', 'URI', 'dataURI', 'download', 'Filename'):
-            if map_to_url in parsed_input_table.colnames:
-                parsed_input_table.rename_column(map_to_url, 'url')
+        for map_to_location in ('url', 'URL', 'uri', 'URI', 'dataURI', 'download', 'Filename'):
+            if map_to_location in parsed_input_table.colnames:
+                parsed_input_table.rename_column(map_to_location, 'location')
                 return parsed_input_table
         return None
 
@@ -809,10 +809,21 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
     def get_selected_url(self):
         if len(self.file_table.selected_rows) != 1:
             return None
-        url = self.file_table.selected_rows[0]['url']
-        if not url.startswith(('http://', 'https://', 'mast:', 'ftp:', 's3:')):
-            return f'https://mast.stsci.edu/search/{self.guess_mission(url)}/api/v0.1/retrieve_product?product_name={url}'  # noqa
-        return url
+        location = self.file_table.selected_rows[0]['location']
+
+        # Check if it's a local file path (absolute, relative, or home directory)
+        # or if it starts with a recognized URL scheme
+        if (location.startswith(('/', './', '../', '~')) or  # Unix-style paths
+                # URL schemes
+                location.startswith(('http://', 'https://', 'mast:', 'ftp:', 's3:')) or
+                (len(location) > 2 and location[1] == ':' and location[2] in ('\\', '/'))):
+            # Windows-style absolute path (e.g., C:\... or C:/...)
+            return location
+
+        # Otherwise, assume it's a MAST product name and construct the URL
+        mission = self.guess_mission(location)
+        return (f'https://mast.stsci.edu/search/{mission}/api/v0.1/'
+                f'retrieve_product?product_name={location}')
 
     @with_spinner('spinner', 'downloading file...')
     def _download_from_file_table(self):

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -361,11 +361,47 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
                      name='observation_table',
                      title='Observations')
 
+    def _file_table_col_visible(self, colname):
+        """
+        Determine if a column should be visible in the file table.
+
+        Parameters
+        ----------
+        colname : str
+            The name of the column to check.
+
+        Returns
+        -------
+        bool
+            True if the column should be visible, False otherwise.
+        """
+        hide_url = self.app.state.settings.get('hide_file_table_url_column', False)
+        if colname == 'url' and hide_url:
+            return False
+        return True
+
     @default('file_table')
     def _default_file_table(self):
-        return Table(self,
-                     name='file_table',
-                     title='Files')
+        file_table = Table(self,
+                           name='file_table',
+                           title='Files')
+
+        # Override _new_col_visible to hide 'url' column if setting is enabled
+        file_table._new_col_visible = self._file_table_col_visible
+
+        return file_table
+
+    @observe('file_table_populated')
+    def _on_file_table_populated(self, change={}):
+        """Remove url from headers_avail if hiding is enabled."""
+        if not change.get('new', False):
+            return
+        hide_url = self.app.state.settings.get('hide_file_table_url_column', False)
+        if hide_url and 'url' in self.file_table.headers_avail:
+            # Remove url from headers_avail (dropdown) but keep in data
+            self.file_table.headers_avail = [
+                h for h in self.file_table.headers_avail if h != 'url'
+            ]
 
     def _on_app_settings_changed(self, new_settings_dict):
         """
@@ -377,6 +413,36 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
             The new settings dictionary from the app state.
         """
         self.server_is_remote = new_settings_dict.get('server_is_remote', False)
+
+        # Update file table URL column visibility if the setting changed
+        hide_url = new_settings_dict.get('hide_file_table_url_column', False)
+
+        # Update the _new_col_visible function with current settings
+        self.file_table._new_col_visible = self._file_table_col_visible
+
+        # Check if url column exists in the actual data
+        url_in_data = (self.file_table._qtable is not None and
+                       'url' in self.file_table._qtable.colnames)
+
+        if url_in_data:
+            if hide_url:
+                # Remove url from both available and visible headers
+                self.file_table.headers_avail = [
+                    h for h in self.file_table.headers_avail if h != 'url'
+                ]
+                self.file_table.headers_visible = [
+                    h for h in self.file_table.headers_visible if h != 'url'
+                ]
+            else:
+                # URL should be available - add it back if missing
+                if 'url' not in self.file_table.headers_avail:
+                    self.file_table.headers_avail = (
+                        self.file_table.headers_avail + ['url']
+                    )
+                if 'url' not in self.file_table.headers_visible:
+                    self.file_table.headers_visible = (
+                        self.file_table.headers_visible + ['url']
+                    )
 
     def _on_collection_data_added(self, msg):
         self.image_data_loaded = any(layer_is_image_data(data) for data in self.app.data_collection)

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -270,6 +270,8 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
     server_is_remote = Bool(False).tag(sync=True)
     # Hide the resolver UI (title, input fields, query results) and show only importer selection
     hide_resolver = Bool(False).tag(sync=True)
+    # Hide only the resolver input fields (for preset loaders), but still show query results
+    hide_resolver_inputs = Bool(False).tag(sync=True)
 
     format_items = List().tag(sync=True)
     format_selected = Unicode().tag(sync=True)

--- a/jdaviz/core/loaders/resolvers/url/url.py
+++ b/jdaviz/core/loaders/resolvers/url/url.py
@@ -18,6 +18,7 @@ class URLResolver(BaseResolver):
     template_file = __file__, "url.vue"
     default_input = 'url'
 
+    title = Unicode("Download from URL").tag(sync=True)
     url = Unicode("").tag(sync=True)
     url_scheme = Unicode("").tag(sync=True)
     url_not_whitelisted = Bool(False).tag(sync=True)

--- a/jdaviz/core/loaders/resolvers/url/url.py
+++ b/jdaviz/core/loaders/resolvers/url/url.py
@@ -129,19 +129,9 @@ class PresetURLResolver(URLResolver):
     """
 
     def __init__(self, url, title=None, *args, **kwargs):
-        # Store url and title before calling parent's init
-        _preset_url = url
-        _preset_title = title
-
-        # Call parent (URLResolver) init
         super().__init__(*args, **kwargs)
 
-        # Set the url after initialization
-        self.url = _preset_url
-
-        # Set custom title if provided
-        if _preset_title is not None:
-            self.title = _preset_title
-
-        # Override to hide input fields
+        self.url = url
+        if title is not None:
+            self.title = title
         self.hide_resolver_inputs = True

--- a/jdaviz/core/loaders/resolvers/url/url.py
+++ b/jdaviz/core/loaders/resolvers/url/url.py
@@ -1,4 +1,4 @@
-from traitlets import Bool, Unicode, observe
+from traitlets import Bool, Unicode, List, observe
 from urllib.parse import urlparse
 import os
 from functools import cached_property
@@ -20,6 +20,8 @@ class URLResolver(BaseResolver):
 
     url = Unicode("").tag(sync=True)
     url_scheme = Unicode("").tag(sync=True)
+    url_not_whitelisted = Bool(False).tag(sync=True)
+    url_prefix_whitelist = List([]).tag(sync=True)
     cache = Bool(True).tag(sync=True)
     local_path = Unicode("").tag(sync=True)
     timeout = FloatHandleEmpty(10).tag(sync=True)
@@ -28,6 +30,33 @@ class URLResolver(BaseResolver):
         self.local_path = os.curdir
         super().__init__(*args, **kwargs)
 
+        # Initialize whitelist from settings
+        whitelist = self.app.state.settings.get('url_prefix_whitelist')
+        if whitelist is not None:
+            self.url_prefix_whitelist = whitelist
+
+        # Listen for changes to app.state.settings
+        self.app.state.add_callback('settings', self._on_app_settings_changed)
+
+    def _on_app_settings_changed(self, new_settings_dict):
+        """
+        Re-validate URL when settings change.
+        """
+        # Update whitelist and re-validate the current URL
+        whitelist = new_settings_dict.get('url_prefix_whitelist')
+        if whitelist is not None:
+            self.url_prefix_whitelist = whitelist
+        else:
+            self.url_prefix_whitelist = []
+        
+        if whitelist is not None and len(whitelist) > 0:
+            url_stripped = self.url.strip()
+            self.url_not_whitelisted = not any(
+                url_stripped.startswith(prefix) for prefix in whitelist
+            )
+        else:
+            self.url_not_whitelisted = False
+
     @property
     def user_api(self):
         return LoaderUserApi(self, expose=['url', 'cache', 'local_path', 'timeout'])
@@ -35,7 +64,15 @@ class URLResolver(BaseResolver):
     @property
     def is_valid(self):
         # NOTE: if changing this, also update the object resolver to reject the same
-        return self.url_scheme in ['http', 'https', 'mast', 'ftp', 's3']
+        valid_scheme = self.url_scheme in ['http', 'https', 'mast', 'ftp', 's3']
+        if not valid_scheme:
+            return False
+
+        # Check whitelist if configured
+        if self.url_not_whitelisted:
+            return False
+
+        return True
 
     @property
     def default_label(self):
@@ -48,6 +85,16 @@ class URLResolver(BaseResolver):
     @observe('url', 'cache', 'timeout')
     def _on_url_changed(self, change):
         self.url_scheme = urlparse(self.url.strip()).scheme
+
+        # Check if URL matches whitelist
+        whitelist = self.app.state.settings.get('url_prefix_whitelist')
+        if whitelist is not None and len(whitelist) > 0:
+            url_stripped = self.url.strip()
+            self.url_not_whitelisted = not any(
+                url_stripped.startswith(prefix) for prefix in whitelist
+            )
+        else:
+            self.url_not_whitelisted = False
 
         # Clear the cached property to force re-download
         # or otherwise read from local file cache.

--- a/jdaviz/core/loaders/resolvers/url/url.py
+++ b/jdaviz/core/loaders/resolvers/url/url.py
@@ -10,7 +10,7 @@ from jdaviz.core.user_api import LoaderUserApi
 from jdaviz.utils import download_uri_to_path, get_cloud_fits
 
 
-__all__ = ['URLResolver']
+__all__ = ['URLResolver', 'PresetURLResolver']
 
 
 @loader_resolver_registry('url')
@@ -112,3 +112,32 @@ class URLResolver(BaseResolver):
 
     def parse_input(self):
         return self._uri_output_file
+
+
+class PresetURLResolver(URLResolver):
+    """
+    A URLResolver variant with a pre-set URL that doesn't show
+    input widgets. Used for programmatically adding URLs.
+
+    This resolver behaves like the URL resolver but hides the input fields
+    by setting hide_resolver_inputs=True, while still showing query results
+    and importer selection.
+    """
+
+    def __init__(self, url, title=None, *args, **kwargs):
+        # Store url and title before calling parent's init
+        _preset_url = url
+        _preset_title = title
+
+        # Call parent (URLResolver) init
+        super().__init__(*args, **kwargs)
+
+        # Set the url after initialization
+        self.url = _preset_url
+
+        # Set custom title if provided
+        if _preset_title is not None:
+            self.title = _preset_title
+
+        # Override to hide input fields
+        self.hide_resolver_inputs = True

--- a/jdaviz/core/loaders/resolvers/url/url.py
+++ b/jdaviz/core/loaders/resolvers/url/url.py
@@ -43,6 +43,9 @@ class URLResolver(BaseResolver):
         """
         Re-validate URL when settings change.
         """
+        # Call parent's method to handle server_is_remote and other settings
+        super()._on_app_settings_changed(new_settings_dict)
+
         # Update whitelist and re-validate the current URL
         whitelist = new_settings_dict.get('url_prefix_whitelist')
         if whitelist is not None:

--- a/jdaviz/core/loaders/resolvers/url/url.py
+++ b/jdaviz/core/loaders/resolvers/url/url.py
@@ -48,7 +48,7 @@ class URLResolver(BaseResolver):
             self.url_prefix_whitelist = whitelist
         else:
             self.url_prefix_whitelist = []
-        
+
         if whitelist is not None and len(whitelist) > 0:
             url_stripped = self.url.strip()
             self.url_not_whitelisted = not any(

--- a/jdaviz/core/loaders/resolvers/url/url.vue
+++ b/jdaviz/core/loaders/resolvers/url/url.vue
@@ -1,6 +1,6 @@
 <template>
   <j-loader
-    title="Download from URL"
+    :title="title"
     :popout_button="popout_button"
     :spinner="spinner"
     :parsed_input_is_resolvable="parsed_input_is_resolvable"

--- a/jdaviz/core/loaders/resolvers/url/url.vue
+++ b/jdaviz/core/loaders/resolvers/url/url.vue
@@ -18,46 +18,50 @@
     :format_selected.sync="format_selected"
     :importer_widget="importer_widget"
     :api_hints_enabled="api_hints_enabled"
+    :hide_resolver="hide_resolver"
+    :hide_resolver_inputs="hide_resolver_inputs"
     :is_wcs_linked="is_wcs_linked"
     :image_data_loaded="image_data_loaded"
     :footprint_select_icon="footprint_select_icon"
     :custom_toolbar_enabled="custom_toolbar_enabled"
   >
-    <v-row style="margin-bottom: 24px">
-      <v-text-field
-        v-model='url'
-        prepend-icon='mdi-link-box'
-        style="padding: 0px 8px"
-        :label="api_hints_enabled ? 'ldr.url =' : ''"
-        :class="api_hints_enabled ? 'api-hint' : null"
-        :error-messages="parsed_input_is_resolvable ? [parsed_input_is_resolvable] : []"
-      ></v-text-field>
-    </v-row>
+    <div v-if="!hide_resolver_inputs">
+      <v-row style="margin-bottom: 24px">
+        <v-text-field
+          v-model='url'
+          prepend-icon='mdi-link-box'
+          style="padding: 0px 8px"
+          :label="api_hints_enabled ? 'ldr.url =' : ''"
+          :class="api_hints_enabled ? 'api-hint' : null"
+          :error-messages="parsed_input_is_resolvable ? [parsed_input_is_resolvable] : []"
+        ></v-text-field>
+      </v-row>
 
-    <v-row v-if="url_not_whitelisted">
-      <v-alert type="warning" style="margin-right: -12px; width: 100%">
-        The URL must start with: {{ url_prefix_whitelist.join(', ') }}
-      </v-alert>
-    </v-row>
+      <v-row v-if="url_not_whitelisted">
+        <v-alert type="warning" style="margin-right: -12px; width: 100%">
+          The URL must start with: {{ url_prefix_whitelist.join(', ') }}
+        </v-alert>
+      </v-row>
 
-    <v-row v-if="url_scheme !== 's3'">
-      <v-text-field
-        v-model.number='timeout'
-        type="number"
-        style="padding: 0px 8px"
-        suffix="s"
-        :label="api_hints_enabled ? 'ldr.timeout =' : 'Timeout (s)'"
-        :class="api_hints_enabled ? 'api-hint' : null"
-      ></v-text-field>
-    </v-row>
+      <v-row v-if="url_scheme !== 's3'">
+        <v-text-field
+          v-model.number='timeout'
+          type="number"
+          style="padding: 0px 8px"
+          suffix="s"
+          :label="api_hints_enabled ? 'ldr.timeout =' : 'Timeout (s)'"
+          :class="api_hints_enabled ? 'api-hint' : null"
+        ></v-text-field>
+      </v-row>
 
-    <plugin-switch
-      v-if="url_scheme !== 's3'"
-      :value.sync="cache"
-      label="Cache File"
-      api_hint="ldr.cache = "
-      :api_hints_enabled="api_hints_enabled"
-      hint="Whether to attempt to read from the cache if this same URL has been previously fetched."
-    ></plugin-switch>
+      <plugin-switch
+        v-if="url_scheme !== 's3'"
+        :value.sync="cache"
+        label="Cache File"
+        api_hint="ldr.cache = "
+        :api_hints_enabled="api_hints_enabled"
+        hint="Whether to attempt to read from the cache if this same URL has been previously fetched."
+      ></plugin-switch>
+    </div>
   </j-loader>
 </template>

--- a/jdaviz/core/loaders/resolvers/url/url.vue
+++ b/jdaviz/core/loaders/resolvers/url/url.vue
@@ -32,6 +32,12 @@
       ></v-text-field>
     </v-row>
 
+    <v-row v-if="url_not_whitelisted">
+      <v-alert type="warning" style="margin-right: -12px; width: 100%">
+        The URL must start with: {{ url_prefix_whitelist.join(', ') }}
+      </v-alert>
+    </v-row>
+
     <v-row v-if="url_scheme !== 's3'">
       <v-text-field
         v-model.number='timeout'

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -261,7 +261,7 @@ def test_resolver_table_as_query(deconfigged_helper):
     ldr = deconfigged_helper.loaders['object']
 
     obs_table = Table({'id': [1, 2, 3], 'fileSetName': ['a', 'b', 'c']})
-    file_table = Table({'id': [1, 2, 3], 'url': ['a', 'b', 'c']})
+    file_table = Table({'id': [1, 2, 3], 'location': ['a', 'b', 'c']})
     invalid_table = Table({'id': [1, 2, 3], 'name': ['a', 'b', 'c']})
 
     assert ldr._obj.parsed_input_is_query is False
@@ -280,29 +280,29 @@ def test_resolver_table_as_query(deconfigged_helper):
     assert ldr._obj.parsed_input_is_query is False
 
 
-def test_hide_file_table_url_column(deconfigged_helper):
-    """Test that hide_file_table_url_column setting works correctly."""
+def test_hide_file_table_location_column(deconfigged_helper):
+    """Test that hide_file_table_location_column setting works correctly."""
     # Test with setting disabled (default behavior)
     ldr = deconfigged_helper.loaders['object']
     file_table = Table({'id': [1, 2, 3],
                         'name': ['a', 'b', 'c'],
-                        'url': ['http://a.fits', 'http://b.fits', 'http://c.fits']})
+                        'location': ['http://a.fits', 'http://b.fits', 'http://c.fits']})
 
     ldr.object = file_table
     assert ldr._obj.parsed_input_is_query is True
     assert ldr._obj.file_table_populated is True
 
-    # URL should be visible in both headers_avail and headers_visible
-    assert 'url' in ldr._obj.file_table.headers_avail
-    assert 'url' in ldr._obj.file_table.headers_visible
+    # location should be visible in both headers_avail and headers_visible
+    assert 'location' in ldr._obj.file_table.headers_avail
+    assert 'location' in ldr._obj.file_table.headers_visible
 
-    # URL data should exist in underlying table
+    # location data should exist in underlying table
     assert ldr._obj.file_table._qtable is not None
-    assert 'url' in ldr._obj.file_table._qtable.colnames
+    assert 'location' in ldr._obj.file_table._qtable.colnames
     assert len(ldr._obj.file_table._qtable) == 3
 
     # Enable the setting and reload data
-    deconfigged_helper.app.state.settings['hide_file_table_url_column'] = True
+    deconfigged_helper.app.state.settings['hide_file_table_location_column'] = True
 
     # Clear the file table so file_table_populated will transition from False to True
     ldr._obj.file_table._clear_table()
@@ -311,42 +311,92 @@ def test_hide_file_table_url_column(deconfigged_helper):
     # Now load new data to trigger the observer
     file_table2 = Table({'id': [4, 5],
                          'name': ['d', 'e'],
-                         'url': ['http://d.fits', 'http://e.fits']})
+                         'location': ['http://d.fits', 'http://e.fits']})
     ldr.object = file_table2
 
     assert ldr._obj.parsed_input_is_query is True
     assert ldr._obj.file_table_populated is True
 
-    # URL should NOT be in headers_avail (not in dropdown)
-    assert 'url' not in ldr._obj.file_table.headers_avail
-    # URL should NOT be in headers_visible
-    assert 'url' not in ldr._obj.file_table.headers_visible
+    # location should NOT be in headers_avail (not in dropdown)
+    assert 'location' not in ldr._obj.file_table.headers_avail
+    # location should NOT be in headers_visible
+    assert 'location' not in ldr._obj.file_table.headers_visible
 
     # But other columns should be visible
     assert 'id' in ldr._obj.file_table.headers_avail
     assert 'name' in ldr._obj.file_table.headers_avail
 
-    # URL data should still exist in underlying table for download functionality
+    # location data should still exist in underlying table for download functionality
     assert ldr._obj.file_table._qtable is not None
-    assert 'url' in ldr._obj.file_table._qtable.colnames
+    assert 'location' in ldr._obj.file_table._qtable.colnames
     assert len(ldr._obj.file_table._qtable) == 2
 
     # Test changing setting back to False
-    deconfigged_helper.app.state.settings['hide_file_table_url_column'] = False
+    deconfigged_helper.app.state.settings['hide_file_table_location_column'] = False
 
     # Clear and reload to test re-enabling
     ldr._obj.file_table._clear_table()
     ldr._obj.file_table_populated = False
 
-    file_table3 = Table({'id': [6], 'name': ['f'], 'url': ['http://f.fits']})
+    file_table3 = Table({'id': [6], 'name': ['f'], 'location': ['http://f.fits']})
     ldr.object = file_table3
 
-    # URL should be visible again
-    assert 'url' in ldr._obj.file_table.headers_avail
-    assert 'url' in ldr._obj.file_table.headers_visible
+    # location should be visible again
+    assert 'location' in ldr._obj.file_table.headers_avail
+    assert 'location' in ldr._obj.file_table.headers_visible
 
     # Reset to default for other tests
-    deconfigged_helper.app.state.settings['hide_file_table_url_column'] = False
+    deconfigged_helper.app.state.settings['hide_file_table_location_column'] = False
+
+
+def test_file_table_local_paths(deconfigged_helper):
+    """Test that local file paths don't get MAST URL prefix."""
+    ldr = deconfigged_helper.loaders['object']
+
+    # Test various local path formats
+    file_table = Table({
+        'id': [1, 2, 3, 4, 5, 6, 7, 8],
+        'location': [
+            '/absolute/unix/path.fits',      # Unix absolute path
+            './relative/path.fits',           # Unix relative path
+            '../parent/path.fits',            # Unix parent relative path
+            '~/home/path.fits',               # Home directory path
+            'C:/windows/path.fits',           # Windows absolute path
+            'C:\\windows\\backslash.fits',   # Windows absolute path with backslashes
+            'http://example.com/file.fits',   # HTTP URL
+            'jwst-product-name'               # MAST product name (no path indicators)
+        ]
+    })
+
+    ldr.object = file_table
+    assert ldr._obj.parsed_input_is_query is True
+    assert ldr._obj.file_table_populated is True
+
+    # Test each path type
+    test_cases = [
+        (0, '/absolute/unix/path.fits', 'Unix absolute path'),
+        (1, './relative/path.fits', 'Unix relative path'),
+        (2, '../parent/path.fits', 'Unix parent relative path'),
+        (3, '~/home/path.fits', 'Home directory path'),
+        (4, 'C:/windows/path.fits', 'Windows absolute path with forward slashes'),
+        (5, 'C:\\windows\\backslash.fits', 'Windows absolute path with backslashes'),
+        (6, 'http://example.com/file.fits', 'HTTP URL'),
+    ]
+
+    for row_idx, expected_path, description in test_cases:
+        ldr.file_table.select_rows(row_idx)
+        result = ldr._obj.get_selected_url()
+        assert result == expected_path, (
+            f"Failed for {description}: expected {expected_path}, got {result}"
+        )
+
+    # Test MAST product name gets the prefix
+    ldr.file_table.select_rows(7)
+    result = ldr._obj.get_selected_url()
+    assert result.startswith('https://mast.stsci.edu/search/jwst/api/'), \
+        f"MAST product name should get URL prefix, got: {result}"
+    assert 'jwst-product-name' in result, \
+        f"MAST URL should contain the product name, got: {result}"
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -278,8 +278,75 @@ def test_resolver_table_as_query(deconfigged_helper):
 
     ldr.object = invalid_table
     assert ldr._obj.parsed_input_is_query is False
-    assert ldr._obj.observation_table_populated is False
-    assert ldr._obj.file_table_populated is False
+
+
+def test_hide_file_table_url_column(deconfigged_helper):
+    """Test that hide_file_table_url_column setting works correctly."""
+    # Test with setting disabled (default behavior)
+    ldr = deconfigged_helper.loaders['object']
+    file_table = Table({'id': [1, 2, 3],
+                        'name': ['a', 'b', 'c'],
+                        'url': ['http://a.fits', 'http://b.fits', 'http://c.fits']})
+
+    ldr.object = file_table
+    assert ldr._obj.parsed_input_is_query is True
+    assert ldr._obj.file_table_populated is True
+
+    # URL should be visible in both headers_avail and headers_visible
+    assert 'url' in ldr._obj.file_table.headers_avail
+    assert 'url' in ldr._obj.file_table.headers_visible
+
+    # URL data should exist in underlying table
+    assert ldr._obj.file_table._qtable is not None
+    assert 'url' in ldr._obj.file_table._qtable.colnames
+    assert len(ldr._obj.file_table._qtable) == 3
+
+    # Enable the setting and reload data
+    deconfigged_helper.app.state.settings['hide_file_table_url_column'] = True
+
+    # Clear the file table so file_table_populated will transition from False to True
+    ldr._obj.file_table._clear_table()
+    ldr._obj.file_table_populated = False
+
+    # Now load new data to trigger the observer
+    file_table2 = Table({'id': [4, 5],
+                         'name': ['d', 'e'],
+                         'url': ['http://d.fits', 'http://e.fits']})
+    ldr.object = file_table2
+
+    assert ldr._obj.parsed_input_is_query is True
+    assert ldr._obj.file_table_populated is True
+
+    # URL should NOT be in headers_avail (not in dropdown)
+    assert 'url' not in ldr._obj.file_table.headers_avail
+    # URL should NOT be in headers_visible
+    assert 'url' not in ldr._obj.file_table.headers_visible
+
+    # But other columns should be visible
+    assert 'id' in ldr._obj.file_table.headers_avail
+    assert 'name' in ldr._obj.file_table.headers_avail
+
+    # URL data should still exist in underlying table for download functionality
+    assert ldr._obj.file_table._qtable is not None
+    assert 'url' in ldr._obj.file_table._qtable.colnames
+    assert len(ldr._obj.file_table._qtable) == 2
+
+    # Test changing setting back to False
+    deconfigged_helper.app.state.settings['hide_file_table_url_column'] = False
+
+    # Clear and reload to test re-enabling
+    ldr._obj.file_table._clear_table()
+    ldr._obj.file_table_populated = False
+
+    file_table3 = Table({'id': [6], 'name': ['f'], 'url': ['http://f.fits']})
+    ldr.object = file_table3
+
+    # URL should be visible again
+    assert 'url' in ldr._obj.file_table.headers_avail
+    assert 'url' in ldr._obj.file_table.headers_visible
+
+    # Reset to default for other tests
+    deconfigged_helper.app.state.settings['hide_file_table_url_column'] = False
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -490,8 +490,17 @@ class LoadersMixin(VuetifyTemplate, HubListener):
         import jdaviz.core.loaders  # noqa
         from jdaviz.core.registries import loader_resolver_registry
         loader_items = []
+        # Determine which loaders to disable
+        disabled_loaders = self.app.state.settings.get('disabled_loaders')
+        if disabled_loaders is None:
+            # Default: disable loaders based on server_is_remote setting
+            if self.app.state.settings.get('server_is_remote', False):
+                disabled_loaders = ['file', 'file drop', 'url', 'object',
+                                    'astroquery', 'virtual observatory']
+            else:
+                disabled_loaders = []
         for name, Resolver in loader_resolver_registry.members.items():
-            if self.app.state.settings.get("server_is_remote") and name in ('file', 'file drop'):
+            if name in disabled_loaders:
                 continue
             loader = Resolver(app=self.app,
                               open_callback=open_accordion,

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -414,3 +414,88 @@ def test_update_existing_data_in_dc(deconfigged_helper,
     deconfigged_helper.app.data_item_remove(dc_data.label)
     assert len(deconfigged_helper.app.existing_data_in_dc) != len_before
     assert dh not in deconfigged_helper.app.existing_data_in_dc
+
+
+def test_add_custom_loader_file(deconfigged_helper, tmp_path):
+    """Test _add_custom_loader with a file resolver."""
+    # Create a temporary FITS file
+    filepath = tmp_path / "test_data.fits"
+    filepath.touch()
+
+    # Add a custom file loader
+    loader_name = deconfigged_helper.app._add_custom_loader('file', str(filepath), name='test_file')
+
+    assert loader_name == 'test_file'
+    assert 'test_file' in deconfigged_helper.app._jdaviz_helper.loaders
+
+    # Check that the loader was added to loader_items
+    loader_names = [item['name'] for item in deconfigged_helper.app.state.loader_items]
+    assert 'test_file' in loader_names
+
+
+def test_add_custom_loader_object(deconfigged_helper, spectrum1d):
+    """Test _add_custom_loader with an object resolver."""
+    from astropy.table import Table
+
+    # Create a simple table object
+    test_table = Table({'col1': [1, 2, 3], 'col2': [4, 5, 6]})
+
+    # Add a custom object loader
+    loader_name = deconfigged_helper.app._add_custom_loader('object', test_table, name='my_table')
+
+    assert loader_name == 'my_table'
+    assert 'my_table' in deconfigged_helper.app._jdaviz_helper.loaders
+
+    # Check that requires_api_support is set correctly for object resolver
+    loader_items = deconfigged_helper.app.state.loader_items
+    my_table_item = [item for item in loader_items if item['name'] == 'my_table'][0]
+    assert my_table_item['requires_api_support'] is True
+
+
+def test_add_custom_loader_url(deconfigged_helper):
+    """Test _add_custom_loader with a URL resolver."""
+    # Use a simple test URL (it doesn't need to be valid for the loader creation)
+    test_url = 'https://example.com/test_data.fits'
+
+    # Add a custom URL loader
+    loader_name = deconfigged_helper.app._add_custom_loader('url', test_url, name='remote_file')
+
+    assert loader_name == 'remote_file'
+    assert 'remote_file' in deconfigged_helper.app._jdaviz_helper.loaders
+
+
+def test_add_custom_loader_invalid_resolver(deconfigged_helper):
+    """Test _add_custom_loader with an invalid resolver type."""
+    with pytest.raises(ValueError, match="Unknown resolver type 'invalid'"):
+        deconfigged_helper.app._add_custom_loader('invalid', 'some_input', name='test')
+
+
+def test_add_custom_loader_unique_names(deconfigged_helper, tmp_path):
+    """Test that _add_custom_loader creates unique names when duplicates exist."""
+    # Create temporary files
+    filepath1 = tmp_path / "data.fits"
+    filepath1.touch()
+    filepath2 = tmp_path / "data2.fits"
+    filepath2.touch()
+
+    # Add two loaders with the same name
+    name1 = deconfigged_helper.app._add_custom_loader('file', str(filepath1), name='data')
+    name2 = deconfigged_helper.app._add_custom_loader('file', str(filepath2), name='data')
+
+    assert name1 == 'data'
+    assert name2 == 'data_1'
+
+
+def test_add_custom_loader_open_in_tray(deconfigged_helper, tmp_path):
+    """Test _add_custom_loader with open_in_tray option."""
+    filepath = tmp_path / "test.fits"
+    filepath.touch()
+
+    # Add a custom file loader with open_in_tray=True
+    loader_name = deconfigged_helper.app._add_custom_loader(
+        'file', str(filepath), name='test', open_in_tray=True
+    )
+
+    # The loader should be selected
+    # Note: This assumes the tray is opened by the method
+    assert loader_name == 'test'

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -360,7 +360,10 @@ def test_remote_server_settings_deconfigged(deconfigged_helper, server_is_remote
     # Defaults
     assert settings['server_is_remote'] is False
     assert settings['remote_enable_importers'] is True
-    settings['server_is_remote'] = server_is_remote
+    # Create a new dict and reassign to trigger callbacks
+    new_settings = settings.copy()
+    new_settings['server_is_remote'] = server_is_remote
+    deconfigged_helper.app.state.settings = new_settings
 
     # Get the loader items and check their widget properties
     loader_items = deconfigged_helper.app.state.loader_items
@@ -423,9 +426,9 @@ def test_add_custom_loader_file(deconfigged_helper, tmp_path):
     filepath.touch()
 
     # Add a custom file loader
-    loader_name = deconfigged_helper.app._add_custom_loader('file', str(filepath), name='test_file')
+    loader = deconfigged_helper.app._add_custom_loader('file', str(filepath), name='test_file')
 
-    assert loader_name == 'test_file'
+    assert repr(loader) == '<test_file API>'
     assert 'test_file' in deconfigged_helper.app._jdaviz_helper.loaders
 
     # Check that the loader was added to loader_items
@@ -441,9 +444,9 @@ def test_add_custom_loader_object(deconfigged_helper, spectrum1d):
     test_table = Table({'col1': [1, 2, 3], 'col2': [4, 5, 6]})
 
     # Add a custom object loader
-    loader_name = deconfigged_helper.app._add_custom_loader('object', test_table, name='my_table')
+    loader = deconfigged_helper.app._add_custom_loader('object', test_table, name='my_table')
 
-    assert loader_name == 'my_table'
+    assert repr(loader) == '<my_table API>'
     assert 'my_table' in deconfigged_helper.app._jdaviz_helper.loaders
 
     # Check that requires_api_support is set correctly for object resolver
@@ -458,9 +461,9 @@ def test_add_custom_loader_url(deconfigged_helper):
     test_url = 'https://example.com/test_data.fits'
 
     # Add a custom URL loader
-    loader_name = deconfigged_helper.app._add_custom_loader('url', test_url, name='remote_file')
+    loader = deconfigged_helper.app._add_custom_loader('url', test_url, name='remote_file')
 
-    assert loader_name == 'remote_file'
+    assert repr(loader) == '<remote_file API>'
     assert 'remote_file' in deconfigged_helper.app._jdaviz_helper.loaders
 
 
@@ -471,19 +474,20 @@ def test_add_custom_loader_invalid_resolver(deconfigged_helper):
 
 
 def test_add_custom_loader_unique_names(deconfigged_helper, tmp_path):
-    """Test that _add_custom_loader creates unique names when duplicates exist."""
+    """Test that _add_custom_loader raises an error when duplicate names exist."""
     # Create temporary files
     filepath1 = tmp_path / "data.fits"
     filepath1.touch()
     filepath2 = tmp_path / "data2.fits"
     filepath2.touch()
 
-    # Add two loaders with the same name
-    name1 = deconfigged_helper.app._add_custom_loader('file', str(filepath1), name='data')
-    name2 = deconfigged_helper.app._add_custom_loader('file', str(filepath2), name='data')
+    # Add first loader with name 'data'
+    loader1 = deconfigged_helper.app._add_custom_loader('file', str(filepath1), name='data')
+    assert repr(loader1) == '<data API>'
 
-    assert name1 == 'data'
-    assert name2 == 'data_1'
+    # Try to add second loader with the same name - should raise error
+    with pytest.raises(ValueError, match="Loader name must be unique. A loader with the name 'data' already exists."):  # noqa
+        deconfigged_helper.app._add_custom_loader('file', str(filepath2), name='data')
 
 
 def test_add_custom_loader_open_in_tray(deconfigged_helper, tmp_path):
@@ -492,10 +496,9 @@ def test_add_custom_loader_open_in_tray(deconfigged_helper, tmp_path):
     filepath.touch()
 
     # Add a custom file loader with open_in_tray=True
-    loader_name = deconfigged_helper.app._add_custom_loader(
+    loader = deconfigged_helper.app._add_custom_loader(
         'file', str(filepath), name='test', open_in_tray=True
     )
 
-    # The loader should be selected
-    # Note: This assumes the tray is opened by the method
-    assert loader_name == 'test'
+    # The loader should be returned and the name should match
+    assert repr(loader) == '<test API>'


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements:
* support for MAST-settings without custom configs using deconfigged
* implements a new private API for adding custom preset loaders (loaders with the inputs FIXED that appear with custom names in the source dropdown).  This allows for embedding an instance of jdaviz with prepopulated files/objects but allowing the user to set the options for how to import the data into jdaviz.

These changes do not affect public API, so I'm putting `no-changelog-entry-needed` - but if anyone thinks this should be listed, I'm happy to do so.

```
import jdaviz as jd

app = jd.gca().app

# MAST-SETTINGS
app.state.settings['server_is_remote'] = True
app.state.settings['remote_enable_importers'] = True
app.state.settings['disabled_loaders'] = ['file', 'file drop', 'object', 'virtual observatory']
app.state.settings['disabled_astroquery_telescopes'] = ['SDSS', 'Gaia']
app.state.settings['url_prefix_whitelist'] = ['mast:', 'MAST:']
app.state.settings['hide_file_table_url_column'] = True


# LOADING DATA - custom loaders
ldr = app._add_custom_loader('file', './image.fits', name='MAST:image.fits', open_in_tray=False, load=True)
ldr = app._add_custom_loader('file', './wfss_x1d.fits', name='MAST:WFSS', format=['1D Spectrum'], open_in_tray=True, load=False)

# to set additional defaults, call on the `ldr` object directly
# ldr.format = '1D Spectrum'
# ldr.importer.data_label = 'blah'
# ldr.load()

# can also pass objects, including tables of products
from astropy.table import QTable
table = QTable()
table['name'] = ['1D Spectrum', '2D Spectrum', '3D Spectrum', 'Image']
table['uri'] = [
    'mast:JWST/product/jw02732004001_02103_00004_mirifushort_x1d.fits',
    'mast:JWST/product/jw01538160001_16101_00004_nrs1_s2d.fits', 
    'mast:JWST/product/jw02732004001_02103_00004_mirifushort_s3d.fits',
    'mast:JWST/product/jw02727-o002_t062_nircam_clear-f090w_i2d.fits'
]
ldr = app._add_custom_loader('object', table, name='MAST:input_list', open_in_tray=True, load=False)
# hide uri by default (but is still accessible to show from the dropdown for now)
ldr.file_table._obj.headers_visible = ['name']

jd.show(tray='loaders')
```



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
