### PR TITLE
 Fix aperture photometry plugin visibility after viewer removal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,9 @@ Bug Fixes
 
 - API hints toggle button to show in popout windows. [#4184]
 
+- Fix aperture photometry plugin remaining visible in tray after all 
+  image viewers are removed. [#4189]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -141,6 +141,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/aperture_photometry.html'  # noqa
 
         self.dataset.add_filter('is_image_or_flux_cube')
+        self.dataset.add_filter('layer_in_viewers')
 
         self.background = SubsetSelect(self,
                                        'background_items',

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -141,7 +141,6 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/aperture_photometry.html'  # noqa
 
         self.dataset.add_filter('is_image_or_flux_cube')
-        self.dataset.add_filter('layer_in_viewers')
 
         self.background = SubsetSelect(self,
                                        'background_items',

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -582,6 +582,31 @@ def test_aper_phot_basic(helper_name, image_2d_wcs, request):
     assert len(tbl) == 1
 
 
+def test_aper_phot_irrelevant_after_viewer_destroy(deconfigged_helper, image_2d_wcs):
+    """
+    Test that aperture photometry plugin is removed from plugin tray
+    when all image viewers are removed.
+    """
+    data = NDData(np.ones((10, 10)), wcs=image_2d_wcs)
+    deconfigged_helper.load(data, data_label='test_image')
+
+    app = deconfigged_helper._app
+    phot_plugin = deconfigged_helper.plugins['Aperture Photometry']
+
+    # Plugin should be exist in plugin tray while an image viewer exists
+    assert phot_plugin._obj.irrelevant_msg == ''
+    tray_labels = [ti['label'] for ti in app.state.tray_items]
+    ap_index = tray_labels.index('Aperture Photometry')
+    assert app.state.tray_items[ap_index]['is_relevant']
+
+    app.vue_destroy_viewer_item(app.get_viewer_ids()[0])
+    assert app.get_viewer_ids() == []
+
+    # Plugin should now not exist in plugin tray since no image viewers remain
+    assert phot_plugin._obj.irrelevant_msg != ''
+    assert not app.state.tray_items[ap_index]['is_relevant']
+
+
 def test_aper_phot_load_table_into_data_collection(imviz_helper, image_2d_wcs):
     """
     Test that aperture photometry table can be loaded back into the data collection

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -763,4 +763,4 @@ def test_deconfigged_image_aperphot_unit_conversions(deconfigged_helper, image_2
 
     # Plugin should now not exist in plugin tray since no image viewers remain
     assert ap._obj.irrelevant_msg != ''
-    assert not app.state.tray_items[ap_index]['is_relevant'] 
+    assert not app.state.tray_items[ap_index]['is_relevant']

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -582,31 +582,6 @@ def test_aper_phot_basic(helper_name, image_2d_wcs, request):
     assert len(tbl) == 1
 
 
-def test_aper_phot_irrelevant_after_viewer_destroy(deconfigged_helper, image_2d_wcs):
-    """
-    Test that aperture photometry plugin is removed from plugin tray
-    when all image viewers are removed.
-    """
-    data = NDData(np.ones((10, 10)), wcs=image_2d_wcs)
-    deconfigged_helper.load(data, data_label='test_image')
-
-    app = deconfigged_helper._app
-    phot_plugin = deconfigged_helper.plugins['Aperture Photometry']
-
-    # Plugin should be exist in plugin tray while an image viewer exists
-    assert phot_plugin._obj.irrelevant_msg == ''
-    tray_labels = [ti['label'] for ti in app.state.tray_items]
-    ap_index = tray_labels.index('Aperture Photometry')
-    assert app.state.tray_items[ap_index]['is_relevant']
-
-    app.vue_destroy_viewer_item(app.get_viewer_ids()[0])
-    assert app.get_viewer_ids() == []
-
-    # Plugin should now not exist in plugin tray since no image viewers remain
-    assert phot_plugin._obj.irrelevant_msg != ''
-    assert not app.state.tray_items[ap_index]['is_relevant']
-
-
 def test_aper_phot_load_table_into_data_collection(imviz_helper, image_2d_wcs):
     """
     Test that aperture photometry table can be loaded back into the data collection
@@ -775,3 +750,17 @@ def test_deconfigged_image_aperphot_unit_conversions(deconfigged_helper, image_2
 
     # Compare output tables row by row
     _compare_image_table_units(orig_tab, new_tab, sb_unit, new_sb_unit)
+
+    # Plugin should be exist in plugin tray while an image viewer exists
+    app = deconfigged_helper._app
+    assert ap._obj.irrelevant_msg == ''
+    tray_labels = [ti['label'] for ti in app.state.tray_items]
+    ap_index = tray_labels.index('Aperture Photometry')
+    assert app.state.tray_items[ap_index]['is_relevant']
+
+    app.vue_destroy_viewer_item(app.get_viewer_ids()[0])
+    assert app.get_viewer_ids() == []
+
+    # Plugin should now not exist in plugin tray since no image viewers remain
+    assert ap._obj.irrelevant_msg != ''
+    assert not app.state.tray_items[ap_index]['is_relevant'] 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -4706,6 +4706,8 @@ class DatasetSelect(SelectPluginComponent):
         self.hub.subscribe(self, RemoveDataMessage, handler=self._update_items)
         self.hub.subscribe(self, DataCollectionAddMessage, handler=self._update_items)
         self.hub.subscribe(self, DataCollectionDeleteMessage, handler=self._update_items)
+        self.hub.subscribe(self, ViewerAddedMessage, handler=self._update_items)
+        self.hub.subscribe(self, ViewerRemovedMessage, handler=self._update_items)
         self.hub.subscribe(self, SubsetRenameMessage, handler=self._update_items)
         self.hub.subscribe(self, DataRenamedMessage, handler=self._on_data_renamed)
         self.hub.subscribe(self, GlobalDisplayUnitChanged,


### PR DESCRIPTION

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request adds a subscription of DatasetSelect to viewer add/remove messages and adds a viewer filter to the aperture photometry plugin so it hides from the tray when all image viewers are removed.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
