### PR TITLE
Fix unit related issue when applying pixarea_fac to data in imviz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,9 @@ Bug Fixes
 
 - Fix broken "Learn More" links throughout app. [#4173]
 
+- Fix units related issue in imviz aperture photometry plugin when applying
+  pixel area factor to data in surface brightness units. [#4188]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -243,9 +243,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
         if self.display_unit == '':
             return False
 
-        # plugin supports all images in imviz and deconfigged as well
-        # as 1d collapsed cubes from cubeviz
-        if self.is_image and self.config in ('imviz', 'deconfigged', 'cubeviz'):
+        # plugin supports all images in deconfigged as well as 1d collapsed cubes in cubeviz
+        if self.is_image and self.config in ('deconfigged', 'cubeviz'):
             return True
 
         # cubes are supported in cubeviz and deconfigged
@@ -912,14 +911,24 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
         rawsum = phot_table['sum'][0]
 
         if include_pixarea_fac:
+            if self._has_display_unit_support:
+                display_solid_angle_unit = u.Unit(self.display_solid_angle_unit)
+            else:
+                if comp.units and check_if_unit_is_per_solid_angle(u.Unit(comp.units)):
+                    display_solid_angle_unit = check_if_unit_is_per_solid_angle(u.Unit(comp.units), return_unit=True)  # noqa: E501
+                else:
+                    # this scenario should not be encountered since 'include_pixarea_fac'
+                    # is True only if data or display unit is surface brightness, but just
+                    # to be safe
+                    m = "Can't apply pixel area factor to data that is not in surface brightness units."  # noqa: E501
+                    self.hub.broadcast(SnackbarMessage(m, color='warning', sender=self))
+                    include_pixarea_fac = False
+
+        if include_pixarea_fac:
             # convert pixarea, which is in arcsec2/pix2 to the display solid angle unit / pix2
 
             if self._has_display_unit_support:
                 display_solid_angle_unit = u.Unit(self.display_solid_angle_unit)
-
-            else:
-                raise NotImplementedError(
-                    f"Unsupported config {self.config} for aperture photometry.")
 
             # if angle unit is pix2, pixarea should be 1 pixel2 per pixel2
             if display_solid_angle_unit == PIX2:


### PR DESCRIPTION
This PR fixes a failing remote data test `test_parse_jwst_nircam_level2` related to unit support in the aperture photometry plugin.

Unit conversion is supported for image viewers are supported in deconfigged but not in imviz, so this PR fixes some logic required for that distinction, including using the data unit (and checking that it is a surface brightness unit) rather than the unit conversion plugin display unit for imviz images.