### PR TITLE
Fix pixel padding discrepancy between deconfigged and imviz

### DIFF
--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -82,10 +82,9 @@ class TestCenterOffset(BaseImviz_WCS_NoWCS):
 
 class TestCenter(BaseDeconfiggedImage_WCS_WCS):
 
-    @pytest.mark.skip(reason='bug when switching this test to deconfigged (JDAT-6023)')
     def test_center_on_pix(self):
 
-        self.orientation_plugin = 'WCS'
+        self.orientation_plugin.align_by = 'WCS'
 
         # This is the second loaded data that is dithered by 1-pix in x
         limits_first_data = np.array([-5.5, 5.5, -5.5, 5.5])

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -278,7 +278,7 @@ class FreezableBqplotImageViewerState(BqplotImageViewerState, FreezableState):
     def reset_limits(self, *event):
         # TODO: use consistent logic for all image viewers by removing this if-statement
         # if/when WCS linking is supported (i.e. in cubeviz)
-        if getattr(self, '_viewer', None) is not None and self._viewer.jdaviz_app.config != 'imviz':
+        if getattr(self, '_viewer', None) is not None and self._viewer.jdaviz_app.config not in ('imviz', 'deconfigged'):  # noqa: E501
             return super().reset_limits(*event)
         if self.reference_data is None:  # Nothing to do
             return

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
@@ -76,10 +76,6 @@ class VOResolver(BaseConeSearchResolver):
         that serve data in that waveband around the source.
         Then update the dropdown accordingly.
         """
-        # Reset output and parsed input disabled messages
-        # since we're changing the query parameters
-        self.parsed_input_is_resolvable = ''
-
         # If waveband was changed to nothing, immediately quit
         # Don't throw an error due to trigger by plugin init
         if not self.waveband_selected:


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address a discrepancy where padding was being applied in imviz but not in deconfigged as caught by a test. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
