### PR TITLE
Fix compatibility with HST products

### DIFF
--- a/.github/workflows/cache-download.yml
+++ b/.github/workflows/cache-download.yml
@@ -7,7 +7,7 @@ env:
   # and append to the previous cache with the new URI(s).
   # NOTE: cached files are not currently accessible when using the _jail fixture (without manually copying them)
   DEFAULT_URIS: 'HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst:hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits,
-                 hst:hst_17183_02_wfc3_uvis_g280_iexr02mt_flt.fits,
+                 mast:HST/product/o3tt02010_sx2.fits,
                  hst:hst_16968_01_acs_wfc_f606w_jezz01l3_flt.fits,
                  hst:jclj01010_drz.fits,
                  jwst:jw01050-o003_t005_miri_ch1-medium_s3d.fits,

--- a/.github/workflows/cache-download.yml
+++ b/.github/workflows/cache-download.yml
@@ -7,7 +7,7 @@ env:
   # and append to the previous cache with the new URI(s).
   # NOTE: cached files are not currently accessible when using the _jail fixture (without manually copying them)
   DEFAULT_URIS: 'HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst:hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits,
-                 mast:HST/product/o3tt02010_sx2.fits,
+                 hst:o3tt02010_sx2.fits,
                  hst:hst_16968_01_acs_wfc_f606w_jezz01l3_flt.fits,
                  hst:jclj01010_drz.fits,
                  jwst:jw01050-o003_t005_miri_ch1-medium_s3d.fits,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,7 +35,7 @@ Bug Fixes
 ---------
 
 - HST products (as defined by ``OBSTYPE``) are now correctly identified as being
