### PR TITLE
Fix socket leak issue from URL request

### DIFF
--- a/jdaviz/configs/default/plugins/about/about.py
+++ b/jdaviz/configs/default/plugins/about/about.py
@@ -38,7 +38,7 @@ class About(PluginTemplateMixin):
         self._plugin_description = 'Information about Jdaviz and links to documentation and resources.'  # noqa
 
     @observe('plugin_opened')
-    def _on_plugin_opened(self, *args):
+    def _on_plugin_opened(self):
         """
         Fetch the latest PyPI version lazily on first open.
 
@@ -47,6 +47,9 @@ class About(PluginTemplateMixin):
         """
         if self._pypi_fetched or not self.plugin_opened:
             return
+
+        # If __version__ is unknown then there's no point to try to fetch the PyPI version,
+        # so skip it and avoid the network call now and in the future.
         self._pypi_fetched = True
 
         if __version__ == 'unknown':
@@ -55,17 +58,13 @@ class About(PluginTemplateMixin):
         _ver_pypi = latest_version_from_pypi('jdaviz')
         if _ver_pypi:
             self.jdaviz_pypi = _ver_pypi
-            self.not_is_latest = (
-                Version(__version__) < Version(_ver_pypi)
-            )
+            self.not_is_latest = Version(__version__) < Version(_ver_pypi)
+
         else:  # pragma: no cover
             self.jdaviz_pypi = 'unknown'
             self.not_is_latest = False
 
     def show_popup(self):
-        """
-        Open the About popup.
-        """
         self._app.force_open_about = True
 
     @property
@@ -101,7 +100,7 @@ def latest_version_from_pypi(package_name):
     version = None
     try:
         with requests.Session() as session:
-            r = session.get(url, timeout=10)
+            r = session.get(url, timeout=60)
             if r.ok:
                 d = r.json()
                 version = d['info']['version']

--- a/jdaviz/configs/default/plugins/about/about.py
+++ b/jdaviz/configs/default/plugins/about/about.py
@@ -59,7 +59,7 @@ class About(PluginTemplateMixin):
 
 def latest_version_from_pypi(package_name):
     """
-    Version info for given package or ``None``.
+    Return the latest version string for a package on PyPI, or ``None``.
 
     Results are cached per-process so repeated calls do not incur
     additional network overhead.
@@ -74,12 +74,14 @@ def latest_version_from_pypi(package_name):
     except Exception:  # nosec # pragma: no cover
         pass
     else:
-        if r.ok:
-            try:
+        try:
+            if r.ok:
                 d = json.loads(r.text)
                 version = d['info']['version']
-            except Exception:  # nosec # pragma: no cover
-                pass
+        except Exception:  # nosec # pragma: no cover
+            pass
+        finally:
+            r.close()
 
     _pypi_version_cache[package_name] = version
     return version

--- a/jdaviz/configs/default/plugins/about/about.py
+++ b/jdaviz/configs/default/plugins/about/about.py
@@ -38,7 +38,7 @@ class About(PluginTemplateMixin):
         self._plugin_description = 'Information about Jdaviz and links to documentation and resources.'  # noqa
 
     @observe('plugin_opened')
-    def _on_plugin_opened(self):
+    def _on_plugin_opened(self, *args):
         """
         Fetch the latest PyPI version lazily on first open.
 

--- a/jdaviz/configs/default/plugins/about/about.py
+++ b/jdaviz/configs/default/plugins/about/about.py
@@ -1,8 +1,6 @@
-import json
-
 import requests
 from packaging.version import Version
-from traitlets import Bool, Unicode
+from traitlets import Bool, Unicode, observe
 
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import PluginTemplateMixin
@@ -22,7 +20,9 @@ _pypi_version_cache = {}
 @tray_registry('about', label="About",
                category='core', sidebar='popup')
 class About(PluginTemplateMixin):
-    """Show information about Jdaviz."""
+    """
+    Show information about Jdaviz.
+    """
     template_file = __file__, "about.vue"
 
     jdaviz_version = Unicode("unknown").tag(sync=True)
