### PR TITLE
Add context manager to help with iopub rate limit issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,9 @@ Bug Fixes
 - Stop using SkyCoord.from_name() to try to resolve sources in the astroquery loader
   that are already RA and Dec coordinates. [#4193]
 
+- Catch more IOPub messages to help avoid/fix "IOPub message rate exceeded" jupyter warning when
+  loading many datasets in a loop. [#4223]
+
 - Fix interference between slice tools of different types (ie ramp vs spectral slices). [#4225]
 
 Mosviz

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -31,7 +31,7 @@ from jdaviz.core.loaders.resolvers import find_matching_resolver
 from jdaviz.core.template_mixin import show_widget
 from jdaviz.core.user_api import (DataApi, SpectralDataApi, SpatialDataApi,
                                   TemporalSpatialDataApi, SpectralSpatialDataApi)
-from jdaviz.utils import data_has_valid_wcs, CONFIGS_WITH_LOADERS
+from jdaviz.utils import data_has_valid_wcs, CONFIGS_WITH_LOADERS, suppress_widget_comms
 from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
                                                check_if_unit_is_per_solid_angle,
                                                flux_conversion_general,
@@ -225,11 +225,16 @@ class ConfigHelper(HubListener):
             If ignore_invalid_kwargs is False, any kwargs that do not match valid inputs
             will raise a ValueError.
         """
-        resolver = find_matching_resolver(self._app, inp,
-                                          resolver=loader,
-                                          format=format,
-                                          target=target,
-                                          **kwargs)
+        # Resolver matching constructs a transient widget-based resolver for every
+        # registered resolver to test validity. We can suppress their frontend
+        # comms avoids flooding Jupyter's IOPub message-rate limit (e.g. when
+        # loading many datasets in a loop).
+        with suppress_widget_comms():
+            resolver = find_matching_resolver(self._app, inp,
+                                              resolver=loader,
+                                              format=format,
+                                              target=target,
+                                              **kwargs)
 
         if 'show_in_viewer' in kwargs.keys():
             if 'viewer' in kwargs.keys():

--- a/jdaviz/tests/test_utils.py
+++ b/jdaviz/tests/test_utils.py
@@ -3,6 +3,9 @@ import warnings
 import numpy as np
 import threading
 
+import ipywidgets.widgets.widget as _widget_mod
+from comm import DummyComm
+
 import pytest
 from astropy.io import fits
 from astropy.units.quantity import Quantity
@@ -13,7 +16,8 @@ from jdaviz.utils import (alpha_index, download_uri_to_path,
                           get_cloud_fits, get_cloud_asdf, cached_uri, escape_brackets,
                           has_wildcard, wildcard_match, _clean_data_for_hash,
                           create_data_hash, parallelize_calculation,
-                          in_ra_comps, in_dec_comps)
+                          in_ra_comps, in_dec_comps,
+                          suppress_widget_comms)
 
 
 @pytest.mark.parametrize("test_input,expected", [(0, 'a'), (1, 'b'), (25, 'z'), (26, 'aa'),
@@ -482,3 +486,34 @@ def test_coord_column():
     for v in variations_to_fail:
         assert not in_ra_comps(v)
         assert not in_dec_comps(v)
+
+
+class TestSuppressWidgetComms:
+
+    def setup_method(self):
+        self.sentinel = object()
+        self.original = _widget_mod.comm.create_comm
+
+    def teardown_method(self):
+        _widget_mod.comm.create_comm = self.original
+
+    def test_suppress_widget_comms_returns_dummy_comm(self):
+        """Within suppress_widget_comms, create_comm yields a no-op DummyComm so
+        transient widgets do not open frontend (IOPub) comms, and the original
+        create_comm is restored on exit."""
+        _widget_mod.comm.create_comm = lambda *a, **k: self.sentinel
+        with suppress_widget_comms():
+            # inside the context, throwaway widgets get a no-op DummyComm
+            assert isinstance(_widget_mod.comm.create_comm(), DummyComm)
+        # the original create_comm is restored on exit
+        assert _widget_mod.comm.create_comm() is self.sentinel
+        assert not isinstance(_widget_mod.comm.create_comm(), DummyComm)
+
+    def test_suppress_widget_comms_restores_on_exception(self):
+        """The original create_comm is restored even if the block raises."""
+        _widget_mod.comm.create_comm = lambda *a, **k: self.sentinel
+        with pytest.raises(ValueError):
+            with suppress_widget_comms():
+                raise ValueError("boom")
+        assert _widget_mod.comm.create_comm() is self.sentinel
+        assert not isinstance(_widget_mod.comm.create_comm(), DummyComm)

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -4,6 +4,9 @@ import time
 import threading
 import warnings
 from collections import deque
+from comm import DummyComm
+from contextlib import contextmanager
+import ipywidgets.widgets.widget as _widget_mod
 from urllib.parse import urlparse
 import fnmatch
 import re
@@ -49,7 +52,7 @@ __all__ = ['SnackbarQueue', 'enable_hot_reloading', 'bqplot_clear_figure',
            'wildcard_match', 'cmap_samples', 'glue_colormaps',
            'att_to_componentid', 'create_data_hash',
            'in_ra_comps', 'in_dec_comps', 'SPECTRAL_AXIS_COMP_LABELS',
-           'hst_obstype']
+           'hst_obstype', 'suppress_widget_comms']
 
 NUMPY_LT_2_0 = not minversion("numpy", "2.0.dev")
 STDATAMODELS_LT_402 = not minversion(stdatamodels, "4.0.2.dev")
@@ -71,6 +74,36 @@ COORD_WORDS_TO_EXCLUDE = ['radius', 'radio', 'radial', 'extragalactic',
                           'infrared', 'fraction', 'gradient', 'ratio',
                           'integrated,' 'radian', 'random', 'parallax', 'range',
                           'decade', 'decadal', 'decrement', 'deconvolve']
+
+
+@contextmanager
+def suppress_widget_comms():
+    """Prevent widgets created within this block from opening frontend comms.
+
+    Every ipywidgets/ipyvuetify widget opens a comm (a message channel to the
+    browser) as soon as it's constructed, which emits messages on Jupyter's IOPub channel.
+    Some of the code constructs temporary widgets, most notably during the loader process, e.g.
+    finding valid resolvers which builds (and throws away) a
+    resolver widget for every resolver on every ``load()`` call. When
+    many datasets are loaded in a loop, the resulting flood of comm messages can
+    exceed Jupyter's IOPub message-rate limit ("IOPub message rate exceeded").
+
+    Here, the ``create_comm`` method temporarily uses a dummy comm (:class:`comm.DummyComm`)
+    to prevent temporary widgets from sending messages to the browser. Widgets constructed in
+    this block are still fully functional Python objects.
+
+    Notes
+    -----
+    This swaps a module-level attribute, so it should only be used on short, synchronous
+    blocks that don't display their widgets (such as resolver matching).
+    """
+
+    original_create_comm = _widget_mod.comm.create_comm
+    _widget_mod.comm.create_comm = lambda *args, **kwargs: DummyComm(*args, **kwargs)
+    try:
+        yield
+    finally:
+        _widget_mod.comm.create_comm = original_create_comm
 
 
 def in_ra_comps(comp):

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -88,9 +88,9 @@ def suppress_widget_comms():
     many datasets are loaded in a loop, the resulting flood of comm messages can
     exceed Jupyter's IOPub message-rate limit ("IOPub message rate exceeded").
 
-    Here, the ``create_comm`` method temporarily uses a dummy comm (:class:`comm.DummyComm`)
-    to prevent temporary widgets from sending messages to the browser. Widgets constructed in
-    this block are still fully functional Python objects.
+    Here, the ``create_comm`` method temporarily uses a dummy comm to prevent temporary widgets
+    from sending messages to the browser. Widgets constructed in this block are still fully
+    functional Python objects.
 
     Notes
     -----

--- a/notebooks/JdavizExample.ipynb
+++ b/notebooks/JdavizExample.ipynb
@@ -20,7 +20,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from time import sleep\n",
     "import warnings\n",
     "# Ignore warnings when loading data\n",
     "warnings.simplefilter('ignore')\n",
@@ -181,12 +180,7 @@
    "id": "548a2866",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# If running cells in rapid succession, this cell may fail.\n",
-    "# We add a slight pause before aligning the images to avoid this.\n",
-    "sleep(1)\n",
-    "jd.plugins['Orientation'].align_by = 'WCS'"
-   ]
+   "source": "jd.plugins['Orientation'].align_by = 'WCS'"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/JdavizImageExample.ipynb
+++ b/notebooks/JdavizImageExample.ipynb
@@ -20,7 +20,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from time import sleep\n",
     "import warnings\n",
     "# Ignore warnings when loading data\n",
     "warnings.simplefilter('ignore')\n",
@@ -201,12 +200,7 @@
    "id": "548a2866",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# If running cells in rapid succession, this cell may fail.\n",
-    "# We add a slight pause before aligning the images to avoid this.\n",
-    "sleep(1)\n",
-    "jd.plugins['Orientation'].align_by = 'WCS'"
-   ]
+   "source": "jd.plugins['Orientation'].align_by = 'WCS'"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address a persistent issue with IOPub message rate limits. This typically occurs when loading a bunch of data all at once and causes the app to break. The fix we apply here is to send messages to a dummy comm during validity checks since we don't end up using most of those resolvers anyway. There may be other places where we can avoid message generation but this was the most obvious/least intrusive. 

I have also updated the example notebooks to remove the `sleep` call that was introduced to avoid the message when running all cells in succession. 

`test_utils` was showing up as CRLF instead of LF in my IDE so the diff is the entire file. If you click the settings icon next to 'submit review', there's an option to 'Hide whitespace'. That will allow you to see the non-line-ending changes to the file. 