### PR TITLE
Fix deconfigged vs imviz regions discrepancies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,9 @@ New Features
 
 - Add support for loading Spectra from BinaryHDU and TableHDU extensions. [#4097]
 
+- Fix discrepancies between deconfigged and imviz when loading subsets/regions
+  when using the WCS/orientation layer [#4130]
+
 Cubeviz
 ^^^^^^^
 - Added ability to load DQ extension in the cubeviz loader, which activates the

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -733,7 +733,12 @@ class PrivateApplication(VuetifyTemplate, HubListener):
             return
 
         if viewer_id is None:
-            viewer = self._jdaviz_helper.default_viewer._obj.glue_viewer
+            if hasattr(self._jdaviz_helper, 'default_viewer'):
+                viewer = self._jdaviz_helper.default_viewer._obj.glue_viewer
+            elif len(self._viewer_store):
+                viewer = list(self._viewer_store.values())[0]
+            else:
+                return
         else:
             viewer = self.get_viewer(viewer_id)
 
@@ -2699,7 +2704,7 @@ class PrivateApplication(VuetifyTemplate, HubListener):
                                 setattr(subset_state, att, cid)
 
                     # Translate bounds through WCS if needed
-                    if (self.config == "imviz" and
+                    if (self.config in ("imviz", "deconfigged") and
                             self._jdaviz_helper.plugins["Orientation"].align_by == "WCS"):
 
                         # Default shape for WCS-only layers is 10x10, but it doesn't really matter

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -908,10 +908,13 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
 
         def _do_recentering(subset, subset_state):
             try:
-                type = 'sky_region' if self._app.config == 'imviz' and self._app._align_by == 'wcs' else 'region'  # noqa: E501
+                if self._app.config in ('imviz', 'deconfigged') and self._app._align_by == 'wcs':
+                    region_type = 'sky_region'
+                else:
+                    region_type = 'region'
                 reg = self._app.get_subsets(subset_name=subset,
-                                            include_sky_region=type == 'sky_region',
-                                            spatial_only=True)[0][type]
+                                            include_sky_region=region_type == 'sky_region',
+                                            spatial_only=True)[0][region_type]
                 aperture = regions2aperture(reg)
                 data = self.recenter_dataset.selected_dc_item
                 comp = data.get_component(data.main_components[0])
@@ -1379,7 +1382,7 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
                                             RectangularAperture, CircularAnnulus,
                                             CirclePixelRegion, EllipsePixelRegion,
                                             RectanglePixelRegion, CircleAnnulusPixelRegion))
-                            and (hasattr(self.app, '_link_type') and self.app._link_type == "wcs")):
+                            and self._app._align_by == 'wcs'):
                         bad_regions.append(
                             (region, 'Pixel region provided but data is aligned by WCS'))
                         continue

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -1383,9 +1383,16 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
                                             CirclePixelRegion, EllipsePixelRegion,
                                             RectanglePixelRegion, CircleAnnulusPixelRegion))
                             and self._app._align_by == 'wcs'):
