### PR TITLE
Programmatically evaluate subsets to avoid creating new subset copies when adjusting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -144,6 +144,9 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Fixed bug where creating new subsets in a fresh app instance and adjusting them creates a copy
+  instead of adjusting the original subset. [#4083]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -1346,7 +1346,8 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
                                             CircleSkyRegion, EllipseSkyRegion,
                                             RectangleSkyRegion, CircleAnnulusSkyRegion))
                             and not has_wcs):
-                        bad_regions.append((region, 'Sky region provided but data has no valid WCS'))
+                        bad_regions.append(
+                            (region, 'Sky region provided but data has no valid WCS'))
                         continue
 
                     if (isinstance(region, (CircularAperture, EllipticalAperture,
@@ -1354,7 +1355,8 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
                                             CirclePixelRegion, EllipsePixelRegion,
                                             RectanglePixelRegion, CircleAnnulusPixelRegion))
                             and (hasattr(self.app, '_link_type') and self.app._link_type == "wcs")):
-                        bad_regions.append((region, 'Pixel region provided but data is aligned by WCS'))
+                        bad_regions.append(
+                            (region, 'Pixel region provided but data is aligned by WCS'))
                         continue
 
                     # photutils: Convert to region shape first

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -189,6 +189,11 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
                                                       selected='combination_mode_selected',
                                                       manual_options=COMBO_OPTIONS)
 
+        # combination_mode defaults to 'new'. Reset to
+        # ReplaceMode so that moving/resizing a subset modifies it
+        # instead of creating a new one.
+        self.session.edit_subset_mode.mode = ReplaceMode
+
     @property
     def user_api(self):
         expose = ['subset', 'combination_mode',

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -1310,136 +1310,141 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
         previous_mode = self.app.session.edit_subset_mode.mode
         previous_subset = self.app.session.edit_subset_mode.edit_subset
 
-        with self.app._jdaviz_helper.batch_load():
-            # This method can edit a particular subset or create a new subset
-            # and apply the combination modes depending on this argument
-            if edit_subset and combination_mode is not None:
-                self.subset.selected = edit_subset
-            elif edit_subset and combination_mode is None:
-                # If combination_mode is not set, assume the user
-                # wants to update the subset in edit_subset
-                self.subset.selected = edit_subset
-                combination_mode = 'replace'
-            else:
-                # self.app.session.edit_subset_mode.edit_subset = None
-                self.subset.selected = self.subset.default_text
-
-            label_index = 0
-            for index, region in enumerate(regions):
-                # Set combination mode for how region will be applied to current subset
-                # or created as a new subset
-                if combo_mode_is_list:
-                    combo_mode = combination_mode[index]
+        self.app._importing_regions = True
+        try:
+            with self.app._jdaviz_helper.batch_load():
+                # This method can edit a particular subset or create a new subset
+                # and apply the combination modes depending on this argument
+                if edit_subset and combination_mode is not None:
+                    self.subset.selected = edit_subset
+                elif edit_subset and combination_mode is None:
+                    # If combination_mode is not set, assume the user
+                    # wants to update the subset in edit_subset
+                    self.subset.selected = edit_subset
+                    combination_mode = 'replace'
                 else:
-                    combo_mode = combination_mode
+                    # self.app.session.edit_subset_mode.edit_subset = None
+                    self.subset.selected = self.subset.default_text
 
-                # Combination_mode should be 'new' if combo_mode is not set or explicitly 'new'
-                if combo_mode == 'new' or combo_mode is None:
-                    self.combination_mode.selected = 'new'
-                elif combo_mode:
-                    self.combination_mode.selected = combo_mode
+                label_index = 0
+                for index, region in enumerate(regions):
+                    # Set combination mode for how region will be applied to current subset
+                    # or created as a new subset
+                    if combo_mode_is_list:
+                        combo_mode = combination_mode[index]
+                    else:
+                        combo_mode = combination_mode
 
-                if (isinstance(region, (SkyCircularAperture, SkyEllipticalAperture,
-                                        SkyRectangularAperture, SkyCircularAnnulus,
-                                        CircleSkyRegion, EllipseSkyRegion,
-                                        RectangleSkyRegion, CircleAnnulusSkyRegion))
-                        and not has_wcs):
-                    bad_regions.append((region, 'Sky region provided but data has no valid WCS'))
-                    continue
+                    # Combination_mode should be 'new' if combo_mode is not set or explicitly 'new'
+                    if combo_mode == 'new' or combo_mode is None:
+                        self.combination_mode.selected = 'new'
+                    elif combo_mode:
+                        self.combination_mode.selected = combo_mode
 
-                if (isinstance(region, (CircularAperture, EllipticalAperture,
-                                        RectangularAperture, CircularAnnulus,
-                                        CirclePixelRegion, EllipsePixelRegion,
-                                        RectanglePixelRegion, CircleAnnulusPixelRegion))
-                        and (hasattr(self.app, '_link_type') and self.app._link_type == "wcs")):
-                    bad_regions.append((region, 'Pixel region provided but data is aligned by WCS'))
-                    continue
+                    if (isinstance(region, (SkyCircularAperture, SkyEllipticalAperture,
+                                            SkyRectangularAperture, SkyCircularAnnulus,
+                                            CircleSkyRegion, EllipseSkyRegion,
+                                            RectangleSkyRegion, CircleAnnulusSkyRegion))
+                            and not has_wcs):
+                        bad_regions.append((region, 'Sky region provided but data has no valid WCS'))
+                        continue
 
-                # photutils: Convert to region shape first
-                if isinstance(region, (CircularAperture, SkyCircularAperture,
-                                       EllipticalAperture, SkyEllipticalAperture,
-                                       RectangularAperture, SkyRectangularAperture,
-                                       CircularAnnulus, SkyCircularAnnulus)):
-                    region = aperture2regions(region)
+                    if (isinstance(region, (CircularAperture, EllipticalAperture,
+                                            RectangularAperture, CircularAnnulus,
+                                            CirclePixelRegion, EllipsePixelRegion,
+                                            RectanglePixelRegion, CircleAnnulusPixelRegion))
+                            and (hasattr(self.app, '_link_type') and self.app._link_type == "wcs")):
+                        bad_regions.append((region, 'Pixel region provided but data is aligned by WCS'))
+                        continue
 
-                # region: Convert to ROI.
-                # NOTE: Out-of-bounds ROI will succeed; this is native glue behavior.
-                if (isinstance(region, (CirclePixelRegion, CircleSkyRegion,
-                                        EllipsePixelRegion, EllipseSkyRegion,
-                                        RectanglePixelRegion, RectangleSkyRegion,
-                                        CircleAnnulusPixelRegion, CircleAnnulusSkyRegion))):
-                    try:
-                        if getattr(data.coords, 'world_n_dim', None) == 3:
-                            data_wcs = _get_celestial_wcs(data.coords)
-                            state = regions2roi(region, wcs=data_wcs)
-                        else:
-                            state = regions2roi(region, wcs=data.coords)
-                    except ValueError:
-                        if '_orig_spatial_wcs' not in data.meta:
-                            bad_regions.append((region,
-                                                f'Failed to load: _orig_spatial_wcs'
-                                                f' meta tag not in {data.label}'))
-                            continue
-                        state = regions2roi(region, wcs=data.meta['_orig_spatial_wcs'])
-                    viewer.apply_roi(state)
+                    # photutils: Convert to region shape first
+                    if isinstance(region, (CircularAperture, SkyCircularAperture,
+                                           EllipticalAperture, SkyEllipticalAperture,
+                                           RectangularAperture, SkyRectangularAperture,
+                                           CircularAnnulus, SkyCircularAnnulus)):
+                        region = aperture2regions(region)
 
-                elif isinstance(region, (CircularROI, CircularAnnulusROI,
-                                         EllipticalROI, RectangularROI)):
-                    viewer.apply_roi(region)
-
-                elif isinstance(region, SpectralRegion):
-                    # Use viewer_name if provided in kwarg, otherwise use
-                    # default spectrum viewer name
-                    range_viewer = self.app.get_viewer(viewer_parameter) if viewer_parameter else self.spectrum_viewer  # noqa
-                    s = RangeSubsetState(lo=region.lower.value, hi=region.upper.value,
-                                         att=range_viewer.state.x_att)
-                    range_viewer.apply_subset_state(s)
-
-                # Last resort: Masked Subset that is static (if data is not a cube)
-                elif data.ndim == 2:
-                    im = None
-                    if hasattr(region, 'to_pixel'):  # Sky region: Convert to pixel region
-                        if not has_wcs:
-                            bad_regions.append((region, 'Sky region provided but data has no valid WCS'))  # noqa
-                            continue
-                        region = region.to_pixel(data.coords)
-
-                    if hasattr(region, 'to_mask'):
+                    # region: Convert to ROI.
+                    # NOTE: Out-of-bounds ROI will succeed; this is native glue behavior.
+                    if (isinstance(region, (CirclePixelRegion, CircleSkyRegion,
+                                            EllipsePixelRegion, EllipseSkyRegion,
+                                            RectanglePixelRegion, RectangleSkyRegion,
+                                            CircleAnnulusPixelRegion, CircleAnnulusSkyRegion))):
                         try:
-                            mask = region.to_mask(**kwargs)
-                            im = mask.to_image(data.shape)  # Can be None
+                            if getattr(data.coords, 'world_n_dim', None) == 3:
+                                data_wcs = _get_celestial_wcs(data.coords)
+                                state = regions2roi(region, wcs=data_wcs)
+                            else:
+                                state = regions2roi(region, wcs=data.coords)
+                        except ValueError:
+                            if '_orig_spatial_wcs' not in data.meta:
+                                bad_regions.append((region,
+                                                    f'Failed to load: _orig_spatial_wcs'
+                                                    f' meta tag not in {data.label}'))
+                                continue
+                            state = regions2roi(region, wcs=data.meta['_orig_spatial_wcs'])
+                        viewer.apply_roi(state)
+
+                    elif isinstance(region, (CircularROI, CircularAnnulusROI,
+                                             EllipticalROI, RectangularROI)):
+                        viewer.apply_roi(region)
+
+                    elif isinstance(region, SpectralRegion):
+                        # Use viewer_name if provided in kwarg, otherwise use
+                        # default spectrum viewer name
+                        range_viewer = self.app.get_viewer(viewer_parameter) if viewer_parameter else self.spectrum_viewer  # noqa
+                        s = RangeSubsetState(lo=region.lower.value, hi=region.upper.value,
+                                             att=range_viewer.state.x_att)
+                        range_viewer.apply_subset_state(s)
+
+                    # Last resort: Masked Subset that is static (if data is not a cube)
+                    elif data.ndim == 2:
+                        im = None
+                        if hasattr(region, 'to_pixel'):  # Sky region: Convert to pixel region
+                            if not has_wcs:
+                                bad_regions.append((region, 'Sky region provided but data has no valid WCS'))  # noqa
+                                continue
+                            region = region.to_pixel(data.coords)
+
+                        if hasattr(region, 'to_mask'):
+                            try:
+                                mask = region.to_mask(**kwargs)
+                                im = mask.to_image(data.shape)  # Can be None
+                            except Exception as e:  # pragma: no cover
+                                bad_regions.append((region, f'Failed to load: {repr(e)}'))
+                                continue
+
+                        # Boolean mask as input is supported but not advertised.
+                        elif (isinstance(region, np.ndarray) and region.shape == data.shape
+                              and region.dtype == np.bool_):
+                            im = region
+
+                        if im is None:
+                            bad_regions.append((region, 'Mask creation failed'))
+                            continue
+
+                        # NOTE: Region creation info is thus lost.
+                        try:
+                            mask_label = f'{msg_prefix} {msg_count}'
+                            state = MaskSubsetState(im, data.pixel_component_ids)
+                            self.app.data_collection.new_subset_group(mask_label, state)
+                            msg_count += 1
                         except Exception as e:  # pragma: no cover
                             bad_regions.append((region, f'Failed to load: {repr(e)}'))
                             continue
-
-                    # Boolean mask as input is supported but not advertised.
-                    elif (isinstance(region, np.ndarray) and region.shape == data.shape
-                          and region.dtype == np.bool_):
-                        im = region
-
-                    if im is None:
+                    else:
                         bad_regions.append((region, 'Mask creation failed'))
                         continue
+                    n_loaded += 1
+                    if max_num_regions is not None and n_loaded >= max_num_regions:
+                        break
 
-                    # NOTE: Region creation info is thus lost.
-                    try:
-                        mask_label = f'{msg_prefix} {msg_count}'
-                        state = MaskSubsetState(im, data.pixel_component_ids)
-                        self.app.data_collection.new_subset_group(mask_label, state)
-                        msg_count += 1
-                    except Exception as e:  # pragma: no cover
-                        bad_regions.append((region, f'Failed to load: {repr(e)}'))
-                        continue
-                else:
-                    bad_regions.append((region, 'Mask creation failed'))
-                    continue
-                n_loaded += 1
-                if max_num_regions is not None and n_loaded >= max_num_regions:
-                    break
+                    if self.combination_mode.selected in ('new', 'replace') and subset_label is not None:  # noqa
+                        self.rename_selected(subset_label[label_index])
+                        label_index += 1
 
-                if self.combination_mode.selected in ('new', 'replace') and subset_label is not None:  # noqa
-                    self.rename_selected(subset_label[label_index])
-                    label_index += 1
+        finally:
+            self.app._importing_regions = False
 
         # Revert edit mode and subset to before the import_region call
         self.app.session.edit_subset_mode.edit_subset = previous_subset

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -189,11 +189,6 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
                                                       selected='combination_mode_selected',
                                                       manual_options=COMBO_OPTIONS)
 
