### PR TITLE
Backport PR #4278 on branch v5.0.x (Fix Python 3.14 ResourceWarning from unclosed HTTPError responses leaking into unrelated tests)

### DIFF
--- a/jdaviz/core/loaders/resolvers/url/test_url.py
+++ b/jdaviz/core/loaders/resolvers/url/test_url.py
@@ -1,0 +1,23 @@
+from jdaviz.core.loaders.resolvers.url.url import URLResolver
+
+
+def test_url_resolver_is_valid(deconfigged_helper):
+    """Test _check_is_valid for URLResolver: success and failure cases."""
+    resolver = URLResolver(app=deconfigged_helper._app)
+
+    # Success: valid scheme, not whitelisted restricted
+    resolver.url = 'https://mast.stsci.edu/data.fits'
+    resolver.url_scheme = 'https'
+    resolver.url_not_whitelisted = False
+    assert resolver._check_is_valid() == ''
+
+    # Failure: invalid URI scheme
+    resolver.url = 'foo://example.com/data.fits'
+    resolver.url_scheme = 'foo'
+    assert 'URI scheme must be one of' in resolver._check_is_valid()
+
+    # Failure: URI not whitelisted
+    resolver.url = 'http://not-a-real-whitelisted-domain.example.com/data.fits'
+    resolver.url_scheme = 'http'
+    resolver.url_not_whitelisted = True
+    assert resolver._check_is_valid() == 'URI is not whitelisted.'

--- a/jdaviz/core/loaders/resolvers/url/url.py
+++ b/jdaviz/core/loaders/resolvers/url/url.py
@@ -147,12 +147,20 @@ class PresetURLResolver(URLResolver):
         # which would attempt an eager download and leak SSL sockets.
         # Format detection happens lazily when first needed
         # (via load() or open_in_tray()).
+        # The _resolver_input_updated override below ensures no download
+        # happens until _ensure_format_detection() is called explicitly.
         with self.defer_resolver_input_updated():
             self.url = url
 
         if title is not None:
             self.title = title
         self.hide_resolver_inputs = True
+
+    def _resolver_input_updated(self, msg={}):
+        """Skip format detection until explicitly requested via _ensure_format_detection."""
+        if not self._format_detection_done:
+            return
+        super()._resolver_input_updated(msg=msg)
 
     def _ensure_format_detection(self):
         """Trigger format detection if not yet done."""

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -932,7 +932,14 @@ def download_uri_to_path(possible_uri, cache=None, local_path=os.curdir, timeout
         if local_path not in (os.curdir, None):
             warnings.warn(local_path_msg, UserWarning)
 
-        return download_file(possible_uri, cache=cache, timeout=timeout)
+        from urllib.error import HTTPError as UrllibHTTPError
+        try:
+            return download_file(possible_uri, cache=cache, timeout=timeout)
+        except UrllibHTTPError as e:
+            # Explicitly close the HTTP response body to prevent ResourceWarning
+            # in Python 3.14+ where unclosed HTTPError responses trigger warnings.
+            e.close()
+            raise
 
     elif parsed_uri.scheme == '':
         raise ValueError(f"The input file '{possible_uri}' cannot be parsed as a "


### PR DESCRIPTION
Backport PR #4278 to fix failing Python 3.14 HTTPError