### PR TITLE
Update python version recommendation in docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,9 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Update docs to reflect new minimum version of Python (>=3.12). Recommend Python 3.13
+  to implicitly reflect testing environments. [#4240]
+
 Mosviz
 
 

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ version conflicts with other packages you may have installed, for example:
 
 .. code-block:: bash
 
-   conda create -n jdaviz-env python=3.12
+   conda create -n jdaviz-env python=3.13
    conda activate jdaviz-env
 
 Installing the released version can be done using pip:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -90,7 +90,7 @@ the interface.
     :alt: Create environment with Anaconda Navigator
 
 Give a name to the environment (in this example we call it jdaviz_navigator) and
-select Python with a version greater than 3.12.
+select Python with a version greater than or equal to 3.12.
 
 .. image:: ./img/navigator_nameenv.png
     :alt: Name environment with Anaconda Navigator

--- a/docs/known_bugs.rst
+++ b/docs/known_bugs.rst
@@ -51,7 +51,7 @@ compatible version:
 
 .. code-block:: bash
 
-    conda create -n jdaviz python=3.12
+    conda create -n jdaviz python=3.13
     conda activate jdaviz
     pip install vispy>=0.6.5
     pip install jdaviz --no-cache-dir

--- a/docs/setup/local.rst
+++ b/docs/setup/local.rst
@@ -91,7 +91,7 @@ the interface.
     :alt: Create environment with Anaconda Navigator
 
 Give a name to the environment (in this example we call it jdaviz_navigator) and
-select Python with a version greater than 3.12.
+select Python with a version greater than or equal to 3.12.
 
 .. image:: ../img/navigator_nameenv.png
     :alt: Name environment with Anaconda Navigator


### PR DESCRIPTION
I decided to update the examples to use Python 3.13 since that coincides with CI checks. I couldn't think of a way to appropriately explain that decision during install so open to suggestions if the reviewer(s) think it's necessary. 
