### PR TITLE
Fix bug with changing link type with subsets defined

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -128,6 +128,8 @@ Imviz
 - Fixed bug where calling `jd.show()` before `batch_load` context caused data not to load correctly
   into the viewer(s) due to absence of linking necessary for glue's rendering backend. [#4079]
 
+- Fixed a bug when trying to change link type multiple times with subsets defined. [#4096]
+
 Mosviz
 ^^^^^^
 
@@ -185,8 +187,6 @@ Imviz
 ^^^^^
 
 - Optimization to orientation plugin to reduce overhead when multiple custom orientations are created. [#3896]
-
-- Fixed a bug when trying to change link type multiple times with subsets defined. [#4096]
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -186,6 +186,8 @@ Imviz
 
 - Optimization to orientation plugin to reduce overhead when multiple custom orientations are created. [#3896]
 
+- Fixed a bug when trying to change link type multiple times with subsets defined. [#4096]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -255,7 +255,8 @@ class Imviz(ImageConfigHelper):
                       viewer=viewer,
                       gwcs_to_fits_sip=gwcs_to_fits_sip)
 
-    def link_data(self, align_by='pixels', wcs_fallback_scheme=None, wcs_fast_approximation=True):
+    def link_data(self, align_by='pixels', wcs_fallback_scheme='pixels',
+                  wcs_fast_approximation=True):
         """(Re)link loaded data in Imviz with the desired link type.
         All existing links will be replaced.
 

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -238,6 +238,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         self.linking_in_progress = True  # Prevent recursion
 
         if self.need_clear_subsets:
+            setattr(self, msg.get('name'), msg.get('old'))
             self.linking_in_progress = False
             raise ValueError("Link type can only be changed after existing subsets "
                              f"are deleted, but {len(self.app.data_collection.subset_groups)} "


### PR DESCRIPTION
Because of `wcs_fallback_scheme` defaulting to `None` instead of `pixels`, the first attempt to change from Pixel to WCS link was actually erroring out while updating `wcs_use_fallback`, so the link type never got changed. The second call wouldn't change `wcs_use_fallback`, so it would actually change the link type and hit the bug of not reverting back to the previous link type if subsets were present. The change in `imviz/helper` is optional to fix the bug, but I think makes more sense as a default given the docstring that the previous default might actually break functionality (although I'm sure there was a reason that was the default).