### PR TITLE
Improve parenting behavior

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,10 @@ New Features
 - Implement a "focus mode" that shows a simplified view of a single viewer.  Focus mode can
   be toggled on/off from the viewer toolbar or via the API. [#4242]
 
+- Parenting now includes a 'None' option to allow multi-extension FITS to be loaded as separate data entries. [#4248]
+
+- 'Auto' parenting can now associate with data already loaded into the app without needing to specify the data label. [#4248]
+
 Mosviz
 ^^^^^^
 

--- a/docs/imviz/displayimages.rst
+++ b/docs/imviz/displayimages.rst
@@ -203,6 +203,8 @@ Single-Pixel Selection
 
 This tool is no longer available as of Jdaviz v3.9; use the :ref:`markers-plugin` plugin instead.
 
+.. _imviz-blinking:
+
 Blinking
 ========
 

--- a/docs/loaders/formats/image.rst
+++ b/docs/loaders/formats/image.rst
@@ -53,6 +53,40 @@ UI Access
    :init-steps-json: [{"action":"disable-toolbar-except","value":"loaders"}]
    :steps-json: [{"action": "show-sidebar", "value": "loaders", "delay": 1500, "caption": "Open the data loader"}, {"action": "select-dropdown", "value": "Format:Image", "delay": 1000, "caption": "Set format to Image"}, {"action": "highlight", "target": "#format-select", "delay": 1500}]
 
+Data Association (Parent Dataset)
+=================================
+
+When loading a file with multiple extensions (e.g. a FITS file with ``SCI``, ``ERR``,
+and ``DQ`` extensions), the importer can *associate* extensions with one another by
+setting up a parent-child relationship. An associated (child) data entry is nested
+under its parent in the data menu and is treated as a layer of the parent rather than
+as an independent image, e.g., child layers are **not** cycled through when
+:ref:`blinking <imviz-blinking>`; only top-level (parent) data are blinked.
+
+The ``Parent Dataset`` dropdown controls this behavior:
+
+- **Auto** (default): non-science extensions (e.g. ``ERR``, ``DQ``) are automatically
+  associated with the matching science extension (``SCI``/``DATA`` of the same version).
+  The science parent may either be loaded in the same import or already present in the
+  data collection from an earlier load (matched by an internal labeling mechanism), so
+  loading an ``ERR`` extension later still associates it with a previously-loaded ``SCI``
+  extension.
+- **None**: no association is created, even when multiple extensions are imported. Each
+  extension is loaded as an independent, top-level data entry.
+- **A specific dataset**: associate the new data as a child of the selected dataset.
+
+.. code-block:: python
+
+    ldr = jdaviz.loaders['file']
+    ldr.filename = 'image.fits'
+    ldr.format = 'Image'
+
+    # default 'Auto' associates ERR/DQ with their SCI extension
+    ldr.importer.parent = 'Auto'
+
+    # disable association entirely
+    ldr.importer.parent = 'None'
+
 See Also
 ========
 

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -699,10 +699,17 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
         *data_labels : str
             The label(s) of the dataset to add to the viewer.
         """
+        available = self.dataset.choices
+
+        for label in data_labels:
+            parent_label = self.app._get_assoc_data_parent(label)
+            available += self.app._get_assoc_data_children(parent_label)
+
         unavailable = [data_label for data_label in data_labels
-                       if data_label not in self.dataset.choices]
+                       if data_label not in available]
         if len(unavailable):
-            raise ValueError(f"Data labels {unavailable} not able to be loaded into '{self.viewer_id}'.  Must be one of: {self.dataset.choices}")  # noqa
+            raise ValueError(f"Data labels {unavailable} not able to be loaded into '{self.viewer_id}'. Must be one of: {available}")  # noqa
+
         for data_label in data_labels:
             self._app.add_data_to_viewer(self.viewer_id, data_label)
 

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -701,6 +701,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
         """
         available = self.dataset.choices
 
+        # TODO: Remove this if we decide to prevent users from removing child data from viewers
         for label in data_labels:
             # Check if incoming labels are children of parent data
             parent_label = self.app._get_assoc_data_parent(label)

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -702,6 +702,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
         available = self.dataset.choices
 
         for label in data_labels:
+            # Check if incoming labels are children of parent data
             parent_label = self.app._get_assoc_data_parent(label)
             available += self.app._get_assoc_data_children(parent_label)
 

--- a/jdaviz/configs/default/tests/test_data_menu.py
+++ b/jdaviz/configs/default/tests/test_data_menu.py
@@ -1,3 +1,4 @@
+import re
 from astropy.io import fits
 from astropy.nddata import NDData
 import astropy.units as u
@@ -91,7 +92,7 @@ def test_data_menu_add_remove_data(imviz_helper):
     assert len(dm._obj.dataset.choices) == 2
 
     with pytest.raises(ValueError,
-                       match="Data labels \\['dne1', 'dne2'\\] not able to be loaded into 'imviz-0'.  Must be one of: \\['image_1', 'image_2'\\]"):  # noqa
+                       match=re.escape("Data labels ['dne1', 'dne2'] not able to be loaded into 'imviz-0'. Must be one of: ['image_1', 'image_2']")):  # noqa
         dm.add_data('dne1', 'dne2')
 
     dm.add_data('image_1', 'image_2')

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -90,7 +90,7 @@ class ImageImporter(BaseImporterToDataCollection):
         super().__init__(*args, **kwargs)
 
         self.parent = DatasetSelect(self, 'parent_items', 'parent_selected',
-                                    multiselect=None, manual_options=['Auto'])
+                                    multiselect=None, manual_options=['Auto', 'None'])
         self.parent.add_filter('is_image', 'not_from_plugin')
         self.parent.selected = 'Auto'
 
@@ -134,7 +134,7 @@ class ImageImporter(BaseImporterToDataCollection):
                                 'ver': hdu.ver,
                                 'name_ver': f"{hdu.name},{hdu.ver}",
                                 'index': index,
-                                'data_hash': create_data_hash(hdu),
+                                'data_hash': create_data_hash(getattr(hdu, 'data', None)),
                                 'obj': hdu}
                                for index, hdu in enumerate(input)]
             elif input_is_roman_asdf:
