### PR TITLE
Add unit conversion support for images in aperture photometry plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,8 @@ New Features
 
 - Style tweaks to scatter axis ticks and labels. [#4139]
 
+- Add support for unit conversions in aperture photometry plugin for images. [#4136]
+
 Cubeviz
 ^^^^^^^
 - Added ability to load DQ extension in the cubeviz loader, which activates the

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
@@ -92,8 +92,11 @@ def test_cubeviz_aperphot_cube_orig_flux(request, helper_str, image_cube_hdu_obj
     helper._app.add_data_to_viewer(unc_viewer, f"{flux_label} collapsed")
 
     plg = helper.plugins["Aperture Photometry"]
+
+    # select collapsed cube dataset, which should now set is_image to True in ap phot plugin
     plg.dataset.selected = f"{flux_label} collapsed"
     plg.aperture.selected = "Subset 1"
+    assert plg._obj.is_image is True
     plg._obj.vue_do_aper_phot()
     row = plg.export_table()[2]
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -118,6 +118,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
     cube_slice = Unicode("").tag(sync=True)
     is_cube = Bool(False).tag(sync=True)
 
+    is_image = Bool(False).tag(sync=True)
+
     # surface brightness display unit
     display_unit = Unicode("").tag(sync=True)
 
@@ -169,6 +171,9 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
         self.session.hub.subscribe(self, SubsetUpdateMessage, handler=self._on_subset_update)
         self.session.hub.subscribe(self, LinkUpdatedMessage, handler=self._on_link_update)
+
+        # initalize cube_wave with None
+        self._cube_wave = None
 
         # Custom dataset filters for Cubes
         def valid_cube_datasets(data):
@@ -226,12 +231,26 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
     @property
     def _has_display_unit_support(self):
         """
-        Currently, unit conversion in this plugin is only supported for cubes.
-        When this is expanded to images in deconfigged, this logic will need
-        to change.
-        """
+        Unit conversion in this plugin is supported for --
 
-        return self.config != 'imviz' and self.display_unit != '' and self.is_cube
+        - Cubes in cubeviz and deconfigged
+        - 2D images in imviz and deconfigged
+
+        -- that have a valid display unit set.
+        """
+        if self.display_unit == '':
+            return False
+
+        # plugin supports all images in imviz and deconfigged as well
+        # as 1d collapsed cubes from cubeviz
+        if self.is_image and self.config in ('imviz', 'deconfigged', 'cubeviz'):
+            return True
+
+        # cubes are supported in cubeviz and deconfigged
+        if self.is_cube and self.config in ('cubeviz', 'deconfigged'):
+            return True
+
+        return False
 
     def _on_slice_changed(self, msg):
         self.cube_slice = f"{msg.value:.3e} {msg.value_unit}"
@@ -252,12 +271,18 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             datasets = [self.dataset.selected_dc_item]
 
         self.is_cube = False
+        self.is_image = False
         for dataset in datasets:
-            # This assumes all cubes, or no cubes.
-            # 'Is cube' here means is it a cube, or a collapsed cube.
-            if dataset.ndim > 2 or dataset.meta.get('plugin', None) == 'Collapse':
+
+            # is_cube is just the inverse of is_image, but tracking them
+            # individually for readability
+            if dataset.ndim > 2:
                 self.is_cube = True
-                break
+                self.is_image = False
+            else:
+                if dataset.ndim == 2:
+                    self.is_image = True
+                    self.is_cube = False
 
         if self.multiselect:
             # defaults are applied within the loop if the auto-switches are enabled,
@@ -570,7 +595,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
                 data = self.dataset.selected_dc_item
 
         comp = data.get_component(data.main_components[0])
-        if data.ndim > 2:
+        if self.is_cube:
             spectral_axis_index = getattr(data, "meta", {}).get("spectral_axis_index", 0)
             if self._cube_slice_ind is not None:
                 if spectral_axis_index == 0:
@@ -685,7 +710,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             # we can use the pre-cached value
             data = self.dataset.selected_dc_item
 
-        if data.ndim > 2:
+        if self.is_cube:
             if "spectral_axis_index" in getattr(data, "meta", {}):
                 spectral_axis_index = data.meta["spectral_axis_index"]
             else:
@@ -778,7 +803,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
         except ValueError:  # Clearer error message
             raise ValueError('Missing or invalid background value')
 
-        if data.ndim > 2:
+        if self.is_cube:
             if spectral_axis_index == 0:
                 comp_data = comp.data[self._cube_slice_ind, :, :]
             else:
@@ -794,7 +819,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
         if hasattr(reg, 'to_pixel'):
             sky_center = reg.center
-            if data.ndim > 2:
+            if self.is_cube:
                 ycenter, xcenter = w.world_to_pixel(self._cube_wave, sky_center)[1]
             else:  # "imviz"
                 xcenter, ycenter = w.world_to_pixel(sky_center)
@@ -802,7 +827,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             xcenter = reg.center.x
             ycenter = reg.center.y
             if data.coords is not None:
-                if data.ndim > 2:
+                if self.is_cube:
                     if spectral_axis_index == 0:
                         sky = w.pixel_to_world(xcenter, ycenter, self._cube_slice_ind)
                     else:
@@ -886,13 +911,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
         if include_pixarea_fac:
             # convert pixarea, which is in arcsec2/pix2 to the display solid angle unit / pix2
-            if data.ndim == 2:  # 2D images
-                # can remove once unit conversion implemented in imviz and
-                # display_solid_angle_unit traitlet is set, for now it will always be the data units
-                display_solid_angle_unit = check_if_unit_is_per_solid_angle(comp.units,
-                                                                            return_unit=True)
 
-            elif self._has_display_unit_support:
+            if self._has_display_unit_support:
                 display_solid_angle_unit = u.Unit(self.display_solid_angle_unit)
 
             else:
@@ -941,12 +961,9 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             indexes=[1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 18, 18, 18])
 
         if self._has_display_unit_support:
-            if data.ndim > 2:
-                slice_val = self._cube_wave
-            else:
-                slice_val = u.Quantity(np.nan, self._cube_wave.unit)
 
-            phot_table.add_column(slice_val, name="slice_wave", index=29)
+            phot_table.add_column(self._cube_wave if self.is_cube else np.nan,
+                                  name="slice_wave", index=29)
 
             if comp.units:
 
@@ -956,7 +973,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
                 # equivalencies for unit conversion, will never be flux<>sb
                 # so only need spectral_density
-                equivs = u.spectral_density(self._cube_wave)
+                equivs = u.spectral_density(getattr(self, '_cube_wave', None))
 
                 if display_unit != '':
                     if phot_table['background'].unit != display_unit:
@@ -1021,8 +1038,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
                 plot_display_unit = None
 
             if self.current_plot_type == "Curve of Growth":
-                if data.ndim > 2:
-                    self.plot.figure.title = f'Curve of growth from aperture center at {slice_val:.4e}'  # noqa: E501
+                if self.is_cube:
+                    self.plot.figure.title = f'Curve of growth from aperture center at {self._cube_wave:.4e}'  # noqa: E501
                     eqv = u.spectral_density(self._cube_wave)
                 else:
                     self.plot.figure.title = 'Curve of growth from aperture center'
@@ -1045,8 +1062,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
                     self.plot.figure.axes[1].label = img_unit or 'Value'
 
                 if self.current_plot_type == "Radial Profile":
-                    if data.ndim > 2:
-                        self.plot.figure.title = f'Radial profile from aperture center at {slice_val:.4e}'  # noqa: E501
+                    if self.is_cube:
+                        self.plot.figure.title = f'Radial profile from aperture center at {self._cube_wave:.4e}'  # noqa: E501
                         eqv = u.spectral_density(self._cube_wave)
                     else:
                         self.plot.figure.title = 'Radial profile from aperture center'
@@ -1059,8 +1076,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
                     self.plot.update_style('profile', line_visible=True, color='gray', size=32)
 
                 else:  # Radial Profile (Raw)
-                    if data.ndim > 2:
-                        self.plot.figure.title = f'Raw radial profile from aperture center at {slice_val:.4e}'  # noqa: E501
+                    if self.is_cube:
+                        self.plot.figure.title = f'Raw radial profile from aperture center at {self._cube_wave:.4e}'  # noqa: E501
                     else:
                         self.plot.figure.title = 'Raw radial profile from aperture center'
                     x_data, y_data = _radial_profile(
@@ -1134,8 +1151,10 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             elif key == 'aperture_sum_mag' and x is not None:
                 tmp.append({'function': key, 'result': f'{x:.3f}', 'unit': unit})
             elif key == 'slice_wave':
-                if data.ndim > 2:
-                    tmp.append({'function': key, 'result': f'{slice_val.value:.4e}', 'unit': slice_val.unit.to_string()})  # noqa: E501
+                if self.is_cube:
+                    tmp.append({'function': key, 'result': f'{self._cube_wave.value:.4e}', 'unit': getattr(self._cube_wave, 'unit', '-')})  # noqa: E501
+                else:
+                    tmp.append({'function': key, 'result': np.nan, 'unit': '-'})
             else:
                 tmp.append({'function': key, 'result': str(x), 'unit': unit})
 

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -5,6 +5,7 @@ import numpy as np
 from astropy import units as u
 from astropy.io import fits
 from astropy.nddata import NDData
+from astropy.table import Table
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils import minversion
 from astropy.utils.data import get_pkg_data_filename
@@ -20,6 +21,7 @@ from jdaviz.configs.imviz.plugins.aper_phot_simple.aper_phot_simple import (
     _curve_of_growth, _radial_profile)
 from jdaviz.configs.imviz.tests.utils import BaseDeconfiggedImage_WCS_WCS, BaseImviz_WCS_NoWCS
 from jdaviz.core.custom_units_and_equivs import PIX2
+from jdaviz.core.unit_conversion_utils import flux_conversion_general
 
 photutils.future_column_names = True
 if minversion(photutils, '2.3.1.dev'):
@@ -631,3 +633,118 @@ def test_aper_phot_load_table_into_data_collection(imviz_helper, image_2d_wcs):
     assert len(loaded_table) == 2
     assert loaded_table['id'][0] == 1
     assert loaded_table['id'][1] == 2
+
+
+# Units that can be converted without spectral density equivalencies
+# (i.e., same physical type, just different scale)
+IMAGE_SB_UNITS = ['MJy / sr', 'Jy / sr', 'mJy / sr']
+
+
+def _compare_image_table_units(orig_tab, new_tab, orig_unit, new_unit):
+    """
+    Compare two photometry tables with different units row by row,
+    and verify the units are as expected and values are equivalent once converted.
+    """
+    assert len(orig_tab) == len(new_tab)
+
+    for i, row in enumerate(orig_tab):
+        new_unit_str = new_tab[i]['unit'] or '-'
+        orig_unit_str = row['unit'] or '-'
+        if new_unit_str != '-' and orig_unit_str != '-':
+            new_u = u.Unit(new_unit_str)
+            new_val = float(new_tab[i]['result']) * new_u
+
+            orig_u = u.Unit(orig_unit_str)
+            orig_val = float(row['result']) * orig_u
+
+            # Convert original value to new unit
+            orig_converted = flux_conversion_general(orig_val.value,
+                                                     orig_u,
+                                                     new_u,
+                                                     equivalencies=[])
+
+            # Low rtol for match since phot table is rounded
+            assert_quantity_allclose(orig_converted, new_val, rtol=1e-03)
+
+
+@pytest.mark.parametrize("sb_unit", [u.Unit(x) for x in IMAGE_SB_UNITS])
+@pytest.mark.parametrize("new_sb_unit", [u.Unit(x) for x in IMAGE_SB_UNITS])
+def test_deconfigged_image_aperphot_unit_conversions(deconfigged_helper, image_2d_wcs,
+                                                     sb_unit, new_sb_unit):
+    """
+    Test deconfigged aperture photometry with unit conversions for 2D images
+    in surface brightness units (e.g., MJy/sr, Jy/sr).
+
+    The aperture photometry plugin should respect the choice of flux unit
+    selected in the Unit Conversion plugin, and inputs and results should
+    be converted based on selection.
+    """
+    if new_sb_unit == sb_unit:  # skip 'converting' to same unit
+        return
+
+    # Get string representations
+    sb_unit_str = sb_unit.to_string()
+    new_sb_unit_str = new_sb_unit.to_string()
+
+    # Create 2D image data with specified surface brightness unit
+    # Use values that are easy to verify (e.g., array of 10s)
+    data_values = np.ones((10, 10)) * 10.0
+    data = NDData(data_values, wcs=image_2d_wcs, unit=sb_unit_str)
+
+    # Load data into deconfigged
+    deconfigged_helper.load(data, data_label='test_image')
+
+    # Get plugins
+    st = deconfigged_helper.plugins['Subset Tools']
+    ap = deconfigged_helper.plugins['Aperture Photometry']
+    uc = deconfigged_helper.plugins['Unit Conversion']
+
+    # Load aperture - simple rectangle for predictable results
+    aper = RectanglePixelRegion(center=PixCoord(x=5, y=5), width=2, height=2)
+    st.import_region(aper, combination_mode='new')
+
+    # Select dataset and aperture in plugin
+    ap.dataset.selected = 'test_image[DATA]'
+    ap.aperture.selected = 'Subset 1'
+
+    # Check initial unit traitlets are set correctly
+    assert ap._obj.display_unit == sb_unit_str
+    # Get the flux unit (without the solid angle) for flux_scaling_display_unit
+    flux_unit = sb_unit * u.sr
+    assert ap._obj.flux_scaling_display_unit == flux_unit.to_string()
+
+    # Set background to manual for easier comparison
+    ap.background.selected = 'Manual'
+    ap.background_value = 1.0
+    ap.flux_scaling = 1.0
+
+    # Do aperture photometry with initial units
+    ap._obj.vue_do_aper_phot()
+    orig_tab = Table(ap._obj.results)
+
+    # Change to new unit via Unit Conversion plugin
+    # The flux unit dropdown controls the numerator of the surface brightness
+    new_flux_unit = new_sb_unit * u.sr
+    uc.flux_unit.selected = new_flux_unit.to_string()
+
+    # Verify display units in aperture phot plugin reflect the change
+    assert ap._obj.display_unit == new_sb_unit_str
+    assert ap._obj.flux_scaling_display_unit == new_flux_unit.to_string()
+
+    # Verify background and flux scaling were converted to new unit
+    # Convert expected value from original to new unit
+    expected_bg = (1.0 * flux_unit).to(new_flux_unit).value
+    assert_allclose(ap.background_value, expected_bg, rtol=1e-5)
+
+    expected_flux_scaling = (1.0 * flux_unit).to(new_flux_unit).value
+    assert_allclose(ap._obj.flux_scaling, expected_flux_scaling, rtol=1e-5)
+
+    # Do aperture photometry with new units
+    ap._obj.vue_do_aper_phot()
+    new_tab = Table(ap._obj.results)
+
+    # Make sure results actually changed (not just reusing old results)
+    assert not np.all(orig_tab == new_tab)
+
+    # Compare output tables row by row
+    _compare_image_table_units(orig_tab, new_tab, sb_unit, new_sb_unit)


### PR DESCRIPTION
This PR changes some config specific logic to support unit conversions in the aperture photometry plugin for images, and adds test coverage for this scenario. 