-        # combination_mode defaults to 'new'. Reset to
-        # ReplaceMode so that moving/resizing a subset modifies it
-        # instead of creating a new one.
-        self.session.edit_subset_mode.mode = ReplaceMode
-
     @property
     def user_api(self):
         expose = ['subset', 'combination_mode',

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -105,14 +105,15 @@ class JdavizViewerMixin(WithCache):
         detected when the centers are within one radius of each
         other.
         """
+        # Zero or negative radius not allowed
+        if old_roi.radius <= 0:
+            return False
+
         # Move: same radius
         if abs(old_roi.radius - new_roi.radius) < rtol * max(old_roi.radius, 1):
             return True
 
         # Resize: centers close
-        if old_roi.radius <= 0:
-            return False
-
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
         return dist < old_roi.radius
 
@@ -125,15 +126,16 @@ class JdavizViewerMixin(WithCache):
         Resize is detected when the centers are within the outer
         radius of each other.
         """
+        # Zero or negative outer radius not allowed
+        if old_roi.outer_radius <= 0:
+            return False
+
         # Move: same inner and outer radius
         if (abs(old_roi.inner_radius - new_roi.inner_radius) < rtol * max(old_roi.inner_radius, 1)
                 and abs(old_roi.outer_radius - new_roi.outer_radius) < rtol * max(old_roi.outer_radius, 1)):  # noqa
             return True
 
         # Resize: centers close
-        if old_roi.outer_radius <= 0:
-            return False
-
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
         return dist < old_roi.outer_radius
 
@@ -146,16 +148,17 @@ class JdavizViewerMixin(WithCache):
         detected when the centers are within the larger radius of
         each other.
         """
+        # Zero or negative max radius not allowed
+        size = max(old_roi.radius_x, old_roi.radius_y)
+        if size <= 0:
+            return False
+
         # Move: same radii
         if (abs(old_roi.radius_x - new_roi.radius_x) < rtol * max(old_roi.radius_x, 1)
                 and abs(old_roi.radius_y - new_roi.radius_y) < rtol * max(old_roi.radius_y, 1)):
             return True
 
         # Resize: centers close
-        size = max(old_roi.radius_x, old_roi.radius_y)
-        if size <= 0:
-            return False
-
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
         return dist < size
 
@@ -172,16 +175,18 @@ class JdavizViewerMixin(WithCache):
         old_h = old_roi.ymax - old_roi.ymin
         new_w = new_roi.xmax - new_roi.xmin
         new_h = new_roi.ymax - new_roi.ymin
+
+        # Zero or negative width/height not allowed
+        size = max(old_w, old_h) / 2
+        if size <= 0:
+            return False
+
         # Move: same width and height
         if (abs(old_w - new_w) < rtol * max(abs(old_w), 1)
                 and abs(old_h - new_h) < rtol * max(abs(old_h), 1)):
             return True
 
         # Resize: centers close
-        size = max(old_w, old_h) / 2
-        if size <= 0:
-            return False
-
         old_cx = (old_roi.xmin + old_roi.xmax) / 2
         old_cy = (old_roi.ymin + old_roi.ymax) / 2
         new_cx = (new_roi.xmin + new_roi.xmax) / 2

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -9,6 +9,7 @@ from glue.config import data_translator
 from glue.core import BaseData
 from glue.core.edit_subset_mode import NewMode, ReplaceMode
 from glue.core.exceptions import IncompatibleAttribute
+from glue.core.roi import CircularAnnulusROI, CircularROI, EllipticalROI, RectangularROI
 from glue.core.subset import Subset
 from glue.core.subset_group import GroupedSubset
 from glue.viewers.histogram.state import HistogramViewerState
@@ -99,131 +100,175 @@ class JdavizViewerMixin(WithCache):
         self._data_menu = DataMenu(viewer=self, app=self.jdaviz_app)
 
     @staticmethod
-    def _is_circular_edit(old_roi, new_roi, rtol=1e-6):
+    def _is_circular_edit(old_roi, new_roi, rtol_move=1e-3, rtol_resize=0.25):
         """
-        Detect resize or move for circular ROIs.
+        Classify the change from *old_roi* to *new_roi* for circular ROIs.
 
-        Move is detected when the radius is unchanged. Resize is
-        detected when the centers are within one radius of each
-        other.
+        Checks for moves, i.e. the radius is unchanged within a specified tolerance, and
+        resizes, i.e. the radius is changed within a specified tolerance relative to
+        the old radius.
+
+        Parameters
+        ----------
+        old_roi : CircularROI
+            The existing circular ROI.
+        new_roi : CircularROI
+            The newly proposed circular ROI.
+        rtol_move : float, optional
+            Relative tolerance for move-related comparisons.
+        rtol_resize : float, optional
+            Relative tolerance for resize-related comparisons.
+
+        Returns
+        -------
+        edit_type : 'move', 'resize', or None
         """
-        # Zero or negative radius not allowed
         if old_roi.radius <= 0:
-            return False, False
+            return None
 
-        tol = rtol * max(old_roi.radius, 1)
+        # Move: radius unchanged.
+        if abs(old_roi.radius - new_roi.radius) < rtol_move * max(old_roi.radius, 1):
+            return 'move'
 
-        # Move: same radius
-        move = False
-        if abs(old_roi.radius - new_roi.radius) < tol:
-            move = True
-
-        # Resize: centers close
+        # Resize: radius changed but center stayed very close
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
-        resize = abs(dist - old_roi.radius) < tol
-        print("circular edit, move, resize", move, resize)
+        if dist < (rtol_resize * max(old_roi.radius, 1)):
+            return 'resize'
 
-        return move, resize
+        return None
 
     @staticmethod
-    def _is_annulus_edit(old_roi, new_roi, rtol=1e-6):
+    def _is_annulus_edit(old_roi, new_roi, rtol_move=1e-3, rtol_resize=0.25):
         """
-        Detect resize or move for annulus ROIs.
+        Classify the change from *old_roi* to *new_roi* for annular ROIs.
 
-        Move is detected when inner and outer radii are unchanged.
-        Resize is detected when the centers are within the outer
-        radius of each other.
+        Checks for moves, i.e. the radii are unchanged within a specified tolerance, and
+        resizes, i.e. the radii change but the new center stays within an area defined
+        by the old radius and a specified tolerance.
+
+        Parameters
+        ----------
+        old_roi : CircularAnnulusROI
+            The existing annular ROI.
+        new_roi : CircularAnnulusROI
+            The newly proposed annular ROI.
+        rtol_move : float, optional
+            Relative tolerance for move-related comparisons.
+        rtol_resize : float, optional
+            Relative tolerance for resize-related comparisons.
+
+        Returns
+        -------
+        edit_type : 'move', 'resize', or None
         """
-        # Outer radius must be larger than inner radius and non-zero
         if old_roi.outer_radius == 0 or old_roi.outer_radius <= old_roi.inner_radius:
-            return False, False
+            return None
 
-        inner_tol = rtol * max(old_roi.inner_radius, 1)
-        outer_tol = rtol * max(old_roi.outer_radius, 1)
+        # Move: both radii unchanged.
+        if (abs(old_roi.inner_radius - new_roi.inner_radius) < rtol_move * max(old_roi.inner_radius, 1)  # noqa
+                and abs(old_roi.outer_radius - new_roi.outer_radius) < rtol_resize * max(old_roi.outer_radius, 1)):  # noqa
+            return 'move'
 
-        # Move: same inner and outer radius
-        move = False
-        if (abs(old_roi.inner_radius - new_roi.inner_radius) < inner_tol
-                and abs(old_roi.outer_radius - new_roi.outer_radius) < outer_tol):
-            move = True
-
-        # Resize: centers close
+        # Resize: radii changed but center stayed very close
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
-        resize = abs(dist - old_roi.outer_radius) < outer_tol
+        if dist < (rtol_resize * max(old_roi.outer_radius, 1)):
+            return 'resize'
 
-        return move, resize
+        return None
 
     @staticmethod
-    def _is_elliptical_edit(old_roi, new_roi, rtol=1e-6):
+    def _is_elliptical_edit(old_roi, new_roi, rtol_move=1e-3, rtol_resize=0.25):
         """
-        Detect resize or move for elliptical ROIs.
+        Classify the change from *old_roi* to *new_roi* for elliptical ROIs.
 
-        Move is detected when both radii are unchanged. Resize is
-        detected when the centers are within the larger radius of
-        each other.
+        Checks for moves, i.e. the radii are unchanged within a specified tolerance, and
+        resizes, i.e. either radius changes but the new center stays within an area defined
+        by the old radius and a specified tolerance.
+
+        Parameters
+        ----------
+        old_roi : EllipticalROI
+            The existing elliptical ROI.
+        new_roi : EllipticalROI
+            The newly proposed elliptical ROI.
+        rtol_move : float, optional
+            Relative tolerance for move-related comparisons.
+        rtol_resize : float, optional
+            Relative tolerance for resize-related comparisons.
+
+        Returns
+        -------
+        edit_type : 'move', 'resize', or None
         """
-        # Zero or negative radii not allowed
         size = max(old_roi.radius_x, old_roi.radius_y)
         if size <= 0 or min(old_roi.radius_x, old_roi.radius_y) <= 0:
-            return False, False
+            return None
 
-        x_tol = rtol * max(old_roi.radius_x, 1)
-        y_tol = rtol * max(old_roi.radius_y, 1)
+        # Move: both radii unchanged.
+        if (abs(old_roi.radius_x - new_roi.radius_x) < rtol_move * max(old_roi.radius_x, 1)
+                and abs(old_roi.radius_y - new_roi.radius_y) < rtol_move * max(old_roi.radius_y, 1)):  # noqa
+            return 'move'
 
-        # Move: same radii
-        move = False
-        if (abs(old_roi.radius_x - new_roi.radius_x) < x_tol
-                and abs(old_roi.radius_y - new_roi.radius_y) < y_tol):
-            move = True
-
-        # Resize: centers close
+        # Resize: radii changed but center stayed very close
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
-        resize = abs(dist - size) < max(x_tol, y_tol)
+        if dist < rtol_resize * max(size, 1):
+            return 'resize'
 
-        return move, resize
+        return None
 
     @staticmethod
-    def _is_rectangular_edit(old_roi, new_roi, rtol=1e-6):
+    def _is_rectangular_edit(old_roi, new_roi, rtol_move=1e-3, rtol_resize=0.25):
         """
-        Detect resize or move for rectangular ROIs.
+        Classify the change from *old_roi* to *new_roi* for rectangular ROIs.
 
-        Move is detected when width and height are unchanged.
-        Resize is detected when the centers are within half the
-        larger dimension of each other.
+        Checks for moves, i.e. the width and height are unchanged within
+        a specified tolerance, and resizes, i.e. when dimensions change
+        but the new center stays within an area defined by the old dimensions
+        and a specified tolerance.
+
+        Parameters
+        ----------
+        old_roi : RectangularROI
+            The existing rectangular ROI.
+        new_roi : RectangularROI
+            The newly proposed rectangular ROI.
+        rtol_move : float, optional
+            Relative tolerance for move-related comparisons.
+        rtol_resize : float, optional
+            Relative tolerance for resize-related comparisons.
+
+        Returns
+        -------
+        edit_type : 'move', 'resize', or None
         """
         old_w = old_roi.xmax - old_roi.xmin
         old_h = old_roi.ymax - old_roi.ymin
         new_w = new_roi.xmax - new_roi.xmin
         new_h = new_roi.ymax - new_roi.ymin
 
-        # Zero or negative width/height not allowed
         size = max(old_w, old_h) / 2
         if size <= 0 or old_w <= 0 or old_h <= 0:
-            return False, False
+            return None
 
-        tol_w = rtol * max(old_w, 1)
-        tol_h = rtol * max(old_h, 1)
+        # Move: same width and height.
+        if (abs(old_w - new_w) < rtol_move * max(old_w, 1) and
+                abs(old_h - new_h) < rtol_move * max(old_h, 1)):
+            return 'move'
 
-        # Move: same width and height
-        move = False
-        if (abs(old_w - new_w) < tol_w
-                and abs(old_h - new_h) < tol_h):
-            move = True
-
-        # Resize: centers close
+        # Resize: dimensions changed but center stayed very close
         old_cx = (old_roi.xmin + old_roi.xmax) / 2
         old_cy = (old_roi.ymin + old_roi.ymax) / 2
         new_cx = (new_roi.xmin + new_roi.xmax) / 2
         new_cy = (new_roi.ymin + new_roi.ymax) / 2
         dist = norm([new_cx - old_cx, new_cy - old_cy])
-        resize = abs(dist - size) < max(tol_w, tol_h)
+        if dist < rtol_resize * max(size, 1):
+            return 'resize'
 
-        return move, resize
+        return None
 
     def _is_roi_edit(self, old_roi, new_roi):
         """
-        Determine whether *new_roi* is a resize or move of *old_roi*.
-        Dispatches to a type-specific handler based on the ROI class.
+        Classify the change from *old_roi* to *new_roi*.
 
         Parameters
         ----------
@@ -234,36 +279,29 @@ class JdavizViewerMixin(WithCache):
 
         Returns
         -------
-        is_move : bool
-            True if *new_roi* represents move.
-        is_resize : bool
-            True if *new_roi* represents a resize.
+        edit_type : 'move', 'resize', or None
         """
-        from glue.core.roi import (CircularAnnulusROI, CircularROI,
-                                   EllipticalROI, RectangularROI)
-
         if not isinstance(new_roi, type(old_roi)) or not isinstance(old_roi, type(new_roi)):
-            return False, False
+            return None
 
-        # match ROI classes to handler
-        dispatch = [(CircularAnnulusROI, self._is_annulus_edit),
+        handlers = [(CircularAnnulusROI, self._is_annulus_edit),
                     (CircularROI, self._is_circular_edit),
                     (EllipticalROI, self._is_elliptical_edit),
                     (RectangularROI, self._is_rectangular_edit)]
 
-        for roi_type, handler in dispatch:
+        for roi_type, handler in handlers:
             if isinstance(old_roi, roi_type):
                 return handler(old_roi, new_roi)
 
-        return False, False
+        return None
 
     @staticmethod
     def _is_range_edit(old_range, new_range, rtol=1e-6):
         """
-        Detect resize or move for 1-D range subsets.
+        Classify the change from *old_range* to *new_range* for 1-D ranges.
 
-        Move is detected when the range width is unchanged.
-        Resize is detected when the one endpoint is fixed.
+        Checks for moves, i.e. the width is unchanged within a specified tolerance, and
+        resizes, i.e. when the width changes but one endpoint is fixed.
 
         Parameters
         ----------
@@ -271,30 +309,30 @@ class JdavizViewerMixin(WithCache):
             The existing 1-D subset state.
         new_range : ROI
             The new ROI with ``min`` and ``max`` attributes.
-            Named 'range' for consistency with the RangeSubsetState,
-            but can be any ROI with these attributes.
+        rtol : float, optional
+            Relative tolerance for the width comparison.
 
         Returns
         -------
-        is_edit : bool
-            True if the change is a resize or move operation.
+        edit_type : 'move', 'resize', or None
         """
         if not (hasattr(new_range, 'min') and hasattr(new_range, 'max')):
-            return False, False
+            return None
 
         old_w = old_range.hi - old_range.lo
         new_w = new_range.max - new_range.min
-        # Zero or negative width not allowed
         if old_w <= 0 or new_w <= 0:
-            return False, False
+            return None
 
-        # Resize: one endpoint fixed
-        resize = True if ((old_range.lo == new_range.min) or
-                          (old_range.hi == new_range.max)) else False
-        # Move: same width
-        move = True if abs(new_w - old_w) < (rtol * max(abs(old_w), 1)) else False
+        # Move: same width.
+        if abs(new_w - old_w) < (rtol * max(abs(old_w), 1)):
+            return 'move'
 
-        return move, resize
+        # Resize: width changed, one endpoint fixed.
+        if old_range.lo == new_range.min or old_range.hi == new_range.max:
+            return 'resize'
+
+        return None
 
     def apply_roi(self, roi, use_current=False):
         """
@@ -309,29 +347,26 @@ class JdavizViewerMixin(WithCache):
 
         edit_subset_mode = self.session.edit_subset_mode
         needs_override = False
-        is_move = False
+        edit_type = None
 
         if (not getattr(self.jdaviz_app, '_importing_regions', False)
                 and len(edit_subset_mode.edit_subset) > 0
                 and edit_subset_mode.mode is NewMode):
 
             existing_state = edit_subset_mode.edit_subset[0].subset_state
-            try:
-                if isinstance(existing_state, RoiSubsetState):
-                    old_roi = existing_state.roi
-                    is_move, is_resize = self._is_roi_edit(old_roi, roi)
-                    # xor
-                    needs_override = is_move != is_resize
-                elif isinstance(existing_state, RangeSubsetState):
-                    is_move, is_resize = self._is_range_edit(existing_state, roi)
-                    # xor
-                    needs_override = is_move != is_resize
 
-            except Exception as e:  # noqa
-                raise e
+            if isinstance(existing_state, RoiSubsetState):
+                old_roi = existing_state.roi
+                edit_type = self._is_roi_edit(old_roi, roi)
+            elif isinstance(existing_state, RangeSubsetState):
+                edit_type = self._is_range_edit(existing_state, roi)
 
-        if needs_override and is_move:
-            # Warn the user via API if a duplicate-sized subset is created.
+            needs_override = edit_type is not None
+
+        if needs_override and edit_type == 'move':
+            # Warn when the new subset has identical dimensions to the
+            # existing one, it will be treated as a move in-place rather
+            # than a new subset.
             warnings.warn(
                 'The new subset has the same dimensions as the '
                 'existing subset and will be treated as a move '
@@ -339,10 +374,10 @@ class JdavizViewerMixin(WithCache):
                 'dimensions, use import_region instead.',
                 stacklevel=2)
 
+        original_mode = edit_subset_mode.mode
         if needs_override:
-            original_mode = edit_subset_mode._mode
             edit_subset_mode._mode = ReplaceMode
-            
+
         try:
             super().apply_roi(roi, use_current=use_current)
         finally:

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -111,14 +111,17 @@ class JdavizViewerMixin(WithCache):
         if old_roi.radius <= 0:
             return False, False
 
+        tol = rtol * max(old_roi.radius, 1)
+
         # Move: same radius
         move = False
-        if abs(old_roi.radius - new_roi.radius) < rtol * max(old_roi.radius, 1):
+        if abs(old_roi.radius - new_roi.radius) < tol:
             move = True
 
         # Resize: centers close
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
-        resize = dist < old_roi.radius
+        resize = abs(dist - old_roi.radius) < tol
+        print("circular edit, move, resize", move, resize)
 
         return move, resize
 
@@ -135,15 +138,18 @@ class JdavizViewerMixin(WithCache):
         if old_roi.outer_radius == 0 or old_roi.outer_radius <= old_roi.inner_radius:
             return False, False
 
+        inner_tol = rtol * max(old_roi.inner_radius, 1)
+        outer_tol = rtol * max(old_roi.outer_radius, 1)
+
         # Move: same inner and outer radius
         move = False
-        if (abs(old_roi.inner_radius - new_roi.inner_radius) < rtol * max(old_roi.inner_radius, 1)
-                and abs(old_roi.outer_radius - new_roi.outer_radius) < rtol * max(old_roi.outer_radius, 1)):  # noqa
+        if (abs(old_roi.inner_radius - new_roi.inner_radius) < inner_tol
+                and abs(old_roi.outer_radius - new_roi.outer_radius) < outer_tol):
             move = True
 
         # Resize: centers close
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
-        resize = dist < old_roi.outer_radius
+        resize = abs(dist - old_roi.outer_radius) < outer_tol
 
         return move, resize
 
@@ -161,15 +167,18 @@ class JdavizViewerMixin(WithCache):
         if size <= 0 or min(old_roi.radius_x, old_roi.radius_y) <= 0:
             return False, False
 
+        x_tol = rtol * max(old_roi.radius_x, 1)
+        y_tol = rtol * max(old_roi.radius_y, 1)
+
         # Move: same radii
         move = False
-        if (abs(old_roi.radius_x - new_roi.radius_x) < rtol * max(old_roi.radius_x, 1)
-                and abs(old_roi.radius_y - new_roi.radius_y) < rtol * max(old_roi.radius_y, 1)):
+        if (abs(old_roi.radius_x - new_roi.radius_x) < x_tol
+                and abs(old_roi.radius_y - new_roi.radius_y) < y_tol):
             move = True
 
         # Resize: centers close
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
-        resize = dist < size
+        resize = abs(dist - size) < max(x_tol, y_tol)
 
         return move, resize
 
@@ -192,10 +201,13 @@ class JdavizViewerMixin(WithCache):
         if size <= 0 or old_w <= 0 or old_h <= 0:
             return False, False
 
+        tol_w = rtol * max(old_w, 1)
+        tol_h = rtol * max(old_h, 1)
+
         # Move: same width and height
         move = False
-        if (abs(old_w - new_w) < rtol * max(abs(old_w), 1)
-                and abs(old_h - new_h) < rtol * max(abs(old_h), 1)):
+        if (abs(old_w - new_w) < tol_w
+                and abs(old_h - new_h) < tol_h):
             move = True
 
         # Resize: centers close
@@ -204,7 +216,7 @@ class JdavizViewerMixin(WithCache):
         new_cx = (new_roi.xmin + new_roi.xmax) / 2
         new_cy = (new_roi.ymin + new_roi.ymax) / 2
         dist = norm([new_cx - old_cx, new_cy - old_cy])
-        resize = dist < size
+        resize = abs(dist - size) < max(tol_w, tol_h)
 
         return move, resize
 
@@ -330,6 +342,7 @@ class JdavizViewerMixin(WithCache):
         if needs_override:
             original_mode = edit_subset_mode._mode
             edit_subset_mode._mode = ReplaceMode
+            
         try:
             super().apply_roi(roi, use_current=use_current)
         finally:

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -209,7 +209,7 @@ class JdavizViewerMixin(WithCache):
         from glue.core.roi import (CircularAnnulusROI, CircularROI,
                                    EllipticalROI, RectangularROI)
 
-        if not isinstance(new_roi, type(old_roi)) or isinstance(old_roi, type(new_roi)):
+        if not isinstance(new_roi, type(old_roi)) or not isinstance(old_roi, type(new_roi)):
             return False
 
         # match ROI classes to handler

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -110,16 +110,12 @@ class JdavizViewerMixin(WithCache):
             return False
 
         # Move: same radius
-        move = False
         if abs(old_roi.radius - new_roi.radius) < rtol * max(old_roi.radius, 1):
-            move = True
+            return True
 
         # Resize: centers close
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
-        resize = dist < old_roi.radius
-
-        # xor
-        return move != resize
+        return dist < old_roi.radius
 
     @staticmethod
     def _is_annulus_edit(old_roi, new_roi, rtol=1e-6):
@@ -135,17 +131,13 @@ class JdavizViewerMixin(WithCache):
             return False
 
         # Move: same inner and outer radius
-        move = False
         if (abs(old_roi.inner_radius - new_roi.inner_radius) < rtol * max(old_roi.inner_radius, 1)
                 and abs(old_roi.outer_radius - new_roi.outer_radius) < rtol * max(old_roi.outer_radius, 1)):  # noqa
-            move = True
+            return True
 
         # Resize: centers close
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
-        resize = dist < old_roi.outer_radius
-
-        # xor
-        return move != resize
+        return dist < old_roi.outer_radius
 
     @staticmethod
     def _is_elliptical_edit(old_roi, new_roi, rtol=1e-6):
@@ -162,17 +154,13 @@ class JdavizViewerMixin(WithCache):
             return False
 
         # Move: same radii
-        move = False
         if (abs(old_roi.radius_x - new_roi.radius_x) < rtol * max(old_roi.radius_x, 1)
                 and abs(old_roi.radius_y - new_roi.radius_y) < rtol * max(old_roi.radius_y, 1)):
-            move = True
+            return True
 
         # Resize: centers close
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
-        resize = dist < size
-
-        # xor
-        return move != resize
+        return dist < size
 
     @staticmethod
     def _is_rectangular_edit(old_roi, new_roi, rtol=1e-6):
@@ -194,10 +182,9 @@ class JdavizViewerMixin(WithCache):
             return False
 
         # Move: same width and height
-        move = False
         if (abs(old_w - new_w) < rtol * max(abs(old_w), 1)
                 and abs(old_h - new_h) < rtol * max(abs(old_h), 1)):
-            move = True
+            return True
 
         # Resize: centers close
         old_cx = (old_roi.xmin + old_roi.xmax) / 2
@@ -205,10 +192,7 @@ class JdavizViewerMixin(WithCache):
         new_cx = (new_roi.xmin + new_roi.xmax) / 2
         new_cy = (new_roi.ymin + new_roi.ymax) / 2
         dist = norm([new_cx - old_cx, new_cy - old_cy])
-        resize = dist < size
-
-        # xor
-        return move != resize
+        return dist < size
 
     def _is_roi_edit(self, old_roi, new_roi):
         """
@@ -251,15 +235,16 @@ class JdavizViewerMixin(WithCache):
         Detect resize or move for 1-D range subsets.
 
         Move is detected when the range width is unchanged.
-        Resize is detected when the new midpoint falls inside the
-        old range.
+        Resize is detected when the one endpoint is fixed.
 
         Parameters
         ----------
-        roi : ROI
-            The new ROI with ``min`` and ``max`` attributes.
-        existing_state : RangeSubsetState
+        old_range : RangeSubsetState
             The existing 1-D subset state.
+        new_range : ROI
+            The new ROI with ``min`` and ``max`` attributes.
+            Named 'range' for consistency with the RangeSubsetState,
+            but can be any ROI with these attributes.
 
         Returns
         -------
@@ -275,8 +260,8 @@ class JdavizViewerMixin(WithCache):
         if old_w <= 0 or new_w <= 0:
             return False
 
-        # Resize: one endpoint fixed, xor
-        resize = True if ((old_range.lo == new_range.min) !=
+        # Resize: one endpoint fixed
+        resize = True if ((old_range.lo == new_range.min) or
                           (old_range.hi == new_range.max)) else False
         # Move: same width
         move = True if abs(new_w - old_w) < (rtol * max(abs(old_w), 1)) else False

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from glue.config import data_translator
 from glue.core import BaseData
+from glue.core.edit_subset_mode import NewMode, ReplaceMode
 from glue.core.exceptions import IncompatibleAttribute
 from glue.core.subset import Subset
 from glue.core.subset_group import GroupedSubset
@@ -93,6 +94,188 @@ class JdavizViewerMixin(WithCache):
         ]
 
         self._data_menu = DataMenu(viewer=self, app=self.jdaviz_app)
+
+    @staticmethod
+    def _roi_centers_close(old_roi, new_roi):
+        """
+        Check whether *old_roi* and *new_roi* have nearby centers.
+
+        Used to detect resize operations where the center stays
+        roughly fixed while the size changes. Uses a center-to-
+        center distance check so that annulus-style ROIs are
+        handled correctly.
+        """
+        def _get_roi_center(roi):
+            """
+            Extract the center coordinates from an ROI.
+
+            Parameters
+            ----------
+            roi : ROI object
+                An ROI with either (xc, yc) or (xmin, xmax, ymin, ymax) attributes.
+
+            Returns
+            -------
+            center : tuple or None
+                (cx, cy) center coordinates, or None if ROI type is not supported.
+            """
+            if hasattr(roi, 'xc'):
+                return roi.xc, roi.yc
+            elif hasattr(roi, 'xmin') and hasattr(roi, 'ymin'):
+                cx = (roi.xmin + roi.xmax) / 2
+                cy = (roi.ymin + roi.ymax) / 2
+                return cx, cy
+            return None
+
+        # Extract centers from both ROIs
+        new_center = _get_roi_center(new_roi)
+        old_center = _get_roi_center(old_roi)
+
+        if new_center is None or old_center is None:
+            return False
+
+        ncx, ncy = new_center
+        ocx, ocy = old_center
+
+        # annulus
+        if hasattr(old_roi, 'outer_radius'):
+            size_of_roi = old_roi.outer_radius
+        # circle
+        elif hasattr(old_roi, 'radius'):
+            size_of_roi = old_roi.radius
+        # ellipse
+        elif hasattr(old_roi, 'radius_x'):
+            size_of_roi = max(old_roi.radius_x, old_roi.radius_y)
+        # rectangle
+        elif hasattr(old_roi, 'xmin'):
+            size_of_roi = max(old_roi.xmax - old_roi.xmin,
+                              old_roi.ymax - old_roi.ymin) / 2
+        else:
+            return False
+
+        if size_of_roi <= 0:
+            return False
+
+        dist = ((ncx - ocx) ** 2 + (ncy - ocy) ** 2) ** 0.5
+        return dist < size_of_roi
+
+    @staticmethod
+    def _rois_same_size(old_roi, new_roi):
+        """
+        Check whether two ROIs have the same dimensions.
+
+        Used to detect move operations where the position changes
+        but the size is preserved exactly by the bqplot brush.
+        """
+        def _dimensions_within_tolerance(old_val, new_val, rtol=1e-6):
+            return abs(old_val - new_val) < rtol * max(old_val, 1)
+
+        if type(old_roi) is not type(new_roi):
+            return False
+
+        # Annulus (check before circular — annulus has no 'radius')
+        if hasattr(old_roi, 'inner_radius') and hasattr(new_roi, 'inner_radius'):
+            return (_dimensions_within_tolerance(old_roi.inner_radius, new_roi.inner_radius)
+                    and
+                    _dimensions_within_tolerance(old_roi.outer_radius, new_roi.outer_radius))
+
+        # Circular
+        if hasattr(old_roi, 'radius') and hasattr(new_roi, 'radius'):
+            return _dimensions_within_tolerance(old_roi.radius, new_roi.radius)
+
+        # Elliptical
+        if hasattr(old_roi, 'radius_x') and hasattr(new_roi, 'radius_x'):
+            return (_dimensions_within_tolerance(old_roi.radius_x, new_roi.radius_x)
+                    and
+                    _dimensions_within_tolerance(old_roi.radius_y, new_roi.radius_y))
+
+        # Rectangular
+        if hasattr(old_roi, 'xmin') and hasattr(new_roi, 'xmin'):
+            old_w = old_roi.xmax - old_roi.xmin
+            old_h = old_roi.ymax - old_roi.ymin
+            new_w = new_roi.xmax - new_roi.xmin
+            new_h = new_roi.ymax - new_roi.ymin
+            return (_dimensions_within_tolerance(old_w, new_w)
+                    and
+                    _dimensions_within_tolerance(old_h, new_h))
+
+        return False
+
+    @staticmethod
+    def _check_range_subset_state_change(roi, existing_state, rtol=1e-6):
+        """
+        Check if an ROI change should trigger ReplaceMode for RangeSubsetState.
+
+        Detects whether the user is resizing (midpoint inside old range)
+        or moving (same width) the existing subset.
+
+        Parameters
+        ----------
+        roi : ROI object
+            The new ROI with 'min' and 'max' attributes.
+        existing_state : RangeSubsetState
+            The existing subset state.
+
+        Returns
+        -------
+        should_replace : bool
+            True if the change is a resize or move operation.
+        """
+        if not (hasattr(roi, 'min') and hasattr(roi, 'max')):
+            return False
+
+        new_w = roi.max - roi.min
+        old_w = existing_state.hi - existing_state.lo
+        new_mid = (roi.min + roi.max) / 2
+
+        # Resize: midpoint inside old range
+        # Move: same width
+        if existing_state.lo <= new_mid <= existing_state.hi:
+            return True
+        elif abs(new_w - old_w) < rtol * max(abs(old_w), 1):
+            return True
+
+        return False
+
+    def apply_roi(self, roi, use_current=False):
+        """
+        Apply an ROI to the viewer.
+
+        Detects whether the user is resizing (center stays within
+        the old ROI) or moving (dimensions stay the same) an
+        existing subset.  When either is detected and mode is
+        NewMode, temporarily switches to ReplaceMode so the subset
+        is modified in-place rather than duplicated.
+        """
+        from glue.core.subset import RoiSubsetState, RangeSubsetState
+
+        edit_subset_mode = self.session.edit_subset_mode
+        needs_override = False
+
+        if len(edit_subset_mode.edit_subset) > 0 and edit_subset_mode.mode is NewMode:
+            existing_state = edit_subset_mode.edit_subset[0].subset_state
+            try:
+                if isinstance(existing_state, RoiSubsetState):
+                    old_roi = existing_state.roi
+                    # Resize: center of new ROI inside old ROI
+                    # Move: dimensions unchanged (bqplot preserves
+                    #        exact size during drag-move)
+                    if self._roi_centers_close(old_roi, roi) or self._rois_same_size(old_roi, roi):
+                        needs_override = True
+                elif isinstance(existing_state, RangeSubsetState):
+                    if self._check_range_subset_state_change(roi, existing_state):
+                        needs_override = True
+            except Exception:  # noqa
+                pass
+
+        if needs_override:
+            original_mode = edit_subset_mode._mode
+            edit_subset_mode._mode = ReplaceMode
+        try:
+            super().apply_roi(roi, use_current=use_current)
+        finally:
+            if needs_override:
+                edit_subset_mode._mode = original_mode
 
     @property
     def user_api(self):

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -1,5 +1,7 @@
 from echo import delay_callback, CallbackProperty
 
+import warnings
+
 import numpy as np
 from numpy.linalg import norm
 
@@ -107,15 +109,17 @@ class JdavizViewerMixin(WithCache):
         """
         # Zero or negative radius not allowed
         if old_roi.radius <= 0:
-            return False
+            return False, False
 
         # Move: same radius
         if abs(old_roi.radius - new_roi.radius) < rtol * max(old_roi.radius, 1):
-            return True
+            move = True
 
         # Resize: centers close
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
-        return dist < old_roi.radius
+        resize = dist < old_roi.radius
+
+        return move, resize
 
     @staticmethod
     def _is_annulus_edit(old_roi, new_roi, rtol=1e-6):
@@ -128,16 +132,18 @@ class JdavizViewerMixin(WithCache):
         """
         # Outer radius must be larger than inner radius and non-zero
         if old_roi.outer_radius == 0 or old_roi.outer_radius <= old_roi.inner_radius:
-            return False
+            return False, False
 
         # Move: same inner and outer radius
         if (abs(old_roi.inner_radius - new_roi.inner_radius) < rtol * max(old_roi.inner_radius, 1)
                 and abs(old_roi.outer_radius - new_roi.outer_radius) < rtol * max(old_roi.outer_radius, 1)):  # noqa
-            return True
+            move = True
 
         # Resize: centers close
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
-        return dist < old_roi.outer_radius
+        resize = dist < old_roi.outer_radius
+
+        return move, resize
 
     @staticmethod
     def _is_elliptical_edit(old_roi, new_roi, rtol=1e-6):
@@ -156,11 +162,13 @@ class JdavizViewerMixin(WithCache):
         # Move: same radii
         if (abs(old_roi.radius_x - new_roi.radius_x) < rtol * max(old_roi.radius_x, 1)
                 and abs(old_roi.radius_y - new_roi.radius_y) < rtol * max(old_roi.radius_y, 1)):
-            return True
+            move = True
 
         # Resize: centers close
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
-        return dist < size
+        resize = dist < size
+
+        return move, resize
 
     @staticmethod
     def _is_rectangular_edit(old_roi, new_roi, rtol=1e-6):
@@ -179,12 +187,12 @@ class JdavizViewerMixin(WithCache):
         # Zero or negative width/height not allowed
         size = max(old_w, old_h) / 2
         if size <= 0 or old_w <= 0 or old_h <= 0:
-            return False
+            return False, False
 
         # Move: same width and height
         if (abs(old_w - new_w) < rtol * max(abs(old_w), 1)
                 and abs(old_h - new_h) < rtol * max(abs(old_h), 1)):
-            return True
+            move = True
 
         # Resize: centers close
         old_cx = (old_roi.xmin + old_roi.xmax) / 2
@@ -192,7 +200,9 @@ class JdavizViewerMixin(WithCache):
         new_cx = (new_roi.xmin + new_roi.xmax) / 2
         new_cy = (new_roi.ymin + new_roi.ymax) / 2
         dist = norm([new_cx - old_cx, new_cy - old_cy])
-        return dist < size
+        resize = dist < size
+
+        return move, resize
 
     def _is_roi_edit(self, old_roi, new_roi):
         """
@@ -208,14 +218,16 @@ class JdavizViewerMixin(WithCache):
 
         Returns
         -------
-        is_edit : bool
-            True if *new_roi* represents a resize or move.
+        is_move : bool
+            True if *new_roi* represents move.
+        is_resize : bool
+            True if *new_roi* represents a resize.
         """
         from glue.core.roi import (CircularAnnulusROI, CircularROI,
                                    EllipticalROI, RectangularROI)
 
         if not isinstance(new_roi, type(old_roi)) or not isinstance(old_roi, type(new_roi)):
-            return False
+            return False, False
 
         # match ROI classes to handler
         dispatch = [(CircularAnnulusROI, self._is_annulus_edit),
@@ -227,7 +239,7 @@ class JdavizViewerMixin(WithCache):
             if isinstance(old_roi, roi_type):
                 return handler(old_roi, new_roi)
 
-        return False
+        return False, False
 
     @staticmethod
     def _is_range_edit(old_range, new_range, rtol=1e-6):
@@ -252,13 +264,13 @@ class JdavizViewerMixin(WithCache):
             True if the change is a resize or move operation.
         """
         if not (hasattr(new_range, 'min') and hasattr(new_range, 'max')):
-            return False
+            return False, False
 
         old_w = old_range.hi - old_range.lo
         new_w = new_range.max - new_range.min
         # Zero or negative width not allowed
         if old_w <= 0 or new_w <= 0:
-            return False
+            return False, False
 
         # Resize: one endpoint fixed
         resize = True if ((old_range.lo == new_range.min) or
@@ -266,8 +278,7 @@ class JdavizViewerMixin(WithCache):
         # Move: same width
         move = True if abs(new_w - old_w) < (rtol * max(abs(old_w), 1)) else False
 
-        # xor
-        return move != resize
+        return move, resize
 
     def apply_roi(self, roi, use_current=False):
         """
@@ -282,16 +293,35 @@ class JdavizViewerMixin(WithCache):
 
         edit_subset_mode = self.session.edit_subset_mode
         needs_override = False
+        is_move = False
 
-        if len(edit_subset_mode.edit_subset) > 0 and edit_subset_mode.mode is NewMode:
+        if (not getattr(self.jdaviz_app, '_importing_regions', False)
+                and len(edit_subset_mode.edit_subset) > 0
+                and edit_subset_mode.mode is NewMode):
+
             existing_state = edit_subset_mode.edit_subset[0].subset_state
             try:
                 if isinstance(existing_state, RoiSubsetState):
-                    needs_override = self._is_roi_edit(existing_state.roi, roi)
+                    old_roi = existing_state.roi
+                    is_move, is_resize = self._is_roi_edit(old_roi, roi)
+                    # xor
+                    needs_override = is_move != is_resize
                 elif isinstance(existing_state, RangeSubsetState):
-                    needs_override = self._is_range_edit(existing_state, roi)
+                    is_move, is_resize = self._is_range_edit(existing_state, roi)
+                    # xor
+                    needs_override = is_move != is_resize
+
             except Exception as e:  # noqa
                 raise e
+
+        if needs_override and is_move:
+            # Warn the user via API if a duplicate-sized subset is created.
+            warnings.warn(
+                'The new subset has the same dimensions as the '
+                'existing subset and will be treated as a move '
+                'operation. To create a new subset with the same '
+                'dimensions, use import_region instead.',
+                stacklevel=2)
 
         if needs_override:
             original_mode = edit_subset_mode._mode

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -112,6 +112,7 @@ class JdavizViewerMixin(WithCache):
             return False, False
 
         # Move: same radius
+        move = False
         if abs(old_roi.radius - new_roi.radius) < rtol * max(old_roi.radius, 1):
             move = True
 
@@ -135,6 +136,7 @@ class JdavizViewerMixin(WithCache):
             return False, False
 
         # Move: same inner and outer radius
+        move = False
         if (abs(old_roi.inner_radius - new_roi.inner_radius) < rtol * max(old_roi.inner_radius, 1)
                 and abs(old_roi.outer_radius - new_roi.outer_radius) < rtol * max(old_roi.outer_radius, 1)):  # noqa
             move = True
@@ -157,9 +159,10 @@ class JdavizViewerMixin(WithCache):
         # Zero or negative radii not allowed
         size = max(old_roi.radius_x, old_roi.radius_y)
         if size <= 0 or min(old_roi.radius_x, old_roi.radius_y) <= 0:
-            return False
+            return False, False
 
         # Move: same radii
+        move = False
         if (abs(old_roi.radius_x - new_roi.radius_x) < rtol * max(old_roi.radius_x, 1)
                 and abs(old_roi.radius_y - new_roi.radius_y) < rtol * max(old_roi.radius_y, 1)):
             move = True
@@ -190,6 +193,7 @@ class JdavizViewerMixin(WithCache):
             return False, False
 
         # Move: same width and height
+        move = False
         if (abs(old_w - new_w) < rtol * max(abs(old_w), 1)
                 and abs(old_h - new_h) < rtol * max(abs(old_h), 1)):
             move = True

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -1,6 +1,7 @@
 from echo import delay_callback, CallbackProperty
 
 import numpy as np
+from numpy.linalg import norm
 
 from glue.config import data_translator
 from glue.core import BaseData
@@ -96,156 +97,181 @@ class JdavizViewerMixin(WithCache):
         self._data_menu = DataMenu(viewer=self, app=self.jdaviz_app)
 
     @staticmethod
-    def _roi_centers_close(old_roi, new_roi):
+    def _is_circular_edit(old_roi, new_roi, rtol=1e-6):
         """
-        Check whether *old_roi* and *new_roi* have nearby centers.
+        Detect resize or move for circular ROIs.
 
-        Used to detect resize operations where the center stays
-        roughly fixed while the size changes. Uses a center-to-
-        center distance check so that annulus-style ROIs are
-        handled correctly.
+        Move is detected when the radius is unchanged. Resize is
+        detected when the centers are within one radius of each
+        other.
         """
-        def _get_roi_center(roi):
-            """
-            Extract the center coordinates from an ROI.
+        # Move: same radius
+        if abs(old_roi.radius - new_roi.radius) < rtol * max(old_roi.radius, 1):
+            return True
 
-            Parameters
-            ----------
-            roi : ROI object
-                An ROI with either (xc, yc) or (xmin, xmax, ymin, ymax) attributes.
-
-            Returns
-            -------
-            center : tuple or None
-                (cx, cy) center coordinates, or None if ROI type is not supported.
-            """
-            if hasattr(roi, 'xc'):
-                return roi.xc, roi.yc
-            elif hasattr(roi, 'xmin') and hasattr(roi, 'ymin'):
-                cx = (roi.xmin + roi.xmax) / 2
-                cy = (roi.ymin + roi.ymax) / 2
-                return cx, cy
-            return None
-
-        # Extract centers from both ROIs
-        new_center = _get_roi_center(new_roi)
-        old_center = _get_roi_center(old_roi)
-
-        if new_center is None or old_center is None:
+        # Resize: centers close
+        if old_roi.radius <= 0:
             return False
 
-        ncx, ncy = new_center
-        ocx, ocy = old_center
-
-        # annulus
-        if hasattr(old_roi, 'outer_radius'):
-            size_of_roi = old_roi.outer_radius
-        # circle
-        elif hasattr(old_roi, 'radius'):
-            size_of_roi = old_roi.radius
-        # ellipse
-        elif hasattr(old_roi, 'radius_x'):
-            size_of_roi = max(old_roi.radius_x, old_roi.radius_y)
-        # rectangle
-        elif hasattr(old_roi, 'xmin'):
-            size_of_roi = max(old_roi.xmax - old_roi.xmin,
-                              old_roi.ymax - old_roi.ymin) / 2
-        else:
-            return False
-
-        if size_of_roi <= 0:
-            return False
-
-        dist = ((ncx - ocx) ** 2 + (ncy - ocy) ** 2) ** 0.5
-        return dist < size_of_roi
+        dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
+        return dist < old_roi.radius
 
     @staticmethod
-    def _rois_same_size(old_roi, new_roi):
+    def _is_annulus_edit(old_roi, new_roi, rtol=1e-6):
         """
-        Check whether two ROIs have the same dimensions.
+        Detect resize or move for annulus ROIs.
 
-        Used to detect move operations where the position changes
-        but the size is preserved exactly by the bqplot brush.
+        Move is detected when inner and outer radii are unchanged.
+        Resize is detected when the centers are within the outer
+        radius of each other.
         """
-        def _dimensions_within_tolerance(old_val, new_val, rtol=1e-6):
-            return abs(old_val - new_val) < rtol * max(old_val, 1)
+        # Move: same inner and outer radius
+        if (abs(old_roi.inner_radius - new_roi.inner_radius)
+                < rtol * max(old_roi.inner_radius, 1)
+                and abs(old_roi.outer_radius - new_roi.outer_radius)
+                < rtol * max(old_roi.outer_radius, 1)):
+            return True
 
-        if type(old_roi) is not type(new_roi):
+        # Resize: centers close
+        if old_roi.outer_radius <= 0:
             return False
 
-        # Annulus (check before circular — annulus has no 'radius')
-        if hasattr(old_roi, 'inner_radius') and hasattr(new_roi, 'inner_radius'):
-            return (_dimensions_within_tolerance(old_roi.inner_radius, new_roi.inner_radius)
-                    and
-                    _dimensions_within_tolerance(old_roi.outer_radius, new_roi.outer_radius))
+        dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
+        return dist < old_roi.outer_radius
 
-        # Circular
-        if hasattr(old_roi, 'radius') and hasattr(new_roi, 'radius'):
-            return _dimensions_within_tolerance(old_roi.radius, new_roi.radius)
+    @staticmethod
+    def _is_elliptical_edit(old_roi, new_roi, rtol=1e-6):
+        """
+        Detect resize or move for elliptical ROIs.
 
-        # Elliptical
-        if hasattr(old_roi, 'radius_x') and hasattr(new_roi, 'radius_x'):
-            return (_dimensions_within_tolerance(old_roi.radius_x, new_roi.radius_x)
-                    and
-                    _dimensions_within_tolerance(old_roi.radius_y, new_roi.radius_y))
+        Move is detected when both radii are unchanged. Resize is
+        detected when the centers are within the larger radius of
+        each other.
+        """
+        # Move: same radii
+        if (abs(old_roi.radius_x - new_roi.radius_x)
+                < rtol * max(old_roi.radius_x, 1)
+                and abs(old_roi.radius_y - new_roi.radius_y)
+                < rtol * max(old_roi.radius_y, 1)):
+            return True
 
-        # Rectangular
-        if hasattr(old_roi, 'xmin') and hasattr(new_roi, 'xmin'):
-            old_w = old_roi.xmax - old_roi.xmin
-            old_h = old_roi.ymax - old_roi.ymin
-            new_w = new_roi.xmax - new_roi.xmin
-            new_h = new_roi.ymax - new_roi.ymin
-            return (_dimensions_within_tolerance(old_w, new_w)
-                    and
-                    _dimensions_within_tolerance(old_h, new_h))
+        # Resize: centers close
+        size = max(old_roi.radius_x, old_roi.radius_y)
+        if size <= 0:
+            return False
+
+        dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
+        return dist < size
+
+    @staticmethod
+    def _is_rectangular_edit(old_roi, new_roi, rtol=1e-6):
+        """
+        Detect resize or move for rectangular ROIs.
+
+        Move is detected when width and height are unchanged.
+        Resize is detected when the centers are within half the
+        larger dimension of each other.
+        """
+        old_w = old_roi.xmax - old_roi.xmin
+        old_h = old_roi.ymax - old_roi.ymin
+        new_w = new_roi.xmax - new_roi.xmin
+        new_h = new_roi.ymax - new_roi.ymin
+        # Move: same width and height
+        if (abs(old_w - new_w) < rtol * max(abs(old_w), 1)
+                and abs(old_h - new_h) < rtol * max(abs(old_h), 1)):
+            return True
+
+        # Resize: centers close
+        size = max(old_w, old_h) / 2
+        if size <= 0:
+            return False
+
+        old_cx = (old_roi.xmin + old_roi.xmax) / 2
+        old_cy = (old_roi.ymin + old_roi.ymax) / 2
+        new_cx = (new_roi.xmin + new_roi.xmax) / 2
+        new_cy = (new_roi.ymin + new_roi.ymax) / 2
+        dist = norm([new_cx - old_cx, new_cy - old_cy])
+        return dist < size
+
+    def _is_roi_edit(self, old_roi, new_roi):
+        """
+        Determine whether *new_roi* is a resize or move of *old_roi*.
+        Dispatches to a type-specific handler based on the ROI class.
+
+        Parameters
+        ----------
+        old_roi : ROI
+            The existing subset's ROI.
+        new_roi : ROI
+            The newly drawn ROI.
+
+        Returns
+        -------
+        is_edit : bool
+            True if *new_roi* represents a resize or move.
+        """
+        from glue.core.roi import (CircularAnnulusROI, CircularROI,
+                                   EllipticalROI, RectangularROI)
+
+        if not (isinstance(new_roi, type(old_roi))
+                or isinstance(old_roi, type(new_roi))):
+            return False
+
+        # Use isinstance so subclasses (e.g. TrueCircularROI)
+        # are matched to their parent handler.
+        dispatch = ((CircularAnnulusROI, self._is_annulus_edit),
+                    (CircularROI, self._is_circular_edit),
+                    (EllipticalROI, self._is_elliptical_edit),
+                    (RectangularROI, self._is_rectangular_edit))
+
+        for roi_type, handler in dispatch:
+            if isinstance(old_roi, roi_type):
+                return handler(old_roi, new_roi)
 
         return False
 
     @staticmethod
-    def _check_range_subset_state_change(roi, existing_state, rtol=1e-6):
+    def _is_range_edit(roi, existing_state, rtol=1e-6):
         """
-        Check if an ROI change should trigger ReplaceMode for RangeSubsetState.
+        Detect resize or move for 1-D range subsets.
 
-        Detects whether the user is resizing (midpoint inside old range)
-        or moving (same width) the existing subset.
+        Move is detected when the range width is unchanged.
+        Resize is detected when the new midpoint falls inside the
+        old range.
 
         Parameters
         ----------
-        roi : ROI object
-            The new ROI with 'min' and 'max' attributes.
+        roi : ROI
+            The new ROI with ``min`` and ``max`` attributes.
         existing_state : RangeSubsetState
-            The existing subset state.
+            The existing 1-D subset state.
 
         Returns
         -------
-        should_replace : bool
+        is_edit : bool
             True if the change is a resize or move operation.
         """
         if not (hasattr(roi, 'min') and hasattr(roi, 'max')):
             return False
-
         new_w = roi.max - roi.min
         old_w = existing_state.hi - existing_state.lo
         new_mid = (roi.min + roi.max) / 2
 
         # Resize: midpoint inside old range
-        # Move: same width
         if existing_state.lo <= new_mid <= existing_state.hi:
             return True
-        elif abs(new_w - old_w) < rtol * max(abs(old_w), 1):
-            return True
 
-        return False
+        # Move: same width
+        return abs(new_w - old_w) < rtol * max(abs(old_w), 1)
 
     def apply_roi(self, roi, use_current=False):
         """
         Apply an ROI to the viewer.
 
-        Detects whether the user is resizing (center stays within
-        the old ROI) or moving (dimensions stay the same) an
-        existing subset.  When either is detected and mode is
-        NewMode, temporarily switches to ReplaceMode so the subset
-        is modified in-place rather than duplicated.
+        Detects whether the user is resizing or moving an existing
+        subset. When detected and mode is NewMode, temporarily
+        switches to ReplaceMode so the subset is modified in-place
+        rather than duplicated.
         """
         from glue.core.subset import RoiSubsetState, RangeSubsetState
 
@@ -256,17 +282,11 @@ class JdavizViewerMixin(WithCache):
             existing_state = edit_subset_mode.edit_subset[0].subset_state
             try:
                 if isinstance(existing_state, RoiSubsetState):
-                    old_roi = existing_state.roi
-                    # Resize: center of new ROI inside old ROI
-                    # Move: dimensions unchanged (bqplot preserves
-                    #        exact size during drag-move)
-                    if self._roi_centers_close(old_roi, roi) or self._rois_same_size(old_roi, roi):
-                        needs_override = True
+                    needs_override = self._is_roi_edit(existing_state.roi, roi)
                 elif isinstance(existing_state, RangeSubsetState):
-                    if self._check_range_subset_state_change(roi, existing_state):
-                        needs_override = True
-            except Exception:  # noqa
-                pass
+                    needs_override = self._is_range_edit(roi, existing_state)
+            except Exception as e:  # noqa
+                raise e
 
         if needs_override:
             original_mode = edit_subset_mode._mode

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -110,12 +110,16 @@ class JdavizViewerMixin(WithCache):
             return False
 
         # Move: same radius
+        move = False
         if abs(old_roi.radius - new_roi.radius) < rtol * max(old_roi.radius, 1):
-            return True
+            move = True
 
         # Resize: centers close
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
-        return dist < old_roi.radius
+        resize = dist < old_roi.radius
+
+        # xor
+        return move != resize
 
     @staticmethod
     def _is_annulus_edit(old_roi, new_roi, rtol=1e-6):
@@ -126,18 +130,22 @@ class JdavizViewerMixin(WithCache):
         Resize is detected when the centers are within the outer
         radius of each other.
         """
-        # Zero or negative outer radius not allowed
-        if old_roi.outer_radius <= 0:
+        # Outer radius must be larger than inner radius and non-zero
+        if old_roi.outer_radius == 0 or old_roi.outer_radius <= old_roi.inner_radius:
             return False
 
         # Move: same inner and outer radius
+        move = False
         if (abs(old_roi.inner_radius - new_roi.inner_radius) < rtol * max(old_roi.inner_radius, 1)
                 and abs(old_roi.outer_radius - new_roi.outer_radius) < rtol * max(old_roi.outer_radius, 1)):  # noqa
-            return True
+            move = True
 
         # Resize: centers close
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
-        return dist < old_roi.outer_radius
+        resize = dist < old_roi.outer_radius
+
+        # xor
+        return move != resize
 
     @staticmethod
     def _is_elliptical_edit(old_roi, new_roi, rtol=1e-6):
@@ -148,19 +156,23 @@ class JdavizViewerMixin(WithCache):
         detected when the centers are within the larger radius of
         each other.
         """
-        # Zero or negative max radius not allowed
+        # Zero or negative radii not allowed
         size = max(old_roi.radius_x, old_roi.radius_y)
-        if size <= 0:
+        if size <= 0 or min(old_roi.radius_x, old_roi.radius_y) <= 0:
             return False
 
         # Move: same radii
+        move = False
         if (abs(old_roi.radius_x - new_roi.radius_x) < rtol * max(old_roi.radius_x, 1)
                 and abs(old_roi.radius_y - new_roi.radius_y) < rtol * max(old_roi.radius_y, 1)):
-            return True
+            move = True
 
         # Resize: centers close
         dist = norm([new_roi.xc - old_roi.xc, new_roi.yc - old_roi.yc])
-        return dist < size
+        resize = dist < size
+
+        # xor
+        return move != resize
 
     @staticmethod
     def _is_rectangular_edit(old_roi, new_roi, rtol=1e-6):
@@ -178,13 +190,14 @@ class JdavizViewerMixin(WithCache):
 
         # Zero or negative width/height not allowed
         size = max(old_w, old_h) / 2
-        if size <= 0:
+        if size <= 0 or old_w <= 0 or old_h <= 0:
             return False
 
         # Move: same width and height
+        move = False
         if (abs(old_w - new_w) < rtol * max(abs(old_w), 1)
                 and abs(old_h - new_h) < rtol * max(abs(old_h), 1)):
-            return True
+            move = True
 
         # Resize: centers close
         old_cx = (old_roi.xmin + old_roi.xmax) / 2
@@ -192,7 +205,10 @@ class JdavizViewerMixin(WithCache):
         new_cx = (new_roi.xmin + new_roi.xmax) / 2
         new_cy = (new_roi.ymin + new_roi.ymax) / 2
         dist = norm([new_cx - old_cx, new_cy - old_cy])
-        return dist < size
+        resize = dist < size
+
+        # xor
+        return move != resize
 
     def _is_roi_edit(self, old_roi, new_roi):
         """
@@ -230,7 +246,7 @@ class JdavizViewerMixin(WithCache):
         return False
 
     @staticmethod
-    def _is_range_edit(roi, existing_state, rtol=1e-6):
+    def _is_range_edit(old_range, new_range, rtol=1e-6):
         """
         Detect resize or move for 1-D range subsets.
 
@@ -250,18 +266,23 @@ class JdavizViewerMixin(WithCache):
         is_edit : bool
             True if the change is a resize or move operation.
         """
-        if not (hasattr(roi, 'min') and hasattr(roi, 'max')):
+        if not (hasattr(new_range, 'min') and hasattr(new_range, 'max')):
             return False
-        new_w = roi.max - roi.min
-        old_w = existing_state.hi - existing_state.lo
-        new_mid = (roi.min + roi.max) / 2
 
-        # Resize: midpoint inside old range
-        if existing_state.lo <= new_mid <= existing_state.hi:
-            return True
+        old_w = old_range.hi - old_range.lo
+        new_w = new_range.max - new_range.min
+        # Zero or negative width not allowed
+        if old_w <= 0 or new_w <= 0:
+            return False
 
+        # Resize: one endpoint fixed, xor
+        resize = True if ((old_range.lo == new_range.min) !=
+                          (old_range.hi == new_range.max)) else False
         # Move: same width
-        return abs(new_w - old_w) < rtol * max(abs(old_w), 1)
+        move = True if abs(new_w - old_w) < (rtol * max(abs(old_w), 1)) else False
+
+        # xor
+        return move != resize
 
     def apply_roi(self, roi, use_current=False):
         """

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -289,7 +289,7 @@ class JdavizViewerMixin(WithCache):
                 if isinstance(existing_state, RoiSubsetState):
                     needs_override = self._is_roi_edit(existing_state.roi, roi)
                 elif isinstance(existing_state, RangeSubsetState):
-                    needs_override = self._is_range_edit(roi, existing_state)
+                    needs_override = self._is_range_edit(existing_state, roi)
             except Exception as e:  # noqa
                 raise e
 

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -126,10 +126,8 @@ class JdavizViewerMixin(WithCache):
         radius of each other.
         """
         # Move: same inner and outer radius
-        if (abs(old_roi.inner_radius - new_roi.inner_radius)
-                < rtol * max(old_roi.inner_radius, 1)
-                and abs(old_roi.outer_radius - new_roi.outer_radius)
-                < rtol * max(old_roi.outer_radius, 1)):
+        if (abs(old_roi.inner_radius - new_roi.inner_radius) < rtol * max(old_roi.inner_radius, 1)
+                and abs(old_roi.outer_radius - new_roi.outer_radius) < rtol * max(old_roi.outer_radius, 1)):  # noqa
             return True
 
         # Resize: centers close
@@ -149,10 +147,8 @@ class JdavizViewerMixin(WithCache):
         each other.
         """
         # Move: same radii
-        if (abs(old_roi.radius_x - new_roi.radius_x)
-                < rtol * max(old_roi.radius_x, 1)
-                and abs(old_roi.radius_y - new_roi.radius_y)
-                < rtol * max(old_roi.radius_y, 1)):
+        if (abs(old_roi.radius_x - new_roi.radius_x) < rtol * max(old_roi.radius_x, 1)
+                and abs(old_roi.radius_y - new_roi.radius_y) < rtol * max(old_roi.radius_y, 1)):
             return True
 
         # Resize: centers close
@@ -213,16 +209,14 @@ class JdavizViewerMixin(WithCache):
         from glue.core.roi import (CircularAnnulusROI, CircularROI,
                                    EllipticalROI, RectangularROI)
 
-        if not (isinstance(new_roi, type(old_roi))
-                or isinstance(old_roi, type(new_roi))):
+        if not isinstance(new_roi, type(old_roi)) or isinstance(old_roi, type(new_roi)):
             return False
 
-        # Use isinstance so subclasses (e.g. TrueCircularROI)
-        # are matched to their parent handler.
-        dispatch = ((CircularAnnulusROI, self._is_annulus_edit),
+        # match ROI classes to handler
+        dispatch = [(CircularAnnulusROI, self._is_annulus_edit),
                     (CircularROI, self._is_circular_edit),
                     (EllipticalROI, self._is_elliptical_edit),
-                    (RectangularROI, self._is_rectangular_edit))
+                    (RectangularROI, self._is_rectangular_edit)]
 
         for roi_type, handler in dispatch:
             if isinstance(old_roi, roi_type):

--- a/jdaviz/configs/default/tests/test_data_menu.py
+++ b/jdaviz/configs/default/tests/test_data_menu.py
@@ -367,7 +367,7 @@ class TestResizeSubset:
         # Create two subsets
         self.imviz_viewer.apply_roi(CircularROI(xc=3, yc=3, radius=2))
         self.imviz_subset_tools.combination_mode = 'new'
-        self.imviz_viewer.apply_roi(CircularROI(xc=7, yc=7, radius=2))
+        self.imviz_viewer.apply_roi(CircularROI(xc=7, yc=7, radius=3))
 
         # Select both subsets
         self.imviz_dm.layer.selected = ['Subset 1', 'Subset 2']

--- a/jdaviz/configs/default/tests/test_viewers.py
+++ b/jdaviz/configs/default/tests/test_viewers.py
@@ -5,13 +5,11 @@ in the deconfigged configuration.
 """
 
 import pytest
-from glue.core.roi import (
-    CircularAnnulusROI,
-    CircularROI,
-    EllipticalROI,
-    RectangularROI,
-    XRangeROI,
-)
+from glue.core.roi import (CircularAnnulusROI,
+                           CircularROI,
+                           EllipticalROI,
+                           RectangularROI,
+                           XRangeROI)
 from glue.core.subset import RangeSubsetState
 from glue_jupyter.bqplot.common.tools import TrueCircularROI
 

--- a/jdaviz/configs/default/tests/test_viewers.py
+++ b/jdaviz/configs/default/tests/test_viewers.py
@@ -23,12 +23,28 @@ from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
 
 class TestROIEdits:
     """
-    Tests for all types of ROI edits.
+    Unit tests for all types of ROI edits as well as
+    app testing.
     """
-
     @pytest.fixture(autouse=True)
-    def setup_class(self):
+    def setup_class(self, deconfigged_helper, image_hdu_wcs, spectrum1d):
         self.JVM = JdavizViewerMixin
+        deconfigged_helper.load(image_hdu_wcs, format='Image')
+        deconfigged_helper.load(spectrum1d, format='1D Spectrum')
+
+        self.app = deconfigged_helper
+        self.image_viewer = deconfigged_helper.app.get_viewer('Image')
+        self.spectrum_viewer = deconfigged_helper.app.get_viewer('1D Spectrum')
+        print(dir(self.spectrum_viewer))
+
+    def _subset_count(self):
+        return len(self.app.plugins['Subset Tools'].get_regions())
+
+    # def _active_subset_state(self):
+    #     esm = self.viewer.session.edit_subset_mode
+    #     if esm.edit_subset:
+    #         return esm.edit_subset[0].subset_state
+    #     return None
 
     # ---------------------------------------------------------------------------
     # _is_circular_edit
@@ -41,16 +57,37 @@ class TestROIEdits:
          (40, 40, 3, False)]  # new draw (move and resize)
     )
     def test_circular_roi_edit(self, delta_xc, delta_yc, delta_r, validity):
