### PR TITLE
Update python versions in tests and add coverage upload to remote tests

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python to build docs with sphinx
       uses: actions/setup-python@cfd55ca82492758d853442341ad4d8010466803a  # v5.6.0
       with:
-        python-version: '3.12'
+        python-version: '3.14'
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python to build docs with sphinx
       uses: actions/setup-python@cfd55ca82492758d853442341ad4d8010466803a  # v5.6.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip
@@ -36,7 +36,7 @@ jobs:
       run: tox -e linkcheck
 
   ci_cron_tests_dev_roman:
-    name: Python 3.11 with latest dev versions of key dependencies and Roman
+    name: Python 3.14 with latest dev versions of key dependencies and Roman
     runs-on: ubuntu-latest
     if: (github.repository == 'spacetelescope/jdaviz' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))
     steps:
@@ -47,16 +47,16 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@cfd55ca82492758d853442341ad4d8010466803a  # v5.6.0
       with:
-        python-version: '3.11'
+        python-version: '3.14'
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox
     - name: Test with tox
-      run: tox -e py311-test-devdeps-romandeps
+      run: tox -e py314-test-devdeps-romandeps
 
   ci_cron_tests_stable_strauss:
-    name: Python 3.12 with stable versions of dependencies and Strauss
+    name: Python 3.13 with stable versions of dependencies and Strauss
     runs-on: ubuntu-latest
     if: (github.repository == 'spacetelescope/jdaviz' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))
     steps:
@@ -67,11 +67,11 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@cfd55ca82492758d853442341ad4d8010466803a  # v5.6.0
       with:
-        python-version: '3.12'
+        python-version: '3.13'
     - name: Install base dependencies
       run: |
         sudo apt-get install libportaudio2
         python -m pip install --upgrade pip
         python -m pip install tox
     - name: Test with tox
-      run: tox -e py312-test-straussdeps
+      run: tox -e py313-test-straussdeps

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -72,8 +72,8 @@ jobs:
 
           - name: Linux - Python 3.14
             os: ubuntu-latest
-            python: '3.13'
-            toxenv: py313-test
+            python: '3.14'
+            toxenv: py314-test
             allow_failure: false
 
           # This also runs on cron but we want to make sure new changes

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -44,33 +44,33 @@ jobs:
             toxenv: securityaudit
             allow_failure: false
 
-          - name: Python 3.11 with coverage checking and all deps
+          - name: Python 3.13 with coverage checking and all deps
             os: ubuntu-latest
-            python: '3.11'
-            toxenv: py311-test-alldeps-cov
+            python: '3.13'
+            toxenv: py313-test-alldeps-cov
             toxposargs: --run-slow
             allow_failure: false
 
-          - name: Python 3.11 with only remote data, coverage checking, and all deps
+          - name: Python 3.13 with only remote data, coverage checking, and all deps
             os: ubuntu-latest
-            python: '3.11'
-            toxenv: py311-test-alldeps-cov
+            python: '3.13'
+            toxenv: py313-test-alldeps-cov
             toxposargs: --remote-data --run-slow -m remote_data
             allow_failure: true
 
-          - name: OS X - Python 3.12
+          - name: OS X - Python 3.13
             os: macos-latest
-            python: '3.12'
-            toxenv: py312-test
+            python: '3.13'
+            toxenv: py313-test
             allow_failure: false
 
-          - name: Windows - Python 3.12
+          - name: Windows - Python 3.13
             os: windows-latest
-            python: '3.12'
-            toxenv: py312-test
+            python: '3.13'
+            toxenv: py313-test
             allow_failure: false
 
-          - name: Linux - Python 3.13
+          - name: Linux - Python 3.14
             os: ubuntu-latest
             python: '3.13'
             toxenv: py313-test
@@ -92,10 +92,10 @@ jobs:
             toxposargs: --remote-data --run-slow -m remote_data
             allow_failure: true
 
-          - name: Python 3.11 with stable versions of dependencies and Roman
+          - name: Python 3.12 with stable versions of dependencies and Roman
             os: ubuntu-latest
-            python: '3.11'
-            toxenv: py311-test-romandeps
+            python: '3.12'
+            toxenv: py312-test-romandeps
             allow_failure: true
 
     steps:

--- a/.github/workflows/predeps_workflows.yml
+++ b/.github/workflows/predeps_workflows.yml
@@ -26,19 +26,19 @@ jobs:
 
           - name: RC testing on Linux with remote data
             os: ubuntu-latest
-            python: '3.12'
-            toxenv: py312-test-predeps
+            python: '3.13'
+            toxenv: py313-test-predeps
             toxposargs: --remote-data
 
           - name: RC testing on OSX
             os: macos-latest
-            python: '3.13'
-            toxenv: py313-test-predeps
+            python: '3.14'
+            toxenv: py314-test-predeps
 
           - name: RC testing on Windows
             os: windows-latest
