### PR TITLE
Don't allow RangeSubsetState in image viewer layer selects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Other Changes and Additions
 
 Bug Fixes
 ---------
+
 - Fix 'add to flux viewer' toggle in DQ cube loader to fix issue where the DQ
   cube was being added to the flux viewer even when toggled off. [#4145]
 
@@ -34,6 +35,7 @@ Bug Fixes
   during iteration error that occurs in many scenarios (linking, batch loading data,
   etc.). [#4150]
 
+- Fix spectral subsets appearing in image viewer data menu. [#4159]
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,7 +35,7 @@ Bug Fixes
   during iteration error that occurs in many scenarios (linking, batch loading data,
   etc.). [#4150]
 
-- Fix spectral subsets appearing in image viewer data menu. [#4159]
+- Fix spectral subsets appearing in image viewer data menu. [#4149]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/configs/default/plugins/data_menu/tests/test_data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/tests/test_data_menu.py
@@ -1,6 +1,8 @@
 import numpy as np
 from astropy.nddata import NDData
+import astropy.units as u
 from regions import CirclePixelRegion, PixCoord
+from specutils import SpectralRegion
 
 
 def test_load_nddata(imviz_helper):
@@ -70,3 +72,18 @@ def test_rename_data_and_subsets(deconfigged_helper, image_hdu_wcs):
     dm.rename('Subset 1', 'my subset')
     assert 'my subset' in [x['label'] for x in dm.layer_items]
     assert 'Subset 1' not in [x['label'] for x in dm.layer_items]
+
+
+def test_only_compatible_subsets_in_menu(deconfigged_helper, image_hdu_wcs, spectrum1d):
+    deconfigged_helper.load(image_hdu_wcs, format='Image', data_label='image_data')
+    deconfigged_helper.load(spectrum1d, format='1D Spectrum', data_label='spectrum')
+
+    subset_plugin = deconfigged_helper.plugins['Subset Tools']._obj
+    subset_plugin.import_region(SpectralRegion(6200 * u.AA, 6800 * u.AA))
+
+    iv = deconfigged_helper.viewers['Image']
+    sv = deconfigged_helper.viewers['1D Spectrum']
+
+    # Make sure the spectral subset is only in the spectrum viewer's data menu
+    assert "Subset 1" not in iv.data_menu.layer.choices
+    assert "Subset 1" in sv.data_menu.layer.choices

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -26,6 +26,7 @@ from glue.core.message import (DataCollectionAddMessage,
                                SubsetDeleteMessage,
                                SubsetUpdateMessage)
 from glue.core.roi import CircularAnnulusROI
+from glue.core.subset import RangeSubsetState
 from glue_jupyter import jglue
 from glue_jupyter.common.toolbar_vuetify import read_icon
 from glue_jupyter.bqplot.histogram import BqplotHistogramView
@@ -2217,6 +2218,7 @@ class LayerSelect(SelectPluginComponent):
         # TODO: all of these add_filter commands should be refactored to pass filters directly
         # to the init and defined in _is_valid_item()
         self.add_filter('not_spatial_subset_in_profile_viewer')
+        self.add_filter('not_spectral_subset_in_image_viewer')
 
         self.filter_is_root = is_root
         self.has_children = has_children
@@ -2282,6 +2284,18 @@ class LayerSelect(SelectPluginComponent):
             # at this point, we are in cubeviz and ALL selected viewers are profile viewers,
             # so we want to exclude spatial subsets
             return get_subset_type(lyr) != 'spatial'
+
+        def not_spectral_subset_in_image_viewer(lyr):
+            if self.plugin.config not in ('deconfigged'):
+                return True
+            if np.any([viewer.__class__.__name__ not in ('CubevizImageView', 'ImvizImageView')
+                       for viewer in self.viewer_objs]):
+                return True
+
+            if hasattr(lyr, 'subset_state'):
+                return not isinstance(lyr.subset_state, RangeSubsetState)
+
+            return True
 
         def is_trace(lyr):
             return 'Trace' in getattr(getattr(lyr, 'data', None), 'meta', [])


### PR DESCRIPTION
I couldn't just check for `get_subset_type(lyr) != 'spectral'` here because it turns out that was returning temporal, due to the way `get_subset_type` currently works. Basically it checks the WCS of the data associated with the subset, and in this case it was checking the `RangeSubsetState` in combination with an image layer and thus not seeing that it was a spectral subset. So, instead I just filter out all `RangeSubsetState` layers from image viewers in deconfigged.

I'll add a test before saying this is ready for review.