### PR TITLE
show API hints button in popout when from notebook

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,8 @@ Bug Fixes
 
 - Fix broken "Learn More" links throughout app. [#4173]
 
+- API hints toggle button to show in popout windows. [#4184]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -244,9 +244,7 @@ class ApplicationState(State):
     show_api_hints = CallbackProperty(
         False, docstring="Whether to show API hints.")
     in_notebook = CallbackProperty(
-        False, docstring="Whether the app is running in a notebook (Jupyter) context. "
-                         "Set to True when show() is called, and used to show the API hints "
-                         "toggle button even in popout windows that lack notebook DOM elements.")
+        False, docstring="Whether the app is running in a notebook (Jupyter) context")
     subset_mode_create = CallbackProperty(
         False, docstring="Whether to create a new subset.")
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -243,6 +243,10 @@ class ApplicationState(State):
         True, docstring="Whether to show app-level toolbar buttons (left of sidebar menu button).")
     show_api_hints = CallbackProperty(
         False, docstring="Whether to show API hints.")
+    in_notebook = CallbackProperty(
+        False, docstring="Whether the app is running in a notebook (Jupyter) context. "
+                         "Set to True when show() is called, and used to show the API hints "
+                         "toggle button even in popout windows that lack notebook DOM elements.")
     subset_mode_create = CallbackProperty(
         False, docstring="Whether to create a new subset.")
 

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -69,7 +69,7 @@
             <v-icon medium>mdi-help-box</v-icon>
           </v-btn>
         </j-tooltip>
-        <j-tooltip v-if="state.show_toolbar_buttons && checkNotebookContext()" tipid="app-api-hints">
+        <j-tooltip v-if="state.show_toolbar_buttons && (checkNotebookContext() || state.in_notebook)" tipid="app-api-hints">
           <v-btn icon @click="state.show_api_hints = !state.show_api_hints" :class="{active : state.show_api_hints}">
             <img :src="state.icons['api']" width="24" class="invert-if-dark" style="opacity: 1.0"/>
           </v-btn>
@@ -193,7 +193,7 @@
               :force_open_about.sync="force_open_about"
             ></j-about-menu>
 
-            <j-tooltip v-if="state.show_toolbar_buttons && checkNotebookContext()" tipid="app-api-hints">
+            <j-tooltip v-if="state.show_toolbar_buttons && (checkNotebookContext() || state.in_notebook)" tipid="app-api-hints">
               <v-btn small icon @click="state.show_api_hints = !state.show_api_hints" :class="{active : state.show_api_hints}">
                 <img :src="state.icons['api']" width="24" class="color-to-white" style="opacity: 1.0; padding-top: 2px; padding-bottom: 2px"/>
               </v-btn>
@@ -227,6 +227,7 @@
                     :api_hints_obj="api_hints_obj || config"
                     :server_is_remote="state.settings.server_is_remote"
                     :disabled_loaders="state.settings.disabled_loaders"
+                    :in_notebook="state.in_notebook"
                   ></j-loader-panel>
                 </v-tab-item>
                 <v-tab-item style="padding-bottom: 40px">
@@ -363,6 +364,7 @@
                 :api_hints_obj="api_hints_obj || config"
                 :server_is_remote="state.settings.server_is_remote"
                 :disabled_loaders="state.settings.disabled_loaders"
+                :in_notebook="state.in_notebook"
               ></j-loader-panel>
             </v-card>
 

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -61,7 +61,7 @@
 
       <v-spacer></v-spacer>
       <v-toolbar-items v-if="config !== 'deconfigged'">
-        <j-tooltip tipid="app-toolbar-popout" span_style="scale: 0.8; margin-left: -4px; margin-right: -4px">
+        <j-tooltip v-if="!state.in_notebook || checkNotebookContext()" tipid="app-toolbar-popout" span_style="scale: 0.8; margin-left: -4px; margin-right: -4px">
           <jupyter-widget :widget="popout_button" ></jupyter-widget>
         </j-tooltip>
         <j-tooltip v-if="state.show_toolbar_buttons" tipid="app-help">
@@ -198,7 +198,7 @@
                 <img :src="state.icons['api']" width="24" class="color-to-white" style="opacity: 1.0; padding-top: 2px; padding-bottom: 2px"/>
               </v-btn>
             </j-tooltip>
-            <j-tooltip tipid="app-toolbar-popout" span_style="scale: 0.8; margin-left: -4px; margin-right: -4px">
+            <j-tooltip v-if="!state.in_notebook || checkNotebookContext()" tipid="app-toolbar-popout" span_style="scale: 0.8; margin-left: -4px; margin-right: -4px">
               <jupyter-widget :widget="popout_button" ></jupyter-widget>
             </j-tooltip>
           </span>

--- a/jdaviz/components/loader_panel.vue
+++ b/jdaviz/components/loader_panel.vue
@@ -27,7 +27,7 @@
 
 <script>
 module.exports = {
-  props: ['loader_items', 'loader_selected', 'api_hints_enabled', 'api_hints_obj', 'server_is_remote', 'disabled_loaders', 'hide_resolver'],
+  props: ['loader_items', 'loader_selected', 'api_hints_enabled', 'api_hints_obj', 'server_is_remote', 'disabled_loaders', 'hide_resolver', 'in_notebook'],
   computed: {
     loader_items_filtered() {
       var has_api_support = this.checkNotebookContext();
@@ -67,7 +67,8 @@ module.exports = {
     checkNotebookContext() {
       this.notebook_context = document.getElementById("ipython-main-app")
         || document.querySelector('.jp-LabShell')
-        || document.querySelector(".lm-Widget#main"); /* Notebook 7 */
+        || document.querySelector(".lm-Widget#main") /* Notebook 7 */
+        || this.in_notebook;
       return this.notebook_context;
     },
   }

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -138,12 +138,11 @@ def show_widget(widget, loc, title, height=None):  # pragma: no cover
                            "To learn more, see our documentation at: "
                            "https://jdaviz.readthedocs.io")
 
-    # Mark the app as being in a notebook context. This is used by the frontend
-    # to show the API hints toggle button even in popout windows that lack the
-    # notebook-specific DOM elements that checkNotebookContext() looks for.
-    _app_state = getattr(widget, 'state', None) or getattr(getattr(widget, '_app', None), 'state', None)
-    if _app_state is not None and hasattr(_app_state, 'in_notebook'):
-        _app_state.in_notebook = True
+    # Store whether the app is in a notebook context within the app state
+    # (used for whether to show the API hints toggle button)
+    app_state = getattr(widget, 'state', None) or getattr(getattr(widget, '_app', None), 'state', None)  # noqa
+    if app_state is not None and hasattr(app_state, 'in_notebook'):
+        app_state.in_notebook = True
 
     if loc == "inline":
         if height is not None:

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -138,6 +138,13 @@ def show_widget(widget, loc, title, height=None):  # pragma: no cover
                            "To learn more, see our documentation at: "
                            "https://jdaviz.readthedocs.io")
 
+    # Mark the app as being in a notebook context. This is used by the frontend
+    # to show the API hints toggle button even in popout windows that lack the
+    # notebook-specific DOM elements that checkNotebookContext() looks for.
+    _app_state = getattr(widget, 'state', None) or getattr(getattr(widget, '_app', None), 'state', None)
+    if _app_state is not None and hasattr(_app_state, 'in_notebook'):
+        _app_state.in_notebook = True
+
     if loc == "inline":
         if height is not None:
             if isinstance(height, int):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request stores whether jdaviz is running in a notebook context in the application state so that popouts also know whether they can show the API hints toggle button.



### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
