### PR TITLE
Fix for Roman L2 DQ support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,8 @@ Bug Fixes
 
 - Fix spectral subsets appearing in image viewer data menu. [#4149]
 
+- Fix Data Quality plugin support for Roman ASDF images. [#4089]
+
 Mosviz
 ^^^^^^
 
@@ -205,8 +207,6 @@ Bug Fixes
 - Fixed using `viewer.show()` with height argument not using the full height inline in the notebook. [#4134]
 
 - Fixed bug where file drop resolver failed to process messages correctly when ipykernel>=7. [#4080]
-
-- Fix Data Quality plugin support for Roman ASDF images. [#4089]
 
 Cubeviz
 ^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -206,6 +206,8 @@ Bug Fixes
 
 - Fixed bug where file drop resolver failed to process messages correctly when ipykernel>=7. [#4080]
 
+- Fix Data Quality plugin support for Roman ASDF images. [#4089]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/plugins/data_quality/data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.py
@@ -334,6 +334,7 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
                     dq_layer.state.v_max = max(flag_bits)
 
                 dq_layer.state.alpha = self.dq_layer_opacity
+                dq_layer.state.cmap_bad = (0, 0, 0, 0)
 
     def update_visibility(self, index):
         self.decoded_flags[index]['show'] = not self.decoded_flags[index]['show']

--- a/jdaviz/configs/default/plugins/data_quality/data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.py
@@ -233,13 +233,16 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
             stretch_object = dq_layer.state.stretch_object
             stretch_object.flags = flag_bits
 
-            with delay_callback(dq_layer.state, 'alpha', 'cmap', 'v_min', 'v_max'):
+            with delay_callback(dq_layer.state, 'alpha', 'cmap', 'v_min', 'v_max', 'cmap_bad'):
                 if len(flag_bits):
                     dq_layer.state.v_min = min(flag_bits)
                     dq_layer.state.v_max = max(flag_bits)
 
                 dq_layer.state.alpha = self.dq_layer_opacity
                 dq_layer.state.cmap = cmap
+
+                # make un-flagged pixels in DQ array transparent:
+                dq_layer.state.cmap_bad = (0, 0, 0, 0)
 
     def get_dq_layers(self, viewers=None):
         if self.dq_layer_selected == '':
@@ -311,7 +314,7 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
 
         for dq_layer in dq_layers:
             with delay_callback(
-                    dq_layer.state, 'v_min', 'v_max', 'alpha', 'stretch', 'cmap'
+                    dq_layer.state, 'v_min', 'v_max', 'alpha', 'stretch', 'cmap', 'cmap_bad'
             ):
                 # set correct stretch and limits:
                 # dq_layer.state.stretch = 'lookup'
@@ -334,6 +337,8 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
                     dq_layer.state.v_max = max(flag_bits)
 
                 dq_layer.state.alpha = self.dq_layer_opacity
+
+                # make un-flagged pixels in DQ array transparent:
                 dq_layer.state.cmap_bad = (0, 0, 0, 0)
 
     def update_visibility(self, index):

--- a/jdaviz/configs/imviz/tests/test_parser_asdf.py
+++ b/jdaviz/configs/imviz/tests/test_parser_asdf.py
@@ -1,13 +1,17 @@
 import asdf
 import numpy as np
+import pytest
+
 import astropy.units as u
 
 from jdaviz.configs.imviz.tests.utils import create_example_gwcs
+from jdaviz.configs.imviz.plugins.parsers import HAS_ROMAN_DATAMODELS
 
 
 def test_asdf_not_rdm(imviz_helper):
     # test support for ASDF files that look like Roman files
-    # for users with or without roman_datamodels:
+    # for users with or without roman_datamodels. In this case,
+    # we've assigned units to the image data:
     in_unit = u.Jy
     in_data = np.arange(16, dtype=np.float32).reshape((4, 4)) * in_unit
     tree = {
@@ -20,7 +24,16 @@ def test_asdf_not_rdm(imviz_helper):
     }
 
     af = asdf.AsdfFile(tree=tree)
-    imviz_helper.load_data(af)
-    out_component = imviz_helper._app.data_collection[0].get_component('DATA')
+    imviz_helper.load(af)
+    out_component = imviz_helper.app.data_collection[0].get_component('DATA')
     np.testing.assert_array_equal(in_data.value, out_component.data)
     assert str(in_unit) == out_component.units
+
+
+@pytest.mark.skipif(not HAS_ROMAN_DATAMODELS, reason="roman_datamodels is not installed")
+def test_asdf_via_rdm(imviz_helper, roman_imagemodel):
+    # test support for ASDF files as roman_datamodels ImageModels. In this
+    # case, the data don't have units.
+    imviz_helper.load(roman_imagemodel)
+    out_component = imviz_helper.app.data_collection[0].get_component('DATA')
+    np.testing.assert_array_equal(roman_imagemodel.data, out_component.data)

--- a/jdaviz/configs/imviz/tests/test_parser_asdf.py
+++ b/jdaviz/configs/imviz/tests/test_parser_asdf.py
@@ -25,7 +25,7 @@ def test_asdf_not_rdm(imviz_helper):
 
     af = asdf.AsdfFile(tree=tree)
     imviz_helper.load(af)
-    out_component = imviz_helper.app.data_collection[0].get_component('DATA')
+    out_component = imviz_helper._app.data_collection[0].get_component('DATA')
     np.testing.assert_array_equal(in_data.value, out_component.data)
     assert str(in_unit) == out_component.units
 
@@ -35,5 +35,5 @@ def test_asdf_via_rdm(imviz_helper, roman_imagemodel):
     # test support for ASDF files as roman_datamodels ImageModels. In this
     # case, the data don't have units.
     imviz_helper.load(roman_imagemodel)
-    out_component = imviz_helper.app.data_collection[0].get_component('DATA')
+    out_component = imviz_helper._app.data_collection[0].get_component('DATA')
     np.testing.assert_array_equal(roman_imagemodel.data, out_component.data)

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -114,12 +114,18 @@ class ImageImporter(BaseImporterToDataCollection):
         if isinstance(input, fits.hdu.image.ImageHDU):
             input = fits.HDUList([input])
 
-        input_is_roman = (HAS_ROMAN_DATAMODELS and
-                          isinstance(input, (rdd.ImageModel, rdd.DataModel)))
+        input_is_roman_imagemodel = (
+            HAS_ROMAN_DATAMODELS and isinstance(input, rdd.ImageModel)
+        )
+        input_is_roman_asdf = isinstance(input, asdf.AsdfFile) and 'roman' in input
+
         input_is_3d_array = isinstance(input, np.ndarray) and input.ndim == 3
-        self.input_has_extensions = (isinstance(input, fits.HDUList) or
-                                     input_is_roman or
-                                     input_is_3d_array)
+        self.input_has_extensions = any((
+            isinstance(input, fits.HDUList),
+            input_is_roman_imagemodel,
+            input_is_roman_asdf,
+            input_is_3d_array
+        ))
         if self.input_has_extensions:
             if isinstance(input, fits.HDUList):
                 filters = [_validate_fits_image2d]
@@ -131,16 +137,26 @@ class ImageImporter(BaseImporterToDataCollection):
                                 'data_hash': create_data_hash(hdu),
                                 'obj': hdu}
                                for index, hdu in enumerate(input)]
-            elif input_is_roman:
-                filters = [_validate_roman_ext]
-                ext_options = [{'label': f"{index}: {key}",
+            elif input_is_roman_asdf:
+                filters = [_validate_asdf_image_ext]
+                ext_options = [{'label': key,
                                 'name': key,
                                 'ver': None,
                                 'name_ver': key,
                                 'index': index,
-                                'data_hash': create_data_hash(input[key]),
-                                'obj': np.array(input[key])}
-                               for index, key in enumerate(roman_extensions)]
+                                'data_hash': create_data_hash(value),
+                                'obj': value}
+                               for index, (key, value) in enumerate(input['roman'].items())]
+            elif input_is_roman_imagemodel:
+                filters = [_validate_roman_imagemodel_ext]
+                ext_options = [{'label': key,
+                                'name': key,
+                                'ver': None,
+                                'name_ver': key,
+                                'index': index,
+                                'data_hash': create_data_hash(value),
+                                'obj': value}
+                               for index, (key, value) in enumerate(input.items())]
             elif input_is_3d_array:
                 # Handle 3D numpy arrays as multiple 2D slices
                 n_slices = min(input.shape[0], MAX_N_SLICE)
@@ -330,7 +346,7 @@ class ImageImporter(BaseImporterToDataCollection):
             else:
                 raise ValueError(f'Cannot load as image with ndim={input.ndim}')
         # asdf
-        elif (isinstance(input, asdf.AsdfFile)):
+        elif isinstance(input, asdf.AsdfFile):
             data = [_roman_asdf_2d_to_glue_data(input, ext=ext)
                     for ext in self.extension.selected_name]
         # roman data models
@@ -441,9 +457,14 @@ def _validate_fits_image2d(item):
             and not wcs_is_spectral(getattr(hdu, 'coords', None)))
 
 
-def _validate_roman_ext(item):
-    name = item.get('name')
-    return name in roman_extensions
+def _validate_asdf_image_ext(item):
+    value = item.get('obj')
+    return getattr(value, 'ndim', None) == 2
+
+
+def _validate_roman_imagemodel_ext(item):
+    value = item.get('obj')
+    return getattr(value, 'ndim', None) == 2
 
 
 def _hdu2data(hdu, hdulist, include_wcs=True):

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -35,6 +35,7 @@ else:
     HAS_ROMAN_DATAMODELS = True
 
 MAX_N_SLICE = 16
+roman_extensions = ['data', 'err', 'dq', 'var_poisson']
 
 __all__ = ['ImageImporter', '_spatial_assign_component_type']
 
@@ -137,9 +138,9 @@ class ImageImporter(BaseImporterToDataCollection):
                                 'ver': None,
                                 'name_ver': key,
                                 'index': index,
-                                'data_hash': create_data_hash(value),
-                                'obj': value}
-                               for index, (key, value) in enumerate(input.items())]
+                                'data_hash': create_data_hash(input[key]),
+                                'obj': np.array(input[key])}
+                               for index, key in enumerate(roman_extensions)]
             elif input_is_3d_array:
                 # Handle 3D numpy arrays as multiple 2D slices
                 n_slices = min(input.shape[0], MAX_N_SLICE)
