### PR TITLE
Adjust legend overflow behavior

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 New Features
 ------------
 
+* Data menu/legend overflow: more data label icons are now shown and two or more icons must be
+  present beyond the overflow limit before the overflow icon will appear. [#4160]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -336,7 +336,14 @@
         return this.layer_items.filter(item => item.visible);
       },
       visible_layer_items_limited: function() {
-        return this.visible_layer_items.slice(0, this.max_legend_items);
+        // When the overflow icon is shown, keep max_legend_items data items so
+        // the total slot count (data + overflow) stays within the available
+        // viewer height.  When no overflow icon is needed we can fill that
+        // spare slot with the next data item instead.
+        const showOverflow = this.visible_layer_items.length > this.max_legend_items + 1
+                             || this.any_layers_hidden;
+        const limit = showOverflow ? this.max_legend_items : this.max_legend_items + 1;
+        return this.visible_layer_items.slice(0, limit);
       },
       any_layers_hidden: function() {
         // True when any layer loaded in the viewer is not visible,
@@ -348,10 +355,11 @@
       has_more_visible_items: function() {
         // During rapid updates (e.g. blinking), hold the last settled value
         // so the "more" indicator doesn't flicker on or off.
+        // Only show overflow icon when two or more items would be hidden.
         if (this.is_updating_layers) {
           return this.settled_has_more;
         }
-        return this.visible_layer_items.length > this.max_legend_items
+        return this.visible_layer_items.length > this.max_legend_items + 1
                || this.any_layers_hidden;
       }
     },
@@ -363,7 +371,7 @@
         this.is_updating_layers = true;
         clearTimeout(this.debounce_timer);
         this.debounce_timer = setTimeout(() => {
-          this.settled_has_more = this.visible_layer_items.length > this.max_legend_items
+          this.settled_has_more = this.visible_layer_items.length > this.max_legend_items + 1
                                  || this.any_layers_hidden;
           this.is_updating_layers = false;
         }, 50);
@@ -429,9 +437,9 @@
         if (!container) return;
         const viewerHeight = container.getBoundingClientRect().height;
         const itemHeight = 30;
-        // Cap legend at 50% of viewer height so it doesn't dominate the view.
+        // Cap legend at 55% of viewer height so it doesn't dominate the view.
         // Reserve 2 slots: 1 for the viewer icon header, 1 for the "more" indicator.
-        const usableHeight = viewerHeight * 0.5;
+        const usableHeight = viewerHeight * 0.55;
         this.max_legend_items = Math.max(1, Math.floor(usableHeight / itemHeight) - 2);
       },
       isSafari() {


### PR DESCRIPTION
This pull request adjusts legend behavior when overflow occurs. 

* Allow more items to be shown before the overflow icon pops up
* Only show overflow icon if 2 or more labels are past the overflow limit
