### PR TITLE
Defer adding data to viewer in batch_load

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -123,6 +123,9 @@ Cubeviz
 Imviz
 ^^^^^
 
+- Fixed bug where calling `jd.show()` before `batch_load` context caused data not to load correctly
+ into the viewer(s) due to absence of linking necessary for glue's rendering backend. [#4079]
+
 Mosviz
 ^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -124,7 +124,7 @@ Imviz
 ^^^^^
 
 - Fixed bug where calling `jd.show()` before `batch_load` context caused data not to load correctly
- into the viewer(s) due to absence of linking necessary for glue's rendering backend. [#4079]
+  into the viewer(s) due to absence of linking necessary for glue's rendering backend. [#4079]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -417,7 +417,6 @@ class Application(VuetifyTemplate, HubListener):
         if self.config == "imviz":
             self._wcs_fast_approximation = None
 
-
         # Subscribe to messages indicating that a new viewer needs to be
         #  created. When received, information is passed to the application
         #  handler to generate the appropriate viewer instance.
@@ -2799,7 +2798,6 @@ class Application(VuetifyTemplate, HubListener):
             self._get_data_item_by_id(event['item_id'])['name'],
             viewer_id=self._get_viewer_item(event['id'])['name']
         )
-
 
     def set_data_visibility(self, viewer_reference, data_label, visible=True, replace=False):
         """

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2808,7 +2808,7 @@ class Application(VuetifyTemplate, HubListener):
         viewer_reference : str
             Reference (or ID) of the viewer
         data_label : str
-            Label of the data to set the visibility.  If not already loaded in the viewer, the
+            Label of the data to set the visibility. If not already loaded in the viewer, the
             data will automatically be loaded before setting the visibility
         visible : bool
             Whether to set the layer(s) to visible.
@@ -2819,9 +2819,7 @@ class Application(VuetifyTemplate, HubListener):
         # issues with multiple layers being added in quick succession
         if getattr(self._jdaviz_helper, '_in_batch_load', 0) > 0:
             # Store for processing after batch_load exits
-            if not hasattr(self._jdaviz_helper, '_pending_set_data_visibility'):
-                self._jdaviz_helper._pending_set_data_visibility = []
-            self._jdaviz_helper._pending_set_data_visibility.append({
+            self._jdaviz_helper.pending_set_data_visibility.append({
                 'viewer_reference': viewer_reference,
                 'data_label': data_label,
                 'visible': visible,

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -417,6 +417,7 @@ class Application(VuetifyTemplate, HubListener):
         if self.config == "imviz":
             self._wcs_fast_approximation = None
 
+
         # Subscribe to messages indicating that a new viewer needs to be
         #  created. When received, information is passed to the application
         #  handler to generate the appropriate viewer instance.
@@ -2799,6 +2800,7 @@ class Application(VuetifyTemplate, HubListener):
             viewer_id=self._get_viewer_item(event['id'])['name']
         )
 
+
     def set_data_visibility(self, viewer_reference, data_label, visible=True, replace=False):
         """
         Set the visibility of the layers corresponding to ``data_label`` in a given viewer.
@@ -2808,13 +2810,27 @@ class Application(VuetifyTemplate, HubListener):
         viewer_reference : str
             Reference (or ID) of the viewer
         data_label : str
