### PR TITLE
Stop using SkyCoord.from_name() on RA and Dec coordinates

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -51,10 +51,10 @@ jobs:
             toxposargs: --run-slow
             allow_failure: false
 
-          - name: Python 3.11 with only remote data and all deps
+          - name: Python 3.11 with only remote data, coverage checking, and all deps
             os: ubuntu-latest
             python: '3.11'
-            toxenv: py311-test-alldeps
+            toxenv: py311-test-alldeps-cov
             toxposargs: --remote-data --run-slow -m remote_data
             allow_failure: true
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -100,6 +100,9 @@ Bug Fixes
 
 - Fix passing strings to selected traitlet without expanding into characters. [#4157]
 
+- Stop using SkyCoord.from_name() to try to resolve sources in the astroquery loader
+  that are already RA and Dec coordinates. [#4193]
+
 5.0 (2026-04-15)
 ================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,9 +74,11 @@ Bug Fixes
 - Fix aperture photometry plugin remaining visible in tray after all
   image viewers are removed. [#4189]
 
+- Stop using SkyCoord.from_name() to try to resolve sources in the astroquery loader
+  that are already RA and Dec coordinates. [#4193]
+
 Mosviz
 ^^^^^^
-
 
 5.0.1 (2026-05-01)
 ==================
@@ -99,9 +101,6 @@ Bug Fixes
   units of other extracted fluxes. [#4156]
 
 - Fix passing strings to selected traitlet without expanding into characters. [#4157]
-
-- Stop using SkyCoord.from_name() to try to resolve sources in the astroquery loader
-  that are already RA and Dec coordinates. [#4193]
 
 5.0 (2026-04-15)
 ================

--- a/jdaviz/core/loaders/resolvers/astroquery/astroquery.py
+++ b/jdaviz/core/loaders/resolvers/astroquery/astroquery.py
@@ -78,19 +78,34 @@ class AstroqueryResolver(BaseConeSearchResolver):
             ],
         )
 
-    @with_spinner(spinner_traitlet="results_loading")
-    def query_archive(self):
-        output = None
-        skycoord_center = None
+    def _source_to_skycoord(self):
+        # Check to see if source is "[RA] [Dec]" (in degrees)
+        split_source = self.source.split(' ')
+        if len(split_source) == 2:
+            try:
+                _ = float(split_source[0])
+                _ = float(split_source[1])
+                return SkyCoord(self.source, unit=u.deg, frame=self.coordframe.selected)
+            except ValueError:
+                pass
 
+        # Otherwise try to resolve coordinates from the source name
         try:
-            skycoord_center = SkyCoord.from_name(self.source, frame=self.coordframe.selected)
+            return SkyCoord.from_name(self.source, frame=self.coordframe.selected)
         except NameResolveError as e:
             # Sesame name resolution can fail when the service is unreachable (SSL timeout,
             # redirect error, etc.). Surface the failure as a snackbar rather than propagating
             # the exception to the caller. Keep processing below so we clear stale results.
             errmsg = f"Unable to resolve source coordinates: {self.source}"
             self.hub.broadcast(SnackbarMessage(errmsg, color='error', sender=self, traceback=e))
+            return None
+
+    @with_spinner(spinner_traitlet="results_loading")
+    def query_archive(self):
+        output = None
+
+        skycoord_center = self._source_to_skycoord()
+
         radius = self.radius * u.Unit(self.radius_unit.selected)
 
         # Only query the selected archive when name resolution succeeded.

--- a/jdaviz/core/loaders/resolvers/astroquery/astroquery.py
+++ b/jdaviz/core/loaders/resolvers/astroquery/astroquery.py
@@ -83,8 +83,6 @@ class AstroqueryResolver(BaseConeSearchResolver):
         split_source = self.source.split(' ')
         if len(split_source) == 2:
             try:
-                _ = float(split_source[0])
-                _ = float(split_source[1])
                 return SkyCoord(self.source, unit=u.deg, frame=self.coordframe.selected)
             except ValueError:
                 pass

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -582,6 +582,15 @@ def test_resolver_table_as_query_astroquery(deconfigged_helper, tmp_path):
     assert len(ldr._obj.output) > 0
 
 
+@pytest.mark.remote_data
+def test_failed_astroquery(deconfigged_helper):
+    ldr = deconfigged_helper.loaders['astroquery']
+    ldr.source = "Bad Object"
+    ldr.query_archive()
+    snackbar_msg = "Unable to resolve source coordinates: Bad Object"
+    assert deconfigged_helper.plugins['Logger'].history[-1]['text'] == snackbar_msg
+
+
 def test_invoke_from_plugin(specviz_helper, spectrum1d, tmp_path):
     s = SpectralRegion(5*u.um, 6*u.um)
     local_path = str(tmp_path / 'spectral_region.ecsv')


### PR DESCRIPTION
Currently the astroquery loader always tried to use `SkyCoord.from_name()` to resolve coordinates from `self.source`, even if that variable already has a numeric RA and Dec, as in the case where the center of the viewer is used as the target. This changes the code to check to see if the source string is two numbers before resorting to `from_name()`. Note that the `from_name()` call is what is currently causing a test failure due to the server/url it uses having moved - I'm not sure if that test is actually trying to resolve a string source name or if this will fix that test.