### PR TITLE
Bug fixes for recent issues around load error display

### DIFF
--- a/jdaviz/core/loaders/parsers/asdf.py
+++ b/jdaviz/core/loaders/parsers/asdf.py
@@ -41,7 +41,7 @@ class ASDFParser(BaseParser):
             except (ImportError, TypeError) as e:  # noqa: F841
                 warnings.warn(
                     f"{self.input} could not be opened with the `roman_datamodels` package, "
-                    "as it gave the following error: {e}. This file will be loaded with the `asdf` directly",  # noqa: E501
+                    f"as it gave the following error: {e}. This file will be loaded with the `asdf` package directly",  # noqa: E501
                     UserWarning
                 )
         else:

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -1233,8 +1233,8 @@ def find_matching_resolver(app,
         for resolver, resolver_name, fmt_label in valid_resolvers:
             if resolver_name not in valid_resolvers_dict:
                 valid_resolvers_dict[resolver_name] = {}
-            fmt_label = f"{fmt_label}: jd.load(obj_to_load, format='{fmt_label})'"
-            valid_resolvers_dict[resolver_name][fmt_label] = 'valid'
+            fmt_label = f"{fmt_label}: jd.load(obj_to_load, format='{fmt_label}')"
+            valid_resolvers_dict[resolver_name][fmt_label] = ''
 
         msg = (f'Multiple valid loaders found for input. '
                f'Please specify a format from the following as:\n'

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -1130,7 +1130,7 @@ def _format_resolver_error(resolver_dict, formats=None, no_align=False):
                     return True
             return False
 
-        if formats is None or not any(formats):
+        if formats is None or not any(formats) or 'object' in formats:
             return True
 
         # Check if there's an arrow separator
@@ -1143,9 +1143,8 @@ def _format_resolver_error(resolver_dict, formats=None, no_align=False):
 
     lines = []
 
-    # ensure 'object' is always last in the output since it has sub-entries
-    object_results = resolver_dict.pop('object')
-    resolver_dict['object'] = object_results
+    # ensure 'object' is always last in the output since it always has sub-entries
+    resolver_dict['object'] = resolver_dict.pop('object')
     for resolver_name, resolver_info in resolver_dict.items():
         status_str = str(resolver_info).replace('\n', ' ')
         if isinstance(resolver_info, dict):

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -1130,7 +1130,7 @@ def _format_resolver_error(resolver_dict, formats=None, no_align=False):
                     return True
             return False
 
-        if formats is None or not any(formats) or 'object' in formats:
+        if formats is None or not any(formats):
             return True
 
         # Check if there's an arrow separator

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -1143,8 +1143,10 @@ def _format_resolver_error(resolver_dict, formats=None, no_align=False):
 
     lines = []
 
-    # ensure 'object' is always last in the output since it always has sub-entries
-    resolver_dict['object'] = resolver_dict.pop('object')
+    if 'object' in resolver_dict:
+        # ensure 'object' is always last in the output since it always has sub-entries
+        resolver_dict['object'] = resolver_dict.pop('object')
+
     for resolver_name, resolver_info in resolver_dict.items():
         status_str = str(resolver_info).replace('\n', ' ')
         if isinstance(resolver_info, dict):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address some small bugs having to do with the new `load` error display (#4058, #4081) as well as a formatting issue in the `asdf` error reporter.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