-        old = CircularROI(xc=10, yc=10, radius=5)
-        new = CircularROI(xc=old.xc + delta_xc, yc=old.yc + delta_yc, radius=old.radius + delta_r)
-        assert self.JVM._is_circular_edit(old, new) == validity
-        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
 
         # Test with zero initial radius, always False since any change would be a new draw
         old = CircularROI(xc=10, yc=10, radius=0)
         new = CircularROI(xc=old.xc + delta_xc, yc=old.yc + delta_yc, radius=old.radius + delta_r)
         assert not self.JVM._is_circular_edit(old, new)
         assert not self.JVM._is_roi_edit(self.JVM, old, new)
+
+        # Check subclass
+        old = TrueCircularROI(xc=10, yc=10, radius=5)
+        new = TrueCircularROI(xc=old.xc + delta_xc,
+                              yc=old.yc + delta_yc,
+                              radius=old.radius + delta_r)
+        assert self.JVM._is_circular_edit(old, new) == validity
+        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
+
+        old = CircularROI(xc=10, yc=10, radius=5)
+        new = CircularROI(xc=old.xc + delta_xc, yc=old.yc + delta_yc, radius=old.radius + delta_r)
+        assert self.JVM._is_circular_edit(old, new) == validity
+        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
+
+        # Test in app behavior: resize, move, and new draw.
+        # Draw initial roi and verify count
+        self.image_viewer.apply_roi(old)
+        assert self._subset_count() == 1
+
+        self.image_viewer.apply_roi(new)
+        assert self._subset_count() == (1 if validity else 2)
+
+        different_roi = CircularROI(xc=100, yc=100, radius=2)
+        self.image_viewer.apply_roi(different_roi)
+        assert self._subset_count() == (2 if validity else 3)
 
     # ---------------------------------------------------------------------------
     # _is_annulus_edit AND _is_elliptical_edit (same logic for both, just different parameters)
