### PR TITLE
lcviz deconfigged compatibility (#4135)

### DIFF
--- a/jdaviz/__init__.py
+++ b/jdaviz/__init__.py
@@ -36,6 +36,32 @@ global _apps
 global _current_index
 
 _apps = []
+_new_app_hooks = []
+
+
+def _register_new_app_hook(hook):
+    """
+    Register a callable to be invoked on every new jdaviz App instance.
+
+    The hook is also immediately applied to all existing App instances,
+    so packages can safely call this regardless of import order.
+
+    Parameters
+    ----------
+    hook : callable
+        A callable that accepts a single argument: the new ``App`` instance.
+
+    Examples
+    --------
+    Register a hook that patches every app with custom behaviour::
+
+        import jdaviz
+        jdaviz.register_new_app_hook(my_package.patch_app)
+    """
+    _new_app_hooks.append(hook)
+    for app in _apps:
+        hook(app)
+
 
 # ipywidgets.Widget.get_state() iterates over _states_to_send, a set
 # that cam be mutated mid-iteration, causing "RuntimeError: Set changed size during iteration".
@@ -84,6 +110,8 @@ def new_app(replace=False, set_as_current=True):
     # rename the internal Application instance and/or merge functionality in with the
     # App class to avoid confusion.
     ca = App(api_hints_obj='jd')
+    for hook in _new_app_hooks:
+        hook(ca)
     if replace:
         _apps[_current_index] = ca
     else:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -235,6 +235,8 @@ class ApplicationState(State):
         0, docstring="Index of the active subtab in the info sidebar.")
     jdaviz_version = CallbackProperty(
         __version__, docstring="Version of Jdaviz.")
