### PR TITLE
add (private for now) add / replace table column methods to table viewer

### DIFF
--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -1623,8 +1623,11 @@ class JdavizTableViewer(JdavizViewerMixin, TableViewer):
         self._add_or_update_column(column_name, data)
 
         # and make the user-added column editable
+
+        # we already know column_name can safely be cast to a string from check
+        # in _add_or_update_column
+        column_name = str(column_name)
         cid = self.layers[0].layer.data.id[column_name]
-        print(cid, type(cid))
         self.state.editable_components = list(self.state.editable_components) + [cid]
 
     def update_column(self, column_name, data):

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -1623,6 +1623,9 @@ class JdavizTableViewer(JdavizViewerMixin, TableViewer):
 
         self._add_or_update_column(column_name, data)
 
+        # and make the user-added column editable
+        self.widget_table.state.editable_components += [self.widget_table.data.id[column_name]]
+
     def update_column(self, column_name, data):
         """
         Update the data in an existing column of the table.

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -1624,7 +1624,7 @@ class JdavizTableViewer(JdavizViewerMixin, TableViewer):
         self._add_or_update_column(column_name, data)
 
         # and make the user-added column editable
-        self.widget_table.state.editable_components += [self.widget_table.data.id[column_name]]
+        self.state.editable_components += [self.widget_table.data.id[column_name]]
 
     def update_column(self, column_name, data):
         """

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -1,3 +1,5 @@
+from cProfile import label
+
 from echo import delay_callback, CallbackProperty
 
 import warnings
@@ -1479,6 +1481,7 @@ class JdavizTableViewer(JdavizViewerMixin, TableViewer):
                     ['jdaviz:table_subset'],
                     ['jdaviz:viewer_clone']
                    ]
+    
 
     def __init__(self, session, *args, **kwargs):
         super().__init__(session, *args, **kwargs)
@@ -1624,7 +1627,9 @@ class JdavizTableViewer(JdavizViewerMixin, TableViewer):
         self._add_or_update_column(column_name, data)
 
         # and make the user-added column editable
