### PR TITLE
Don't match pan/zoom across image viewer types

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -2,7 +2,6 @@ import time
 import os
 
 from glue.config import viewer_tool
-from glue_jupyter.bqplot.image import BqplotImageView
 from glue.viewers.common.tool import CheckableTool
 import numpy as np
 from specutils import Spectrum
@@ -10,6 +9,7 @@ from specutils import Spectrum
 from jdaviz.core.events import SliceToolStateMessage, SliceSelectSliceMessage
 from jdaviz.core.tools import PanZoom, BoxZoom, _MatchedZoomMixin
 from jdaviz.configs.default.plugins.tools import ProfileFromCube
+from jdaviz.configs.cubeviz.plugins.viewers import CubevizImageView
 
 __all__ = []
 
@@ -25,7 +25,7 @@ class _PixelMatchedZoomMixin(_MatchedZoomMixin):
         return ['zoom_center_x', 'zoom_center_y', 'zoom_radius']
 
     def _is_matched_viewer(self, viewer):
-        return isinstance(viewer, BqplotImageView)
+        return isinstance(viewer, CubevizImageView)
 
 
 @viewer_tool

--- a/jdaviz/configs/imviz/plugins/tools.py
+++ b/jdaviz/configs/imviz/plugins/tools.py
@@ -4,9 +4,9 @@ from echo import delay_callback
 
 from glue.config import viewer_tool
 from glue.viewers.common.tool import CheckableTool
-from glue_jupyter.bqplot.image import BqplotImageView
 from glue_jupyter.utils import debounced
 
+from jdaviz.configs.imviz.plugins.viewers import ImvizImageView
 from jdaviz.core.tools import BoxZoom, PanZoom, _MatchedZoomMixin
 from jdaviz.utils import get_top_layer_index
 
@@ -24,7 +24,7 @@ class _ImvizMatchedZoomMixin(_MatchedZoomMixin):
         return ['zoom_center_x', 'zoom_center_y', 'zoom_radius']
 
     def _is_matched_viewer(self, viewer):
-        return isinstance(viewer, BqplotImageView)
+        return isinstance(viewer, ImvizImageView)
 
 
 @viewer_tool


### PR DESCRIPTION
While investigating the failed spectral extraction message when making a spatial subset in a cube viewer with an `ImvizImageView` also in the app, I noticed that the matched zoom was propagating between these viewer types as well. I made the viewer type check in both zoom tools more restrictive, and interestingly this fixed the original problem with the subset as well.

At some point we will want to make this less restrictive again and perhaps check for linkage between the data in the viewers instead, or define the subsets and zoom by WCS between viewers if possible rather than by pixel. But for now this works since we're not fully supporting mixed data workflows yet.