### PR TITLE
allow 'add_to_data_collection' to omit adding to viewer without referencing selection on self.viewer

### DIFF
--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -343,13 +343,11 @@ class BaseImporterToDataCollection(BaseImporter):
             Label of the parent data entry. If provided, establishes this data
             as a child of the parent (e.g., DQ layer as child of SCI layer).
             Used by the Data Quality plugin to associate layers.
-        viewer_select : `~jdaviz.core.template_mixin.ViewerSelect`, False, or None, optional
+        viewer_select : `~jdaviz.core.template_mixin.ViewerSelect`, ``False``, or None, optional
             Viewer selection component to determine which viewers to add the
             data to. If not provided or ``None``, uses ``self.viewer``. Pass
-            ``False`` to skip adding the data to any viewer entirely, without
-            needing to provide a viewer_select component or override the current
-            setting of the loader viewer select when adding to data collection
-            from a plugin, for example.
+            ``False`` to skip adding the data to any viewer entirely independent
+              the selection on ``self.viewer``.
         cls : class, optional
             The native data class to store in metadata for later export via
             ``get_data``. If not provided, uses the class of the input data.
@@ -417,60 +415,63 @@ class BaseImporterToDataCollection(BaseImporter):
         if self._app.config in CONFIGS_WITH_LOADERS:
             self._app._link_new_data_by_component_type(data_label)
 
-        # Determine which viewer(s) to add the data to, if any
-
+        # Determine which viewer(s) to add the data to.
         viewer_select = viewer_select if viewer_select is not None else self.viewer
 
-        if viewer_select:
-            # user requested creating a new viewer for this data.
-            if viewer_select.create_new.selected:
-                viewer_reference = viewer_select.create_new.selected_item.get('reference')
-                viewer_label = viewer_select.new_label.value.strip()
+        if viewer_select is False:
+            # return without adding to viewers or broadcasting snackbar message that
+            # data was loaded but not added to viewers. we don't want this snackbar
+            # if data is being added to DC intentionally without a viewer from a plugin
+            return
 
-                # Create the new viewer instance
-                viewer_dict = viewer_registry.members.get(viewer_reference)
-                viewer_cls = viewer_dict.get('cls')
-                self._app._on_new_viewer(NewViewerMessage(viewer_cls, data=None, sender=self.app),
-                                         vid=viewer_label,
-                                         name=viewer_label,
-                                         open_data_menu_if_empty=False)
-                viewer = self._app._jdaviz_helper.viewers.get(viewer_label)
-                viewer.data_menu.add_data(data_label)
+        # user requested creating a new viewer for this data.
+        if viewer_select.create_new.selected:
+            viewer_reference = viewer_select.create_new.selected_item.get('reference')
+            viewer_label = viewer_select.new_label.value.strip()
 
-                # default to selecting this new viewer for next import
-                viewer_select.create_new.selected = ''
-                viewer_select.selected = [viewer_label]
+            # Create the new viewer instance
+            viewer_dict = viewer_registry.members.get(viewer_reference)
+            viewer_cls = viewer_dict.get('cls')
+            self._app._on_new_viewer(NewViewerMessage(viewer_cls, data=None, sender=self.app),
+                                     vid=viewer_label,
+                                     name=viewer_label,
+                                     open_data_menu_if_empty=False)
+            viewer = self._app._jdaviz_helper.viewers.get(viewer_label)
+            viewer.data_menu.add_data(data_label)
 
-        else:
-            # if no viewers selected, just notify user that data was loaded
-            # but not displayed anywhere.
-            if viewer_select is False or len(viewer_select.selected) == 0:
-                if len(self._app._jdaviz_helper.viewers):
-                    msg = f"{data_label} loaded without any viewers selected - add manually from viewer data-menu"  # noqa
-                else:
-                    msg = f"{data_label} loaded but no viewers were created.  Create viewers manually and add data from data-menu"  # noqa
-                # Don't warn for WCS-only layers (orientation reference layers)
-                # or for data added via a plugin (e.g moment maps)
-                from_plugin = new_dc_entry.meta.get('plugin', False)
-                if not new_dc_entry.meta.get(_wcs_only_label, False) and not from_plugin:
-                    self._app.hub.broadcast(SnackbarMessage(msg, sender=self, color='warning'))
+            # default to selecting this new viewer for next import
+            viewer_select.create_new.selected = ''
+            viewer_select.selected = [viewer_label]
 
