### PR TITLE
CLI fixes and updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ New Features
 - Support in plot options to set which columns are visible for table viewers. [#4033]
 
 - Added `skewer` mode to footprint selection that only selects when clicking inside a footprint.
-  Footprint selection tools now support control+click or command+click to toggle 
+  Footprint selection tools now support control+click or command+click to toggle
   selections (add/remove individual footprints without replacing the current selection). [#3962, #4034]
 
 - Added ability to load catalogs from FITS file extensions through the Catalog loader. [#3998]
@@ -51,7 +51,7 @@ New Features
 - Provide better error reporting when attempting to load data via `load`
   and loaders infrastructure. [#4058]
 
-- Allow launching generalized Jdaviz from the command line and deprecate configs from that interface. [#4087]
+- Allow launching generalized Jdaviz from the command line and deprecate configs from that interface. [#4087, #4115]
 
 - Added ability to load spectra with 'IVAR' and 'VAR' uncertainty extensions. [#4091]
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -26,10 +26,25 @@ these deprecated configurations are still available from the command line. For c
 configurations during their deprecation period, you can specify ``--layout=flexible`` to launch the new
 generalized Jdaviz from the command line. To load a file into a configuration::
 
-    jdaviz --layout=[imviz|specviz|cubeviz|mosviz|specviz2d|flexible] /path/to/data/file
+    jdaviz --layout=[imviz|specviz|cubeviz|mosviz|specviz2d|flexible] --filepath=/path/to/data/file --file_format=FileFormat
 
 This will warn that the ``--layout`` argument is deprecated. In the future, running the ``jdaviz``
 command will simply launch the generalized Jdaviz application without going through a launcher page.
+You can also specify filepath and file format using the shorter ``-fp`` and ``-ff``, respectively, which
+may be useful if loading multiple files. Note that the file format is generally required because many files can be read,
+for example, using either the image loader or the catalog loader. The current list of supported file formats is:
+
+    * Image
+    * Catalog
+    * 1D Spectrum
+    * 2D Spectrum
+    * 3D Spectrum
+    * Ramp
+    * Ramp Integration
+    * Subset
+    * Trace
+    * Line List
+    * Footprint
 
 Currently, running the command ``jdaviz`` without any additional input will still run a launcher. To launch the
 modern generalized ``jdaviz`` from here, click the Jdaviz logo in the top right.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -26,13 +26,12 @@ these deprecated configurations are still available from the command line. For c
 configurations during their deprecation period, you can specify ``--layout=flexible`` to launch the new
 generalized Jdaviz from the command line. To load a file into a configuration::
 
-    jdaviz --layout=[imviz|specviz|cubeviz|mosviz|specviz2d|flexible] --filepath=/path/to/data/file --file_format=FileFormat
+    jdaviz --layout=[imviz|specviz|cubeviz|mosviz|specviz2d|flexible] --filepath="/path/to/data/file" --file_format="FileFormat"
 
 This will warn that the ``--layout`` argument is deprecated. In the future, running the ``jdaviz``
 command will simply launch the generalized Jdaviz application without going through a launcher page.
 You can also specify filepath and file format using the shorter ``-fp`` and ``-ff``, respectively, which
-may be useful if loading multiple files. Note that the file format is generally required because many files can be read,
-for example, using either the image loader or the catalog loader. See :ref:`loaders-formats` for the current list
+may be useful if loading multiple files. Note that the file format is generally required because many files can be read by multiple loaders. See :ref:`loaders-formats` for the current list
 of available data formats. Note that you will need to enclose multi-word formats in quotation marks, for example
 ``--file_format='1D Spectrum'``.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -32,19 +32,9 @@ This will warn that the ``--layout`` argument is deprecated. In the future, runn
 command will simply launch the generalized Jdaviz application without going through a launcher page.
 You can also specify filepath and file format using the shorter ``-fp`` and ``-ff``, respectively, which
 may be useful if loading multiple files. Note that the file format is generally required because many files can be read,
-for example, using either the image loader or the catalog loader. The current list of supported file formats is:
-
-    * Image
-    * Catalog
-    * 1D Spectrum
-    * 2D Spectrum
-    * 3D Spectrum
-    * Ramp
-    * Ramp Integration
-    * Subset
-    * Trace
-    * Line List
-    * Footprint
+for example, using either the image loader or the catalog loader. See :ref:`loaders-formats` for the current list
+of available data formats. Note that you will need to enclose multi-word formats in quotation marks, for example
+``--file_format='1D Spectrum'``.
 
 Currently, running the command ``jdaviz`` without any additional input will still run a launcher. To launch the
 modern generalized ``jdaviz`` from here, click the Jdaviz logo in the top right.

--- a/docs/quickstart_configs.rst
+++ b/docs/quickstart_configs.rst
@@ -40,11 +40,15 @@ To see the syntax and usage, from a terminal, type::
 
 Typical usage to load a file into a desired configuration::
 
-    jdaviz --layout=[imviz|specviz|cubeviz|mosviz|specviz2d] /path/to/data/file
+    jdaviz --layout=[imviz|specviz|cubeviz|mosviz|specviz2d] --filepath /path/to/data/file
 
 For example, to load a FITS image into Imviz::
 
-    jdaviz --layout=imviz my_image.fits
+    jdaviz --layout=imviz --filepath=my_image.fits --file_format=Image
+
+You can also specify filepath and file format using the shorter ``-fp`` and ``-ff``, respectively. Note that
+the file format is generally required because many files can be read as, for example, using either the image
+loader or the catalog loader.
 
 To learn more about the various ``jdaviz`` application configurations and loading data,
 see the :ref:`imviz`, :ref:`specviz`, :ref:`cubeviz`, :ref:`mosviz`, or :ref:`specviz2d` tools.

--- a/docs/quickstart_configs.rst
+++ b/docs/quickstart_configs.rst
@@ -40,7 +40,7 @@ To see the syntax and usage, from a terminal, type::
 
 Typical usage to load a file into a desired configuration::
 
-    jdaviz --layout=[imviz|specviz|cubeviz|mosviz|specviz2d] --filepath /path/to/data/file
+    jdaviz --layout=[imviz|specviz|cubeviz|mosviz|specviz2d] --filepath=/path/to/data/file
 
 For example, to load a FITS image into Imviz::
 

--- a/docs/quickstart_configs.rst
+++ b/docs/quickstart_configs.rst
@@ -44,11 +44,10 @@ Typical usage to load a file into a desired configuration::
 
 For example, to load a FITS image into Imviz::
 
-    jdaviz --layout=imviz --filepath=my_image.fits --file_format=Image
+    jdaviz --layout=imviz --filepath="my_image.fits" --file_format="Image"
 
 You can also specify filepath and file format using the shorter ``-fp`` and ``-ff``, respectively. Note that
-the file format is generally required because many files can be read as, for example, using either the image
-loader or the catalog loader.
+the file format is generally required because many files can be read by multiple loaders.
 
 To learn more about the various ``jdaviz`` application configurations and loading data,
 see the :ref:`imviz`, :ref:`specviz`, :ref:`cubeviz`, :ref:`mosviz`, or :ref:`specviz2d` tools.

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -58,9 +58,9 @@ def main(filepaths=None, layout='default', instrument=None, browser='default',
     else:
         file_list = []
 
-
     if layout == 'flexible' and filepaths and not file_formats:
-        raise ValueError("'file_formats' argument is required for flexible Jdaviz layout when loading files")
+        raise ValueError("'file_formats' argument is required for flexible Jdaviz "
+                         "layout when loading files")
 
     if layout == '' and len(file_list) > 1:
         raise ValueError("'layout' argument is required when specifying multiple files")

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -19,7 +19,7 @@ DEFAULT_HISTORY_VERBOSITY = 'info'
 
 def main(filepaths=None, layout='default', instrument=None, browser='default',
          theme='auto', verbosity=DEFAULT_VERBOSITY, history_verbosity=DEFAULT_HISTORY_VERBOSITY,
-         host='localhost', port=0, hotreload=False):
+         host='localhost', port=0, hotreload=False, file_formats=None):
     """
     Start a Jdaviz application instance with data loaded from FILENAME.
 
@@ -27,6 +27,8 @@ def main(filepaths=None, layout='default', instrument=None, browser='default',
     ----------
     filepaths : list of str, optional
         List of paths to the file(s) to be loaded into the Jdaviz application.
+    file_formats : list of str, optional
+        List of file formats for loading, one for each filepath
     layout : str, optional
         Optional specification for which configuration to use on startup.
     instrument : str, optional
@@ -56,6 +58,10 @@ def main(filepaths=None, layout='default', instrument=None, browser='default',
     else:
         file_list = []
 
+
+    if layout == 'flexible' and filepaths and not file_formats:
+        raise ValueError("'file_formats' argument is required for flexible Jdaviz layout when loading files")
+
     if layout == '' and len(file_list) > 1:
         raise ValueError("'layout' argument is required when specifying multiple files")
 
@@ -64,8 +70,11 @@ def main(filepaths=None, layout='default', instrument=None, browser='default',
     os.environ['JDAVIZ_START_DIR'] = os.path.abspath('.')
 
     from jdaviz import solara
+    print([f[0] for f in file_formats])
     solara.config = layout.capitalize()
     solara.data_list = file_list
+    solara.format_list = [f[0] for f in file_formats]  # We get a list of lists from argparse
+
     if layout == 'mosviz':
         solara.load_data_kwargs = {'instrument': instrument}
     solara.theme = theme
@@ -110,6 +119,9 @@ def _main(config=None):
         filepaths_nargs = 1
     parser.add_argument('filepaths', type=str, nargs=filepaths_nargs, default=None,
                         help='The paths to the files to be loaded into the Jdaviz application.')
+    parser.add_argument('--file_formats', type=str, nargs=filepaths_nargs, default=None,
+                        action='append',
+                        help='The formats of the files to be loaded into the Jdaviz application.')
     parser.add_argument('--instrument', type=str, default='nirspec',
                         help='Manually specifies which instrument parser to use, for Mosviz')
     parser.add_argument('--browser', type=str, default='default',
@@ -137,7 +149,7 @@ def _main(config=None):
 
     main(filepaths=args.filepaths, layout=layout, instrument=args.instrument, browser=args.browser,
          theme=args.theme, verbosity=args.verbosity, history_verbosity=args.history_verbosity,
-         host=args.host, port=args.port, hotreload=args.hotreload)
+         host=args.host, port=args.port, hotreload=args.hotreload, file_formats=args.file_formats)
 
 
 def _specviz():

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -70,7 +70,7 @@ def main(filepaths=None, layout='default', instrument=None, browser='default',
     solara.config = layout.capitalize()
     solara.data_list = file_list
     if file_formats is not None:
-        solara.format_list = [f[0] for f in file_formats]
+        solara.format_list = [f[0].title() for f in file_formats]
 
     if layout == 'mosviz':
         solara.load_data_kwargs = {'instrument': instrument}

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -117,9 +117,10 @@ def _main(config=None):
                             help='Configuration to use.', deprecated=True)
     if (config == "mosviz") or ("mosviz" in sys.argv):
         filepaths_nargs = 1
-    parser.add_argument('filepaths', type=str, nargs=filepaths_nargs, default=None,
+    parser.add_argument('-fp', '--filepath', type=str, nargs=filepaths_nargs, default=None,
+                        action='append',
                         help='The paths to the files to be loaded into the Jdaviz application.')
-    parser.add_argument('--file_formats', type=str, nargs=filepaths_nargs, default=None,
+    parser.add_argument('-ff', '--file_format', type=str, nargs=filepaths_nargs, default=None,
                         action='append',
                         help='The formats of the files to be loaded into the Jdaviz application.')
     parser.add_argument('--instrument', type=str, default='nirspec',

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -70,10 +70,10 @@ def main(filepaths=None, layout='default', instrument=None, browser='default',
     os.environ['JDAVIZ_START_DIR'] = os.path.abspath('.')
 
     from jdaviz import solara
-    print([f[0] for f in file_formats])
     solara.config = layout.capitalize()
     solara.data_list = file_list
-    solara.format_list = [f[0] for f in file_formats]  # We get a list of lists from argparse
+    if file_formats is not None:
+        solara.format_list = [f[0] for f in file_formats]  # We get a list of lists from argparse
 
     if layout == 'mosviz':
         solara.load_data_kwargs = {'instrument': instrument}

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -48,13 +48,10 @@ def main(filepaths=None, layout='default', instrument=None, browser='default',
     hotreload : bool
         Whether to enable hot-reloading of the UI (for development)
     """
+
     if filepaths:
         # Convert paths to posix string; windows paths are not JSON compliant
-        file_list = [pathlib.Path(f).absolute().as_posix() for f in filepaths]
-        if layout == "imviz":
-            # Imviz multiloading should be done all at once for batch processing.
-            # Imviz convention is a single string of consecutive, comma-separated file paths
-            file_list = [','.join(file_list)]
+        file_list = [pathlib.Path(f[0]).absolute().as_posix() for f in filepaths]
     else:
         file_list = []
 
@@ -73,7 +70,7 @@ def main(filepaths=None, layout='default', instrument=None, browser='default',
     solara.config = layout.capitalize()
     solara.data_list = file_list
     if file_formats is not None:
-        solara.format_list = [f[0] for f in file_formats]  # We get a list of lists from argparse
+        solara.format_list = [f[0] for f in file_formats]
 
     if layout == 'mosviz':
         solara.load_data_kwargs = {'instrument': instrument}
@@ -114,7 +111,7 @@ def _main(config=None):
     filepaths_nargs = '*'
     if config is None:
         parser.add_argument('--layout', default='', choices=ALL_JDAVIZ_CONFIGS + ['flexible',],
-                            help='Configuration to use.', deprecated=True)
+                            help='Configuration to use.')
     if (config == "mosviz") or ("mosviz" in sys.argv):
         filepaths_nargs = 1
     parser.add_argument('-fp', '--filepath', type=str, nargs=filepaths_nargs, default=None,
@@ -143,14 +140,17 @@ def _main(config=None):
     parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
     args = parser.parse_args()
 
+    if args.layout != '':
+        print("\033[31mWarning: option '--layout' is deprecated as of Jdaviz 5.0\033[0m")
+
     if config is None:
         layout = args.layout
     else:
         layout = config
 
-    main(filepaths=args.filepaths, layout=layout, instrument=args.instrument, browser=args.browser,
+    main(filepaths=args.filepath, layout=layout, instrument=args.instrument, browser=args.browser,
          theme=args.theme, verbosity=args.verbosity, history_verbosity=args.history_verbosity,
-         host=args.host, port=args.port, hotreload=args.hotreload, file_formats=args.file_formats)
+         host=args.host, port=args.port, hotreload=args.hotreload, file_formats=args.file_format)
 
 
 def _specviz():

--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -111,15 +111,18 @@ def _main(config=None):
     filepaths_nargs = '*'
     if config is None:
         parser.add_argument('--layout', default='', choices=ALL_JDAVIZ_CONFIGS + ['flexible',],
-                            help='Configuration to use.')
+                            help='Configuration to use. Deprecated as of 5.0.')
     if (config == "mosviz") or ("mosviz" in sys.argv):
         filepaths_nargs = 1
     parser.add_argument('-fp', '--filepath', type=str, nargs=filepaths_nargs, default=None,
                         action='append',
-                        help='The paths to the files to be loaded into the Jdaviz application.')
+                        help=('The path to a file to be loaded into the Jdaviz application.'
+                              ' May be repeated to load multiple files.'))
     parser.add_argument('-ff', '--file_format', type=str, nargs=filepaths_nargs, default=None,
                         action='append',
-                        help='The formats of the files to be loaded into the Jdaviz application.')
+                        help=('The format of a file to be loaded into the Jdaviz application.'
+                              'The same number of filepath and file_format arguments must '
+                              'be specified, and will be associated based on input order.'))
     parser.add_argument('--instrument', type=str, default='nirspec',
                         help='Manually specifies which instrument parser to use, for Mosviz')
     parser.add_argument('--browser', type=str, default='default',

--- a/jdaviz/solara.py
+++ b/jdaviz/solara.py
@@ -88,6 +88,9 @@ def Jdaviz():
     def load_app():
         set_app_or_launcher(get_app_or_launcher())
 
+    # We need to use use_effect so that the initial Solara render happens before the app
+    # instantiates internal Solara components (file_drop, file_browser), which would otherwise
+    # be detected and rendered at the top level outside the app.
     solara.use_effect(load_app, [config, data_list, format_list])
 
     return solara.Column(children=[app_or_launcher] if app_or_launcher is not None else [])
@@ -102,5 +105,4 @@ def Page():
     solara.Style(Path(__file__).parent / "solara.css")
 
     solara.Title("Jdaviz")
-    # solara.display(Jdaviz())
     Jdaviz()

--- a/jdaviz/solara.py
+++ b/jdaviz/solara.py
@@ -37,6 +37,33 @@ def on_kernel_start():
     return on_kernel_close
 
 
+def get_app_or_launcher():
+    if config is None or not hasattr(jdaviz.configs, config):
+        if config == 'Flexible':
+            viz = jdaviz.gca()
+            if not len(data_list):
+                jdaviz.loaders['file'].open_in_tray()
+            else:
+                with jdaviz.batch_load():
+                    for filename, format in zip(data_list, format_list):
+                        jdaviz.load(filename, format=format)
+        else:
+            from jdaviz.core.launcher import Launcher
+            launcher = Launcher(height='100vh',
+                                filepath=(data_list[0] if len(data_list) == 1 else ''))
+            return launcher.main_with_launcher
+
+    else:
+        viz = getattr(jdaviz.configs, config)(verbosity=jdaviz_verbosity,
+                                              history_verbosity=jdaviz_history_verbosity)
+        for data in data_list:
+            if config == 'Mosviz':
+                viz.load(directory=data, **load_data_kwargs)
+            else:
+                viz.load(data, **load_data_kwargs)
+
+    return viz.app
+
 @solara.component
 def Page():
     solara.Title("Jdaviz")
@@ -55,29 +82,6 @@ def Page():
 
     solara.Style(Path(__file__).parent / "solara.css")
 
-    if config is None or not hasattr(jdaviz.configs, config):
-        if config == 'Flexible':
-            viz = jdaviz.gca()
-            if not len(data_list):
-                jdaviz.loaders['file'].open_in_tray()
-            else:
-                with jdaviz.batch_load():
-                    for filename, format in zip(data_list, format_list):
-                        jdaviz.load(filename, format=format)
-        else:
-            from jdaviz.core.launcher import Launcher
-            launcher = Launcher(height='100vh',
-                                filepath=(data_list[0] if len(data_list) == 1 else ''))
-            solara.display(launcher.main_with_launcher)
-            return
+    app_or_launcher = solara.use_memo(get_app_or_launcher, [data_list, format_list])
 
-    else:
-        viz = getattr(jdaviz.configs, config)(verbosity=jdaviz_verbosity,
-                                              history_verbosity=jdaviz_history_verbosity)
-        for data in data_list:
-            if config == 'Mosviz':
-                viz.load(directory=data, **load_data_kwargs)
-            else:
-                viz.load(data, **load_data_kwargs)
-
-    solara.display(viz.app)
+    solara.display(app_or_launcher)

--- a/jdaviz/solara.py
+++ b/jdaviz/solara.py
@@ -64,6 +64,7 @@ def get_app_or_launcher():
 
     return viz.app
 
+
 @solara.component
 def Page():
     solara.Title("Jdaviz")

--- a/jdaviz/solara.py
+++ b/jdaviz/solara.py
@@ -53,9 +53,9 @@ def get_app_or_launcher():
     Return either the app instance or the launcher page as appropriate
     '''
     main = ipyvuetify.Sheet(class_="mx-25",
-                 attributes={"id": "popout-widget-container"},
-                 color="#00212C",
-                 height='100vh')
+                            attributes={"id": "popout-widget-container"},
+                            color="#00212C",
+                            height='100vh')
 
     if config is None or not hasattr(jdaviz.configs, config):
         if config == 'Flexible':
@@ -85,14 +85,16 @@ def get_app_or_launcher():
     main.children = [viz.app]
     return main
 
+
 def Jdaviz():
     # Create the shared widgets, using use_memo to ensure we only do it once
     solara.use_memo(create_shared_widgets, [])
 
     app_or_launcher = solara.use_memo(get_app_or_launcher, [config, data_list, format_list])
 
-    #return app_or_launcher
+    # return app_or_launcher
     return solara.Column(children=[app_or_launcher])
+
 
 @solara.component
 def Page():

--- a/jdaviz/solara.py
+++ b/jdaviz/solara.py
@@ -69,11 +69,12 @@ def get_app_or_launcher():
     else:
         viz = getattr(jdaviz.configs, config)(verbosity=jdaviz_verbosity,
                                               history_verbosity=jdaviz_history_verbosity)
-        for data in data_list:
-            if config == 'Mosviz':
-                viz.load(directory=data, **load_data_kwargs)
-            else:
-                viz.load(data, **load_data_kwargs)
+        with jdaviz.batch_load():
+            for filename, format in zip(data_list, format_list):
+                if config == 'Mosviz':
+                    viz.load(directory=filename, format=format, **load_data_kwargs)
+                else:
+                    viz.load(filename, format=format, **load_data_kwargs)
 
     return viz.app
 

--- a/jdaviz/solara.py
+++ b/jdaviz/solara.py
@@ -7,6 +7,7 @@ import solara.lab
 import ipygoldenlayout
 import ipysplitpanes
 import ipyvue
+import ipyvuetify
 
 import jdaviz
 from jdaviz.app import custom_components
@@ -37,7 +38,25 @@ def on_kernel_start():
     return on_kernel_close
 
 
+def create_shared_widgets():
+    ipysplitpanes.SplitPanes()
+    ipygoldenlayout.GoldenLayout()
+    for name, path in custom_components.items():
+        ipyvue.register_component_from_file(None, name,
+                                            os.path.join(os.path.dirname(jdaviz.__file__), path))
+
+    ipyvue.register_component_from_file('g-viewer-tab', "container.vue", jdaviz.__file__)
+
+
 def get_app_or_launcher():
+    '''
+    Return either the app instance or the launcher page as appropriate
+    '''
+    main = ipyvuetify.Sheet(class_="mx-25",
+                 attributes={"id": "popout-widget-container"},
+                 color="#00212C",
+                 height='100vh')
+
     if config is None or not hasattr(jdaviz.configs, config):
         if config == 'Flexible':
             viz = jdaviz.gca()
@@ -49,7 +68,7 @@ def get_app_or_launcher():
                         jdaviz.load(filename, format=format)
         else:
             from jdaviz.core.launcher import Launcher
-            launcher = Launcher(height='100vh',
+            launcher = Launcher(main=main, height='100vh',
                                 filepath=(data_list[0] if len(data_list) == 1 else ''))
             return launcher.main_with_launcher
 
@@ -62,29 +81,27 @@ def get_app_or_launcher():
             else:
                 viz.load(data, **load_data_kwargs)
 
-    return viz.app
+    main.color = 'transparent'
+    main.children = [viz.app]
+    return main
 
+def Jdaviz():
+    # Create the shared widgets, using use_memo to ensure we only do it once
+    solara.use_memo(create_shared_widgets, [])
+
+    app_or_launcher = solara.use_memo(get_app_or_launcher, [config, data_list, format_list])
+
+    #return app_or_launcher
+    return solara.Column(children=[app_or_launcher])
 
 @solara.component
 def Page():
-    solara.Title("Jdaviz")
-
     if config is None:
         solara.Text("No config defined")
         return
 
-    ipysplitpanes.SplitPanes()
-    ipygoldenlayout.GoldenLayout()
-    for name, path in custom_components.items():
-        ipyvue.register_component_from_file(None, name,
-                                            os.path.join(os.path.dirname(jdaviz.__file__), path))
-
-    ipyvue.register_component_from_file('g-viewer-tab', "container.vue", jdaviz.__file__)
-
     solara.Style(Path(__file__).parent / "solara.css")
 
-    app_or_launcher = solara.use_memo(get_app_or_launcher, [config, data_list, format_list])
-
-    children = [app_or_launcher]
-    solara.Column(children=children, gap="0px")
-    #solara.display(app_or_launcher)
+    solara.Title("Jdaviz")
+    # solara.display(Jdaviz())
+    return Jdaviz()

--- a/jdaviz/solara.py
+++ b/jdaviz/solara.py
@@ -13,6 +13,7 @@ from jdaviz.app import custom_components
 
 config = None
 data_list = []
+format_list = []
 load_data_kwargs = {}
 jdaviz_verbosity = 'error'
 jdaviz_history_verbosity = 'info'
@@ -57,12 +58,12 @@ def Page():
     if config is None or not hasattr(jdaviz.configs, config):
         if config == 'Flexible':
             viz = jdaviz.gca()
-            jdaviz.loaders['file'].open_in_tray()
-            if len(data_list) > 1:
-                raise ValueError("Currently only one filepath can be provided for"
-                                 "flexible mode at runtime")
-            elif len(data_list):
-                jdaviz.loaders['file'].filepath = data_list[0]
+            if not len(data_list):
+                jdaviz.loaders['file'].open_in_tray()
+            else:
+                with jdaviz.batch_load():
+                    for filename, format in zip(data_list, format_list):
+                        jdaviz.load(filename, format=format)
         else:
             from jdaviz.core.launcher import Launcher
             launcher = Launcher(height='100vh',

--- a/jdaviz/solara.py
+++ b/jdaviz/solara.py
@@ -7,7 +7,6 @@ import solara.lab
 import ipygoldenlayout
 import ipysplitpanes
 import ipyvue
-import ipyvuetify
 
 import jdaviz
 from jdaviz.app import custom_components
@@ -52,11 +51,6 @@ def get_app_or_launcher():
     '''
     Return either the app instance or the launcher page as appropriate
     '''
-    main = ipyvuetify.Sheet(class_="mx-25",
-                            attributes={"id": "popout-widget-container"},
-                            color="#00212C",
-                            height='100vh')
-
     if config is None or not hasattr(jdaviz.configs, config):
         if config == 'Flexible':
             viz = jdaviz.gca()
@@ -68,7 +62,7 @@ def get_app_or_launcher():
                         jdaviz.load(filename, format=format)
         else:
             from jdaviz.core.launcher import Launcher
-            launcher = Launcher(main=main, height='100vh',
+            launcher = Launcher(height='100vh',
                                 filepath=(data_list[0] if len(data_list) == 1 else ''))
             return launcher.main_with_launcher
 
@@ -81,9 +75,7 @@ def get_app_or_launcher():
             else:
                 viz.load(data, **load_data_kwargs)
 
-    main.color = 'transparent'
-    main.children = [viz.app]
-    return main
+    return viz.app
 
 
 @solara.component

--- a/jdaviz/solara.py
+++ b/jdaviz/solara.py
@@ -83,6 +83,8 @@ def Page():
 
     solara.Style(Path(__file__).parent / "solara.css")
 
-    app_or_launcher = solara.use_memo(get_app_or_launcher, [data_list, format_list])
+    app_or_launcher = solara.use_memo(get_app_or_launcher, [config, data_list, format_list])
 
-    solara.display(app_or_launcher)
+    children = [app_or_launcher]
+    solara.Column(children=children, gap="0px")
+    #solara.display(app_or_launcher)

--- a/jdaviz/solara.py
+++ b/jdaviz/solara.py
@@ -86,14 +86,19 @@ def get_app_or_launcher():
     return main
 
 
+@solara.component
 def Jdaviz():
     # Create the shared widgets, using use_memo to ensure we only do it once
     solara.use_memo(create_shared_widgets, [])
 
-    app_or_launcher = solara.use_memo(get_app_or_launcher, [config, data_list, format_list])
+    app_or_launcher, set_app_or_launcher = solara.use_state(None)
 
-    # return app_or_launcher
-    return solara.Column(children=[app_or_launcher])
+    def load_app():
+        set_app_or_launcher(get_app_or_launcher())
+
+    solara.use_effect(load_app, [config, data_list, format_list])
+
+    return solara.Column(children=[app_or_launcher] if app_or_launcher is not None else [])
 
 
 @solara.component
@@ -106,4 +111,4 @@ def Page():
 
     solara.Title("Jdaviz")
     # solara.display(Jdaviz())
-    return Jdaviz()
+    Jdaviz()


### PR DESCRIPTION
This enables loading multiple files with format specified through CLI. The user needs to be able to specify the file format for the loader to load files in deconfigged from the CLI. This enables that with a `file_format` argument, which should be specified for each file, e.g.:

```
jdaviz --layout=flexible -fp /Users/rosteen/Data/NIRCam/jw02727-o002_t062_nircam_clear-f277w_i2d.fits -ff Image -fp /Users/rosteen/Data/NIRCam/jw02727-o002_t062_nircam_clear-f150w_i2d.fits -ff Image
```

This PR also fixes the faulty rendering of extra `file-browser` and `file-drop` elements above the app when specifying a `--layout` argument from the command line.