-            python: '3.11'
-            toxenv: py311-test-predeps
+            python: '3.12'
+            toxenv: py312-test-predeps
 
     steps:
     - name: Checkout code

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,18 +23,18 @@ jobs:
 
     - uses: actions/setup-python@cfd55ca82492758d853442341ad4d8010466803a  # v5.6.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Build pytestargs from labels
       id: build-pytestargs
       run: |
         pytestargs=""
-        
+
         # Add --skip-remote-failures if 'skip-remote-failures' label is present
         if ${{ contains(github.event.pull_request.labels.*.name, 'skip-remote-failures') }}; then
           pytestargs="--skip-remote-failures"
         fi
-        
+
         # Export as step output so later steps can reference it.
         echo "pytestargs=$pytestargs" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -29,7 +29,7 @@ jobs:
 
     - uses: actions/setup-python@cfd55ca82492758d853442341ad4d8010466803a  # v5.6.0
       with:
-        python-version: "3.11"
+        python-version: "3.12"
 
     - uses: ConorMacBride/install-package@v1
       with:
@@ -114,7 +114,7 @@ jobs:
 
     - uses: actions/setup-python@cfd55ca82492758d853442341ad4d8010466803a  # v5.6.0
       with:
-        python-version: "3.11"
+        python-version: "3.12"
 
     - name: Install jdaviz
       run: pip install .[test,qt]

--- a/docs/configs_deprecated.rst
+++ b/docs/configs_deprecated.rst
@@ -90,7 +90,7 @@ contextual information like on-sky views of the spectrograph slit.
 
 .. warning::
 
-   As of ``jdaviz`` version 4.2, please use Python 3.11 or
+   As of ``jdaviz`` version 5.0, please use Python 3.12 or
    greater to get the latest bug fixes and feature additions for ``jdaviz``.
 
 .. note::

--- a/docs/configs_deprecated.rst
+++ b/docs/configs_deprecated.rst
@@ -90,7 +90,7 @@ contextual information like on-sky views of the spectrograph slit.
 
 .. warning::
 
-   As of ``jdaviz`` version 5.0, please use Python 3.12 or
+   As of ``jdaviz`` version 5.1, please use Python 3.12 or
    greater to get the latest bug fixes and feature additions for ``jdaviz``.
 
 .. note::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,7 +35,7 @@ to avoid version conflicts with other packages you may have installed, for examp
 
 .. code-block:: bash
 
-    conda create -n jdaviz-env python=3.11
+    conda create -n jdaviz-env python=3.13
     conda activate jdaviz-env
 
 Pip Install
@@ -59,7 +59,7 @@ Common Issues
 If you encounter problems while following these installation instructions,
 please consult :ref:`known installation issues <known_issues_installation>`.
 
-Note that ``jdaviz`` requires Python 3.11 or newer. If your ``pip`` corresponds to an older version of
+Note that ``jdaviz`` requires Python 3.12 or newer. If your ``pip`` corresponds to an older version of
 Python, it will raise an error that it cannot find a valid package.
 
 Users occasionally encounter problems running the pure ``pip`` install above. For those
@@ -90,7 +90,7 @@ the interface.
     :alt: Create environment with Anaconda Navigator
 
 Give a name to the environment (in this example we call it jdaviz_navigator) and
-select Python with a version greater than 3.11.
+select Python with a version greater than 3.12.
 
 .. image:: ./img/navigator_nameenv.png
     :alt: Name environment with Anaconda Navigator

--- a/docs/setup/local.rst
+++ b/docs/setup/local.rst
@@ -36,7 +36,7 @@ to avoid version conflicts with other packages you may have installed, for examp
 
 .. code-block:: bash
 
-    conda create -n jdaviz-env python=3.11
+    conda create -n jdaviz-env python=3.13
     conda activate jdaviz-env
 
 Pip Install
@@ -60,7 +60,7 @@ Common Issues
 If you encounter problems while following these installation instructions,
 please consult :ref:`known installation issues <known_issues_installation>`.
 
-Note that ``jdaviz`` requires Python 3.11 or newer. If your ``pip`` corresponds to an older version of
+Note that ``jdaviz`` requires Python 3.12 or newer. If your ``pip`` corresponds to an older version of
 Python, it will raise an error that it cannot find a valid package.
 
 Users occasionally encounter problems running the pure ``pip`` install above. For those
@@ -91,7 +91,7 @@ the interface.
     :alt: Create environment with Anaconda Navigator
 
 Give a name to the environment (in this example we call it jdaviz_navigator) and
-select Python with a version greater than 3.11.
+select Python with a version greater than 3.12.
 
 .. image:: ../img/navigator_nameenv.png
     :alt: Name environment with Anaconda Navigator

--- a/jdaviz/core/loaders/resolvers/url/test_url.py
+++ b/jdaviz/core/loaders/resolvers/url/test_url.py
@@ -1,6 +1,10 @@
+import pytest
+
 from jdaviz.core.loaders.resolvers.url.url import URLResolver
 
 
