### PR TITLE
View table subsets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,7 +29,7 @@ New Features
   top of the loader window when fetching files from selected footprints. Success
   messages auto-dismiss after 4 seconds and a progress indicator appears on the file
   table during loading. [#4203]
-  
+
 - Fix issue in Line Lists where a new custom line was not plotted at the redshifted wavelength. [#4224]
 
 - Fix issue where erase_spectral_lines() permanently set 'show' to False for all lines, with new option to
@@ -39,6 +39,8 @@ New Features
   and catalog targets. [#4060]
 
 - Add "set layer to top" button in plot options. [#4218]
+
+- Show basic table subset information in the Subset Tools plugin. [#4266]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -620,9 +620,7 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
                 n_rows_selected = len(subset_state.indices)
                 subset_type = "Table Selection"
                 subset_definition = [{"name": "Selected rows", "att": "indices",
-                                      "value": subset_state.indices},
-                                      {"name": "n_selected_rows", "att": None,
-                                       "value": n_rows_selected}]
+                                      "value": f'Selected {n_rows_selected} rows from table:\n {subset_state.indices}'},]
 
             if len(subset_definition) > 0:
                 # Note: .append() does not work for List traitlet.

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -11,7 +11,7 @@ from glue.core.edit_subset_mode import (AndMode, AndNotMode, OrMode,
                                         ReplaceMode, XorMode, NewMode)
 from glue.core.roi import CircularROI, CircularAnnulusROI, EllipticalROI, RectangularROI
 from glue.core.subset import (RoiSubsetState, RangeSubsetState, CompositeSubsetState,
-                              MaskSubsetState)
+                              MaskSubsetState, ElementSubsetState)
 from glue.icons import icon_path
 from glue_jupyter.widgets.subset_mode_vuetify import SelectionModeMenu
 from glue_jupyter.common.toolbar_vuetify import read_icon
@@ -615,6 +615,14 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
                                       "value": total_masked,
                                       "orig": total_masked}]
                 subset_type = "Mask"
+
+            elif isinstance(subset_state, ElementSubsetState):
+                n_rows_selected = len(subset_state.indices)
+                subset_type = "Table Selection"
+                subset_definition = [{"name": "selected rows", "att": "indices",
+                                      "value": subset_state.indices},
+                                      {"name": "n_selected_rows", "att": None,
+                                       "value": n_rows_selected}]
 
             if len(subset_definition) > 0:
                 # Note: .append() does not work for List traitlet.

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -619,7 +619,7 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
             elif isinstance(subset_state, ElementSubsetState):
                 n_rows_selected = len(subset_state.indices)
                 subset_type = "Table Selection"
-                subset_definition = [{"name": "selected rows", "att": "indices",
+                subset_definition = [{"name": "Selected rows", "att": "indices",
                                       "value": subset_state.indices},
                                       {"name": "n_selected_rows", "att": None,
                                        "value": n_rows_selected}]

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -619,8 +619,9 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
             elif isinstance(subset_state, ElementSubsetState):
                 n_rows_selected = len(subset_state.indices)
                 subset_type = "Table Selection"
+                val_str = f'Selected {n_rows_selected} rows from table:\n {subset_state.indices}'
                 subset_definition = [{"name": "Selected rows", "att": "indices",
-                                      "value": f'Selected {n_rows_selected} rows from table:\n {subset_state.indices}'},]
+                                      "value": val_str},]
 
             if len(subset_definition) > 0:
                 # Note: .append() does not work for List traitlet.

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.vue
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.vue
@@ -149,15 +149,10 @@
             persistent-hint
           ></v-text-field>
         </j-flex-row>
-        <j-flex-row v-else-if="item.name === 'n_rows_selected' || item.name === 'Selected rows'" class="row-no-outside-padding">
-          <v-text-field
-            :label="item.name"
-            :value="item.value"
-            style="padding-top: 0px; margin-top: 0px; margin-bottom: 10px;"
-            :readonly="true"
-            :hint="item.name === 'Selected rows' ? 'Subset includes these rows from the table' : 'Number of rows in subset'"
-            persistent-hint
-          ></v-text-field>
+        <j-flex-row v-else-if="item.name === 'Selected rows'" class="row-no-outside-padding">
+          <div style="white-space: pre-line;">
+            {{ item.value }}
+          </div>
         </j-flex-row>
         <j-flex-row v-else class="row-no-outside-padding">
           <v-text-field

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.vue
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.vue
@@ -149,6 +149,16 @@
             persistent-hint
           ></v-text-field>
         </j-flex-row>
+        <j-flex-row v-else-if="item.name === 'n_rows_selected' || item.name === 'Selected rows'" class="row-no-outside-padding">
+          <v-text-field
+            :label="item.name"
+            :value="item.value"
+            style="padding-top: 0px; margin-top: 0px; margin-bottom: 10px;"
+            :readonly="true"
+            :hint="item.name === 'Selected rows' ? 'Subset includes these rows from the table' : 'Number of rows in subset'"
+            persistent-hint
+          ></v-text-field>
+        </j-flex-row>
         <j-flex-row v-else class="row-no-outside-padding">
           <v-text-field
             :label="api_hints_enabled ? 'plg.update_subset(\'' + subset_selected + '\', subregion=' + index + ', ' + item.att + '=' + item.value + ')' : item.name"


### PR DESCRIPTION
This shows some very basic non-editable information in the Subset Tools plugin for table subsets (just the number of rows selected and which rows those are). It could probably be prettier, I went back and forth a bit before settling on something very basic for now.