### PR TITLE
update docs to remove mention of spectrum list/concatenate

### DIFF
--- a/docs/load.rst
+++ b/docs/load.rst
@@ -88,8 +88,6 @@ Available formats
 -----------------
 
 - ``'1D Spectrum'`` - For individual 1D :class:`~specutils.Spectrum` objects or files containing a single spectrum
-- ``'1D Spectrum List'`` - For `~specutils.SpectrumList` objects or files containing multiple spectra
-- ``'1D Spectrum Concatenated'`` - For combining multiple spectra into a single spectrum
 - ``'Image'`` - For 2D image data
 - ``'2D Spectrum'`` - For 2D spectral data
 - ``'3D Spectrum'`` - For 3D spectral cube data

--- a/docs/specviz/import_data.rst
+++ b/docs/specviz/import_data.rst
@@ -150,7 +150,7 @@ they can be manipulated and analyzed in the application as a single entity:
 
     from specutils import SpectrumList
     spec_list = SpectrumList([spec1d_1, spec1d_2])
-    specviz.load(spec_list, format="1D Spectrum List")
+    specviz.load(spec_list, format="1D Spectrum", extension="*")
     specviz.show()
 
 In the screenshot below, the combined spectrum is plotted in gray, and one of


### PR DESCRIPTION
This PR removes mentions in the docs of the no-longer existing "1D Spectrum List" or "1D Spectrum Concatenated" importer/format options (as of #3953)