-                        bad_regions.append(
-                            (region, 'Pixel region provided but data is aligned by WCS'))
-                        continue
+                        if has_wcs:
+                            wcs = data.coords
+                            if getattr(wcs, 'world_n_dim', None) == 3:
+                                wcs = _get_celestial_wcs(wcs)
+                            region = region.to_sky(wcs)
+                        else:
+                            bad_regions.append((region, 'Pixel region provided but data '
+                                                        'is aligned by WCS with no valid '
+                                                        'WCS for conversion'))
+                            continue
 
                     # photutils: Convert to region shape first
                     if isinstance(region, (CircularAperture, SkyCircularAperture,

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -595,6 +595,11 @@ class JdavizViewerMixin(WithCache):
                 return layer
 
     def _apply_layer_defaults(self, layer_state):
+        # Hide subset layers on orientation layers to avoid rendering artifacts.
+        if (layer_state.layer.label != layer_state.layer.data.label
+                and layer_state.layer.data.meta.get(_wcs_only_label, False)):
+            layer_state.visible = False
+
         if hasattr(layer_state, 'as_steps'):
             if layer_state.layer.label != layer_state.layer.data.label:
                 # then this is a subset, so default based on the parent data layer

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -595,7 +595,7 @@ class JdavizViewerMixin(WithCache):
                 return layer
 
     def _apply_layer_defaults(self, layer_state):
-        # Hide subset layers on orientation layers to avoid rendering artifacts.
+        # Hide subsets on orientation layers to avoid rendering artifacts.
         if (layer_state.layer.label != layer_state.layer.data.label
                 and layer_state.layer.data.meta.get(_wcs_only_label, False)):
             layer_state.visible = False

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -116,7 +116,7 @@ class TestLink_WCS_WCS(BaseDeconfiggedImage_WCS_WCS, BaseLinkHandler):
 
         # Add subsets
         self.subset_plugin.import_region([
-            CirclePixelRegion(center=PixCoord(x=2.55, y=3.55), radius=1.05),
+            CirclePixelRegion(center=PixCoord(x=2.55, y=3.55), radius=1.05).to_sky(self.wcs_1),
             CirclePixelRegion(center=PixCoord(x=6, y=2), radius=5).to_sky(self.wcs_1),
             PolygonPixelRegion(vertices=PixCoord(x=[1, 2, 2], y=[1, 1, 2])).to_sky(self.wcs_1),
             PolygonPixelRegion(vertices=PixCoord(x=[2, 3, 3], y=[2, 2, 3])).to_sky(self.wcs_1)

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -116,7 +116,7 @@ class TestLink_WCS_WCS(BaseDeconfiggedImage_WCS_WCS, BaseLinkHandler):
 
         # Add subsets
         self.subset_plugin.import_region([
-            CirclePixelRegion(center=PixCoord(x=2.55, y=3.55), radius=1.05).to_sky(self.wcs_1),
+            CirclePixelRegion(center=PixCoord(x=2.55, y=3.55), radius=1.05),
             CirclePixelRegion(center=PixCoord(x=6, y=2), radius=5).to_sky(self.wcs_1),
             PolygonPixelRegion(vertices=PixCoord(x=[1, 2, 2], y=[1, 1, 2])).to_sky(self.wcs_1),
             PolygonPixelRegion(vertices=PixCoord(x=[2, 3, 3], y=[2, 2, 3])).to_sky(self.wcs_1)

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -218,7 +218,6 @@ class TestDeleteOrientation(BaseDeconfiggedImage_WCS_WCS):
         assert self.viewer.state.reference_data.label == "Default orientation"
         assert viewer_2._obj.glue_viewer.state.reference_data.label == "Default orientation"
 
-    @pytest.mark.skip(reason='bug when switching this test to deconfigged (JDAT-6025)')
     @pytest.mark.parametrize("klass", [EllipseSkyRegion, RectangleSkyRegion])
     @pytest.mark.parametrize(
         ("angle", "sbst_theta"),

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -224,9 +224,8 @@ class TestSimpleAperPhot(BaseDeconfiggedImage_WCS_WCS):
     def test_batch_phot(self):
 
         self.orientation_plugin.align_by = 'WCS'
-        self.subset_plugin.import_region(
-            CirclePixelRegion(center=PixCoord(x=4.5, y=4.5), radius=4.5)
-        )  # Draw a circle
+        reg = CirclePixelRegion(center=PixCoord(x=4.5, y=4.5), radius=4.5).to_sky(self.wcs_1)
+        self.subset_plugin.import_region(reg)  # Draw a circle
 
         phot_plugin = self.helper.plugins['Aperture Photometry']
         assert phot_plugin.dataset.choices == ['has_wcs_1', 'has_wcs_2']

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -224,8 +224,9 @@ class TestSimpleAperPhot(BaseDeconfiggedImage_WCS_WCS):
     def test_batch_phot(self):
 
         self.orientation_plugin.align_by = 'WCS'
-        reg = CirclePixelRegion(center=PixCoord(x=4.5, y=4.5), radius=4.5).to_sky(self.wcs_1)
-        self.subset_plugin.import_region(reg)  # Draw a circle
+        self.subset_plugin.import_region(
+            CirclePixelRegion(center=PixCoord(x=4.5, y=4.5), radius=4.5)
+        )  # Draw a circle
 
         phot_plugin = self.helper.plugins['Aperture Photometry']
         assert phot_plugin.dataset.choices == ['has_wcs_1', 'has_wcs_2']

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -32,7 +32,6 @@ else:
 
 class TestSimpleAperPhot(BaseDeconfiggedImage_WCS_WCS):
 
-    @pytest.mark.skip(reason='bug when switching this test to deconfigged (JDAT-6025)')
     def test_plugin_wcs_dithered(self):
         self.orientation_plugin.align_by = 'WCS'
 
@@ -135,7 +134,7 @@ class TestSimpleAperPhot(BaseDeconfiggedImage_WCS_WCS):
         self.helper.plugins['Subset Tools'].combination_mode = 'new'
         self.helper.plugins['Subset Tools'].import_region(reg)
 
-        phot_plugin.dataset.selected = 'has_wcs_1[SCI,1]'
+        phot_plugin.dataset.selected = 'has_wcs_1'
         phot_plugin.aperture.selected = 'Subset 2'
         phot_plugin.current_plot_type = 'Radial Profile'
         phot_plugin._obj.vue_do_aper_phot()
@@ -150,7 +149,7 @@ class TestSimpleAperPhot(BaseDeconfiggedImage_WCS_WCS):
         assert_quantity_allclose(tbl[-1]['sum_aper_area'], 28.274334 * PIX2, rtol=1e-4)
         assert_allclose(tbl[-1]['sum'], 28.274334, rtol=1e-4)
         assert_allclose(tbl[-1]['mean'], 1, rtol=1e-4)
-        assert tbl[-1]['data_label'] == 'has_wcs_1[SCI,1]'
+        assert tbl[-1]['data_label'] == 'has_wcs_1'
         assert tbl[-1]['subset_label'] == 'Subset 2'
 
         # Make sure it also works on a rectangle subset.
@@ -159,7 +158,7 @@ class TestSimpleAperPhot(BaseDeconfiggedImage_WCS_WCS):
         self.helper.plugins['Subset Tools'].combination_mode = 'new'
         self.helper.plugins['Subset Tools'].import_region(reg)
 
-        phot_plugin.dataset.selected = 'has_wcs_1[SCI,1]'
+        phot_plugin.dataset.selected = 'has_wcs_1'
         phot_plugin.aperture.selected = 'Subset 3'
         phot_plugin.background.selected = 'Subset 3'
         assert_allclose(phot_plugin.background_value, 1)
@@ -175,7 +174,7 @@ class TestSimpleAperPhot(BaseDeconfiggedImage_WCS_WCS):
         assert_quantity_allclose(tbl[-1]['sum_aper_area'], 81 * PIX2)
         assert_allclose(tbl[-1]['sum'], 0)
         assert_allclose(tbl[-1]['mean'], 0)
-        assert tbl[-1]['data_label'] == 'has_wcs_1[SCI,1]'
+        assert tbl[-1]['data_label'] == 'has_wcs_1'
         assert tbl[-1]['subset_label'] == 'Subset 3'
 
         # Make sure background auto-updates.
@@ -186,8 +185,8 @@ class TestSimpleAperPhot(BaseDeconfiggedImage_WCS_WCS):
 
         hdu3 = fits.ImageHDU(np.ones((10, 10)) + 1, name='SCI')
         hdu3.header.update(self.wcs_2.to_header())
-        self.helper.load_data(hdu3, data_label='twos')
-        phot_plugin.dataset.selected = 'twos[SCI,1]'
+        self.helper.load(hdu3, format='Image', data_label='twos')
+        phot_plugin.dataset.selected = 'twos'
         assert_allclose(phot_plugin.background_value, 2)  # Recalculate based on new Data
 
         # Curve of growth

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3110,10 +3110,14 @@ class SubsetSelect(SelectPluginComponent):
         if subset_state is None:
             return None
 
-        type = 'sky_region' if self._app.config == 'imviz' and self._app._align_by == 'wcs' else 'region'  # noqa: E501
+        if self._app.config in ('imviz', 'deconfigged') and self._app._align_by == 'wcs':
+            region_type = 'sky_region'
+        else:
+            region_type = 'region'
+
         reg = self._app.get_subsets(subset_name=subset,
-                                    include_sky_region=type == 'sky_region',
-                                    spatial_only=True)[0][type]
+                                    include_sky_region=region_type == 'sky_region',
+                                    spatial_only=True)[0][region_type]
         reg.meta['label'] = subset
 
         return reg

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3507,11 +3507,14 @@ class ApertureSubsetSelect(SubsetSelect):
                 pixel_region = spatial_region
             else:
                 if viewer is None:
-                    # TODO: deconfigged jdaviz does not have a 'default' viewer,
-                    # viewer should be passed explicitly in this case. retaining this
-                    # fallback for now to avoid errors for config-specific calls
-                    # to this method.
-                    viewer = self.app._jdaviz_helper.default_viewer._obj.glue_viewer
+                    if hasattr(self.app._jdaviz_helper, 'default_viewer'):
+                        viewer = self.app._jdaviz_helper.default_viewer._obj.glue_viewer
+                    elif len(self.image_viewers):
+                        viewer = self.image_viewers[0]
+                    else:
+                        validity = {'is_aperture': False,
+                                    'aperture_message': 'no viewer available'}
+                        return [], [], validity
                 wcs = getattr(viewer.state.reference_data, 'coords', None)
                 if wcs is None:
                     validity = {'is_aperture': False,

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -189,7 +189,7 @@ def _is_image_viewer(viewer):
 
 
 class ViewerPropertiesMixin:
-    # assumes that self.app is defined by the class
+    # assumes that self._app is defined by the class
     def get_matching_viewers(self, filter_or_cls, raise_if_none=False):
         """
         Get all viewers matching a filter
@@ -207,8 +207,8 @@ class ViewerPropertiesMixin:
             A list of viewer instances of the specified class type.
         """
         # mixin can be used on the Application object itself or on anything
-        # that defines self.app to point to the Application object
-        app = getattr(self, 'app', self)
+        # that defines self._app to point to the Application object
+        app = getattr(self, '_app', self)
 
         def is_match(viewer):
             if inspect.isclass(filter_or_cls):
@@ -3507,8 +3507,8 @@ class ApertureSubsetSelect(SubsetSelect):
                 pixel_region = spatial_region
             else:
                 if viewer is None:
-                    if hasattr(self.app._jdaviz_helper, 'default_viewer'):
-                        viewer = self.app._jdaviz_helper.default_viewer._obj.glue_viewer
+                    if hasattr(self._app._jdaviz_helper, 'default_viewer'):
+                        viewer = self._app._jdaviz_helper.default_viewer._obj.glue_viewer
                     elif len(self.image_viewers):
                         viewer = self.image_viewers[0]
                     else:


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address a discrepancy that appeared when we moved some tests from using Imviz to deconfigged---photometry table results differed, a result of loading regions as subsets when WCS.

As it turns out this unearthed a handful of cascading issues:
* hardcoded checks for region type for Imviz only -> 
* region-handling behavior in some tests, the code now attempts to autoconvert pixel regions when WCS aligned ->
* deconfigged and 'default' viewers, this was a TODO that reared its head after fixing the other issues

A second possibly related discrepancy was identified when using subsets for aperture photometry. In Imviz, the selected subset would render in both the app layer and in the orientation layer which showed up as a cross + circular aperture. This was due to how Imviz handled `_expected_subset_layer_default` which sets a subset layer's visibility but didn't process the orientation layer's subset leaving it visible. We fix that by explicitly setting it to False when setting defaults. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
