### PR TITLE
Fix VO/Astroquery invalid msg issue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,9 +91,12 @@ Bug Fixes
 
 - Fix treating input tables as queries and add support for exports from MAST portal. [#4234]
 
+- Fixed a bug with the astroquery/VO loaders where the loader would get stuck on a failed query. [#4257]
+
 
 Mosviz
 ------
+
 
 5.0.2 (2026-06-12)
 ==================

--- a/jdaviz/components/loader.vue
+++ b/jdaviz/components/loader.vue
@@ -155,16 +155,18 @@
             />
           </j-flex-row>
 
-          <j-flex-row v-if="parsed_input_is_empty">
-            <v-alert type="warning" style="margin-right: -12px; width: 100%">
-                Input is empty.
-            </v-alert>
-          </j-flex-row>
           <j-flex-row v-if="parsed_input_not_resolvable_message">
             <v-alert type="warning" style="margin-right: -12px; width: 100%">
                 Input cannot be resolved: {{ parsed_input_not_resolvable_message }}
             </v-alert>
           </j-flex-row>
+
+          <j-flex-row v-if="parsed_input_is_empty">
+            <v-alert type="warning" style="margin-right: -12px; width: 100%">
+                Input is empty.
+            </v-alert>
+          </j-flex-row>
+
           <j-flex-row v-else-if="!parsed_input_is_query && format_items.length == 0 && valid_import_formats">
               <v-alert type="warning" style="margin-right: -12px; width: 100%">
                   No compatible importer found. Supported input types include: {{ valid_import_formats }}.

--- a/jdaviz/core/loaders/resolvers/astroquery/astroquery.vue
+++ b/jdaviz/core/loaders/resolvers/astroquery/astroquery.vue
@@ -5,7 +5,6 @@
     :spinner="spinner"
     :spinner_success_message="spinner_success_message"
     :parsed_input_is_empty="parsed_input_is_empty"
-    :parsed_input_not_resolvable_message="parsed_input_not_resolvable_message"
     :parsed_input_is_query="parsed_input_is_query"
     v-model:treat_table_as_query="treat_table_as_query"
     v-model:limit_to_science_products="limit_to_science_products"

--- a/jdaviz/core/loaders/resolvers/astroquery/astroquery.vue
+++ b/jdaviz/core/loaders/resolvers/astroquery/astroquery.vue
@@ -62,7 +62,6 @@
             hint="Enter a source name or coordinates in degrees to center your query on"
             :disabled="viewer_selected !== 'Manual'"
             :rules="[() => !!source || 'This field is required']"
-            :error-messages="parsed_input_not_resolvable_message ? [parsed_input_not_resolvable_message] : []"
             persistent-hint>
           </v-text-field>
         </div>

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -741,7 +741,7 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
         self.observation_table_populated = False
         self.file_table_populated = False
         self.parsed_input_not_resolvable_message = ''
-        
+
         self._update_format_items()
 
     @cached_property

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -712,6 +712,7 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
                 self.parsed_input_is_query = True
                 self.observation_table_populated = True
                 self.file_table_populated = False
+                self.parsed_input_not_resolvable_message = ''
                 return
 
             elif self.treat_table_as_query and observation_table is not None:
@@ -730,9 +731,10 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
                 self.parsed_input_is_query = True
                 self.observation_table_populated = True
                 self.file_table_populated = False
+                self.parsed_input_is_resolvable = ''
                 return
 
-        self.parsed_input_not_resolvable_message = ""
+        self.parsed_input_not_resolvable_message = ''
         self.parsed_input_is_empty = False
         self.parsed_input_is_query = False
         self.observation_table_populated = False

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -632,10 +632,11 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
             self.parsed_input_is_query = False
             self.observation_table_populated = False
             self.file_table_populated = False
+            self.parsed_input_not_resolvable_message = str(e)
+
             self.observation_table._clear_table()
             self.file_table._clear_table()
             self._update_format_items()
-            self.parsed_input_not_resolvable_message = str(e)
             return
 
         if parsed_input is None or getattr(parsed_input, '__len__', lambda: 1)() == 0:
@@ -643,10 +644,11 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
             self.parsed_input_is_query = False
             self.observation_table_populated = False
             self.file_table_populated = False
+            self.parsed_input_not_resolvable_message = 'Parsed input is empty or None, cannot resolve.'  # noqa
+
             self.observation_table._clear_table()
             self.file_table._clear_table()
             self._update_format_items()
-            self.parsed_input_not_resolvable_message = 'Parsed input is empty or None, cannot resolve.' # noqa
             return
 
         # first attempt to parse the input as a table
@@ -677,6 +679,7 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
                 self.observation_table_populated = False
                 self.file_table_populated = False
                 self.parsed_input_not_resolvable_message = ''
+
                 self.observation_table._clear_table()
                 self.file_table._clear_table()
                 self._update_format_items()
@@ -738,6 +741,7 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
         self.observation_table_populated = False
         self.file_table_populated = False
         self.parsed_input_not_resolvable_message = ''
+        
         self._update_format_items()
 
     @cached_property

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -672,11 +672,11 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
             if is_query and not self.treat_table_as_query:
                 # Keep parsed_input_is_query True so the toggle switch stays visible.
                 # Set everything else in the meantime.
-                self.parsed_input_not_resolvable_message = ''
                 self.parsed_input_is_empty = False
                 self.parsed_input_is_query = True
                 self.observation_table_populated = False
                 self.file_table_populated = False
+                self.parsed_input_not_resolvable_message = ''
                 self.observation_table._clear_table()
                 self.file_table._clear_table()
                 self._update_format_items()
@@ -695,11 +695,11 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
 
                     # Technically input isn't complete yet but if we don't set this now
                     # the UI will appear bugged with the 'input is empty' message for astroquery
-                    self.parsed_input_not_resolvable_message = ''
                     self.parsed_input_is_empty = False
                     self.parsed_input_is_query = True
                     self.observation_table_populated = False
                     self.file_table_populated = True
+                    self.parsed_input_not_resolvable_message = ''
                     return
 
                 for row in observation_table:
@@ -726,19 +726,18 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
                                                           if h not in ['s_region']]
 
                 # See 'input is empty' comment above
-                self.parsed_input_not_resolvable_message = ''
                 self.parsed_input_is_empty = False
                 self.parsed_input_is_query = True
                 self.observation_table_populated = True
                 self.file_table_populated = False
-                self.parsed_input_is_resolvable = ''
+                self.parsed_input_not_resolvable_message = ''
                 return
 
-        self.parsed_input_not_resolvable_message = ''
         self.parsed_input_is_empty = False
         self.parsed_input_is_query = False
         self.observation_table_populated = False
         self.file_table_populated = False
+        self.parsed_input_not_resolvable_message = ''
         self._update_format_items()
 
     @cached_property

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.vue
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.vue
@@ -68,7 +68,6 @@
             hint="Enter a source name or coordinates in degrees to center your query on"
             :disabled="viewer_selected !== 'Manual'"
             :rules="[() => !!source || 'This field is required']"
-            :error-messages="parsed_input_not_resolvable_message ? [parsed_input_not_resolvable_message] : []"
             persistent-hint>
           </v-text-field>
         </div>

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.vue
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.vue
@@ -5,7 +5,6 @@
     :spinner="spinner"
     :spinner_success_message="spinner_success_message"
     :parsed_input_is_empty="parsed_input_is_empty"
-    :parsed_input_not_resolvable_message="parsed_input_not_resolvable_message"
     :parsed_input_is_query="parsed_input_is_query"
     v-model:treat_table_as_query="treat_table_as_query"
     :observation_table="observation_table"


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address an issue where failed queries lock the source selection UI in an unusable state. This is due to a variable `parsed_input_not_resolvable_message` not being reset properly. 

This PR:

- prevents the locked state by moving the error from `ldr.source` to the warning banner in the importer (adjusted to be above 'input is empty')
- correctly resets `parsed_input_not_resolvable_message` on a successful query

Follow-up effort will address warning/error disparities between VO (snackbars + banner) and astroquery (just the banner)

The new banner style can be seen in this screenshot. Note: vue3

<img width="359" height="676" alt="Screenshot 2026-06-24 at 4 58 21 PM" src="https://github.com/user-attachments/assets/c5ec3d6f-4fca-4fd1-92da-32c42a2555ff" />