+# Ignore more strict 404 handling in python 3.14 for now
+@pytest.mark.filterwarnings('ignore::pytest.PytestUnraisableExceptionWarning')
 def test_url_resolver_is_valid(deconfigged_helper):
     """Test _check_is_valid for URLResolver: success and failure cases."""
     resolver = URLResolver(app=deconfigged_helper._app)

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -472,7 +472,7 @@ def test_add_custom_loader_object(deconfigged_helper, spectrum1d):
     assert my_table_item['requires_api_support'] is True
 
 
-# Ignore bad 404 handling in python 3.14 for now
+# Ignore more strict 404 handling in python 3.14 for now
 @pytest.mark.filterwarnings('ignore::pytest.PytestUnraisableExceptionWarning')
 def test_add_custom_loader_url(deconfigged_helper):
     """Test _add_custom_loader with a URL resolver."""
@@ -486,7 +486,7 @@ def test_add_custom_loader_url(deconfigged_helper):
     assert 'remote_file' in deconfigged_helper._app._jdaviz_helper.loaders
 
 
-# Ignore bad 404 handling in python 3.14 for now
+# Ignore more strict 404 handling in python 3.14 for now
 @pytest.mark.filterwarnings('ignore::pytest.PytestUnraisableExceptionWarning')
 def test_add_custom_loader_invalid_resolver(deconfigged_helper):
     """Test _add_custom_loader with an invalid resolver type."""

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -472,6 +472,7 @@ def test_add_custom_loader_object(deconfigged_helper, spectrum1d):
     assert my_table_item['requires_api_support'] is True
 
 
+@pytest.mark.filterwarnings('ignore::pytest.PytestUnraisableExceptionWarning')
 def test_add_custom_loader_url(deconfigged_helper):
     """Test _add_custom_loader with a URL resolver."""
     # Use a simple test URL (it doesn't need to be valid for the loader creation)

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -472,6 +472,7 @@ def test_add_custom_loader_object(deconfigged_helper, spectrum1d):
     assert my_table_item['requires_api_support'] is True
 
 
+# Ignore bad 404 handling in python 3.14 for now
 @pytest.mark.filterwarnings('ignore::pytest.PytestUnraisableExceptionWarning')
 def test_add_custom_loader_url(deconfigged_helper):
     """Test _add_custom_loader with a URL resolver."""
@@ -485,6 +486,8 @@ def test_add_custom_loader_url(deconfigged_helper):
     assert 'remote_file' in deconfigged_helper._app._jdaviz_helper.loaders
 
 
+# Ignore bad 404 handling in python 3.14 for now
+@pytest.mark.filterwarnings('ignore::pytest.PytestUnraisableExceptionWarning')
 def test_add_custom_loader_invalid_resolver(deconfigged_helper):
     """Test _add_custom_loader with an invalid resolver type."""
     with pytest.raises(ValueError, match="Unknown resolver type 'invalid'"):

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -472,8 +472,7 @@ def test_add_custom_loader_object(deconfigged_helper, spectrum1d):
     assert my_table_item['requires_api_support'] is True
 
 
-# Ignore more strict 404 handling in python 3.14 
-# TODO: for now
+# TODO: comply with more strict 404 handling in python 3.14 instead of skipping
 @pytest.mark.filterwarnings('ignore::pytest.PytestUnraisableExceptionWarning')
 def test_add_custom_loader_url(deconfigged_helper):
     """Test _add_custom_loader with a URL resolver."""
@@ -487,7 +486,7 @@ def test_add_custom_loader_url(deconfigged_helper):
     assert 'remote_file' in deconfigged_helper._app._jdaviz_helper.loaders
 
 
-# Ignore more strict 404 handling in python 3.14 for now
+# TODO: comply with more strict 404 handling in python 3.14 instead of skipping
 @pytest.mark.filterwarnings('ignore::pytest.PytestUnraisableExceptionWarning')
 def test_add_custom_loader_invalid_resolver(deconfigged_helper):
     """Test _add_custom_loader with an invalid resolver type."""

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -472,7 +472,8 @@ def test_add_custom_loader_object(deconfigged_helper, spectrum1d):
     assert my_table_item['requires_api_support'] is True
 
 
-# Ignore more strict 404 handling in python 3.14 for now
+# Ignore more strict 404 handling in python 3.14 
+# TODO: for now
 @pytest.mark.filterwarnings('ignore::pytest.PytestUnraisableExceptionWarning')
 def test_add_custom_loader_url(deconfigged_helper):
     """Test _add_custom_loader with a URL resolver."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "jdaviz"
 description = "Astronomical data analysis development leveraging the Jupyter platform"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 authors = [
     { name = "JDADF Developers"},
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310,311,312,313}-test{,-alldeps,-devdeps,-predeps,-remotedata}{-romandeps,-straussdeps}{,-cov}
+    py{312,313,314}-test{,-alldeps,-devdeps,-predeps,-remotedata}{-romandeps,-straussdeps}{,-cov}
     linkcheck
     codestyle
     pep517


### PR DESCRIPTION
Does what it says on the tin. Python 3.11 is now out of the scientific python support window, and 3.14 has been out for a while so we should be testing against it.