@@ -65,14 +102,6 @@ class TestROIEdits:
          (40, 40, 0, 2, False)]  # different outer/y radius
     )
     def test_annulus_elliptical_roi_edit(self, delta_xc, delta_yc, delta_ixr, delta_oyr, validity):
-        old = CircularAnnulusROI(xc=10, yc=10, inner_radius=3, outer_radius=6)
-        new = CircularAnnulusROI(xc=old.xc + delta_xc,
-                                 yc=old.yc + delta_yc,
-                                 inner_radius=old.inner_radius + delta_ixr,
-                                 outer_radius=old.outer_radius + delta_oyr)
-        assert self.JVM._is_annulus_edit(old, new) == validity
-        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
-
         # Test with zero initial outer radius and smaller initial outer radius,
         # always False since any change would be a new draw
         for old_ir, old_or in ((0, 0), (1, 0)):
@@ -84,18 +113,29 @@ class TestROIEdits:
             assert not self.JVM._is_annulus_edit(old, new)
             assert not self.JVM._is_roi_edit(self.JVM, old, new)
 
+        old = CircularAnnulusROI(xc=10, yc=10, inner_radius=3, outer_radius=6)
+        new = CircularAnnulusROI(xc=old.xc + delta_xc,
+                                 yc=old.yc + delta_yc,
+                                 inner_radius=old.inner_radius + delta_ixr,
+                                 outer_radius=old.outer_radius + delta_oyr)
+        assert self.JVM._is_annulus_edit(old, new) == validity
+        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
+
+        # Test in app behavior: resize, move, and new draw.
+        # Draw initial roi and verify count
+        self.image_viewer.apply_roi(old)
+        assert self._subset_count() == 1
+
+        self.image_viewer.apply_roi(new)
+        assert self._subset_count() == (1 if validity else 2)
+
+        different_roi = CircularAnnulusROI(xc=100, yc=100, inner_radius=2, outer_radius=4)
+        self.image_viewer.apply_roi(different_roi)
+        assert self._subset_count() == (2 if validity else 3)
+
         # ---------------------------------------------------------------------------
         # _is_elliptical_edit
         # ---------------------------------------------------------------------------
-
-        old = EllipticalROI(xc=10, yc=10, radius_x=3, radius_y=6)
-        new = EllipticalROI(xc=old.xc + delta_xc,
-                            yc=old.yc + delta_yc,
-                            radius_x=old.radius_x + delta_ixr,
-                            radius_y=old.radius_y + delta_oyr)
-        assert self.JVM._is_elliptical_edit(old, new) == validity
-        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
-
         # Test with zero initial x/y radius
         for i, j in ((0, 1), (1, 0)):
             old = EllipticalROI(xc=10, yc=10, radius_x=i, radius_y=j)
@@ -105,6 +145,27 @@ class TestROIEdits:
                                 radius_y=old.radius_y + delta_oyr)
             assert not self.JVM._is_elliptical_edit(old, new)
             assert not self.JVM._is_roi_edit(self.JVM, old, new)
