### PR TITLE
Roman catalog detection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ New Features
 - Label default behavior now adjusts for added *or* removed data/viewers i.e. viewer -> viewer (1) ->
   viewer (2) -> remove viewer (2) -> default is again viewer(2) [#4192]
 
+- Imported Catalogs default to the first ra/dec/x/y match if multiple options are available.
+  Increased the list of strings to exclude: now excludes bounding box and source position error columns. [#4216]
 - Add option to limit results to science products when retrieving files from an archive query
   results table. [#4194]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ New Features
 - Label default behavior now adjusts for added *or* removed data/viewers i.e. viewer -> viewer (1) ->
   viewer (2) -> remove viewer (2) -> default is again viewer(2) [#4192]
 
+- Imported Catalogs default to the first ra/dec/x/y match if multiple options are available. [#4216]
+
 - Add option to limit results to science products when retrieving files from an archive query
   results table. [#4194]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ New Features
 - Label default behavior now adjusts for added *or* removed data/viewers i.e. viewer -> viewer (1) ->
   viewer (2) -> remove viewer (2) -> default is again viewer(2) [#4192]
 
+- Add option to limit results to science products when retrieving files from an archive query
+  results table. [#4194]
+
 - Imported Catalogs default to the first ra/dec/x/y match if multiple options are available.
   Increased the list of strings to exclude: now excludes bounding box and source position error columns. [#4216]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,11 +21,6 @@ New Features
 
 - Imported Catalogs default to the first ra/dec/x/y match if multiple options are available.
   Increased the list of strings to exclude: now excludes bounding box and source position error columns. [#4216]
-- Add option to limit results to science products when retrieving files from an archive query
-  results table. [#4194]
-
-- Imported Catalogs default to the first ra/dec/x/y match if multiple options are available.
-  Increased the list of strings to exclude: now excludes bounding box and source position error columns. [#4216]
 
 - Add option to limit results to science products when retrieving files from an archive query
   results table. [#4194]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,8 @@ New Features
 - Label default behavior now adjusts for added *or* removed data/viewers i.e. viewer -> viewer (1) ->
   viewer (2) -> remove viewer (2) -> default is again viewer(2) [#4192]
 
-- Imported Catalogs default to the first ra/dec/x/y match if multiple options are available. [#4216]
+- Imported Catalogs default to the first ra/dec/x/y match if multiple options are available.
+  Increased the list of strings to exclude: now excludes bounding box and source position error columns. [#4216]
 
 - Add option to limit results to science products when retrieving files from an archive query
   results table. [#4194]

--- a/jdaviz/configs/specviz2d/tests/test_mouseover_multiple_2d.py
+++ b/jdaviz/configs/specviz2d/tests/test_mouseover_multiple_2d.py
@@ -8,7 +8,8 @@ from jdaviz.core.marks import PluginLine
 class TestMouseoverMultiple2DSpectra:
 
     @pytest.fixture(scope='class')
-    def spectrum_no_wavelength(self):
+    @classmethod
+    def spectrum_no_wavelength(cls):
         """
         Create a 2D spectrum with no wavelength mapping (no WCS, no spectral_axis).
         """

--- a/jdaviz/core/loaders/importers/catalog/catalog.py
+++ b/jdaviz/core/loaders/importers/catalog/catalog.py
@@ -296,10 +296,9 @@ class CatalogImporter(BaseImporterToDataCollection):
             else:
                 raise NotImplementedError(f"Not a valid coordinate column: {col}.")
 
-            for c in all_column_names:
-                tokens = re.split(r'[\s_\-\.]+', c)
-                if self._check_col_tokens(col, token_pattern, tokens):
-                    idx = get_idx(c, all_column_names, None)
+            idx = next((get_idx(c, all_column_names, None) for c in all_column_names
+                        if self._check_col_tokens(col, token_pattern, re.split(r'[\s_\-\.]+', c))),
+                       None)
 
         # if no good candidate found, default to '---' (no selection) for
         # the default selection.

--- a/jdaviz/core/loaders/importers/catalog/catalog.py
+++ b/jdaviz/core/loaders/importers/catalog/catalog.py
@@ -341,7 +341,9 @@ class CatalogImporter(BaseImporterToDataCollection):
         """
 
         ra = self.col_ra_selected
+        print("selected ra:", self.col_ra_selected)
         dec = self.col_dec_selected
+        print("selected dec:", self.col_dec_selected)
         x = self.col_x_selected
         y = self.col_y_selected
 
@@ -393,7 +395,7 @@ class CatalogImporter(BaseImporterToDataCollection):
             else:
                 import_disabled = False
 
-            # disable import if RA is selectedut Dec is not (or vice versa)
+            # disable import if RA is selected but Dec is not (or vice versa)
             if (ra in ['---', ''] or ra is None) != (dec in ['---', ''] or dec is None):
                 print("ra:", ra, "dec:", dec)
                 print('import disabled because ra OR dec is none')

--- a/jdaviz/core/loaders/importers/catalog/catalog.py
+++ b/jdaviz/core/loaders/importers/catalog/catalog.py
@@ -341,9 +341,7 @@ class CatalogImporter(BaseImporterToDataCollection):
         """
 
         ra = self.col_ra_selected
-        print("selected ra:", self.col_ra_selected)
         dec = self.col_dec_selected
-        print("selected dec:", self.col_dec_selected)
         x = self.col_x_selected
         y = self.col_y_selected
 
@@ -366,7 +364,6 @@ class CatalogImporter(BaseImporterToDataCollection):
                     self.col_dec_has_unit = True
                 # disable import if RA is selected but Dec is not (or vice versa)
                 if (ra in ['---', ''] or ra is None) != (dec in ['---', ''] or dec is None):
-                    print("import disabled because ra or dec is None")
                     import_disabled = True
                 return
 
@@ -390,21 +387,17 @@ class CatalogImporter(BaseImporterToDataCollection):
             # disable import if the same ra and dec columns are selected
             # and they are NOT a SkyCoord column (which contains both RA and Dec),
             if ra == dec and not isinstance(input[axis], SkyCoord):
-                print('import disabled because ra == dec')
                 import_disabled = True
             else:
                 import_disabled = False
 
             # disable import if RA is selected but Dec is not (or vice versa)
             if (ra in ['---', ''] or ra is None) != (dec in ['---', ''] or dec is None):
-                print("ra:", ra, "dec:", dec)
-                print('import disabled because ra OR dec is none')
                 import_disabled = True
 
         elif msg['name'] in ('col_x_selected', 'col_y_selected'):
             # disable import if RA is selected but Dec is not (or vice versa)
             if (x in ['---', ''] or x is None) != (y in ['---', ''] or y is None):
-                print('import disabled because x or y is none')
                 import_disabled = True
 
         # finally, set the import_disabled_msg traitlet based on what was determined

--- a/jdaviz/core/loaders/importers/catalog/catalog.py
+++ b/jdaviz/core/loaders/importers/catalog/catalog.py
@@ -393,7 +393,7 @@ class CatalogImporter(BaseImporterToDataCollection):
             else:
                 import_disabled = False
 
-            # disable import if RA is selected but Dec is not (or vice versa)
+            # disable import if RA is selectedut Dec is not (or vice versa)
             if (ra in ['---', ''] or ra is None) != (dec in ['---', ''] or dec is None):
                 print('import disabled because ra OR dec is none')
                 import_disabled = True

--- a/jdaviz/core/loaders/importers/catalog/catalog.py
+++ b/jdaviz/core/loaders/importers/catalog/catalog.py
@@ -364,6 +364,7 @@ class CatalogImporter(BaseImporterToDataCollection):
                     self.col_dec_has_unit = True
                 # disable import if RA is selected but Dec is not (or vice versa)
                 if (ra in ['---', ''] or ra is None) != (dec in ['---', ''] or dec is None):
+                    print("import disabled because ra or dec is None")
                     import_disabled = True
                 return
 
@@ -387,17 +388,20 @@ class CatalogImporter(BaseImporterToDataCollection):
             # disable import if the same ra and dec columns are selected
             # and they are NOT a SkyCoord column (which contains both RA and Dec),
             if ra == dec and not isinstance(input[axis], SkyCoord):
+                print('import disabled because ra == dec')
                 import_disabled = True
             else:
                 import_disabled = False
 
             # disable import if RA is selected but Dec is not (or vice versa)
             if (ra in ['---', ''] or ra is None) != (dec in ['---', ''] or dec is None):
+                print('import disabled because ra OR dec is none')
                 import_disabled = True
 
         elif msg['name'] in ('col_x_selected', 'col_y_selected'):
             # disable import if RA is selected but Dec is not (or vice versa)
             if (x in ['---', ''] or x is None) != (y in ['---', ''] or y is None):
+                print('import disabled because x or y is none')
                 import_disabled = True
 
         # finally, set the import_disabled_msg traitlet based on what was determined

--- a/jdaviz/core/loaders/importers/catalog/catalog.py
+++ b/jdaviz/core/loaders/importers/catalog/catalog.py
@@ -395,6 +395,7 @@ class CatalogImporter(BaseImporterToDataCollection):
 
             # disable import if RA is selectedut Dec is not (or vice versa)
             if (ra in ['---', ''] or ra is None) != (dec in ['---', ''] or dec is None):
+                print("ra:", ra, "dec:", dec)
                 print('import disabled because ra OR dec is none')
                 import_disabled = True
 

--- a/jdaviz/core/loaders/importers/catalog/test_catalog.py
+++ b/jdaviz/core/loaders/importers/catalog/test_catalog.py
@@ -144,6 +144,7 @@ def test_roman_catalog_detection(deconfigged_helper):
     tab = QTable({'ra_err': ra, 'dec_err': dec,
                   'ra': ra, 'dec': dec,
                   'ra_centroid': ra, 'dec_centroid': dec,
+                  'ra_min': ra, 'dec_min': dec,
                   'x': x, 'y': y,
                   'x_model': x, 'y_model': y})
 

--- a/jdaviz/core/loaders/importers/catalog/test_catalog.py
+++ b/jdaviz/core/loaders/importers/catalog/test_catalog.py
@@ -54,7 +54,7 @@ def test_pixel_column_detection(deconfigged_helper):
     """Test automatic detection of x/y columns with various naming
     conventions, and that non-pixel-coordinate columns are not misidentified as
     pixel-coordinate columns (e.g 'galaxy' which contains 'x' but should not be
-    identified as x pixel-coordinate)."""
+    identified as x pixel-coordinate). """
 
     x_variations = ['X', 'xpix', 'xpixel', 'pixel_x', 'x_coord', 'xsource']
     y_variations = ['Y', 'ypix', 'ypixel', 'pixel_y', 'y_coord', 'ysource']
@@ -127,6 +127,35 @@ def test_pixcoord_column_detection(deconfigged_helper):
     assert isinstance(importer.input['pix'][0], PixCoord)
     assert 'X' in importer.output.keys()
     assert 'Y' in importer.output.keys()
+
+def roman_catalog_detection(deconfigged_helper):
+    """
+    Test automatic detection of ra/dec columns when input catalog has multiple columns that could
+    be interpreted as coordinates (e.g., 'ra', 'ra_centroid', 'ra_err'), which will be the case
+    for Roman source catalogs. CatalogImporter should default to the first match.
+    """
+    ra = [149.0, 150.0, 151.0] * u.degree
+    dec = [1.9, 2.0, 2.1] * u.degree
+    ra_centroid = [149.5, 150.5, 151.5] * u.degree
+    dec_centroid = [1.95, 2.05, 2.15] * u.degree
+    x = [1, 2, 3]
+    y = [4, 5, 6]
+    x_model = [2, 3, 4]
+    y_model = [5, 6, 7]
+
+    tab = QTable({'ra': ra, 'dec': dec, 'ra_centroid': ra_centroid, 'dec_centroid': dec_centroid,
+                'x': x, 'y': y, 'x_model': x_model, 'y_model': y_model})
+
+    ldr = deconfigged_helper.loaders['object']
+    ldr.object = tab
+    ldr.format = 'Catalog'
+    importer = ldr.importer
+
+    # make sure the coordinate columns were correctly identified
+    assert importer.col_ra == 'ra'
+    assert importer.col_dec == 'dec'
+    assert importer.col_x == 'x'
+    assert importer.col_y == 'y'
 
 
 def test_catalog_importer_is_valid(deconfigged_helper):

--- a/jdaviz/core/loaders/importers/catalog/test_catalog.py
+++ b/jdaviz/core/loaders/importers/catalog/test_catalog.py
@@ -128,30 +128,31 @@ def test_pixcoord_column_detection(deconfigged_helper):
     assert 'X' in importer.output.keys()
     assert 'Y' in importer.output.keys()
 
-def roman_catalog_detection(deconfigged_helper):
+
+def test_roman_catalog_detection(deconfigged_helper):
     """
     Test automatic detection of ra/dec columns when input catalog has multiple columns that could
     be interpreted as coordinates (e.g., 'ra', 'ra_centroid', 'ra_err'), which will be the case
-    for Roman source catalogs. CatalogImporter should default to the first match.
+    for Roman photometric catalogs. CatalogImporter should default to the first match,
+    but should exclude uncertainty or window columns like 'ra_min' or 'ra_err'.
     """
     ra = [149.0, 150.0, 151.0] * u.degree
     dec = [1.9, 2.0, 2.1] * u.degree
-    ra_centroid = [149.5, 150.5, 151.5] * u.degree
-    dec_centroid = [1.95, 2.05, 2.15] * u.degree
     x = [1, 2, 3]
     y = [4, 5, 6]
-    x_model = [2, 3, 4]
-    y_model = [5, 6, 7]
 
-    tab = QTable({'ra': ra, 'dec': dec, 'ra_centroid': ra_centroid, 'dec_centroid': dec_centroid,
-                'x': x, 'y': y, 'x_model': x_model, 'y_model': y_model})
+    tab = QTable({'ra_err': ra, 'dec_err': dec,
+                  'ra': ra, 'dec': dec,
+                  'ra_centroid': ra, 'dec_centroid': dec,
+                  'x': x, 'y': y,
+                  'x_model': x, 'y_model': y})
 
     ldr = deconfigged_helper.loaders['object']
     ldr.object = tab
     ldr.format = 'Catalog'
     importer = ldr.importer
 
-    # make sure the coordinate columns were correctly identified
+    # make sure the coordinate columns default to the first not-excluded match
     assert importer.col_ra == 'ra'
     assert importer.col_dec == 'dec'
     assert importer.col_x == 'x'

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -374,7 +374,7 @@ def test_astroquery_load_catalog_source(deconfigged_helper):
     ldr.importer.col_other = ['parallax', 'pm', 'bp_rp', 'phot_rp_mean_mag']
     ldr.importer.viewer.create_new = 'Scatter'
     print(ldr.importer.input)
-    print(ldr.importer.keys())
+    print(ldr.importer.input.keys())
 
     if len(ldr.importer.input) == 0:
         pytest.skip("no catalog available")

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -373,17 +373,15 @@ def test_astroquery_load_catalog_source(deconfigged_helper):
     ldr.importer.col_id = 'source_id'
     ldr.importer.col_other = ['parallax', 'pm', 'bp_rp', 'phot_rp_mean_mag']
     ldr.importer.viewer.create_new = 'Scatter'
-    print(ldr.importer.input)
+
     print(ldr.importer.input.keys())
+    print('returned no results', deconfigged_helper._get_loader('astroquery').returned_no_results)
 
     if len(ldr.importer.input) == 0:
         pytest.skip("no catalog available")
     else:
         ldr.load()
-    if ldr.importer.returned_no_results is True:
-        pytest.skip("no results")
-    else:
-        ldr.load()
+
     assert 'Scatter' in deconfigged_helper.viewers
     assert 'Catalog' in deconfigged_helper.viewers['Scatter'].data_menu.layer.choices
 

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -373,7 +373,7 @@ def test_astroquery_load_catalog_source(deconfigged_helper):
     ldr.importer.col_id = 'source_id'
     ldr.importer.col_other = ['parallax', 'pm', 'bp_rp', 'phot_rp_mean_mag']
     ldr.importer.viewer.create_new = 'Scatter'
-    if len(ldr.importer._input) == 0:
+    if len(ldr.importer.input) == 0:
         pytest.skip("no catalog available")
     else:
         ldr.load()

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -376,9 +376,9 @@ def test_astroquery_load_catalog_source(deconfigged_helper):
 
     print(ldr.importer.input.keys())
     print('returned no results', deconfigged_helper._get_loader('astroquery').returned_no_results)
-    print("input ra:", ldr.importer.input.ra, "output ra:", ldr.importer.col_ra)
-    print("input dec:", ldr.importer.input.dec, "output dec:", ldr.importer.col_dec)
-    print("input id:", ldr.importer.input.id, "output id:", ldr.importer.col_id)
+    print("output ra:", ldr.importer.col_ra)
+    print("output dec:", ldr.importer.col_dec)
+    print("output id:", ldr.importer.col_id)
 
     if len(ldr.importer.input) == 0:
         pytest.skip("no catalog available")

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -374,6 +374,7 @@ def test_astroquery_load_catalog_source(deconfigged_helper):
     ldr.importer.col_other = ['parallax', 'pm', 'bp_rp', 'phot_rp_mean_mag']
     ldr.importer.viewer.create_new = 'Scatter'
     print(ldr.importer.input)
+    print(ldr.importer.keys())
 
     if len(ldr.importer.input) == 0:
         pytest.skip("no catalog available")

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -373,6 +373,8 @@ def test_astroquery_load_catalog_source(deconfigged_helper):
     ldr.importer.col_id = 'source_id'
     ldr.importer.col_other = ['parallax', 'pm', 'bp_rp', 'phot_rp_mean_mag']
     ldr.importer.viewer.create_new = 'Scatter'
+    print(ldr.importer.input)
+
     if len(ldr.importer.input) == 0:
         pytest.skip("no catalog available")
     else:

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -373,7 +373,10 @@ def test_astroquery_load_catalog_source(deconfigged_helper):
     ldr.importer.col_id = 'source_id'
     ldr.importer.col_other = ['parallax', 'pm', 'bp_rp', 'phot_rp_mean_mag']
     ldr.importer.viewer.create_new = 'Scatter'
-    ldr.load()
+    if len(ldr.importer._input) == 0:
+        pytest.skip("no catalog available")
+    else:
+        ldr.load()
     assert 'Scatter' in deconfigged_helper.viewers
     assert 'Catalog' in deconfigged_helper.viewers['Scatter'].data_menu.layer.choices
 

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -378,6 +378,7 @@ def test_astroquery_load_catalog_source(deconfigged_helper):
     print('returned no results', deconfigged_helper._get_loader('astroquery').returned_no_results)
     print("input ra:", ldr.importer.input.ra, "output ra:", ldr.importer.col_ra)
     print("input dec:", ldr.importer.input.dec, "output dec:", ldr.importer.col_dec)
+    print("input id:", ldr.importer.input.id, "output id:", ldr.importer.col_id)
 
     if len(ldr.importer.input) == 0:
         pytest.skip("no catalog available")

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -373,19 +373,8 @@ def test_astroquery_load_catalog_source(deconfigged_helper):
     ldr.importer.col_id = 'source_id'
     ldr.importer.col_other = ['parallax', 'pm', 'bp_rp', 'phot_rp_mean_mag']
     ldr.importer.viewer.create_new = 'Scatter'
-
-    print(ldr.importer.input.keys())
-    print('returned no results', deconfigged_helper._get_loader('astroquery').returned_no_results)
-
-    print("output ra:", ldr.importer.col_ra)
-    print("output dec:", ldr.importer.col_dec)
-    print("output id:", ldr.importer.col_id)
-    print("output x and y:", ldr.importer.col_x, ldr.importer.col_y)
-
-    if len(ldr.importer.input) == 0:
-        pytest.skip("no catalog available")
-    else:
-        ldr.load()
+    print('checking if returned no results:', deconfigged_helper._get_loader('astroquery').returned_no_results)
+    ldr.load()
 
     assert 'Scatter' in deconfigged_helper.viewers
     assert 'Catalog' in deconfigged_helper.viewers['Scatter'].data_menu.layer.choices

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -373,7 +373,6 @@ def test_astroquery_load_catalog_source(deconfigged_helper):
     ldr.importer.col_id = 'source_id'
     ldr.importer.col_other = ['parallax', 'pm', 'bp_rp', 'phot_rp_mean_mag']
     ldr.importer.viewer.create_new = 'Scatter'
-    print('checking if returned no results:', deconfigged_helper._get_loader('astroquery').returned_no_results)
     ldr.load()
 
     assert 'Scatter' in deconfigged_helper.viewers

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -380,6 +380,10 @@ def test_astroquery_load_catalog_source(deconfigged_helper):
         pytest.skip("no catalog available")
     else:
         ldr.load()
+    if ldr.importer.returned_no_results is True:
+        pytest.skip("no results")
+    else:
+        ldr.load()
     assert 'Scatter' in deconfigged_helper.viewers
     assert 'Catalog' in deconfigged_helper.viewers['Scatter'].data_menu.layer.choices
 

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -376,9 +376,11 @@ def test_astroquery_load_catalog_source(deconfigged_helper):
 
     print(ldr.importer.input.keys())
     print('returned no results', deconfigged_helper._get_loader('astroquery').returned_no_results)
+
     print("output ra:", ldr.importer.col_ra)
     print("output dec:", ldr.importer.col_dec)
     print("output id:", ldr.importer.col_id)
+    print("output x and y:", ldr.importer.col_x, ldr.importer.col_y)
 
     if len(ldr.importer.input) == 0:
         pytest.skip("no catalog available")

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -376,6 +376,8 @@ def test_astroquery_load_catalog_source(deconfigged_helper):
 
     print(ldr.importer.input.keys())
     print('returned no results', deconfigged_helper._get_loader('astroquery').returned_no_results)
+    print("input ra:", ldr.importer.input.ra, "output ra:", ldr.importer.col_ra)
+    print("input dec:", ldr.importer.input.dec, "output dec:", ldr.importer.col_dec)
 
     if len(ldr.importer.input) == 0:
         pytest.skip("no catalog available")

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -74,7 +74,7 @@ COORD_WORDS_TO_EXCLUDE = ['radius', 'radio', 'radial', 'extragalactic',
                           'infrared', 'fraction', 'gradient', 'ratio',
                           'integrated,' 'radian', 'random', 'parallax', 'range',
                           'decade', 'decadal', 'decrement', 'deconvolve',
-                          'err', 'psf', 'bbox', 'min', 'max']
+                          'err', 'bbox', 'min', 'max']
 
 
 @contextmanager

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -73,7 +73,8 @@ SPECTRAL_AXIS_COMP_LABELS = ('Wavelength', 'Wave', 'Frequency', 'Energy',
 COORD_WORDS_TO_EXCLUDE = ['radius', 'radio', 'radial', 'extragalactic',
                           'infrared', 'fraction', 'gradient', 'ratio',
                           'integrated,' 'radian', 'random', 'parallax', 'range',
-                          'decade', 'decadal', 'decrement', 'deconvolve']
+                          'decade', 'decadal', 'decrement', 'deconvolve',
+                          'err', 'psf', 'bbox', 'min', 'max']
 
 
 @contextmanager

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -74,7 +74,7 @@ COORD_WORDS_TO_EXCLUDE = ['radius', 'radio', 'radial', 'extragalactic',
                           'infrared', 'fraction', 'gradient', 'ratio',
                           'integrated,' 'radian', 'random', 'parallax', 'range',
                           'decade', 'decadal', 'decrement', 'deconvolve',
-                          'err', 'bbox', 'min', 'max', 'error']
+                          'err', 'bbox', 'min', 'max', 'error', 'xp']
 
 
 @contextmanager

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -74,7 +74,7 @@ COORD_WORDS_TO_EXCLUDE = ['radius', 'radio', 'radial', 'extragalactic',
                           'infrared', 'fraction', 'gradient', 'ratio',
                           'integrated,' 'radian', 'random', 'parallax', 'range',
                           'decade', 'decadal', 'decrement', 'deconvolve',
-                          'err', 'bbox', 'min', 'max']
+                          'err', 'bbox', 'min', 'max', 'error']
 
 
 @contextmanager


### PR DESCRIPTION
This PR updates the CatalogImporter to detect ra/dec/x/y columns when there are multiple columns that satisfy the requirements to be coordinates, such as 'ra', 'ra_centroid', 'ra_err', etc. This is in preparation for Roman source catalogs which will include various quantities from the source extraction procedure, including positional uncertainties. Uncertainty or min/max columns should be excluded. The intended behavior is to default to the first (non-excluded) match. Added test coverage for input catalogs with multiple coordinate options.

Fixes #JDAT-6141

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
