### PR TITLE
fix data-menu access in sonify (skipped) test

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/sonify_data/tests/test_sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/tests/test_sonify_data.py
@@ -41,14 +41,14 @@ def test_sonify_data(cubeviz_helper, spectrum1d_cube_larger):
     assert sonify_plg.stream_active
 
     # Add sonified data to uncert-viewer
-    uncert_viewer = cubeviz_helper.viewers['uncert-viewer']._obj
+    uncert_viewer = cubeviz_helper.viewers['uncert-viewer']
     uncert_viewer.data_menu.add_data('Sonified data')
     assert 'Sonified data' in uncert_viewer.data_menu.data_labels_loaded
 
     event_data = {'event': 'mousemove', 'domain': {'x': 1, 'y': 1}}
-    uncert_viewer._viewer_mouse_event(event_data)
+    uncert_viewer._obj.glue_viewer._viewer_mouse_event(event_data)
 
-    compsig = uncert_viewer.combined_sonified_grid[(1, 1)]
+    compsig = uncert_viewer._obj.glue_viewer.combined_sonified_grid[(1, 1)]
     sigmax = abs(compsig).max()
     INT_MAX = 2**15 - 1
     if sigmax > INT_MAX:


### PR DESCRIPTION
Previously running tests locally would give:

```
>       uncert_viewer.data_menu.add_data('Sonified data')
        ^^^^^^^^^^^^^^^^^^^^^^^
E       AttributeError: 'JdavizViewerWindow' object has no attribute 'data_menu'

cubeviz/plugins/sonify_data/tests/test_sonify_data.py:45: AttributeError
```