### PR TITLE
modifications to tests for changes in regions package

### DIFF
--- a/jdaviz/configs/default/plugins/export/tests/test_export.py
+++ b/jdaviz/configs/default/plugins/export/tests/test_export.py
@@ -316,7 +316,8 @@ class TestExportSubsets:
         assert contents[3] == '-33.407217'
         assert_allclose(float(contents[4]), 0.088886, rtol=1e-04)
         assert_allclose(float(contents[5]), 0.044443, rtol=1e-04)
-        assert_allclose(float(contents[6]), 11.625269, rtol=1e-04)
+        # see JDAT-6173
+        assert_allclose(float(contents[6]), 11.623824, rtol=1e-03)
 
 
 @pytest.mark.usefixtures('_jail')

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -254,8 +254,17 @@ class TestDeleteOrientation(BaseDeconfiggedImage_WCS_WCS):
         out_reg = self.helper._app.get_subsets(include_sky_region=True)["Subset 1"][0]["sky_region"]
         assert_allclose(out_reg.center.ra.deg, reg.center.ra.deg)
         assert_allclose(out_reg.center.dec.deg, reg.center.dec.deg)
+
         assert_quantity_allclose(out_reg.width, reg.width, rtol=1e-5)
         assert_quantity_allclose(out_reg.height, reg.height, rtol=1e-5)
+
+        if isinstance(klass, EllipseSkyRegion):
+            assert_quantity_allclose(out_reg.angle, reg.angle, rtol=1e-5)
+
+        elif isinstance(klass, RectangleSkyRegion):
+            # FIXME: However, sky angle has to stay the same as per regions convention.
+            with pytest.raises(AssertionError, match="Not equal to tolerance"):
+                assert_quantity_allclose(out_reg.angle, reg.angle)
 
 
 class TestOrientationNoData(BaseDeconfiggedImage_WCS_WCS):

--- a/jdaviz/configs/imviz/tests/test_orientation.py
+++ b/jdaviz/configs/imviz/tests/test_orientation.py
@@ -256,9 +256,6 @@ class TestDeleteOrientation(BaseDeconfiggedImage_WCS_WCS):
         assert_allclose(out_reg.center.dec.deg, reg.center.dec.deg)
         assert_quantity_allclose(out_reg.width, reg.width, rtol=1e-5)
         assert_quantity_allclose(out_reg.height, reg.height, rtol=1e-5)
-        # FIXME: However, sky angle has to stay the same as per regions convention.
-        with pytest.raises(AssertionError, match="Not equal to tolerance"):
-            assert_quantity_allclose(out_reg.angle, reg.angle)
 
 
 class TestOrientationNoData(BaseDeconfiggedImage_WCS_WCS):


### PR DESCRIPTION
There were some recent changes in the Regions package ([see changelog](https://github.com/astropy/regions/blob/main/CHANGES.rst)) that made some changes to pixel-sky conversions. As a result, some of our tests that use SkyRegions/PixelRegions need to be updated.

This [PR in regions](https://github.com/astropy/regions/pull/677) fixes one of the subset tests.

Another test was failing because it was failing to demonstrate some now-fixed behavior, so I removed that assertion and the test now passes (by not failing to fail).

The final failing test in test_export_subsets I simply increased the tolerance to account for different sky values when using different  versions of 'regions'. I made a follow up ticket (JDAT-6173) to actually test this round tripping without using hard-coded values and actually comparing an exported file to a round-tripped region, so once this is done that arbitrary-feeling change in tolerance can go away.