### PR TITLE
Enable flux<>sb conversions for deconfigged, fix unit conversion issue for moment maps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,16 @@ New Features
 
 - Line list loader to allow loading custom line lists from a table or file. [#4082]
 
+- Avoid attempting to convert units in image viewers that are likely moment map data. This
+  fix allows the user to load moment map data into an existing image viewer, and use
+  unit converison functionality when there is moment map data in a viewer. [#4085]
+
+- Add ability to toggle between flux and surface brightness in deconfigged.
+  Avoid attempting to convert units in image viewers that are likely moment map
+  data. This fix allows the user to load moment map data into an existing image
+  viewer, and use unit converison functionality when there is moment map data in
+  an Image or 3D Spectrum viewer. [#4085]
+
 Cubeviz
 ^^^^^^^
 - Added ability to load DQ extension in the cubeviz loader, which activates the

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -355,7 +355,6 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
                                                                    spectral_axis_unit,
                                                                    desired_freq_unit,
                                                                    desired_length_unit)
-
                 moment = moment_temp.to(moment_zero_unit_temp.unit, u.spectral())
 
                 # if flux and spectral axis units were incompatible in terms of freq/wav

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -277,17 +277,22 @@ def test_moment_create_new_image_viewer_deconfigged(deconfigged_helper, image_cu
     image_viewer = deconfigged_helper.viewers['Image']
     assert 'moment 0' in image_viewer.data_menu.data_labels_visible
 
-    # currently blocked by issue with units in JDAT-5951, uncomment this
-    # portion of the test once that ticket is resolved
+    # now calculate another moment map and add it to the existing Image viewer
+    # and make sure it is added
+    mm.add_results.label = 'moment 01'
+    mm.add_results.viewer.selected = 'Image'
+    mm.calculate_moment()
 
-    # # now calculate another moment map and add it to the existing Image viewer
-    # # and make sure it is added
-    # mm.add_results.label = 'moment 00'
-    # mm.add_results.viewer.selected = 'Image'
-    # mm.calculate_moment()
+    image_viewer = deconfigged_helper.app.get_viewer('Image')
+    assert 'moment 01' in image_viewer.data_menu.layer.choices
 
-    # image_viewer = deconfigged_helper.app.get_viewer('Image')
-    # assert 'moment 00' in image_viewer.data_menu.layer.choices
+    # calculate a higher order moment and make sure we can add it to an existing
+    # image viewer as well
+    mm.n_moment = 1
+    mm.reference_wavelength = 1.0
+    mm.add_results.label = 'moment 1'
+    mm.add_results.viewer.selected = 'Image'
+    mm.calculate_moment()
 
 
 def test_write_momentmap(cubeviz_helper, spectrum1d_cube, tmp_path):
@@ -393,9 +398,9 @@ def test_correct_output_spectral_y_units(cubeviz_helper, spectrum1d_cube_custom_
     assert mm.moment.unit == moment_unit.replace('m', 'um')
 
 
-@pytest.mark.parametrize("flux_unit", [u.Unit(x) for x in SPEC_PHOTON_FLUX_DENSITY_UNITS][1:2])
+@pytest.mark.parametrize("flux_unit", [u.Unit(x) for x in [SPEC_PHOTON_FLUX_DENSITY_UNITS[1]]])
 @pytest.mark.parametrize("angle_unit", [u.sr, PIX2])
-@pytest.mark.parametrize("new_flux_unit", [u.Unit(x) for x in SPEC_PHOTON_FLUX_DENSITY_UNITS][1:2])
+@pytest.mark.parametrize("new_flux_unit", [u.Unit(x) for x in [SPEC_PHOTON_FLUX_DENSITY_UNITS[1]]])
 def test_moment_zero_unit_flux_conversions(cubeviz_helper,
                                            spectrum1d_cube_custom_fluxunit,
                                            flux_unit, angle_unit, new_flux_unit):
@@ -409,7 +414,6 @@ def test_moment_zero_unit_flux_conversions(cubeviz_helper,
     flux dropdown menu in the unit conversion plugin should be supported
     by moment maps.
     """
-
     if new_flux_unit == flux_unit:  # skip 'converting' to same unit
         return
     new_flux_unit_str = new_flux_unit.to_string()
@@ -434,6 +438,8 @@ def test_moment_zero_unit_flux_conversions(cubeviz_helper,
     # convert to new flux unit
     uc.flux_unit.selected = new_flux_unit_str
 
+    # make sure moment map plugin labels (which say what units the output will be
+    # in) are updated with the new flux unit
     new_mm_unit = (new_flux_unit * u.m / u.Unit(angle_unit)).to_string()
     assert mm.output_unit_items[0]['label'] == 'Surface Brightness'
     assert mm.output_unit_items[0]['unit_str'] == new_mm_unit

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
@@ -146,47 +146,55 @@ def test_flux_unit_choices(cubeviz_helper, flux_unit, expected_choices):
     assert uc_plg.flux_unit.choices == expected_choices
 
 
+@pytest.mark.parametrize("helper_name", ["deconfigged_helper", "cubeviz_helper"])
 @pytest.mark.parametrize("angle_unit", [u.sr, PIX2])
-def test_unit_translation(cubeviz_helper, angle_unit):
+def test_unit_translation(helper_name, angle_unit, request):
+    helper = request.getfixturevalue(helper_name)
+
     # custom cube so PIXAR_SR is in metadata, and Flux units, and in MJy
     w, wcs_dict = cubeviz_wcs_dict()
     flux = np.zeros((30, 20, 3001), dtype=np.float32)
     flux[5:15, 1:11, :] = 1
     cube = Spectrum(flux=flux * u.MJy / angle_unit, wcs=w, meta=wcs_dict)
-    cubeviz_helper.load_data(cube, data_label="test")
+
+    helper.load(cube, data_label="test")
 
     center = PixCoord(5, 10)
-    cubeviz_helper.plugins['Subset Tools'].import_region(CirclePixelRegion(center, radius=2.5))
+    helper.plugins['Subset Tools'].import_region(CirclePixelRegion(center, radius=2.5))
 
-    uc_plg = cubeviz_helper.plugins['Unit Conversion']
+    uc_plg = helper.plugins['Unit Conversion']
+
+    sum_dataset = 'test (sum)'
 
     # test that the scale factor was set
-    assert np.all(cubeviz_helper.app.data_collection['Spectrum (sum)'].meta['_pixel_scale_factor'] != 1)  # noqa
+    assert np.all(helper.app.data_collection[sum_dataset].meta['_pixel_scale_factor'] != 1)  # noqa
 
     # When the dropdown is displayed, this ensures the loaded
     # data collection item units will be used for translations.
     assert uc_plg._obj.spectral_y_type_selected == 'Flux'
 
     # accessing from get_data(use_display_units=True) should return flux-like units
-    assert cubeviz_helper.app._get_display_unit('spectral_y') == u.MJy
-    assert cubeviz_helper.datasets['Spectrum (sum)'].get_data(use_display_units=True).unit == u.MJy
+    assert helper.app._get_display_unit('spectral_y') == u.MJy
+    assert helper.datasets[sum_dataset].get_data(use_display_units=True).unit == u.MJy
 
     # to have access to display units
-    viewer_1d = cubeviz_helper.app.get_viewer(
-        cubeviz_helper._default_spectrum_viewer_reference_name)
+    if helper_name == "cubeviz_helper":
+        viewer_1d = helper.app.get_viewer(helper._default_spectrum_viewer_reference_name)
+    elif helper_name == "deconfigged_helper":
+        viewer_1d = helper.app.get_viewer('1D Spectrum')
 
     # change global y-units from Flux -> Surface Brightness
     uc_plg._obj.spectral_y_type_selected = 'Surface Brightness'
 
     assert uc_plg._obj.spectral_y_type_selected == 'Surface Brightness'
-    y_display_unit = u.Unit(viewer_1d.state.y_display_unit)
 
     # check if units translated
+    y_display_unit = u.Unit(viewer_1d.state.y_display_unit)
     assert y_display_unit == u.MJy / angle_unit
 
     # get_data(use_display_units=True) should return surface brightness-like units
-    assert cubeviz_helper.app._get_display_unit('spectral_y') == u.MJy / angle_unit
-    assert cubeviz_helper.datasets['Spectrum (sum)'].get_data(use_display_units=True).unit == u.MJy / angle_unit  # noqa
+    assert helper.app._get_display_unit('spectral_y') == u.MJy / angle_unit
+    assert helper.datasets[sum_dataset].get_data(use_display_units=True).unit == u.MJy / angle_unit  # noqa
 
 
 @pytest.mark.parametrize("angle_unit", [u.sr, PIX2])

--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -349,3 +349,23 @@ def test_data_unload_reload(specviz2d_helper):
     uc = specviz2d_helper.plugins['Unit Conversion']
     assert uc.flux_unit.selected == viewer.state.y_display_unit == 'MJy'
     assert uc.spectral_unit == viewer.state.x_display_unit == 'um'
+
+
+def test_toggle_spectral_y_type_deconfigged(deconfigged_helper, spectrum1d):
+    """
+    Test toggling between flux and surface brightness by setting
+    'spectral_y_type' in the unit conversion plugin.
+    """
+    deconfigged_helper.load(spectrum1d, format='1D Spectrum')
+    plg = deconfigged_helper.plugins["Unit Conversion"]
+
+    # the initial selection should be "Flux" since the input spectrum is in flux units
+    assert plg.spectral_y_type == "Flux"
+
+    # toggle to surface brightness, then back to flux, and check that
+    # spectral_y_type updates accordingly
+    plg.spectral_y_type = "Surface Brightness"
+    assert plg.spectral_y_type == "Surface Brightness"
+
+    plg.spectral_y_type = "Flux"
+    assert plg.spectral_y_type == "Flux"

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -180,7 +180,7 @@ class UnitConversion(PluginTemplateMixin):
             readonly = ['sb_unit']
         if self.has_time:
             expose += ['time_unit']
-        if self.config == 'cubeviz':
+        if self.config in ['cubeviz', 'deconfigged']:
             expose += ['spectral_y_type', 'spectral_y_unit']
         return PluginUserApi(self, expose=expose, readonly=readonly)
 

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.vue
@@ -64,7 +64,7 @@
       ></v-text-field>
     </v-row>
 
-    <div v-if="config == 'cubeviz'">
+    <div v-if="config == 'cubeviz' || config == 'deconfigged'">
       <v-row>
         <v-divider></v-divider>
       </v-row>

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -429,7 +429,9 @@ class BaseImporterToDataCollection(BaseImporter):
             else:
                 msg = f"{data_label} loaded but no viewers were created.  Create viewers manually and add data from data-menu"  # noqa
             # Don't warn for WCS-only layers (orientation reference layers)
-            if not new_dc_entry.meta.get(_wcs_only_label, False):
+            # or for data added via a plugin (e.g moment maps)
+            from_plugin = new_dc_entry.meta.get('plugin', False)
+            if not new_dc_entry.meta.get(_wcs_only_label, False) and not from_plugin:
                 self.app.hub.broadcast(SnackbarMessage(msg, sender=self, color='warning'))
 
         # otherwise, add data to all selected viewers.

--- a/jdaviz/core/unit_conversion_utils.py
+++ b/jdaviz/core/unit_conversion_utils.py
@@ -315,6 +315,55 @@ def create_equivalent_spectral_axis_units_list(spectral_axis_unit,
     return sorted(units_to_strings(local_units)) + spectral_axis_unit_equivalencies_titles
 
 
+def _check_if_unit_is_from_moment_map(unit):
+    """
+    Check if a unit is likely from a moment map to avoid attempting unit
+    conversion on this data. Check for moment 0 by multiplying by length/freq unit
+    and checking if the result is a flux or surface brightness unit.
+    Check for higher order moments (N) by checking if the unit is a length/frequency
+    or velocity unit (km/s)^N. This is by no means a perfect check, but data with
+    these units is likely a result from the moment map plugin and we can avoid
+    conversions in this case, and raise an error in other failed unit conversion
+    cases.
+
+    Parameters
+    ----------
+    unit : u.Unit
+        Unit object to check if it is likely from a moment map.
+
+    Returns
+    -------
+    bool
+        True if the unit is likely from a moment map, False otherwise.
+    """
+
+    # first check if unit is a moment 0 unit. moment 0 units will be
+    # flux * spectral_axis_unit or surface brightness * spectral_axis_unit,
+    # so we can catch those cases by multiplying the unit by length/freq unit
+    # and checking the phyical type of the result.
+
+    # test with a length unit and a frequency unit (doesn't matter specifically
+    # which units, we just care about the physical type)
+    u1 = unit * u.um
+    u2 = unit * u.Hz
+
+    types = ['flux', 'surface brightness']
+    if u1.physical_type in types or u2.physical_type in types:
+        return True
+
+    # check for higher order moments. these will either have units of length/freq
+    # or (km/s) ^ N
+    elif unit.physical_type == 'length' or unit.physical_type == 'frequency':
+        return True
+
+    # velocity ^ N, will always be in km / s so we can check this directly
+    elif unit.bases == [u.Unit("km"), u.Unit("s")]:
+        return True
+
+    else:
+        return False
+
+
 def flux_conversion_general(values, original_unit, target_unit,
                             equivalencies=None, with_unit=True):
     """
@@ -367,18 +416,25 @@ def flux_conversion_general(values, original_unit, target_unit,
             return values
         return values * u.Unit(original_unit)
 
-    if isinstance(original_unit, str):
-        original_unit = u.Unit(original_unit)
-    if isinstance(target_unit, str):
-        target_unit = u.Unit(target_unit)
+    # convert to Unit object (if not already, which is handled in when casting)
+    original_unit = u.Unit(original_unit)
+    target_unit = u.Unit(target_unit)
 
+    # get solid angle component of input and target (e.g sr in Jy/sr) if present
     solid_angle_in_orig = check_if_unit_is_per_solid_angle(original_unit,
                                                            return_unit=True)
     solid_angle_in_targ = check_if_unit_is_per_solid_angle(target_unit,
                                                            return_unit=True)
 
-    with u.set_enabled_equivalencies(equivalencies):
+    # if the units being converted are likely from a moment map, skip conversion
+    # (which will fail anyway) without erroring and just return input (with or
+    # without units attached, as requested)
+    if _check_if_unit_is_from_moment_map(original_unit):
+        if with_unit:
+            return values * original_unit
+        return values
 
+    with u.set_enabled_equivalencies(equivalencies):
         # first possible case we want to catch before trying to translate: both
         # the original and target unit are per-pixel-squared SB units
         # and also require an additional equivalency, so we need to multiply out
@@ -387,6 +443,7 @@ def flux_conversion_general(values, original_unit, target_unit,
         if solid_angle_in_orig == solid_angle_in_targ == PIX2:
             converted_values = (values * (original_unit * PIX2)).to(target_unit * PIX2)
             converted_values = converted_values / PIX2  # re-apply pix2 unit
+
         else:
             try:
                 # if units can be converted straight away with provided
@@ -397,11 +454,16 @@ def flux_conversion_general(values, original_unit, target_unit,
                 # convert directly is if one unit is a flux and one is a sb and
                 # they also require an additional equivalency
                 if not bool(solid_angle_in_targ) == bool(solid_angle_in_orig):
-                    converted_values = (values * original_unit * (solid_angle_in_orig or 1)).to(target_unit * (solid_angle_in_targ or 1))  # noqa
-                    converted_values = (converted_values / (solid_angle_in_orig or 1)).to(target_unit)  # noqa
+                    cv = (values * original_unit * (solid_angle_in_orig or 1))
+                    cv = cv.to(target_unit * (solid_angle_in_targ or 1))
+                    converted_values = (cv / (solid_angle_in_orig or 1)).to(target_unit)
                 else:
+                    # for all other cases (not including moment map units, which
+                    # were excluded above before attempting to convert), raise
+                    # an error if units can't be converted.
                     raise u.UnitConversionError(f'Could not convert {original_unit} to {target_unit} with provided equivalencies.')  # noqa
 
+        # return converted values with or without units, based on with_unit kwarg
         if not with_unit:
             return converted_values.value
 
@@ -417,7 +479,7 @@ def handle_squared_flux_unit_conversions(value, original_unit=None,
     This function is specifically designed to address cases where squared
     units, such as (MJy/sr)**2 to (Jy/sr)**2, appear in contexts like
     variance columns of aperture photometry output tables. When additional
-    equivalencies are required, direct conversion may fail, so this workaround.
+    equivalencies are required, direct conversion may fail, so this workaround
     is required.
 
     Parameters
@@ -527,7 +589,7 @@ def units_to_strings(unit_list):
 def convert_integrated_sb_unit(u1, spectral_axis_unit, desired_freq_unit, desired_length_unit):
     """
     Converts an integrated surface brightness unit (moment 0 unit) to a surface
-    brighntess unit that is compatible with the spectral axis unit that the surface
+    brightness unit that is compatible with the spectral axis unit that the surface
     brightness was integrated over.
 
     This function adjusts an integrated flux unit to ensure compatibility with a given
@@ -550,7 +612,6 @@ def convert_integrated_sb_unit(u1, spectral_axis_unit, desired_freq_unit, desire
         The converted flux unit compatible with the given spectral axis unit. If the
         units are already compatible, the input unit ``u1`` is returned unchanged.
     """
-
     uu = u1 / spectral_axis_unit
 
     # multiply solid angle unit out of surface brightness to compare just flux components
@@ -559,6 +620,7 @@ def convert_integrated_sb_unit(u1, spectral_axis_unit, desired_freq_unit, desire
     # then check if flux unit is a per-frequency or per-wavelength flux unit
     wav_units = _spectral_and_photon_flux_density_units(wav_only=True, as_units=True)
     freq_units = _spectral_and_photon_flux_density_units(freq_only=True, as_units=True)
+
     if np.any([flux.unit.is_equivalent(x) for x in wav_units]):
         flux_unit_type = 'length'
     elif np.any([flux.unit.is_equivalent(x) for x in freq_units]):
@@ -645,6 +707,37 @@ def to_flux_density_unit(input_unit, pixar_sr=1.0):
 
 
 def spectrum_ensure_flux_density_unit(spectrum):
+    """
+    Ensure a Spectrum has flux in spectral flux density units.
+
+    If the input spectrum already has flux in a spectral flux density unit,
+    it is returned unchanged. If the flux is in a supported flux or surface
+    brightness unit, a new Spectrum is returned with flux converted to a
+    spectral flux density unit using :func:`to_flux_density_unit`.
+
+    When converting, uncertainty is preserved when possible:
+
+    - If ``spectrum.uncertainty`` has a ``quantity`` attribute (e.g.
+      ``StdDevUncertainty``), the same uncertainty class is retained and
+      rebuilt with the converted flux unit.
+    - Otherwise, a unit-scaled array-like uncertainty is created.
+
+    Parameters
+    ----------
+    spectrum : `specutils.Spectrum`
+        Input spectrum to check and convert.
+
+    Returns
+    -------
+    `specutils.Spectrum`
+        The original spectrum (if already in spectral flux density) or a new
+        converted spectrum.
+
+    Raises
+    ------
+    NotImplementedError
+        Returned if the flux unit physical type is unsupported by this helper.
+    """
     if (spectrum.flux.unit.physical_type == 'spectral flux density'
             or spectrum.flux.unit.is_equivalent(u.Jy, u.spectral_density(1*u.m))):
         return spectrum


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This PR enables the ability to switch between flux and surface brightness on the spectral y axis in relevant viewers for deconfigged. 

This pull request also fixes an issue in deconfigged where moment map data in viewers was causing issues with unit conversion. This prevented adding moment map data to an existing image viewer, because unit conversion was attempted. The solution for this is to try to detect units that are likely moment map units (either an integrated flux/SB unit, or velocity^N unit), and skip unit conversion in these cases without raising an error. 

Also added in a fix to suppress a 'no viewer selected' snackbar from the importer when the data being added is coming from a plugin.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