@@ -412,6 +412,71 @@ class ImageImporter(BaseImporterToDataCollection):
         else:
             return [{}] * len(self.output)
 
+    def _data_label_for_ext(self, base_data_label, ext_item):
+        """
+        Determine the data label for some extension of the file.
+        """
+        if self.data_label_is_prefix:
+            # If data_label is a prefix, we need to append the extension
+            # to the data label.
+            return self._get_label_with_extension(base_data_label,
+                                                  ext_item.get('name'),
+                                                  ver=ext_item.get('ver', None))
+
+        # If data_label is not a prefix, we use it as is.
+        return base_data_label
+
+    @staticmethod
+    def _find_sci_parent_ext(ext_item, candidate_ext_items):
+        """
+        Return the SCI/DATA extension (matching ver) that should act as the
+        parent of ``ext_item``, or None if no suitable science parent exists.
+        """
+        for other_ext_item in candidate_ext_items:
+            if other_ext_item is ext_item:
+                # an extension can't be its own parent
+                continue
+
+            if (other_ext_item.get('name').lower() in ('sci', 'data')
+                    and other_ext_item.get('ver', None) == ext_item.get('ver', None)):
+                return other_ext_item
+
+        return None
+
+    def _determine_parent_label(self, parent_selected, ext_item, base_data_label,
+                                selected_ext_items, all_ext_items, dc_hash_to_label):
+        """
+        Determine the parent data label to associate with the extension being
+        imported based on the ``Parent Dataset`` selection.
+
+        * ``'None'``: never associate, even with multiple extensions.
+        * a specific dataset label: associate with that dataset.
+        * ``'Auto'``: associate other extensions (e.g. ERR, DQ) with the
+          matching science (SCI/DATA, matching ver) extension. The science parent
+          may either be part of the current import or already present in the data
+          collection (matched by data hash), so that extensions loaded later still
+          associate with a previously-loaded science extension.
+        """
+        if parent_selected == 'None':
+            return None
+        elif parent_selected != 'Auto':
+            return parent_selected
+
+        parent_ext = self._find_sci_parent_ext(ext_item, all_ext_items)
+        # Data coming from a plugin is never auto-associated
+        if (getattr(self.input, 'meta', {}).get('plugin', None) is not None or
+                parent_ext is None):
+            return None
+
+        # If the science parent is part of the current import, use its new label
+        if any(parent_ext is sel_ext for sel_ext in selected_ext_items):
+            return self._data_label_for_ext(base_data_label, parent_ext)
+
+        # Otherwise associate with a matching science parent already in the
+        # data collection (matched by data hash from the extension dropdown)
+        parent_hash = parent_ext.get('data_hash')
+        return dc_hash_to_label.get(parent_hash, None)
+
     def __call__(self):
 
         base_data_label = self.data_label_value
@@ -420,6 +485,19 @@ class ImageImporter(BaseImporterToDataCollection):
         ext_items = self.ext_items
 
         parent_selected = self.parent.selected
+
+        # Grab all extensions available in the extension dropdown.
+        # Used to find a parent even when said parent isn't part of the current selection.
+        if self.input_has_extensions:
+            all_ext_items = self.extension.items
+        else:
+            all_ext_items = ext_items
+
+        # Map data hash -> label for data already in the data collection so that
+        # 'Auto' can associate new children with a previously loaded parent.
+        dc_hash_to_label = {data.meta.get('_data_hash'): data.label
+                            for data in self._app.data_collection}
+
         for output, ext_item in zip(outputs, ext_items):
             if output is None:
                 # needed for NDData where one of the "extensions" might
@@ -428,40 +506,12 @@ class ImageImporter(BaseImporterToDataCollection):
                 continue
 
             # Determine data label
