### PR TITLE
Fix inline viewer not using max height

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -165,6 +165,8 @@ Bug Fixes
 - Fixed bug where creating new subsets in a fresh app instance and adjusting them creates a copy
   instead of adjusting the original subset. [#4083]
 
+- Fixed using `viewer.show()` with height argument not using the full height inline in the notebook. [#4134]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/viewer_window.vue
+++ b/jdaviz/viewer_window.vue
@@ -65,9 +65,10 @@ module.exports = {
     ensureFullHeightChain() {
       const popoutSelector = ".jupyter-widgets-popout-container";
       const sidecarSelector = ".jp-LinkedOutputView .lm-Panel";
+      const inlineSelector = ".widget-box"
 
       const topElement = this.$refs.top;
-      const fullHeightTarget = topElement.closest(sidecarSelector) || topElement.closest(popoutSelector);
+      const fullHeightTarget = topElement.closest(sidecarSelector) || topElement.closest(popoutSelector) || topElement.closest(inlineSelector);
       const fullWidthTarget = topElement.closest(".lm-Widget");
 
       let el = topElement.parentElement;


### PR DESCRIPTION
#3932 made the sidecar full height workaround more restrictive, which inadvertently made the inline `viewer.show` not use the full height. This fixes the inline case, and I think is restrictive enough to avoid the previous bug, but I don't remember exactly what the buggy case was before so hopefully someone else can check it.