### PR TITLE
Allow subset recentering in deconfigged and update docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -371,6 +371,8 @@ def scan_directory_for_links(base_path, directory, data_type_map=None):
         'url': 'URL',
     }
 
+    links.append({'text': 'Overview', 'href': os.path.join(directory, 'index')})
+
     for filename in sorted(os.listdir(dir_path)):
         if filename.endswith('.rst') and filename != 'index.rst' and filename != 'extensions.rst':
             # Convert filename to title (e.g., 'file_drop.rst' -> 'File Drop')

--- a/docs/subsets/index.rst
+++ b/docs/subsets/index.rst
@@ -97,7 +97,8 @@ performed. Click Recenter to change its parameters and move it to the calculated
     manually edit the subset (see below) or load your own aperture object
     (:ref:`imviz-import-regions-api`).
 
-Note that angle is reported in degrees as a counter-clockwise rotation about the center.
+Note that angle is reported in degrees as a counter-clockwise rotation about the center. Recentering and rotating subsets
+are only applicable to spatial subsets and are unavailable for spectral subsets.
 
 From the API
 ------------
@@ -150,9 +151,3 @@ If you set a value for ``edit_subset`` but not ``combination_mode``, the assumpt
 that the new region is replacing the existing subset named in ``edit_subset``.
 This API method acts independently of the UI so all settings from before ``import_region``
 was called will be restored afterward.
-
-See Also
-========
-
-- :doc:`../specviz/plugins` - For spectral subset creation
-- Individual subset type pages for detailed information

--- a/docs/subsets/index.rst
+++ b/docs/subsets/index.rst
@@ -37,30 +37,6 @@ Subsets allow you to select regions of interest in your data for focused analysi
 **Advanced**
   - **Composite**: Combine multiple subsets with boolean operations
 
-Creating Subsets
-================
-
-Subsets can be created interactively using the subset tools in the viewer toolbar:
-
-.. code-block:: python
-
-    import jdaviz
-    from jdaviz import Imviz
-
-    imviz = Imviz()
-    imviz.show()
-    imviz.load('image.fits', format='Image')
-
-    # Use the subset tools in the toolbar to create regions
-
-Or programmatically via the API:
-
-.. code-block:: python
-
-    # Create a circular subset
-    region = CirclePixelRegion(center=PixCoord(100, 100), radius=20)
-    imviz.load_regions(region)
-
 UI Access
 =========
 
@@ -69,6 +45,111 @@ UI Access
    :enable-only: subsets
    :demo-repeat: false
 
