### PR TITLE
fix for dev test

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_regions.py
@@ -2,12 +2,13 @@
 Generic handling logic already covered in
 jdaviz/configs/imviz/tests/test_regions.py
 """
-import numpy as np
-import pytest
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from regions import (PixCoord, CirclePixelRegion, CircleSkyRegion, EllipsePixelRegion,
                      EllipseSkyRegion)
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
 from specutils import Spectrum, SpectralRegion
 
 from jdaviz.configs.imviz.tests.test_regions import BaseRegionHandler
@@ -76,7 +77,14 @@ class TestLoadRegions(BaseRegionHandler):
         assert isinstance(spatial_subsets_as_regions['Subset 1'], EllipsePixelRegion)
         # ensure agreement between app.get_subsets and subset_tools.get_regions
         ss = self.cubeviz.app.get_subsets()
-        assert ss['Subset 1'][0]['region'] == spatial_subsets_as_regions['Subset 1']
+
+        actual = spatial_subsets_as_regions['Subset 1']
+        expected = ss['Subset 1'][0]['region']
+        assert type(actual) is type(expected)
+        assert_allclose(actual.center.x, expected.center.x)
+        assert_allclose(actual.center.y, expected.center.y)
+        assert_allclose(actual.width, expected.width)
+        assert_allclose(actual.height, expected.height)
 
         # NOTE: This does not test that spectrum from Subset is actually scientifically accurate.
         # Get spectral regions only.

--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -2,6 +2,7 @@ import os
 import re
 
 import numpy as np
+from numpy.testing import assert_allclose
 import pytest
 from astropy import units as u
 from astropy.io import fits
@@ -313,9 +314,9 @@ class TestExportSubsets:
         assert contents[1] == 'ICRS'
         assert contents[2] == '9.124032'
         assert contents[3] == '-33.407217'
-        assert contents[4] == '0.088886'
-        assert contents[5] == '0.044443'
-        assert contents[6] == '11.625269'
+        assert_allclose(float(contents[4]), 0.088886, rtol=1e-04)
+        assert_allclose(float(contents[5]), 0.044443, rtol=1e-04)
+        assert_allclose(float(contents[6]), 11.625269, rtol=1e-04)
 
 
 @pytest.mark.usefixtures('_jail')

--- a/jdaviz/configs/imviz/tests/test_delete_data.py
+++ b/jdaviz/configs/imviz/tests/test_delete_data.py
@@ -104,6 +104,6 @@ class TestDeleteWCSLayerWithSubset(BaseImviz_WCS_GWCS):
         out_reg_d = self.imviz.app.get_subsets(include_sky_region=True)['Subset 1'][0]['sky_region']
         assert_allclose(reg.center.ra.deg, out_reg_d.center.ra.deg)
         assert_allclose(reg.center.dec.deg, out_reg_d.center.dec.deg)
-        assert_quantity_allclose(reg.height, out_reg_d.height)
-        assert_quantity_allclose(reg.width, out_reg_d.width)
-        assert_quantity_allclose(reg.angle, out_reg_d.angle)
+        assert_quantity_allclose(reg.height, out_reg_d.height, rtol=1e-5)
+        assert_quantity_allclose(reg.width, out_reg_d.width, rtol=1e-5)
+        assert_quantity_allclose(reg.angle, out_reg_d.angle, rtol=1e-5)

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -252,8 +252,8 @@ class TestDeleteOrientation(BaseImviz_WCS_WCS):
         out_reg = self.imviz.app.get_subsets(include_sky_region=True)["Subset 1"][0]["sky_region"]
         assert_allclose(out_reg.center.ra.deg, reg.center.ra.deg)
         assert_allclose(out_reg.center.dec.deg, reg.center.dec.deg)
-        assert_quantity_allclose(out_reg.width, reg.width)
-        assert_quantity_allclose(out_reg.height, reg.height)
+        assert_quantity_allclose(out_reg.width, reg.width, rtol=1e-5)
+        assert_quantity_allclose(out_reg.height, reg.height, rtol=1e-5)
         # FIXME: However, sky angle has to stay the same as per regions convention.
         with pytest.raises(AssertionError, match="Not equal to tolerance"):
             assert_quantity_allclose(out_reg.angle, reg.angle)

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -2,10 +2,12 @@ import warnings
 
 import numpy as np
 import pytest
+import regions
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.data import get_pkg_data_filename
 from glue.core.roi import CircularROI, CircularAnnulusROI, EllipticalROI, RectangularROI, XRangeROI
+from packaging.version import Version
 
 from glue.core.subset_group import GroupedSubset
 from regions import (PixCoord, CirclePixelRegion, CircleSkyRegion, RectanglePixelRegion,
@@ -16,6 +18,14 @@ from astropy.nddata import NDData
 from astropy.utils.data import download_file
 
 from jdaviz.utils import get_subset_type, MultiMaskSubsetState
+
+
+# due to improvements in calcuations in the regions package, we have a version
+# check on this that will be removed once we have a minimum version of regions
+# of 0.12
+EXPECTED_CIRCLE_SKY_RADIUS_ARCSEC = (
+    28001.08106569353 if Version(regions.__version__) <= Version('0.11') else 27843.243375
+)
 
 
 def test_region_from_subset_2d(cubeviz_helper):
@@ -954,7 +964,7 @@ class TestRegionsFromSubsets:
         assert isinstance(sky_region, CircleSkyRegion)
         assert_allclose(sky_region.center.ra.deg, 24.40786313)
         assert_allclose(sky_region.center.dec.deg, 22.45185308)
-        assert_allclose(sky_region.radius.arcsec, 28001.08106569353)
+        assert_allclose(sky_region.radius.arcsec, EXPECTED_CIRCLE_SKY_RADIUS_ARCSEC)
 
         # and that it is None when not specified
         subsets = cubeviz_helper.app.get_subsets()
@@ -970,7 +980,7 @@ class TestRegionsFromSubsets:
         sky_region_1 = subsets['Subset 1'][1]['sky_region']
         assert_allclose(sky_region_0.center.ra.deg, 24.40786313)
         assert_allclose(sky_region_0.center.dec.deg, 22.45185308)
-        assert_allclose(sky_region_0.radius.arcsec, 28001.08106569353)
+        assert_allclose(sky_region_0.radius.arcsec, EXPECTED_CIRCLE_SKY_RADIUS_ARCSEC)
         assert_allclose(sky_region_1.center.ra.deg, 28.41569583)
         assert_allclose(sky_region_1.center.dec.deg, 25.44814949)
         assert_allclose(sky_region_1.radius.arcsec, 25816.498273)
@@ -999,7 +1009,7 @@ class TestRegionsFromSubsets:
         assert isinstance(sky_region, CircleSkyRegion)
         assert_allclose(sky_region.center.ra.deg, 24.40786313)
         assert_allclose(sky_region.center.dec.deg, 22.45185308)
-        assert_allclose(sky_region.radius.arcsec, 28001.08106569353)
+        assert_allclose(sky_region.radius.arcsec, EXPECTED_CIRCLE_SKY_RADIUS_ARCSEC)
 
         # now test a composite subset, each component should have a sky region
         subset_plugin.import_region(CircularROI(30, 30, 10),
@@ -1011,7 +1021,7 @@ class TestRegionsFromSubsets:
         sky_region_1 = subsets['Subset 1'][1]['sky_region']
         assert_allclose(sky_region_0.center.ra.deg, 24.40786313)
         assert_allclose(sky_region_0.center.dec.deg, 22.45185308)
-        assert_allclose(sky_region_0.radius.arcsec, 28001.08106569353)
+        assert_allclose(sky_region_0.radius.arcsec, EXPECTED_CIRCLE_SKY_RADIUS_ARCSEC)
         assert_allclose(sky_region_1.center.ra.deg, 28.41569583)
         assert_allclose(sky_region_1.center.dec.deg, 25.44814949)
         assert_allclose(sky_region_1.radius.arcsec, 25816.498273)

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -23,9 +23,7 @@ from jdaviz.utils import get_subset_type, MultiMaskSubsetState
 # due to improvements in calcuations in the regions package, we have a version
 # check on this that will be removed once we have a minimum version of regions
 # of 0.12
-EXPECTED_CIRCLE_SKY_RADIUS_ARCSEC = (
-    28001.08106569353 if Version(regions.__version__) <= Version('0.11') else 27843.243375
-)
+IS_REGIONS_0_11_OR_OLDER = Version(regions.__version__) <= Version('0.11')
 
 
 def test_region_from_subset_2d(cubeviz_helper):
@@ -964,7 +962,10 @@ class TestRegionsFromSubsets:
         assert isinstance(sky_region, CircleSkyRegion)
         assert_allclose(sky_region.center.ra.deg, 24.40786313)
         assert_allclose(sky_region.center.dec.deg, 22.45185308)
-        assert_allclose(sky_region.radius.arcsec, EXPECTED_CIRCLE_SKY_RADIUS_ARCSEC)
+        if IS_REGIONS_0_11_OR_OLDER:
+            assert_allclose(sky_region.radius.arcsec, 28001.08106569353)
+        else:
+            assert_allclose(sky_region.radius.arcsec, 27843.243375)
 
         # and that it is None when not specified
         subsets = cubeviz_helper.app.get_subsets()
@@ -980,10 +981,16 @@ class TestRegionsFromSubsets:
         sky_region_1 = subsets['Subset 1'][1]['sky_region']
         assert_allclose(sky_region_0.center.ra.deg, 24.40786313)
         assert_allclose(sky_region_0.center.dec.deg, 22.45185308)
-        assert_allclose(sky_region_0.radius.arcsec, EXPECTED_CIRCLE_SKY_RADIUS_ARCSEC)
+        if IS_REGIONS_0_11_OR_OLDER:
+            assert_allclose(sky_region_0.radius.arcsec, 28001.08106569353)
+        else:
+            assert_allclose(sky_region_0.radius.arcsec, 27843.243375)
         assert_allclose(sky_region_1.center.ra.deg, 28.41569583)
         assert_allclose(sky_region_1.center.dec.deg, 25.44814949)
-        assert_allclose(sky_region_1.radius.arcsec, 25816.498273)
+        if IS_REGIONS_0_11_OR_OLDER:
+            assert_allclose(sky_region_1.radius.arcsec, 25816.498273)
+        else:
+            assert_allclose(sky_region_1.radius.arcsec, 25662.37978)
 
         # and that they are both None when not specified
         subsets = cubeviz_helper.app.get_subsets()
@@ -1009,7 +1016,10 @@ class TestRegionsFromSubsets:
         assert isinstance(sky_region, CircleSkyRegion)
         assert_allclose(sky_region.center.ra.deg, 24.40786313)
         assert_allclose(sky_region.center.dec.deg, 22.45185308)
-        assert_allclose(sky_region.radius.arcsec, EXPECTED_CIRCLE_SKY_RADIUS_ARCSEC)
+        if IS_REGIONS_0_11_OR_OLDER:
+            assert_allclose(sky_region.radius.arcsec, 28001.08106569353)
+        else:
+            assert_allclose(sky_region.radius.arcsec, 27843.243375)
 
         # now test a composite subset, each component should have a sky region
         subset_plugin.import_region(CircularROI(30, 30, 10),
@@ -1021,10 +1031,16 @@ class TestRegionsFromSubsets:
         sky_region_1 = subsets['Subset 1'][1]['sky_region']
         assert_allclose(sky_region_0.center.ra.deg, 24.40786313)
         assert_allclose(sky_region_0.center.dec.deg, 22.45185308)
-        assert_allclose(sky_region_0.radius.arcsec, EXPECTED_CIRCLE_SKY_RADIUS_ARCSEC)
+        if IS_REGIONS_0_11_OR_OLDER:
+            assert_allclose(sky_region_0.radius.arcsec, 28001.08106569353)
+        else:
+            assert_allclose(sky_region_0.radius.arcsec, 27843.243375)
         assert_allclose(sky_region_1.center.ra.deg, 28.41569583)
         assert_allclose(sky_region_1.center.dec.deg, 25.44814949)
-        assert_allclose(sky_region_1.radius.arcsec, 25816.498273)
+        if IS_REGIONS_0_11_OR_OLDER:
+            assert_allclose(sky_region_1.radius.arcsec, 25816.498273)
+        else:
+            assert_allclose(sky_region_1.radius.arcsec, 25662.37978)
 
     def test_no_wcs_sky_regions(self, imviz_helper):
         """ Make sure that if sky regions are requested and there is no WCS,


### PR DESCRIPTION
3.13 dev tests are failing due to updates in computations of region sizes in the regions package. 

for small differences in region sizes, the tolerance for the test is increased to accept slightly differing values.

in the one case where the difference was significant, this fix adds a version check for the truth value of a test that can be removed once regions 0.12 is released.

(from @larrybradley "The reason for the large difference is that the test WCS has 1 degree per pixel with a CRPIX at (0, 0).  The position of the aperture is over 35 degrees from the CRPIX, which results in significant projection effects.  The regions updates improve the region conversion in such instances.") 