-            if self.data_label_is_prefix:
-                # If data_label is a prefix, we need to append the extension
-                # to the data label.
-                data_label = self._get_label_with_extension(base_data_label,
-                                                            ext_item.get('name'),
-                                                            ver=ext_item.get('ver', None))
-            else:
-                # If data_label is not a prefix, we use it as is.
-                data_label = base_data_label
+            data_label = self._data_label_for_ext(base_data_label, ext_item)
 
             # Determine parent
-            if (parent_selected == 'Auto' and
-                    len(ext_items) > 1 and
-                    getattr(self.input, 'meta', {}).get('plugin', None) is None):
-                # If parent is set to 'Auto', use SCI/DATA extension
-                # as parent of any other selected extensions with same ver (if applicable)
-                for other_ext_item in ext_items:
-                    if (other_ext_item.get('name') in ('SCI', 'sci', 'DATA', 'data')
-                            and other_ext_item.get('ver', None) == ext_item.get('ver', None)):
-                        parent_ext_item = other_ext_item
-                        break
-                else:
-                    # No SCI/DATA extension found, so default to no parent
-                    parent_ext_item = None
-                    parent_data_label = None
-                if parent_ext_item is not None:
-                    # assume self.data_label_is_prefix is True
-                    parent_data_label = self._get_label_with_extension(base_data_label,
-                                                                       parent_ext_item.get('name'),
-                                                                       ver=parent_ext_item.get('ver', None))  # noqa
-            elif parent_selected == 'Auto':
-                parent_data_label = None
-            else:
-                parent_data_label = parent_selected
+            parent_data_label = self._determine_parent_label(parent_selected, ext_item,
+                                                             base_data_label, ext_items,
+                                                             all_ext_items, dc_hash_to_label)
 
             if self.gwcs_to_fits_sip:
                 output = self._glue_data_wcs_to_fits(output)

--- a/jdaviz/core/loaders/importers/image/image.vue
+++ b/jdaviz/core/loaders/importers/image/image.vue
@@ -19,7 +19,7 @@
       label="Parent Dataset"
       api_hint="ldr.importer.parent ="
       :api_hints_enabled="api_hints_enabled"
-      hint="Advanced: manually select a dataset to associate as the parent of the new data entry, 'Auto' will automatically associate non-science extensions with the science extension."
+      hint="Select a dataset to associate as the parent of the new data entry. 'Auto' associates non-science extensions with the matching science extension; 'None' imports the data without any association."
     ></plugin-dataset-select>
     <plugin-auto-label
       v-model:value="data_label_value"

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -808,33 +808,38 @@ class TestParenting:
         self.ldr.object = _make_multi_sci_hdul()
 
     def test_load_image_parent_default_auto(self):
+        ldr = self.ldr
+        dcf_helper = self.dcf_helper
+
         # the default parent selection should be 'Auto'
-        assert self.ldr.importer.parent.selected == 'Auto'
-        assert 'Auto' in self.ldr.importer.parent.choices
-        assert 'None' in self.ldr.importer.parent.choices
+        assert ldr.importer.parent.selected == 'Auto'
+        assert 'Auto' in ldr.importer.parent.choices
+        assert 'None' in ldr.importer.parent.choices
 
-        self.ldr.importer.extension = ['SCI,1', 'ERR,1', 'SCI,2', 'ERR,2']
-        self.ldr.load()
+        ldr.importer.extension = ['SCI,1', 'ERR,1', 'SCI,2', 'ERR,2']
+        ldr.load()
 
-        assert len(self.dcf_helper._app.data_collection) == 4
-        assert len(self.dcf_helper.viewers['Image'].data_menu.data_labels_loaded) == 4
-        assert self.dcf_helper._app._get_assoc_data_parent('Image[ERR,1]') == 'Image[SCI,1]'
-        assert self.dcf_helper._app._get_assoc_data_children('Image[SCI,1]') == ['Image[ERR,1]']
+        assert len(dcf_helper._app.data_collection) == 4
+        assert len(dcf_helper.viewers['Image'].data_menu.data_labels_loaded) == 4
+        assert dcf_helper._app._get_assoc_data_parent('Image[ERR,1]') == 'Image[SCI,1]'
+        assert dcf_helper._app._get_assoc_data_children('Image[SCI,1]') == ['Image[ERR,1]']
 
-        assert self.dcf_helper._app._get_assoc_data_parent('Image[ERR,2]') == 'Image[SCI,2]'
-        assert self.dcf_helper._app._get_assoc_data_children('Image[SCI,2]') == ['Image[ERR,2]']
+        assert dcf_helper._app._get_assoc_data_parent('Image[ERR,2]') == 'Image[SCI,2]'
+        assert dcf_helper._app._get_assoc_data_children('Image[SCI,2]') == ['Image[ERR,2]']
 
     def test_load_image_parent_none(self):
-        # 'None' should prevent any parenting, even with multiple extensions
-        self.ldr.importer.extension = ['SCI,1', 'ERR,1', 'SCI,2', 'ERR,2']
-        self.ldr.importer.parent = 'None'
-        self.ldr.load()
+        """'None' should prevent any parenting, even with multiple extensions"""
+        ldr = self.ldr
+        dcf_helper = self.dcf_helper
+        ldr.importer.extension = ['SCI,1', 'ERR,1', 'SCI,2', 'ERR,2']
+        ldr.importer.parent = 'None'
+        ldr.load()
 