-            # otherwise, add data to all selected viewers.
+        # if no viewers selected, just notify user that data was loaded
+        # but not displayed anywhere.
+        elif len(viewer_select.selected) == 0:
+            if len(self._app._jdaviz_helper.viewers):
+                msg = f"{data_label} loaded without any viewers selected - add manually from viewer data-menu"  # noqa
             else:
-                failed_viewers = []
-                exceptions = []
-                for viewer_label in viewer_select.selected:
-                    viewer = self._app._jdaviz_helper.viewers.get(viewer_label)
-                    try:
-                        viewer.data_menu.add_data(data_label)
-                    except Exception as e:
-                        failed_viewers.append(viewer_label)
-                        exceptions.append(str(e))
-                # Report any failures (e.g., incompatible data types for the viewer)
-                if len(failed_viewers) > 0:
-                    msg = f"Failed to add {data_label} to viewers: {', '.join(failed_viewers)}"
-                    self._app.hub.broadcast(SnackbarMessage(msg, sender=self, color='error',
-                                                            traceback=exceptions))
+                msg = f"{data_label} loaded but no viewers were created.  Create viewers manually and add data from data-menu"  # noqa
+            # Don't warn for WCS-only layers (orientation reference layers)
+            # or for data added via a plugin (e.g moment maps)
+            from_plugin = new_dc_entry.meta.get('plugin', False)
+            if not new_dc_entry.meta.get(_wcs_only_label, False) and not from_plugin:
+                self._app.hub.broadcast(SnackbarMessage(msg, sender=self, color='warning'))
+
+        # otherwise, add data to all selected viewers.
+        else:
+            failed_viewers = []
+            exceptions = []
+            for viewer_label in viewer_select.selected:
+                viewer = self._app._jdaviz_helper.viewers.get(viewer_label)
+                try:
+                    viewer.data_menu.add_data(data_label)
+                except Exception as e:
+                    failed_viewers.append(viewer_label)
+                    exceptions.append(str(e))
+            # Report any failures (e.g., incompatible data types for the viewer)
+            if len(failed_viewers) > 0:
+                msg = f"Failed to add {data_label} to viewers: {', '.join(failed_viewers)}"
+                self._app.hub.broadcast(SnackbarMessage(msg, sender=self, color='error',
+                                                        traceback=exceptions))
 
     @with_spinner('import_spinner')
     def __call__(self):

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -417,60 +417,60 @@ class BaseImporterToDataCollection(BaseImporter):
         if self._app.config in CONFIGS_WITH_LOADERS:
             self._app._link_new_data_by_component_type(data_label)
 
-        # Determine which viewer(s) to add the data to.
-        if viewer_select is False:
-            return
+        # Determine which viewer(s) to add the data to, if any
 
         viewer_select = viewer_select if viewer_select is not None else self.viewer
 
-        # user requested creating a new viewer for this data.
-        if viewer_select.create_new.selected:
-            viewer_reference = viewer_select.create_new.selected_item.get('reference')
-            viewer_label = viewer_select.new_label.value.strip()
+        if viewer_select:
+            # user requested creating a new viewer for this data.
+            if viewer_select.create_new.selected:
+                viewer_reference = viewer_select.create_new.selected_item.get('reference')
+                viewer_label = viewer_select.new_label.value.strip()
 
