### PR TITLE
Fix issue with dq layer in viewer

### DIFF
--- a/jdaviz/configs/default/plugins/data_quality/data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.py
@@ -179,19 +179,23 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
 
     @property
     def validate_flag_decode_possible(self):
+        if not hasattr(self, 'dq_layer'):
+            return False
         return (
-            self.flag_map_selected is not None and
             len(self.dq_layer.selected_obj) > 0 and
             len(self.unique_flags) > 0
         )
 
     @observe('flag_map_selected')
     def update_flag_map_definitions_selected(self, event):
+        if self.flag_map_selected is None:
+            return
+
         flag_map_key = self.flag_map_selected.lower().replace('/', '-')
         selected = self.flag_map_definitions[flag_map_key]
         self.flag_map_definitions_selected = selected
 
-        # clear decoded_flags with a meaningless one:
+        # re-decode with the real flag map:
         self.init_decoding()
         self._update_cmap()
 
@@ -203,7 +207,7 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
         unique_flags = self.unique_flags
         cmap, rgba_colors = generate_listed_colormap(n_flags=len(unique_flags))
         self.decoded_flags = decode_flags(
-            flag_map=self.flag_map_definitions_selected,
+            flag_map=self.flag_map_definitions_selected or {},
             unique_flags=unique_flags,
             rgba_colors=rgba_colors
         )

--- a/jdaviz/configs/default/plugins/data_quality/data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/data_quality.py
@@ -20,7 +20,7 @@ from jdaviz.configs.default.plugins.data_quality.dq_utils import (
 
 __all__ = ['DataQuality']
 
-telescope_names = {
+TELESCOPE_NAMES = {
     "jwst": "JWST",
     "roman": "Roman",
     "hst-stis": "HST/STIS",
@@ -148,7 +148,7 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
     def load_default_flag_maps(self):
         for name in dq_flag_map_paths:
             self.flag_map_definitions[name] = load_flag_map(name)
-            self.flag_map_items = self.flag_map_items + [telescope_names[name]]
+            self.flag_map_items = self.flag_map_items + [TELESCOPE_NAMES[name]]
 
     @property
     def dq_layer_selected_flattened(self):
@@ -396,7 +396,7 @@ class DataQuality(PluginTemplateMixin, ViewerSelectMixin):
                     if i is not None
                 )
 
-            flag_map_to_select = telescope_names.get(telescope.lower())
+            flag_map_to_select = TELESCOPE_NAMES.get(telescope.lower())
             self.flag_map_selected = flag_map_to_select
 
     def vue_hide_all_flags(self, event):

--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -1,6 +1,7 @@
 import warnings
 import pytest
 
+from astropy.io import fits
 from astropy.utils import minversion
 import gwcs
 import numpy as np
@@ -77,6 +78,43 @@ def test_roman_against_rdm():
 
     for flag in flag_map_expected:
         assert flag_map_loaded[flag]['name'] == flag_map_expected[flag]['name']
+
+
+@pytest.mark.parametrize('helper_name', ['imviz_helper', 'deconfigged_helper'])
+def test_dq_display_without_telescop_metadata(helper_name, request, multi_extension_image_hdu_wcs):
+    """
+    DQ layers must be properly initialized with the lookup stretch
+    and a DQ colormap even when the FITS file has no TELESCOP header
+    (telescope auto-detection fails). Previously the DQ layer was
+    left with default stretch=linear + cmap=gray, rendering as a
+    completely black picture.
+    """
+    helper = request.getfixturevalue(helper_name)
+    helper.load(multi_extension_image_hdu_wcs, extension=('SCI', 'DQ'), format='Image')
+    dq_plugin = helper.plugins['Data Quality']._obj
+
+    # No telescope metadata → flag_map_selected stays None
+    assert dq_plugin.flag_map_selected is None
+
+    # DQ flags should still be decoded (with raw bit values since no flag map is available)
+    assert len(dq_plugin.decoded_flags) == 3
+    decoded_flag_values = [f['flag'] for f in dq_plugin.decoded_flags]
+    # The flag values from the fixture
+    assert decoded_flag_values == [1, 4, 5]
+
+    # DQ layer must have the lookup stretch and transparent bad pixels
+    viewer_name = 'Image' if helper_name == 'deconfigged_helper' else 'imviz-0'
+    viewer = helper._app.get_viewer(viewer_name)
+    dq_layers = dq_plugin.get_dq_layers([viewer])
+    assert len(dq_layers) == 1
+
+    dq_layer = dq_layers[0]
+    assert dq_layer.state.stretch == 'lookup'
+    assert dq_layer.state.cmap_bad == (0, 0, 0, 0)
+    assert dq_layer.state.alpha == dq_plugin.dq_layer_opacity
+
+    # v_min/v_max should span the actual flag range
+    assert dq_layer.state.v_min, dq_layer.state.v_max == (1, 5)
 
 
 @pytest.mark.remote_data

--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -1,7 +1,6 @@
 import warnings
 import pytest
 
-from astropy.io import fits
 from astropy.utils import minversion
 import gwcs
 import numpy as np

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -681,11 +681,15 @@ def image_hdu_wcs():
 
 @pytest.fixture
 def multi_extension_image_hdu_wcs():
+    dq_arr = np.zeros((10, 10), dtype=np.int32)
+    dq_arr[2, 3] = 1
+    dq_arr[5, 5] = 4
+    dq_arr[7, 8] = 5
     return fits.HDUList([fits.PrimaryHDU(),
                          _image_hdu_wcs(),
                          _image_hdu_nowcs(np.zeros((10, 10)), name='MASK'),
                          _image_hdu_nowcs(name='ERR'),
-                         _image_hdu_nowcs(name='DQ')])
+                         _image_hdu_nowcs(dq_arr, name='DQ')])
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR fixes an issue where DQ layers were showing as completely black images in the viewer. This seems to occur when there is no telescope information to be found in the HDU list metadata (`TELESCOP` keyword) and so was mostly an issue with synthetic data. 

The fix catches these scenarios by adding some checks for `flag_map_selected` to allow the raw values to be used when no mapping is available. 

I added a test and modified one of the fixtures in `conftest` to accommodate. 