### PR TITLE
Filter out 2D spectra from aperture photometry

### DIFF
--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -4722,7 +4722,7 @@ class DatasetSelect(SelectPluginComponent):
             return len(data.shape) == 3
 
         def is_image_or_flux_cube(data):
-            return is_image(data) or is_flux_cube(data)
+            return (is_image(data) or is_flux_cube(data)) and not is_2d_spectrum_or_trace(data)
 
         def is_spectrum(data):
             return (len(data.shape) == 1


### PR DESCRIPTION
The Aperture Photometry plugin was incorrectly showing in deconfigged if a 2D spectrum was loaded, since the `is_image` check only looks for the data to be 2D. This restricts to not allow 2D spectra.