### PR TITLE
Remove starlette pin to avoid critical vulnerability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "spherical-geometry",
     # This pin can be removed once Solara releases a compatibility fix
     # See https://github.com/widgetti/solara/pull/1151
-    "starlette<1.0"
+    "starlette>=1.0.1"
 ]
 license-files = ["LICENSE.rst", "licenses/IPYFILECHOOSER_LICENSE.rst", "licenses/IMEXAM_LICENSE.txt", "licenses/GINGA_LICENSE.txt", "licenses/TEMPLATE_LICENCE.rst"]
 dynamic = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,7 @@ dependencies = [
     "s3fs>=2024.10.0",
     "joblib>=1.3.0",
     "ipyvuedraggable>=1.1.0",
-    "spherical-geometry",
-    # This pin can be removed once Solara releases a compatibility fix
-    # See https://github.com/widgetti/solara/pull/1151
-    "starlette>=1.0.1"
+    "spherical-geometry"
 ]
 license-files = ["LICENSE.rst", "licenses/IPYFILECHOOSER_LICENSE.rst", "licenses/IMEXAM_LICENSE.txt", "licenses/GINGA_LICENSE.txt", "licenses/TEMPLATE_LICENCE.rst"]
 dynamic = [


### PR DESCRIPTION
See https://arstechnica.com/information-technology/2026/05/millions-of-ai-agents-imperiled-by-critical-vulnerability-in-open-source-package/. Solara fixed compatibility with >1.0 so we're good to remove the max pin. I don't think we were using Starlette (via Solara) in a way that would expose any vulnerability, luckily.