### PR TITLE
Support for inverse variance and variance uncertainty extensions when loading cubes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,8 @@ New Features
 - Provide better error reporting when attempting to load data via `load`
   and loaders infrastructure. [#4058]
 
+- Added ability to load spectra with 'IVAR' uncertainty extensions. [#4091]
+
 Cubeviz
 ^^^^^^^
 - Added ability to load DQ extension in the cubeviz loader, which activates the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,7 +49,7 @@ New Features
 - Provide better error reporting when attempting to load data via `load`
   and loaders infrastructure. [#4058]
 
-- Added ability to load spectra with 'IVAR' uncertainty extensions. [#4091]
+- Added ability to load spectra with 'IVAR' and 'VAR' uncertainty extensions. [#4091]
 
 Cubeviz
 ^^^^^^^

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -151,12 +151,19 @@ def test_spectrum3d_parse(image_cube_hdu_obj, cubeviz_helper):
 
 @pytest.mark.filterwarnings('ignore')
 def test_fits_image_hdu_parse_with_inverse_var(image_cube_hdu_obj, deconfigged_helper):
-    hdul = image_cube_hdu_obj.copy()
+    """
+    Test loading a cube that contains an IVAR (inverse variance) extension for
+    its uncertainty. the IVAR extension will be converted to a standard deviation
+    type internally for consistency.
+    """
 
-    # change ERR to IVAR, and make the values 4.0 (which, when converted to
-    # StdDevUncertainty, should be 0.5 which we'll check later)
+    # use existing test fixture, but change ERR ext to IVAR
+    hdul = image_cube_hdu_obj.copy()
     hdul[2].name = 'IVAR'
     hdul[2].header['EXTNAME'] = 'IVAR'
+
+    # make the values 4.0 (which, when converted to StdDevUncertainty, should be
+    # 0.5 which we'll check later)
     hdul[2].data = np.full_like(hdul[2].data, 4.0)
 
     deconfigged_helper.load(hdul, format='3D Spectrum')
@@ -167,6 +174,7 @@ def test_fits_image_hdu_parse_with_inverse_var(image_cube_hdu_obj, deconfigged_h
     # now check the actual values of the uncertainty, since they were 4.0 in inverse
     # variance they should be 0.5 in standard deviation
     unc_data = deconfigged_helper.datasets['3D Spectrum [UNC]'].get_data()
+
     # the BUNIT keyword in the header is applying a factor of
     # '1E-17 erg*s^-1*cm^-2*Angstrom^-1' so account for that in the expected value here
     bunit = 1E-17

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -149,6 +149,30 @@ def test_spectrum3d_parse(image_cube_hdu_obj, cubeviz_helper):
     assert label_mouseover.as_text() == ('', '', '')
 
 
+@pytest.mark.filterwarnings('ignore')
+def test_fits_image_hdu_parse_with_inverse_var(image_cube_hdu_obj, deconfigged_helper):
+    hdul = image_cube_hdu_obj.copy()
+
+    # change ERR to IVAR, and make the values 4.0 (which, when converted to
+    # StdDevUncertainty, should be 0.5 which we'll check later)
+    hdul[2].name = 'IVAR'
+    hdul[2].header['EXTNAME'] = 'IVAR'
+    hdul[2].data = np.full_like(hdul[2].data, 4.0)
+
+    deconfigged_helper.load(hdul, format='3D Spectrum')
+
+    # data collection should contain flux, mask, uncert, and extracted spectrum
+    assert len(deconfigged_helper.app.data_collection) == 4
+
+    # now check the actual values of the uncertainty, since they were 4.0 in inverse
+    # variance they should be 0.5 in standard deviation
+    unc_data = deconfigged_helper.datasets['3D Spectrum [UNC]'].get_data()
+    # the BUNIT keyword in the header is applying a factor of
+    # '1E-17 erg*s^-1*cm^-2*Angstrom^-1' so account for that in the expected value here
+    bunit = 1E-17
+    assert_allclose(unc_data.flux, 0.5 * bunit * unc_data.unit)
+
+
 @pytest.mark.parametrize("flux_unit", [u.nJy, u.DN, u.DN / u.s])
 def test_spectrum3d_no_wcs_parse(cubeviz_helper, flux_unit):
     sc = Spectrum(flux=np.ones(24).reshape((2, 3, 4)) * flux_unit, spectral_axis_index=2)  # x, y, z

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -150,20 +150,25 @@ def test_spectrum3d_parse(image_cube_hdu_obj, cubeviz_helper):
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_fits_image_hdu_parse_with_inverse_var(image_cube_hdu_obj, deconfigged_helper):
+@pytest.mark.parametrize(
+    ('unc_extname', 'expected_stddev_value'),
+    [('IVAR', 0.5), ('VAR', 2.0)]
+)
+def test_fits_image_hdu_parse_with_inverse_var(image_cube_hdu_obj, deconfigged_helper,
+                                               unc_extname, expected_stddev_value):
     """
-    Test loading a cube that contains an IVAR (inverse variance) extension for
-    its uncertainty. the IVAR extension will be converted to a standard deviation
-    type internally for consistency.
+    Test loading cubes that contain IVAR (inverse variance) and VAR (variance)
+    uncertainty extensions. Both should be converted to standard deviation
+    internally for consistency.
     """
 
-    # use existing test fixture, but change ERR ext to IVAR
+    # use existing test fixture, but change ERR ext to requested uncertainty type
     hdul = image_cube_hdu_obj.copy()
-    hdul[2].name = 'IVAR'
-    hdul[2].header['EXTNAME'] = 'IVAR'
+    hdul[2].name = unc_extname
+    hdul[2].header['EXTNAME'] = unc_extname
 
-    # make the values 4.0 (which, when converted to StdDevUncertainty, should be
-    # 0.5 which we'll check later)
+    # with values initially set t\o 4.0, when converted from IVAR to stddev,
+    # we should get 0.5 and when converted from VAR to stddev, we should get 2.0
     hdul[2].data = np.full_like(hdul[2].data, 4.0)
 
     deconfigged_helper.load(hdul, format='3D Spectrum')
@@ -171,14 +176,13 @@ def test_fits_image_hdu_parse_with_inverse_var(image_cube_hdu_obj, deconfigged_h
     # data collection should contain flux, mask, uncert, and extracted spectrum
     assert len(deconfigged_helper.app.data_collection) == 4
 
-    # now check the actual values of the uncertainty, since they were 4.0 in inverse
-    # variance they should be 0.5 in standard deviation
+    # now check the actual values of the uncertainty after conversion to stddev
     unc_data = deconfigged_helper.datasets['3D Spectrum [UNC]'].get_data()
 
     # the BUNIT keyword in the header is applying a factor of
     # '1E-17 erg*s^-1*cm^-2*Angstrom^-1' so account for that in the expected value here
     bunit = 1E-17
-    assert_allclose(unc_data.flux, 0.5 * bunit * unc_data.unit)
+    assert_allclose(unc_data.flux, expected_stddev_value * bunit * unc_data.unit)
 
 
 @pytest.mark.parametrize("flux_unit", [u.nJy, u.DN, u.DN / u.s])

--- a/jdaviz/core/loaders/importers/spectrum_common.py
+++ b/jdaviz/core/loaders/importers/spectrum_common.py
@@ -488,7 +488,9 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
         if unc_data is not None:
             if self.unc_extension.selected_obj.header.get('EXTNAME', '') == 'IVAR':
                 # if it's an IVAR, convert to standard deviation
-                unc_data = 1 / np.sqrt(unc_data)
+                unc = InverseVariance(unc_data).represent_as(StdDevUncertainty)
+                unc.unit = data_unit
+            else:
             unc = StdDevUncertainty(unc_data * data_unit)
         else:
             unc = None

--- a/jdaviz/core/loaders/importers/spectrum_common.py
+++ b/jdaviz/core/loaders/importers/spectrum_common.py
@@ -4,7 +4,7 @@ import numpy as np
 from asdf import AsdfFile
 from astropy import units as u
 from astropy.io import fits
-from astropy.nddata import StdDevUncertainty
+from astropy.nddata import InverseVariance, StdDevUncertainty
 from astropy.wcs import WCS
 from functools import cached_property
 from glue.core import HubListener
@@ -293,7 +293,7 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
         Returns
         -------
         bool
-            True if the HDU is a valid light curve HDU, False otherwise.
+            True if the HDU is a valid flux HDU, False otherwise.
         """
         if item.get('label') == 'None':
             # require selection for flux
@@ -340,7 +340,7 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
         Returns
         -------
         bool
-            True if the HDU is a valid uncertainty extension. False otherwise.
+            True if the HDU is a valid uncertainty HDU. False otherwise.
         """
         hdu = item.get('obj')
         return (len(getattr(hdu, 'shape', [])) == self.supported_flux_ndim
@@ -376,7 +376,7 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
         Returns
         -------
         bool
-            True if the HDU is a valid light curve HDU, False otherwise.
+            True if the HDU is a valid mask HDU, False otherwise.
         """
         hdu = item.get('obj')
         return (len(getattr(hdu, 'shape', [])) == self.supported_flux_ndim
@@ -491,7 +491,7 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
                 unc = InverseVariance(unc_data).represent_as(StdDevUncertainty)
                 unc.unit = data_unit
             else:
-            unc = StdDevUncertainty(unc_data * data_unit)
+                unc = StdDevUncertainty(unc_data * data_unit)
         else:
             unc = None
 

--- a/jdaviz/core/loaders/importers/spectrum_common.py
+++ b/jdaviz/core/loaders/importers/spectrum_common.py
@@ -486,12 +486,12 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
             mask_data = None
 
         if unc_data is not None:
+            # if extension is IVAR/VAR, convert to standard deviation for
+            # consistency internally
             if self.unc_extension.selected_obj.header.get('EXTNAME', '') == 'IVAR':
-                # if extension is IVAR, convert to standard deviation
                 unc = InverseVariance(unc_data).represent_as(StdDevUncertainty)
                 unc.unit = data_unit
             elif self.unc_extension.selected_obj.header.get('EXTNAME', '') == 'VAR':
-                # if extension is VAR, convert to standard deviation
                 unc = VarianceUncertainty(unc_data).represent_as(StdDevUncertainty)
                 unc.unit = data_unit
             else:

--- a/jdaviz/core/loaders/importers/spectrum_common.py
+++ b/jdaviz/core/loaders/importers/spectrum_common.py
@@ -340,11 +340,11 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
         Returns
         -------
         bool
-            True if the HDU is a valid light curve HDU, False otherwise.
+            True if the HDU is a valid uncertainty extension. False otherwise.
         """
         hdu = item.get('obj')
         return (len(getattr(hdu, 'shape', [])) == self.supported_flux_ndim
-                and hdu.header.get('EXTNAME', '') == 'ERR')
+                and (hdu.header.get('EXTNAME', '') in ['ERR', 'IVAR']))
 
     def asdf_roman_is_valid_unc(self, item):
         # TODO: should this instead have options just to include or not
@@ -486,6 +486,9 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
             mask_data = None
 
         if unc_data is not None:
+            if self.unc_extension.selected_obj.header.get('EXTNAME', '') == 'IVAR':
+                # if it's an IVAR, convert to standard deviation
+                unc_data = 1 / np.sqrt(unc_data)
             unc = StdDevUncertainty(unc_data * data_unit)
         else:
             unc = None

--- a/jdaviz/core/loaders/importers/spectrum_common.py
+++ b/jdaviz/core/loaders/importers/spectrum_common.py
@@ -487,10 +487,11 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
 
         if unc_data is not None:
             if self.unc_extension.selected_obj.header.get('EXTNAME', '') == 'IVAR':
-                # if it's an IVAR, convert to standard deviation
+                # if extension is IVAR, convert to standard deviation
                 unc = InverseVariance(unc_data).represent_as(StdDevUncertainty)
                 unc.unit = data_unit
             elif self.unc_extension.selected_obj.header.get('EXTNAME', '') == 'VAR':
+                # if extension is VAR, convert to standard deviation
                 unc = VarianceUncertainty(unc_data).represent_as(StdDevUncertainty)
                 unc.unit = data_unit
             else:

--- a/jdaviz/core/loaders/importers/spectrum_common.py
+++ b/jdaviz/core/loaders/importers/spectrum_common.py
@@ -4,7 +4,7 @@ import numpy as np
 from asdf import AsdfFile
 from astropy import units as u
 from astropy.io import fits
-from astropy.nddata import InverseVariance, StdDevUncertainty
+from astropy.nddata import InverseVariance, StdDevUncertainty, VarianceUncertainty
 from astropy.wcs import WCS
 from functools import cached_property
 from glue.core import HubListener
@@ -344,7 +344,7 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
         """
         hdu = item.get('obj')
         return (len(getattr(hdu, 'shape', [])) == self.supported_flux_ndim
-                and (hdu.header.get('EXTNAME', '') in ['ERR', 'IVAR']))
+                and (hdu.header.get('EXTNAME', '') in ['ERR', 'IVAR', 'VAR']))
 
     def asdf_roman_is_valid_unc(self, item):
         # TODO: should this instead have options just to include or not
@@ -489,6 +489,9 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
             if self.unc_extension.selected_obj.header.get('EXTNAME', '') == 'IVAR':
                 # if it's an IVAR, convert to standard deviation
                 unc = InverseVariance(unc_data).represent_as(StdDevUncertainty)
+                unc.unit = data_unit
+            elif self.unc_extension.selected_obj.header.get('EXTNAME', '') == 'VAR':
+                unc = VarianceUncertainty(unc_data).represent_as(StdDevUncertainty)
                 unc.unit = data_unit
             else:
                 unc = StdDevUncertainty(unc_data * data_unit)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull requests allows hdu lists that contain variance or inverse variance extensions to be loaded. Previously only extensions labeled 'ERR' were able to be loaded, and these were treated as standard deviation uncertainties, but now extensions labeled 'IVAR' or 'VAR' can also be loaded.

For consistency, when an inverse variance uncertainty extension is loaded, it is converted to a StdDevUncertainty.

This fixes a reported issue when loading manga cubes where the uncertainty extension (IVAR) was being filtered out of the uncertainty selection dropdown. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