+
+        old = EllipticalROI(xc=10, yc=10, radius_x=3, radius_y=6)
+        new = EllipticalROI(xc=old.xc + delta_xc,
+                            yc=old.yc + delta_yc,
+                            radius_x=old.radius_x + delta_ixr,
+                            radius_y=old.radius_y + delta_oyr)
+        assert self.JVM._is_elliptical_edit(old, new) == validity
+        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
+
+        # Test in app behavior: resize, move, and new draw.
+        # Draw initial roi and verify count
+        annulus_count = self._subset_count()
+        self.image_viewer.apply_roi(old)
+        assert self._subset_count() == annulus_count + 1
+
+        self.image_viewer.apply_roi(new)
+        assert self._subset_count() == (annulus_count + (1 if validity else 2))
+
+        different_roi = EllipticalROI(xc=100, yc=100, radius_x=2, radius_y=4)
+        self.image_viewer.apply_roi(different_roi)
+        assert self._subset_count() == (annulus_count + (2 if validity else 3))
 
     # ---------------------------------------------------------------------------
     # _is_rectangular_edit
@@ -117,14 +178,6 @@ class TestROIEdits:
     )
     def test_rectangle_resize_same_center(self, delta_xmin, delta_xmax, delta_ymin, delta_ymax,
                                           validity):
-        old = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
-        new = RectangularROI(xmin=old.xmin + delta_xmin,
-                             xmax=old.xmax + delta_xmax,
-                             ymin=old.ymin + delta_ymin,
-                             ymax=old.ymax + delta_ymax)
-        assert self.JVM._is_rectangular_edit(old, new) == validity
-        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
-
         # Test with zero size
         for xmax, ymax in ((0, 1), (1, 0)):
             old = RectangularROI(xmin=0, xmax=xmax, ymin=0, ymax=ymax)
@@ -134,6 +187,26 @@ class TestROIEdits:
                                  ymax=old.ymax + delta_ymax)
             assert not self.JVM._is_rectangular_edit(old, new)
             assert not self.JVM._is_roi_edit(self.JVM, old, new)
+
+        old = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
+        new = RectangularROI(xmin=old.xmin + delta_xmin,
+                             xmax=old.xmax + delta_xmax,
+                             ymin=old.ymin + delta_ymin,
+                             ymax=old.ymax + delta_ymax)
+        assert self.JVM._is_rectangular_edit(old, new) == validity
+        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
+
+        # Test in app behavior: resize, move, and new draw.
+        # Draw initial roi and verify count
+        self.image_viewer.apply_roi(old)
+        assert self._subset_count() == 1
+
+        self.image_viewer.apply_roi(new)
+        assert self._subset_count() == (1 if validity else 2)
+
+        different_roi = RectangularROI(xmin=100, xmax=150, ymin=100, ymax=150)
+        self.image_viewer.apply_roi(different_roi)
+        assert self._subset_count() == (2 if validity else 3)
 
     # ---------------------------------------------------------------------------
     # _is_roi_edit  (dispatcher)
@@ -160,161 +233,21 @@ class TestROIEdits:
     )
     def test_range_edits(self, delta_min, delta_max, validity):
         old_rss = RangeSubsetState(lo=10, hi=20)
-        new_roi = XRangeROI(old_rss.lo + delta_min, old_rss.hi + delta_max)
+        new_roi = XRangeROI(min=old_rss.lo + delta_min, max=old_rss.hi + delta_max)
         assert self.JVM._is_range_edit(old_rss, new_roi) == validity
+
+        # Test in app behavior: resize, move, and new draw.
+        # Draw initial roi and verify count
+        # self.spectrum_viewer.apply_roi(old_rss)
+        # assert self._subset_count() == 1
+        #
+        # self.spectrum_viewer.apply_roi(new_roi)
+        # assert self._subset_count() == (1 if validity else 2)
+        #
+        # different_roi = XRangeROI(min=100, max=150)
+        # self.spectrum_viewer.apply_roi(different_roi)
+        # assert self._subset_count() == (2 if validity else 3)
 
     def test_range_no_min_max_attributes(self):
         rss = RangeSubsetState(lo=10, hi=20)
         assert not self.JVM._is_range_edit(object(), rss)
-
-# ---------------------------------------------------------------------------
-# Programmatic test: apply_roi in deconfigged
-# ---------------------------------------------------------------------------
-
-
-class TestDeconfiggedSubsetEditInPlace:
-    """
-    End-to-end test verifying that resize and move operations in
-    deconfigged modify subsets in-place, while new draws create
-    new subsets.
-    """
-
-    @pytest.fixture(autouse=True)
-    def setup_method(self, deconfigged_helper, image_2d_wcs):
-        """
-        Set up deconfigged app with a 100x100 image.
-        """
-        arr = np.ones((100, 100))
-        ndd = NDData(arr, wcs=image_2d_wcs)
-        deconfigged_helper.load(ndd, data_label='test_image')
-        self.app = deconfigged_helper
-        self.viewer = list(
-            deconfigged_helper.app.get_viewers_of_cls('ImvizImageView')
-        )[0]
-
-    def _subset_count(self):
-        return len(self.app.app.data_collection.subset_groups)
-
-    def _active_subset_state(self):
-        esm = self.viewer.session.edit_subset_mode
-        if esm.edit_subset:
-            return esm.edit_subset[0].subset_state
-        return None
-
-    def test_draw_creates_new_subset(self):
-        """
-        Drawing a circle should create a new subset.
-        """
-        self.viewer.apply_roi(CircularROI(xc=50, yc=50, radius=10))
-        assert self._subset_count() == 1
-
-    def test_resize_modifies_in_place(self):
-        """
-        Resizing (same center, different radius) should modify
-        the existing subset rather than creating a second one.
-        """
-        self.viewer.apply_roi(CircularROI(xc=50, yc=50, radius=10))
-        self.viewer.apply_roi(CircularROI(xc=50, yc=50, radius=15))
-        assert self._subset_count() == 1
-        assert np.isclose(self._active_subset_state().roi.radius, 15)
-
-    def test_move_modifies_in_place(self):
-        """
-        Moving (same radius, different center) should modify
-        the existing subset rather than creating a second one.
-        """
-        self.viewer.apply_roi(CircularROI(xc=50, yc=50, radius=10))
-        self.viewer.apply_roi(CircularROI(xc=60, yc=55, radius=10))
-        assert self._subset_count() == 1
-        assert np.isclose(self._active_subset_state().roi.xc, 60)
-
-    def test_new_draw_elsewhere_creates_second_subset(self):
-        """
-        Drawing a differently sized region far away should create
-        a new subset, not modify the existing one.
-        """
-        self.viewer.apply_roi(CircularROI(xc=20, yc=20, radius=5))
-        self.viewer.apply_roi(CircularROI(xc=80, yc=80, radius=12))
-        assert self._subset_count() == 2
-
-    def test_annulus_resize_in_place(self):
-        """
-        Resizing an annulus should modify it in-place (regression
-        for the center-in-hole bug).
-        """
-        self.viewer.apply_roi(
-            CircularAnnulusROI(xc=50, yc=50, inner_radius=5, outer_radius=10)
-        )
-        self.viewer.apply_roi(
-            CircularAnnulusROI(xc=50, yc=50, inner_radius=7, outer_radius=14)
-        )
-        assert self._subset_count() == 1
-
-    def test_annulus_move_in_place(self):
-        """
-        Moving an annulus should modify it in-place.
-        """
-        self.viewer.apply_roi(
-            CircularAnnulusROI(xc=50, yc=50, inner_radius=5, outer_radius=10)
-        )
-        self.viewer.apply_roi(
-            CircularAnnulusROI(xc=60, yc=55, inner_radius=5, outer_radius=10)
-        )
-        assert self._subset_count() == 1
-
-    def test_rectangle_resize_in_place(self):
-        """
-        Resizing a rectangle should modify it in-place.
-        """
-        self.viewer.apply_roi(RectangularROI(xmin=40, xmax=60, ymin=40, ymax=60))
-        self.viewer.apply_roi(RectangularROI(xmin=35, xmax=65, ymin=35, ymax=65))
-        assert self._subset_count() == 1
-
-    def test_rectangle_move_in_place(self):
-        """
-        Moving a rectangle should modify it in-place.
-        """
-        self.viewer.apply_roi(RectangularROI(xmin=40, xmax=60, ymin=40, ymax=60))
-        self.viewer.apply_roi(RectangularROI(xmin=50, xmax=70, ymin=50, ymax=70))
-        assert self._subset_count() == 1
-
-    def test_mode_restored_after_override(self):
-        """
-        After an in-place edit the mode should remain NewMode so
-        that subsequent new draws still create new subsets.
-        """
-        esm = self.viewer.session.edit_subset_mode
-        self.viewer.apply_roi(CircularROI(xc=50, yc=50, radius=10))
-        self.viewer.apply_roi(CircularROI(xc=50, yc=50, radius=15))
-        assert esm.mode is NewMode
-
-    def test_multiple_subsets_then_edit(self):
-        """
-        Create two subsets, then resize the second; only the
-        second should be modified.
-        """
-        self.viewer.apply_roi(CircularROI(xc=20, yc=20, radius=5))
-        self.viewer.apply_roi(CircularROI(xc=80, yc=80, radius=12))
-        assert self._subset_count() == 2
-        self.viewer.apply_roi(CircularROI(xc=80, yc=80, radius=18))
-        assert self._subset_count() == 2
-
-    def test_true_circular_resize_in_place(self):
-        """
-        TrueCircularROI (from bqplot:truecircle) should resize
-        in-place just like CircularROI.
-        """
-        self.viewer.apply_roi(TrueCircularROI(xc=50, yc=50, radius=10))
-        self.viewer.apply_roi(TrueCircularROI(xc=50, yc=50, radius=15))
-        assert self._subset_count() == 1
-        assert np.isclose(self._active_subset_state().roi.radius, 15)
-
-    def test_true_circular_move_in_place(self):
-        """
-        TrueCircularROI (from bqplot:truecircle) should move
-        in-place just like CircularROI.
-        """
-        self.viewer.apply_roi(TrueCircularROI(xc=50, yc=50, radius=10))
-        self.viewer.apply_roi(TrueCircularROI(xc=60, yc=55, radius=10))
-        assert self._subset_count() == 1
-        assert np.isclose(self._active_subset_state().roi.xc, 60)