-        self.state.editable_components += [self.widget_table.data.id[column_name]]
+        cid = self.layers[0].layer.data.get_component(column_name)
+        self.state.editable_components = list(self.state.editable_components) + [cid]
+
 
     def update_column(self, column_name, data):
         """

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -1511,6 +1511,7 @@ class JdavizTableViewer(JdavizViewerMixin, TableViewer):
         self.hub.subscribe(self, ViewerRemovedMessage,
                            handler=self._on_viewer_removed)
 
+
     def _on_table_select_row_click(self, msg):
         """Handle click from image viewer to select/toggle closest table row."""
         # Only respond if this message is for this table viewer
@@ -1563,6 +1564,94 @@ class JdavizTableViewer(JdavizViewerMixin, TableViewer):
             self.widget_table.checked = current_checked
         except Exception:  # nosec # pragma: no cover
             pass
+
+    def _add_or_update_column(self, column_name, data=None):
+        """
+        Add a new column to the table or update it if it already exists.
+        If data is None, the column will be filled with None-type values.
+        """
+
+        tab = self.widget_table
+        nrows = tab.data.size
+
+        # some input checking with informative error messages
+        if column_name is None:
+            raise ValueError("Column name must be provided.")
+
+        try:
+            column_name = str(column_name)
+        except TypeError:
+            raise ValueError("Column name must be convertible to a string.")
+
+        if data is not None and len(data) != nrows:
+            s = "Length of new column data does not match number of rows in the table."
+            raise ValueError(s)
+
+        if data is None:
+            data = [None] * nrows
+
+        if column_name in [c.label for c in tab.data.components]:
+            # Update existing column with new data or NaN if data is None
+            tab.data.update_components({tab.data.get_component(column_name): data})
+        else:
+            # Add new column
+            tab.data.add_component(data, column_name)
+
+    def add_column(self, column_name, data=None):
+        """
+        Add a new data column to the table.
+
+        Parameters
+        ----------
+        column_name : str
+            The name of the column to add.
+        data : list-like, optional
+            The data for the column. Must be the same length as the number of
+            rows in the table. If None, the column will be filled with None-type
+            values.
+
+        Raises
+        ------
+        ValueError
+            If column_name is not provided, not a string, or if data length does
+            not match number of rows in the table.
+        """
+
+        # make sure column name is not in table already
+        if column_name in [c.label for c in self.widget_table.data.components]:
+            raise ValueError(f"Column '{column_name}' already exists in the table. Use update_column to update it instead.")  # noqa: E501
+
+        self._add_or_update_column(column_name, data)
+
+    def update_column(self, column_name, data):
+        """
+        Update the data in an existing column of the table.
+
+        Parameters
+        ----------
+        column_name : str
+            The name of the column to update.
+        data : list-like
+            The data for the column. Must be the same length as the number of
+            rows in the table.
+
+        Raises
+        ------
+        ValueError
+            If column_name is not provided, not a string, or if data length does
+            not match number of rows in the table.
+        """
+        # convert column_name to string, if possible, otherwise raise error
+        try:
+            column_name = str(column_name)
+        except TypeError:
+            raise ValueError("Column name must be convertible to a string.")
+
+        # make sure column name is already in table before trying to update
+        if column_name not in [c.label for c in self.widget_table.data.components]:
+            raise ValueError(f"Column '{column_name}' does not exist in the table. Use add_column to add it first.")  # noqa: E501
+
+        self._add_or_update_column(column_name, data)
 
     def _on_checked_changed(self, change):
         """Update highlight marks in image viewers when checked rows change."""

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -1623,7 +1623,8 @@ class JdavizTableViewer(JdavizViewerMixin, TableViewer):
         self._add_or_update_column(column_name, data)
 
         # and make the user-added column editable
-        cid = self.layers[0].layer.data.get_component(column_name)
+        cid = self.layers[0].layer.data.id[column_name]
+        print(cid, type(cid))
         self.state.editable_components = list(self.state.editable_components) + [cid]
 
     def update_column(self, column_name, data):

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -1,5 +1,3 @@
-from cProfile import label
-
 from echo import delay_callback, CallbackProperty
 
 import warnings
@@ -1481,7 +1479,6 @@ class JdavizTableViewer(JdavizViewerMixin, TableViewer):
                     ['jdaviz:table_subset'],
                     ['jdaviz:viewer_clone']
                    ]
-    
 
     def __init__(self, session, *args, **kwargs):
         super().__init__(session, *args, **kwargs)
@@ -1513,7 +1510,6 @@ class JdavizTableViewer(JdavizViewerMixin, TableViewer):
         # if this table viewer is removed while tools are active
         self.hub.subscribe(self, ViewerRemovedMessage,
                            handler=self._on_viewer_removed)
-
 
     def _on_table_select_row_click(self, msg):
         """Handle click from image viewer to select/toggle closest table row."""
@@ -1629,7 +1625,6 @@ class JdavizTableViewer(JdavizViewerMixin, TableViewer):
         # and make the user-added column editable
         cid = self.layers[0].layer.data.get_component(column_name)
         self.state.editable_components = list(self.state.editable_components) + [cid]
-
 
     def update_column(self, column_name, data):
         """

--- a/jdaviz/tests/test_table_viewer_tools.py
+++ b/jdaviz/tests/test_table_viewer_tools.py
@@ -320,6 +320,74 @@ class TestTableViewerTools:
 
         toolbar.restore_tools()
 
