### PR TITLE
Adding custom emission line to Line List with correct redshift

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,8 +22,9 @@ New Features
 - Add option to limit results to science products when retrieving files from an archive query
   results table. [#4194]
 
-- Fix issue in Line Lists where a new custom line was not plotted at the redshifted wavelength.
-  Fix another issue where erase_spectral_lines() permanently set Show to False with new option to
+- Fix issue in Line Lists where a new custom line was not plotted at the redshifted wavelength. [#4224]
+
+- Fix issue where erase_spectral_lines() permanently set 'show' to False for all lines, with new option to
   reset all emission lines to show == True. [#4224]
 
 Mosviz

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ New Features
 - Add option to limit results to science products when retrieving files from an archive query
   results table. [#4194]
 
+- Fix issue in Line Lists where a new custom line was not plotted at the redshifted wavelength. [#6070]
+
 Mosviz
 ^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ New Features
 - Add option to limit results to science products when retrieving files from an archive query
   results table. [#4194]
 
-- Fix issue in Line Lists where a new custom line was not plotted at the redshifted wavelength. [#6070]
+- Fix issue in Line Lists where a new custom line was not plotted at the redshifted wavelength. [#4224]
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,9 @@ New Features
 - Add option to limit results to science products when retrieving files from an archive query
   results table. [#4194]
 
-- Fix issue in Line Lists where a new custom line was not plotted at the redshifted wavelength. [#4224]
+- Fix issue in Line Lists where a new custom line was not plotted at the redshifted wavelength.
+  Fix another issue where erase_spectral_lines() permanently set Show to False with new option to
+  reset all emission lines to show == True. [#4224]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/configs/default/plugins/line_lists/line_list_mixin.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_list_mixin.py
@@ -11,7 +11,7 @@ class LineListMixin:
 
     _redshift = 0
 
-    def load_line_list(self, line_table):
+    def load_line_list(self, line_table, replace=False):
         """
         Convenience function to load a line list and update the plugin UI.
         Delegates to the Line Lists plugin to avoid code duplication.

--- a/jdaviz/configs/default/plugins/line_lists/line_list_mixin.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_list_mixin.py
@@ -11,7 +11,7 @@ class LineListMixin:
 
     _redshift = 0
 
-    def load_line_list(self, line_table, replace=False):
+    def load_line_list(self, line_table):
         """
         Convenience function to load a line list and update the plugin UI.
         Delegates to the Line Lists plugin to avoid code duplication.
@@ -33,23 +33,23 @@ class LineListMixin:
                 return None
             return self._app.get_viewer(viewer_reference)
 
-    def erase_spectral_lines(self, name=None):
+    def erase_spectral_lines(self, name=None, show_none=True):
         """Convenience function to get to the viewer function"""
         viewer = self._get_spectrum_viewer()
         if viewer is not None:
-            viewer.erase_spectral_lines(name=name)
+            viewer.erase_spectral_lines(name=name, show_none=show_none)
 
     def plot_spectral_line(self, line, global_redshift=None):
         """Convenience function to get to the viewer function"""
         viewer = self._get_spectrum_viewer()
         if viewer is not None:
-            viewer.plot_spectral_line(line, global_redshift)
+            viewer.plot_spectral_line(line, global_redhsift=global_redshift)
 
-    def plot_spectral_lines(self, global_redshift=None):
+    def plot_spectral_lines(self, line=None, global_redshift=None):
         """Convenience function to get to the viewer function"""
         viewer = self._get_spectrum_viewer()
         if viewer is not None:
-            viewer.plot_spectral_lines(global_redshift)
+            viewer.plot_spectral_lines(line, global_redshift)
 
     @property
     def spectral_lines(self):

--- a/jdaviz/configs/default/plugins/line_lists/line_list_mixin.py
+++ b/jdaviz/configs/default/plugins/line_lists/line_list_mixin.py
@@ -45,11 +45,11 @@ class LineListMixin:
         if viewer is not None:
             viewer.plot_spectral_line(line, global_redhsift=global_redshift)
 
-    def plot_spectral_lines(self, line=None, global_redshift=None):
+    def plot_spectral_lines(self, line=None, global_redshift=None, show_all=True):
         """Convenience function to get to the viewer function"""
         viewer = self._get_spectrum_viewer()
         if viewer is not None:
-            viewer.plot_spectral_lines(line, global_redshift)
+            viewer.plot_spectral_lines(line, global_redshift, show_all=show_all)
 
     @property
     def spectral_lines(self):

--- a/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
@@ -157,10 +157,10 @@ class TestLineLists:
             specviz_helper.load_line_list(lt)
 
         # Load a line, and apply redshift globally
-        specviz_helper.plot_spectral_line("Halpha")
+        specviz_helper.plot_spectral_lines("Halpha")
         specviz_helper.set_redshift(0.01)
         # Load second line, redshift should also be applied to it
-        specviz_helper.plot_spectral_line("O III")
+        specviz_helper.plot_spectral_lines("O III")
 
         viewer_lines = [mark for mark in specviz_helper._app.get_viewer(
             specviz_helper._default_spectrum_viewer_reference_name).figure.marks
@@ -180,7 +180,7 @@ class TestLineLists:
             specviz_helper.load_line_list(lt)
 
         # Load a line, so we can apply redshift
-        specviz_helper.plot_spectral_line("Halpha")
+        specviz_helper.plot_spectral_lines("Halpha")
         global_redshift = 0.01
         specviz_helper.set_redshift(global_redshift)
         # Load remaining lines

--- a/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
@@ -240,12 +240,12 @@ class TestLineLists:
         helper.plot_spectral_lines('O III 5007.0')
 
         # Verify that lines were plotted at the correct observed wavelength
-        try:
-            viewer_lines = [mark for mark in helper._app.get_viewer('1D Spectrum').figure.marks
-                            if isinstance(mark, SpectralLine)]
-        except AttributeError:
+        if hasattr(helper, '_default_spectrum_viewer_reference_name'):
             viewer_lines = [mark for mark in helper._app.get_viewer(
                             helper._default_spectrum_viewer_reference_name).figure.marks
+                            if isinstance(mark, SpectralLine)]
+        else:
+            viewer_lines = [mark for mark in helper._app.get_viewer('1D Spectrum').figure.marks
                             if isinstance(mark, SpectralLine)]
         assert np.all([line.redshift == 0.1 for line in viewer_lines])
 

--- a/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
+++ b/jdaviz/configs/default/plugins/line_lists/tests/test_line_lists.py
@@ -41,8 +41,8 @@ class TestLineLists:
         assert np.all(specviz_helper.spectral_lines["show"] == False)  # noqa
         assert specviz_helper.plugins['Line Lists']._obj.rs_enabled is False
 
-        specviz_helper.plot_spectral_line("Halpha")
-        specviz_helper.plot_spectral_line("O III 5007.0")
+        specviz_helper.plot_spectral_lines("Halpha")
+        specviz_helper.plot_spectral_lines("O III 5007.0")
 
         assert np.all(specviz_helper.spectral_lines["show"])
 
@@ -198,10 +198,15 @@ class TestLineLists:
         helper = request.getfixturevalue(helper_name)
 
         if helper_name == 'specviz_helper':
-            helper.load_data(spectrum1d)
+            helper.load_data(spectrum1d, data_label='Test Spectrum')
         else:
             # For deconfigged, load data and create a viewer
             helper.load(spectrum1d, format='1D Spectrum', data_label='Test Spectrum')
+
+        # Set redshift, make sure it is globally applied
+        helper.set_redshift(0.1)
+        ll_plugin = helper.plugins['Line Lists']._obj
+        assert ll_plugin.rs_redshift == 0.1
 
         # Create a line list table with metadata
         lt = QTable()
@@ -219,7 +224,6 @@ class TestLineLists:
         assert 'Test Lines' in helper.spectral_lines['listname']
 
         # Verify plugin internals
-        ll_plugin = helper.plugins['Line Lists']._obj
         assert 'Test Lines' in ll_plugin.loaded_lists
         assert len(ll_plugin.list_contents['Test Lines']['lines']) == 3
         assert ll_plugin.list_contents['Test Lines']['medium'] == 'Vacuum'
@@ -233,7 +237,17 @@ class TestLineLists:
         assert line_hbeta["listname"] == "Test Lines"
 
         # Test plotting lines
-        helper.plot_spectral_line('O III 5007.0')
+        helper.plot_spectral_lines('O III 5007.0')
+
+        # Verify that lines were plotted at the correct observed wavelength
+        try:
+            viewer_lines = [mark for mark in helper._app.get_viewer('1D Spectrum').figure.marks
+                            if isinstance(mark, SpectralLine)]
+        except AttributeError:
+            viewer_lines = [mark for mark in helper._app.get_viewer(
+                            helper._default_spectrum_viewer_reference_name).figure.marks
+                            if isinstance(mark, SpectralLine)]
+        assert np.all([line.redshift == 0.1 for line in viewer_lines])
 
         # Test erasing lines
         helper.erase_spectral_lines()

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -146,6 +146,9 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
             for row in line_table:
                 if row["listname"] is None:
                     row["listname"] = "Custom"
+                    # Assume a custom line should be shown (necessary if erase_spectral_lines()
+                    # has previously been called, since that permanently sets "show" to 0)
+                    row["show"] = True
 
         # Convert colors to hexa values, or set to default (red)
         if "colors" not in line_table.colnames:
@@ -247,22 +250,21 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
         # Deprecated wrapper preserved for backward compatibility.
         warnings.warn(
             "plot_spectral_line is deprecated; use plot_spectral_lines(line=...) instead",
-            DeprecationWarning,
+            DeprecationWarning, stacklevel=2
         )
         return self.plot_spectral_lines(line=line, global_redshift=global_redshift,
                                         plot_units=plot_units, **kwargs)
 
-    def plot_spectral_lines(self, line=None, colors=None, global_redshift=None,
+    def plot_spectral_lines(self, line=None, global_redshift=None, colors=None,
                             plot_units=None, **kwargs):
         """Plot either a single spectral line or the set loaded in ``self.spectral_lines``.
 
-        If ``line`` is provided (a table row or a string index/linename), the
-        function will behave like the old ``plot_spectral_line``. If ``line`` is
-        None, the function behaves like the old ``plot_spectral_lines`` and
-        draws all rows that have ``show == True``.
+        If ``line`` is provided (a table row, a string index/linename, or a QTable), the
+        function will plot that specific line(s). If ``line`` is None, the function behaves
+        like the old ``plot_spectral_lines`` and draws all rows.
 
         Examples:
-            Plot all enabled lines:
+            Plot all lines:
                 plot_spectral_lines()
 
             Plot a single line by name:
@@ -278,7 +280,25 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
             if global_redshift is None:
                 global_redshift = line
             line = None
-        fig = self.figure
+
+        # Get the redshift: prefer global_redshift, then the Line Lists
+        # plugin's redshift (if available), then self.redshift, then 0
+        redshift = 0
+        if global_redshift is None:
+            try:
+                ll_plugin = self.jdaviz_app.get_tray_item_from_name('g-line-list')
+                # plugin trait is `rs_redshift`; allow for None/empty
+                plugin_redshift = getattr(ll_plugin, 'rs_redshift', None)
+                if plugin_redshift is not None:
+                    redshift = float(plugin_redshift)
+                else:
+                    redshift = self.redshift if self.redshift is not None else 0
+            except Exception:
+                # If plugin not available or any error, fall back
+                redshift = self.redshift if self.redshift is not None else 0
+        else:
+            redshift = global_redshift
+        #print(f"redshift:{redshift}")
 
         # Single-line behavior
         if line is not None:
@@ -294,22 +314,16 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
                     else:
                         raise KeyError(f"Line '{line}' not found in spectral_lines table")
 
+            # Erase this line if it already existed, to avoid duplication
+            self.erase_spectral_lines(name_rest=line["name_rest"])
+
             if plot_units is None:
                 plot_units = self.data()[0].spectral_axis.unit
-
-            # Get the redshift: prefer global_redshift, then self.redshift, then 0
-            if global_redshift is None:
-                redshift = self.redshift if self.redshift is not None else 0
-            else:
-                redshift = global_redshift
 
             color = colors if colors is not None else line["colors"]
 
             mark = self._create_spectral_mark(line, plot_units, redshift, color,
                                               **kwargs)
-
-            # Erase this line if it already existed, to avoid duplication
-            self.erase_spectral_lines(name_rest=line["name_rest"])
 
             # Add mark and broadcast
             self.figure.marks = self.figure.marks + [mark]
@@ -317,31 +331,32 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
             self._broadcast_plotted_lines()
             return
 
-        # Multi-line behavior (original plot_spectral_lines)
+        # Handle QTable passed as first argument
+        lines_to_plot = self.spectral_lines
         self.erase_spectral_lines(show_none=False)
+            # Reset all show flags to True so they will be plotted
+        self.spectral_lines["show"] = True
+        if plot_units is None:
+            plot_units = self.data()[0].spectral_axis.unit
 
-        # Check to see if colors were defined for each line
+                # Check to see if colors were defined for each line
         if colors is None:
             colors = ["indigo"]
-        if "colors" in self.spectral_lines.columns:
-            colors = self.spectral_lines["colors"]
-        elif len(colors) != len(self.spectral_lines):
-            colors = colors * len(self.spectral_lines)
-
-        lines = self.spectral_lines
-        plot_units = self.data()[0].spectral_axis.unit
-
-        # apply redshift to all lines in the table
-        redshift = self.redshift if global_redshift is None else global_redshift
+        if "colors" in lines_to_plot.colnames:
+            colors = lines_to_plot["colors"]
+        elif len(colors) != len(lines_to_plot):
+            colors = colors * len(lines_to_plot)
 
         marks = []
-        for line, color in zip(lines, colors):
-            if not line["show"]:
+        for line_row, color in zip(lines_to_plot, colors):
+             # Only plot if show is not explicitly False
+            if "show" in lines_to_plot.colnames and not line_row["show"]:
                 continue
-            marks.append(self._create_spectral_mark(line, plot_units, redshift,
-                                                    color, **kwargs))
-        fig.marks = fig.marks + marks
+            marks.append(self._create_spectral_mark(line_row, plot_units, redshift,
+                                                            color, **kwargs))
+        self.figure.marks = self.figure.marks + marks
         self._broadcast_plotted_lines()
+        return
 
     def available_linelists(self):
         return get_available_linelists()

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -244,7 +244,7 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
                             table_index=line["name_rest"],
                             colors=[color], **kwargs)
 
-    @deprecated(since="5.2", alternative="plot_spectral_lines", details="Use plot_spectral_lines instead") # noqa
+    @deprecated(since="5.2", alternative="plot_spectral_lines")
     def plot_spectral_line(self, line, global_redshift=None, plot_units=None, **kwargs):
         # Deprecated wrapper preserved for backward compatibility.
         return self.plot_spectral_lines(line=line, global_redshift=global_redshift,

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -244,7 +244,7 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
                             table_index=line["name_rest"],
                             colors=[color], **kwargs)
 
-    @deprecated(since="5.2", alternative="plot_spectral_lines", details="Use plot_spectral_lines instead")
+    @deprecated(since="5.2", alternative="plot_spectral_lines", details="Use plot_spectral_lines instead") # noqa
     def plot_spectral_line(self, line, global_redshift=None, plot_units=None, **kwargs):
         # Deprecated wrapper preserved for backward compatibility.
         return self.plot_spectral_lines(line=line, global_redshift=global_redshift,
@@ -330,7 +330,7 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
         # Check to see if colors were defined for each line
         if colors is None:
             colors = ["indigo"]
-            
+
         if "colors" in lines_to_plot.colnames:
             colors = lines_to_plot["colors"]
         elif len(colors) != len(lines_to_plot):

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -3,6 +3,7 @@ import warnings
 import numpy as np
 from astropy import table
 from astropy import units as u
+from astropy.utils.decorators import deprecated
 from functools import cached_property
 from matplotlib.colors import cnames
 from specutils import Spectrum
@@ -243,12 +244,9 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
                             table_index=line["name_rest"],
                             colors=[color], **kwargs)
 
+    @deprecated(since="5.2", alternative="plot_spectral_lines", details="Use plot_spectral_lines instead")
     def plot_spectral_line(self, line, global_redshift=None, plot_units=None, **kwargs):
         # Deprecated wrapper preserved for backward compatibility.
-        warnings.warn(
-            "plot_spectral_line is deprecated; use plot_spectral_lines(line=...) instead",
-            DeprecationWarning, stacklevel=2
-        )
         return self.plot_spectral_lines(line=line, global_redshift=global_redshift,
                                         plot_units=plot_units, **kwargs)
 
@@ -280,22 +278,13 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
 
         # Get the redshift: prefer global_redshift, then the Line Lists
         # plugin's redshift (if available), then self.redshift, then 0
-        # for some reason, redshift needs to be initialized
-        redshift = 0
-        if global_redshift is None:
-            try:
-                ll_plugin = self.jdaviz_app.get_tray_item_from_name('g-line-list')
-                # plugin trait is `rs_redshift`; allow for None/empty
-                plugin_redshift = getattr(ll_plugin, 'rs_redshift', None)
-                if plugin_redshift is not None:
-                    redshift = float(plugin_redshift)
-                else:
-                    redshift = self.redshift if self.redshift is not None else 0
-            except Exception:
-                # If plugin not available or any error, fall back
-                redshift = self.redshift if self.redshift is not None else 0
-        else:
+        redshift = self.redshift if self.redshift is not None else 0
+        if global_redshift is not None:
             redshift = global_redshift
+        else:
+            ll_plugin = self.jdaviz_app.get_tray_item_from_name('g-line-list')
+            # plugin trait is `rs_redshift`; allow for None/empty
+            redshift = float(getattr(ll_plugin, 'rs_redshift', redshift))
 
         # Single-line behavior: old plot_spectral_line
         if line is not None:
@@ -341,6 +330,7 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
         # Check to see if colors were defined for each line
         if colors is None:
             colors = ["indigo"]
+            
         if "colors" in lines_to_plot.colnames:
             colors = lines_to_plot["colors"]
         elif len(colors) != len(lines_to_plot):

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -146,9 +146,6 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
             for row in line_table:
                 if row["listname"] is None:
                     row["listname"] = "Custom"
-                    # Assume a custom line should be shown (necessary if erase_spectral_lines()
-                    # has previously been called, since that permanently sets "show" to 0)
-                    row["show"] = True
 
         # Convert colors to hexa values, or set to default (red)
         if "colors" not in line_table.colnames:
@@ -283,6 +280,7 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
 
         # Get the redshift: prefer global_redshift, then the Line Lists
         # plugin's redshift (if available), then self.redshift, then 0
+        # for some reason, redshift needs to be initialized
         redshift = 0
         if global_redshift is None:
             try:
@@ -299,7 +297,7 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
         else:
             redshift = global_redshift
 
-        # Single-line behavior
+        # Single-line behavior: old plot_spectral_line
         if line is not None:
             if isinstance(line, str):
                 # Try the full index first, otherwise name only
@@ -350,7 +348,7 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
 
         marks = []
         for line_row, color in zip(lines_to_plot, colors):
-             # Only plot if show is not explicitly False
+             # Plot only the lines with show=True
             if "show" in lines_to_plot.colnames and not line_row["show"]:
                 continue
             marks.append(self._create_spectral_mark(line_row, plot_units, redshift,

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -333,7 +333,7 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
         self.erase_spectral_lines(show_none=False)
         # Reset all show flags to True so they will be plotted.
         # Necessary if erase_spectral_lines() has previously been called
-        if show_all==True:
+        if show_all is True:
             self.spectral_lines["show"] = True
         if plot_units is None:
             plot_units = self.data()[0].spectral_axis.unit
@@ -348,11 +348,11 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
 
         marks = []
         for line_row, color in zip(lines_to_plot, colors):
-             # Plot only the lines with show=True
+            # Plot only the lines with show=True
             if "show" in lines_to_plot.colnames and not line_row["show"]:
                 continue
             marks.append(self._create_spectral_mark(line_row, plot_units, redshift,
-                                                            color, **kwargs))
+                                                    color, **kwargs))
         self.figure.marks = self.figure.marks + marks
         self._broadcast_plotted_lines()
         return

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -177,7 +177,7 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
 
         # Plot redshifted lines that have show=True
         if np.any(self.spectral_lines["show"]):
-            self.plot_spectral_lines()
+            self.plot_spectral_lines(show_all=False)
 
         if return_table:
             return line_table
@@ -256,7 +256,7 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
                                         plot_units=plot_units, **kwargs)
 
     def plot_spectral_lines(self, line=None, global_redshift=None, colors=None,
-                            plot_units=None, **kwargs):
+                            plot_units=None, show_all=True, **kwargs):
         """Plot either a single spectral line or the set loaded in ``self.spectral_lines``.
 
         If ``line`` is provided (a table row, a string index/linename, or a QTable), the
@@ -273,8 +273,8 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
 
             Plot all lines with custom redshift:
                 plot_spectral_lines(global_redshift=0.01)
-                plot_spectral_lines(colors=None, global_redshift=0.01)
         """
+
         # if line is a numeric type, treat it as global_redshift
         if isinstance(line, (int, float)):
             if global_redshift is None:
@@ -298,12 +298,11 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
                 redshift = self.redshift if self.redshift is not None else 0
         else:
             redshift = global_redshift
-        #print(f"redshift:{redshift}")
 
         # Single-line behavior
         if line is not None:
             if isinstance(line, str):
-                # Try the full index first (for backend calls), otherwise name only
+                # Try the full index first, otherwise name only
                 try:
                     line = self.spectral_lines.loc[line]
                 except KeyError:
@@ -316,6 +315,7 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
 
             # Erase this line if it already existed, to avoid duplication
             self.erase_spectral_lines(name_rest=line["name_rest"])
+            self.spectral_lines.loc[line["name_rest"]]["show"] = True
 
             if plot_units is None:
                 plot_units = self.data()[0].spectral_axis.unit
@@ -327,19 +327,20 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
 
             # Add mark and broadcast
             self.figure.marks = self.figure.marks + [mark]
-            line["show"] = True
             self._broadcast_plotted_lines()
             return
 
-        # Handle QTable passed as first argument
+        # If line is None, plot the whole table given to load_line_list
         lines_to_plot = self.spectral_lines
         self.erase_spectral_lines(show_none=False)
-            # Reset all show flags to True so they will be plotted
-        self.spectral_lines["show"] = True
+        # Reset all show flags to True so they will be plotted.
+        # Necessary if erase_spectral_lines() has previously been called
+        if show_all==True:
+            self.spectral_lines["show"] = True
         if plot_units is None:
             plot_units = self.data()[0].spectral_axis.unit
 
-                # Check to see if colors were defined for each line
+        # Check to see if colors were defined for each line
         if colors is None:
             colors = ["indigo"]
         if "colors" in lines_to_plot.colnames:

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -172,6 +172,10 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
 
         self._broadcast_plotted_lines()
 
+        # Plot redshifted lines that have show=True
+        if np.any(self.spectral_lines["show"]):
+            self.plot_spectral_lines()
+
         if return_table:
             return line_table
 
@@ -227,67 +231,115 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
             fig.marks = temp_marks
             self._broadcast_plotted_lines()
 
+    def _create_spectral_mark(self, line, plot_units, redshift, color, **kwargs):
+        """
+        Create and return a SpectralLine mark for a table row.
+        This centralizes construction to prevent duplicating SpectralLine(...) calls.
+        """
+        return SpectralLine(self,
+                            line['rest'].to_value(plot_units),
+                            redshift,
+                            name=line["linename"],
+                            table_index=line["name_rest"],
+                            colors=[color], **kwargs)
+
     def plot_spectral_line(self, line, global_redshift=None, plot_units=None, **kwargs):
-        if isinstance(line, str):
-            # Try the full index first (for backend calls), otherwise name only
-            try:
-                line = self.spectral_lines.loc[line]
-            except KeyError:
-                line = self.spectral_lines.loc["linename", line]
-        if plot_units is None:
-            plot_units = self.data()[0].spectral_axis.unit
+        # Deprecated wrapper preserved for backward compatibility.
+        warnings.warn(
+            "plot_spectral_line is deprecated; use plot_spectral_lines(line=...) instead",
+            DeprecationWarning,
+        )
+        return self.plot_spectral_lines(line=line, global_redshift=global_redshift,
+                                        plot_units=plot_units, **kwargs)
 
-        if global_redshift is None:
-            redshift = self.redshift
-        else:
-            redshift = global_redshift
+    def plot_spectral_lines(self, line=None, colors=None, global_redshift=None,
+                            plot_units=None, **kwargs):
+        """Plot either a single spectral line or the set loaded in ``self.spectral_lines``.
 
-        line_mark = SpectralLine(self,
-                                 line['rest'].to_value(plot_units),
-                                 redshift,
-                                 name=line["linename"],
-                                 table_index=line["name_rest"],
-                                 colors=[line["colors"]], **kwargs)
+        If ``line`` is provided (a table row or a string index/linename), the
+        function will behave like the old ``plot_spectral_line``. If ``line`` is
+        None, the function behaves like the old ``plot_spectral_lines`` and
+        draws all rows that have ``show == True``.
 
-        # Erase this line if it already existed, to avoid duplication
-        self.erase_spectral_lines(name_rest=line["name_rest"])
+        Examples:
+            Plot all enabled lines:
+                plot_spectral_lines()
 
-        self.figure.marks = self.figure.marks + [line_mark]
-        line["show"] = True
-        self._broadcast_plotted_lines()
+            Plot a single line by name:
+                plot_spectral_lines(line='Halpha')
+                plot_spectral_lines('Halpha')
 
-    def plot_spectral_lines(self, colors=["blue"], global_redshift=None, **kwargs):
+            Plot all lines with custom redshift:
+                plot_spectral_lines(global_redshift=0.01)
+                plot_spectral_lines(colors=None, global_redshift=0.01)
         """
-        Plots a user-provided astropy table of spectral lines in the viewer.
-        """
+        # if line is a numeric type, treat it as global_redshift
+        if isinstance(line, (int, float)):
+            if global_redshift is None:
+                global_redshift = line
+            line = None
         fig = self.figure
+
+        # Single-line behavior
+        if line is not None:
+            if isinstance(line, str):
+                # Try the full index first (for backend calls), otherwise name only
+                try:
+                    line = self.spectral_lines.loc[line]
+                except KeyError:
+                    # Look up by linename column
+                    linename_match = self.spectral_lines['linename'] == line
+                    if np.any(linename_match):
+                        line = self.spectral_lines[linename_match][0]
+                    else:
+                        raise KeyError(f"Line '{line}' not found in spectral_lines table")
+
+            if plot_units is None:
+                plot_units = self.data()[0].spectral_axis.unit
+
+            # Get the redshift: prefer global_redshift, then self.redshift, then 0
+            if global_redshift is None:
+                redshift = self.redshift if self.redshift is not None else 0
+            else:
+                redshift = global_redshift
+
+            color = colors if colors is not None else line["colors"]
+
+            mark = self._create_spectral_mark(line, plot_units, redshift, color,
+                                              **kwargs)
+
+            # Erase this line if it already existed, to avoid duplication
+            self.erase_spectral_lines(name_rest=line["name_rest"])
+
+            # Add mark and broadcast
+            self.figure.marks = self.figure.marks + [mark]
+            line["show"] = True
+            self._broadcast_plotted_lines()
+            return
+
+        # Multi-line behavior (original plot_spectral_lines)
         self.erase_spectral_lines(show_none=False)
 
         # Check to see if colors were defined for each line
+        if colors is None:
+            colors = ["indigo"]
         if "colors" in self.spectral_lines.columns:
             colors = self.spectral_lines["colors"]
         elif len(colors) != len(self.spectral_lines):
-            colors = colors*len(self.spectral_lines)
+            colors = colors * len(self.spectral_lines)
 
         lines = self.spectral_lines
         plot_units = self.data()[0].spectral_axis.unit
 
-        if global_redshift is None:
-            redshift = self.redshift
-        else:
-            redshift = global_redshift
+        # apply redshift to all lines in the table
+        redshift = self.redshift if global_redshift is None else global_redshift
 
         marks = []
         for line, color in zip(lines, colors):
             if not line["show"]:
                 continue
-            line = SpectralLine(self,
-                                line['rest'].to_value(plot_units),
-                                redshift,
-                                name=line["linename"],
-                                table_index=line["name_rest"],
-                                colors=[color], **kwargs)
-            marks.append(line)
+            marks.append(self._create_spectral_mark(line, plot_units, redshift,
+                                                    color, **kwargs))
         fig.marks = fig.marks + marks
         self._broadcast_plotted_lines()
 

--- a/jdaviz/configs/specviz2d/tests/test_mouseover_multiple_2d.py
+++ b/jdaviz/configs/specviz2d/tests/test_mouseover_multiple_2d.py
@@ -8,7 +8,8 @@ from jdaviz.core.marks import PluginLine
 class TestMouseoverMultiple2DSpectra:
 
     @pytest.fixture(scope='class')
-    def spectrum_no_wavelength(self):
+    @classmethod
+    def spectrum_no_wavelength(cls):
         """
         Create a 2D spectrum with no wavelength mapping (no WCS, no spectral_axis).
         """


### PR DESCRIPTION
This pull request addresses an issue where adding a custom emission line to the Line List plugin did not immediately plot it in the viewer at the redshifted wavelength unless the user manually changed the redshift. The global redshift is now applied when calling plot_spectral_lines(...) so that all emission lines are plotted at the correct redshifted wavelength when loaded.

I combined plot_spectral_line and plot_spectral_lines into one function that can take a line name, a float redshift, or if None it will plot all lines with 'show' == True.

This also fixes a separate issue where calling erase_spectral_lines permanently set 'show' to False for every line. The new argument "show_all" in plot_spectral_lines allows the user to reset 'show' to True for all lines, or if set to False, the function will honor the previous 'show' values.

I also added test coverage to check that the Spectral Line marks are displayed at the correct redshift.

Fixes #JDAT-6070

### Change log entry

- [x] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