--- a/jdaviz/configs/default/tests/test_viewers.py
+++ b/jdaviz/configs/default/tests/test_viewers.py
@@ -1,0 +1,372 @@
+"""
+Tests for JdavizViewerMixin ROI edit-detection helpers and the
+``apply_roi`` override that lets users resize/move subsets in-place
+in the deconfigged configuration.
+"""
+
+import numpy as np
+import pytest
+from astropy.nddata import NDData
+from glue.core.edit_subset_mode import NewMode
+from glue.core.roi import (
+    CircularAnnulusROI,
+    CircularROI,
+    EllipticalROI,
+    RectangularROI,
+    XRangeROI,
+)
+from glue_jupyter.bqplot.common.tools import TrueCircularROI
+
+from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
+
+_M = JdavizViewerMixin
+
+
+# ---------------------------------------------------------------------------
+# _is_circular_edit
+# ---------------------------------------------------------------------------
+
+class TestIsCircularEdit:
+    """
+    Tests for ``JdavizViewerMixin._is_circular_edit``.
+    """
+
+    def test_resize_same_center(self):
+        old = CircularROI(xc=10, yc=10, radius=5)
+        new = CircularROI(xc=10, yc=10, radius=8)
+        assert _M._is_circular_edit(old, new)
+
+    def test_resize_center_within_radius(self):
+        old = CircularROI(xc=10, yc=10, radius=5)
+        new = CircularROI(xc=12, yc=10, radius=8)
+        assert _M._is_circular_edit(old, new)
+
+    def test_move_same_radius(self):
+        old = CircularROI(xc=10, yc=10, radius=5)
+        new = CircularROI(xc=50, yc=50, radius=5)
+        assert _M._is_circular_edit(old, new)
+
+    def test_new_draw(self):
+        old = CircularROI(xc=10, yc=10, radius=5)
+        new = CircularROI(xc=50, yc=50, radius=12)
+        assert not _M._is_circular_edit(old, new)
+
+    def test_zero_radius(self):
+        old = CircularROI(xc=10, yc=10, radius=0)
+        new = CircularROI(xc=10, yc=10, radius=5)
+        assert not _M._is_circular_edit(old, new)
+
+
+# ---------------------------------------------------------------------------
+# _is_annulus_edit
+# ---------------------------------------------------------------------------
+
+class TestIsAnnulusEdit:
+    """
+    Tests for ``JdavizViewerMixin._is_annulus_edit``.
+    """
+
+    def test_resize_same_center(self):
+        old = CircularAnnulusROI(xc=10, yc=10, inner_radius=3, outer_radius=6)
+        new = CircularAnnulusROI(xc=10, yc=10, inner_radius=4, outer_radius=8)
+        assert _M._is_annulus_edit(old, new)
+
+    def test_move_same_radii(self):
+        old = CircularAnnulusROI(xc=10, yc=10, inner_radius=3, outer_radius=6)
+        new = CircularAnnulusROI(xc=50, yc=50, inner_radius=3, outer_radius=6)
+        assert _M._is_annulus_edit(old, new)
+
+    def test_new_draw(self):
+        old = CircularAnnulusROI(xc=10, yc=10, inner_radius=3, outer_radius=6)
+        new = CircularAnnulusROI(xc=50, yc=50, inner_radius=5, outer_radius=10)
+        assert not _M._is_annulus_edit(old, new)
+
+    def test_different_inner_only(self):
+        old = CircularAnnulusROI(xc=10, yc=10, inner_radius=3, outer_radius=6)
+        new = CircularAnnulusROI(xc=50, yc=50, inner_radius=4, outer_radius=6)
+        assert not _M._is_annulus_edit(old, new)
+
+    def test_zero_outer_radius(self):
+        old = CircularAnnulusROI(xc=10, yc=10, inner_radius=0, outer_radius=0)
+        new = CircularAnnulusROI(xc=10, yc=10, inner_radius=2, outer_radius=5)
+        assert not _M._is_annulus_edit(old, new)
+
+
+# ---------------------------------------------------------------------------
+# _is_elliptical_edit
+# ---------------------------------------------------------------------------
+
+class TestIsEllipticalEdit:
+    """
+    Tests for ``JdavizViewerMixin._is_elliptical_edit``.
+    """
+
+    def test_resize_same_center(self):
+        old = EllipticalROI(xc=10, yc=10, radius_x=5, radius_y=3)
+        new = EllipticalROI(xc=10, yc=10, radius_x=8, radius_y=6)
+        assert _M._is_elliptical_edit(old, new)
+
+    def test_move_same_radii(self):
+        old = EllipticalROI(xc=10, yc=10, radius_x=5, radius_y=3)
+        new = EllipticalROI(xc=50, yc=50, radius_x=5, radius_y=3)
+        assert _M._is_elliptical_edit(old, new)
+
+    def test_new_draw(self):
+        old = EllipticalROI(xc=10, yc=10, radius_x=5, radius_y=3)
+        new = EllipticalROI(xc=50, yc=50, radius_x=8, radius_y=6)
+        assert not _M._is_elliptical_edit(old, new)
+
+
+# ---------------------------------------------------------------------------
+# _is_rectangular_edit
+# ---------------------------------------------------------------------------
+
+class TestIsRectangularEdit:
+    """
+    Tests for ``JdavizViewerMixin._is_rectangular_edit``.
+    """
+
+    def test_resize_same_center(self):
+        old = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
+        new = RectangularROI(xmin=-2, xmax=12, ymin=-2, ymax=12)
+        assert _M._is_rectangular_edit(old, new)
+
+    def test_move_same_size(self):
+        old = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
+        new = RectangularROI(xmin=50, xmax=60, ymin=50, ymax=60)
+        assert _M._is_rectangular_edit(old, new)
+
+    def test_new_draw(self):
+        old = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
+        new = RectangularROI(xmin=50, xmax=80, ymin=50, ymax=80)
+        assert not _M._is_rectangular_edit(old, new)
+
+
+# ---------------------------------------------------------------------------
+# _is_roi_edit  (dispatcher)
+# ---------------------------------------------------------------------------
+
+class TestIsRoiEdit:
+    """
+    Tests for the ``_is_roi_edit`` dispatch method.
+    """
+
+    def test_dispatches_circular(self):
+        old = CircularROI(xc=10, yc=10, radius=5)
+        new = CircularROI(xc=10, yc=10, radius=8)
+        assert _M._is_roi_edit(_M, old, new)
+
+    def test_dispatches_true_circular(self):
+        old = TrueCircularROI(xc=10, yc=10, radius=5)
+        new = TrueCircularROI(xc=10, yc=10, radius=8)
+        assert _M._is_roi_edit(_M, old, new)
+
+    def test_dispatches_true_circular_move(self):
+        old = TrueCircularROI(xc=10, yc=10, radius=5)
+        new = TrueCircularROI(xc=50, yc=50, radius=5)
+        assert _M._is_roi_edit(_M, old, new)
+
+    def test_dispatches_annulus(self):
+        old = CircularAnnulusROI(xc=10, yc=10, inner_radius=3, outer_radius=6)
+        new = CircularAnnulusROI(xc=10, yc=10, inner_radius=4, outer_radius=8)
+        assert _M._is_roi_edit(_M, old, new)
+
+    def test_dispatches_elliptical(self):
+        old = EllipticalROI(xc=10, yc=10, radius_x=5, radius_y=3)
+        new = EllipticalROI(xc=50, yc=50, radius_x=5, radius_y=3)
+        assert _M._is_roi_edit(_M, old, new)
+
+    def test_dispatches_rectangular(self):
+        old = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
+        new = RectangularROI(xmin=50, xmax=60, ymin=50, ymax=60)
+        assert _M._is_roi_edit(_M, old, new)
+
+    def test_different_types_returns_false(self):
+        old = CircularROI(xc=10, yc=10, radius=5)
+        new = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
+        assert not _M._is_roi_edit(_M, old, new)
+
+    def test_unsupported_type_returns_false(self):
+        assert not _M._is_roi_edit(_M, object(), object())
+
+
+# ---------------------------------------------------------------------------
+# _is_range_edit
+# ---------------------------------------------------------------------------
+
+class TestIsRangeEdit:
+    """
+    Tests for ``JdavizViewerMixin._is_range_edit``.
+    """
+
+    @pytest.fixture()
+    def _make_state(self):
+        from glue.core.subset import RangeSubsetState
+        return RangeSubsetState(lo=10, hi=20)
+
+    def test_resize_midpoint_inside(self, _make_state):
+        roi = XRangeROI(12, 22)
+        assert _M._is_range_edit(roi, _make_state)
+
+    def test_move_same_width(self, _make_state):
+        roi = XRangeROI(25, 35)
+        assert _M._is_range_edit(roi, _make_state)
+
+    def test_new_draw(self, _make_state):
+        roi = XRangeROI(50, 80)
+        assert not _M._is_range_edit(roi, _make_state)
+
+    def test_no_min_max_attributes(self, _make_state):
+        assert not _M._is_range_edit(object(), _make_state)
+
+
+# ---------------------------------------------------------------------------
+# Programmatic test: apply_roi in deconfigged
+# ---------------------------------------------------------------------------
+
+class TestDeconfiggedSubsetEditInPlace:
+    """
+    End-to-end test verifying that resize and move operations in
+    deconfigged modify subsets in-place, while new draws create
+    new subsets.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self, deconfigged_helper, image_2d_wcs):
+        """
+        Set up deconfigged app with a 100x100 image.
+        """
+        arr = np.ones((100, 100))
+        ndd = NDData(arr, wcs=image_2d_wcs)
+        deconfigged_helper.load(ndd, data_label='test_image')
+        self.app = deconfigged_helper
+        self.viewer = list(
+            deconfigged_helper.app.get_viewers_of_cls('ImvizImageView')
+        )[0]
+
+    def _subset_count(self):
+        return len(self.app.app.data_collection.subset_groups)
+
+    def _active_subset_state(self):
+        esm = self.viewer.session.edit_subset_mode
+        if esm.edit_subset:
+            return esm.edit_subset[0].subset_state
+        return None
+
+    def test_draw_creates_new_subset(self):
+        """
+        Drawing a circle should create a new subset.
+        """
+        self.viewer.apply_roi(CircularROI(xc=50, yc=50, radius=10))
+        assert self._subset_count() == 1
+
+    def test_resize_modifies_in_place(self):
+        """
+        Resizing (same center, different radius) should modify
+        the existing subset rather than creating a second one.
+        """
+        self.viewer.apply_roi(CircularROI(xc=50, yc=50, radius=10))
+        self.viewer.apply_roi(CircularROI(xc=50, yc=50, radius=15))
+        assert self._subset_count() == 1
+        assert np.isclose(self._active_subset_state().roi.radius, 15)
+
+    def test_move_modifies_in_place(self):
+        """
+        Moving (same radius, different center) should modify
+        the existing subset rather than creating a second one.
+        """
+        self.viewer.apply_roi(CircularROI(xc=50, yc=50, radius=10))
+        self.viewer.apply_roi(CircularROI(xc=60, yc=55, radius=10))
+        assert self._subset_count() == 1
+        assert np.isclose(self._active_subset_state().roi.xc, 60)
+
+    def test_new_draw_elsewhere_creates_second_subset(self):
+        """
+        Drawing a differently sized region far away should create
+        a new subset, not modify the existing one.
+        """
+        self.viewer.apply_roi(CircularROI(xc=20, yc=20, radius=5))
+        self.viewer.apply_roi(CircularROI(xc=80, yc=80, radius=12))
+        assert self._subset_count() == 2
+
+    def test_annulus_resize_in_place(self):
+        """
+        Resizing an annulus should modify it in-place (regression
+        for the center-in-hole bug).
+        """
+        self.viewer.apply_roi(
+            CircularAnnulusROI(xc=50, yc=50, inner_radius=5, outer_radius=10)
+        )
+        self.viewer.apply_roi(
+            CircularAnnulusROI(xc=50, yc=50, inner_radius=7, outer_radius=14)
+        )
+        assert self._subset_count() == 1
+
+    def test_annulus_move_in_place(self):
+        """
+        Moving an annulus should modify it in-place.
+        """
+        self.viewer.apply_roi(
+            CircularAnnulusROI(xc=50, yc=50, inner_radius=5, outer_radius=10)
+        )
+        self.viewer.apply_roi(
+            CircularAnnulusROI(xc=60, yc=55, inner_radius=5, outer_radius=10)
+        )
+        assert self._subset_count() == 1
+
+    def test_rectangle_resize_in_place(self):
+        """
+        Resizing a rectangle should modify it in-place.
+        """
+        self.viewer.apply_roi(RectangularROI(xmin=40, xmax=60, ymin=40, ymax=60))
+        self.viewer.apply_roi(RectangularROI(xmin=35, xmax=65, ymin=35, ymax=65))
+        assert self._subset_count() == 1
+
+    def test_rectangle_move_in_place(self):
+        """
+        Moving a rectangle should modify it in-place.
+        """
+        self.viewer.apply_roi(RectangularROI(xmin=40, xmax=60, ymin=40, ymax=60))
+        self.viewer.apply_roi(RectangularROI(xmin=50, xmax=70, ymin=50, ymax=70))
+        assert self._subset_count() == 1
+
+    def test_mode_restored_after_override(self):
+        """
+        After an in-place edit the mode should remain NewMode so
+        that subsequent new draws still create new subsets.
+        """
+        esm = self.viewer.session.edit_subset_mode
+        self.viewer.apply_roi(CircularROI(xc=50, yc=50, radius=10))
+        self.viewer.apply_roi(CircularROI(xc=50, yc=50, radius=15))
+        assert esm.mode is NewMode
+
+    def test_multiple_subsets_then_edit(self):
+        """
+        Create two subsets, then resize the second; only the
+        second should be modified.
+        """
+        self.viewer.apply_roi(CircularROI(xc=20, yc=20, radius=5))
+        self.viewer.apply_roi(CircularROI(xc=80, yc=80, radius=12))
+        assert self._subset_count() == 2
+        self.viewer.apply_roi(CircularROI(xc=80, yc=80, radius=18))
+        assert self._subset_count() == 2
+
+    def test_true_circular_resize_in_place(self):
+        """
+        TrueCircularROI (from bqplot:truecircle) should resize
+        in-place just like CircularROI.
+        """
+        self.viewer.apply_roi(TrueCircularROI(xc=50, yc=50, radius=10))
+        self.viewer.apply_roi(TrueCircularROI(xc=50, yc=50, radius=15))
+        assert self._subset_count() == 1
+        assert np.isclose(self._active_subset_state().roi.radius, 15)
+
+    def test_true_circular_move_in_place(self):
+        """
+        TrueCircularROI (from bqplot:truecircle) should move
+        in-place just like CircularROI.
+        """
+        self.viewer.apply_roi(TrueCircularROI(xc=50, yc=50, radius=10))
+        self.viewer.apply_roi(TrueCircularROI(xc=60, yc=55, radius=10))
+        assert self._subset_count() == 1
+        assert np.isclose(self._active_subset_state().roi.xc, 60)

--- a/jdaviz/configs/default/tests/test_viewers.py
+++ b/jdaviz/configs/default/tests/test_viewers.py
@@ -32,22 +32,23 @@ class TestROIEdits:
     # _is_circular_edit
     # ---------------------------------------------------------------------------
     @pytest.mark.parametrize(
-        ('delta_xc', 'delta_yc', 'delta_r', 'validity'),  # validity is (is_move, is_resize)
-        [(0, 0, 3, (False, True)),  # resize same center
-         (2, 0, 3, (False, True)),  # resize center within radius
-         (40, 40, 0, (True, False)),  # move same radius
-         (40, 40, 3, (False, False))]  # new draw (move and resize)
+        ('delta_xc', 'delta_yc', 'delta_r', 'validity'),
+        # validity is 'move', 'resize', or None (new draw).
+        [(0, 0, 3, 'resize'),   # same center, radius changed → resize
+         (2, 0, 3, None),       # center moved, radius changed → new draw
+         (40, 40, 0, 'move'),   # same radius, center moved far → move
+         (40, 40, 3, None)]     # center moved far and radius changed → new draw
     )
     def test_circular_roi_edit(self, delta_xc, delta_yc, delta_r, validity,
                                deconfigged_helper, image_hdu_wcs):
 
-        # Test with zero initial radius, always False since any change would be a new draw
+        # Zero initial radius: always None (any change is a new draw).
         old = CircularROI(xc=10, yc=10, radius=0)
         new = CircularROI(xc=old.xc + delta_xc, yc=old.yc + delta_yc, radius=old.radius + delta_r)
-        assert not all(JdavizViewerMixin._is_circular_edit(old, new))
-        assert not all(JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new))
+        assert JdavizViewerMixin._is_circular_edit(old, new) is None
+        assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) is None
 
-        # Check subclass
+        # Check subclass.
         old = TrueCircularROI(xc=10, yc=10, radius=5)
         new = TrueCircularROI(xc=old.xc + delta_xc,
                               yc=old.yc + delta_yc,
@@ -55,7 +56,7 @@ class TestROIEdits:
         assert JdavizViewerMixin._is_circular_edit(old, new) == validity
         assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) == validity
 
-        # Check parent class and use for the app testing
+        # Check parent class and use for the app testing.
         old = CircularROI(xc=10, yc=10, radius=5)
         new = CircularROI(xc=old.xc + delta_xc, yc=old.yc + delta_yc, radius=old.radius + delta_r)
         assert JdavizViewerMixin._is_circular_edit(old, new) == validity
@@ -65,44 +66,75 @@ class TestROIEdits:
         deconfigged_helper.load(image_hdu_wcs, format='Image')
         image_viewer = deconfigged_helper.app.get_viewer('Image')
 
-        # Draw initial roi and verify count
+        # Draw initial roi and verify count.
         image_viewer.apply_roi(old)
         assert self._subset_count(deconfigged_helper) == 1
 
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', UserWarning)
             image_viewer.apply_roi(new)
-        assert self._subset_count(deconfigged_helper) == (1 if any(validity) else 2)
+        assert self._subset_count(deconfigged_helper) == (1 if validity is not None else 2)
 
         different_roi = CircularROI(xc=100, yc=100, radius=2)
         image_viewer.apply_roi(different_roi)
-        assert self._subset_count(deconfigged_helper) == (2 if any(validity) else 3)
+        assert self._subset_count(deconfigged_helper) == (2 if validity is not None else 3)
+
+    def test_circular_small_move_radius_drift(self):
+        """
+        A small center move paired with a slight radius drift must not create a
+        new subset. Because the center barely moved the operation is caught as
+        'resize', not None.
+        """
+        old = CircularROI(xc=10, yc=10, radius=5)
+
+        # 1 % radius drift + tiny center movement → caught as resize.
+        result = JdavizViewerMixin._is_circular_edit(
+            old, CircularROI(xc=10.1, yc=10, radius=5 * 1.01))
+        assert result == 'resize'
+
+        # Drift within rtol=1e-3 → still a move.
+        result2 = JdavizViewerMixin._is_circular_edit(
+            old, CircularROI(xc=10.5, yc=10, radius=5 * (1 + 5e-4)))
+        assert result2 == 'move'
+
+        # Large center movement with radius change → new draw.
+        result3 = JdavizViewerMixin._is_circular_edit(
+            old, CircularROI(xc=old.xc + 3.0, yc=old.yc, radius=old.radius + 1.0))
+        assert result3 is None
+
+        # All results must be valid, never anything unexpected.
+        for dx in (0.1, 1.0, 3.0, 4.9):
+            for dr in (0.0, 0.1, 1.0, 3.0):
+                result = JdavizViewerMixin._is_circular_edit(
+                    old,
+                    CircularROI(xc=old.xc + dx, yc=old.yc, radius=old.radius + dr)
+                )
+                assert result in ('move', 'resize', None), \
+                    f'Unexpected result {result!r} for dx={dx}, dr={dr}'
 
     # ---------------------------------------------------------------------------
-    # _is_annulus_edit AND _is_elliptical_edit (same logic for both, just different parameters)
+    # _is_annulus_edit AND _is_elliptical_edit
     # ---------------------------------------------------------------------------
-
     @pytest.mark.parametrize(
         ('delta_xc', 'delta_yc', 'delta_ixr', 'delta_oyr', 'validity'),
-        [(0, 0, 1, 2, (False, True)),  # resize same center
-         (40, 40, 0, 0, (True, False)),  # move same radii
-         (40, 40, 2, 4, (False, False)),  # new draw (move and resize)
-         (40, 40, 1, 0, (False, False)),  # different inner/x radius
-         (40, 40, 0, 2, (False, False))]  # different outer/y radius
+        [(0, 0, 1, 2, 'resize'),   # same center, radii changed → resize
+         (40, 40, 0, 0, 'move'),   # same radii, center moved far → move
+         (40, 40, 2, 4, None),     # center moved far + radii changed → new draw
+         (40, 40, 1, 0, None),     # center moved far + inner/x radius changed → new draw
+         (40, 40, 0, 2, None)]     # center moved far + outer/y radius changed → new draw
     )
     def test_annulus_elliptical_roi_edit(self, delta_xc, delta_yc, delta_ixr, delta_oyr, validity):
-        # Test with zero initial outer radius and smaller initial outer radius,
-        # always False since any change would be a new draw
+        # Invalid initial outer radius: always None.
         for old_ir, old_or in ((0, 0), (1, 0)):
             old = CircularAnnulusROI(xc=10, yc=10, inner_radius=old_ir, outer_radius=old_or)
             new = CircularAnnulusROI(xc=old.xc + delta_xc,
                                      yc=old.yc + delta_yc,
                                      inner_radius=old.inner_radius + delta_ixr,
                                      outer_radius=old.outer_radius + delta_oyr)
-            assert not all(JdavizViewerMixin._is_annulus_edit(old, new))
-            assert not any(JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new))
+            assert JdavizViewerMixin._is_annulus_edit(old, new) is None
+            assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) is None
 
-        # Check with 'valid' initial parameters
+        # Valid initial parameters.
         old = CircularAnnulusROI(xc=10, yc=10, inner_radius=3, outer_radius=6)
         new = CircularAnnulusROI(xc=old.xc + delta_xc,
                                  yc=old.yc + delta_yc,
@@ -114,17 +146,17 @@ class TestROIEdits:
         # ---------------------------------------------------------------------------
         # _is_elliptical_edit
         # ---------------------------------------------------------------------------
-        # Test with zero initial x/y radius
+        # Invalid (zero) initial x/y radius: always None.
         for i, j in ((0, 1), (1, 0)):
             old = EllipticalROI(xc=10, yc=10, radius_x=i, radius_y=j)
             new = EllipticalROI(xc=old.xc + delta_xc,
                                 yc=old.yc + delta_yc,
                                 radius_x=old.radius_x + delta_ixr,
                                 radius_y=old.radius_y + delta_oyr)
-            assert not all(JdavizViewerMixin._is_elliptical_edit(old, new))
-            assert not all(JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new))
+            assert JdavizViewerMixin._is_elliptical_edit(old, new) is None
+            assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) is None
 
-        # Check with 'valid' initial parameters
+        # Valid initial parameters.
         old = EllipticalROI(xc=10, yc=10, radius_x=3, radius_y=6)
         new = EllipticalROI(xc=old.xc + delta_xc,
                             yc=old.yc + delta_yc,
@@ -138,23 +170,23 @@ class TestROIEdits:
     # ---------------------------------------------------------------------------
     @pytest.mark.parametrize(
         ('delta_xmin', 'delta_xmax', 'delta_ymin', 'delta_ymax', 'validity'),
-        [(-2, 2, -2, 2, (False, True)),  # resize same center
-         (50, 50, 50, 50, (True, False)),  # move same size
-         (50, 70, 50, 70, (False, False))]  # new draw (move and resize)
+        [(-2, 2, -2, 2, 'resize'),   # same center (dist=0), dims changed → resize
+         (50, 50, 50, 50, 'move'),   # same dims, center moved far → move
+         (50, 70, 50, 70, None)]     # dims changed + center far → new draw
     )
     def test_rectangle_resize_same_center(self, delta_xmin, delta_xmax, delta_ymin, delta_ymax,
                                           validity):
-        # Test with zero size
+        # Zero-size rect: always None.
         for xmax, ymax in ((0, 1), (1, 0)):
             old = RectangularROI(xmin=0, xmax=xmax, ymin=0, ymax=ymax)
             new = RectangularROI(xmin=old.xmin + delta_xmin,
                                  xmax=old.xmax + delta_xmax,
                                  ymin=old.ymin + delta_ymin,
                                  ymax=old.ymax + delta_ymax)
-            assert not all(JdavizViewerMixin._is_rectangular_edit(old, new))
-            assert not all(JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new))
+            assert JdavizViewerMixin._is_rectangular_edit(old, new) is None
+            assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) is None
 
-        # Check with 'valid' initial parameters
+        # Valid initial parameters.
         old = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
         new = RectangularROI(xmin=old.xmin + delta_xmin,
                              xmax=old.xmax + delta_xmax,
@@ -164,16 +196,16 @@ class TestROIEdits:
         assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) == validity
 
     # ---------------------------------------------------------------------------
-    # _is_roi_edit False cases
+    # _is_roi_edit None cases
     # ---------------------------------------------------------------------------
 
     def test_roi_edit_different_types(self):
         old = CircularROI(xc=10, yc=10, radius=5)
         new = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
-        assert not all(JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new))
+        assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) is None
 
     def test_roi_edit_unsupported_type(self):
-        assert not all(JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, object(), object()))
+        assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, object(), object()) is None
 
     # ---------------------------------------------------------------------------
     # _is_range_edit
@@ -181,10 +213,10 @@ class TestROIEdits:
 
     @pytest.mark.parametrize(
         ('delta_min', 'delta_max', 'validity'), [
-            (2, 2, (True, False)),  # move, same width
-            (5, 0, (False, True)),  # resize lo, same hi endpoint
-            (0, 5, (False, True)),  # resize hi, same lo endpoint
-            (50, 80, (False, False))]  # new draw
+            (2, 2, 'move'),     # same width → move
+            (5, 0, 'resize'),   # lo moved, hi fixed → resize
+            (0, 5, 'resize'),   # hi moved, lo fixed → resize
+            (50, 80, None)]     # neither endpoint fixed → new draw
     )
     def test_range_edits(self, delta_min, delta_max, validity,
                          deconfigged_helper, spectrum1d):
@@ -196,7 +228,7 @@ class TestROIEdits:
         deconfigged_helper.load(spectrum1d, format='1D Spectrum')
         spectrum_viewer = deconfigged_helper.app.get_viewer('1D Spectrum')
 
-        # Draw initial roi and verify count
+        # Draw initial roi and verify count.
         initial_roi = XRangeROI(min=old_rss.lo, max=old_rss.hi)
         spectrum_viewer.apply_roi(initial_roi)
         assert self._subset_count(deconfigged_helper) == 1
@@ -204,12 +236,12 @@ class TestROIEdits:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', UserWarning)
             spectrum_viewer.apply_roi(new_roi)
-        assert self._subset_count(deconfigged_helper) == (1 if any(validity) else 2)
+        assert self._subset_count(deconfigged_helper) == (1 if validity is not None else 2)
 
         different_roi = XRangeROI(min=100, max=150)
         spectrum_viewer.apply_roi(different_roi)
-        assert self._subset_count(deconfigged_helper) == (2 if any(validity) else 3)
+        assert self._subset_count(deconfigged_helper) == (2 if validity is not None else 3)
 
     def test_range_no_min_max_attributes(self):
         rss = RangeSubsetState(lo=10, hi=20)
-        assert not all(JdavizViewerMixin._is_range_edit(rss, object()))
+        assert JdavizViewerMixin._is_range_edit(rss, object()) is None

--- a/jdaviz/configs/default/tests/test_viewers.py
+++ b/jdaviz/configs/default/tests/test_viewers.py
@@ -21,6 +21,7 @@ class TestROIEdits:
     Unit tests for all types of ROI edits as well as
     app testing.
     """
+
     @staticmethod
     def _subset_count(app):
         return len(app.plugins['Subset Tools'].get_regions())
@@ -52,6 +53,7 @@ class TestROIEdits:
         assert JdavizViewerMixin._is_circular_edit(old, new) == validity
         assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) == validity
 
+        # Check parent class and use for the app testing
         old = CircularROI(xc=10, yc=10, radius=5)
         new = CircularROI(xc=old.xc + delta_xc, yc=old.yc + delta_yc, radius=old.radius + delta_r)
         assert JdavizViewerMixin._is_circular_edit(old, new) == validity
@@ -96,6 +98,7 @@ class TestROIEdits:
             assert not JdavizViewerMixin._is_annulus_edit(old, new)
             assert not JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new)
 
+        # Check with 'valid' initial parameters
         old = CircularAnnulusROI(xc=10, yc=10, inner_radius=3, outer_radius=6)
         new = CircularAnnulusROI(xc=old.xc + delta_xc,
                                  yc=old.yc + delta_yc,
@@ -117,6 +120,7 @@ class TestROIEdits:
             assert not JdavizViewerMixin._is_elliptical_edit(old, new)
             assert not JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new)
 
+        # Check with 'valid' initial parameters
         old = EllipticalROI(xc=10, yc=10, radius_x=3, radius_y=6)
         new = EllipticalROI(xc=old.xc + delta_xc,
                             yc=old.yc + delta_yc,
@@ -146,6 +150,7 @@ class TestROIEdits:
             assert not JdavizViewerMixin._is_rectangular_edit(old, new)
             assert not JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new)
 
+        # Check with 'valid' initial parameters
         old = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
         new = RectangularROI(xmin=old.xmin + delta_xmin,
                              xmax=old.xmax + delta_xmax,
@@ -155,7 +160,7 @@ class TestROIEdits:
         assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) == validity
 
     # ---------------------------------------------------------------------------
-    # _is_roi_edit  (dispatcher)
+    # _is_roi_edit False cases
     # ---------------------------------------------------------------------------
 
     def test_roi_edit_different_types(self):

--- a/jdaviz/configs/default/tests/test_viewers.py
+++ b/jdaviz/configs/default/tests/test_viewers.py
@@ -106,18 +106,6 @@ class TestROIEdits:
         assert JdavizViewerMixin._is_annulus_edit(old, new) == validity
         assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) == validity
 
-        # Test in app behavior: resize, move, and new draw.
-        # Draw initial roi and verify count
-        # self.image_viewer.apply_roi(old)
-        # assert self._subset_count() == 1
-        #
-        # self.image_viewer.apply_roi(new)
-        # assert self._subset_count() == (1 if validity else 2)
-        #
-        # different_roi = CircularAnnulusROI(xc=100, yc=100, inner_radius=2, outer_radius=4)
-        # self.image_viewer.apply_roi(different_roi)
-        # assert self._subset_count() == (2 if validity else 3)
-
         # ---------------------------------------------------------------------------
         # _is_elliptical_edit
         # ---------------------------------------------------------------------------
@@ -138,19 +126,6 @@ class TestROIEdits:
                             radius_y=old.radius_y + delta_oyr)
         assert JdavizViewerMixin._is_elliptical_edit(old, new) == validity
         assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) == validity
