### PR TITLE
sidecar title 'deconfigged' -> 'jdaviz'

### DIFF
--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -31,7 +31,7 @@ from jdaviz.core.loaders.resolvers import find_matching_resolver
 from jdaviz.core.template_mixin import show_widget
 from jdaviz.core.user_api import (DataApi, SpectralDataApi, SpatialDataApi,
                                   TemporalSpatialDataApi, SpectralSpatialDataApi)
-from jdaviz.utils import (JDAVIZ_CONFIGS, data_has_valid_wcs, CONFIGS_WITH_LOADERS,
+from jdaviz.utils import (data_has_valid_wcs, CONFIGS_WITH_LOADERS,
                           suppress_widget_comms)
 from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
                                                check_if_unit_is_per_solid_angle,
@@ -486,7 +486,7 @@ class ConfigHelper(HubListener):
                                              model_label=model_label,
                                              x=x, y=y)
 
-    def show(self, loc="inline", title=None, height=None,
+    def show(self, loc="inline", title="jdaviz", height=None,
              tray=None):  # pragma: no cover
         """Display the Jdaviz application.
 
@@ -525,8 +525,7 @@ class ConfigHelper(HubListener):
                 * ``popout:tab`` (Opens Jdaviz in a new, detached tab in your browser)
 
         title : str, optional
-            The title of the sidecar tab.  Defaults to the name of the
-            application; e.g., "specviz".
+            The title of the sidecar tab.  Defaults to "jdaviz".
 
             NOTE: Only applicable to a "sidecar" display.
 
@@ -543,9 +542,6 @@ class ConfigHelper(HubListener):
         If "sidecar" is requested in the "classic" Jupyter notebook, the app will appear inline,
         as only JupyterLab has a mechanism to have multiple tabs.
         """
-        if title is None:
-            config = self._app.config
-            title = "jdaviz" if config not in JDAVIZ_CONFIGS else config
         if height is not None:
             if isinstance(height, int):
                 height = f"{height}px"


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description

Calls to `jdaviz.show('sidecar', title=None)` is designed to show the name of the config being displayed within the sidecar. The title used to be 'imviz', 'specviz', etc., but since 5.0 the title reads "deconfigged", which should not be user-facing language:
<img width="1192" height="714" alt="Screenshot 2026-07-01 at 09 40 43" src="https://github.com/user-attachments/assets/72746a8c-f470-4c35-8e18-f51dd98d7abe" />

This PR sets the default title to "jdaviz".
<img width="1358" height="713" alt="Screenshot 2026-07-01 at 10 17 07" src="https://github.com/user-attachments/assets/5607327e-72a5-4c42-aa0d-44346a28a14d" />

I'm considering this a bugfix because "deconfigged" shouldn't be there.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
