### PR TITLE
Force tooltip z-order to be very high

### DIFF
--- a/jdaviz/components/tooltip.vue
+++ b/jdaviz/components/tooltip.vue
@@ -1,6 +1,6 @@
 <template>
   <v-tooltip v-if="getTooltipHtml()" bottom :open-delay="getOpenDelay()"
-      :nudge-bottom="getNudgeBottom()" z-index="10000">
+      :nudge-bottom="getNudgeBottom()">
     <template v-slot:activator="{ on, attrs }">
       <span v-bind="attrs" v-on="on" :style="getSpanStyle()">
         <slot></slot>

--- a/jdaviz/components/tooltip.vue
+++ b/jdaviz/components/tooltip.vue
@@ -1,6 +1,6 @@
 <template>
   <v-tooltip v-if="getTooltipHtml()" bottom :open-delay="getOpenDelay()"
-      :nudge-bottom="getNudgeBottom()">
+      :nudge-bottom="getNudgeBottom()" z-index="10000">
     <template v-slot:activator="{ on, attrs }">
       <span v-bind="attrs" v-on="on" :style="getSpanStyle()">
         <slot></slot>

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -14,8 +14,6 @@
               <div
                 v-if="Object.keys(viewer_icons).length > 1 || Object.keys(visible_layers).length == 0 || data_menu_open"
                 :class="loaded_n_data === 0 && !data_menu_open ? 'viewer-label pulse' : 'viewer-label'"
-                @mouseenter="showFloatingLabel($event, viewer_reference || viewer_id)"
-                @mouseleave="hideFloatingLabel()"
               >
                 <span style="float: right">
                   <j-layer-viewer-icon-stylized
@@ -34,10 +32,7 @@
                 <span class="invert-if-dark" style="margin-left: 30px; margin-right: 36px; line-height: 28px">{{viewer_reference || viewer_id}}</span>
               </div>
 
-              <div v-for="item in layer_items" class="viewer-label"
-                @mouseenter="showFloatingLabel($event, item.label)"
-                @mouseleave="hideFloatingLabel()"
-              >
+              <div v-for="item in layer_items" class="viewer-label">
                 <div v-if="item.visible">
                   <span style="float: right">
                     <j-layer-viewer-icon-stylized
@@ -333,7 +328,6 @@
       this.jupyterLabCell = this.$el.closest(".jp-Notebook-cell");
     },
     beforeDestroy() {
-      this.hideFloatingLabel();
       let element = document.getElementById(`dm-target-${this.viewer_id}`).parentElement
       if (element === null) {
         return
@@ -420,57 +414,6 @@
         } else {
           return 'False'
         }
-      },
-      showFloatingLabel(event, label) {
-        this.hideFloatingLabel();
-        const el = event.currentTarget;
-        const rect = el.getBoundingClientRect();
-
-        // Read font properties from the actual text span
-        const textSpan = el.querySelector('.invert-if-dark');
-        const computed = textSpan
-          ? window.getComputedStyle(textSpan)
-          : null;
-
-        const floater = document.createElement('div');
-        floater.textContent = label;
-        Object.assign(floater.style, {
-          position: 'fixed',
-          top: rect.top + 'px',
-          right: (window.innerWidth - rect.right) + 'px',
-          height: rect.height + 'px',
-          backgroundColor: '#e5e5e5',
-          // Text is always dark on the light background (the
-          // original uses filter:invert in dark mode to achieve
-          // the same result).
-          color: 'rgba(0, 0, 0, 0.87)',
-          whiteSpace: 'nowrap',
-          lineHeight: rect.height + 'px',
-          paddingLeft: '30px',
-          paddingRight: '36px',
-          borderTopLeftRadius: '4px',
-          borderBottomLeftRadius: '4px',
-          zIndex: '10001',
-          pointerEvents: 'none',
-          fontFamily: computed
-            ? computed.fontFamily
-            : 'Roboto, sans-serif',
-          fontSize: computed
-            ? computed.fontSize
-            : '14px',
-        });
-
-        const target = document.querySelector('[data-app]');
-        if (target) {
-          target.appendChild(floater);
-        }
-        this._floatingLabel = floater;
-      },
-      hideFloatingLabel() {
-        if (this._floatingLabel && this._floatingLabel.parentNode) {
-          this._floatingLabel.parentNode.removeChild(this._floatingLabel);
-        }
-        this._floatingLabel = null;
       }
     },
   }

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -14,6 +14,8 @@
               <div
                 v-if="Object.keys(viewer_icons).length > 1 || Object.keys(visible_layers).length == 0 || data_menu_open"
                 :class="loaded_n_data === 0 && !data_menu_open ? 'viewer-label pulse' : 'viewer-label'"
+                @mouseenter="showFloatingLabel($event, viewer_reference || viewer_id)"
+                @mouseleave="hideFloatingLabel()"
               >
                 <span style="float: right">
                   <j-layer-viewer-icon-stylized
@@ -32,7 +34,10 @@
                 <span class="invert-if-dark" style="margin-left: 30px; margin-right: 36px; line-height: 28px">{{viewer_reference || viewer_id}}</span>
               </div>
 