-
-        # Test in app behavior: resize, move, and new draw.
-        # Draw initial roi and verify count
-        # annulus_count = self._subset_count()
-        # self.image_viewer.apply_roi(old)
-        # assert self._subset_count() == annulus_count + 1
-        #
-        # self.image_viewer.apply_roi(new)
-        # assert self._subset_count() == (annulus_count + (1 if validity else 2))
-        #
-        # different_roi = EllipticalROI(xc=100, yc=100, radius_x=2, radius_y=4)
-        # self.image_viewer.apply_roi(different_roi)
-        # assert self._subset_count() == (annulus_count + (2 if validity else 3))
 
     # ---------------------------------------------------------------------------
     # _is_rectangular_edit
@@ -180,18 +155,6 @@ class TestROIEdits:
                              ymax=old.ymax + delta_ymax)
         assert JdavizViewerMixin._is_rectangular_edit(old, new) == validity
         assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) == validity
-
-        # Test in app behavior: resize, move, and new draw.
-        # Draw initial roi and verify count
-        # self.image_viewer.apply_roi(old)
-        # assert self._subset_count() == 1
-        #
-        # self.image_viewer.apply_roi(new)
-        # assert self._subset_count() == (1 if validity else 2)
-        #
-        # different_roi = RectangularROI(xmin=100, xmax=150, ymin=100, ymax=150)
-        # self.image_viewer.apply_roi(different_roi)
-        # assert self._subset_count() == (2 if validity else 3)
 
     # ---------------------------------------------------------------------------
     # _is_roi_edit  (dispatcher)

--- a/jdaviz/configs/default/tests/test_viewers.py
+++ b/jdaviz/configs/default/tests/test_viewers.py
@@ -4,6 +4,8 @@ Tests for JdavizViewerMixin ROI edit-detection helpers and the
 in the deconfigged configuration.
 """
 
+import warnings
+
 import pytest
 from glue.core.roi import (CircularAnnulusROI,
                            CircularROI,
@@ -67,7 +69,9 @@ class TestROIEdits:
         image_viewer.apply_roi(old)
         assert self._subset_count(deconfigged_helper) == 1
 
-        image_viewer.apply_roi(new)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            image_viewer.apply_roi(new)
         assert self._subset_count(deconfigged_helper) == (1 if validity else 2)
 
         different_roi = CircularROI(xc=100, yc=100, radius=2)
@@ -197,7 +201,9 @@ class TestROIEdits:
         spectrum_viewer.apply_roi(initial_roi)
         assert self._subset_count(deconfigged_helper) == 1
 
-        spectrum_viewer.apply_roi(new_roi)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            spectrum_viewer.apply_roi(new_roi)
         assert self._subset_count(deconfigged_helper) == (1 if validity else 2)
 
         different_roi = XRangeROI(min=100, max=150)

--- a/jdaviz/configs/default/tests/test_viewers.py
+++ b/jdaviz/configs/default/tests/test_viewers.py
@@ -32,11 +32,11 @@ class TestROIEdits:
     # _is_circular_edit
     # ---------------------------------------------------------------------------
     @pytest.mark.parametrize(
-        ('delta_xc', 'delta_yc', 'delta_r', 'validity'),
-        [(0, 0, 3, True),  # resize same center
-         (2, 0, 3, True),  # resize center within radius
-         (40, 40, 0, True),  # move same radius
-         (40, 40, 3, False)]  # new draw (move and resize)
+        ('delta_xc', 'delta_yc', 'delta_r', 'validity'),  # validity is (is_move, is_resize)
+        [(0, 0, 3, (False, True)),  # resize same center
+         (2, 0, 3, (False, True)),  # resize center within radius
+         (40, 40, 0, (True, False)),  # move same radius
+         (40, 40, 3, (False, False))]  # new draw (move and resize)
     )
     def test_circular_roi_edit(self, delta_xc, delta_yc, delta_r, validity,
                                deconfigged_helper, image_hdu_wcs):
@@ -44,8 +44,8 @@ class TestROIEdits:
         # Test with zero initial radius, always False since any change would be a new draw
         old = CircularROI(xc=10, yc=10, radius=0)
         new = CircularROI(xc=old.xc + delta_xc, yc=old.yc + delta_yc, radius=old.radius + delta_r)
-        assert not JdavizViewerMixin._is_circular_edit(old, new)
-        assert not JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new)
+        assert not all(JdavizViewerMixin._is_circular_edit(old, new))
+        assert not all(JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new))
 
         # Check subclass
         old = TrueCircularROI(xc=10, yc=10, radius=5)
@@ -72,11 +72,11 @@ class TestROIEdits:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', UserWarning)
             image_viewer.apply_roi(new)
-        assert self._subset_count(deconfigged_helper) == (1 if validity else 2)
+        assert self._subset_count(deconfigged_helper) == (1 if any(validity) else 2)
 
         different_roi = CircularROI(xc=100, yc=100, radius=2)
         image_viewer.apply_roi(different_roi)
-        assert self._subset_count(deconfigged_helper) == (2 if validity else 3)
+        assert self._subset_count(deconfigged_helper) == (2 if any(validity) else 3)
 
     # ---------------------------------------------------------------------------
     # _is_annulus_edit AND _is_elliptical_edit (same logic for both, just different parameters)
@@ -84,11 +84,11 @@ class TestROIEdits:
 
     @pytest.mark.parametrize(
         ('delta_xc', 'delta_yc', 'delta_ixr', 'delta_oyr', 'validity'),
-        [(0, 0, 1, 2, True),  # resize same center
-         (40, 40, 0, 0, True),  # move same radii
-         (40, 40, 2, 4, False),  # new draw (move and resize)
-         (40, 40, 1, 0, False),  # different inner/x radius
-         (40, 40, 0, 2, False)]  # different outer/y radius
+        [(0, 0, 1, 2, (False, True)),  # resize same center
+         (40, 40, 0, 0, (True, False)),  # move same radii
+         (40, 40, 2, 4, (False, False)),  # new draw (move and resize)
+         (40, 40, 1, 0, (False, False)),  # different inner/x radius
+         (40, 40, 0, 2, (False, False))]  # different outer/y radius
     )
     def test_annulus_elliptical_roi_edit(self, delta_xc, delta_yc, delta_ixr, delta_oyr, validity):
         # Test with zero initial outer radius and smaller initial outer radius,
@@ -99,8 +99,8 @@ class TestROIEdits:
                                      yc=old.yc + delta_yc,
                                      inner_radius=old.inner_radius + delta_ixr,
                                      outer_radius=old.outer_radius + delta_oyr)
-            assert not JdavizViewerMixin._is_annulus_edit(old, new)
-            assert not JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new)
+            assert not all(JdavizViewerMixin._is_annulus_edit(old, new))
+            assert not any(JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new))
 
         # Check with 'valid' initial parameters
         old = CircularAnnulusROI(xc=10, yc=10, inner_radius=3, outer_radius=6)
@@ -121,8 +121,8 @@ class TestROIEdits:
                                 yc=old.yc + delta_yc,
                                 radius_x=old.radius_x + delta_ixr,
                                 radius_y=old.radius_y + delta_oyr)
-            assert not JdavizViewerMixin._is_elliptical_edit(old, new)
-            assert not JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new)
+            assert not all(JdavizViewerMixin._is_elliptical_edit(old, new))
+            assert not all(JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new))
 
         # Check with 'valid' initial parameters
         old = EllipticalROI(xc=10, yc=10, radius_x=3, radius_y=6)
@@ -138,9 +138,9 @@ class TestROIEdits:
     # ---------------------------------------------------------------------------
     @pytest.mark.parametrize(
         ('delta_xmin', 'delta_xmax', 'delta_ymin', 'delta_ymax', 'validity'),
-        [(-2, 2, -2, 2, True),  # resize same center
-         (50, 50, 50, 50, True),  # move same size
-         (50, 70, 50, 70, False)]  # new draw (move and resize)
+        [(-2, 2, -2, 2, (False, True)),  # resize same center
+         (50, 50, 50, 50, (True, False)),  # move same size
+         (50, 70, 50, 70, (False, False))]  # new draw (move and resize)
     )
     def test_rectangle_resize_same_center(self, delta_xmin, delta_xmax, delta_ymin, delta_ymax,
                                           validity):
@@ -151,8 +151,8 @@ class TestROIEdits:
                                  xmax=old.xmax + delta_xmax,
                                  ymin=old.ymin + delta_ymin,
                                  ymax=old.ymax + delta_ymax)
-            assert not JdavizViewerMixin._is_rectangular_edit(old, new)
-            assert not JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new)
+            assert not all(JdavizViewerMixin._is_rectangular_edit(old, new))
+            assert not all(JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new))
 
         # Check with 'valid' initial parameters
         old = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
@@ -170,10 +170,10 @@ class TestROIEdits:
     def test_roi_edit_different_types(self):
         old = CircularROI(xc=10, yc=10, radius=5)
         new = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
-        assert not JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new)
+        assert not all(JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new))
 
     def test_roi_edit_unsupported_type(self):
-        assert not JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, object(), object())
+        assert not all(JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, object(), object()))
 
     # ---------------------------------------------------------------------------
     # _is_range_edit
@@ -181,10 +181,10 @@ class TestROIEdits:
 
     @pytest.mark.parametrize(
         ('delta_min', 'delta_max', 'validity'), [
-            (2, 2, True),  # move, same width
-            (5, 0, True),  # resize lo, same hi endpoint
-            (0, 5, True),  # resize hi, same lo endpoint
-            (50, 80, False)]  # new draw
+            (2, 2, (True, False)),  # move, same width
+            (5, 0, (False, True)),  # resize lo, same hi endpoint
+            (0, 5, (False, True)),  # resize hi, same lo endpoint
+            (50, 80, (False, False))]  # new draw
     )
     def test_range_edits(self, delta_min, delta_max, validity,
                          deconfigged_helper, spectrum1d):
@@ -204,12 +204,12 @@ class TestROIEdits:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', UserWarning)
             spectrum_viewer.apply_roi(new_roi)
-        assert self._subset_count(deconfigged_helper) == (1 if validity else 2)
+        assert self._subset_count(deconfigged_helper) == (1 if any(validity) else 2)
 
         different_roi = XRangeROI(min=100, max=150)
         spectrum_viewer.apply_roi(different_roi)
-        assert self._subset_count(deconfigged_helper) == (2 if validity else 3)
+        assert self._subset_count(deconfigged_helper) == (2 if any(validity) else 3)
 
     def test_range_no_min_max_attributes(self):
         rss = RangeSubsetState(lo=10, hi=20)
-        assert not JdavizViewerMixin._is_range_edit(rss, object())
+        assert not all(JdavizViewerMixin._is_range_edit(rss, object()))

--- a/jdaviz/configs/default/tests/test_viewers.py
+++ b/jdaviz/configs/default/tests/test_viewers.py
@@ -15,210 +15,157 @@ from glue.core.roi import (
     RectangularROI,
     XRangeROI,
 )
+from glue.core.subset import RangeSubsetState
 from glue_jupyter.bqplot.common.tools import TrueCircularROI
 
 from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
 
-_M = JdavizViewerMixin
 
-
-# ---------------------------------------------------------------------------
-# _is_circular_edit
-# ---------------------------------------------------------------------------
-
-class TestIsCircularEdit:
+class TestROIEdits:
     """
-    Tests for ``JdavizViewerMixin._is_circular_edit``.
+    Tests for all types of ROI edits.
     """
 
-    def test_resize_same_center(self):
-        old = CircularROI(xc=10, yc=10, radius=5)
-        new = CircularROI(xc=10, yc=10, radius=8)
-        assert _M._is_circular_edit(old, new)
+    @pytest.fixture(autouse=True)
+    def setup_class(self):
+        self.JVM = JdavizViewerMixin
 
-    def test_resize_center_within_radius(self):
+    # ---------------------------------------------------------------------------
+    # _is_circular_edit
+    # ---------------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        ('delta_xc', 'delta_yc', 'delta_r', 'validity'),
+        [(0, 0, 3, True),  # resize same center
+         (2, 0, 3, True),  # resize center within radius
+         (40, 40, 0, True),  # move same radius
+         (40, 40, 3, False)]  # new draw (move and resize)
+    )
+    def test_circular_roi_edit(self, delta_xc, delta_yc, delta_r, validity):
         old = CircularROI(xc=10, yc=10, radius=5)
-        new = CircularROI(xc=12, yc=10, radius=8)
-        assert _M._is_circular_edit(old, new)
+        new = CircularROI(xc=old.xc + delta_xc, yc=old.yc + delta_yc, radius=old.radius + delta_r)
+        assert self.JVM._is_circular_edit(old, new) == validity
+        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
 
-    def test_move_same_radius(self):
-        old = CircularROI(xc=10, yc=10, radius=5)
-        new = CircularROI(xc=50, yc=50, radius=5)
-        assert _M._is_circular_edit(old, new)
-
-    def test_new_draw(self):
-        old = CircularROI(xc=10, yc=10, radius=5)
-        new = CircularROI(xc=50, yc=50, radius=12)
-        assert not _M._is_circular_edit(old, new)
-
-    def test_zero_radius(self):
+        # Test with zero initial radius, always False since any change would be a new draw
         old = CircularROI(xc=10, yc=10, radius=0)
-        new = CircularROI(xc=10, yc=10, radius=5)
-        assert not _M._is_circular_edit(old, new)
+        new = CircularROI(xc=old.xc + delta_xc, yc=old.yc + delta_yc, radius=old.radius + delta_r)
+        assert not self.JVM._is_circular_edit(old, new)
+        assert not self.JVM._is_roi_edit(self.JVM, old, new)
 
+    # ---------------------------------------------------------------------------
+    # _is_annulus_edit AND _is_elliptical_edit (same logic for both, just different parameters)
+    # ---------------------------------------------------------------------------
 
-# ---------------------------------------------------------------------------
-# _is_annulus_edit
-# ---------------------------------------------------------------------------
-
-class TestIsAnnulusEdit:
-    """
-    Tests for ``JdavizViewerMixin._is_annulus_edit``.
-    """
-
-    def test_resize_same_center(self):
+    @pytest.mark.parametrize(
+        ('delta_xc', 'delta_yc', 'delta_ixr', 'delta_oyr', 'validity'),
+        [(0, 0, 1, 2, True),  # resize same center
+         (40, 40, 0, 0, True),  # move same radii
+         (40, 40, 2, 4, False),  # new draw (move and resize)
+         (40, 40, 1, 0, False),  # different inner/x radius
+         (40, 40, 0, 2, False)]  # different outer/y radius
+    )
+    def test_annulus_elliptical_roi_edit(self, delta_xc, delta_yc, delta_ixr, delta_oyr, validity):
         old = CircularAnnulusROI(xc=10, yc=10, inner_radius=3, outer_radius=6)
-        new = CircularAnnulusROI(xc=10, yc=10, inner_radius=4, outer_radius=8)
-        assert _M._is_annulus_edit(old, new)
+        new = CircularAnnulusROI(xc=old.xc + delta_xc,
+                                 yc=old.yc + delta_yc,
+                                 inner_radius=old.inner_radius + delta_ixr,
+                                 outer_radius=old.outer_radius + delta_oyr)
+        assert self.JVM._is_annulus_edit(old, new) == validity
+        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
 
-    def test_move_same_radii(self):
-        old = CircularAnnulusROI(xc=10, yc=10, inner_radius=3, outer_radius=6)
-        new = CircularAnnulusROI(xc=50, yc=50, inner_radius=3, outer_radius=6)
-        assert _M._is_annulus_edit(old, new)
+        # Test with zero initial outer radius and smaller initial outer radius,
+        # always False since any change would be a new draw
+        for old_ir, old_or in ((0, 0), (1, 0)):
+            old = CircularAnnulusROI(xc=10, yc=10, inner_radius=old_ir, outer_radius=old_or)
+            new = CircularAnnulusROI(xc=old.xc + delta_xc,
+                                     yc=old.yc + delta_yc,
+                                     inner_radius=old.inner_radius + delta_ixr,
+                                     outer_radius=old.outer_radius + delta_oyr)
+            assert not self.JVM._is_annulus_edit(old, new)
+            assert not self.JVM._is_roi_edit(self.JVM, old, new)
 
-    def test_new_draw(self):
-        old = CircularAnnulusROI(xc=10, yc=10, inner_radius=3, outer_radius=6)
-        new = CircularAnnulusROI(xc=50, yc=50, inner_radius=5, outer_radius=10)
-        assert not _M._is_annulus_edit(old, new)
+        # ---------------------------------------------------------------------------
+        # _is_elliptical_edit
+        # ---------------------------------------------------------------------------
 
-    def test_different_inner_only(self):
-        old = CircularAnnulusROI(xc=10, yc=10, inner_radius=3, outer_radius=6)
-        new = CircularAnnulusROI(xc=50, yc=50, inner_radius=4, outer_radius=6)
-        assert not _M._is_annulus_edit(old, new)
+        old = EllipticalROI(xc=10, yc=10, radius_x=3, radius_y=6)
+        new = EllipticalROI(xc=old.xc + delta_xc,
+                            yc=old.yc + delta_yc,
+                            radius_x=old.radius_x + delta_ixr,
+                            radius_y=old.radius_y + delta_oyr)
+        assert self.JVM._is_elliptical_edit(old, new) == validity
+        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
 
-    def test_zero_outer_radius(self):
-        old = CircularAnnulusROI(xc=10, yc=10, inner_radius=0, outer_radius=0)
-        new = CircularAnnulusROI(xc=10, yc=10, inner_radius=2, outer_radius=5)
-        assert not _M._is_annulus_edit(old, new)
+        # Test with zero initial x/y radius
+        for i, j in ((0, 1), (1, 0)):
+            old = EllipticalROI(xc=10, yc=10, radius_x=i, radius_y=j)
+            new = EllipticalROI(xc=old.xc + delta_xc,
+                                yc=old.yc + delta_yc,
+                                radius_x=old.radius_x + delta_ixr,
+                                radius_y=old.radius_y + delta_oyr)
+            assert not self.JVM._is_elliptical_edit(old, new)
+            assert not self.JVM._is_roi_edit(self.JVM, old, new)
 
-
-# ---------------------------------------------------------------------------
-# _is_elliptical_edit
-# ---------------------------------------------------------------------------
-
-class TestIsEllipticalEdit:
-    """
-    Tests for ``JdavizViewerMixin._is_elliptical_edit``.
-    """
-
-    def test_resize_same_center(self):
-        old = EllipticalROI(xc=10, yc=10, radius_x=5, radius_y=3)
-        new = EllipticalROI(xc=10, yc=10, radius_x=8, radius_y=6)
-        assert _M._is_elliptical_edit(old, new)
-
-    def test_move_same_radii(self):
-        old = EllipticalROI(xc=10, yc=10, radius_x=5, radius_y=3)
-        new = EllipticalROI(xc=50, yc=50, radius_x=5, radius_y=3)
-        assert _M._is_elliptical_edit(old, new)
-
-    def test_new_draw(self):
-        old = EllipticalROI(xc=10, yc=10, radius_x=5, radius_y=3)
-        new = EllipticalROI(xc=50, yc=50, radius_x=8, radius_y=6)
-        assert not _M._is_elliptical_edit(old, new)
-
-
-# ---------------------------------------------------------------------------
-# _is_rectangular_edit
-# ---------------------------------------------------------------------------
-
-class TestIsRectangularEdit:
-    """
-    Tests for ``JdavizViewerMixin._is_rectangular_edit``.
-    """
-
-    def test_resize_same_center(self):
+    # ---------------------------------------------------------------------------
+    # _is_rectangular_edit
+    # ---------------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        ('delta_xmin', 'delta_xmax', 'delta_ymin', 'delta_ymax', 'validity'),
+        [(-2, 2, -2, 2, True),  # resize same center
+         (50, 50, 50, 50, True),  # move same size
+         (50, 70, 50, 70, False)]  # new draw (move and resize)
+    )
+    def test_rectangle_resize_same_center(self, delta_xmin, delta_xmax, delta_ymin, delta_ymax,
+                                          validity):
         old = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
-        new = RectangularROI(xmin=-2, xmax=12, ymin=-2, ymax=12)
-        assert _M._is_rectangular_edit(old, new)
+        new = RectangularROI(xmin=old.xmin + delta_xmin,
+                             xmax=old.xmax + delta_xmax,
+                             ymin=old.ymin + delta_ymin,
+                             ymax=old.ymax + delta_ymax)
+        assert self.JVM._is_rectangular_edit(old, new) == validity
+        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
 
-    def test_move_same_size(self):
-        old = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
-        new = RectangularROI(xmin=50, xmax=60, ymin=50, ymax=60)
-        assert _M._is_rectangular_edit(old, new)
+        # Test with zero size
+        for xmax, ymax in ((0, 1), (1, 0)):
+            old = RectangularROI(xmin=0, xmax=xmax, ymin=0, ymax=ymax)
+            new = RectangularROI(xmin=old.xmin + delta_xmin,
+                                 xmax=old.xmax + delta_xmax,
+                                 ymin=old.ymin + delta_ymin,
+                                 ymax=old.ymax + delta_ymax)
+            assert not self.JVM._is_rectangular_edit(old, new)
+            assert not self.JVM._is_roi_edit(self.JVM, old, new)
 
-    def test_new_draw(self):
-        old = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
-        new = RectangularROI(xmin=50, xmax=80, ymin=50, ymax=80)
-        assert not _M._is_rectangular_edit(old, new)
+    # ---------------------------------------------------------------------------
+    # _is_roi_edit  (dispatcher)
+    # ---------------------------------------------------------------------------
 
-
-# ---------------------------------------------------------------------------
-# _is_roi_edit  (dispatcher)
-# ---------------------------------------------------------------------------
-
-class TestIsRoiEdit:
-    """
-    Tests for the ``_is_roi_edit`` dispatch method.
-    """
-
-    def test_dispatches_circular(self):
-        old = CircularROI(xc=10, yc=10, radius=5)
-        new = CircularROI(xc=10, yc=10, radius=8)
-        assert _M._is_roi_edit(_M, old, new)
-
-    def test_dispatches_true_circular(self):
-        old = TrueCircularROI(xc=10, yc=10, radius=5)
-        new = TrueCircularROI(xc=10, yc=10, radius=8)
-        assert _M._is_roi_edit(_M, old, new)
-
-    def test_dispatches_true_circular_move(self):
-        old = TrueCircularROI(xc=10, yc=10, radius=5)
-        new = TrueCircularROI(xc=50, yc=50, radius=5)
-        assert _M._is_roi_edit(_M, old, new)
-
-    def test_dispatches_annulus(self):
-        old = CircularAnnulusROI(xc=10, yc=10, inner_radius=3, outer_radius=6)
-        new = CircularAnnulusROI(xc=10, yc=10, inner_radius=4, outer_radius=8)
-        assert _M._is_roi_edit(_M, old, new)
-
-    def test_dispatches_elliptical(self):
-        old = EllipticalROI(xc=10, yc=10, radius_x=5, radius_y=3)
-        new = EllipticalROI(xc=50, yc=50, radius_x=5, radius_y=3)
-        assert _M._is_roi_edit(_M, old, new)
-
-    def test_dispatches_rectangular(self):
-        old = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
-        new = RectangularROI(xmin=50, xmax=60, ymin=50, ymax=60)
-        assert _M._is_roi_edit(_M, old, new)
-
-    def test_different_types_returns_false(self):
+    def test_roi_edit_different_types(self):
         old = CircularROI(xc=10, yc=10, radius=5)
         new = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
-        assert not _M._is_roi_edit(_M, old, new)
+        assert not self.JVM._is_roi_edit(self.JVM, old, new)
 
-    def test_unsupported_type_returns_false(self):
-        assert not _M._is_roi_edit(_M, object(), object())
+    def test_roi_edit_unsupported_type(self):
+        assert not self.JVM._is_roi_edit(self.JVM, object(), object())
 
+    # ---------------------------------------------------------------------------
+    # _is_range_edit
+    # ---------------------------------------------------------------------------
 
-# ---------------------------------------------------------------------------
-# _is_range_edit
-# ---------------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        ('delta_min', 'delta_max', 'validity'), [
+            (2, 2, True),  # move, same width
+            (5, 0, True),  # resize lo, same hi endpoint
+            (0, 5, True),  # resize hi, same lo endpoint
+            (50, 80, False)]  # new draw
+    )
+    def test_range_edits(self, delta_min, delta_max, validity):
+        old_rss = RangeSubsetState(lo=10, hi=20)
+        new_roi = XRangeROI(old_rss.lo + delta_min, old_rss.hi + delta_max)
+        assert self.JVM._is_range_edit(old_rss, new_roi) == validity
 
-class TestIsRangeEdit:
-    """
-    Tests for ``JdavizViewerMixin._is_range_edit``.
-    """
-
-    @pytest.fixture()
-    def _make_state(self):
-        from glue.core.subset import RangeSubsetState
-        return RangeSubsetState(lo=10, hi=20)
-
-    def test_resize_midpoint_inside(self, _make_state):
-        roi = XRangeROI(12, 22)
-        assert _M._is_range_edit(roi, _make_state)
-
-    def test_move_same_width(self, _make_state):
-        roi = XRangeROI(25, 35)
-        assert _M._is_range_edit(roi, _make_state)
-
-    def test_new_draw(self, _make_state):
-        roi = XRangeROI(50, 80)
-        assert not _M._is_range_edit(roi, _make_state)
-
-    def test_no_min_max_attributes(self, _make_state):
-        assert not _M._is_range_edit(object(), _make_state)
-
+    def test_range_no_min_max_attributes(self):
+        rss = RangeSubsetState(lo=10, hi=20)
+        assert not self.JVM._is_range_edit(object(), rss)
 
 # ---------------------------------------------------------------------------
 # Programmatic test: apply_roi in deconfigged

--- a/jdaviz/configs/default/tests/test_viewers.py
+++ b/jdaviz/configs/default/tests/test_viewers.py
@@ -23,25 +23,9 @@ class TestROIEdits:
     Unit tests for all types of ROI edits as well as
     app testing.
     """
