### PR TITLE
Fix tabbed viewer

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1070,7 +1070,7 @@ class Application(VuetifyTemplate, HubListener):
         name : str
             The label to show in the viewer toolbar for the custom tool set.
         """
-        for viewer in self._viewer_store.values():
+        for viewer in list(self._viewer_store.values()):
             tools_nested, selected_tool = callable(viewer)
             if tools_nested is None:
                 tools_nested = viewer.toolbar._original_tools_nested[:3]
@@ -2010,7 +2010,7 @@ class Application(VuetifyTemplate, HubListener):
             self._update_layer_icons(old_label, new_label)
 
             # Update viewer layer states and reference data
-            for viewer_id, viewer in self._viewer_store.items():
+            for viewer_id, viewer in list(self._viewer_store.items()):
                 # Update reference data if it matches old label
                 if (hasattr(viewer.state, 'reference_data')
                         and viewer.state.reference_data is not None
@@ -2286,7 +2286,7 @@ class Application(VuetifyTemplate, HubListener):
     def get_viewer_reference_names(self):
         """Return a list of available viewer reference names."""
         # Cannot sort because of None
-        return [self._viewer_item_by_id(vid).get('reference') for vid in self._viewer_store]
+        return [self._viewer_item_by_id(vid).get('reference') for vid in list(self._viewer_store)]
 
     def get_viewers_of_cls(self, cls):
         """Return a list of viewers of a specific class."""
@@ -2294,7 +2294,7 @@ class Application(VuetifyTemplate, HubListener):
             cls_name = cls
         else:
             cls_name = cls.__name__
-        return [viewer for viewer in self._viewer_store.values()
+        return [viewer for viewer in list(self._viewer_store.values())
                 if viewer.__class__.__name__ == cls_name]
 
     def _update_viewer_reference_name(
@@ -2951,7 +2951,7 @@ class Application(VuetifyTemplate, HubListener):
             self._reparent_subsets(data)
 
         # Make sure the data isn't loaded in any viewers and isn't the selected orientation
-        for viewer_id, viewer in self._viewer_store.items():
+        for viewer_id, viewer in list(self._viewer_store.items()):
             if orientation_plugin is not None and self._align_by == 'wcs':
                 if viewer.state.reference_data.label == data_label:
                     self._change_reference_data(base_wcs_layer_label, viewer_id)

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -335,7 +335,7 @@
                 <g-viewer-tab
                   v-for="(stack, index) in state.stack_items"
                   :stack="stack"
-                  :key="stack.viewers.map(v => v.id).join('-') + stack.children.map(v => v.id).join('-')"
+                  :key="stack.id"
                   :data_items="state.data_items"
                   :app_settings="state.settings"
                   :config="config"

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -351,7 +351,7 @@ class ConfigHelper(HubListener):
             dict of viewer objects
         """
         return {viewer._ref_or_id: JdavizViewerWindow(viewer, app=self.app).user_api
-                for viewer in self.app._viewer_store.values()}
+                for viewer in list(self.app._viewer_store.values())}
 
     def _get_clone_viewer_reference(self, reference):
         base_name = reference.split("[")[0]


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes adding a new viewer while other viewers are tabbed in golden layout.

To reproduce previously:

```
import jdaviz as jd
jd.show()


jd.load('https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:JWST/product/jw01050-o003_t005_miri_ch1-medium_s3d.fits', cache=False, format='3D Spectrum')

# this works if the viewers are not tabbed,
# but if you first drag "3D Spectrum (1)" to be a taba with "3D Spectrum", it fails with a traceback 
vc = jd.new_viewers['1D Spectrum']
vc.dataset.select_all()
vc()
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