+    def test_add_column(self):
+        """
+        Test that add_column adds a new column to the table, and that the
+        expected errors are raised when trying to do this incorrectly.
+        """
+        tv = self.table_viewer
+
+        # add a new column with valid data
+        new_data = ['a', 'b', 'c', 'd', 'e']
+        tv.add_column('new_col', new_data)
+
+        # make sure the column was added to the table in the viewer
+        assert 'new_col' in [c.label for c in tv.widget_table.data.components]
+        assert np.all(tv.widget_table.data.get_component('new_col').data == new_data)
+
+        # try to add a column with a name that already exists, should raise ValueError
+        m = "Column 'ra' already exists in the table. Use update_column to update it instead."
+        with pytest.raises(ValueError, match=m):
+            tv.add_column('ra', new_data)
+
+        # try to add a column with data of incorrect length, should raise ValueError
+        m = "Length of new column data does not match number of rows in the table."
+        with pytest.raises(ValueError, match=m):
+            tv.add_column('new_col_invalid', ['a', 'b'])
+
+        # try to add a column with non-string that can't be converted to a string
+        # should raise ValueError
+        class BadString:
+            def __str__(self):
+                return 42
+
+        with pytest.raises(ValueError, match="Column name must be a string."):
+            tv.add_column(BadString(), new_data)
+
+        # but a non-string that CAN be converted to a string should work (e.g. an int)
+        tv.add_column(123, new_data)
+        assert '123' in [c.label for c in tv.widget_table.data.components]
+
+        # adding a column with data=None should create a column of all None values
+        # (this logic was retained from how MosViz handled this)
+        tv.add_column('none_col', None)
+        assert 'none_col' in [c.label for c in tv.widget_table.data.components]
+        assert np.all(tv.widget_table.data.get_component('none_col').data == [None])
+
+    def test_update_column(self):
+        """
+        Test that update_column updates an existing column in the table, and that the
+        expected errors are raised when trying to do this incorrectly.
+        """
+        tv = self.table_viewer
+
+        # update an existing column with valid data
+        new_ra_data = [10, 20, 30, 40, 50]
+        tv.update_column('ra', new_ra_data)
+
+        # make sure the column was updated in the table in the viewer
+        assert np.all(tv.widget_table.data.get_component('ra').data == new_ra_data)
+
+        # try to update a column that doesn't exist, should raise ValueError
+        m = "Column 'nonexistent_col' does not exist in the table. Use add_column to add it first."
+        with pytest.raises(ValueError, match=m):
+            tv.update_column('nonexistent_col', new_ra_data)
+
+        # try to update a column with data of incorrect length, should raise ValueError
+        m = "Length of new column data does not match number of rows in the table."
+        with pytest.raises(ValueError, match=m):
+            tv.update_column('ra', [10, 20])
+
 
 class TestTableViewerToolsMultipleViewers:
     """Test table viewer tools with multiple image viewers."""

--- a/jdaviz/tests/test_table_viewer_tools.py
+++ b/jdaviz/tests/test_table_viewer_tools.py
@@ -351,7 +351,7 @@ class TestTableViewerTools:
             def __str__(self):
                 return 42
 
-        with pytest.raises(ValueError, match="Column name must be a string."):
+        with pytest.raises(ValueError, match='Column name must be convertible to a string.'):
             tv.add_column(BadString(), new_data)
 
         # but a non-string that CAN be converted to a string should work (e.g. an int)
@@ -363,6 +363,12 @@ class TestTableViewerTools:
         tv.add_column('none_col', None)
         assert 'none_col' in [c.label for c in tv.widget_table.data.components]
         assert np.all(tv.widget_table.data.get_component('none_col').data == [None])
+
+        # ensure that user-defined columns are editable by default
+        editable = [x.label for x in list(tv.state.editable_components)]
+        assert 'new_col' in editable
+        assert '123' in editable
+        assert 'none_col' in editable
 
     def test_update_column(self):
         """


### PR DESCRIPTION
This PR adds add column / replace column methods to the Table viewer. 

I weighed making a table column mixin class so that there would be less code duplication between mosviz and the table viewer, but decided not to since it will eventually be reverted once mosviz is gone.