-            Label of the data to set the visiblity.  If not already loaded in the viewer, the
+            Label of the data to set the visibility.  If not already loaded in the viewer, the
             data will automatically be loaded before setting the visibility
         visible : bool
             Whether to set the layer(s) to visible.
         replace : bool
             Whether to disable the visibility of all other layers in the viewer
         """
+        # During batch_load, defer the entire set_data_visibility call to prevent rendering
+        # issues with multiple layers being added in quick succession
+        if getattr(self._jdaviz_helper, '_in_batch_load', 0) > 0:
+            # Store for processing after batch_load exits
+            if not hasattr(self._jdaviz_helper, '_pending_set_data_visibility'):
+                self._jdaviz_helper._pending_set_data_visibility = []
+            self._jdaviz_helper._pending_set_data_visibility.append({
+                'viewer_reference': viewer_reference,
+                'data_label': data_label,
+                'visible': visible,
+                'replace': replace
+            })
+            return
+
         viewer_item = self._get_viewer_item(viewer_reference)
         viewer_id = viewer_item['id']
         viewer = self.get_viewer_by_id(viewer_id)
@@ -2837,7 +2853,7 @@ class Application(VuetifyTemplate, HubListener):
             data = self.data_collection[data_label]
 
             # set the original color based on metadata preferences, if provided, and otherwise
-            # based on the colorcycler
+            # based on the color-cycler
             # NOTE: this is intentionally not a single line to avoid incrementing the color-cycler
             # unless it is used
             color = data.meta.get('_default_color')
@@ -2916,13 +2932,12 @@ class Application(VuetifyTemplate, HubListener):
         # Sets the plot axes labels to be the units of the most recently
         # active data.
         viewer_data_labels = [layer.layer.label for layer in viewer.layers]
-        if len(viewer_data_labels) > 0 and getattr(self._jdaviz_helper, '_in_batch_load', 0) == 0:
+        if len(viewer_data_labels) > 0:
             # This "if" is nested on purpose to make parent "if" available
             # for other configs in the future, as needed.
             if self.config == 'imviz':
                 viewer.on_limits_change()  # Trigger compass redraw
-
-        if layers_finalized_message:
+        if layers_finalized_message is not None:
             self.hub.broadcast(layers_finalized_message)
 
     def data_item_remove(self, data_label):

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2815,10 +2815,12 @@ class Application(VuetifyTemplate, HubListener):
         replace : bool
             Whether to disable the visibility of all other layers in the viewer
         """
