### PR TITLE
avoid RuntimeError: Set changed size during iteration when loading MM

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -856,7 +856,11 @@ class Application(VuetifyTemplate, HubListener):
 
         # Add all new links to the data collection
         if new_links:
-            self.data_collection.add_link(new_links)
+            # Use delay_link_manager_update() to batch link updates and prevent
+            # widget trait modifications during iteration (which causes RuntimeError
+            # in ipywidgets on Python 3.12+)
+            with self.data_collection.delay_link_manager_update():
+                self.data_collection.add_link(new_links)
 
     def _link_new_data(self, reference_data=None, data_to_be_linked=None):
         """
@@ -919,7 +923,9 @@ class Application(VuetifyTemplate, HubListener):
                 isinstance(linked_data.coords, SpectralGWCS) and linked_data.ndim == 1):
             wc_old = ref_data.world_component_ids[ref_data.meta['spectral_axis_index']]
             wc_new = linked_data.world_component_ids[linked_data.meta['spectral_axis_index']]
-            self.data_collection.add_link(LinkSameWithUnits(wc_old, wc_new))
+            # Use delay_link_manager_update() to prevent widget trait modification during iteration
+            with self.data_collection.delay_link_manager_update():
+                self.data_collection.add_link(LinkSameWithUnits(wc_old, wc_new))
             return
 
         # NOTE: if Cubeviz ever supports multiple cubes, we might want to reintroduce WCS-linking

--- a/jdaviz/configs/mosviz/plugins/parsers.py
+++ b/jdaviz/configs/mosviz/plugins/parsers.py
@@ -142,7 +142,9 @@ def link_data_in_table(app, data_obj=None):
 
             wc_spec_ids.append(LinkSameWithUnits(wc_spec_1d[0], wc_spec_2d[1]))
 
-    app.session.data_collection.add_link(wc_spec_ids)
+    # Use delay_link_manager_update() to prevent widget trait modification during iteration
+    with app.session.data_collection.delay_link_manager_update():
+        app.session.data_collection.add_link(wc_spec_ids)
 
 
 @data_parser_registry("mosviz-nirspec-directory-parser")


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes an issue where the set changes size during iteration when calculating a moment map and loading it back into the app.  This only occurs when the app is visible, and so is not possible to add a regression test that reproduces the former error.