### PR TITLE
Modify default label behavior to reduce potential confusion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,8 @@ New Features
 
 - Importing Catalogs now has improved automatic detection of ra/dec/x/y columns. [#4183]
 
-- Label default behavior now adjusts for added or removed data/viewers for any that uses
-  _app.return_unique_name. Viewer default labels are now automatically updated as well. [#4192]
+- Label default behavior now adjusts for added or removed data/viewers for any that enforce a unique naming scheme
+  i.e. viewer -> viewer (1) -> viewer (2) etc. Viewer default labels are now automatically updated as well. [#4192]
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,8 @@ New Features
 
 - Importing Catalogs now has improved automatic detection of ra/dec/x/y columns. [#4183]
 
-- Label default behavior now adjusts for added or removed data/viewers for any that enforce a unique naming scheme
-  i.e. viewer -> viewer (1) -> viewer (2) etc. Viewer default labels are now automatically updated as well. [#4192]
+- Label default behavior now adjusts for added *or* removed data/viewers i.e. viewer -> viewer (1) ->
+  viewer (2) -> remove viewer (2) -> default is again viewer(2) [#4192]
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ New Features
 
 - Importing Catalogs now has improved automatic detection of ra/dec/x/y columns. [#4183]
 
+- Label default behavior now adjusts for added or removed data/viewers for any that uses
+  _app.return_unique_name. Viewer default labels are now automatically updated as well. [#4192]
 
 Mosviz
 ^^^^^^
@@ -67,7 +69,7 @@ Bug Fixes
 
 - API hints toggle button to show in popout windows. [#4184]
 
-- Fix aperture photometry plugin remaining visible in tray after all 
+- Fix aperture photometry plugin remaining visible in tray after all
   image viewers are removed. [#4189]
 
 Mosviz

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2207,7 +2207,7 @@ class PrivateApplication(VuetifyTemplate, HubListener):
         match = check_if_dup.match(label)
         label_without_dup = match.group(1) if match else label
 
-        if label in exist_labels:
+        if any(label_without_dup in label for label in exist_labels):
             label = f"{label_without_dup} ({max_number + 1})"
 
         elif label not in exist_labels and label_without_dup not in exist_labels:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2170,16 +2170,21 @@ class PrivateApplication(VuetifyTemplate, HubListener):
         # removed so that the remainder of the label can be checked
         # against the label.
         check_if_dup = re.compile(r"(.*)(\s\(\d*\))$")
+
+        # Helper function to extract base label (without dup suffix)
+        def get_base_label(lbl):
+            m = check_if_dup.match(lbl)
+            return m.group(1) if m else lbl
+
         number_of_duplicates = 0
         max_number = 0
         for exist_label in exist_labels:
             # If label is a duplicate of another label
             if re.fullmatch(check_if_dup, exist_label):
-                exist_label_split = exist_label.split(" ")
-                exist_label_without_dup = " ".join(exist_label_split[:-1])
+                exist_label_without_dup = get_base_label(exist_label)
+                # Extract number from the dup suffix
+                number_dup = int(exist_label.split()[-1][1:-1])
                 exist_label = exist_label_without_dup
-                # Remove parentheses and cast to float
-                number_dup = int(exist_label_split[-1][1:-1])
                 # Used to keep track the max number of duplicates,
                 # even if not all duplicates are loaded (or some
                 # are renamed)
@@ -2204,10 +2209,10 @@ class PrivateApplication(VuetifyTemplate, HubListener):
         # causes issues. This block alters the duplicate number to be something unique
         # (one more than the max number duplicate found)
         # if a duplicate is still found in data_collection.
-        match = check_if_dup.match(label)
-        label_without_dup = match.group(1) if match else label
+        label_without_dup = get_base_label(label)
 
-        if any(label_without_dup in label for label in exist_labels):
+        if any(get_base_label(exist_label) == label_without_dup
+               for exist_label in exist_labels):
             label = f"{label_without_dup} ({max_number + 1})"
 
         elif label not in exist_labels and label_without_dup not in exist_labels:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2204,10 +2204,15 @@ class PrivateApplication(VuetifyTemplate, HubListener):
         # causes issues. This block alters the duplicate number to be something unique
         # (one more than the max number duplicate found)
         # if a duplicate is still found in data_collection.
+        match = check_if_dup.match(label)
+        label_without_dup = match.group(1) if match else label
+
         if label in exist_labels:
-            label_split = label.split(" ")
-            label_without_dup = " ".join(label_split[:-1])
             label = f"{label_without_dup} ({max_number + 1})"
+
+        elif label not in exist_labels and label_without_dup not in exist_labels:
+            # Reset label to base if items have been deleted
+            label = label_without_dup
 
         return label
 

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -368,6 +368,8 @@ def test_astroquery_load_catalog_source(deconfigged_helper):
     assert 'Catalog' in ldr.format.choices
     ldr.format = 'Catalog'
 
+    ldr.importer.col_ra = 'ra'
+    ldr.importer.col_dec = 'dec'
     ldr.importer.col_id = 'source_id'
     ldr.importer.col_other = ['parallax', 'pm', 'bp_rp', 'phot_rp_mean_mag']
     ldr.importer.viewer.create_new = 'Scatter'

--- a/jdaviz/core/viewer_creators/test_viewer_creators.py
+++ b/jdaviz/core/viewer_creators/test_viewer_creators.py
@@ -133,7 +133,7 @@ class TestViewerCreatorObject:
         # Remove the last viewer and check that the new default label is reset
         self.dcf_helper._app.vue_destroy_viewer_item('1D Spectrum (2)')
         assert self.creator.viewer_label_default == '1D Spectrum (1)'
-        
+
         # Check duplicate validation
         self.creator.viewer_label_value = '1D Spectrum'
 

--- a/jdaviz/core/viewer_creators/test_viewer_creators.py
+++ b/jdaviz/core/viewer_creators/test_viewer_creators.py
@@ -112,27 +112,37 @@ class TestViewerCreatorObject:
         idx = labels.index('1D Spectrum')
         assert self.dcf_helper._app.state.new_viewer_items[idx]['is_relevant'] is True
 
-    def test_viewer_label_validation_duplicate(self):
+    def test_viewer_label_defaults_and_duplicates(self):
         """
-        Test that duplicate viewer labels are properly rejected.
+        Test that duplicate viewer labels are properly handled.
         """
         # Create first viewer
         viewer1 = self.dcf_helper.new_viewers['1D Spectrum']()
         assert viewer1._obj.id == '1D Spectrum (1)'
 
-        # Try to create another with the same label
-        creator = self.dcf_helper.new_viewers['1D Spectrum']._obj
-        # The default should update to avoid conflict
-        assert creator.viewer_label_default != '1D Spectrum'
+        # Create another two with the same label
+        viewer2 = self.dcf_helper.new_viewers['1D Spectrum']()
+        # The defaults should update to avoid conflict
+        assert viewer2._obj.id == '1D Spectrum (2)'
+        assert self.creator.viewer_label_default == '1D Spectrum (3)'
 
-        creator.viewer_label_value = '1D Spectrum'
+        # Remove the middle viewer and check that the new default label is not changed
+        self.dcf_helper._app.vue_destroy_viewer_item('1D Spectrum (1)')
+        assert self.creator.viewer_label_default == '1D Spectrum (3)'
+
+        # Remove the last viewer and check that the new default label is reset
+        self.dcf_helper._app.vue_destroy_viewer_item('1D Spectrum (2)')
+        assert self.creator.viewer_label_default == '1D Spectrum (1)'
+        
+        # Check duplicate validation
+        self.creator.viewer_label_value = '1D Spectrum'
 
         msg = "Viewer label '1D Spectrum' already in use."
-        assert creator.viewer_label_invalid_msg == msg
+        assert self.creator.viewer_label_invalid_msg == msg
 
         # Calling should raise ValueError
         with pytest.raises(ValueError, match=msg):
-            creator()
+            self.creator()
 
     def test_viewer_creator_with_datasets(self):
         """

--- a/jdaviz/core/viewer_creators/test_viewer_creators.py
+++ b/jdaviz/core/viewer_creators/test_viewer_creators.py
@@ -117,11 +117,11 @@ class TestViewerCreatorObject:
         Test that duplicate viewer labels are properly handled.
         """
         # Create first viewer
-        viewer1 = self.dcf_helper.new_viewers['1D Spectrum']()
+        viewer1 = self.creator()
         assert viewer1._obj.id == '1D Spectrum (1)'
 
         # Create another two with the same label
-        viewer2 = self.dcf_helper.new_viewers['1D Spectrum']()
+        viewer2 = self.creator()
         # The defaults should update to avoid conflict
         assert viewer2._obj.id == '1D Spectrum (2)'
         assert self.creator.viewer_label_default == '1D Spectrum (3)'

--- a/jdaviz/core/viewer_creators/viewer_creators.py
+++ b/jdaviz/core/viewer_creators/viewer_creators.py
@@ -115,11 +115,6 @@ class BaseViewerCreator(PluginTemplateMixin, DatasetMultiSelectMixin, ViewerSele
                                       vid=self.viewer_label_value,
                                       name=self.viewer_label_value)
 
-        # Reset auto mode after successful creation so the label field advances
-        # to the next unique default. Without this, if there's a viewer failure,
-        # the `invalid_msg` is set making it seem as if the issue were a label
-        # issue not a viewer creation issue.
-        self.viewer_label_auto = True
         dm = nv.data_menu
         for dataset in self.dataset.selected:
             dm.add_data(dataset)

--- a/jdaviz/core/viewer_creators/viewer_creators.py
+++ b/jdaviz/core/viewer_creators/viewer_creators.py
@@ -112,6 +112,12 @@ class BaseViewerCreator(PluginTemplateMixin, DatasetMultiSelectMixin, ViewerSele
                                                        sender=self.app),
                                       vid=self.viewer_label_value,
                                       name=self.viewer_label_value)
+
+        # Reset auto mode after successful creation so the label field advances
+        # to the next unique default. Without this, if there's a viewer failure,
+        # the `invalid_msg` is set making it seem as if the issue were a label
+        # issue not a viewer creation issue.
+        self.viewer_label_auto = True
         dm = nv.data_menu
         for dataset in self.dataset.selected:
             dm.add_data(dataset)

--- a/jdaviz/core/viewer_creators/viewer_creators.py
+++ b/jdaviz/core/viewer_creators/viewer_creators.py
@@ -95,11 +95,13 @@ class BaseViewerCreator(PluginTemplateMixin, DatasetMultiSelectMixin, ViewerSele
             self.viewer_label_invalid_msg = ''
 
     @observe('viewer_items')
-    def _viewer_items_changed(self, *args):
+    def _viewer_items_changed(self, event):
         if not hasattr(self, 'viewer'):
             return
-        if self.viewer_label_default in self.viewer.choices:
-            self.viewer_label_default = self._app.return_unique_name(self.viewer_label_default, 'viewer')  # noqa
+
+        # This now works for viewers added or destroyed
+        self.viewer_label_default = self._app.return_unique_name(self.viewer_label_default,
+                                                                 'viewer')
 
     def __call__(self):
         """

--- a/jdaviz/core/viewer_creators/viewer_creators.py
+++ b/jdaviz/core/viewer_creators/viewer_creators.py
@@ -95,7 +95,7 @@ class BaseViewerCreator(PluginTemplateMixin, DatasetMultiSelectMixin, ViewerSele
             self.viewer_label_invalid_msg = ''
 
     @observe('viewer_items')
-    def _viewer_items_changed(self, event):
+    def _viewer_items_changed(self, *args):
         if not hasattr(self, 'viewer'):
             return
 

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -100,6 +100,23 @@ def test_duplicate_data_labels(deconfigged_helper, input_data, input_format, req
     assert any([dc_entry.label == expected_label_base for dc_entry in dc])
     assert any([dc_entry.label == f'{expected_label_base} (1)' for dc_entry in dc])
 
+    # Add one more to check that it iterates correctly
+    deconfigged_helper.load(input_data, format=input_format)
+    assert any([dc_entry.label == f'{expected_label_base} (2)' for dc_entry in dc])
+    # Check default label
+    assert (deconfigged_helper._app.return_data_label(expected_label_base) ==
+            f'{expected_label_base} (3)')
+
+    # Now remove data from the middle and check that the default label is still (3)
+    deconfigged_helper._app.data_item_remove(f'{expected_label_base} (1)')
+    assert (deconfigged_helper._app.return_data_label(expected_label_base) ==
+            f'{expected_label_base} (3)')
+
+    # Remove data from the top and check that the default label is reset to (1)
+    deconfigged_helper._app.data_item_remove(f'{expected_label_base} (2)')
+    assert (deconfigged_helper._app.return_data_label(expected_label_base) ==
+            f'{expected_label_base} (1)')
+
     # Test overwrite when using custom labels
     deconfigged_helper.load(input_data, format=input_format, data_label="test")
     deconfigged_helper.load(input_data, format=input_format, data_label="test")


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address some inconsistencies with label defaults, namely:

* viewer labels not updating after a new viewer is created... which may have been a design choice but runs into an issue when the viewer creations silently/explicitly fails. Currently, viewer creation is not atomic so if a viewer fails to load fully, the attempted viewer label may still populate the viewer store. In the UI prior to this PR, this meant that the viewer label field would show an error because the default label would not change automatically even though the real source of the issue was the underlying error. This became even more confusing when a viewer was removed and an attempt was made to re-add it + silent/explicit failure -> leading the user to potentially believe that something was wrong with our cleanup in the first place.

    - This has been solved by setting `viewer_label_auto` to true in `viewer_creators.py`. 

* label defaults only ever iterate upwards even if viewers are removed, e.g. default is: `Image` -> `Image (1)` -> `Image (2)` + delete `Image (2)` -> `Image (3)` (where it should be `Image (2)`). This was mostly a nuisance discovered while testing the prior bug but should be a nice QoL update. 

    - This has been solved by modifying the `return_unique_name` function to work in both directions, up and down. 