### PR TITLE
add 'copy label' button next to label in data menu

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ New Features
 - Errors from load are now more explicit, either as a result of known invalid cases or
   as errors producing during import. [#4159]
 
+- Data labels are now able to be copied from the data menu with the addition of a copy to clipboard button. [#4177]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -215,6 +215,16 @@
                           @cancel="(newLabel) => {check_rename({old_label: item.label, new_label: newLabel, is_subset: item.is_subset})}"
                           @rename="(newLabel) => {rename_item({old_label: item.label, new_label: newLabel})}"
                         />
+                        <j-tooltip :tooltipcontent="copied_label === item.label ? 'Copied' : 'Copy label to clipboard'">
+                          <v-btn
+                            icon
+                            x-small
+                            style="margin-left: 2px; opacity: 0.6"
+                            @click.stop="copyLabel(item.label)"
+                          >
+                            <v-icon small>{{ copied_label === item.label ? 'mdi-check' : 'mdi-clipboard-outline' }}</v-icon>
+                          </v-btn>
+                        </j-tooltip>
                       </div>
                     </v-list-item-content>
                     <v-list-item-action>
@@ -325,6 +335,7 @@
         data_menu_open: false,
         hover_api_hint: '',
         lock_hover_api_hint: false,
+        copied_label: '',
         debounce_timer: null,
         is_updating_layers: false,
         settled_has_more: false,
@@ -479,6 +490,12 @@
         const offsetX = event.clientX - draggedBounds.left;
         const offsetY = event.clientY - draggedBounds.top;
         event.dataTransfer.setDragImage(dragGhostEl, offsetX, offsetY);
+      },
+      copyLabel(label) {
+        navigator.clipboard.writeText(label).then(() => {
+          this.copied_label = label;
+          setTimeout(() => { this.copied_label = ''; }, 1500);
+        });
       },
       onDragEnd() {
         if (this._dragGhostParent && this._dragGhostParent.parentNode) {

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -223,7 +223,6 @@
                           <v-btn
                             icon
                             x-small
-                            style="opacity: 0.6"
                             @click.stop="copyLabel(item.label)"
                           >
                             <v-icon small>{{ copied_label === item.label ? 'mdi-check' : 'mdi-clipboard-outline' }}</v-icon>

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -215,40 +215,42 @@
                           @cancel="(newLabel) => {check_rename({old_label: item.label, new_label: newLabel, is_subset: item.is_subset})}"
                           @rename="(newLabel) => {rename_item({old_label: item.label, new_label: newLabel})}"
                         />
+                      </div>
+                    </v-list-item-content>
+                    <v-list-item-action>
+                      <div style="display: flex; align-items: center;">
                         <j-tooltip :tooltipcontent="copied_label === item.label ? 'Copied' : 'Copy label to clipboard'">
                           <v-btn
                             icon
                             x-small
-                            style="margin-left: 2px; opacity: 0.6"
+                            style="opacity: 0.6"
                             @click.stop="copyLabel(item.label)"
                           >
                             <v-icon small>{{ copied_label === item.label ? 'mdi-check' : 'mdi-clipboard-outline' }}</v-icon>
                           </v-btn>
                         </j-tooltip>
+                        <j-tooltip
+                          v-if="disabled_layers_due_to_pixel_sky_mismatch.includes(item.label)"
+                          tooltipcontent="Layer cannot be made visible when catalog does not contain coordinates (pixel or sky) that correspond to current alignment type."
+                        >
+                          <v-btn icon disabled>
+                            <v-icon>mdi-eye-off</v-icon>
+                          </v-btn>
+                        </j-tooltip>
+                        <j-tooltip
+                          v-else-if="viewer_supports_visible_toggle"
+                          :tooltipcontent="api_hints_enabled ? '' : item.is_sonified ? 'Toggle sonification' :'Toggle visibility'"
+                        >
+                          <plugin-switch
+                            :value="item.visible"
+                            @click="(value) => {set_layer_visibility({layer: item.label, value: value})}"
+                            @mouseover = "() => {hover_api_hint = 'dm.set_layer_visibility(\'' + item.label + '\', '+boolToString(item.visible)+')'}"
+                            @mouseleave = "() => {if (!lock_hover_api_hint) {hover_api_hint = ''}}"
+                            :api_hints_enabled="false"
+                            :use_icon="item.is_sonified ? 'speaker' : 'eye'"
+                          />
+                        </j-tooltip>
                       </div>
-                    </v-list-item-content>
-                    <v-list-item-action>
-                      <j-tooltip
-                        v-if="disabled_layers_due_to_pixel_sky_mismatch.includes(item.label)"
-                        tooltipcontent="Layer cannot be made visible when catalog does not contain coordinates (pixel or sky) that correspond to current alignment type."
-                      >
-                        <v-btn icon disabled>
-                          <v-icon>mdi-eye-off</v-icon>
-                        </v-btn>
-                      </j-tooltip>
-                      <j-tooltip
-                        v-else-if="viewer_supports_visible_toggle"
-                        :tooltipcontent="api_hints_enabled ? '' : item.is_sonified ? 'Toggle sonification' :'Toggle visibility'"
-                      >
-                        <plugin-switch
-                          :value="item.visible"
-                          @click="(value) => {set_layer_visibility({layer: item.label, value: value})}"
-                          @mouseover = "() => {hover_api_hint = 'dm.set_layer_visibility(\'' + item.label + '\', '+boolToString(item.visible)+')'}"
-                          @mouseleave = "() => {if (!lock_hover_api_hint) {hover_api_hint = ''}}"
-                          :api_hints_enabled="false"
-                          :use_icon="item.is_sonified ? 'speaker' : 'eye'"
-                        />
-                      </j-tooltip>
                     </v-list-item-action>
                   </v-list-item>
                 </draggable>


### PR DESCRIPTION
This PR adds a button in the data menu to allow the user to copy the data label to the clipboard. When the button is clicked, the clipboard icon temporarily turns into a check mark to show that the label was successfully copied, and then turns back into the clipboard icon. No tests since it's not really possible to add test coverage for this (at least im not sure how).