+    downstream_packages = ListCallbackProperty(
+        docstring="List of downstream packages registered with this app instance.")
     global_search = CallbackProperty(
         '', docstring="Global search string.")
     global_search_menu = CallbackProperty(

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -190,6 +190,7 @@
               :api_hints_obj="api_hints_obj"
               :api_hints_enabled="state.show_api_hints"
               :about_widget="state.tray_items[state.tray_items.map(ti => ti.label).indexOf('About')].widget"
+              :downstream_packages="state.downstream_packages"
               :force_open_about.sync="force_open_about"
             ></j-about-menu>
 

--- a/jdaviz/components/about_menu.vue
+++ b/jdaviz/components/about_menu.vue
@@ -17,6 +17,12 @@
           @click="() => {popup_open = !popup_open}"
           style="font-family: monospace; font-size: 10pt; text-transform: lowercase; margin-left: 4px; margin-right: 6px; padding: 2px">
         v{{ jdaviz_version }}
+        <span
+          v-if="downstream_packages && downstream_packages.length > 0"
+          style="margin-left: 4px; border-radius: 10px; padding: 0 4px; font-size: 9pt; line-height: 1.6"
+        >
+          + {{ downstream_packages.length == 1 ? downstream_packages[0].abbreviation : downstream_packages.length }}
+        </span>
         </v-btn>
       </j-tooltip>
     </template>
@@ -30,7 +36,7 @@
 
 <script>
   module.exports = {
-    props: ['jdaviz_version', 'api_hints_obj', 'api_hints_enabled', 'about_widget', 'force_open_about'],
+    props: ['jdaviz_version', 'api_hints_obj', 'api_hints_enabled', 'about_widget', 'force_open_about', 'downstream_packages'],
     data: function () {
       return {
         popup_open: false,

--- a/jdaviz/configs/cubeviz/plugins/slice/slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/slice.py
@@ -149,8 +149,10 @@ class BaseSlicePlugin(PluginTemplateMixin, ViewerSelectMixin):
         # middle of the first found layer)
         self._clear_cache()
         for viewer in self.slice_indicator_viewers:
+            x_att_pixel = getattr(viewer.state, 'x_att_pixel', None)
+            x_att_pixel_str = str(x_att_pixel) if x_att_pixel is not None else ''
             if (str(viewer.state.x_att) not in self.valid_slice_att_names and
-                    str(viewer.state.x_att_pixel) not in self.valid_slice_att_names):
+                    x_att_pixel_str not in self.valid_slice_att_names):
                 # avoid setting value to degs, before x_att is changed to wavelength, for example
                 continue
             if (self._app._get_display_unit(viewer.slice_display_unit_name) == ''
@@ -432,7 +434,22 @@ class SpectralSlice(BaseSlicePlugin):
         self.allow_disable_snapping = False
 
         self.viewer.add_filter(lambda viewer: isinstance(viewer, (CubevizImageView, CubevizProfileView)))  # noqa
+        if self.config == 'deconfigged':
+            self.hub.subscribe(self, RemoveDataMessage, handler=self._set_relevant)
         self._set_relevant()
+
+    @observe('viewer_items')
+    def _set_relevant(self, *args):
+        if (self.config == 'deconfigged' and
+                not any(d.meta.get('_importer') == 'Spectrum3DImporter'
+                        for d in self._app.data_collection)):
+            self.irrelevant_msg = 'No spectral cube data loaded'
+            return
+        super()._set_relevant(*args)
+
+    def _on_add_data(self, msg):
+        self._set_relevant()
+        super()._on_add_data(msg)
 
     @observe('vdocs')
     def _update_docs_link(self, *args):

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -86,7 +86,8 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
             self.sound_device_indexes = None
             self.refresh_device_list()
 
-        self.add_to_viewer_selected = 'flux-viewer'
+        self._set_default_viewer_selected()
+        self.observe(self._on_add_to_viewer_items_changed, names=['add_to_viewer_items'])
         self.sonified_cube = None
         self.sonified_viewers = []
         self.sonification_wl_ranges = None
@@ -103,7 +104,18 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
                            handler=self._data_added_to_viewer)
 
         if self.config == "deconfigged":
+            self.dataset.add_filter('is_flux_cube')
             self.observe_traitlets_for_relevancy(traitlets_to_observe=['dataset_items'])
+
+    def _set_default_viewer_selected(self):
+        """Set add_to_viewer_selected to 'flux-viewer' if it is a valid choice."""
+        valid_labels = [item.get('label') for item in self.add_to_viewer_items]
+        if 'flux-viewer' in valid_labels and self.add_to_viewer_selected in ('', 'None'):
+            self.add_to_viewer_selected = 'flux-viewer'
+
+    def _on_add_to_viewer_items_changed(self, change):
+        """Defer setting the default viewer until choices are populated."""
+        self._set_default_viewer_selected()
 
     def _get_supported_viewers(self):
         """Return viewer types that can display sonified data."""

--- a/jdaviz/configs/default/plugins/about/about.py
+++ b/jdaviz/configs/default/plugins/about/about.py
@@ -1,6 +1,6 @@
 import requests
 from packaging.version import Version
-from traitlets import Bool, Unicode, observe
+from traitlets import Bool, List, Unicode, observe
 
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import PluginTemplateMixin
@@ -28,6 +28,7 @@ class About(PluginTemplateMixin):
     jdaviz_version = Unicode("unknown").tag(sync=True)
     jdaviz_pypi = Unicode("unknown").tag(sync=True)
     not_is_latest = Bool(False).tag(sync=True)
+    downstream_packages = List([]).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -66,6 +67,26 @@ class About(PluginTemplateMixin):
 
     def show_popup(self):
         self._app.force_open_about = True
+
+    def register_downstream_package(self, name, version, abbreviation=None):
+        """
+        Register a downstream package to be listed in the About panel.
+
+        Parameters
+        ----------
+        name : str
+            The display name of the downstream package.
+        version : str
+            The installed version string.
+        abbreviation : str, optional
+            Short label shown as a badge on the version button in the app bar.
+            Defaults to the first two characters of ``name`` in lowercase.
+        """
+        entry = {'name': name, 'version': version,
+                 'abbreviation': abbreviation or name[:2].lower()}
+        if entry not in self.downstream_packages:
+            self.downstream_packages = self.downstream_packages + [entry]
+            self._app.state.downstream_packages = self._app.state.downstream_packages + [entry]
 
     @property
     def user_api(self):

--- a/jdaviz/configs/default/plugins/about/about.vue
+++ b/jdaviz/configs/default/plugins/about/about.vue
@@ -11,20 +11,24 @@
     <v-row>
       <v-text-field class="v-messages v-messages__message text--secondary"
         v-model="jdaviz_version"
-        label="Version"
+        label="jdaviz version"
         hint="Version of installed Jdaviz."
         readonly>
       </v-text-field>
     </v-row>
 
-    <v-row v-if="not_is_latest">
-      <span class="v-messages v-messages__message text--secondary" style="color: red !important">
-        A newer version ({{ jdaviz_pypi }}) is available from PyPI.
-      </span>
-      <j-docs-link link="https://pypi.org/project/jdaviz/" linktext="Go to PyPI">
-        Please update Jdaviz and restart your session.
-      </j-docs-link>
-    </v-row>
+    <div v-if="not_is_latest">
+      <v-row>
+        <span class="v-messages v-messages__message text--secondary" style="color: red !important">
+          A newer version ({{ jdaviz_pypi }}) is available from PyPI.
+        </span>
+      </v-row>
+      <v-row>
+        <j-docs-link link="https://pypi.org/project/jdaviz/" linktext="Go to PyPI">
+          Please update Jdaviz and restart your session.
+        </j-docs-link>
+      </v-row>
+    </div>
 
     <v-row>
       <j-docs-link link="https://github.com/spacetelescope/jdaviz/blob/main/CHANGES.rst" linktext="Change Log">
@@ -38,6 +42,15 @@
         For further assistance, please contact the
 
       </j-docs-link>
+    </v-row>
+
+    <v-row v-for="pkg in downstream_packages" :key="pkg.name">
+      <v-text-field class="v-messages v-messages__message text--secondary"
+        :value="pkg.version"
+        :label="pkg.name + ' version'"
+        :hint="'Version of installed ' + pkg.name + '.'"
+        readonly>
+      </v-text-field>
     </v-row>
 
   </j-tray-plugin>

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -50,6 +50,20 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
                              'value:unreliable': None,
                              'index': np.nan}
 
+    # Downstream configs may extend the markers table by setting these at import time.
+    # _extra_headers: list of additional column names appended to the config-specific headers.
+    # _extra_default_values: dict of {column_name: default_value} for extra columns.
+    _extra_headers = []
+    _extra_default_values = {}
+
+    # When True, headers_visible and export_table() will omit fully-unpopulated columns.
+    _table_skip_empty_columns = True
+
+    @property
+    def coords_info(self):
+        """Convenience accessor for the CoordsInfo toolbar tool."""
+        return self._app.session.application._tools.get('g-coords-info')
+
     @property
     def user_api(self):
         return PluginUserApi(self, expose=('table', 'measurements_table',
@@ -93,10 +107,13 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
             # allow downstream configs to override headers
             headers = kwargs.get('headers', [])
 
+        headers += list(self._extra_headers)
         headers += ['data_label']
         self.table.headers_avail = headers
         self.table.headers_visible = headers
-        self.table._default_values_by_colname = self._default_table_values
+        default_values = {**self._default_table_values, **self._extra_default_values}
+        self.table._default_values_by_colname = default_values
+        self.table._skip_empty_columns = self._table_skip_empty_columns
 
         self._distance_marks = {}
         self._distance_first_point = None
@@ -470,10 +487,6 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
         return {viewer_id: self._get_mark(viewer)
                 for viewer_id, viewer in self._app._viewer_store.items()
                 if hasattr(viewer, 'figure')}
-
-    @property
-    def coords_info(self):
-        return self._app.session.application._tools['g-coords-info']
 
     @observe('is_active')
     def _on_is_active_changed(self, *args):

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -484,6 +484,32 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
     table_columns_visible_value = List().tag(sync=True)
     table_columns_visible_sync = Dict().tag(sync=True)
 
+    # Downstream configs may register extra layer filter functions and user_api
+    # modifications at import time via the classmethods below, rather than subclassing.
+    _layer_filter_hooks = []
+    _user_api_expose_extra = []
+    _user_api_remove = []
+
+    @classmethod
+    def register_layer_filter(cls, filter_factory):
+        """Register a layer filter factory.
+
+        The factory is called once per plugin instance during ``__init__`` with
+        the plugin instance as its only argument, and must return a filter
+        callable ``(layer_state) -> bool``.  Using a factory (rather than a bare
+        filter function) lets the filter close over plugin attributes such as
+        ``self.layer`` that are not available until instantiation.
+        """
+        cls._layer_filter_hooks = list(cls._layer_filter_hooks) + [filter_factory]
+
+    @classmethod
+    def register_user_api(cls, expose=None, remove=None):
+        """Register extra user_api attributes to expose or remove."""
+        if expose:
+            cls._user_api_expose_extra = list(cls._user_api_expose_extra) + list(expose)
+        if remove:
+            cls._user_api_remove = list(cls._user_api_remove) + list(remove)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -499,6 +525,10 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
         self.layer.filters += [is_not_wcs_only,
                                'catalog_has_correct_coords_based_on_link_type',
                                'not_in_table_viewer']
+
+        # Apply any layer filter factories registered by downstream configs
+        for filter_factory in self._layer_filter_hooks:
+            self.layer.add_filter(filter_factory(self))
 
         self.swatches_palette = [
             ['#FF0000', '#AA0000', '#550000'],
@@ -832,6 +862,12 @@ class PlotOptions(PluginTemplateMixin, ViewerSelectMixin):
                        'marker_color_mode', 'marker_color',
                        'marker_color_col', 'marker_colormap',
                        'marker_colormap_vmin', 'marker_colormap_vmax']
+
+        # Apply any user_api modifications registered by downstream configs
+        if self._user_api_expose_extra:
+            expose += [e for e in self._user_api_expose_extra if e not in expose]
+        if self._user_api_remove:
+            expose = [e for e in expose if e not in self._user_api_remove]
 
         return PluginUserApi(self, expose)
 

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -126,6 +126,10 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
     can_freeze = Bool(False).tag(sync=True)
     server_is_remote = Bool(False).tag(sync=True)
 
+    # Downstream configs can set _default_can_freeze = True at import time to enable
+    # the freeze button without subclassing this plugin.
+    _default_can_freeze = False
+
     icon_replace = Unicode(read_icon(os.path.join(icon_path("glue_replace", icon_format="svg")), 'svg+xml')).tag(sync=True)  # noqa
     icon_or = Unicode(read_icon(os.path.join(icon_path("glue_or", icon_format="svg")), 'svg+xml')).tag(sync=True)  # noqa
     icon_and = Unicode(read_icon(os.path.join(icon_path("glue_and", icon_format="svg")), 'svg+xml')).tag(sync=True)  # noqa
@@ -140,6 +144,9 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        # Apply can_freeze default (downstream configs may set _default_can_freeze = True)
+        self.can_freeze = self._default_can_freeze
 
         # Initialize server_is_remote from settings
         self.server_is_remote = self.app.state.settings.get('server_is_remote', False)

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -14,7 +14,7 @@ from jdaviz.configs.mosviz.plugins.viewers import (MosvizImageView,
 from jdaviz.configs.rampviz.plugins.viewers import RampvizImageView, RampvizProfileView
 from jdaviz.configs.specviz.plugins.viewers import Spectrum1DViewer, Spectrum2DViewer
 from jdaviz.core.custom_units_and_equivs import PIX2
-from jdaviz.core.events import ViewerAddedMessage, GlobalDisplayUnitChanged
+from jdaviz.core.events import ViewerAddedMessage, ViewerRenamedMessage, GlobalDisplayUnitChanged
 from jdaviz.core.helpers import data_has_valid_wcs
 from jdaviz.core.marks import PluginScatter, PluginLine
 from jdaviz.core.registries import tool_registry
@@ -42,6 +42,37 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
     _viewer_classes_with_marker = (Spectrum1DViewer, Spectrum2DViewer,
                                    RampvizProfileView, MosvizProfile2DView,
                                    ImvizImageView)
+
+    # Downstream configs may register custom viewer update handlers at import time.
+    # Keys are viewer classes; values are callables with signature
+    # (coords_info_instance, viewer, x, y, mouseevent=True).
+    _viewer_update_handlers = {}
+
+    @classmethod
+    def register_viewer_class(cls, viewer_cls, with_marker=False):
+        """Register a new viewer class to receive mouseover callbacks.
+
+        Parameters
+        ----------
+        viewer_cls : type
+            The viewer class to register.
+        with_marker : bool
+            If True, a scatter marker will be created for this viewer type
+            so the cursor snapping indicator is displayed.
+        """
+        if viewer_cls not in cls._supported_viewer_classes:
+            cls._supported_viewer_classes = cls._supported_viewer_classes + (viewer_cls,)
+        if with_marker and viewer_cls not in cls._viewer_classes_with_marker:
+            cls._viewer_classes_with_marker = cls._viewer_classes_with_marker + (viewer_cls,)
+
+    @classmethod
+    def register_viewer_update_handler(cls, viewer_cls, handler):
+        """Register a handler called from ``update_display`` for a custom viewer type.
+
+        The handler must have the signature
+        ``handler(coords_info, viewer, x, y, mouseevent=True)``.
+        """
+        cls._viewer_update_handlers = {**cls._viewer_update_handlers, viewer_cls: handler}
 
     dataset_icon = Unicode("").tag(
         sync=True
@@ -81,6 +112,8 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
 
         # subscribe to mouse events on any new viewers
         self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewer_added)
+        # keep marks dict in sync when a viewer is renamed
+        self.hub.subscribe(self, ViewerRenamedMessage, handler=self._viewer_renamed)
         if self.config in ("cubeviz", 'deconfigged'):
             self.hub.subscribe(
                 self, GlobalDisplayUnitChanged, handler=self._on_global_display_unit_changed
@@ -123,6 +156,10 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
 
     def _on_viewer_added(self, msg):
         self._create_viewer_callbacks(self._app.get_viewer_by_id(msg.viewer_id))
+
+    def _viewer_renamed(self, msg):
+        if msg.old_viewer_ref in self._marks:
+            self._marks[msg.new_viewer_ref] = self._marks.pop(msg.old_viewer_ref)
 
     def _on_global_display_unit_changed(self, msg):
 
@@ -266,6 +303,12 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                          RampvizImageView)
                         ):
             self._image_viewer_update(viewer, x, y, mouseevent=mouseevent)
+        else:
+            # Dispatch to any handler registered by a downstream config
+            for vcls, handler in self._viewer_update_handlers.items():
+                if isinstance(viewer, vcls):
+                    handler(self, viewer, x, y, mouseevent=mouseevent)
+                    return
 
     def _image_shape_inds(self, image):
         # return the indices in image.shape for the x and y dimension, respectively

--- a/jdaviz/configs/rampviz/plugins/ramp_extraction/ramp_extraction.py
+++ b/jdaviz/configs/rampviz/plugins/ramp_extraction/ramp_extraction.py
@@ -202,6 +202,8 @@ class RampExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
     def _on_subset_delete(self, msg={}):
 
         viewer = self.integration_viewer
+        if viewer is None or viewer.figure is None:
+            return
         subset_lbl = msg.subset.label
         viewer.figure.marks = [
             mark for mark in viewer.figure.marks
@@ -211,6 +213,8 @@ class RampExtraction(PluginTemplateMixin, ApertureSubsetSelectMixin,
     @observe('is_active', 'show_subset_preview', 'aperture_selected')
     def _update_subset_previews(self, msg={}):
         # remove preview marks for non-selected subsets
+        if self.integration_viewer is None or self.integration_viewer.figure is None:
+            return
 
         for mark in self.integration_viewer.figure.marks:
             if isinstance(mark, PluginLine) and mark.label is not None:

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -207,6 +207,13 @@ class ImageImporter(BaseImporterToDataCollection):
         if self._app.config not in ('deconfigged', 'imviz', 'mastviz', 'cubeviz', 'rampviz'):
             # NOTE: temporary during deconfig process
             return False
+
+        # Reject FITS files that look like light curves (have BinTableHDU with TIME column)
+        if isinstance(self.input, fits.HDUList):
+            for hdu in self.input:
+                if isinstance(hdu, fits.BinTableHDU) and 'TIME' in hdu.columns.names:
+                    return False
+
         # flat image, not a cube
         # isinstance NDData
         if self.input_has_extensions and not len(self.extension.choices):

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -776,6 +776,15 @@ class PluginTemplateMixin(TemplateMixin):
     docs_link = Unicode("").tag(sync=True)  # set to non-empty to override value in vue file
     docs_description = Unicode("").tag(sync=True)  # set to non-empty to override value in vue file
     _plugin_description = Unicode("").tag(sync=True)  # noqa shorter description of plugin, displayed below title in menu
+
+    # Downstream configs may set _docs_link_fmt to a format string using {vdocs} to override
+    # the default docs link without subclassing.
+    _docs_link_fmt = ''
+
+    @observe('vdocs')
+    def _update_docs_link(self, *args):
+        if self._docs_link_fmt:
+            self.docs_link = self._docs_link_fmt.format(vdocs=self.vdocs)
     plugin_opened = Bool(False).tag(sync=True)  # noqa any instance of the plugin is open (recently sent an "alive" ping)
     uses_active_status = Bool(False).tag(sync=True)  # noqa whether the plugin has live-preview marks, set to True in plugins to expose keep_active switch
     keep_active = Bool(False).tag(sync=True)  # noqa whether the live-preview marks show regardless of active state, inapplicable unless uses_active_status is True
@@ -6085,6 +6094,11 @@ class Table(PluginSubcomponent):
     enable_clear = Bool(True).tag(sync=True)
     clear_btn_lbl = Unicode('Clear Table').tag(sync=True)
 
+    # When True, headers_visible and export_table() will omit columns whose
+    # every row value is empty (nan / empty string). Useful for configs that
+    # share a common wide header set but only populate a subset of columns.
+    _skip_empty_columns = False
+
     # Loader panel traitlets for "Load into App" functionality
     loader_items = List([]).tag(sync=True)
     loader_selected = Unicode('object').tag(sync=True)
@@ -6143,6 +6157,20 @@ class Table(PluginSubcomponent):
     @staticmethod
     def _new_col_visible(colname):
         return True
+
+    def _compute_populated_headers(self):
+        """Return ``headers_avail`` filtered to columns with at least one non-empty value.
+
+        A value is considered empty when its JSON-display representation equals ``''``
+        (i.e. NaN floats, all-NaN tuples, and empty strings all render as ``''``).
+        When the table has no rows every header in ``headers_avail`` is returned.
+        """
+        if not self.items:
+            return list(self.headers_avail)
+        return [
+            h for h in self.headers_avail
+            if any(item.get(h, '') != '' for item in self.items)
+        ]
 
     @observe('selected_rows')
     def _selected_rows_changed(self, msg):
@@ -6296,6 +6324,8 @@ class Table(PluginSubcomponent):
 
         # clean data to show in the UI
         self.items = self.items + [{k: json_safe(k, v) for k, v in item.items()}]
+        if self._skip_empty_columns:
+            self.headers_visible = self._compute_populated_headers()
         self._plugin.session.hub.broadcast(PluginTableAddedMessage(sender=self))
 
     def __len__(self):
@@ -6306,6 +6336,9 @@ class Table(PluginSubcomponent):
         self.selected_rows = []
         self.selected_indices = []
         self._qtable = None
+        if self._skip_empty_columns:
+            # Reset to show all available headers so the next mark populates cleanly
+            self.headers_visible = list(self.headers_avail)
         self._plugin.session.hub.broadcast(PluginTableModifiedMessage(sender=self))
 
     def clear_table(self):
@@ -6436,6 +6469,10 @@ class Table(PluginSubcomponent):
         """
         if filename is None:
             # TODO: default to only showing selected columns?
+            if self._skip_empty_columns and self._qtable is not None:
+                populated = self._compute_populated_headers()
+                cols = [c for c in self._qtable.colnames if c in populated]
+                return self._qtable[cols] if cols else self._qtable
             return self._qtable
 
         if "_orig_colnames_for_jdaviz_export" in self._qtable.meta:


### PR DESCRIPTION
Manual backport of PR #4135, conflicts caused by:
* #4159 not being backported (this PR modifying is_valid logic - so needs to return False instead of a string in the backport)
* #4131 not being backported (this PR modifying table logic by skipping empty columns, conflicting with similar blocks of code modified in $4131)