### PR TITLE
Simplify checks for 1D/2D spectra and traces

### DIFF
--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -197,6 +197,8 @@ class BaseImporterToDataCollection(BaseImporter):
     viewer_label_auto = Bool(True).tag(sync=True)
     viewer_label_invalid_msg = Unicode().tag(sync=True)
 
+    data_type = None
+
     def __init__(self, app, resolver, parser, input, **kwargs):
         super().__init__(app, resolver, parser, input, **kwargs)
         self.data_label = AutoTextField(self, 'data_label_value',
@@ -318,7 +320,8 @@ class BaseImporterToDataCollection(BaseImporter):
     def add_to_data_collection(self, data, data_label=None, data_hash=None,
                                parent=None,
                                viewer_select=None,
-                               cls=None):
+                               cls=None,
+                               data_type=None):
         """
         Add data to the data collection (and optionally to viewers).
 
@@ -386,6 +389,10 @@ class BaseImporterToDataCollection(BaseImporter):
         data.meta['_importer'] = self.__class__.__name__
         # Create a hashed representation of the data if not already present
         data.meta['_data_hash'] = data_hash if data_hash is not None else create_data_hash(data)
+        if data_type is not None:
+            data.meta['_data_type'] = data_type
+        elif self.data_type is not None:
+            data.meta['_data_type'] = self.data_type
 
         # Add the data to data collection.
         self._app.add_data(data, data_label=data_label)

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -197,8 +197,6 @@ class BaseImporterToDataCollection(BaseImporter):
     viewer_label_auto = Bool(True).tag(sync=True)
     viewer_label_invalid_msg = Unicode().tag(sync=True)
 
-    data_type = None
-
     def __init__(self, app, resolver, parser, input, **kwargs):
         super().__init__(app, resolver, parser, input, **kwargs)
         self.data_label = AutoTextField(self, 'data_label_value',
@@ -391,8 +389,6 @@ class BaseImporterToDataCollection(BaseImporter):
         data.meta['_data_hash'] = data_hash if data_hash is not None else create_data_hash(data)
         if data_type is not None:
             data.meta['_data_type'] = data_type
-        elif self.data_type is not None:
-            data.meta['_data_type'] = self.data_type
 
         # Add the data to data collection.
         self._app.add_data(data, data_label=data_label)

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -44,8 +44,6 @@ class Spectrum2DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
     ext_viewer_label_auto = Bool(True).tag(sync=True)
     ext_viewer_label_invalid_msg = Unicode().tag(sync=True)
 
-    data_type = '2D Spectrum'
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -44,6 +44,8 @@ class Spectrum2DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
     ext_viewer_label_auto = Bool(True).tag(sync=True)
     ext_viewer_label_invalid_msg = Unicode().tag(sync=True)
 
+    data_type = '2D Spectrum'
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -186,4 +188,5 @@ class Spectrum2DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
         self._app.hub.broadcast(msg)
 
         if ext is not None:
-            self.add_to_data_collection(ext, ext_data_label, viewer_select=self.ext_viewer)
+            self.add_to_data_collection(ext, ext_data_label, viewer_select=self.ext_viewer,
+                                        data_type='1D Spectrum')

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
@@ -116,8 +116,6 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
     ext_viewer_label_auto = Bool(True).tag(sync=True)
     ext_viewer_label_invalid_msg = Unicode().tag(sync=True)
 
-    data_type = '3D Spectrum'
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
@@ -116,6 +116,8 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
     ext_viewer_label_auto = Bool(True).tag(sync=True)
     ext_viewer_label_invalid_msg = Unicode().tag(sync=True)
 
+    data_type = '3D Spectrum'
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -503,7 +505,8 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
         self._app.hub.broadcast(msg)
 
         if ext is not None:
-            self.add_to_data_collection(ext, ext_data_label, viewer_select=self.ext_viewer)
+            self.add_to_data_collection(ext, ext_data_label, viewer_select=self.ext_viewer,
+                                        data_type='1D Spectrum')
 
             if self.has_dq and not self.flux_only:
                 dq_hdu = self.dq_extension.selected_obj

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -4869,14 +4869,10 @@ class DatasetSelect(SelectPluginComponent):
             return (is_image(data) or is_flux_cube(data)) and not is_2d_spectrum_or_trace(data)
 
         def is_spectrum(data):
-            return (len(data.shape) == 1
-                    and data.coords is not None
-                    and wcs_is_spectral(getattr(data, 'coords', None)))
+                return data.meta.get('_importer') in ('SpectrumImporter')
 
         def is_2d_spectrum_or_trace(data):
-            return (data.ndim == 2
-                    and data.coords is not None
-                    and wcs_is_spectral(getattr(data, 'coords', None))) or 'Trace' in data.meta
+                return data.meta.get('_importer') in ('Spectrum2DImporter', 'TraceImporter')
 
         def is_spectrum_or_flux_cube(data):
             return is_spectrum(data) or is_flux_cube(data)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -4869,10 +4869,12 @@ class DatasetSelect(SelectPluginComponent):
             return (is_image(data) or is_flux_cube(data)) and not is_2d_spectrum_or_trace(data)
 
         def is_spectrum(data):
-                return data.meta.get('_importer') in ('SpectrumImporter')
+            return (data.meta.get('_importer') == 'SpectrumImporter' or
+                    data.meta.get('_data_type') == '1D Spectrum')
 
         def is_2d_spectrum_or_trace(data):
-                return data.meta.get('_importer') in ('Spectrum2DImporter', 'TraceImporter')
+            return (data.meta.get('_importer') in ('Spectrum2DImporter', 'TraceImporter') and
+                    data.meta.get('_data_type') != '1D Spectrum')
 
         def is_spectrum_or_flux_cube(data):
             return is_spectrum(data) or is_flux_cube(data)


### PR DESCRIPTION
Now checks for the importer in these cases like a lot of the other is_valid checks, and additionally adds a `_data_type` field in `meta` to distinguish cases where a collapsed 1D spectrum is being loaded by the 2D or 3D spectrum importer. This is purely internal so I don't think it needs a changelog, and it should be covered by existing tests.