-              <div v-for="item in layer_items" class="viewer-label">
+              <div v-for="item in layer_items" class="viewer-label"
+                @mouseenter="showFloatingLabel($event, item.label)"
+                @mouseleave="hideFloatingLabel()"
+              >
                 <div v-if="item.visible">
                   <span style="float: right">
                     <j-layer-viewer-icon-stylized
@@ -328,6 +333,7 @@
       this.jupyterLabCell = this.$el.closest(".jp-Notebook-cell");
     },
     beforeDestroy() {
+      this.hideFloatingLabel();
       let element = document.getElementById(`dm-target-${this.viewer_id}`).parentElement
       if (element === null) {
         return
@@ -414,6 +420,57 @@
         } else {
           return 'False'
         }
+      },
+      showFloatingLabel(event, label) {
+        this.hideFloatingLabel();
+        const el = event.currentTarget;
+        const rect = el.getBoundingClientRect();
+
+        // Read font properties from the actual text span
+        const textSpan = el.querySelector('.invert-if-dark');
+        const computed = textSpan
+          ? window.getComputedStyle(textSpan)
+          : null;
+
+        const floater = document.createElement('div');
+        floater.textContent = label;
+        Object.assign(floater.style, {
+          position: 'fixed',
+          top: rect.top + 'px',
+          right: (window.innerWidth - rect.right) + 'px',
+          height: rect.height + 'px',
+          backgroundColor: '#e5e5e5',
+          // Text is always dark on the light background (the
+          // original uses filter:invert in dark mode to achieve
+          // the same result).
+          color: 'rgba(0, 0, 0, 0.87)',
+          whiteSpace: 'nowrap',
+          lineHeight: rect.height + 'px',
+          paddingLeft: '30px',
+          paddingRight: '36px',
+          borderTopLeftRadius: '4px',
+          borderBottomLeftRadius: '4px',
+          zIndex: '10001',
+          pointerEvents: 'none',
+          fontFamily: computed
+            ? computed.fontFamily
+            : 'Roboto, sans-serif',
+          fontSize: computed
+            ? computed.fontSize
+            : '14px',
+        });
+
+        const target = document.querySelector('[data-app]');
+        if (target) {
+          target.appendChild(floater);
+        }
+        this._floatingLabel = floater;
+      },
+      hideFloatingLabel() {
+        if (this._floatingLabel && this._floatingLabel.parentNode) {
+          this._floatingLabel.parentNode.removeChild(this._floatingLabel);
+        }
+        this._floatingLabel = null;
       }
     },
   }

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -33,28 +33,25 @@
               </div>
 
               <div v-for="item in layer_items" class="viewer-label">
-                <div v-if="item.visible">
-                  <span style="float: right">
-                    <j-layer-viewer-icon-stylized
-                      tooltip="View data layers and subsets"
-                      :label="item.label"
-                      :icon="item.icon"
-                      :visible="item.visible"
-                      :is_subset="item.is_subset"
-                      :colors="item.colors"
-                      :linewidth="item.linewidth"
-                      :cmap_samples="cmap_samples"
-                      btn_style="margin-bottom: 0px"
-                      @click="() => {data_menu_open = !data_menu_open}"
-                    />
-                  </span>
-                  <span class="invert-if-dark" style="margin-left: 30px; margin-right: 36px; line-height: 28px">
-                    <j-subset-icon v-if="item.subset_type" :subset_type="item.subset_type" />
-                    <j-child-layer-icon v-if="/\d/.test(item.icon)" :icon="item.icon" />
-                    <j-plugin-live-results-icon v-if="item.live_plugin_results" />
-                    {{ item.label }}
-                  </span>
-                </div>
+                <v-tooltip v-if="item.visible" left :open-delay="300">
+                  <template v-slot:activator="{ on: labelOn, attrs: labelAttrs }">
+                    <span v-bind="labelAttrs" v-on="labelOn" style="float: right; display: inline-block">
+                      <j-layer-viewer-icon-stylized
+                        tooltip="View data layers and subsets"
+                        :label="item.label"
+                        :icon="item.icon"
+                        :visible="item.visible"
+                        :is_subset="item.is_subset"
+                        :colors="item.colors"
+                        :linewidth="item.linewidth"
+                        :cmap_samples="cmap_samples"
+                        btn_style="margin-bottom: 0px"
+                        @click="() => {data_menu_open = !data_menu_open}"
+                      />
+                    </span>
+                  </template>
+                  <span>{{ item.label }}</span>
+                </v-tooltip>
               </div>
             </div>
           </template>

--- a/jdaviz/main_styles.vue
+++ b/jdaviz/main_styles.vue
@@ -166,6 +166,7 @@ div.output_wrapper {
   border-radius: 2px !important;
   border: 1px #003B4D solid !important;
   color: black !important;
+  z-index: 10000 !important;
 }
 
 .v-expansion-panel-content__wrap {


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address an issue where the tooltip hover was being hidden behind sub-menus. This was easily solved by adjusting the z-order for those tooltips but in testing the solution, I realized the same issue was happening with data labels on-hover in the data menu.

I attempted to adjust the z-order for the data label hover but it didn't work so I had to take a different approach and instituted a method to override the inherited behavior and force the hover label to the front. It's a little more convoluted than I'd like but it was the only thing that seemed to work...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
