### PR TITLE
patch to ipywidgets.Widget.get_state to avoid set size changed during iteration error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,11 @@ Bug Fixes
 - Fix 'add to flux viewer' toggle in DQ cube loader to fix issue where the DQ
   cube was being added to the flux viewer even when toggled off. [#4145]
 
+- Workaround patch to ipywidgets.Widget.get_state to avoid set size changed
+  during iteration error that occurs in many scenarios (linking, batch loading data,
+  etc.). [#4150]
+
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/__init__.py
+++ b/jdaviz/__init__.py
@@ -49,7 +49,8 @@ def safe_get_state(self, key=None, drop_defaults=False):
 
     # make a copy of the keys to send so that observers can safely mutate
     # the original set without causing a RuntimeError
-    key = copy.copy(key)
+    if key is not None:
+        key = copy.copy(key)
     return orig_get_state(self, key=key, drop_defaults=drop_defaults)
 
 
@@ -62,7 +63,7 @@ def new_app(replace=False, set_as_current=True):
     Create a new jdaviz application instance and assign as the current instance.
 
     Parameters
-    ---------
+    ----------
     replace : bool, optional
         If True, replaces the current application instance with the new one.
         Default is False, which means a new instance is added to the list of applications.

--- a/jdaviz/__init__.py
+++ b/jdaviz/__init__.py
@@ -37,6 +37,22 @@ global _current_index
 
 _apps = []
 
+# ipywidgets.Widget.get_state() iterates over _states_to_send, a set
+# that cam be mutated mid-iteration, causing "RuntimeError: Set changed size during iteration".
+# pass in a copy of the set (rather than the live set) to avoid this.
+import ipywidgets as ipywidgets
+import copy
+orig_get_state = ipywidgets.Widget.get_state
+
+def safe_get_state(self, key=None, drop_defaults=False):
+    
+    # make a copy of the set of keys to send so that observers can safely mutate the original set
+    key = copy.copy(key)
+    return orig_get_state(self, key=key, drop_defaults=drop_defaults)
+
+# override the original get_state with the safe version
+ipywidgets.Widget.get_state = safe_get_state
+
 
 def new_app(replace=False, set_as_current=True):
     """

--- a/jdaviz/__init__.py
+++ b/jdaviz/__init__.py
@@ -44,11 +44,14 @@ import ipywidgets as ipywidgets
 import copy
 orig_get_state = ipywidgets.Widget.get_state
 
+
 def safe_get_state(self, key=None, drop_defaults=False):
-    
-    # make a copy of the set of keys to send so that observers can safely mutate the original set
+
+    # make a copy of the keys to send so that observers can safely mutate
+    # the original set without causing a RuntimeError
     key = copy.copy(key)
     return orig_get_state(self, key=key, drop_defaults=drop_defaults)
+
 
 # override the original get_state with the safe version
 ipywidgets.Widget.get_state = safe_get_state
@@ -59,7 +62,7 @@ def new_app(replace=False, set_as_current=True):
     Create a new jdaviz application instance and assign as the current instance.
 
     Parameters
-    ----------
+    ---------
     replace : bool, optional
         If True, replaces the current application instance with the new one.
         Default is False, which means a new instance is added to the list of applications.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This PR fixes a bug where the traceback 'RuntimeError: Set changed size during iteration' is encountered. This bug can be triggered in many different ways, including batch loading images, looping through images to link by WCS, calculating moment maps and sequentially adding them to the viewer etc. 

I think this is the root cause of the issue: the live set of widget properties to be synced is passed to get_state, however other callbacks are modifying this set while its being looped over, resulting in the RuntimeError. The solution is to make a copy of the set before the loop begins. 

I will open an issue for an upstream fix, and if that is accepted this patch can be removed after the next ipywidgets release

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