@@ -330,7 +331,8 @@ class ImageImporter(BaseImporterToDataCollection):
                 raise ValueError(f'Cannot load as image with ndim={input.ndim}')
         # asdf
         elif (isinstance(input, asdf.AsdfFile)):
-            data = [_roman_asdf_2d_to_glue_data(input, ext='data')]
+            data = [_roman_asdf_2d_to_glue_data(input, ext=ext)
+                    for ext in self.extension.selected_name]
         # roman data models
         elif HAS_ROMAN_DATAMODELS and isinstance(input, (rdd.DataModel, rdd.ImageModel)):
             data = [_roman_asdf_2d_to_glue_data(input, ext=ext)
@@ -441,7 +443,7 @@ def _validate_fits_image2d(item):
 
 def _validate_roman_ext(item):
     name = item.get('name')
-    return name in ['data', 'dq', 'err', 'var_poisson', 'var_rnoise']
+    return name in roman_extensions
 
 
 def _hdu2data(hdu, hdulist, include_wcs=True):

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -70,8 +70,8 @@ from jdaviz.core.sonified_layers import SonifiedDataLayerArtist
 from jdaviz.style_registry import PopoutStyleWrapper
 from jdaviz.utils import (
     get_subset_type, is_wcs_only, is_not_wcs_only, wcs_is_spectral,
-    _wcs_only_label, layer_is_not_dq as layer_is_not_dq_global,
-    wildcard_match, CONFIGS_WITH_LOADERS
+    _wcs_only_label, layer_is_not_dq as utils_layer_is_not_dq,
+    wildcard_match, CONFIGS_WITH_LOADERS, layer_is_dq as utils_layer_is_dq
 )
 
 
@@ -2304,9 +2304,7 @@ class LayerSelect(SelectPluginComponent):
             return not is_trace(lyr)
 
         def is_dq_layer(lyr):
-            return getattr(
-                getattr(lyr, 'data', None), 'meta', ''
-            ).get('_extname', '').upper() == 'DQ'
+            return utils_layer_is_dq(lyr)
 
         def catalog_has_correct_coords_based_on_link_type(lyr):
             """
@@ -4863,7 +4861,7 @@ class DatasetSelect(SelectPluginComponent):
                 return True
             return data_row == app_row
 
-        layer_is_not_dq = layer_is_not_dq_global
+        layer_is_not_dq = utils_layer_is_not_dq
 
         return super()._is_valid_item(data, locals())
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2304,7 +2304,9 @@ class LayerSelect(SelectPluginComponent):
             return not is_trace(lyr)
 
         def is_dq_layer(lyr):
-            return getattr(getattr(lyr, 'data', None), 'meta', '').get('_extname', '') == 'DQ'
+            return getattr(
+                getattr(lyr, 'data', None), 'meta', ''
+            ).get('_extname', '').upper() == 'DQ'
 
         def catalog_has_correct_coords_based_on_link_type(lyr):
             """

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -352,8 +352,17 @@ def is_not_wcs_only(layer):
     return not is_wcs_only(layer)
 
 
-def layer_is_not_dq(data):
-    return '[DQ' not in data.label
+def layer_is_dq(lyr):
+    data = getattr(lyr, 'data', None)
+    metadata = getattr(data, 'meta', {})
+    extension = metadata.get('_extname', '')
+    if extension is None:
+        return False
+    return extension.upper() == 'DQ'
+
+
+def layer_is_not_dq(lyr):
+    return not layer_is_dq(lyr)
 
 
 def standardize_metadata(metadata):


### PR DESCRIPTION
This PR fixes some issues with loading DQ on Roman images.

1. on main, we were searching for the available extensions in the Roman ASDF file by calling `ImageModel.items()`. That was supported in older versions of `roman_datamodels`, but not the latest versions. I swap that iterator for a fixed set of available Roman extensions.
2. `roman_datamodels` used to produce DQ layers with with `model.meta[_extname] == 'DQ'`. now it's lower case, and that also prevents jdaviz from recognizing the layer as a DQ layer.
3. I update the plugin to use the public glue API for transparent pixels. I put the corrections in https://github.com/cshanahan1/jdaviz/pull/4, which got merged into #4077, but the fix was removed before it got merged to main. This PR implements an extra missing call to `cmap_bad` compared to my PR to Clare's PR.

Test this with the following code after [downloading this L2 Roman ASDF image](https://stsci.box.com/shared/static/7cmy09mi8w8kpkenvm89z4g1oabhh3py.asdf):

```python
import roman_datamodels.datamodels as rdd
from jdaviz import Imviz

imviz = Imviz()
level2_path = 'r0034001001001001001_0003_wfi05_f062_cal.asdf'
imviz.load(rdd.open(level2_path), format='Image', extension=['data', 'dq'])
imviz.show()
```

### Follow up

- [ ] This PR fixes the case where the user passes a `roman_datamodels.ImageModel`, but not an ASDF file path. That will require a different fix.
- [X] When a DQ array is loaded, mouseover doesn't work as intended anymore. The pixel `Value` is the DQ array value, and `nan` elsewhere.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