-    @pytest.fixture(autouse=True)
-    def setup_class(self, deconfigged_helper, image_hdu_wcs, spectrum1d):
-        self.JVM = JdavizViewerMixin
-        deconfigged_helper.load(image_hdu_wcs, format='Image')
-        deconfigged_helper.load(spectrum1d, format='1D Spectrum')
-
-        self.app = deconfigged_helper
-        self.image_viewer = deconfigged_helper.app.get_viewer('Image')
-        self.spectrum_viewer = deconfigged_helper.app.get_viewer('1D Spectrum')
-        print(dir(self.spectrum_viewer))
-
-    def _subset_count(self):
-        return len(self.app.plugins['Subset Tools'].get_regions())
-
-    # def _active_subset_state(self):
-    #     esm = self.viewer.session.edit_subset_mode
-    #     if esm.edit_subset:
-    #         return esm.edit_subset[0].subset_state
-    #     return None
+    @staticmethod
+    def _subset_count(app):
+        return len(app.plugins['Subset Tools'].get_regions())
 
     # ---------------------------------------------------------------------------
     # _is_circular_edit
@@ -53,38 +37,42 @@ class TestROIEdits:
          (40, 40, 0, True),  # move same radius
          (40, 40, 3, False)]  # new draw (move and resize)
     )
-    def test_circular_roi_edit(self, delta_xc, delta_yc, delta_r, validity):
+    def test_circular_roi_edit(self, delta_xc, delta_yc, delta_r, validity,
+                               deconfigged_helper, image_hdu_wcs):
 
         # Test with zero initial radius, always False since any change would be a new draw
         old = CircularROI(xc=10, yc=10, radius=0)
         new = CircularROI(xc=old.xc + delta_xc, yc=old.yc + delta_yc, radius=old.radius + delta_r)
-        assert not self.JVM._is_circular_edit(old, new)
-        assert not self.JVM._is_roi_edit(self.JVM, old, new)
+        assert not JdavizViewerMixin._is_circular_edit(old, new)
+        assert not JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new)
 
         # Check subclass
         old = TrueCircularROI(xc=10, yc=10, radius=5)
         new = TrueCircularROI(xc=old.xc + delta_xc,
                               yc=old.yc + delta_yc,
                               radius=old.radius + delta_r)
-        assert self.JVM._is_circular_edit(old, new) == validity
-        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
+        assert JdavizViewerMixin._is_circular_edit(old, new) == validity
+        assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) == validity
 
         old = CircularROI(xc=10, yc=10, radius=5)
         new = CircularROI(xc=old.xc + delta_xc, yc=old.yc + delta_yc, radius=old.radius + delta_r)
-        assert self.JVM._is_circular_edit(old, new) == validity
-        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
+        assert JdavizViewerMixin._is_circular_edit(old, new) == validity
+        assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) == validity
 
         # Test in app behavior: resize, move, and new draw.
-        # Draw initial roi and verify count
-        self.image_viewer.apply_roi(old)
-        assert self._subset_count() == 1
+        deconfigged_helper.load(image_hdu_wcs, format='Image')
+        image_viewer = deconfigged_helper.app.get_viewer('Image')
 
-        self.image_viewer.apply_roi(new)
-        assert self._subset_count() == (1 if validity else 2)
+        # Draw initial roi and verify count
+        image_viewer.apply_roi(old)
+        assert self._subset_count(deconfigged_helper) == 1
+
+        image_viewer.apply_roi(new)
+        assert self._subset_count(deconfigged_helper) == (1 if validity else 2)
 
         different_roi = CircularROI(xc=100, yc=100, radius=2)
-        self.image_viewer.apply_roi(different_roi)
-        assert self._subset_count() == (2 if validity else 3)
+        image_viewer.apply_roi(different_roi)
+        assert self._subset_count(deconfigged_helper) == (2 if validity else 3)
 
     # ---------------------------------------------------------------------------
     # _is_annulus_edit AND _is_elliptical_edit (same logic for both, just different parameters)
@@ -107,16 +95,16 @@ class TestROIEdits:
                                      yc=old.yc + delta_yc,
                                      inner_radius=old.inner_radius + delta_ixr,
                                      outer_radius=old.outer_radius + delta_oyr)
-            assert not self.JVM._is_annulus_edit(old, new)
-            assert not self.JVM._is_roi_edit(self.JVM, old, new)
+            assert not JdavizViewerMixin._is_annulus_edit(old, new)
+            assert not JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new)
 
         old = CircularAnnulusROI(xc=10, yc=10, inner_radius=3, outer_radius=6)
         new = CircularAnnulusROI(xc=old.xc + delta_xc,
                                  yc=old.yc + delta_yc,
                                  inner_radius=old.inner_radius + delta_ixr,
                                  outer_radius=old.outer_radius + delta_oyr)
-        assert self.JVM._is_annulus_edit(old, new) == validity
-        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
+        assert JdavizViewerMixin._is_annulus_edit(old, new) == validity
+        assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) == validity
 
         # Test in app behavior: resize, move, and new draw.
         # Draw initial roi and verify count
@@ -140,16 +128,16 @@ class TestROIEdits:
                                 yc=old.yc + delta_yc,
                                 radius_x=old.radius_x + delta_ixr,
                                 radius_y=old.radius_y + delta_oyr)
-            assert not self.JVM._is_elliptical_edit(old, new)
-            assert not self.JVM._is_roi_edit(self.JVM, old, new)
+            assert not JdavizViewerMixin._is_elliptical_edit(old, new)
+            assert not JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new)
 
         old = EllipticalROI(xc=10, yc=10, radius_x=3, radius_y=6)
         new = EllipticalROI(xc=old.xc + delta_xc,
                             yc=old.yc + delta_yc,
                             radius_x=old.radius_x + delta_ixr,
                             radius_y=old.radius_y + delta_oyr)
-        assert self.JVM._is_elliptical_edit(old, new) == validity
-        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
+        assert JdavizViewerMixin._is_elliptical_edit(old, new) == validity
+        assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) == validity
 
         # Test in app behavior: resize, move, and new draw.
         # Draw initial roi and verify count
@@ -182,16 +170,16 @@ class TestROIEdits:
                                  xmax=old.xmax + delta_xmax,
                                  ymin=old.ymin + delta_ymin,
                                  ymax=old.ymax + delta_ymax)
-            assert not self.JVM._is_rectangular_edit(old, new)
-            assert not self.JVM._is_roi_edit(self.JVM, old, new)
+            assert not JdavizViewerMixin._is_rectangular_edit(old, new)
+            assert not JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new)
 
         old = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
         new = RectangularROI(xmin=old.xmin + delta_xmin,
                              xmax=old.xmax + delta_xmax,
                              ymin=old.ymin + delta_ymin,
                              ymax=old.ymax + delta_ymax)
-        assert self.JVM._is_rectangular_edit(old, new) == validity
-        assert self.JVM._is_roi_edit(self.JVM, old, new) == validity
+        assert JdavizViewerMixin._is_rectangular_edit(old, new) == validity
+        assert JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new) == validity
 
         # Test in app behavior: resize, move, and new draw.
         # Draw initial roi and verify count
@@ -212,10 +200,10 @@ class TestROIEdits:
     def test_roi_edit_different_types(self):
         old = CircularROI(xc=10, yc=10, radius=5)
         new = RectangularROI(xmin=0, xmax=10, ymin=0, ymax=10)
-        assert not self.JVM._is_roi_edit(self.JVM, old, new)
+        assert not JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, old, new)
 
     def test_roi_edit_unsupported_type(self):
-        assert not self.JVM._is_roi_edit(self.JVM, object(), object())
+        assert not JdavizViewerMixin._is_roi_edit(JdavizViewerMixin, object(), object())
 
     # ---------------------------------------------------------------------------
     # _is_range_edit
@@ -228,23 +216,28 @@ class TestROIEdits:
             (0, 5, True),  # resize hi, same lo endpoint
             (50, 80, False)]  # new draw
     )
-    def test_range_edits(self, delta_min, delta_max, validity):
+    def test_range_edits(self, delta_min, delta_max, validity,
+                         deconfigged_helper, spectrum1d):
         old_rss = RangeSubsetState(lo=10, hi=20)
         new_roi = XRangeROI(min=old_rss.lo + delta_min, max=old_rss.hi + delta_max)
-        assert self.JVM._is_range_edit(old_rss, new_roi) == validity
+        assert JdavizViewerMixin._is_range_edit(old_rss, new_roi) == validity
 
         # Test in app behavior: resize, move, and new draw.
+        deconfigged_helper.load(spectrum1d, format='1D Spectrum')
+        spectrum_viewer = deconfigged_helper.app.get_viewer('1D Spectrum')
+
         # Draw initial roi and verify count
-        # self.spectrum_viewer.apply_roi(old_rss)
-        # assert self._subset_count() == 1
-        #
-        # self.spectrum_viewer.apply_roi(new_roi)
-        # assert self._subset_count() == (1 if validity else 2)
-        #
-        # different_roi = XRangeROI(min=100, max=150)
-        # self.spectrum_viewer.apply_roi(different_roi)
-        # assert self._subset_count() == (2 if validity else 3)
+        initial_roi = XRangeROI(min=old_rss.lo, max=old_rss.hi)
+        spectrum_viewer.apply_roi(initial_roi)
+        assert self._subset_count(deconfigged_helper) == 1
+
+        spectrum_viewer.apply_roi(new_roi)
+        assert self._subset_count(deconfigged_helper) == (1 if validity else 2)
+
+        different_roi = XRangeROI(min=100, max=150)
+        spectrum_viewer.apply_roi(different_roi)
+        assert self._subset_count(deconfigged_helper) == (2 if validity else 3)
 
     def test_range_no_min_max_attributes(self):
         rss = RangeSubsetState(lo=10, hi=20)
-        assert not self.JVM._is_range_edit(object(), rss)
+        assert not JdavizViewerMixin._is_range_edit(rss, object())

--- a/jdaviz/configs/default/tests/test_viewers.py
+++ b/jdaviz/configs/default/tests/test_viewers.py
@@ -4,10 +4,7 @@ Tests for JdavizViewerMixin ROI edit-detection helpers and the
 in the deconfigged configuration.
 """
 
-import numpy as np
 import pytest
-from astropy.nddata import NDData
-from glue.core.edit_subset_mode import NewMode
 from glue.core.roi import (
     CircularAnnulusROI,
     CircularROI,

--- a/jdaviz/configs/default/tests/test_viewers.py
+++ b/jdaviz/configs/default/tests/test_viewers.py
@@ -171,6 +171,7 @@ class TestROIEdits:
 # Programmatic test: apply_roi in deconfigged
 # ---------------------------------------------------------------------------
 
+
 class TestDeconfiggedSubsetEditInPlace:
     """
     End-to-end test verifying that resize and move operations in

--- a/jdaviz/configs/default/tests/test_viewers.py
+++ b/jdaviz/configs/default/tests/test_viewers.py
@@ -123,15 +123,15 @@ class TestROIEdits:
 
         # Test in app behavior: resize, move, and new draw.
         # Draw initial roi and verify count
-        self.image_viewer.apply_roi(old)
-        assert self._subset_count() == 1
-
-        self.image_viewer.apply_roi(new)
-        assert self._subset_count() == (1 if validity else 2)
-
-        different_roi = CircularAnnulusROI(xc=100, yc=100, inner_radius=2, outer_radius=4)
-        self.image_viewer.apply_roi(different_roi)
-        assert self._subset_count() == (2 if validity else 3)
+        # self.image_viewer.apply_roi(old)
+        # assert self._subset_count() == 1
+        #
+        # self.image_viewer.apply_roi(new)
+        # assert self._subset_count() == (1 if validity else 2)
+        #
+        # different_roi = CircularAnnulusROI(xc=100, yc=100, inner_radius=2, outer_radius=4)
+        # self.image_viewer.apply_roi(different_roi)
+        # assert self._subset_count() == (2 if validity else 3)
 
         # ---------------------------------------------------------------------------
         # _is_elliptical_edit
@@ -156,16 +156,16 @@ class TestROIEdits:
 
         # Test in app behavior: resize, move, and new draw.
         # Draw initial roi and verify count
-        annulus_count = self._subset_count()
-        self.image_viewer.apply_roi(old)
-        assert self._subset_count() == annulus_count + 1
-
-        self.image_viewer.apply_roi(new)
-        assert self._subset_count() == (annulus_count + (1 if validity else 2))
-
-        different_roi = EllipticalROI(xc=100, yc=100, radius_x=2, radius_y=4)
-        self.image_viewer.apply_roi(different_roi)
-        assert self._subset_count() == (annulus_count + (2 if validity else 3))
+        # annulus_count = self._subset_count()
+        # self.image_viewer.apply_roi(old)
+        # assert self._subset_count() == annulus_count + 1
+        #
+        # self.image_viewer.apply_roi(new)
+        # assert self._subset_count() == (annulus_count + (1 if validity else 2))
+        #
+        # different_roi = EllipticalROI(xc=100, yc=100, radius_x=2, radius_y=4)
+        # self.image_viewer.apply_roi(different_roi)
+        # assert self._subset_count() == (annulus_count + (2 if validity else 3))
 
     # ---------------------------------------------------------------------------
     # _is_rectangular_edit
@@ -198,15 +198,15 @@ class TestROIEdits:
 
         # Test in app behavior: resize, move, and new draw.
         # Draw initial roi and verify count
-        self.image_viewer.apply_roi(old)
-        assert self._subset_count() == 1
-
-        self.image_viewer.apply_roi(new)
-        assert self._subset_count() == (1 if validity else 2)
-
-        different_roi = RectangularROI(xmin=100, xmax=150, ymin=100, ymax=150)
-        self.image_viewer.apply_roi(different_roi)
-        assert self._subset_count() == (2 if validity else 3)
+        # self.image_viewer.apply_roi(old)
+        # assert self._subset_count() == 1
+        #
+        # self.image_viewer.apply_roi(new)
+        # assert self._subset_count() == (1 if validity else 2)
+        #
+        # different_roi = RectangularROI(xmin=100, xmax=150, ymin=100, ymax=150)
+        # self.image_viewer.apply_roi(different_roi)
+        # assert self._subset_count() == (2 if validity else 3)
 
     # ---------------------------------------------------------------------------
     # _is_roi_edit  (dispatcher)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address an issue when creating new subsets in a fresh app instance and then attempting to adjust them. Instead of the subsets being adjusted, a copy is created using the dimensions of the adjusted subset. This is due to the default edit mode being `new` instead of `replace`. 

The fix overrides `apply_roi` to detect whether an incoming ROI represents a resize or move of an existing subset or a new subset entirely. It does this using geometric calculations to detect changes to the subset. It's necessary to use the geometric approach because bqplot's brush selectors expose no trait or signal that distinguishes a new draw from a resize or move, all mouse behavior follows the path of `brushing=True` → drag → `brushing=False` → `apply_roi(new_roi)`. So any other approach (that I can think of) would have to come upstream to expose the interaction.

To apply the fix to the configs (since subsets are initialized differently there), we set a flag with regards to `_importing_regions` to avoid an issue where the move/resize check is applied during that process.

Closes #3873 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