+Creating Subsets
+================
+
+Subsets can be created interactively using the subset tools in the viewer toolbar:
+
+.. code-block:: python
+
+    import jdaviz as jd
+
+    jd.show()
+    jd.load('image.fits', format='Image')
+
+    # Use the subset tools in the toolbar to create regions
+
+Or programmatically via the API:
+
+.. code-block:: python
+
+    # Create a circular subset
+    from regions import CirclePixelRegion, PixCoord
+    region = CirclePixelRegion(center=PixCoord(100, 100), radius=20)
+    st = jd.plugins['Subset Tools']
+    st.import_region(region)
+
+You can also choose the operation that will be applied by the selector tool
+(``replace``, ``add``, ``and``, ``xor``, or ``remove``).
+
+Editing Subsets
+===============
+
+If an existing subset is selected, the parameters of the subset will be shown. Note that in addition to parameters for compound
+regions (e.g., a subset with multiple disjoint regions) being displayed, the logical operations joining them (``OR``, ``AND``, etc.) are
+shown as well for each region. This shows how all regions are added together to create the subset shown in the viewer.
+
+For a simple subset, you can edit its parameters by changing the values
+in the corresponding editable text fields. Once you have entered the new
+value(s), click :guilabel:`Update` to apply. You should see the subset
+parameters, shape, and orientation (if applicable) all update concurrently.
+
+For spatial subsets only, you can choose to recenter the viewer on a single subset or group of subsets. To switch to multiselect mode,
+click the icon in the top right of the tool and select multiple subsets from the drop-down menu. The centroid is calculated by
+photutils.aperture.ApertureStats.centroid, which is the center-of-mass of the data within the aperture. No background subtraction is
+performed. Click Recenter to change its parameters and move it to the calculated centroid. This may take multiple iterations to converge.
+
+.. note::
+
+    If you want accurate centroid calculations, it is recommended that you
+    use a background-subtracted image. Alternately, you could calculate
+    the centroid outside of Jdaviz (e.g., using ``photutils``) and then
+    manually edit the subset (see below) or load your own aperture object
+    (:ref:`imviz-import-regions-api`).
+
+Note that angle is reported in degrees as a counter-clockwise rotation about the center.
+
+From the API
+------------
+
+You can update the attributes of an existing subset via the Subset Tools API. To
+see what attributes are available for a given subset, call the ``update_subset`` method
+with only the subset specified:
+
+.. code-block:: python
+
+  st = jd.plugins['Subset Tools']
+  st.update_subset(subset_label='Subset 1')
+
+This will return a dictionary with the name (as displayed in the UI), attribute, and
+value for each editable attribute of each subregion of the specified subset. Note that
+passing ``subset_label`` in the ``update_subset`` call will also set the selected subset
+in the plugin UI to the specified subset. If ``subset_label`` is not specified,
+``update_subset`` will operate on the currently selected subset in the plugin.
+The attributes returned by the call above can be updated by passing their new
+values as keyword arguments, for example:
+
+.. code-block:: python
+
+  st.update_subset(subset_label='Subset 1', xmin=10, xmax = 20)
+
+In the case of a compound subset, the subregion to update must be specified as well:
+
+.. code-block:: python
+
+  st.update_subset(subset_label='Subset 1', subregion=0, xmin=10, xmax = 20)
+
+You can also create a new subset using the ``import_region`` method. This method takes a
+region and either creates a new subset with that region or appends it to another subset
+using the ``edit_subset`` and ``combination_mode`` arguments. for example:
+
+.. code-block:: python
+
+  st.import_region(CirclePixelRegion(center=PixCoord(x=4.5, y=4.5), radius=4.5))
+
+will create a new subset but
+
+.. code-block:: python
+
+  st.import_region(CirclePixelRegion(center=PixCoord(x=4.5, y=4.5), radius=4.5), edit_subset='Subset 1',
+   combination_mode='or')
+
+will append the region to the existing Subset 1 using the 'or' ``combination_mode``.
+Other options for ``combination_mode`` include "and", "andnot", "new", "replace", and "xor".
+If you set a value for ``edit_subset`` but not ``combination_mode``, the assumption will be
+that the new region is replacing the existing subset named in ``edit_subset``.
+This API method acts independently of the UI so all settings from before ``import_region``
+was called will be restored afterward.
 
 See Also
 ========

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -880,7 +880,7 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
         in the selected data layer.
         """
         # Composite region cannot be centered. This only works for Imviz.
-        if not self.is_centerable or self.config != 'imviz':  # no-op
+        if not self.is_centerable or self.config not in ('imviz', 'deconfigged'):  # no-op
             raise NotImplementedError(
                 f'Cannot recenter: is_centerable={self.is_centerable}, config={self.config}')
 

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.vue
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.vue
@@ -68,7 +68,7 @@
     </v-row>
 
     <!-- Sub-plugin for recentering of spatial subset (Imviz only) -->
-    <v-row v-if="config=='imviz' && is_centerable">
+    <v-row v-if="(config=='imviz' || config=='deconfigged') && is_centerable">
       <v-expansion-panels accordion v-model="subplugins_opened">
         <v-expansion-panel>
           <v-expansion-panel-header >


### PR DESCRIPTION
While migrating the Subset Tools docs to the deconfigged documentation I noticed that we hadn't enabled recentering spatial subsets in deconfigged, so I went ahead and did that. 

One thing I noticed is that there's now way to get from the documentation landing page to the `index` page for the Subset Tools (and other index pages), only links to go to the individual subset type pages. @kecnry any thoughts on a good way to enable the user to go straight to this page? Maybe make the `Subsets` heading here a clickable link?

<img width="551" height="514" alt="Screenshot 2026-03-30 at 12 48 37 PM" src="https://github.com/user-attachments/assets/0d99f6c8-dd2c-43fa-91af-a7a8efb2fd6a" />
