### PR TITLE
Better horizontal spacing in the app toolbar for small displays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -87,7 +87,7 @@ Bug Fixes
 - Update the File Drop Resolver to parse input the same way as the File Resolver,
   which fixes a bug where the resolver would not correctly parse some file types. [#4250]
 
-Mosviz
+- Fix horizontal spacing of the app-level toolbar for small displays. [#4245]
 
 
 5.0.2 (2026-06-12)
@@ -123,8 +123,6 @@ Bug Fixes
 
 - Fix interference between slice tools of different types (ie ramp vs spectral slices). [#4225]
 
-Mosviz
-^^^^^^
 
 5.0.1 (2026-05-01)
 ==================

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.vue
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.vue
@@ -1,5 +1,5 @@
 <template>
-  <div @mouseover="show_dataset_selected = true" @mouseleave="show_dataset_selected = false" style="min-width: 300px">
+  <div @mouseover="show_dataset_selected = true" @mouseleave="show_dataset_selected = false">
     <div v-if="icon" style="position: absolute; height: 100%">
       <v-toolbar-items>
         <v-btn icon rounded="0">
@@ -25,7 +25,7 @@
         </span>
       </v-toolbar-items>
     </div>
-    <div v-else style="position: absolute; height: 100%">
+    <div v-else style="height: 100%">
       <v-toolbar-items>
         <j-tooltip tipid='coords-info-cycle'>
           <v-btn icon rounded="0" @click="next_layer()">


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description

The horizontal spacing of the app-level toolbar enforces a 300px-wide empty horizontal area to the right the layer select button and to the left of the group of widgets on the right (search, version, api hints, popout). I'm not sure why we do that, I would guess that this was meant as "reserved space" for coords-info that appear while hovering on data?

In practice, this causes the widgets on the right to overflow whenever the jdaviz container is ~<1000px. While I'm sure we'd all prefer >>1000px of horizontal space for the container, folks using RRN on a laptop will hit this limit.

This PR makes minor CSS adjustments to make the right-side widgets fully visible so long as there are sufficient horizontal pixels to do so. I'm aware that there are lots of ways to improve the horizontal spacing, and we should talk it over with Jenn. In this PR, I'm only trying to get the app to fit better for immediate use. I'm using a bugfix milestone because the current behavior isn't great, and so we can use the improvement sooner rather than later.

##### Demo

In this example, I'm using sidecar so that I can make a good screengrab, but the same overflow occurs if you display jdaviz within the notebook and change the width of the browser window.

On main:
```python
import jdaviz as jd

jd.show('sidecar:split-right')
```

https://github.com/user-attachments/assets/b32efd91-f352-48b6-bbc9-56ffa352c298

After this PR:


https://github.com/user-attachments/assets/aaecfd9b-5455-4bc2-bfbd-f6e1fb305cfa


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
