### PR TITLE
Multiply single spaxel value by PIXAR_SR if needed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,9 @@ Bug Fixes
 
 - Fix Data Quality plugin support for Roman ASDF images. [#4089]
 
+- Multiply values from spectrum-at-spaxel tool by PIXAR_SR when available to match
+  units of other extracted fluxes. [#4156]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
@@ -115,9 +115,18 @@ def test_spectrum_at_spaxel_altkey_true(cubeviz_helper, spectrum1d_cube,
                                          'World 13h39m59.9192s +27d00m00.7200s (ICRS)',
                                          '204.9996633015 27.0001999996 (deg)')
 
+    flux_viewer.toolbar.active_tool.on_mouse_move(
+        {'event': 'mousemove', 'domain': {'x': 2, 'y': 1}})
+    if cube_type == 'Surface Brightness':
+        # test cube has PIXAR_ST = 10
+        assert_allclose(flux_viewer.toolbar.active_tool._mark.y, [60, 140])
+    else:
+        assert_allclose(flux_viewer.toolbar.active_tool._mark.y, [6, 14])
+
     # Click on spaxel location
     x = 1
     y = 1
+
     flux_viewer.toolbar.active_tool.on_mouse_event(
         {'event': 'click', 'domain': {'x': x, 'y': y}, 'altKey': False})
     assert len(flux_viewer.native_marks) == 3

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -152,6 +152,11 @@ class SpectrumPerSpaxel(ProfileFromCube):
                 return
             cube_data = cube_data[0]
 
+        if 'PIXAR_SR' in cube_data.meta:
+            scale = cube_data.meta['PIXAR_SR']
+        else:
+            scale = None
+
         if isinstance(cube_data, Spectrum):
             spectrum = cube_data
         else:
@@ -175,6 +180,8 @@ class SpectrumPerSpaxel(ProfileFromCube):
                 y_values = spectrum.flux[x, y, :].value
             else:
                 y_values = spectrum.flux[:, y, x].value
+            if spectrum.flux.unit.physical_type == 'surface brightness' and scale is not None:
+                y_values *= scale
             if np.all(np.isnan(y_values)):
                 self._mark.visible = False
                 return

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -152,10 +152,7 @@ class SpectrumPerSpaxel(ProfileFromCube):
                 return
             cube_data = cube_data[0]
 
-        if 'PIXAR_SR' in cube_data.meta:
-            scale = cube_data.meta['PIXAR_SR']
-        else:
-            scale = None
+        scale = cube_data.meta.get('PIXAR_SR', 1)
 
         if isinstance(cube_data, Spectrum):
             spectrum = cube_data
@@ -180,7 +177,7 @@ class SpectrumPerSpaxel(ProfileFromCube):
                 y_values = spectrum.flux[x, y, :].value
             else:
                 y_values = spectrum.flux[:, y, x].value
-            if spectrum.flux.unit.physical_type == 'surface brightness' and scale is not None:
+            if spectrum.flux.unit.physical_type == 'surface brightness':
                 y_values *= scale
             if np.all(np.isnan(y_values)):
                 self._mark.visible = False

--- a/jdaviz/configs/cubeviz/plugins/tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tools.py
@@ -1,6 +1,7 @@
 import time
 import os
 
+import astropy.units as u
 from glue.config import viewer_tool
 from glue.viewers.common.tool import CheckableTool
 import numpy as np
@@ -160,6 +161,7 @@ class SpectrumPerSpaxel(ProfileFromCube):
             spectrum = cube_data.get_object(statistic=None)
         # Note: change this when Spectrum.with_spectral_axis is fixed.
         x_unit = self._profile_viewer.state.x_display_unit
+        y_unit = self._profile_viewer.state.y_display_unit
         if spectrum.spectral_axis.unit != x_unit:
             new_spectral_axis = spectrum.spectral_axis.to(x_unit)
             spectrum = Spectrum(spectrum.flux, new_spectral_axis)
@@ -177,7 +179,9 @@ class SpectrumPerSpaxel(ProfileFromCube):
                 y_values = spectrum.flux[x, y, :].value
             else:
                 y_values = spectrum.flux[:, y, x].value
-            if spectrum.flux.unit.physical_type == 'surface brightness':
+            # Convert to flux if possible and necessary
+            if (spectrum.flux.unit.physical_type == 'surface brightness' and
+                    'flux' in str(u.Unit(y_unit).physical_type)):
                 y_values *= scale
             if np.all(np.isnan(y_values)):
                 self._mark.visible = False


### PR DESCRIPTION
Spaxel tool needs to multiply surface brightness by PIXAR_SR to match the units of the extracted fluxes.