-  either images or 2D spectra. [#]
+  either images or 2D spectra. [#4217]
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,9 @@ Mosviz
 Bug Fixes
 ---------
 
+- HST products (as defined by ``OBSTYPE``) are now correctly identified as being
+  either images or 2D spectra. [#]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -217,7 +217,7 @@ def test_data_quality_plugin(helper_name, request):
 
 
 @pytest.mark.remote_data
-def test_data_quality_plugin_hst_wfc3(imviz_helper):
+def test_data_quality_plugin_hst_STIS(imviz_helper):
 
     # load HST/STIS observations:
     uri = "mast:HST/product/o3tt02010_sx2.fits"

--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -220,7 +220,7 @@ def test_data_quality_plugin(helper_name, request):
 def test_data_quality_plugin_hst_wfc3(imviz_helper):
 
     # load HST/WFC3-UVIS observations:
-    uri = "mast:HST/product/hst_17183_02_wfc3_uvis_g280_iexr02mt_flt.fits"
+    uri = "mast:HST/product/o3tt02010_sx2.fits"
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         imviz_helper.load_data(cached_uri(uri), cache=True, ext=('SCI', 'DQ'))
@@ -230,10 +230,12 @@ def test_data_quality_plugin_hst_wfc3(imviz_helper):
     dq_plugin = imviz_helper.plugins['Data Quality']._obj
 
     # mission+instrument+detector identified:
-    assert dq_plugin.flag_map_selected == 'HST/WFC3-UVIS'
+    assert dq_plugin.flag_map_selected == 'HST/STIS'
 
     flag_map_selected = dq_plugin.flag_map_definitions_selected
-    assert flag_map_selected[0]['description'] == 'Reed Solomon decoding error'
+    assert flag_map_selected[0]['description'] == ('Error in the Reed-Solomon decoding '
+                                                   '(an algorithm for error correction in '
+                                                   'digital communications).')
 
 
 @pytest.mark.remote_data

--- a/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
+++ b/jdaviz/configs/default/plugins/data_quality/tests/test_data_quality.py
@@ -219,7 +219,7 @@ def test_data_quality_plugin(helper_name, request):
 @pytest.mark.remote_data
 def test_data_quality_plugin_hst_wfc3(imviz_helper):
 
-    # load HST/WFC3-UVIS observations:
+    # load HST/STIS observations:
     uri = "mast:HST/product/o3tt02010_sx2.fits"
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/spectral_extraction.py
@@ -965,7 +965,7 @@ class SpectralExtraction2D(PluginTemplateMixin):
         elif self.bg_trace_selected == 'From Plugin':
             trace = self.export_trace(add_data=False)
         else:
-            trace = self.bg_trace.get_selected_spectrum(use_disaply_units=True)
+            trace = self.bg_trace.get_selected_spectrum(use_display_units=True)
 
         return trace
 

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -646,6 +646,51 @@ def mos_spectrum2d_as_hdulist():
 
 
 @pytest.fixture
+def hst_product_hdulist():
+    """Factory for synthetic HST FITS products that can be either imaging or
+    spectroscopic depending on the observation mode. Used to reproduce the
+    ambiguous cases where the WCS alone is insufficient to identify the format.
+    """
+    def _make_hdulist(obstype='SPECTROSCOPIC', wcs_type='spectral', dispaxis=None,
+                      instrument='STIS', obsmode='ACCUM', shape=(20, 30), n_sci=1):
+        primary = fits.PrimaryHDU()
+        primary.header['TELESCOP'] = 'HST'
+        primary.header['INSTRUME'] = instrument
+        primary.header['OBSTYPE'] = obstype
+        primary.header['OBSMODE'] = obsmode
+
+        if wcs_type == 'spectral':
+            wcs_cards = {'CTYPE1': 'WAVE', 'CUNIT1': 'Angstrom',
+                         'CRVAL1': 5000.0, 'CRPIX1': 1.0, 'CDELT1': 1.0,
+                         'CTYPE2': 'ANGLE', 'CUNIT2': 'deg',
+                         'CRVAL2': 0.0, 'CRPIX2': 1.0, 'CDELT2': 1e-5}
+        elif wcs_type == 'celestial':
+            wcs_cards = {'CTYPE1': 'RA---TAN', 'CUNIT1': 'deg',
+                         'CTYPE2': 'DEC--TAN', 'CUNIT2': 'deg',
+                         'CRVAL1': 5.0, 'CRVAL2': 5.0,
+                         'CRPIX1': 1.0, 'CRPIX2': 1.0,
+                         'CDELT1': -1.5e-5, 'CDELT2': 1.5e-5}
+        else:  # no WCS
+            wcs_cards = {}
+
+        np.random.seed(42)
+        hdus = [primary]
+        for ver in range(1, n_sci + 1):
+            for extname in ('SCI', 'ERR', 'DQ'):
+                hdu = fits.ImageHDU(np.random.sample(shape).astype(np.float32))
+                hdu.name = extname
+                hdu.ver = ver
+                hdu.header['EXTNAME'] = extname
+                hdu.header.update(wcs_cards)
+                if dispaxis is not None:
+                    hdu.header['DISPAXIS'] = dispaxis
+                hdus.append(hdu)
+        return fits.HDUList(hdus)
+
+    return _make_hdulist
+
+
+@pytest.fixture
 def mos_image():
     header = {
         'WCSAXES': 2,

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -20,7 +20,7 @@ from jdaviz.core.template_mixin import (SelectFileExtensionComponent,
 from jdaviz.core.loaders.importers import BaseImporterToDataCollection
 from jdaviz.core.registries import loader_importer_registry
 from jdaviz.core.user_api import ImporterUserApi
-from jdaviz.utils import wcs_is_spectral
+from jdaviz.utils import wcs_is_spectral, hst_obstype
 
 from jdaviz.utils import (
     PRIHDR_KEY, in_dec_comps, in_ra_comps, standardize_metadata, standardize_roman_metadata,
@@ -226,6 +226,12 @@ class ImageImporter(BaseImporterToDataCollection):
             for hdu in self.input:
                 if isinstance(hdu, fits.BinTableHDU) and 'TIME' in hdu.columns.names:
                     return 'contains TIME column'
+
+            # Some HST products share file suffixes/structure between imaging and
+            # spectroscopic observations. The OBSTYPE header keyword is used to
+            # delineate between the two.
+            if hst_obstype(self.input) == 'spectroscopic':
+                return 'HST spectroscopic product (OBSTYPE=SPECTROSCOPIC).'
 
         # flat image, not a cube
         # isinstance NDData

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -134,7 +134,7 @@ class Spectrum2DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
         # spectroscopic observations. The OBSTYPE header keyword is used to
         # delineate between the two.
         if hst_obstype(self.input) == 'imaging':
-            return 'HST imaging products are not valid as a 2D spectrum.'
+            return 'HST imaging products (OBSTYPE=IMAGING) are not valid as a 2D spectrum.'
 
         if self.spectrum.flux.ndim != 2:
             return 'Spectrum flux must be 2D.'

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.py
@@ -8,7 +8,7 @@ from jdaviz.core.loaders.importers import (BaseImporterToDataCollection,
                                            SpectrumInputExtensionsMixin,
                                            _spectrum_assign_component_type)
 from jdaviz.core.loaders.importers.image.image import _spatial_assign_component_type
-from jdaviz.utils import SPECTRAL_AXIS_COMP_LABELS
+from jdaviz.utils import SPECTRAL_AXIS_COMP_LABELS, hst_obstype
 from jdaviz.core.template_mixin import (AutoTextField,
                                         ViewerSelectCreateNew)
 from jdaviz.core.user_api import ImporterUserApi
@@ -129,6 +129,12 @@ class Spectrum2DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
         if self._app.config not in ('deconfigged', 'specviz2d'):
             # NOTE: temporary during deconfig process
             return 'spectrum2d importer is only supported in specviz2d, generalized jdaviz.'
+
+        # Some HST products share file suffixes/structure between imaging and
+        # spectroscopic observations. The OBSTYPE header keyword is used to
+        # delineate between the two.
+        if hst_obstype(self.input) == 'imaging':
+            return 'HST imaging products are not valid as a 2D spectrum.'
 
         if self.spectrum.flux.ndim != 2:
             return 'Spectrum flux must be 2D.'

--- a/jdaviz/core/loaders/importers/spectrum_common.py
+++ b/jdaviz/core/loaders/importers/spectrum_common.py
@@ -20,6 +20,7 @@ from jdaviz.core.unit_conversion_utils import check_if_unit_is_per_solid_angle
 from jdaviz.core.custom_units_and_equivs import PIX2, _eqv_flux_to_sb_pixel
 from jdaviz.utils import (standardize_metadata,
                           create_data_hash,
+                          hst_obstype,
                           PRIHDR_KEY,
                           SPECTRAL_AXIS_COMP_LABELS,
                           _get_celestial_wcs)
@@ -321,6 +322,18 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
             True if the HDU is a valid flux HDU, False otherwise.
         """
         hdu = item.get('obj')
+
+        # Some HST products share file suffixes/structure between imaging and
+        # spectroscopic observations. The OBSTYPE header keyword is used to
+        # delineate between the two.
+        obstype = hst_obstype(self.input)
+        if obstype is not None and self.supported_flux_ndim == 2:
+            if obstype == 'imaging':
+                return False
+            # spectroscopic: accept the standard science image extensions
+            if (len(getattr(hdu, 'shape', [])) == 2
+                    and hdu.header.get('EXTNAME', '').upper() in ('SCI', 'FLUX', 'DATA')):
+                return True
 
         # Check for Binary Table HDU with spectral columns (for 1D spectra only)
         if isinstance(hdu, (fits.BinTableHDU, fits.TableHDU)):

--- a/jdaviz/core/loaders/importers/spectrum_common.py
+++ b/jdaviz/core/loaders/importers/spectrum_common.py
@@ -330,7 +330,7 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
         if obstype is not None and self.supported_flux_ndim == 2:
             if obstype == 'imaging':
                 return False
-            # spectroscopic: accept the standard science image extensions
+
             if (len(getattr(hdu, 'shape', [])) == 2
                     and hdu.header.get('EXTNAME', '').upper() in ('SCI', 'FLUX', 'DATA')):
                 return True

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -278,11 +278,17 @@ def test_hst_product_identification_and_load(deconfigged_helper, hst_product_hdu
                                              obstype, wcs_type, dispaxis, instrument, expected):
     hdulist = hst_product_hdulist(obstype=obstype, wcs_type=wcs_type,
                                   dispaxis=dispaxis, instrument=instrument)
+    options = {'2D Spectrum', 'Image'}
+    unexpected = options.difference({expected}).pop()
     ldr = deconfigged_helper.loaders['object']
     ldr.object = hdulist
 
     choices = ldr.format.choices
     assert expected in choices
+    # Some HST products share file suffixes/structure between imaging and
+    # spectroscopic observations. The OBSTYPE header keyword is used to
+    # delineate between the two.
+    assert unexpected not in choices
 
     ldr.format = expected
     ldr.importer()

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -278,16 +278,16 @@ def test_hst_product_identification_and_load(deconfigged_helper, hst_product_hdu
                                              obstype, wcs_type, dispaxis, instrument, expected):
     hdulist = hst_product_hdulist(obstype=obstype, wcs_type=wcs_type,
                                   dispaxis=dispaxis, instrument=instrument)
-    options = {'2D Spectrum', 'Image'}
-    unexpected = options.difference({expected}).pop()
     ldr = deconfigged_helper.loaders['object']
     ldr.object = hdulist
 
-    choices = ldr.format.choices
-    assert expected in choices
     # Some HST products share file suffixes/structure between imaging and
     # spectroscopic observations. The OBSTYPE header keyword is used to
     # delineate between the two.
+    options = {'2D Spectrum', 'Image'}
+    unexpected = options.difference({expected}).pop()
+    choices = ldr.format.choices
+    assert expected in choices
     assert unexpected not in choices
 
     ldr.format = expected

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -261,6 +261,30 @@ def test_spectrum3d_load_flux_then_err_only(deconfigged_helper, image_cube_hdu_o
     assert expected_err_label in [d.label for d in deconfigged_helper._app.data_collection]
 
 
+@pytest.mark.parametrize(
+    "obstype, wcs_type, dispaxis, instrument, expected",
+    [
+        # STIS sx2/flt/raw spectroscopic: spectral WCS + DISPAXIS
+        ('SPECTROSCOPIC', 'spectral', 1, 'STIS', '2D Spectrum'),
+        # WFC3/IR grism drz spectroscopic: celestial WCS, no DISPAXIS.
+        ('SPECTROSCOPIC', 'celestial', None, 'WFC3', '2D Spectrum'),
+        # ACS drz imaging: celestial WCS, no DISPAXIS
+        ('IMAGING', 'celestial', None, 'ACS', 'Image'),
+        # COS flt imaging: celestial WCS but DISPAXIS present.
+        ('IMAGING', 'celestial', 1, 'COS', 'Image'),
+    ],
+)
+def test_hst_product_identifications(deconfigged_helper, hst_product_hdulist,
+                                     obstype, wcs_type, dispaxis, instrument, expected):
+    hdulist = hst_product_hdulist(obstype=obstype, wcs_type=wcs_type,
+                                  dispaxis=dispaxis, instrument=instrument)
+    ldr = deconfigged_helper.loaders['object']
+    ldr.object = hdulist
+
+    choices = ldr.format.choices
+    assert expected in choices
+
+
 @pytest.mark.remote_data
 @pytest.mark.filterwarnings(r"ignore::astropy.wcs.wcs.FITSFixedWarning")
 @pytest.mark.xfail(reason='spectral_axis unit failure is due to a temporary fix'

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -275,7 +275,7 @@ def test_spectrum3d_load_flux_then_err_only(deconfigged_helper, image_cube_hdu_o
     ],
 )
 def test_hst_product_identification_and_load(deconfigged_helper, hst_product_hdulist,
-                                              obstype, wcs_type, dispaxis, instrument, expected):
+                                             obstype, wcs_type, dispaxis, instrument, expected):
     hdulist = hst_product_hdulist(obstype=obstype, wcs_type=wcs_type,
                                   dispaxis=dispaxis, instrument=instrument)
     ldr = deconfigged_helper.loaders['object']

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -274,8 +274,8 @@ def test_spectrum3d_load_flux_then_err_only(deconfigged_helper, image_cube_hdu_o
         ('IMAGING', 'celestial', 1, 'COS', 'Image'),
     ],
 )
-def test_hst_product_identifications(deconfigged_helper, hst_product_hdulist,
-                                     obstype, wcs_type, dispaxis, instrument, expected):
+def test_hst_product_identification_and_load(deconfigged_helper, hst_product_hdulist,
+                                              obstype, wcs_type, dispaxis, instrument, expected):
     hdulist = hst_product_hdulist(obstype=obstype, wcs_type=wcs_type,
                                   dispaxis=dispaxis, instrument=instrument)
     ldr = deconfigged_helper.loaders['object']
@@ -283,6 +283,9 @@ def test_hst_product_identifications(deconfigged_helper, hst_product_hdulist,
 
     choices = ldr.format.choices
     assert expected in choices
+
+    ldr.format = expected
+    ldr.importer()
 
 
 @pytest.mark.remote_data

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -48,7 +48,8 @@ __all__ = ['SnackbarQueue', 'enable_hot_reloading', 'bqplot_clear_figure',
            'get_reference_image_data', 'standardize_roman_metadata',
            'wildcard_match', 'cmap_samples', 'glue_colormaps',
            'att_to_componentid', 'create_data_hash',
-           'in_ra_comps', 'in_dec_comps', 'SPECTRAL_AXIS_COMP_LABELS']
+           'in_ra_comps', 'in_dec_comps', 'SPECTRAL_AXIS_COMP_LABELS',
+           'hst_obstype']
 
 NUMPY_LT_2_0 = not minversion("numpy", "2.0.dev")
 STDATAMODELS_LT_402 = not minversion(stdatamodels, "4.0.2.dev")
@@ -926,6 +927,39 @@ def layer_is_wcs_only(layer):
 def get_wcs_only_layer_labels(app):
     return [data.label for data in app.data_collection
             if layer_is_wcs_only(data)]
+
+
+def hst_obstype(hdulist):
+    """Return the HST observation type from the ``OBSTYPE`` keyword.
+
+    Some HST products share file suffixes/structure between imaging and
+    spectroscopic observations (e.g. STIS sx2/raw, WFC3/IR grism drz),
+    and their per-extension WCS is not always sufficient to distinguish the two.
+    The ``OBSTYPE`` keyword is used instead.
+
+    Parameters
+    ----------
+    hdulist : `astropy.io.fits.HDUList`
+        The HDUList to inspect.
+
+    Returns
+    -------
+    str or None
+        ``'imaging'`` or ``'spectroscopic'`` for HST products with a recognized
+        ``OBSTYPE``, otherwise ``None`` (including for non-HST data).
+    """
+    if not isinstance(hdulist, fits.HDUList) or len(hdulist) == 0:
+        return None
+
+    primary_header = hdulist[0].header
+    if str(primary_header.get('TELESCOP', '')).strip().lower() != 'hst':
+        return None
+
+    obstype = str(primary_header.get('OBSTYPE', '')).strip().lower()
+    if obstype in ('imaging', 'spectroscopic'):
+        return obstype
+
+    return None
 
 
 def wcs_is_spectral(wcs):


### PR DESCRIPTION
This pull request is to address HST compatibility issues where some HST Images/2D Spectra were being registered as valid 2D Spectra, Images, or neither. The fix here is to use an HST header keyword `OBSTYPE` to make that determination and enforce it for both images and 2d spectra. A test was also created to verify the filtering (and subsequent loading) works. 

Note: milestone-ing to 5.1 because something in #4125 fixed an issue I was seeing with one of the HST sample files.