### PR TITLE
Fix "learn more" links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,8 @@ Bug Fixes
 
 - Fix missing toggle for cube fitting in Model Fitting plugin in generalized Jdaviz. [#4172]
 
+- Fix broken "Learn More" links throughout app. [#4173]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/moment_maps.py
@@ -92,6 +92,8 @@ class MomentMap(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMix
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Create a 2D image from a data cube.'
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/moment_maps.html'  # noqa
 
         self.moment = None
 

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.py
@@ -74,6 +74,9 @@ class BaseSlicePlugin(PluginTemplateMixin, ViewerSelectMixin):
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Select and interact with slice of cube in image viewers.'
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/spectral_slice.html'  # noqa
+
 
         self._cached_properties = ['valid_selection_values', 'valid_selection_values_sorted',
                                    'valid_indicator_values', 'valid_indicator_values_sorted',

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.py
@@ -77,7 +77,6 @@ class BaseSlicePlugin(PluginTemplateMixin, ViewerSelectMixin):
         if self.config == 'deconfigged':
             self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/spectral_slice.html'  # noqa
 
-
         self._cached_properties = ['valid_selection_values', 'valid_selection_values_sorted',
                                    'valid_indicator_values', 'valid_indicator_values_sorted',
                                    'valid_values', 'valid_values_sorted']

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -73,6 +73,9 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
 
         self._plugin_description = 'Sonify a data cube'
         self.docs_description = 'Sonify a data cube using the Strauss package.'
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/sonify.html'
+
         if not self.has_strauss or sd.default.device[1] < 0:
             self.disabled_msg = ('To use Sonify Data, install strauss and restart Jdaviz. You '
                                  'can do this by running pip install strauss in the command'

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -136,6 +136,9 @@ class SpectralExtraction3D(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Extract a spectrum from a spectral cube.'
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/3d_spectral_extraction.html'  # noqa
+
 
         self.extracted_spec = None
 

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -139,7 +139,6 @@ class SpectralExtraction3D(PluginTemplateMixin, ApertureSubsetSelectMixin,
         if self.config == 'deconfigged':
             self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/3d_spectral_extraction.html'  # noqa
 
-
         self.extracted_spec = None
 
         self.dataset.filters = ['is_flux_cube']

--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -64,6 +64,7 @@ class Collapse(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMixi
         self._plugin_description = 'Collapse a spectral cube along one axis.'
 
         if self.config == "deconfigged":
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/collapse.html'
             self.observe_traitlets_for_relevancy(traitlets_to_observe=['dataset_items'])
 
     def _get_supported_viewers(self):

--- a/jdaviz/configs/default/plugins/data_quality/data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.py
@@ -80,6 +80,8 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Data Quality layer visualization options.'
+        if self.congif == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/data_quality.html'  # noqa
 
         self.icons = {k: v for k, v in self._app.state.icons.items()}
 

--- a/jdaviz/configs/default/plugins/data_quality/data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.py
@@ -80,7 +80,7 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Data Quality layer visualization options.'
-        if self.congif == 'deconfigged':
+        if self.config == 'deconfigged':
             self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/data_quality.html'  # noqa
 
         self.icons = {k: v for k, v in self._app.state.icons.items()}

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -130,6 +130,9 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
         # description displayed under plugin title in tray
         self._plugin_description = 'Export data/plots and other outputs to a file.'
 
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/export/index.html'
+
         # NOTE: if adding export support for non-plugin products, also update the language
         # in the UI as well as in _set_dataset_not_supported_msg
         self.dataset.filters = ['is_not_wcs_only', 'not_child_layer',

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -73,6 +73,7 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
         self._plugin_description = 'Smooth data with a Gaussian kernel.'
 
         if self._app.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/gaussian_smooth.html'  # noqa
             self.observe_traitlets_for_relevancy(traitlets_to_observe=['dataset_items'])
 
     def _get_supported_viewers(self):

--- a/jdaviz/configs/default/plugins/line_lists/line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_lists.py
@@ -136,6 +136,9 @@ class LineListTool(PluginTemplateMixin, ViewerSelectMixin, CustomToolbarToggleMi
         # description displayed under plugin title in tray
         self._plugin_description = 'Plot spectral lines from preset or custom line lists.'
 
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/line_lists.html'  # noqa
+
     def _irrelevant_msg_callback(self, *args):
         if not hasattr(self, 'viewer'):
             return None

--- a/jdaviz/configs/default/plugins/logger/logger.py
+++ b/jdaviz/configs/default/plugins/logger/logger.py
@@ -33,6 +33,9 @@ class Logger(PluginTemplateMixin):
         # description displayed under plugin title in tray
         self._plugin_description = 'Access history of logger messages.'
 
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/info/logger.html'
+
         self.popup_verbosity = SelectPluginComponent(self,
                                                      items='popup_verbosity_items',
                                                      selected='popup_verbosity_selected',

--- a/jdaviz/configs/default/plugins/logger/logger.py
+++ b/jdaviz/configs/default/plugins/logger/logger.py
@@ -33,9 +33,6 @@ class Logger(PluginTemplateMixin):
         # description displayed under plugin title in tray
         self._plugin_description = 'Access history of logger messages.'
 
-        if self.config == 'deconfigged':
-            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/info/logger.html'
-
         self.popup_verbosity = SelectPluginComponent(self,
                                                      items='popup_verbosity_items',
                                                      selected='popup_verbosity_selected',

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -88,6 +88,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
                        'world_ra', 'world_dec', 'world:unreliable',
                        'value', 'value:unit', 'value:unreliable',
                        'viewer']
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/info/markers.html'
         else:
             # allow downstream configs to override headers
             headers = kwargs.get('headers', [])

--- a/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
+++ b/jdaviz/configs/default/plugins/metadata_viewer/metadata_viewer.py
@@ -48,6 +48,7 @@ class MetadataViewer(PluginTemplateMixin, DatasetSelectMixin):
 
         if self.config == "deconfigged":
             self.observe_traitlets_for_relevancy(traitlets_to_observe=['dataset_items'])
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/info/metadata.html'
 
     @property
     def user_api(self):

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -144,6 +144,9 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         # description displayed under plugin title in tray
         self._plugin_description = 'Fit an analytic model to data or a subset of data.'
 
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/model_fitting.html'  # noqa
+
         # create the label first so that when model_component defaults to the first selection,
         # the label automatically defaults as well
         self.model_component_label = AutoTextField(self, 'comp_label', 'comp_label_default',

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -490,6 +490,9 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
         # description displayed under plugin title in tray
         self._plugin_description = 'Set viewer and layer display options.'
 
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/settings/plot_options.html'  # noqa
+
         self.layer = LayerSelect(self, 'layer_items', 'layer_selected',
                                  'viewer_selected', 'layer_multiselect')
 

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -157,6 +157,8 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
             self._plugin_description = 'Select and interact with spectral subsets.'
         else:
             self._plugin_description = 'Select and interact with subsets.'
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/subsets/index.html'
 
         self.components = {
             'g-subset-mode': SelectionModeMenu(session=self.session)

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -137,6 +137,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Perform aperture photometry for drawn regions.'
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/aperture_photometry.html'  # noqa
 
         self.dataset.add_filter('is_image_or_flux_cube')
 

--- a/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
+++ b/jdaviz/configs/imviz/plugins/catalogs/catalogs.py
@@ -81,6 +81,8 @@ class Catalogs(PluginTemplateMixin, ViewerSelectMixin,
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Query catalog for objects within region on sky.'
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/catalog_search.html'  # noqa
 
         self.viewer.add_filter('is_imviz_image_viewer')
 

--- a/jdaviz/configs/imviz/plugins/compass/compass.py
+++ b/jdaviz/configs/imviz/plugins/compass/compass.py
@@ -39,6 +39,8 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Show active data label, compass, and zoom box.'
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/compass.html'  # noqa
 
         self.hub.subscribe(self, AddDataMessage, handler=self._on_viewer_data_changed)
         self.hub.subscribe(self, RemoveDataMessage, handler=self._on_viewer_data_changed)

--- a/jdaviz/configs/imviz/plugins/footprints/footprints.py
+++ b/jdaviz/configs/imviz/plugins/footprints/footprints.py
@@ -219,6 +219,8 @@ class Footprints(PluginTemplateMixin, ViewerSelectMixin,
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Show instrument footprints as overlays on image viewers.'
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/footprints.html'  # noqa
 
         self.viewer.multiselect = True  # multiselect always enabled
         # require a viewer's reference data to have WCS so that footprints can be mapped to sky

--- a/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
+++ b/jdaviz/configs/imviz/plugins/line_profile_xy/line_profile_xy.py
@@ -32,6 +32,8 @@ class LineProfileXY(PluginTemplateMixin, ViewerSelectMixin):
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Plot line profiles across X and Y.'
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/image_profiles.html'  # noqa
 
         self.plot_across_x = Plot(self, name='across_x')
         self.plot_across_y = Plot(self, name='across_y')

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -107,6 +107,8 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         self._plugin_description = 'Rotate image viewer orientation and choose alignment (pixel or sky).'  # noqa
 
         self.docs_description = "Control how images are aligned (by pixel or WCS) and set the orientation/rotation of the viewer."  # noqa
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/orientation.html'  # noqa
 
         self.viewer._allow_multiselect = False
         self.viewer.add_filter('is_imviz_image_viewer', 'reference_has_wcs')

--- a/jdaviz/configs/rampviz/plugins/ramp_extraction/ramp_extraction.py
+++ b/jdaviz/configs/rampviz/plugins/ramp_extraction/ramp_extraction.py
@@ -94,6 +94,9 @@ class RampExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
         # description displayed under plugin title in tray
         self._plugin_description = 'Extract a ramp from a ramp cube.'
 
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/ramp_extraction.html'  # noqa
+
         self.dataset.filters = ['is_ramp_group_cube']
 
         # TODO: in the future this could be generalized with support in SelectPluginComponent

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -95,7 +95,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, TableMixin,
         self._plugin_description = 'Return statistics for spectral line.'
 
         if self.config == 'deconfigged':
-            self.docs_link = f'https://jdaviz.readthedocs.io/en/{vdocs}/plugins/line_analysis.html'  # noqa
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/line_analysis.html'  # noqa
 
         self.update_results(None)
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -95,7 +95,7 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, TableMixin,
         self._plugin_description = 'Return statistics for spectral line.'
 
         if self.config == 'deconfigged':
-            self.docs_link = f'https://jdaviz.readthedocs.io/en/{vdocs}/plugins/line_analysis.html'
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{vdocs}/plugins/line_analysis.html'  # noqa
 
         self.update_results(None)
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -94,6 +94,9 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, TableMixin,
         # description displayed under plugin title in tray
         self._plugin_description = 'Return statistics for spectral line.'
 
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{vdocs}/plugins/line_analysis.html'
+
         self.update_results(None)
 
         # require entries to be in spectrum-viewer (not other cubeviz images, etc)

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -104,6 +104,8 @@ class UnitConversion(PluginTemplateMixin):
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Convert the units of displayed physical quantities.'
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{vdocs}/settings/display_units.html'
 
         self._cached_properties = ['image_layers']
 

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -106,8 +106,7 @@ class UnitConversion(PluginTemplateMixin):
         self._plugin_description = 'Convert the units of displayed physical quantities.'
 
         if self.config == 'deconfigged':
-            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/settings/display_units.html'
-
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/settings/display_units.html'  # noqa
 
         self._cached_properties = ['image_layers']
 

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -104,8 +104,10 @@ class UnitConversion(PluginTemplateMixin):
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Convert the units of displayed physical quantities.'
+
         if self.config == 'deconfigged':
-            self.docs_link = f'https://jdaviz.readthedocs.io/en/{vdocs}/settings/display_units.html'
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/settings/display_units.html'
+
 
         self._cached_properties = ['image_layers']
 

--- a/jdaviz/configs/specviz2d/plugins/cross_dispersion_profile/cross_dispersion_profile.py
+++ b/jdaviz/configs/specviz2d/plugins/cross_dispersion_profile/cross_dispersion_profile.py
@@ -95,6 +95,9 @@ class CrossDispersionProfile(PluginTemplateMixin, PlotMixin):
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Visualize cross-dispersion profile.'
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/cross_dispersion_profile.html'  # noqa
+
 
         self.dataset = DatasetSelect(self,
                                      'dataset_items',

--- a/jdaviz/configs/specviz2d/plugins/cross_dispersion_profile/cross_dispersion_profile.py
+++ b/jdaviz/configs/specviz2d/plugins/cross_dispersion_profile/cross_dispersion_profile.py
@@ -98,7 +98,6 @@ class CrossDispersionProfile(PluginTemplateMixin, PlotMixin):
         if self.config == 'deconfigged':
             self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/cross_dispersion_profile.html'  # noqa
 
-
         self.dataset = DatasetSelect(self,
                                      'dataset_items',
                                      'dataset_selected',

--- a/jdaviz/configs/specviz2d/plugins/cross_dispersion_profile/cross_dispersion_profile.vue
+++ b/jdaviz/configs/specviz2d/plugins/cross_dispersion_profile/cross_dispersion_profile.vue
@@ -1,8 +1,10 @@
 <template>
   <j-tray-plugin
     plugin_key="Cross Dispersion Profile"
+    :config="config"
     :api_hints_enabled.sync="api_hints_enabled"
     :description="docs_description"
+    :link="docs_link"
     :uses_active_status="uses_active_status"
     :keep_active.sync="keep_active"
     @plugin-ping="plugin_ping($event)"

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -277,7 +277,6 @@ class SpectralExtraction2D(PluginTemplateMixin):
         if self.config == 'deconfigged':
             self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/2d_spectral_extraction.html'  # noqa
 
-
         # TRACE
         self.trace_trace = DatasetSelect(self,
                                          'trace_trace_items',

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -274,6 +274,9 @@ class SpectralExtraction2D(PluginTemplateMixin):
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Extract 1D spectrum from 2D image.'
+        if self.config == 'deconfigged':
+            self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/2d_spectral_extraction.html'  # noqa
+
 
         # TRACE
         self.trace_trace = DatasetSelect(self,


### PR DESCRIPTION
The existing logic to point to the config docs (mostly in the vue files) doesn't work for deconfigged. For now I'm overriding in the deconfigged case until we fully deprecate the old configs.