### PR TITLE
bugfix when loading catalogs with strings to be parsed as units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,8 @@ Bug Fixes
 - Fix units related issue in imviz aperture photometry plugin when applying
   pixel area factor to data in surface brightness units. [#4188]
 
+- Fix bug related to loading catalogs where units are determined from coordinate string. [#4199]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/core/loaders/importers/catalog/catalog.py
+++ b/jdaviz/core/loaders/importers/catalog/catalog.py
@@ -475,12 +475,12 @@ class CatalogImporter(BaseImporterToDataCollection):
             # determine if the string format is recognizable as Lon/Lat coordinates.
             if isinstance(ra[0], str):
                 try:
-                    ra = SkyCoord(ra, ra).ra  # dummy value 'ra' twice, just to parse string
+                    ra = SkyCoord(ra[0], 90 * u.deg).ra  # dummy value 'ra' twice, just to parse string
                 except (ValueError, u.UnitTypeError):
                     raise ValueError("Could not parse RA column as string coordinates.")
             if isinstance(dec[0], str):
                 try:
-                    dec = SkyCoord(dec, dec).dec  # dummy value 'dec' twice, just to parse string
+                    dec = SkyCoord(0 * u.deg, dec[0]).dec  # dummy value 'dec' twice, just to parse string
                 except (ValueError, u.UnitTypeError):
                     raise ValueError("Could not parse Dec column as string coordinates.")
 

--- a/jdaviz/core/loaders/importers/catalog/catalog.py
+++ b/jdaviz/core/loaders/importers/catalog/catalog.py
@@ -475,12 +475,12 @@ class CatalogImporter(BaseImporterToDataCollection):
             # determine if the string format is recognizable as Lon/Lat coordinates.
             if isinstance(ra[0], str):
                 try:
-                    ra = SkyCoord(ra[0], 90 * u.deg).ra  # dummy value 'ra' twice, just to parse string
+                    ra = SkyCoord(ra[0], 90 * u.deg).ra  # dummy value just to parse string
                 except (ValueError, u.UnitTypeError):
                     raise ValueError("Could not parse RA column as string coordinates.")
             if isinstance(dec[0], str):
                 try:
-                    dec = SkyCoord(0 * u.deg, dec[0]).dec  # dummy value 'dec' twice, just to parse string
+                    dec = SkyCoord(0 * u.deg, dec[0]).dec  # dummy value just to parse string
                 except (ValueError, u.UnitTypeError):
                     raise ValueError("Could not parse Dec column as string coordinates.")
 

--- a/jdaviz/core/loaders/importers/catalog/catalog.py
+++ b/jdaviz/core/loaders/importers/catalog/catalog.py
@@ -475,12 +475,12 @@ class CatalogImporter(BaseImporterToDataCollection):
             # determine if the string format is recognizable as Lon/Lat coordinates.
             if isinstance(ra[0], str):
                 try:
-                    ra = SkyCoord(ra[0], 90 * u.deg).ra  # dummy value just to parse string
+                    ra = SkyCoord(ra, 90 * u.deg).ra  # dummy value just to parse string
                 except (ValueError, u.UnitTypeError):
                     raise ValueError("Could not parse RA column as string coordinates.")
             if isinstance(dec[0], str):
                 try:
-                    dec = SkyCoord(0 * u.deg, dec[0]).dec  # dummy value just to parse string
+                    dec = SkyCoord(0 * u.deg, dec).dec  # dummy value just to parse string
                 except (ValueError, u.UnitTypeError):
                     raise ValueError("Could not parse Dec column as string coordinates.")
 

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -50,12 +50,12 @@ def _make_catalog_xy_radec(with_units=True, colnames=None):
 
 def _make_catalog_string_coord_columns():
     # complete nonsense coordinates, just care about parsing the units
-    ra = ['5° 55′ 55″', '5° 55′ 55″', '5° 55′ 55″']
-    dec = ['4° 44′ 44″', '4° 44′ 44″', '4° 44′ 44″']
-    x = ['1', '2', '3']
-    y = ['4', '5', '6']
-    obj_id = ['source1', 'source2', 'source3']
-    flux = [10, 20, 30] * u.Jy
+    ra = ['5° 55′ 55″', '5° 55′ 55″', '5° 55′ 55″', '09h59m46.18778822s']
+    dec = ['4° 44′ 44″', '4° 44′ 44″', '4° 44′ 44″', '+02d11m32.14597268s']
+    x = ['1', '2', '3', '4']
+    y = ['4', '5', '6', '7']
+    obj_id = ['source1', 'source2', 'source3', 'source4']
+    flux = [10, 20, 30, 40] * u.Jy
 
     return QTable(data=[ra, dec, x, y, obj_id, flux],
                   names=['RA', 'Dec', 'X', 'Y', 'Obj_ID', 'flux'])


### PR DESCRIPTION
This PR fixes a bug when loading catalogs for which units should be determined from the coordinate columns themselves when passed in as strings (e.g '09h59m46.18778822s'). The strings are passed through SkyCoord only temporarily to make use of the string to quantity functionality there. The bug was triggered when you had RA values with an absolute value greater than 90 degrees, which were invalid input as a dummy value for declination. This fixes that by just using a fixed in-range place holder value. The test that covers loading units from strings is extended to now include this case.