### PR TITLE
fix for loading DQ cubes without adding to viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,8 @@ Other Changes and Additions
 
 Bug Fixes
 ---------
+- Fix 'add to flux viewer' toggle in DQ cube loader to fix issue where the DQ
+  cube was being added to the flux viewer even when toggled off. [#4145]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
@@ -519,10 +519,11 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
                 # add to flux viewer based on checkbox, or don't add to any viewer
                 if self.config == 'cubeviz':
                     viewer_for_dq = self.dq_viewer
-                elif self.dq_add_to_flux_viewer:
-                    viewer_for_dq = self.viewer
                 else:
-                    viewer_for_dq = None
+                    viewer_for_dq = self.viewer
+                    if not self.dq_add_to_flux_viewer:
+                        self.viewer.selected = []
+
                 self.add_to_data_collection(dq_cube,
                                             dq_data_label,
                                             parent=data_label,

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
@@ -358,7 +358,7 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
         if self.has_mask:
             expose += ['mask_data_label', 'mask_viewer']
         if self.has_dq:
-            expose += ['dq_data_label', 'dq_viewer']
+            expose += ['dq_data_label', 'dq_viewer', 'dq_add_to_flux_viewer']
         expose += ['extension']
         if self.has_unc:
             expose += ['unc_extension']
@@ -523,9 +523,14 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
                     # setting viewer=None will default to self.viewer in
                     # add_to_data_collection and we don't want to clear this
                     # selection, so pass it a 'viewer' class that has a selected
-                    # attribute to get around this.
+                    # and create_new.selected to get around this.
+
                     class NoViewer:
                         selected = []
+
+                        class create_new:
+                            selected = []
+
                     viewer_for_dq = NoViewer()
                 else:
                     viewer_for_dq = self.viewer

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
@@ -519,10 +519,16 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
                 # add to flux viewer based on checkbox, or don't add to any viewer
                 if self.config == 'cubeviz':
                     viewer_for_dq = self.dq_viewer
+                elif not self.dq_add_to_flux_viewer:
+                    # setting viewer=None will default to self.viewer in
+                    # add_to_data_collection and we don't want to clear this
+                    # selection, so pass it a 'viewer' class that has a selected
+                    # attribute to get around this.
+                    class NoViewer:
+                        selected = []
+                    viewer_for_dq = NoViewer()
                 else:
                     viewer_for_dq = self.viewer
-                    if not self.dq_add_to_flux_viewer:
-                        self.viewer.selected = []
 
                 self.add_to_data_collection(dq_cube,
                                             dq_data_label,

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -783,3 +783,34 @@ def test_invalid_kwargs_error_message(specviz_helper, spectrum1d):
                                          r"invalid_arg1, invalid_arg2"):
         specviz_helper.load(spectrum1d, format='1D Spectrum',
                             invalid_arg1='foo', invalid_arg2='bar')
+
+
+def test_load_cube_no_dq_in_viewer(deconfigged_helper):
+    """
+    Test loading a cube that has a DQ extension but using setting the
+    'Add to Flux Viewer' toggle to False so the DQ cube is only added to the
+    data collection.
+    """
+
+    flux_data = np.ones((5, 10, 10), dtype=np.float32)
+    dq_data = np.zeros((5, 10, 10), dtype=np.int32)
+
+    # create HDUList with Primary + FLUX + DQ extensions
+    hdul = fits.HDUList([
+        fits.PrimaryHDU(),
+        fits.ImageHDU(data=flux_data, name='FLUX'),
+        fits.ImageHDU(data=dq_data, name='DQ')
+    ])
+
+    deconfigged_helper.load(hdul, format='3D Spectrum', dq_add_to_flux_viewer=False)
+
+    # make sure the flux viewer '3D Spectrum' only has one dataset loaded
+    data_in_flux_viewer = deconfigged_helper.viewers['3D Spectrum'].data_menu.data_labels_loaded
+    assert len(data_in_flux_viewer) == 1
+    assert '3D Spectrum' in data_in_flux_viewer
+
+    # but the DQ extension should be in the data collection, along with FLUX and
+    # the automatic extraction for a total of 3 items
+    datasets = deconfigged_helper.datasets
+    assert len(datasets) == 3
+    assert '3D Spectrum [DQ]' in datasets


### PR DESCRIPTION
This PR fixes an issue where toggling off 'add to flux viewer' for the DQ cube loader was still adding it to the flux viewer. Passing 'viewer = None' to add to data collection default to self.viewer which may have a selection. to get around this, use a fake viewer select class that has the attributes add_to_data_collection expects and indicates a non-selection