### PR TITLE
Fix Specviz2D mouseover bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -136,6 +136,9 @@ Specviz2d
 
 - Fixed bug where loading two 2D spectra failed to display in the spectrum-2d viewer. [#3983]
 
+- Fixed bug where mouseover fails to display in 2D Spectra viewer when no wavelength mapping
+  is provided. [#4093]
+
 4.5.1 (2026-03-06)
 ==================
 

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -693,7 +693,9 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                     self.marks[matched_marker_id].update_xy([wave_matched, wave_matched], [0, 1])
                     self.marks[matched_marker_id].visible = True
                 else:
-                    self.marks[matched_marker_id].visible = False
+                    # No WCS/wavelength mapping - use pixel coordinate directly
+                    self.marks[matched_marker_id].update_xy([x, x], [0, 1])
+                    self.marks[matched_marker_id].visible = True
 
     def _spectrum_viewer_update(self, viewer, x, y, mouseevent=True):
         def _cursor_fallback():

--- a/jdaviz/configs/specviz2d/tests/test_mouseover_multiple_2d.py
+++ b/jdaviz/configs/specviz2d/tests/test_mouseover_multiple_2d.py
@@ -27,34 +27,13 @@ class TestMouseoverMultiple2DSpectra:
                 break
         return line_visible
 
-    @pytest.mark.parametrize('spec', ['mos_spectrum2d', 'spectrum2d'])  # 'spectrum_no_wavelength'])
+    @pytest.mark.parametrize('spec', ['mos_spectrum2d', 'spectrum2d', 'spectrum_no_wavelength'])
     def test_single_2d_spectrum(self, deconfigged_helper, spec, request):
         """
         Test mouseover handling for a single 2D spectrum with WCS, no WCS,
         and no wavelength mapping.
         """
         deconfigged_helper.load(request.getfixturevalue(spec), format='2D Spectrum')
-
-        viewer_1d = deconfigged_helper.viewers['1D Spectrum']._obj.glue_viewer
-        viewer_2d = deconfigged_helper.viewers['2D Spectrum']._obj.glue_viewer
-
-        # Get the coordinates info object for mouseover
-        label_mouseover = deconfigged_helper._coords_info
-
-        # Test mouseover on 2D spectrum with WCS
-        assert self._mouseover_and_check_line_visible(viewer_2d, label_mouseover, 5, 5)
-        # Test mouseover on 1d spectrum linked to the 2D spectrum
-        assert self._mouseover_and_check_line_visible(viewer_1d, label_mouseover, 5, 5)
-
-    # TODO: Move this into parametrized test above once mouseover handling for 2D spectra
-    #  with no wavelength mapping is resolved.
-    @pytest.mark.xfail(reason="Mouseover handling for 2D spectra with no wavelength mapping is being investigated.")  # noqa
-    def test_single_2d_spectrum_no_wavelength(self, deconfigged_helper, spectrum_no_wavelength):
-        """
-        Test mouseover handling for a single 2D spectrum with WCS, no WCS,
-        and no wavelength mapping.
-        """
-        deconfigged_helper.load(spectrum_no_wavelength, format='2D Spectrum')
 
         viewer_1d = deconfigged_helper.viewers['1D Spectrum']._obj.glue_viewer
         viewer_2d = deconfigged_helper.viewers['2D Spectrum']._obj.glue_viewer


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address a bug where specviz2d mouseover fails when no wavelength mapping is provided.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