-            # Create the new viewer instance
-            viewer_dict = viewer_registry.members.get(viewer_reference)
-            viewer_cls = viewer_dict.get('cls')
-            self._app._on_new_viewer(NewViewerMessage(viewer_cls, data=None, sender=self.app),
-                                     vid=viewer_label,
-                                     name=viewer_label,
-                                     open_data_menu_if_empty=False)
-            viewer = self._app._jdaviz_helper.viewers.get(viewer_label)
-            viewer.data_menu.add_data(data_label)
-
-            # default to selecting this new viewer for next import
-            viewer_select.create_new.selected = ''
-            viewer_select.selected = [viewer_label]
-
-        # if no viewers selected, just notify user that data was loaded
-        # but not displayed anywhere.
-        elif len(viewer_select.selected) == 0:
-            if len(self._app._jdaviz_helper.viewers):
-                msg = f"{data_label} loaded without any viewers selected - add manually from viewer data-menu"  # noqa
-            else:
-                msg = f"{data_label} loaded but no viewers were created.  Create viewers manually and add data from data-menu"  # noqa
-            # Don't warn for WCS-only layers (orientation reference layers)
-            # or for data added via a plugin (e.g moment maps)
-            from_plugin = new_dc_entry.meta.get('plugin', False)
-            if not new_dc_entry.meta.get(_wcs_only_label, False) and not from_plugin:
-                self._app.hub.broadcast(SnackbarMessage(msg, sender=self, color='warning'))
-
-        # otherwise, add data to all selected viewers.
-        else:
-            failed_viewers = []
-            exceptions = []
-            for viewer_label in viewer_select.selected:
+                # Create the new viewer instance
+                viewer_dict = viewer_registry.members.get(viewer_reference)
+                viewer_cls = viewer_dict.get('cls')
+                self._app._on_new_viewer(NewViewerMessage(viewer_cls, data=None, sender=self.app),
+                                         vid=viewer_label,
+                                         name=viewer_label,
+                                         open_data_menu_if_empty=False)
                 viewer = self._app._jdaviz_helper.viewers.get(viewer_label)
-                try:
-                    viewer.data_menu.add_data(data_label)
-                except Exception as e:
-                    failed_viewers.append(viewer_label)
-                    exceptions.append(str(e))
-            # Report any failures (e.g., incompatible data types for the viewer)
-            if len(failed_viewers) > 0:
-                msg = f"Failed to add {data_label} to viewers: {', '.join(failed_viewers)}"
-                self._app.hub.broadcast(SnackbarMessage(msg, sender=self, color='error',
-                                                        traceback=exceptions))
+                viewer.data_menu.add_data(data_label)
+
+                # default to selecting this new viewer for next import
+                viewer_select.create_new.selected = ''
+                viewer_select.selected = [viewer_label]
+
+        else:
+            # if no viewers selected, just notify user that data was loaded
+            # but not displayed anywhere.
+            if viewer_select is False or len(viewer_select.selected) == 0:
+                if len(self._app._jdaviz_helper.viewers):
+                    msg = f"{data_label} loaded without any viewers selected - add manually from viewer data-menu"  # noqa
+                else:
+                    msg = f"{data_label} loaded but no viewers were created.  Create viewers manually and add data from data-menu"  # noqa
+                # Don't warn for WCS-only layers (orientation reference layers)
+                # or for data added via a plugin (e.g moment maps)
+                from_plugin = new_dc_entry.meta.get('plugin', False)
+                if not new_dc_entry.meta.get(_wcs_only_label, False) and not from_plugin:
+                    self._app.hub.broadcast(SnackbarMessage(msg, sender=self, color='warning'))
+
+            # otherwise, add data to all selected viewers.
+            else:
+                failed_viewers = []
+                exceptions = []
+                for viewer_label in viewer_select.selected:
+                    viewer = self._app._jdaviz_helper.viewers.get(viewer_label)
+                    try:
+                        viewer.data_menu.add_data(data_label)
+                    except Exception as e:
+                        failed_viewers.append(viewer_label)
+                        exceptions.append(str(e))
+                # Report any failures (e.g., incompatible data types for the viewer)
+                if len(failed_viewers) > 0:
+                    msg = f"Failed to add {data_label} to viewers: {', '.join(failed_viewers)}"
+                    self._app.hub.broadcast(SnackbarMessage(msg, sender=self, color='error',
+                                                            traceback=exceptions))
 
     @with_spinner('import_spinner')
     def __call__(self):

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -343,9 +343,13 @@ class BaseImporterToDataCollection(BaseImporter):
             Label of the parent data entry. If provided, establishes this data
             as a child of the parent (e.g., DQ layer as child of SCI layer).
             Used by the Data Quality plugin to associate layers.