-        assert len(self.dcf_helper._app.data_collection) == 4
-        assert len(self.dcf_helper.viewers['Image'].data_menu.data_labels_loaded) == 4
+        assert len(dcf_helper._app.data_collection) == 4
+        assert len(dcf_helper.viewers['Image'].data_menu.data_labels_loaded) == 4
         for label in ('Image[SCI,1]', 'Image[ERR,1]', 'Image[SCI,2]', 'Image[ERR,2]'):
-            assert self.dcf_helper._app._get_assoc_data_parent(label) is None
-            assert self.dcf_helper._app._get_assoc_data_children(label) == []
+            assert dcf_helper._app._get_assoc_data_parent(label) is None
+            assert dcf_helper._app._get_assoc_data_children(label) == []
 
     @pytest.mark.parametrize('rename', (False, True))
     def test_load_image_auto_parent_existing_in_dc(self, rename):
@@ -842,50 +847,56 @@ class TestParenting:
         'Auto' should associate a child extension loaded later with a matching
         science extension that is already in the data collection (matched by hash)
         """
+        ldr = self.ldr
+        dcf_helper = self.dcf_helper
+
         # first load only the science extension
-        self.ldr.importer.extension = 'SCI,2'
-        self.ldr.load()
+        ldr.importer.extension = 'SCI,2'
+        ldr.load()
 
         primary_label = 'Image[SCI,2]'
 
-        assert [d.label for d in self.dcf_helper._app.data_collection] == [primary_label]
-        assert self.dcf_helper._app._get_assoc_data_children(primary_label) == []
+        assert [d.label for d in dcf_helper._app.data_collection] == [primary_label]
+        assert dcf_helper._app._get_assoc_data_children(primary_label) == []
 
         # Now test with a rename in-between
         if rename:
-            self.dcf_helper.viewers['Image'].data_menu.rename(primary_label, 'new name')
+            dcf_helper.viewers['Image'].data_menu.rename(primary_label, 'new name')
             primary_label = 'new name'
 
         # then load only the matching error extension; it should auto-associate
         # with the already-loaded science extension
-        self.ldr.importer.extension = 'ERR,2'
-        self.ldr.load()
+        ldr.importer.extension = 'ERR,2'
+        ldr.load()
 
-        assert len(self.dcf_helper.viewers['Image'].data_menu.data_labels_loaded) == 2
-        assert self.dcf_helper._app._get_assoc_data_parent('Image[ERR,2]') == primary_label
-        assert self.dcf_helper._app._get_assoc_data_children(primary_label) == ['Image[ERR,2]']
+        assert len(dcf_helper.viewers['Image'].data_menu.data_labels_loaded) == 2
+        assert dcf_helper._app._get_assoc_data_parent('Image[ERR,2]') == primary_label
+        assert dcf_helper._app._get_assoc_data_children(primary_label) == ['Image[ERR,2]']
 
         # This should raise 'Data labels {unavailable} not able to be loaded...'
         # if parent child association doesn't work correctly (i.e. the previous behavior)
-        self.dcf_helper.viewers['Image'].data_menu.add_data('Image[ERR,2]')
+        dcf_helper.viewers['Image'].data_menu.add_data('Image[ERR,2]')
 
     # TODO: Remove skip once this behavior is fixed
     @pytest.skip
-    def test_load_unload_parenting_behavior(self, deconfigged_helper):
-        # Default parent selection is 'auto'
-        self.ldr.importer.extension = ['SCI,1', 'ERR,1']
-        self.ldr.load()
+    def test_load_unload_parenting_behavior(self):
+        ldr = self.ldr
+        dcf_helper = self.dcf_helper
 
-        dm = self.dcf_helper.viewers['Image'].data_menu
+        # Default parent selection is 'auto'
+        ldr.importer.extension = ['SCI,1', 'ERR,1']
+        ldr.load()
+
+        dm = dcf_helper.viewers['Image'].data_menu
         dm.layer = ['Image[ERR,1]']
         dm.remove_from_app()
 
-        self.ldr.importer.extension = 'ERR,1'
-        self.ldr.importer.parent = 'None'
-        self.ldr.load()
+        ldr.importer.extension = 'ERR,1'
+        ldr.importer.parent = 'None'
+        ldr.load()
 
-        assert self.dcf_helper._app._get_assoc_data_parent('Image[ERR,1]') is None
-        assert self.dcf_helper._app._get_assoc_data_children('Image[SCI,1]') == []
+        assert dcf_helper._app._get_assoc_data_parent('Image[ERR,1]') is None
+        assert dcf_helper._app._get_assoc_data_children('Image[SCI,1]') == []
 
 
 def test_load_image_align_by(deconfigged_helper, image_nddata_wcs):

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -878,7 +878,7 @@ class TestParenting:
         dcf_helper.viewers['Image'].data_menu.add_data('Image[ERR,2]')
 
     # TODO: Remove skip once this behavior is fixed
-    @pytest.skip
+    @pytest.mark.skip
     def test_load_unload_parenting_behavior(self):
         ldr = self.ldr
         dcf_helper = self.dcf_helper

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -832,7 +832,8 @@ class TestParenting:
             assert deconfigged_helper._app._get_assoc_data_parent(label) is None
             assert deconfigged_helper._app._get_assoc_data_children(label) == []
 
-    def test_load_image_auto_parent_existing_in_dc(self, deconfigged_helper):
+    @pytest.mark.parametrize('rename', (False, True))
+    def test_load_image_auto_parent_existing_in_dc(self, deconfigged_helper, rename):
         # 'Auto' should associate a child extension loaded later with a matching
         # science extension that is already in the data collection (matched by hash)
         hdul = _make_multi_sci_hdul()
@@ -843,16 +844,23 @@ class TestParenting:
         ldr.importer.extension = 'SCI,2'
         ldr.load()
 
-        assert [d.label for d in deconfigged_helper._app.data_collection] == ['Image[SCI,2]']
-        assert deconfigged_helper._app._get_assoc_data_children('Image[SCI,2]') == []
+        primary_label = 'Image[SCI,2]'
+
+        assert [d.label for d in deconfigged_helper._app.data_collection] == [primary_label]
+        assert deconfigged_helper._app._get_assoc_data_children(primary_label) == []
+
+        # Now test with a rename in-between
+        if rename:
+            deconfigged_helper.viewers['Image'].data_menu.rename(primary_label, 'new name')
+            primary_label = 'new name'
 
         # then load only the matching error extension; it should auto-associate
         # with the already-loaded science extension
         ldr.importer.extension = 'ERR,2'
         ldr.load()
 
-        assert deconfigged_helper._app._get_assoc_data_parent('Image[ERR,2]') == 'Image[SCI,2]'
-        assert deconfigged_helper._app._get_assoc_data_children('Image[SCI,2]') == ['Image[ERR,2]']
+        assert deconfigged_helper._app._get_assoc_data_parent('Image[ERR,2]') == primary_label
+        assert deconfigged_helper._app._get_assoc_data_children(primary_label) == ['Image[ERR,2]']
 
 
 def test_load_image_align_by(deconfigged_helper, image_nddata_wcs):

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -801,73 +801,91 @@ def test_loaders_extension_select(imviz_helper):
 
 class TestParenting:
 
-    def test_load_image_parent_default_auto(self, deconfigged_helper):
+    @pytest.fixture(autouse=True)
+    def _setup(self, deconfigged_helper):
+        self.dcf_helper = deconfigged_helper
+        self.ldr = deconfigged_helper.loaders['object']
+        self.ldr.object = _make_multi_sci_hdul()
+
+    def test_load_image_parent_default_auto(self):
         # the default parent selection should be 'Auto'
-        ldr = deconfigged_helper.loaders['object']
-        ldr.object = _make_multi_sci_hdul()
-        assert ldr.importer.parent.selected == 'Auto'
-        assert 'Auto' in ldr.importer.parent.choices
-        assert 'None' in ldr.importer.parent.choices
+        assert self.ldr.importer.parent.selected == 'Auto'
+        assert 'Auto' in self.ldr.importer.parent.choices
+        assert 'None' in self.ldr.importer.parent.choices
 
-        ldr.importer.extension = ['SCI,1', 'ERR,1', 'SCI,2', 'ERR,2']
-        ldr.load()
+        self.ldr.importer.extension = ['SCI,1', 'ERR,1', 'SCI,2', 'ERR,2']
+        self.ldr.load()
 
-        assert len(deconfigged_helper._app.data_collection) == 4
-        assert len(deconfigged_helper.viewers['Image'].data_menu.data_labels_loaded) == 4
-        assert deconfigged_helper._app._get_assoc_data_parent('Image[ERR,1]') == 'Image[SCI,1]'
-        assert deconfigged_helper._app._get_assoc_data_children('Image[SCI,1]') == ['Image[ERR,1]']
+        assert len(self.dcf_helper._app.data_collection) == 4
+        assert len(self.dcf_helper.viewers['Image'].data_menu.data_labels_loaded) == 4
+        assert self.dcf_helper._app._get_assoc_data_parent('Image[ERR,1]') == 'Image[SCI,1]'
+        assert self.dcf_helper._app._get_assoc_data_children('Image[SCI,1]') == ['Image[ERR,1]']
 
-        assert deconfigged_helper._app._get_assoc_data_parent('Image[ERR,2]') == 'Image[SCI,2]'
-        assert deconfigged_helper._app._get_assoc_data_children('Image[SCI,2]') == ['Image[ERR,2]']
+        assert self.dcf_helper._app._get_assoc_data_parent('Image[ERR,2]') == 'Image[SCI,2]'
+        assert self.dcf_helper._app._get_assoc_data_children('Image[SCI,2]') == ['Image[ERR,2]']
 
-    def test_load_image_parent_none(self, deconfigged_helper):
+    def test_load_image_parent_none(self):
         # 'None' should prevent any parenting, even with multiple extensions
-        ldr = deconfigged_helper.loaders['object']
-        ldr.object = _make_multi_sci_hdul()
-        ldr.importer.extension = ['SCI,1', 'ERR,1', 'SCI,2', 'ERR,2']
-        ldr.importer.parent = 'None'
-        ldr.load()
+        self.ldr.importer.extension = ['SCI,1', 'ERR,1', 'SCI,2', 'ERR,2']
+        self.ldr.importer.parent = 'None'
+        self.ldr.load()
 
-        assert len(deconfigged_helper._app.data_collection) == 4
-        assert len(deconfigged_helper.viewers['Image'].data_menu.data_labels_loaded) == 4
+        assert len(self.dcf_helper._app.data_collection) == 4
+        assert len(self.dcf_helper.viewers['Image'].data_menu.data_labels_loaded) == 4
         for label in ('Image[SCI,1]', 'Image[ERR,1]', 'Image[SCI,2]', 'Image[ERR,2]'):
-            assert deconfigged_helper._app._get_assoc_data_parent(label) is None
-            assert deconfigged_helper._app._get_assoc_data_children(label) == []
+            assert self.dcf_helper._app._get_assoc_data_parent(label) is None
+            assert self.dcf_helper._app._get_assoc_data_children(label) == []
 
     @pytest.mark.parametrize('rename', (False, True))
-    def test_load_image_auto_parent_existing_in_dc(self, deconfigged_helper, rename):
-        # 'Auto' should associate a child extension loaded later with a matching
-        # science extension that is already in the data collection (matched by hash)
-        hdul = _make_multi_sci_hdul()
-
+    def test_load_image_auto_parent_existing_in_dc(self, rename):
+        """
+        'Auto' should associate a child extension loaded later with a matching
+        science extension that is already in the data collection (matched by hash)
+        """
         # first load only the science extension
-        ldr = deconfigged_helper.loaders['object']
-        ldr.object = hdul
-        ldr.importer.extension = 'SCI,2'
-        ldr.load()
+        self.ldr.importer.extension = 'SCI,2'
+        self.ldr.load()
 
         primary_label = 'Image[SCI,2]'
 
-        assert [d.label for d in deconfigged_helper._app.data_collection] == [primary_label]
-        assert deconfigged_helper._app._get_assoc_data_children(primary_label) == []
+        assert [d.label for d in self.dcf_helper._app.data_collection] == [primary_label]
+        assert self.dcf_helper._app._get_assoc_data_children(primary_label) == []
 
         # Now test with a rename in-between
         if rename:
-            deconfigged_helper.viewers['Image'].data_menu.rename(primary_label, 'new name')
+            self.dcf_helper.viewers['Image'].data_menu.rename(primary_label, 'new name')
             primary_label = 'new name'
 
         # then load only the matching error extension; it should auto-associate
         # with the already-loaded science extension
-        ldr.importer.extension = 'ERR,2'
-        ldr.load()
+        self.ldr.importer.extension = 'ERR,2'
+        self.ldr.load()
 
-        assert len(deconfigged_helper.viewers['Image'].data_menu.data_labels_loaded) == 2
-        assert deconfigged_helper._app._get_assoc_data_parent('Image[ERR,2]') == primary_label
-        assert deconfigged_helper._app._get_assoc_data_children(primary_label) == ['Image[ERR,2]']
+        assert len(self.dcf_helper.viewers['Image'].data_menu.data_labels_loaded) == 2
+        assert self.dcf_helper._app._get_assoc_data_parent('Image[ERR,2]') == primary_label
+        assert self.dcf_helper._app._get_assoc_data_children(primary_label) == ['Image[ERR,2]']
 
         # This should raise 'Data labels {unavailable} not able to be loaded...'
         # if parent child association doesn't work correctly (i.e. the previous behavior)
-        deconfigged_helper.viewers['Image'].data_menu.add_data('Image[ERR,2]')
+        self.dcf_helper.viewers['Image'].data_menu.add_data('Image[ERR,2]')
+
+    # TODO: Remove skip once this behavior is fixed
+    @pytest.skip
+    def test_load_unload_parenting_behavior(self, deconfigged_helper):
+        # Default parent selection is 'auto'
+        self.ldr.importer.extension = ['SCI,1', 'ERR,1']
+        self.ldr.load()
+
+        dm = self.dcf_helper.viewers['Image'].data_menu
+        dm.layer = ['Image[ERR,1]']
+        dm.remove_from_app()
+
+        self.ldr.importer.extension = 'ERR,1'
+        self.ldr.importer.parent = 'None'
+        self.ldr.load()
+
+        assert self.dcf_helper._app._get_assoc_data_parent('Image[ERR,1]') is None
+        assert self.dcf_helper._app._get_assoc_data_children('Image[SCI,1]') == []
 
 
 def test_load_image_align_by(deconfigged_helper, image_nddata_wcs):

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -875,11 +875,13 @@ class TestParenting:
 
         # This should raise 'Data labels {unavailable} not able to be loaded...'
         # if parent child association doesn't work correctly (i.e. the previous behavior)
+        # TODO: Remove this if we decide to prevent users from removing child data from viewers
         dcf_helper.viewers['Image'].data_menu.add_data('Image[ERR,2]')
 
     # TODO: Remove skip once this behavior is fixed
     @pytest.mark.skip
-    def test_load_unload_parenting_behavior(self):
+    @pytest.mark.parametrize('remove_from', ('viewer', 'app'))
+    def test_load_unload_parenting_behavior(self, remove_from):
         ldr = self.ldr
         dcf_helper = self.dcf_helper
 
@@ -887,13 +889,23 @@ class TestParenting:
         ldr.importer.extension = ['SCI,1', 'ERR,1']
         ldr.load()
 
-        dm = dcf_helper.viewers['Image'].data_menu
-        dm.layer = ['Image[ERR,1]']
-        dm.remove_from_app()
-
+        # Get ready for the next round
         ldr.importer.extension = 'ERR,1'
         ldr.importer.parent = 'None'
-        ldr.load()
+
+        dm = dcf_helper.viewers['Image'].data_menu
+        dm.layer = ['Image[ERR,1]']
+
+        if remove_from == 'viewer':
+            # Remove from viewer and use data_menu.add_data
+            # TODO: remove this and the parametrization if we decide to
+            #  prevent users from removing child data from viewers (keep remove_from_app though)
+            dm.remove_from_viewer()
+            dm.add_data('Image[ERR,1]')
+        else:
+            # Remove from app and load again
+            dm.remove_from_app()
+            ldr.load()
 
         assert dcf_helper._app._get_assoc_data_parent('Image[ERR,1]') is None
         assert dcf_helper._app._get_assoc_data_children('Image[SCI,1]') == []

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -813,6 +813,7 @@ class TestParenting:
         ldr.load()
 
         assert len(deconfigged_helper._app.data_collection) == 4
+        assert len(deconfigged_helper.viewers['Image'].data_menu.data_labels_loaded) == 4
         assert deconfigged_helper._app._get_assoc_data_parent('Image[ERR,1]') == 'Image[SCI,1]'
         assert deconfigged_helper._app._get_assoc_data_children('Image[SCI,1]') == ['Image[ERR,1]']
 
@@ -828,6 +829,7 @@ class TestParenting:
         ldr.load()
 
         assert len(deconfigged_helper._app.data_collection) == 4
+        assert len(deconfigged_helper.viewers['Image'].data_menu.data_labels_loaded) == 4
         for label in ('Image[SCI,1]', 'Image[ERR,1]', 'Image[SCI,2]', 'Image[ERR,2]'):
             assert deconfigged_helper._app._get_assoc_data_parent(label) is None
             assert deconfigged_helper._app._get_assoc_data_children(label) == []
@@ -859,8 +861,13 @@ class TestParenting:
         ldr.importer.extension = 'ERR,2'
         ldr.load()
 
+        assert len(deconfigged_helper.viewers['Image'].data_menu.data_labels_loaded) == 2
         assert deconfigged_helper._app._get_assoc_data_parent('Image[ERR,2]') == primary_label
         assert deconfigged_helper._app._get_assoc_data_children(primary_label) == ['Image[ERR,2]']
+
+        # This should raise 'Data labels {unavailable} not able to be loaded...'
+        # if parent child association doesn't work correctly (i.e. the previous behavior)
+        deconfigged_helper.viewers['Image'].data_menu.add_data('Image[ERR,2]')
 
 
 def test_load_image_align_by(deconfigged_helper, image_nddata_wcs):

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -747,16 +747,23 @@ def test_freq_wavelength_linking(deconfigged_helper, spectrum1d):
     assert len(deconfigged_helper._app.data_collection.external_links) == 4
 
 
+def _make_multi_sci_hdul():
+    sci1 = np.ones((2, 2), dtype=np.float32)
+    err1 = np.full((2, 2), 2, dtype=np.float32)
+    sci2 = np.full((2, 2), 3, dtype=np.float32)
+    err2 = np.full((2, 2), 4, dtype=np.float32)
+    return fits.HDUList([fits.PrimaryHDU(),
+                         fits.ImageHDU(sci1, name='SCI', ver=1),
+                         fits.ImageHDU(err1, name='ERR', ver=1),
+                         fits.ImageHDU(sci2, name='SCI', ver=2),
+                         fits.ImageHDU(err2, name='ERR', ver=2)
+                         ])
+
+
 def test_load_image_mult_sci_extension(imviz_helper):
     # test loading an image with multiple SCI extensions and
     # ensure that automatic parenting logic is handled correctly
-    arr = np.zeros((2, 2), dtype=np.float32)
-    hdul = fits.HDUList([fits.PrimaryHDU(),
-                        fits.ImageHDU(arr, name='SCI', ver=1),
-                        fits.ImageHDU(arr, name='ERR', ver=1),
-                        fits.ImageHDU(arr, name='SCI', ver=2),
-                        fits.ImageHDU(arr, name='ERR', ver=2)
-                         ])
+    hdul = _make_multi_sci_hdul()
 
     # imviz_helper._load(hdul, extension=('SCI,1', 'SCI,2', 'ERR,2'))
     imviz_helper.load_data(hdul, ext=('SCI,1', 'SCI,2', 'ERR,2'))
@@ -771,13 +778,7 @@ def test_load_image_mult_sci_extension(imviz_helper):
 
 def test_loaders_extension_select(imviz_helper):
     # tests internal logic of SelectFileExtensionComponent
-    arr = np.zeros((2, 2), dtype=np.float32)
-    hdul = fits.HDUList([fits.PrimaryHDU(),
-                        fits.ImageHDU(arr, name='SCI', ver=1),
-                        fits.ImageHDU(arr, name='ERR', ver=1),
-                        fits.ImageHDU(arr, name='SCI', ver=2),
-                        fits.ImageHDU(arr, name='ERR', ver=2)
-                         ])
+    hdul = _make_multi_sci_hdul()
 
     ldr = imviz_helper.loaders['object']
     ldr.object = hdul
@@ -796,6 +797,62 @@ def test_loaders_extension_select(imviz_helper):
     # case of providing index
     ldr.importer.extension = [1, 3]
     assert ldr.importer.extension.selected == ['1: [SCI,1]', '3: [SCI,2]']
+
+
+class TestParenting:
+
+    def test_load_image_parent_default_auto(self, deconfigged_helper):
+        # the default parent selection should be 'Auto'
+        ldr = deconfigged_helper.loaders['object']
+        ldr.object = _make_multi_sci_hdul()
+        assert ldr.importer.parent.selected == 'Auto'
+        assert 'Auto' in ldr.importer.parent.choices
+        assert 'None' in ldr.importer.parent.choices
+
+        ldr.importer.extension = ['SCI,1', 'ERR,1', 'SCI,2', 'ERR,2']
+        ldr.load()
+
+        assert len(deconfigged_helper._app.data_collection) == 4
+        assert deconfigged_helper._app._get_assoc_data_parent('Image[ERR,1]') == 'Image[SCI,1]'
+        assert deconfigged_helper._app._get_assoc_data_children('Image[SCI,1]') == ['Image[ERR,1]']
+
+        assert deconfigged_helper._app._get_assoc_data_parent('Image[ERR,2]') == 'Image[SCI,2]'
+        assert deconfigged_helper._app._get_assoc_data_children('Image[SCI,2]') == ['Image[ERR,2]']
+
+    def test_load_image_parent_none(self, deconfigged_helper):
+        # 'None' should prevent any parenting, even with multiple extensions
+        ldr = deconfigged_helper.loaders['object']
+        ldr.object = _make_multi_sci_hdul()
+        ldr.importer.extension = ['SCI,1', 'ERR,1', 'SCI,2', 'ERR,2']
+        ldr.importer.parent = 'None'
+        ldr.load()
+
+        assert len(deconfigged_helper._app.data_collection) == 4
+        for label in ('Image[SCI,1]', 'Image[ERR,1]', 'Image[SCI,2]', 'Image[ERR,2]'):
+            assert deconfigged_helper._app._get_assoc_data_parent(label) is None
+            assert deconfigged_helper._app._get_assoc_data_children(label) == []
+
+    def test_load_image_auto_parent_existing_in_dc(self, deconfigged_helper):
+        # 'Auto' should associate a child extension loaded later with a matching
+        # science extension that is already in the data collection (matched by hash)
+        hdul = _make_multi_sci_hdul()
+
+        # first load only the science extension
+        ldr = deconfigged_helper.loaders['object']
+        ldr.object = hdul
+        ldr.importer.extension = 'SCI,2'
+        ldr.load()
+
+        assert [d.label for d in deconfigged_helper._app.data_collection] == ['Image[SCI,2]']
+        assert deconfigged_helper._app._get_assoc_data_children('Image[SCI,2]') == []
+
+        # then load only the matching error extension; it should auto-associate
+        # with the already-loaded science extension
+        ldr.importer.extension = 'ERR,2'
+        ldr.load()
+
+        assert deconfigged_helper._app._get_assoc_data_parent('Image[ERR,2]') == 'Image[SCI,2]'
+        assert deconfigged_helper._app._get_assoc_data_children('Image[SCI,2]') == ['Image[ERR,2]']
 
 
 def test_load_image_align_by(deconfigged_helper, image_nddata_wcs):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address parenting behavior. It: 

- [x] adds "None" as an option in the parent dropdown to prevent parenting when it's not desired
- [x] updates 'auto' behavior to automatically associate new data with data already in the app (if possible)
- [x] updates the description in the UI -- the ticket requested a mention of blinking but the text is long as-is
- [x] adds test coverage
- [x] updates the docs with info about parenting