-        # During batch_load, defer the entire set_data_visibility call to prevent rendering
-        # issues with multiple layers being added in quick succession
-        if getattr(self._jdaviz_helper, '_in_batch_load', 0) > 0:
-            # Store for processing after batch_load exits
+        # During batch_load, defer viewer assignment until after linking completes.
+        # Only defer at the outermost batch_load level (== 1). Nested batch_loads
+        # (level > 1, e.g. a plugin live-update triggered inside import_region) are
+        # already handled by _delayed_show_in_viewer_labels in template_mixin, so
+        # intercepting them here as well would cause double-deferral and wrong layer ordering.
+        if getattr(self._jdaviz_helper, '_in_batch_load', 0) == 1:
             self._jdaviz_helper.pending_set_data_visibility.append({
                 'viewer_reference': viewer_reference,
                 'data_label': data_label,

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -108,12 +108,12 @@ class TestParseImage:
             with imviz_helper.batch_load():
                 for i in range(n_slices):
                     imviz_helper.load_data(arr[i, :, :], data_label=f'{data_label}_{i}')
-                # all set_data_visibility calls must be deferred —
+                # all set_data_visibility calls must be deferred
                 # no layers should be loaded into the viewer yet.
                 assert viewer.data_menu.data_labels_loaded == []
                 assert len(imviz_helper.pending_set_data_visibility) == n_slices
 
-            # After batch_load exits: link manager has run, all layers should now be loaded.
+            # After batch_load exits, link manager has run, all layers should now be loaded.
             assert len(viewer.data_menu.data_labels_loaded) == n_slices
             assert len(imviz_helper.pending_set_data_visibility) == 0
 

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -107,6 +107,10 @@ class TestParseImage:
             with imviz_helper.batch_load():
                 for i in range(n_slices):
                     imviz_helper.load_data(arr[i, :, :], data_label=f'{data_label}_{i}')
+                    # Check that data is not yet visible in the viewer
+                    # (i.e. pending visibility is working)
+                    assert imviz_helper.viewers.get('imviz-0').data_menu.data_labels_loaded == []
+                    assert len(imviz_helper.pending_set_data_visibility) > 0
 
         assert len(imviz_helper.app.data_collection) == n_slices
         assert len(imviz_helper.app.data_collection.links) == 8

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -98,6 +98,7 @@ class TestParseImage:
         slice_shape = (2, 3)
         arr = np.stack([np.zeros(slice_shape) + i for i in range(n_slices)])
         data_label = 'my_slices'
+        viewer = imviz_helper.viewers.get('imviz-0')
 
         if not manual_loop:
             # We use higher level load_data() here to make sure linking does not crash.
@@ -107,15 +108,14 @@ class TestParseImage:
             with imviz_helper.batch_load():
                 for i in range(n_slices):
                     imviz_helper.load_data(arr[i, :, :], data_label=f'{data_label}_{i}')
-                # all set_data_visibility calls must be deferred,
+                # all set_data_visibility calls must be deferred —
                 # no layers should be loaded into the viewer yet.
-                assert imviz_helper.viewers.get('imviz-0').data_menu.data_labels_loaded == []
+                assert viewer.data_menu.data_labels_loaded == []
                 assert len(imviz_helper.pending_set_data_visibility) == n_slices
 
-            # After batch_load exits, the link manager has run,
-            # all layers should now be loaded.
-            viewer = imviz_helper.viewers.get('imviz-0')._obj
-            assert len(viewer.layers) == n_slices
+            # After batch_load exits: link manager has run, all layers should now be loaded.
+            assert len(viewer.data_menu.data_labels_loaded) == n_slices
+            assert len(imviz_helper.pending_set_data_visibility) == 0
 
         assert len(imviz_helper.app.data_collection) == n_slices
         assert len(imviz_helper.app.data_collection.links) == 8

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -103,14 +103,19 @@ class TestParseImage:
             # We use higher level load_data() here to make sure linking does not crash.
             imviz_helper.load_data(arr, data_label=data_label)
         else:
-            # Manual loop with unique labels for each slice
+            # Manual loop with unique labels for each slice.
             with imviz_helper.batch_load():
                 for i in range(n_slices):
                     imviz_helper.load_data(arr[i, :, :], data_label=f'{data_label}_{i}')
-                    # Check that data is not yet visible in the viewer
-                    # (i.e. pending visibility is working)
-                    assert imviz_helper.viewers.get('imviz-0').data_menu.data_labels_loaded == []
-                    assert len(imviz_helper.pending_set_data_visibility) > 0
+                # all set_data_visibility calls must be deferred,
+                # no layers should be loaded into the viewer yet.
+                assert imviz_helper.viewers.get('imviz-0').data_menu.data_labels_loaded == []
+                assert len(imviz_helper.pending_set_data_visibility) == n_slices
+
+            # After batch_load exits, the link manager has run,
+            # all layers should now be loaded.
+            viewer = imviz_helper.viewers.get('imviz-0')._obj
+            assert len(viewer.layers) == n_slices
 
         assert len(imviz_helper.app.data_collection) == n_slices
         assert len(imviz_helper.app.data_collection.links) == 8

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -111,6 +111,12 @@ class ConfigHelper(HubListener):
         if not self._in_batch_load:
             self.app.hub.broadcast(ExitBatchLoadMessage(sender=self.app))
 
+            # Process any deferred set_data_visibility calls that were queued during batch_load
+            pending_calls = getattr(self, '_pending_set_data_visibility', [])
+            for call_kwargs in pending_calls:
+                self.app.set_data_visibility(**call_kwargs)
+            self._pending_set_data_visibility = []
+
             # add any data to viewers that were requested but deferred
             for data_label, viewer_ref in self._delayed_show_in_viewer_labels.items():
                 self.app.set_data_visibility(viewer_ref, data_label,

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -85,6 +85,7 @@ class ConfigHelper(HubListener):
 
         self._in_batch_load = 0
         self._delayed_show_in_viewer_labels = {}  # label: viewer_reference pairs
+        self.pending_set_data_visibility = []  # list of kwarg dicts for set_data_visibility
 
     def _propagate_callback_to_viewers(self, method, msg):
         # viewers don't have access to the app/hub to subscribe to messages, so we'll
@@ -111,11 +112,10 @@ class ConfigHelper(HubListener):
         if not self._in_batch_load:
             self.app.hub.broadcast(ExitBatchLoadMessage(sender=self.app))
 
-            # Process any deferred set_data_visibility calls that were queued during batch_load
-            pending_calls = getattr(self, '_pending_set_data_visibility', [])
-            for call_kwargs in pending_calls:
+            # Process any deferred set_data_visibility calls
+            for call_kwargs in self.pending_set_data_visibility:
                 self.app.set_data_visibility(**call_kwargs)
-            self._pending_set_data_visibility = []
+            self.pending_set_data_visibility = []
 
             # add any data to viewers that were requested but deferred
             for data_label, viewer_ref in self._delayed_show_in_viewer_labels.items():


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address an issue when adding data to viewers in the `batch_load` context when the app is visible via `jd.show()`. With linking disabled, the non-reference layers would initialize with an empty rendering state since glue needs to map subsequent data through the reference data's coordinate system. The solution is then to simply delay adding the data to the viewer (`viewer.add_data`) in `set_data_visibility`. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #3940 

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