@@ -32,20 +32,40 @@ class About(PluginTemplateMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.jdaviz_version = __version__
+        self._pypi_fetched = False
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Information about Jdaviz and links to documentation and resources.'  # noqa
 
-        if __version__ != "unknown":
-            _ver_pypi = latest_version_from_pypi("jdaviz")
-            if _ver_pypi:
-                self.jdaviz_pypi = _ver_pypi
-                self.not_is_latest = Version(__version__) < Version(_ver_pypi)
-            else:  # pragma: no cover
-                self.jdaviz_pypi = "unknown"
-                self.not_is_latest = False
+    @observe('plugin_opened')
+    def _on_plugin_opened(self, *args):
+        """
+        Fetch the latest PyPI version lazily on first open.
+
+        The network call is deferred from ``__init__`` so that app
+        startup never opens (and potentially leaks) SSL sockets.
+        """
+        if self._pypi_fetched or not self.plugin_opened:
+            return
+        self._pypi_fetched = True
+
+        if __version__ == 'unknown':
+            return
+
+        _ver_pypi = latest_version_from_pypi('jdaviz')
+        if _ver_pypi:
+            self.jdaviz_pypi = _ver_pypi
+            self.not_is_latest = (
+                Version(__version__) < Version(_ver_pypi)
+            )
+        else:  # pragma: no cover
+            self.jdaviz_pypi = 'unknown'
+            self.not_is_latest = False
 
     def show_popup(self):
+        """
+        Open the About popup.
+        """
         self._app.force_open_about = True
 
     @property
@@ -63,6 +83,16 @@ def latest_version_from_pypi(package_name):
 
     Results are cached per-process so repeated calls do not incur
     additional network overhead.
+
+    Parameters
+    ----------
+    package_name : str
+        The PyPI package name to look up.
+
+    Returns
+    -------
+    version : str or None
+        Latest version string, or ``None`` on failure.
     """
     if package_name in _pypi_version_cache:
         return _pypi_version_cache[package_name]
@@ -70,18 +100,13 @@ def latest_version_from_pypi(package_name):
     url = f'https://pypi.org/pypi/{package_name}/json'
     version = None
     try:
-        r = requests.get(url, timeout=10)
+        with requests.Session() as session:
+            r = session.get(url, timeout=10)
+            if r.ok:
+                d = r.json()
+                version = d['info']['version']
     except Exception:  # nosec # pragma: no cover
         pass
-    else:
-        try:
-            if r.ok:
-                d = json.loads(r.text)
-                version = d['info']['version']
-        except Exception:  # nosec # pragma: no cover
-            pass
-        finally:
-            r.close()
 
     _pypi_version_cache[package_name] = version
     return version

--- a/jdaviz/configs/default/plugins/about/about.py
+++ b/jdaviz/configs/default/plugins/about/about.py
@@ -15,6 +15,9 @@ except ImportError:  # pragma: no cover
 
 __all__ = ['About']
 
+# Module-level cache so the PyPI check runs at most once per process.
+_pypi_version_cache = {}
+
 
 @tray_registry('about', label="About",
                category='core', sidebar='popup')
@@ -55,18 +58,28 @@ class About(PluginTemplateMixin):
 
 
 def latest_version_from_pypi(package_name):
-    """Version info for given package or `None`."""
-    url = f"https://pypi.org/pypi/{package_name}/json"
+    """
+    Version info for given package or ``None``.
+
+    Results are cached per-process so repeated calls do not incur
+    additional network overhead.
+    """
+    if package_name in _pypi_version_cache:
+        return _pypi_version_cache[package_name]
+
+    url = f'https://pypi.org/pypi/{package_name}/json'
+    version = None
     try:
-        r = requests.get(url, timeout=60)
+        r = requests.get(url, timeout=10)
     except Exception:  # nosec # pragma: no cover
         pass
     else:
         if r.ok:
             try:
                 d = json.loads(r.text)
-                v = d["info"]["version"]
+                version = d['info']['version']
             except Exception:  # nosec # pragma: no cover
                 pass
-            else:
-                return v
+
+    _pypi_version_cache[package_name] = version
+    return version

--- a/jdaviz/configs/default/plugins/about/tests/test_about_plugin.py
+++ b/jdaviz/configs/default/plugins/about/tests/test_about_plugin.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import patch
 
 from jdaviz import __version__
 from jdaviz.configs.default.plugins.about.about import latest_version_from_pypi
@@ -16,12 +17,31 @@ def test_get_latest_version_from_pypi():
     assert v is None
 
 
-# NOTE: The PyPI version check is cached per-process, so only the first
-# Application init in a given process triggers a network request.
 def test_about_basic(specviz_helper):
-    plg = specviz_helper.plugins["About"]._obj
+    """
+    Test that the About plugin populates version info lazily.
+
+    The PyPI check is deferred until the plugin is first opened,
+    so before simulating an open we expect the default 'unknown'.
+    """
+    plg = specviz_helper.plugins['About']._obj
 
     assert plg.jdaviz_version == __version__
-    assert isinstance(plg.jdaviz_pypi, str)
-    # not_is_latest can be non-deterministic because user can be running
-    # this test from an older version going forward, so we skip checking it.
+
+    # Before opening, pypi version has not been fetched yet.
+    assert plg.jdaviz_pypi == 'unknown'
+    assert plg._pypi_fetched is False
+
+    # Simulate the plugin being opened (triggers the lazy fetch).
+    # Mock the network call to avoid real HTTP requests in
+    # non-remote tests.
+    with patch(
+        'jdaviz.configs.default.plugins.about.about'
+        '.latest_version_from_pypi',
+        return_value='99.0.0',
+    ):
+        plg.plugin_opened = True
+
+    assert plg._pypi_fetched is True
+    assert plg.jdaviz_pypi == '99.0.0'
+    assert plg.not_is_latest is True

--- a/jdaviz/configs/default/plugins/about/tests/test_about_plugin.py
+++ b/jdaviz/configs/default/plugins/about/tests/test_about_plugin.py
@@ -16,11 +16,8 @@ def test_get_latest_version_from_pypi():
     assert v is None
 
 
-# NOTE: Theoretically now all the tests in jdaviz are remote data tests
-# because all the viz loads About plugin and About plugin always polls
-# PyPI for the latest release version. If that bothers you or PyPI
-# starts blocking us as spammer, we can consider caching it at package level
-# but that introduces new non-standard package attributes.
+# NOTE: The PyPI version check is cached per-process, so only the first
+# Application init in a given process triggers a network request.
 def test_about_basic(specviz_helper):
     plg = specviz_helper.plugins["About"]._obj
 

--- a/jdaviz/core/loaders/resolvers/url/url.py
+++ b/jdaviz/core/loaders/resolvers/url/url.py
@@ -131,7 +131,13 @@ class PresetURLResolver(URLResolver):
     def __init__(self, url, title=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # Set the URL without triggering _resolver_input_updated,
+        # which would attempt an eager download and leak SSL sockets.
+        # Format detection happens later when the user opens or loads.
+        self._defer_resolver_input_updated = True
         self.url = url
+        self._defer_resolver_input_updated = False
+
         if title is not None:
             self.title = title
         self.hide_resolver_inputs = True

--- a/jdaviz/core/loaders/resolvers/url/url.py
+++ b/jdaviz/core/loaders/resolvers/url/url.py
@@ -129,15 +129,32 @@ class PresetURLResolver(URLResolver):
     """
 
     def __init__(self, url, title=None, *args, **kwargs):
+        self._format_detection_done = False
         super().__init__(*args, **kwargs)
 
         # Set the URL without triggering _resolver_input_updated,
         # which would attempt an eager download and leak SSL sockets.
-        # Format detection happens later when the user opens or loads.
-        self._defer_resolver_input_updated = True
-        self.url = url
-        self._defer_resolver_input_updated = False
+        # Format detection happens lazily when first needed
+        # (via load() or open_in_tray()).
+        with self.defer_resolver_input_updated():
+            self.url = url
 
         if title is not None:
             self.title = title
         self.hide_resolver_inputs = True
+
+    def _ensure_format_detection(self):
+        """Trigger format detection if not yet done."""
+        if not self._format_detection_done:
+            self._format_detection_done = True
+            self._resolver_input_updated()
+
+    def load(self):
+        """Import into jdaviz with all selected options."""
+        self._ensure_format_detection()
+        return super().load()
+
+    def open_in_tray(self):
+        """Show this resolver in the sidebar tray."""
+        self._ensure_format_detection()
+        return super().open_in_tray()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,8 @@ addopts = "--doctest-rst --import-mode=append --ignore-glob='*/jdaviz/qt.py'"
 xfail_strict = true
 filterwarnings = [
     "error",
+    # Ignore SSL socket warnings from failed astroquery requests (e.g., when Gaia archive is down)
+    "ignore:Exception ignored in.*ssl\\.SSLSocket.*:pytest.PytestUnraisableExceptionWarning",
     # This line handles the DeprecationWarning from jupyter_core
     "ignore:Jupyter is migrating its paths.*:DeprecationWarning:jupyter_core.utils",
     # This ignores AstropyPendingDeprecationWarning from spectral_cube


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request addresses an issue with socket leaks when an exception is thrown during a URL request. To avoid the leak, we defer calling `_resolver_input_updated` since that's where the exception gets caught leaving the socket open.

It also attempts to limit errant networking calls whenever the app is instantiated (in CI) in `about.py`. In pytest, this *should* only send out a network call once per process rather than once per setup so if this is the cause of the socket issue, it's less likely to occur. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
