### PR TITLE
Fix compass orientation when WCS linked

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,8 @@ Bug Fixes
 - Update docs to reflect new minimum version of Python (>=3.12). Recommend Python 3.13
   to implicitly reflect testing environments. [#4240]
 
+- Fixed a bug in the compass plugin where the image would be flipped when WCS linked. [#4252]
+
 Mosviz
 
 

--- a/jdaviz/configs/imviz/plugins/compass/compass.py
+++ b/jdaviz/configs/imviz/plugins/compass/compass.py
@@ -30,7 +30,6 @@ class Compass(PluginTemplateMixin, ViewerSelectMixin):
     icon = Unicode("").tag(sync=True)
     data_label = Unicode("").tag(sync=True)
     img_data = Unicode("").tag(sync=True)
-    flip_horizontal = Bool(False).tag(sync=True)  # set by canvas rotation plugin
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/jdaviz/configs/imviz/plugins/compass/compass.vue
+++ b/jdaviz/configs/imviz/plugins/compass/compass.vue
@@ -23,25 +23,10 @@
       </v-chip>
     </v-row>
 
-    <img class='invert-in-dark' v-if="img_data" :src="`data:image/png;base64,${img_data}`" :style="'width: 100%; max-width: 400px; margin-top: 50px; transform: rotateY('+viewer_rotateY(flip_horizontal)+')'" />
+    <img class='invert-in-dark' v-if="img_data" :src="`data:image/png;base64,${img_data}`" :style="'width: 100%; max-width: 400px; margin-top: 50px'" />
 
   </j-tray-plugin>
 </template>
-
-<script>
-module.exports = {
-  methods: {
-    viewer_rotateY(flip_horizontal) {
-      if (flip_horizontal) {
-        return '180deg'
-      } else {
-        return '0deg'
-      }
-    }
-  }
-};
-</script>
-
 
 <style>
 .theme--dark .invert-in-dark {

--- a/jdaviz/configs/imviz/wcs_utils.py
+++ b/jdaviz/configs/imviz/wcs_utils.py
@@ -487,14 +487,6 @@ def _get_rotated_nddata_from_label(
         lat_axis = wcs.wcs.lat
         lon_axis = wcs.wcs.lng
 
-    if (
-        not has_east_left and target_wcs_east_left and
-        'imviz-compass' in [item['name'] for item in app.state.tray_items]
-    ):
-        # if an east/west flip is necessary, pass that along to the compass:
-        compass_plugin = app.get_tray_item_from_name('imviz-compass')
-        compass_plugin.flip_horizontal = not compass_plugin.flip_horizontal
-
     if cdelt_signs is None:
         cdelt_signs = [None, None]
         cdelt_signs[lon_axis] = (


### PR DESCRIPTION
When WCS linked, the compass plugin shows a flipped image. This is due to some deprecated canvas rotation code (`flip_horizontal` traitlet), removed in this PR.

On main,
<img width="346" height="385" alt="Screenshot 2026-06-22 at 9 29 03 AM" src="https://github.com/user-attachments/assets/6ecd2d79-f5dc-4bd2-ae9f-4b98a864fee6" />

with the fix,
<img width="346" height="385" alt="Screenshot 2026-06-22 at 9 29 24 AM" src="https://github.com/user-attachments/assets/5ead7b3e-5671-412f-b01f-51a66337b01c" />