-        viewer_select : `~jdaviz.core.template_mixin.ViewerSelect`, optional
+        viewer_select : `~jdaviz.core.template_mixin.ViewerSelect`, False, or None, optional
             Viewer selection component to determine which viewers to add the
-            data to. If not provided, uses ``self.viewer``.
+            data to. If not provided or ``None``, uses ``self.viewer``. Pass
+            ``False`` to skip adding the data to any viewer entirely, without
+            needing to provide a viewer_select component or override the current
+            setting of the loader viewer select when adding to data collection
+            from a plugin, for example.
         cls : class, optional
             The native data class to store in metadata for later export via
             ``get_data``. If not provided, uses the class of the input data.
@@ -414,6 +418,9 @@ class BaseImporterToDataCollection(BaseImporter):
             self._app._link_new_data_by_component_type(data_label)
 
         # Determine which viewer(s) to add the data to.
+        if viewer_select is False:
+            return
+
         viewer_select = viewer_select if viewer_select is not None else self.viewer
 
         # user requested creating a new viewer for this data.

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
@@ -571,21 +571,8 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
                 # add to flux viewer based on checkbox, or don't add to any viewer
                 if self.config == 'cubeviz':
                     viewer_for_dq = self.dq_viewer
-                elif not self.dq_add_to_flux_viewer:
-                    # setting viewer=None will default to self.viewer in
-                    # add_to_data_collection and we don't want to clear this
-                    # selection, so pass it a 'viewer' class that has a selected
-                    # and create_new.selected to get around this.
-
-                    class NoViewer:
-                        selected = []
-
-                        class create_new:
-                            selected = []
-
-                    viewer_for_dq = NoViewer()
                 else:
-                    viewer_for_dq = self.viewer
+                    viewer_for_dq = self.viewer if self.dq_add_to_flux_viewer else False
 
                 self.add_to_data_collection(dq_cube,
                                             dq_data_label,

--- a/jdaviz/core/loaders/importers/test_importer.py
+++ b/jdaviz/core/loaders/importers/test_importer.py
@@ -1,7 +1,9 @@
 from unittest.mock import patch
 import pytest
 
-from specutils import SpectrumList
+import astropy.units as u
+from specutils import Spectrum, SpectrumList
+
 from jdaviz.core.loaders.importers.importer import BaseImporter
 from jdaviz.core.registries import loader_importer_registry
 from jdaviz.conftest import _create_spectrum1d_with_spectral_unit
@@ -373,3 +375,27 @@ class TestDataLabelOverwrite:
         new_data = deconfigged_helper._app.data_collection['viewer_test']
         # Verify it's actually different data (the object should be different)
         assert new_data is not original_data
+
+
+def test_add_to_data_collection_viewer_select_false(deconfigged_helper):
+    """Test that viewer_select=False adds data to the data collection but not to any viewer,
+    even when a viewer is selected in the importer."""
+    ldr = deconfigged_helper.loaders['object']
+    obj = Spectrum(flux=[1, 2, 3]*u.Jy, spectral_axis=[1, 2, 3]*u.nm)
+    ldr.object = obj
+    ldr.format = '1D Spectrum'
+
+    importer = ldr.importer._obj
+    label = importer.data_label_value
+
+    # select a viewer to confirm it is overridden by viewer_select=False
+    importer.viewer.create_new.selected = '1D Spectrum'
+
+    importer.add_to_data_collection(obj, viewer_select=False)
+
+    # data should be in the data collection but not in any viewer
+    assert label in deconfigged_helper._app.data_collection
+
+    for viewer in deconfigged_helper._app._viewer_store.values():
+        if hasattr(viewer, '_data_menu'):
+            assert label not in viewer._data_menu.data_labels_loaded


### PR DESCRIPTION
This PR adds 'False' as an argument to add_to_data_collection to allow adding data to the data collection but not to a viewer without overriding the selection on self.viewer. This is necessary, for example, when you want to add something to the data collection from a plugin but not to a viewer without changing the viewer selection in the loader. 

This adds test coverage and also swaps out some code that previously had a workaround for this scenario. No change log since this is an internal method.