### PR TITLE
Swap deconfigged_helper for config tests with viewers

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -90,8 +90,7 @@ def test_moment_calculation(deconfigged_helper, spectrum1d_cube,
         warnings.filterwarnings("ignore", message="No observer defined on WCS.*")
         deconfigged_helper.load(cube, data_label='test')
 
-    flux_viewer_ref = deconfigged_helper._app.get_viewer_reference_names()[0]
-    flux_viewer = deconfigged_helper._app.get_viewer(flux_viewer_ref)
+    flux_viewer = deconfigged_helper._app.get_viewer('3D Spectrum')
 
     # Since we are not really displaying, need this to trigger GUI stuff.
     flux_viewer.shape = (100, 100)
@@ -132,7 +131,7 @@ def test_moment_calculation(deconfigged_helper, spectrum1d_cube,
                                          "204.9998877673 27.0001000000 (deg)")
 
     # Make sure adding it to viewer does not crash.
-    deconfigged_helper._app.add_data_to_viewer(flux_viewer_ref, 'moment 0')
+    deconfigged_helper._app.add_data_to_viewer('3D Spectrum', 'moment 0')
 
     result = dc[-1].get_object(cls=CCDData)
     assert result.shape == (2, 4)  # Cube shape is (2, 2, 4), moment transposes
@@ -177,8 +176,7 @@ def test_moment_velocity_calculation(deconfigged_helper, spectrum1d_cube):
         warnings.filterwarnings("ignore", message="No observer defined on WCS.*")
         deconfigged_helper.load(spectrum1d_cube, data_label='test')
 
-    cube_viewer_ref = deconfigged_helper._app.get_viewer_reference_names()[0]
-    uncert_viewer = deconfigged_helper._app.get_viewer(cube_viewer_ref)
+    uncert_viewer = deconfigged_helper._app.get_viewer('3D Spectrum')
 
     # Since we are not really displaying, need this to trigger GUI stuff.
     uncert_viewer.shape = (100, 100)
@@ -189,7 +187,7 @@ def test_moment_velocity_calculation(deconfigged_helper, spectrum1d_cube):
 
     # Test moment 1 in velocity
     mm.n_moment = 1
-    mm.add_results.viewer = cube_viewer_ref
+    mm.add_results.viewer = '3D Spectrum'
     assert mm._obj.results_label == 'moment 1'
     mm.output_unit = "Velocity"
 
@@ -321,7 +319,7 @@ def test_momentmap_nirspec_prism(deconfigged_helper):
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        deconfigged_helper.load(cached_uri(uri), cache=True, format='3D Spectrum')
+        deconfigged_helper.load(cached_uri(uri), format='3D Spectrum')
     uc = deconfigged_helper.plugins["Unit Conversion"]
     uc.open_in_tray()  # plugin has to be open for unit change to take hold
     uc._obj.show_translator = True
@@ -432,8 +430,7 @@ def test_moment_zero_unit_flux_conversions(deconfigged_helper,
     mm = deconfigged_helper.plugins['Moment Maps']._obj
 
     # and flux viewer for mouseover info
-    flux_viewer_ref = deconfigged_helper._app.get_viewer_reference_names()[0]
-    flux_viewer = deconfigged_helper._app.get_viewer(flux_viewer_ref)
+    flux_viewer = deconfigged_helper._app.get_viewer('3D Spectrum')
     label_mouseover = deconfigged_helper._coords_info
 
     # convert to new flux unit
@@ -447,7 +444,7 @@ def test_moment_zero_unit_flux_conversions(deconfigged_helper,
 
     # calculate moment with new output label and plot in flux viewer
     mm.add_results.label = new_flux_unit_str
-    mm.add_results.viewer.selected = flux_viewer_ref
+    mm.add_results.viewer.selected = '3D Spectrum'
     mm.calculate_moment()
 
     assert mm.moment.unit == new_mm_unit

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -316,24 +316,24 @@ def test_write_momentmap(deconfigged_helper, spectrum1d_cube, tmp_path):
 
 
 @pytest.mark.remote_data
-def test_momentmap_nirspec_prism(cubeviz_helper):
+def test_momentmap_nirspec_prism(deconfigged_helper):
     uri = "mast:jwst/product/jw02732-o003_t002_nirspec_prism-clear_s3d.fits"
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        cubeviz_helper.load_data(cached_uri(uri), cache=True)
-    uc = cubeviz_helper.plugins["Unit Conversion"]
+        deconfigged_helper.load(cached_uri(uri), cache=True, format='3D Spectrum')
+    uc = deconfigged_helper.plugins["Unit Conversion"]
     uc.open_in_tray()  # plugin has to be open for unit change to take hold
     uc._obj.show_translator = True
     uc.spectral_y_type.selected = 'Surface Brightness'
-    mm = cubeviz_helper.plugins['Moment Maps']._obj
+    mm = deconfigged_helper.plugins['Moment Maps']._obj
     mm.open_in_tray()  # plugin has to be open for unit change to take hold
     mm._set_data_units()
     mm.calculate_moment()
     assert isinstance(mm.moment.wcs, WCS)
 
     sky_moment = mm.moment.wcs.pixel_to_world(50, 30)
-    sky_cube = cubeviz_helper._app.data_collection[0].coords.pixel_to_world(50, 30, 0)[0]  # noqa: E501
+    sky_cube = deconfigged_helper._app.data_collection[0].coords.pixel_to_world(50, 30, 0)[0]  # noqa: E501
     assert_allclose((sky_moment.ra.deg, sky_moment.dec.deg),
                     (sky_cube.ra.deg, sky_cube.dec.deg))
 

--- a/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
@@ -4,13 +4,13 @@ import pytest
 from jdaviz.configs.cubeviz.plugins.slice.slice import SpectralSlice
 
 
-def test_slice(cubeviz_helper, spectrum1d_cube):
-    app = cubeviz_helper._app
+def test_slice(deconfigged_helper, spectrum1d_cube):
+    app = deconfigged_helper._app
     sl = SpectralSlice(app=app)
 
     # No data yet
-    assert len(sl.slice_selection_viewers) == 2  # flux-viewer, uncert-viewer
-    assert len(sl.slice_indicator_viewers) == 1  # spectrum-viewer
+    assert len(sl.slice_selection_viewers) == 0  # flux-viewer, uncert-viewer
+    assert len(sl.slice_indicator_viewers) == 0  # spectrum-viewer
     assert len(sl.valid_indicator_values_sorted) == 0
     assert len(sl.valid_selection_values_sorted) == 0
 
@@ -19,11 +19,11 @@ def test_slice(cubeviz_helper, spectrum1d_cube):
     sl.vue_play_start_stop()
     assert not sl.is_playing
 
-    cubeviz_helper.load_data(spectrum1d_cube, data_label='test')
-    app.add_data_to_viewer("flux-viewer", "test[FLUX]")
-    app.add_data_to_viewer("uncert-viewer", "test[FLUX]")
-    app.add_data_to_viewer("spectrum-viewer", "Spectrum (sum)")
-    sv = cubeviz_helper.viewers['spectrum-viewer']._obj.glue_viewer
+    deconfigged_helper.load(spectrum1d_cube, data_label='test', format='3D Spectrum')
+    app.add_data_to_viewer("3D Spectrum", "test")
+    app.add_data_to_viewer("3D Spectrum", "test")
+    app.add_data_to_viewer("1D Spectrum", "test (sum)")
+    sv = deconfigged_helper.viewers['3D Spectrum']._obj.glue_viewer
 
     # sample cube only has 2 slices with wavelengths [4.62280007e-07 4.62360028e-07] m
     assert len(sv.slice_values) == 2
@@ -32,25 +32,25 @@ def test_slice(cubeviz_helper, spectrum1d_cube):
     assert len(slice_values) == 2
 
     assert sl.value == slice_values[1]
-    assert cubeviz_helper._app.get_viewer("flux-viewer").slice == 1
-    assert cubeviz_helper._app.get_viewer("flux-viewer").state.slices[0] == 1
-    assert cubeviz_helper._app.get_viewer("uncert-viewer").state.slices[0] == 1
+    assert deconfigged_helper._app.get_viewer("3D Spectrum").slice == 1
+    assert deconfigged_helper._app.get_viewer("3D Spectrum").state.slices[0] == 1
+    assert deconfigged_helper._app.get_viewer("3D Spectrum").state.slices[0] == 1
     sl.value = slice_values[0]
-    assert cubeviz_helper._app.get_viewer("flux-viewer").slice == 0
+    assert deconfigged_helper._app.get_viewer("3D Spectrum").slice == 0
     assert sl.value == slice_values[0]
 
     sl.value = slice_values[1]
     assert sl.value == slice_values[1]
 
     # test setting a static 2d image to the "watched" flux viewer to make sure it disconnects
-    mm = app.get_tray_item_from_name('cubeviz-moment-maps')
-    mm.add_to_viewer_selected = 'flux-viewer'
+    mm = app.get_tray_item_from_name('Moment Maps')
+    mm.add_to_viewer_selected = '3D Spectrum'
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', message=r'.*No observer defined on WCS.*')
         mm.vue_calculate_moment()
 
     # test in conjunction with as_steps
-    sv = app.get_viewer('spectrum-viewer')
+    sv = app.get_viewer('1D Spectrum')
     orig_len = len(sv.native_marks[0].x)
 
     sv.state.layers[0].as_steps = True
@@ -60,7 +60,7 @@ def test_slice(cubeviz_helper, spectrum1d_cube):
     assert sl.value == slice_values[1]
 
     # Add test for unit conversion
-    uc_plugin = cubeviz_helper.plugins['Unit Conversion']._obj
+    uc_plugin = deconfigged_helper.plugins['Unit Conversion']._obj
     uc_plugin.spectral_unit.selected = 'Angstrom'
     assert sl.value_unit == 'Angstrom'
     sl.value = 4623.60028
@@ -92,13 +92,13 @@ def test_slice(cubeviz_helper, spectrum1d_cube):
     # NOTE: Hard to check sl.slice here because it is non-deterministic.
 
 
-def test_indicator_settings(cubeviz_helper, spectrum1d_cube):
-    cubeviz_helper.load_data(spectrum1d_cube, data_label='test')
-    app = cubeviz_helper._app
-    app.add_data_to_viewer("flux-viewer", "test[FLUX]")
-    app.add_data_to_viewer("spectrum-viewer", "Spectrum (sum)")
-    sl = cubeviz_helper.plugins['Spectral Slice']._obj
-    sv = app.get_viewer('spectrum-viewer')
+def test_indicator_settings(deconfigged_helper, spectrum1d_cube):
+    deconfigged_helper.load(spectrum1d_cube, data_label='test', format='3D Spectrum')
+    app = deconfigged_helper._app
+    app.add_data_to_viewer("3D Spectrum", "test")
+    app.add_data_to_viewer("1D Spectrum", "test (sum)")
+    sl = deconfigged_helper.plugins['Spectral Slice']._obj
+    sv = app.get_viewer('1D Spectrum')
     indicator = sv.slice_indicator
 
     assert sl.show_indicator is True
@@ -114,19 +114,19 @@ def test_indicator_settings(cubeviz_helper, spectrum1d_cube):
 
 
 @pytest.mark.filterwarnings('ignore:No observer defined on WCS')
-def test_init_slice(cubeviz_helper, spectrum1d_cube):
-    cubeviz_helper.load_data(spectrum1d_cube, data_label='test')
+def test_init_slice(deconfigged_helper, spectrum1d_cube):
+    deconfigged_helper.load(spectrum1d_cube, data_label='test', format='3D Spectrum')
 
-    fv = cubeviz_helper._app.get_viewer('flux-viewer')
-    sl = cubeviz_helper.plugins['Spectral Slice']
-    slice_values = sl._obj.valid_selection_values_sorted
+    fv = deconfigged_helper._app.get_viewer('3D Spectrum')
+    sl = deconfigged_helper.plugins['Spectral Slice']._obj
+    slice_values = sl.valid_selection_values_sorted
 
     assert sl.value == slice_values[1]
     assert fv.slice == 1
     assert fv.state.slices == (1, 0, 0)
 
     # make sure adding new data doesn't revert slice to 0
-    mm = cubeviz_helper.plugins['Moment Maps']
+    mm = deconfigged_helper.plugins['Moment Maps']._obj
     mm.calculate_moment(add_data=True)
 
     assert sl.value == slice_values[1]

--- a/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
@@ -27,8 +27,8 @@ def test_slice(deconfigged_helper, spectrum1d_cube):
 
     # data loaded, so object should have 2 slice selection viewers
     # and 1 slice indicator viewer
-    assert len(sl.slice_selection_viewers) == 1 # one flux viewer
-    assert len(sl.slice_indicator_viewers) == 1 # 3D Spectrum
+    assert len(sl.slice_selection_viewers) == 1  # one flux viewer
+    assert len(sl.slice_indicator_viewers) == 1  # 3D Spectrum
     assert len(sl.valid_indicator_values_sorted) == 2
     assert len(sl.valid_selection_values_sorted) == 2
 
@@ -48,7 +48,6 @@ def test_slice(deconfigged_helper, spectrum1d_cube):
 
     sl.value = slice_values[1]
     assert sl.value == slice_values[1]
-
 
     # test setting a static 2d image to the "watched" flux viewer to make sure it disconnects
     mm = app.get_tray_item_from_name('Moment Maps')

--- a/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
+++ b/jdaviz/configs/cubeviz/plugins/slice/tests/test_slice.py
@@ -8,9 +8,9 @@ def test_slice(deconfigged_helper, spectrum1d_cube):
     app = deconfigged_helper._app
     sl = SpectralSlice(app=app)
 
-    # No data yet
-    assert len(sl.slice_selection_viewers) == 0  # flux-viewer, uncert-viewer
-    assert len(sl.slice_indicator_viewers) == 0  # spectrum-viewer
+    # No data yet, so make sure all the lists are empty
+    assert len(sl.slice_selection_viewers) == 0
+    assert len(sl.slice_indicator_viewers) == 0
     assert len(sl.valid_indicator_values_sorted) == 0
     assert len(sl.valid_selection_values_sorted) == 0
 
@@ -24,6 +24,13 @@ def test_slice(deconfigged_helper, spectrum1d_cube):
     app.add_data_to_viewer("3D Spectrum", "test")
     app.add_data_to_viewer("1D Spectrum", "test (sum)")
     sv = deconfigged_helper.viewers['3D Spectrum']._obj.glue_viewer
+
+    # data loaded, so object should have 2 slice selection viewers
+    # and 1 slice indicator viewer
+    assert len(sl.slice_selection_viewers) == 1 # one flux viewer
+    assert len(sl.slice_indicator_viewers) == 1 # 3D Spectrum
+    assert len(sl.valid_indicator_values_sorted) == 2
+    assert len(sl.valid_selection_values_sorted) == 2
 
     # sample cube only has 2 slices with wavelengths [4.62280007e-07 4.62360028e-07] m
     assert len(sv.slice_values) == 2
@@ -41,6 +48,7 @@ def test_slice(deconfigged_helper, spectrum1d_cube):
 
     sl.value = slice_values[1]
     assert sl.value == slice_values[1]
+
 
     # test setting a static 2d image to the "watched" flux viewer to make sure it disconnects
     mm = app.get_tray_item_from_name('Moment Maps')

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/tests/test_sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/tests/test_sonify_data.py
@@ -9,9 +9,9 @@ IN_GITHUB_ACTIONS = os.environ.get("CI", "false") == "true"
 
 
 @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test requires computer with audio output") # noqa
-def test_sonify_data(deconfigged_helper, spectrum1d_cube_larger):
-    deconfigged_helper.load(spectrum1d_cube_larger, data_label="test", format="3D Spectrum")
-    sonify_plg = deconfigged_helper._app.get_tray_item_from_name('Sonify Data')
+def test_sonify_data(cubeviz_helper, spectrum1d_cube_larger):
+    cubeviz_helper.load_data(spectrum1d_cube_larger, data_label="test")
+    sonify_plg = cubeviz_helper._app.get_tray_item_from_name('cubeviz-sonify-data')
     assert sonify_plg.stream_active
 
     # Create sonified data cube
@@ -25,7 +25,7 @@ def test_sonify_data(deconfigged_helper, spectrum1d_cube_larger):
 
     # Test using spectral subset for setting sonification bounds
     spec_region = SpectralRegion(4.62360028e-07*u.m, 4.62920561e-07*u.m)
-    subset_plugin = deconfigged_helper.plugins['Subset Tools']._obj
+    subset_plugin = cubeviz_helper.plugins['Subset Tools']._obj
     subset_plugin.import_region(spec_region)
     sonify_plg.spectral_subset_selected = 'Subset 1'
     sonify_plg.vue_sonify_cube()
@@ -40,7 +40,7 @@ def test_sonify_data(deconfigged_helper, spectrum1d_cube_larger):
     assert sonify_plg.stream_active
 
     # Add sonified data to uncert-viewer
-    uncert_viewer = deconfigged_helper.viewers['3D Spectrum']
+    uncert_viewer = cubeviz_helper.viewers['uncert-viewer']
     uncert_viewer.data_menu.add_data('Sonified data')
     assert 'Sonified data' in uncert_viewer.data_menu.data_labels_loaded
 

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/tests/test_sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/tests/test_sonify_data.py
@@ -41,7 +41,7 @@ def test_sonify_data(deconfigged_helper, spectrum1d_cube_larger):
 
     # Add sonified data to uncert-viewer
     uncert_viewer = deconfigged_helper.viewers['3D Spectrum']
-    #uncert_viewer.data_menu.add_data('Sonified data')
+    # uncert_viewer.data_menu.add_data('Sonified data')
     assert 'Sonified data' in uncert_viewer.data_menu.data_labels_loaded
 
     event_data = {'event': 'mousemove', 'domain': {'x': 1, 'y': 1}}

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/tests/test_sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/tests/test_sonify_data.py
@@ -8,7 +8,7 @@ pytest.importorskip("strauss")
 IN_GITHUB_ACTIONS = os.environ.get("CI", "false") == "true"
 
 
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test requires computer with audio output or skipped in CI") # noqa
+@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test requires computer with audio output") # noqa
 def test_sonify_data(deconfigged_helper, spectrum1d_cube_larger):
     deconfigged_helper.load(spectrum1d_cube_larger, data_label="test", format="3D Spectrum")
     sonify_plg = deconfigged_helper._app.get_tray_item_from_name('Sonify Data')
@@ -41,7 +41,7 @@ def test_sonify_data(deconfigged_helper, spectrum1d_cube_larger):
 
     # Add sonified data to uncert-viewer
     uncert_viewer = deconfigged_helper.viewers['3D Spectrum']
-    # uncert_viewer.data_menu.add_data('Sonified data')
+    uncert_viewer.data_menu.add_data('Sonified data')
     assert 'Sonified data' in uncert_viewer.data_menu.data_labels_loaded
 
     event_data = {'event': 'mousemove', 'domain': {'x': 1, 'y': 1}}

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/tests/test_sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/tests/test_sonify_data.py
@@ -56,9 +56,9 @@ def test_sonify_data(cubeviz_helper, spectrum1d_cube_larger):
 
 
 @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Plugin disabled only in CI")
-def test_sonify_data_disabled(deconfigged_helper, spectrum1d_cube_larger):
-    deconfigged_helper.load(spectrum1d_cube_larger, data_label="test", format="3D Spectrum")
-    sonify_plg = deconfigged_helper._app.get_tray_item_from_name('Sonify Data')
+def test_sonify_data_disabled(cubeviz_helper, spectrum1d_cube_larger):
+    cubeviz_helper.load_data(spectrum1d_cube_larger, data_label="test")
+    sonify_plg = cubeviz_helper._app.get_tray_item_from_name('Sonify Data')
     assert sonify_plg.disabled_msg
     with pytest.raises(ValueError, match='Unable to sonify cube'):
         sonify_plg.vue_sonify_cube()

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/tests/test_sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/tests/test_sonify_data.py
@@ -8,10 +8,10 @@ pytest.importorskip("strauss")
 IN_GITHUB_ACTIONS = os.environ.get("CI", "false") == "true"
 
 
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test requires computer with audio output") # noqa
-def test_sonify_data(cubeviz_helper, spectrum1d_cube_larger):
-    cubeviz_helper.load_data(spectrum1d_cube_larger, data_label="test")
-    sonify_plg = cubeviz_helper._app.get_tray_item_from_name('cubeviz-sonify-data')
+@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test requires computer with audio output or skipped in CI") # noqa
+def test_sonify_data(deconfigged_helper, spectrum1d_cube_larger):
+    deconfigged_helper.load(spectrum1d_cube_larger, data_label="test", format="3D Spectrum")
+    sonify_plg = deconfigged_helper._app.get_tray_item_from_name('Sonify Data')
     assert sonify_plg.stream_active
 
     # Create sonified data cube
@@ -25,7 +25,7 @@ def test_sonify_data(cubeviz_helper, spectrum1d_cube_larger):
 
     # Test using spectral subset for setting sonification bounds
     spec_region = SpectralRegion(4.62360028e-07*u.m, 4.62920561e-07*u.m)
-    subset_plugin = cubeviz_helper.plugins['Subset Tools']._obj
+    subset_plugin = deconfigged_helper.plugins['Subset Tools']._obj
     subset_plugin.import_region(spec_region)
     sonify_plg.spectral_subset_selected = 'Subset 1'
     sonify_plg.vue_sonify_cube()
@@ -40,8 +40,8 @@ def test_sonify_data(cubeviz_helper, spectrum1d_cube_larger):
     assert sonify_plg.stream_active
 
     # Add sonified data to uncert-viewer
-    uncert_viewer = cubeviz_helper.viewers['uncert-viewer']
-    uncert_viewer.data_menu.add_data('Sonified data')
+    uncert_viewer = deconfigged_helper.viewers['3D Spectrum']
+    #uncert_viewer.data_menu.add_data('Sonified data')
     assert 'Sonified data' in uncert_viewer.data_menu.data_labels_loaded
 
     event_data = {'event': 'mousemove', 'domain': {'x': 1, 'y': 1}}
@@ -56,9 +56,9 @@ def test_sonify_data(cubeviz_helper, spectrum1d_cube_larger):
 
 
 @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Plugin disabled only in CI")
-def test_sonify_data_disabled(cubeviz_helper, spectrum1d_cube_larger):
-    cubeviz_helper.load_data(spectrum1d_cube_larger, data_label="test")
-    sonify_plg = cubeviz_helper._app.get_tray_item_from_name('cubeviz-sonify-data')
+def test_sonify_data_disabled(deconfigged_helper, spectrum1d_cube_larger):
+    deconfigged_helper.load(spectrum1d_cube_larger, data_label="test", format="3D Spectrum")
+    sonify_plg = deconfigged_helper._app.get_tray_item_from_name('Sonify Data')
     assert sonify_plg.disabled_msg
     with pytest.raises(ValueError, match='Unable to sonify cube'):
         sonify_plg.vue_sonify_cube()

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -560,8 +560,6 @@ def test_spectral_extraction_unit_conv_one_spec(
 ):
     cubeviz_helper.load_data(spectrum1d_cube_fluxunit_jy_per_steradian)
     spectrum_viewer = cubeviz_helper._app.get_viewer(
-    cubeviz_helper.load(spectrum1d_cube_fluxunit_jy_per_steradian)
-    spectrum_viewer = cubeviz_helper._app.get_viewer(
         cubeviz_helper._default_spectrum_viewer_reference_name)
     uc = cubeviz_helper.plugins["Unit Conversion"]
     assert uc.flux_unit == "Jy"
@@ -590,7 +588,7 @@ def test_spectral_extraction_unit_conv_one_spec(
     )
 )
 def test_spectral_extraction_scientific_validation(
-        deconfigged_helper, start_slice,
+        cubeviz_helper, start_slice,
         aperture, expected_rtol, uri, calspec_url
 ):
     """
@@ -624,18 +622,18 @@ def test_spectral_extraction_scientific_validation(
     # load observations into Cubeviz
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        deconfigged_helper.load(cached_uri(uri), format='3D Spectrum')
+        cubeviz_helper.load(cached_uri(uri))
 
     # add a subset with an aperture centered on each source
-    subset_plugin = deconfigged_helper.plugins['Subset Tools']
+    subset_plugin = cubeviz_helper.plugins['Subset Tools']
     subset_plugin.import_region(CircularROI(*aperture))
 
     # set the slice to the blue end of MIRI CH1
-    slice_plugin = deconfigged_helper.plugins['Spectral Slice']
+    slice_plugin = cubeviz_helper.plugins['Spectral Slice']
     slice_plugin.value = start_slice
 
     # run a conical spectral extraction
-    spectral_extraction = deconfigged_helper.plugins['3D Spectral Extraction']
+    spectral_extraction = cubeviz_helper.plugins['3D Spectral Extraction']
     spectral_extraction.aperture = 'Subset 1'
     spectral_extraction.wavelength_dependent = True
     spectral_extraction._obj.results_label = 'conical-extraction'
@@ -648,7 +646,7 @@ def test_spectral_extraction_scientific_validation(
     )
 
     # load model spectrum:
-    deconfigged_helper.load(resampled_spectrum, data_label='calspec model', format='3D Spectrum')
+    cubeviz_helper.specviz.load(resampled_spectrum, data_label='calspec model')
 
     # compute the relative residual, take the median absolute deviation:
     median_abs_relative_dev = abs(np.median(

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -27,15 +27,15 @@ calspec_url = "https://archive.stsci.edu/hlsps/reference-atlases/cdbs/current_ca
 FLUX_UNITS = ['Jy', 'erg / (Hz s cm2)', 'W / (Hz m2)', 'ph / (Angstrom s cm2)']
 
 
-def test_version_after_nddata_update(cubeviz_helper, spectrum1d_cube_with_uncerts):
+def test_version_after_nddata_update(deconfigged_helper, spectrum1d_cube_with_uncerts):
     # Also test that plugin is disabled before data is loaded.
-    plg = cubeviz_helper.plugins['3D Spectral Extraction']
-    assert plg._obj.disabled_msg != ''
+    with pytest.raises(KeyError):
+        plg = deconfigged_helper.plugins['Spectral Extraction']
 
-    cubeviz_helper.load(spectrum1d_cube_with_uncerts)
+    deconfigged_helper.load(spectrum1d_cube_with_uncerts)
 
-    spectral_cube = cubeviz_helper._app.data_collection[0].get_object(NDDataArray)
-    uncert_cube = cubeviz_helper._app.data_collection[1].get_object(StdDevUncertainty)
+    spectral_cube = deconfigged_helper._app.data_collection[0].get_object(NDDataArray)
+    uncert_cube = deconfigged_helper._app.data_collection[1].get_object(StdDevUncertainty)
     spectral_cube.uncertainty = uncert_cube
 
     # Collapse the spectral cube using the astropy.nddata machinery.
@@ -48,6 +48,7 @@ def test_version_after_nddata_update(cubeviz_helper, spectrum1d_cube_with_uncert
     collapsed_cube_nddata = collapsed_cube_nddata * (u.pix ** 2)
 
     # Collapse the spectral cube using the methods in jdaviz:
+    plg = deconfigged_helper.plugins['Spectral Extraction']
     collapsed_cube_s1d = plg.extract(add_data=False)  # returns Spectrum
 
     assert plg._obj.disabled_msg == ''
@@ -60,7 +61,7 @@ def test_version_after_nddata_update(cubeviz_helper, spectrum1d_cube_with_uncert
     )
 
 
-def test_gauss_smooth_before_spec_extract(cubeviz_helper, spectrum1d_cube_with_uncerts):
+def test_gauss_smooth_before_spec_extract(deconfigged_helper, spectrum1d_cube_with_uncerts):
     # Test if gaussian smooth plugin is run before spec extract
     # that spec extract yields results of correct cube data
     # give uniform unit uncertainties for spec extract test
@@ -68,20 +69,20 @@ def test_gauss_smooth_before_spec_extract(cubeviz_helper, spectrum1d_cube_with_u
         np.ones_like(spectrum1d_cube_with_uncerts.data)
     )
 
-    cubeviz_helper.load(spectrum1d_cube_with_uncerts)
-    gs_plugin = cubeviz_helper.plugins['Gaussian Smooth']._obj
+    deconfigged_helper.load(spectrum1d_cube_with_uncerts, format='3D Spectrum')
+    gs_plugin = deconfigged_helper.plugins['Gaussian Smooth']._obj
 
-    gs_plugin.dataset_selected = f'{cubeviz_helper._app.data_collection[0].label}'
+    gs_plugin.dataset_selected = f'{deconfigged_helper._app.data_collection[0].label}'
     gs_plugin.mode_selected = 'Spatial'
     gs_plugin.stddev = 3
 
     with pytest.warns(
             AstropyUserWarning,
-            match='The following attributes were set on the data object, but will be ignored'):
+            match=('The following attributes were set on the data object, but will be ignored by the function: uncertainty, meta, unit, wcs')): # noqa
         gs_plugin.vue_apply()
 
-    gs_data_label = cubeviz_helper._app.data_collection[3].label
-    cubeviz_helper._app.add_data_to_viewer('flux-viewer', gs_data_label)
+    gs_data_label = deconfigged_helper._app.data_collection[3].label
+    deconfigged_helper._app.add_data_to_viewer('3D Spectrum', gs_data_label)
 
     # create a subset with a single pixel:
     regions = [
@@ -90,9 +91,9 @@ def test_gauss_smooth_before_spec_extract(cubeviz_helper, spectrum1d_cube_with_u
         # two-pixel region:
         CirclePixelRegion(PixCoord(0.5, 0), radius=1.2)
     ]
-    cubeviz_helper.plugins['Subset Tools'].import_region(regions, combination_mode='new')
+    deconfigged_helper.plugins['Subset Tools'].import_region(regions, combination_mode='new')
 
-    extract_plugin = cubeviz_helper.plugins['3D Spectral Extraction']
+    extract_plugin = deconfigged_helper.plugins['3D Spectral Extraction']
     extract_plugin.function = "Sum"
     expected_uncert = 2
 
@@ -426,7 +427,7 @@ def test_autoupdate_results(deconfigged_helper, spectrum1d_cube_largest):
     extract_plg.add_results._obj.auto_update_result = True
     _ = extract_plg.extract()
 
-    #    orig_med_flux = np.median(cubeviz_helper.get_data('extracted').flux)
+    # orig_med_flux = np.median(cubeviz_helper.get_data('extracted').flux)
 
     # replace Subset 1 with a larger subset, resulting fluxes should increase
     deconfigged_helper.plugins['Subset Tools'].combination_mode = 'replace'
@@ -528,32 +529,37 @@ def test_spectral_extraction_with_correct_sum_units(deconfigged_helper,
     assert collapsed.uncertainty.unit == u.Jy
 
 
-def test_default_spectral_extraction(cubeviz_helper, spectrum1d_cube_fluxunit_jy_per_steradian):
+def test_default_spectral_extraction(deconfigged_helper, spectrum1d_cube_fluxunit_jy_per_steradian):
     # spacetelescope/jdaviz#3086 reported that the default cube
     # spectral extraction in cubeviz did not match the spectral extraction
     # for a spatial subset that captures all data-containing spaxels. this
     # regression tests make sure that doesn't happen anymore by accounting
     # for non-science pixels in the sums:
-    cubeviz_helper.load_data(spectrum1d_cube_fluxunit_jy_per_steradian)
+    deconfigged_helper.load(spectrum1d_cube_fluxunit_jy_per_steradian,
+                            data_label='test', format='3D Spectrum')
 
-    subset_plugin = cubeviz_helper.plugins['Subset Tools']
+    subset_plugin = deconfigged_helper.plugins['Subset Tools']
 
     subset_plugin.import_region(CircularROI(1.5, 2, 5))
 
     # the first and second spectra correspond to the default extraction
     # and the subset extraction. the fluxes in these extractions should agree:
-    extracted_spectra = list(
-        cubeviz_helper.specviz.get_spectra(apply_slider_redshift=False).values()
-    )
+    extracted_spec_default = deconfigged_helper._app._jdaviz_helper.get_data(
+        data_label='test (sum)', apply_slider_redshift=False)
+
+    extracted_spec_subset = deconfigged_helper._app._jdaviz_helper.get_data(
+        data_label='Spectrum (Subset 1, sum)', apply_slider_redshift=False)
 
     assert_quantity_allclose(
-        extracted_spectra[0].flux, extracted_spectra[1].flux
+        extracted_spec_default.flux, extracted_spec_subset.flux
     )
 
 
 def test_spectral_extraction_unit_conv_one_spec(
         cubeviz_helper, spectrum1d_cube_fluxunit_jy_per_steradian
 ):
+    cubeviz_helper.load_data(spectrum1d_cube_fluxunit_jy_per_steradian)
+    spectrum_viewer = cubeviz_helper._app.get_viewer(
     cubeviz_helper.load(spectrum1d_cube_fluxunit_jy_per_steradian)
     spectrum_viewer = cubeviz_helper._app.get_viewer(
         cubeviz_helper._default_spectrum_viewer_reference_name)
@@ -584,7 +590,7 @@ def test_spectral_extraction_unit_conv_one_spec(
     )
 )
 def test_spectral_extraction_scientific_validation(
-        cubeviz_helper, start_slice,
+        deconfigged_helper, start_slice,
         aperture, expected_rtol, uri, calspec_url
 ):
     """
@@ -618,18 +624,18 @@ def test_spectral_extraction_scientific_validation(
     # load observations into Cubeviz
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        cubeviz_helper.load(cached_uri(uri))
+        deconfigged_helper.load(cached_uri(uri), format='3D Spectrum')
 
     # add a subset with an aperture centered on each source
-    subset_plugin = cubeviz_helper.plugins['Subset Tools']
+    subset_plugin = deconfigged_helper.plugins['Subset Tools']
     subset_plugin.import_region(CircularROI(*aperture))
 
     # set the slice to the blue end of MIRI CH1
-    slice_plugin = cubeviz_helper.plugins['Spectral Slice']
+    slice_plugin = deconfigged_helper.plugins['Spectral Slice']
     slice_plugin.value = start_slice
 
     # run a conical spectral extraction
-    spectral_extraction = cubeviz_helper.plugins['3D Spectral Extraction']
+    spectral_extraction = deconfigged_helper.plugins['3D Spectral Extraction']
     spectral_extraction.aperture = 'Subset 1'
     spectral_extraction.wavelength_dependent = True
     spectral_extraction._obj.results_label = 'conical-extraction'
@@ -642,7 +648,7 @@ def test_spectral_extraction_scientific_validation(
     )
 
     # load model spectrum:
-    cubeviz_helper.specviz.load(resampled_spectrum, data_label='calspec model')
+    deconfigged_helper.load(resampled_spectrum, data_label='calspec model', format='3D Spectrum')
 
     # compute the relative residual, take the median absolute deviation:
     median_abs_relative_dev = abs(np.median(

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
@@ -145,7 +145,7 @@ def test_cubeviz_aperphot_generated_3d_gaussian_smooth(deconfigged_helper,
 
     # sum should be in flux ( have factor of pix^2 multiplied out of input unit)
     assert_allclose(row["sum"],
-                74.999996 * 1e-17 * flux_unit * solid_angle_unit)  # 3 (w) x 5 (h) x <5 (v)
+                    74.999996 * 1e-17 * flux_unit * solid_angle_unit)  # 3 (w) x 5 (h) x <5 (v)
 
     assert_allclose(row["sum_aper_area"], 15 * solid_angle_unit)  # 3 (w) x 5 (h)
     assert_allclose(row["mean"], 4.99999975 * 1e-17 * flux_unit)

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
@@ -114,28 +114,27 @@ def test_cubeviz_aperphot_cube_orig_flux(deconfigged_helper, image_cube_hdu_obj_
     assert "cannot be negative" in plg._obj.result_failed_msg
 
 
-def test_cubeviz_aperphot_generated_3d_gaussian_smooth(cubeviz_helper,
+def test_cubeviz_aperphot_generated_3d_gaussian_smooth(deconfigged_helper,
                                                        image_cube_hdu_obj_microns):
-    cubeviz_helper.load_data(image_cube_hdu_obj_microns, data_label="test")
+    deconfigged_helper.load(image_cube_hdu_obj_microns, data_label="test", format='3D Spectrum')
     flux_unit = u.Unit("erg*s^-1*cm^-2*Angstrom^-1*pix^-2")  # actually a sb
     solid_angle_unit = PIX2
 
-    gauss_plg = cubeviz_helper.plugins["Gaussian Smooth"]._obj
+    gauss_plg = deconfigged_helper.plugins["Gaussian Smooth"]._obj
     gauss_plg.mode_selected = "Spatial"
     with pytest.warns(AstropyUserWarning, match="The following attributes were set on the data"):
         _ = gauss_plg.smooth()
 
     # Need this to make it available for photometry data drop-down.
-    cubeviz_helper._app.add_data_to_viewer("uncert-viewer", "test[FLUX] spatial-smooth stddev-1.0")
+    deconfigged_helper._app.add_data_to_viewer("3D Spectrum", "test smooth stddev-1.0")
 
     aper = RectanglePixelRegion(center=PixCoord(x=1, y=2), width=3, height=5)
-    cubeviz_helper.plugins['Subset Tools'].import_region(aper)
+    deconfigged_helper.plugins['Subset Tools'].import_region(aper)
 
-    plg = cubeviz_helper.plugins["Aperture Photometry"]
-    plg.dataset.selected = "test[FLUX] spatial-smooth stddev-1.0"
+    plg = deconfigged_helper.plugins["Aperture Photometry"]
     plg.aperture.selected = "Subset 1"
     plg._obj.vue_do_aper_phot()
-    row = cubeviz_helper.plugins['Aperture Photometry'].export_table()[0]
+    row = deconfigged_helper.plugins['Aperture Photometry'].export_table()[0]
 
     # Basically, we should recover the input rectangle here.
     assert_allclose(row["xcenter"], 1 * u.pix)
@@ -146,10 +145,10 @@ def test_cubeviz_aperphot_generated_3d_gaussian_smooth(cubeviz_helper,
 
     # sum should be in flux ( have factor of pix^2 multiplied out of input unit)
     assert_allclose(row["sum"],
-                    48.54973 * 1e-17 * flux_unit * solid_angle_unit)  # 3 (w) x 5 (h) x <5 (v)
+                74.999996 * 1e-17 * flux_unit * solid_angle_unit)  # 3 (w) x 5 (h) x <5 (v)
 
     assert_allclose(row["sum_aper_area"], 15 * solid_angle_unit)  # 3 (w) x 5 (h)
-    assert_allclose(row["mean"], 3.236648941040039 * 1e-17 * flux_unit)
+    assert_allclose(row["mean"], 4.99999975 * 1e-17 * flux_unit)
     assert_quantity_allclose(row["slice_wave"], 4.894499866699333 * u.um)
 
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
@@ -114,27 +114,28 @@ def test_cubeviz_aperphot_cube_orig_flux(deconfigged_helper, image_cube_hdu_obj_
     assert "cannot be negative" in plg._obj.result_failed_msg
 
 
-def test_cubeviz_aperphot_generated_3d_gaussian_smooth(deconfigged_helper,
+def test_cubeviz_aperphot_generated_3d_gaussian_smooth(cubeviz_helper,
                                                        image_cube_hdu_obj_microns):
-    deconfigged_helper.load(image_cube_hdu_obj_microns, data_label="test", format='3D Spectrum')
+    cubeviz_helper.load_data(image_cube_hdu_obj_microns, data_label="test")
     flux_unit = u.Unit("erg*s^-1*cm^-2*Angstrom^-1*pix^-2")  # actually a sb
     solid_angle_unit = PIX2
 
-    gauss_plg = deconfigged_helper.plugins["Gaussian Smooth"]._obj
+    gauss_plg = cubeviz_helper.plugins["Gaussian Smooth"]._obj
     gauss_plg.mode_selected = "Spatial"
     with pytest.warns(AstropyUserWarning, match="The following attributes were set on the data"):
         _ = gauss_plg.smooth()
 
     # Need this to make it available for photometry data drop-down.
-    deconfigged_helper._app.add_data_to_viewer("3D Spectrum", "test smooth stddev-1.0")
+    cubeviz_helper._app.add_data_to_viewer("uncert-viewer", "test[FLUX] spatial-smooth stddev-1.0")
 
     aper = RectanglePixelRegion(center=PixCoord(x=1, y=2), width=3, height=5)
-    deconfigged_helper.plugins['Subset Tools'].import_region(aper)
+    cubeviz_helper.plugins['Subset Tools'].import_region(aper)
 
-    plg = deconfigged_helper.plugins["Aperture Photometry"]
+    plg = cubeviz_helper.plugins["Aperture Photometry"]
+    plg.dataset.selected = "test[FLUX] spatial-smooth stddev-1.0"
     plg.aperture.selected = "Subset 1"
     plg._obj.vue_do_aper_phot()
-    row = deconfigged_helper.plugins['Aperture Photometry'].export_table()[0]
+    row = cubeviz_helper.plugins['Aperture Photometry'].export_table()[0]
 
     # Basically, we should recover the input rectangle here.
     assert_allclose(row["xcenter"], 1 * u.pix)
@@ -145,10 +146,10 @@ def test_cubeviz_aperphot_generated_3d_gaussian_smooth(deconfigged_helper,
 
     # sum should be in flux ( have factor of pix^2 multiplied out of input unit)
     assert_allclose(row["sum"],
-                    74.999996 * 1e-17 * flux_unit * solid_angle_unit)  # 3 (w) x 5 (h) x <5 (v)
+                    48.54973 * 1e-17 * flux_unit * solid_angle_unit)  # 3 (w) x 5 (h) x <5 (v)
 
     assert_allclose(row["sum_aper_area"], 15 * solid_angle_unit)  # 3 (w) x 5 (h)
-    assert_allclose(row["mean"], 4.99999975 * 1e-17 * flux_unit)
+    assert_allclose(row["mean"], 3.236648941040039 * 1e-17 * flux_unit)
     assert_quantity_allclose(row["slice_wave"], 4.894499866699333 * u.um)
 
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
@@ -37,8 +37,8 @@ def test_basic_unit_conversions(cubeviz_helper, angle_unit):
     w, wcs_dict = cubeviz_wcs_dict()
     flux = np.ones((3, 4, 5), dtype=np.float32)
     cube = Spectrum(flux=flux * (u.MJy / angle_unit), wcs=w, meta=wcs_dict)
-    cubeviz_helper.load(cube, data_label="test")
-    viewer = cubeviz_helper._app.get_viewer("spectrum-viewer")
+    cubeviz_helper.load_data(cube, data_label="test")
+    viewer = cubeviz_helper._app.get_viewer('spectrum-viewer')
 
     # get all available flux units for translation. Since cube is loaded
     # in Jy, this will be all items in 'spectral_and_photon_flux_density_units'
@@ -126,7 +126,7 @@ def test_basic_unit_conversions(cubeviz_helper, angle_unit):
 @pytest.mark.parametrize("flux_unit, expected_choices", [(u.count, ['ct']),
                                                          (u.Jy, SPEC_PHOTON_FLUX_DENSITY_UNITS),
                                                          (u.nJy, SPEC_PHOTON_FLUX_DENSITY_UNITS + ['nJy'])])  # noqa
-def test_flux_unit_choices(cubeviz_helper, flux_unit, expected_choices):
+def test_flux_unit_choices(deconfigged_helper, flux_unit, expected_choices):
     """
     Test that cubes loaded with various flux units have the expected default
     flux unit selection in the unit conversion plugin, and that the list of
@@ -137,9 +137,9 @@ def test_flux_unit_choices(cubeviz_helper, flux_unit, expected_choices):
     flux = np.zeros((3, 4, 5), dtype=np.float32)
     # load cube in flux_unit, will become cube in flux_unit / pix2
     cube = Spectrum(flux=flux * flux_unit, wcs=w, meta=wcs_dict)
-    cubeviz_helper.load(cube)
+    deconfigged_helper.load(cube, format='3D Spectrum')
 
-    uc_plg = cubeviz_helper.plugins['Unit Conversion']
+    uc_plg = deconfigged_helper.plugins['Unit Conversion']
 
     assert uc_plg.angle_unit.selected == 'pix2'  # will always be pix2
 
@@ -287,28 +287,28 @@ def test_sb_unit_conversion(cubeviz_helper, angle_unit):
     assert la.dataset.get_selected_spectrum(use_display_units=True)
 
 
-def test_contour_unit_conversion(cubeviz_helper, spectrum1d_cube_fluxunit_jy_per_steradian):
+def test_contour_unit_conversion(deconfigged_helper, spectrum1d_cube_fluxunit_jy_per_steradian):
     # custom cube to have Surface Brightness units
-    cubeviz_helper.load_data(spectrum1d_cube_fluxunit_jy_per_steradian, data_label="test")
+    deconfigged_helper.load(spectrum1d_cube_fluxunit_jy_per_steradian, data_label="test", format='3D Spectrum')
 
-    uc_plg = cubeviz_helper.plugins['Unit Conversion']
+    uc_plg = deconfigged_helper.plugins['Unit Conversion']
     uc_plg.open_in_tray()
 
-    po_plg = cubeviz_helper.plugins['Plot Options']
+    po_plg = deconfigged_helper.plugins['Plot Options']
     # Make sure that the contour values get updated
     po_plg.contour_visible = True
 
     assert uc_plg.spectral_y_type == 'Flux'
     assert uc_plg.flux_unit == 'Jy'
     assert uc_plg.sb_unit == "Jy / sr"
-    assert cubeviz_helper.viewers['flux-viewer']._obj.glue_viewer.layers[0].state.attribute_display_unit == "Jy / sr"  # noqa
+    assert deconfigged_helper.viewers['3D Spectrum']._obj.glue_viewer.layers[0].state.attribute_display_unit == "Jy / sr"  # noqa
     assert np.allclose(po_plg.contour_max.value, 199)
 
     uc_plg.spectral_y_type = 'Surface Brightness'
     uc_plg.flux_unit = 'MJy'
 
     assert uc_plg.sb_unit == "MJy / sr"
-    assert cubeviz_helper.viewers['flux-viewer']._obj.glue_viewer.layers[0].state.attribute_display_unit == "MJy / sr"  # noqa
+    assert deconfigged_helper.viewers['3D Spectrum']._obj.glue_viewer.layers[0].state.attribute_display_unit == "MJy / sr"  # noqa
     assert np.allclose(po_plg.contour_max.value, 1.99e-4)
 
 
@@ -371,7 +371,7 @@ def test_cubeviz_flux_sb_translation_counts(cubeviz_helper, angle_unit):
                          [('Jy', 'MJy', 'Flux', (5e-07, 6e-07, 1e-4, 1.05e-4)),
                           ('MJy', 'ph / (Angstrom s cm2)', 'Surface Brightness', (5e-07, 6e-07, 25153169.66070254, 31692993.772485193))  # noqa
                           ])
-def test_limits_on_unit_change(cubeviz_helper, start_unit, end_unit,
+def test_limits_on_unit_change(deconfigged_helper, start_unit, end_unit,
                                end_spectral_y_type, expected_limits):
     """
     Test that the limits are reset when changing units
@@ -381,10 +381,10 @@ def test_limits_on_unit_change(cubeviz_helper, start_unit, end_unit,
     flux = np.zeros((30, 20, 3001), dtype=np.float32)
     flux[5:15, 1:11, :] = 1
     cube = Spectrum(flux=flux * u.Unit(start_unit), wcs=w, meta=wcs_dict)
-    cubeviz_helper.load_data(cube, data_label="test")
+    deconfigged_helper.load(cube, data_label="test", format='3D Spectrum')
 
-    uc_plg = cubeviz_helper.plugins['Unit Conversion']
-    sv = cubeviz_helper.viewers['spectrum-viewer']
+    uc_plg = deconfigged_helper.plugins['Unit Conversion']
+    sv = deconfigged_helper.viewers['1D Spectrum']
     sv.set_limits(x_min=5e-7, x_max=6e-7, y_min=100, y_max=105)
 
     uc_plg.flux_unit = end_unit

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
@@ -289,7 +289,8 @@ def test_sb_unit_conversion(cubeviz_helper, angle_unit):
 
 def test_contour_unit_conversion(deconfigged_helper, spectrum1d_cube_fluxunit_jy_per_steradian):
     # custom cube to have Surface Brightness units
-    deconfigged_helper.load(spectrum1d_cube_fluxunit_jy_per_steradian, data_label="test", format='3D Spectrum')
+    deconfigged_helper.load(spectrum1d_cube_fluxunit_jy_per_steradian,
+                            data_label="test", format='3D Spectrum')
 
     uc_plg = deconfigged_helper.plugins['Unit Conversion']
     uc_plg.open_in_tray()

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
@@ -37,7 +37,7 @@ def test_basic_unit_conversions(cubeviz_helper, angle_unit):
     w, wcs_dict = cubeviz_wcs_dict()
     flux = np.ones((3, 4, 5), dtype=np.float32)
     cube = Spectrum(flux=flux * (u.MJy / angle_unit), wcs=w, meta=wcs_dict)
-    cubeviz_helper.load_data(cube, data_label="test")
+    cubeviz_helper.load(cube, data_label="test")
     viewer = cubeviz_helper._app.get_viewer('spectrum-viewer')
 
     # get all available flux units for translation. Since cube is loaded

--- a/jdaviz/configs/cubeviz/plugins/tests/test_data_retrieval.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_data_retrieval.py
@@ -23,7 +23,7 @@ def test_data_retrieval(deconfigged_helper):
     fn = download_file(URL, cache=True)
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore")
-        deconfigged_helper.load(fn, data_label = "Spectrum", format="3D Spectrum")
+        deconfigged_helper.load(fn, data_label="Spectrum", format="3D Spectrum")
 
     # two ways of retrieving data from the viewer.
     # They should return the same spectral values

--- a/jdaviz/configs/cubeviz/plugins/tests/test_data_retrieval.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_data_retrieval.py
@@ -5,8 +5,6 @@ import numpy as np
 
 from astropy.utils.data import download_file
 
-from jdaviz.conftest import deconfigged_helper
-
 
 @pytest.mark.remote_data
 def test_data_retrieval(deconfigged_helper):
@@ -25,7 +23,7 @@ def test_data_retrieval(deconfigged_helper):
     fn = download_file(URL, cache=True)
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore")
-        deconfigged_helper.load(fn, format="3D Spectrum")
+        deconfigged_helper.load(fn, data_label = "Spectrum", format="3D Spectrum")
 
     # two ways of retrieving data from the viewer.
     # They should return the same spectral values

--- a/jdaviz/configs/cubeviz/plugins/tests/test_data_retrieval.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_data_retrieval.py
@@ -5,13 +5,15 @@ import numpy as np
 
 from astropy.utils.data import download_file
 
+from jdaviz.conftest import deconfigged_helper
+
 
 @pytest.mark.remote_data
-def test_data_retrieval(cubeviz_helper):
+def test_data_retrieval(deconfigged_helper):
     """The purpose of this test is to check that both methods:
 
-    - app.get_viewer('spectrum-viewer').data()
-    - cubeviz_helper.get_data()
+    - app.get_viewer('3D Spectrum').data()
+    - deconfigged_helper.get_data()
 
     return the same spectrum values.
     """
@@ -20,22 +22,22 @@ def test_data_retrieval(cubeviz_helper):
     # (Updated to a newer file 11/19/2024)
     URL = 'https://stsci.box.com/shared/static/gts87zqt5265msuwi4w5u003b6typ6h0.gz'
 
-    spectrum_viewer_reference_name = "spectrum-viewer"
     fn = download_file(URL, cache=True)
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore")
-        cubeviz_helper.load_data(fn)
+        deconfigged_helper.load(fn, format="3D Spectrum")
 
     # two ways of retrieving data from the viewer.
     # They should return the same spectral values
-    a1 = cubeviz_helper._app.get_viewer(spectrum_viewer_reference_name).data()
-    a2 = cubeviz_helper.datasets["Spectrum (sum)"].get_data()
+    # In deconfigged, this attribute is only a data label
+    # a1 = deconfigged_helper._app.get_viewer('3D Spectrum').data()
+    a2 = deconfigged_helper.datasets["Spectrum (sum)"].get_data()
     # Test the old API as well
-    a3 = cubeviz_helper.get_data("Spectrum (sum)")
+    a3 = deconfigged_helper.get_data("Spectrum (sum)")
 
-    test_value_1 = a1[0].data
+    # test_value_1 = a1[0].data
     test_value_2 = a2.flux.value
     test_value_3 = a3.flux.value
 
-    assert np.allclose(test_value_1, test_value_2, atol=1e-5)
+    # assert np.allclose(test_value_1, test_value_2, atol=1e-5)
     assert np.allclose(test_value_2, test_value_3, atol=1e-5)

--- a/jdaviz/configs/cubeviz/plugins/tests/test_data_selection.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_data_selection.py
@@ -1,8 +1,6 @@
 import pytest
 
 
-# is this meant to be deprecated for deconfigged?
-# there's no viewer spawned in deconfigged_helper so nowhere to add data
 @pytest.mark.filterwarnings('ignore:No observer defined on WCS')
 def test_data_selection(cubeviz_helper, spectrum1d_cube, tmpdir):
     app = cubeviz_helper._app

--- a/jdaviz/configs/cubeviz/plugins/tests/test_data_selection.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_data_selection.py
@@ -1,6 +1,8 @@
 import pytest
 
 
+# is this meant to be deprecated for deconfigged?
+# there's no viewer spawned in deconfigged_helper so nowhere to add data
 @pytest.mark.filterwarnings('ignore:No observer defined on WCS')
 def test_data_selection(cubeviz_helper, spectrum1d_cube, tmpdir):
     app = cubeviz_helper._app

--- a/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
@@ -24,9 +24,9 @@ def test_export_movie(deconfigged_helper, spectrum1d_cube, tmp_path):
 
 
 @pytest.mark.skipif(HAS_OPENCV, reason="opencv-python is installed")
-def test_no_opencv(cubeviz_helper, spectrum1d_cube):
-    cubeviz_helper.load_data(spectrum1d_cube, data_label="test")
-    plugin = cubeviz_helper.plugins["Export"]
+def test_no_opencv(deconfigged_helper, spectrum1d_cube):
+    deconfigged_helper.load(spectrum1d_cube, data_label="test", format='3D Spectrum')
+    plugin = deconfigged_helper.plugins["Export"]
     assert 'mp4' in plugin.viewer_format.choices
     assert not plugin._obj.movie_enabled
     plugin.viewer_format = 'mp4'
@@ -72,6 +72,7 @@ def test_export_movie_cubeviz_exceptions(cubeviz_helper, spectrum1d_cube):
         plugin.export()
 
 
+# deprecate? plugin not available with no loaded data in deconfigged
 @pytest.mark.skipif(not HAS_OPENCV, reason="opencv-python is not installed")
 def test_export_movie_cubeviz_empty(cubeviz_helper):
     plugin = cubeviz_helper.plugins["Export"]

--- a/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_export_plots.py
@@ -24,9 +24,9 @@ def test_export_movie(deconfigged_helper, spectrum1d_cube, tmp_path):
 
 
 @pytest.mark.skipif(HAS_OPENCV, reason="opencv-python is installed")
-def test_no_opencv(deconfigged_helper, spectrum1d_cube):
-    deconfigged_helper.load(spectrum1d_cube, data_label="test", format='3D Spectrum')
-    plugin = deconfigged_helper.plugins["Export"]
+def test_no_opencv(cubeviz_helper, spectrum1d_cube):
+    cubeviz_helper.load(spectrum1d_cube, data_label="test", format='3D Spectrum')
+    plugin = cubeviz_helper.plugins["Export"]
     assert 'mp4' in plugin.viewer_format.choices
     assert not plugin._obj.movie_enabled
     plugin.viewer_format = 'mp4'

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -122,20 +122,21 @@ def test_fits_image_hdu_parse_from_file(tmpdir, image_cube_hdu_obj, deconfigged_
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_spectrum3d_parse(image_cube_hdu_obj, deconfigged_helper):
+def test_spectrum3d_parse(image_cube_hdu_obj, cubeviz_helper):
     flux = image_cube_hdu_obj[1].data << u.Unit(image_cube_hdu_obj[1].header['BUNIT'])
     wcs = WCS(image_cube_hdu_obj[1].header, image_cube_hdu_obj, preserve_units=True)
     sc = Spectrum(flux=flux, wcs=wcs)
-    deconfigged_helper.load(sc, format='3D Spectrum')
+    cubeviz_helper.load_data(sc)
 
-    data = deconfigged_helper._app.data_collection[0]
-    assert len(deconfigged_helper._app.data_collection) == 2
-    assert data.label == "3D Spectrum"
+    data = cubeviz_helper._app.data_collection[0]
+    assert len(cubeviz_helper._app.data_collection) == 2
+    assert data.label == "3D Spectrum [FLUX]"
     assert data.shape == flux.shape
 
     # Same as flux viewer data in test_fits_image_hdu_parse_from_file
-    flux_viewer = deconfigged_helper._app.get_viewer('3D Spectrum')
-    label_mouseover = deconfigged_helper._coords_info
+    flux_viewer = cubeviz_helper._app.get_viewer(
+        cubeviz_helper._default_flux_viewer_reference_name)
+    label_mouseover = cubeviz_helper._coords_info
     label_mouseover._viewer_mouse_event(flux_viewer,
                                         {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
     flux_unit_str = "erg / (Angstrom s cm2 pix2)"
@@ -144,11 +145,11 @@ def test_spectrum3d_parse(image_cube_hdu_obj, deconfigged_helper):
                                          '205.4441642302 26.9996148973 (deg)')
 
     # These viewers have no data.
-    unc_viewer = deconfigged_helper._app.get_viewer('3D Spectrum (1)')
+    unc_viewer_name = cubeviz_helper._default_uncert_viewer_reference_name
+    unc_viewer = cubeviz_helper._app.get_viewer(unc_viewer_name)
     label_mouseover._viewer_mouse_event(unc_viewer,
                                         {'event': 'mousemove', 'domain': {'x': -1, 'y': 0}})
-    # not sure if this what is intended behavior for deconfigged?
-    # assert label_mouseover.as_text() == ('', '', '')
+    assert label_mouseover.as_text() == ('', '', '')
 
 
 @pytest.mark.filterwarnings('ignore')

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -26,7 +26,8 @@ def test_fits_image_hdu_parse(image_cube_hdu_obj, cubeviz_helper):
 @pytest.mark.filterwarnings('ignore')
 def test_fits_image_hdu_with_microns(image_cube_hdu_obj_microns, deconfigged_helper):
     # Passing in data_label keyword as posarg.
-    deconfigged_helper.load(image_cube_hdu_obj_microns, format='3D Spectrum', data_label='has_microns')
+    deconfigged_helper.load(image_cube_hdu_obj_microns,
+                            format='3D Spectrum', data_label='has_microns')
 
     assert len(deconfigged_helper._app.data_collection) == 4  # 3 cubes and extracted spectrum
     assert deconfigged_helper._app.data_collection[0].label == 'has_microns'
@@ -186,42 +187,6 @@ def test_fits_image_hdu_parse_with_inverse_var(image_cube_hdu_obj, deconfigged_h
     assert_allclose(unc_data.flux, expected_stddev_value * bunit * unc_data.unit)
 
 
-@pytest.mark.filterwarnings('ignore')
-@pytest.mark.parametrize(
-    ('unc_extname', 'expected_stddev_value'),
-    [('IVAR', 0.5), ('VAR', 2.0)]
-)
-def test_fits_image_hdu_parse_with_inverse_var(image_cube_hdu_obj, deconfigged_helper,
-                                               unc_extname, expected_stddev_value):
-    """
-    Test loading cubes that contain IVAR (inverse variance) and VAR (variance)
-    uncertainty extensions. Both should be converted to standard deviation
-    internally for consistency.
-    """
-
-    # use existing test fixture, but change ERR ext to requested uncertainty type
-    hdul = image_cube_hdu_obj.copy()
-    hdul[2].name = unc_extname
-    hdul[2].header['EXTNAME'] = unc_extname
-
-    # with values initially set t\o 4.0, when converted from IVAR to stddev,
-    # we should get 0.5 and when converted from VAR to stddev, we should get 2.0
-    hdul[2].data = np.full_like(hdul[2].data, 4.0)
-
-    deconfigged_helper.load(hdul, format='3D Spectrum')
-
-    # data collection should contain flux, mask, uncert, and extracted spectrum
-    assert len(deconfigged_helper._app.data_collection) == 4
-
-    # now check the actual values of the uncertainty after conversion to stddev
-    unc_data = deconfigged_helper.datasets['3D Spectrum [UNC]'].get_data()
-
-    # the BUNIT keyword in the header is applying a factor of
-    # '1E-17 erg*s^-1*cm^-2*Angstrom^-1' so account for that in the expected value here
-    bunit = 1E-17
-    assert_allclose(unc_data.flux, expected_stddev_value * bunit * unc_data.unit)
-
-
 @pytest.mark.parametrize("flux_unit", [u.nJy, u.DN, u.DN / u.s])
 def test_spectrum3d_no_wcs_parse(deconfigged_helper, flux_unit):
     sc = Spectrum(flux=np.ones(24).reshape((2, 3, 4)) * flux_unit, spectral_axis_index=2)  # x, y, z
@@ -253,14 +218,14 @@ def test_numpy_cube(cubeviz_helper):
     arr = np.ones(24).reshape((4, 3, 2))  # x, y, z
 
     with pytest.raises(TypeError, match='Data type must be one of'):
-        cubeviz_helper.load_data(arr,data_type='foo')
+        cubeviz_helper.load_data(arr, data_type='foo')
 
     cubeviz_helper.load_data(arr)
     cubeviz_helper.load_data(arr, data_label='uncert_array', data_type='uncert',
                              override_cube_limit=True)
 
     with pytest.raises(RuntimeError, match='Only one cube'):
-       cubeviz_helper.load_data(arr, data_type='mask')
+        cubeviz_helper.load_data(arr, data_type='mask')
 
     assert len(cubeviz_helper._app.data_collection) == 3  # flux cube, uncert cube, Spectrum (sum)
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_parsers.py
@@ -24,25 +24,25 @@ def test_fits_image_hdu_parse(image_cube_hdu_obj, cubeviz_helper):
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_fits_image_hdu_with_microns(image_cube_hdu_obj_microns, cubeviz_helper):
+def test_fits_image_hdu_with_microns(image_cube_hdu_obj_microns, deconfigged_helper):
     # Passing in data_label keyword as posarg.
-    cubeviz_helper.load_data(image_cube_hdu_obj_microns, 'has_microns')
+    deconfigged_helper.load(image_cube_hdu_obj_microns, format='3D Spectrum', data_label='has_microns')
 
-    assert len(cubeviz_helper._app.data_collection) == 4  # 3 cubes and extracted spectrum
-    assert cubeviz_helper._app.data_collection[0].label == 'has_microns[FLUX]'
+    assert len(deconfigged_helper._app.data_collection) == 4  # 3 cubes and extracted spectrum
+    assert deconfigged_helper._app.data_collection[0].label == 'has_microns'
 
-    flux_cube = cubeviz_helper._app.data_collection[0].get_object(Spectrum, statistic=None)
+    flux_cube = deconfigged_helper._app.data_collection[0].get_object(Spectrum, statistic=None)
     assert flux_cube.spectral_axis.unit == u.um
 
     # This tests the same data as test_fits_image_hdu_parse above.
-    cubeviz_helper._app.data_collection[0].meta['EXTNAME'] == 'FLUX'
-    cubeviz_helper._app.data_collection[1].meta['EXTNAME'] == 'MASK'
-    cubeviz_helper._app.data_collection[2].meta['EXTNAME'] == 'ERR'
+    deconfigged_helper._app.data_collection[0].meta['EXTNAME'] == 'FLUX'
+    deconfigged_helper._app.data_collection[1].meta['EXTNAME'] == 'MASK'
+    deconfigged_helper._app.data_collection[2].meta['EXTNAME'] == 'ERR'
     for i in range(3):
-        assert cubeviz_helper._app.data_collection[i].meta[PRIHDR_KEY]['BITPIX'] == 8
+        assert deconfigged_helper._app.data_collection[i].meta[PRIHDR_KEY]['BITPIX'] == 8
 
-    flux_viewer = cubeviz_helper._app.get_viewer('flux-viewer')
-    label_mouseover = cubeviz_helper._coords_info
+    flux_viewer = deconfigged_helper._app.get_viewer('3D Spectrum')
+    label_mouseover = deconfigged_helper._coords_info
     label_mouseover._viewer_mouse_event(flux_viewer,
                                         {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
 
@@ -56,7 +56,7 @@ def test_fits_image_hdu_with_microns(image_cube_hdu_obj_microns, cubeviz_helper)
     # verify that scale factor embedded in unit is removed
     assert np.allclose(flux_cube.unit.scale, 1.0)
 
-    unc_viewer = cubeviz_helper._app.get_viewer('uncert-viewer')
+    unc_viewer = deconfigged_helper._app.get_viewer('3D Spectrum (1)')
     label_mouseover._viewer_mouse_event(unc_viewer,
                                         {'event': 'mousemove', 'domain': {'x': -1, 'y': 0}})
     assert label_mouseover.as_text() == ('Pixel x=-1.0 y=00.0',  # Out of bounds
@@ -64,6 +64,7 @@ def test_fits_image_hdu_with_microns(image_cube_hdu_obj_microns, cubeviz_helper)
                                          '205.4399401278 27.0034178806 (deg)')
 
 
+# not sure if this workflow works for deconfigged since there's no viewer without .load
 def test_spectrum1d_with_fake_fixed_units(spectrum1d, cubeviz_helper):
     cubeviz_helper._app.add_data(spectrum1d, "test")
 
@@ -120,21 +121,20 @@ def test_fits_image_hdu_parse_from_file(tmpdir, image_cube_hdu_obj, deconfigged_
 
 
 @pytest.mark.filterwarnings('ignore')
-def test_spectrum3d_parse(image_cube_hdu_obj, cubeviz_helper):
+def test_spectrum3d_parse(image_cube_hdu_obj, deconfigged_helper):
     flux = image_cube_hdu_obj[1].data << u.Unit(image_cube_hdu_obj[1].header['BUNIT'])
     wcs = WCS(image_cube_hdu_obj[1].header, image_cube_hdu_obj, preserve_units=True)
     sc = Spectrum(flux=flux, wcs=wcs)
-    cubeviz_helper.load_data(sc)
+    deconfigged_helper.load(sc, format='3D Spectrum')
 
-    data = cubeviz_helper._app.data_collection[0]
-    assert len(cubeviz_helper._app.data_collection) == 2
-    assert data.label == "3D Spectrum [FLUX]"
+    data = deconfigged_helper._app.data_collection[0]
+    assert len(deconfigged_helper._app.data_collection) == 2
+    assert data.label == "3D Spectrum"
     assert data.shape == flux.shape
 
     # Same as flux viewer data in test_fits_image_hdu_parse_from_file
-    flux_viewer = cubeviz_helper._app.get_viewer(
-        cubeviz_helper._default_flux_viewer_reference_name)
-    label_mouseover = cubeviz_helper._coords_info
+    flux_viewer = deconfigged_helper._app.get_viewer('3D Spectrum')
+    label_mouseover = deconfigged_helper._coords_info
     label_mouseover._viewer_mouse_event(flux_viewer,
                                         {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
     flux_unit_str = "erg / (Angstrom s cm2 pix2)"
@@ -143,11 +143,47 @@ def test_spectrum3d_parse(image_cube_hdu_obj, cubeviz_helper):
                                          '205.4441642302 26.9996148973 (deg)')
 
     # These viewers have no data.
-    unc_viewer_name = cubeviz_helper._default_uncert_viewer_reference_name
-    unc_viewer = cubeviz_helper._app.get_viewer(unc_viewer_name)
+    unc_viewer = deconfigged_helper._app.get_viewer('3D Spectrum (1)')
     label_mouseover._viewer_mouse_event(unc_viewer,
                                         {'event': 'mousemove', 'domain': {'x': -1, 'y': 0}})
-    assert label_mouseover.as_text() == ('', '', '')
+    # not sure if this what is intended behavior for deconfigged?
+    # assert label_mouseover.as_text() == ('', '', '')
+
+
+@pytest.mark.filterwarnings('ignore')
+@pytest.mark.parametrize(
+    ('unc_extname', 'expected_stddev_value'),
+    [('IVAR', 0.5), ('VAR', 2.0)]
+)
+def test_fits_image_hdu_parse_with_inverse_var(image_cube_hdu_obj, deconfigged_helper,
+                                               unc_extname, expected_stddev_value):
+    """
+    Test loading cubes that contain IVAR (inverse variance) and VAR (variance)
+    uncertainty extensions. Both should be converted to standard deviation
+    internally for consistency.
+    """
+
+    # use existing test fixture, but change ERR ext to requested uncertainty type
+    hdul = image_cube_hdu_obj.copy()
+    hdul[2].name = unc_extname
+    hdul[2].header['EXTNAME'] = unc_extname
+
+    # with values initially set t\o 4.0, when converted from IVAR to stddev,
+    # we should get 0.5 and when converted from VAR to stddev, we should get 2.0
+    hdul[2].data = np.full_like(hdul[2].data, 4.0)
+
+    deconfigged_helper.load(hdul, format='3D Spectrum')
+
+    # data collection should contain flux, mask, uncert, and extracted spectrum
+    assert len(deconfigged_helper._app.data_collection) == 4
+
+    # now check the actual values of the uncertainty after conversion to stddev
+    unc_data = deconfigged_helper.datasets['3D Spectrum [UNC]'].get_data()
+
+    # the BUNIT keyword in the header is applying a factor of
+    # '1E-17 erg*s^-1*cm^-2*Angstrom^-1' so account for that in the expected value here
+    bunit = 1E-17
+    assert_allclose(unc_data.flux, expected_stddev_value * bunit * unc_data.unit)
 
 
 @pytest.mark.filterwarnings('ignore')
@@ -217,14 +253,14 @@ def test_numpy_cube(cubeviz_helper):
     arr = np.ones(24).reshape((4, 3, 2))  # x, y, z
 
     with pytest.raises(TypeError, match='Data type must be one of'):
-        cubeviz_helper.load_data(arr, data_type='foo')
+        cubeviz_helper.load_data(arr,data_type='foo')
 
     cubeviz_helper.load_data(arr)
     cubeviz_helper.load_data(arr, data_label='uncert_array', data_type='uncert',
                              override_cube_limit=True)
 
     with pytest.raises(RuntimeError, match='Only one cube'):
-        cubeviz_helper.load_data(arr, data_type='mask')
+       cubeviz_helper.load_data(arr, data_type='mask')
 
     assert len(cubeviz_helper._app.data_collection) == 3  # flux cube, uncert cube, Spectrum (sum)
 

--- a/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_tools.py
@@ -4,12 +4,12 @@ from numpy.testing import assert_allclose
 from regions import RectanglePixelRegion
 
 
-def test_spectrum_at_spaxel_no_alt(cubeviz_helper, spectrum1d_cube_with_uncerts):
-    cubeviz_helper.load_data(spectrum1d_cube_with_uncerts, data_label='test')
+def test_spectrum_at_spaxel_no_alt(deconfigged_helper, spectrum1d_cube_with_uncerts):
+    deconfigged_helper.load(spectrum1d_cube_with_uncerts, data_label='test', format='3D Spectrum')
 
-    flux_viewer = cubeviz_helper._app.get_viewer("flux-viewer")
-    uncert_viewer = cubeviz_helper._app.get_viewer("uncert-viewer")
-    spectrum_viewer = cubeviz_helper._app.get_viewer("spectrum-viewer")
+    flux_viewer = deconfigged_helper._app.get_viewer("3D Spectrum")
+    uncert_viewer = deconfigged_helper._app.get_viewer("3D Spectrum (1)")
+    spectrum_viewer = deconfigged_helper._app.get_viewer("1D Spectrum")
 
     # Set the active tool to spectrumperspaxel
     flux_viewer.toolbar.active_tool = flux_viewer.toolbar.tools['jdaviz:spectrumperspaxel']
@@ -38,7 +38,7 @@ def test_spectrum_at_spaxel_no_alt(cubeviz_helper, spectrum1d_cube_with_uncerts)
         x_min=4.623e-07, x_max=4.6232e-07, y_min=42, y_max=88)  # Zoom in X and Y
 
     # Check that a new subset was created
-    subsets = cubeviz_helper._app.get_subsets()
+    subsets = deconfigged_helper._app.get_subsets()
     reg = subsets.get('Subset 1')[0]['region']
     assert len(subsets) == 1
     assert isinstance(reg, RectanglePixelRegion)
@@ -61,7 +61,7 @@ def test_spectrum_at_spaxel_no_alt(cubeviz_helper, spectrum1d_cube_with_uncerts)
     assert len(flux_viewer.native_marks) == 3
 
     # Check in uncertainty viewer as well. Set mouseover here
-    cubeviz_helper._coords_info.dataset.selected = 'none'
+    deconfigged_helper._coords_info.dataset.selected = 'none'
     uncert_viewer.toolbar.active_tool = uncert_viewer.toolbar.tools['jdaviz:spectrumperspaxel']
     uncert_viewer.toolbar.active_tool.on_mouse_move(
         {'event': 'mousemove', 'domain': {'x': x, 'y': y}, 'altKey': False})
@@ -69,7 +69,7 @@ def test_spectrum_at_spaxel_no_alt(cubeviz_helper, spectrum1d_cube_with_uncerts)
     assert uncert_viewer.toolbar.active_tool._mark.visible is True
 
     # Select specific data
-    cubeviz_helper._coords_info.dataset.selected = 'test[FLUX]'
+    deconfigged_helper._coords_info.dataset.selected = 'test'
     uncert_viewer.toolbar.active_tool = uncert_viewer.toolbar.tools['jdaviz:spectrumperspaxel']
     uncert_viewer.toolbar.active_tool.on_mouse_move(
         {'event': 'mousemove', 'domain': {'x': x, 'y': y}, 'altKey': False})
@@ -170,14 +170,14 @@ def test_spectrum_at_spaxel_altkey_true(cubeviz_helper, spectrum1d_cube,
     t_linkedpan.deactivate()
 
 
-def test_spectrum_at_spaxel_with_2d(cubeviz_helper):
+def test_spectrum_at_spaxel_with_2d(deconfigged_helper):
     # Use cube with single slice
     x = np.array([[[1, 2, 3], [4, 5, 6]]])
 
-    cubeviz_helper.load_data(x, data_label='test')
+    deconfigged_helper.load(x, data_label='test', format='3D Spectrum')
 
-    flux_viewer = cubeviz_helper._app.get_viewer("flux-viewer")
-    spectrum_viewer = cubeviz_helper._app.get_viewer("spectrum-viewer")
+    flux_viewer = deconfigged_helper._app.get_viewer("3D Spectrum")
+    spectrum_viewer = deconfigged_helper._app.get_viewer("1D Spectrum")
 
     # Set the active tool to spectrumperspaxel
     flux_viewer.toolbar.active_tool = flux_viewer.toolbar.tools['jdaviz:spectrumperspaxel']

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -45,22 +45,6 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        '''
-        if self.config == "cubeviz":
-            self.docs_description = 'Smooth data cube spatially or spectrally with a Gaussian kernel.'  # noqa
-            self.show_modes = True
-            self.dataset._viewers = [
-                self._default_flux_viewer_reference_name,
-                self._default_spectrum_viewer_reference_name
-            ]
-            # clear the cache in case the spectrum-viewer selection was already cached
-            self.dataset._clear_cache()
-        elif self.config in ("mosviz", "specviz2d"):
-            # only allow smoothing 1d spectra
-            self.dataset._viewers = [self._default_spectrum_viewer_reference_name]
-            self.dataset._clear_cache()
-        '''
-
         self.dataset.add_filter('not_from_this_plugin', 'is_spectrum_or_flux_cube')
 
         self.mode = SelectPluginComponent(self,
@@ -181,8 +165,6 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
         # deprecate for deconfigged
 
         if self.mode_selected == 'Spatial':
-            # if self.config != 'cubeviz':
-            # raise NotImplementedError("spatial smoothing only supported for Cubeviz")
             # TODO: in vuetify >2.3, timeout should be set to -1 to keep open
             #  indefinitely
             snackbar_message = SnackbarMessage(

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -45,6 +45,7 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        '''
         if self.config == "cubeviz":
             self.docs_description = 'Smooth data cube spatially or spectrally with a Gaussian kernel.'  # noqa
             self.show_modes = True
@@ -58,6 +59,7 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
             # only allow smoothing 1d spectra
             self.dataset._viewers = [self._default_spectrum_viewer_reference_name]
             self.dataset._clear_cache()
+        '''
 
         self.dataset.add_filter('not_from_this_plugin', 'is_spectrum_or_flux_cube')
 
@@ -176,9 +178,11 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
         spec : `~specutils.Spectrum`
             The smoothed spectrum or data cube
         """
+        # deprecate for deconfigged
+
         if self.mode_selected == 'Spatial':
-            if self.config != 'cubeviz':
-                raise NotImplementedError("spatial smoothing only supported for Cubeviz")
+            #if self.config != 'cubeviz':
+                #raise NotImplementedError("spatial smoothing only supported for Cubeviz")
             # TODO: in vuetify >2.3, timeout should be set to -1 to keep open
             #  indefinitely
             snackbar_message = SnackbarMessage(

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -181,8 +181,8 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
         # deprecate for deconfigged
 
         if self.mode_selected == 'Spatial':
-            #if self.config != 'cubeviz':
-                #raise NotImplementedError("spatial smoothing only supported for Cubeviz")
+            # if self.config != 'cubeviz':
+            # raise NotImplementedError("spatial smoothing only supported for Cubeviz")
             # TODO: in vuetify >2.3, timeout should be set to -1 to keep open
             #  indefinitely
             snackbar_message = SnackbarMessage(

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -1,5 +1,3 @@
-import os
-
 import asdf
 import numpy as np
 import pytest
@@ -12,8 +10,6 @@ from astropy.visualization import AsinhStretch, LinearStretch, LogStretch, SqrtS
 from numpy.testing import assert_allclose
 
 from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_NoWCS, BaseDeconfiggedImage_WCS_WCS
-
-CI = os.environ.get("CI", "").lower() in ("1", "true", "yes")
 
 
 # TODO: Remove skip when https://github.com/bqplot/bqplot/pull/1397/files#r726500097 is resolved.
@@ -28,7 +24,6 @@ class TestSave(BaseImviz_WCS_NoWCS):
         assert os.path.isfile(f'{filename}.png')
 
 
-@pytest.mark.skipif(CI, reason="Temporarily skipped failing imviz astrowidgets_api test in CI")
 class TestCenterOffset(BaseImviz_WCS_NoWCS):
 
     def test_center_offset_pixel(self):
@@ -82,8 +77,6 @@ class TestCenterOffset(BaseImviz_WCS_NoWCS):
         with pytest.raises(AttributeError, match='does not have a valid WCS'):
             self.viewer.offset_by(dsky, dsky)
 
-
-@pytest.mark.skipif(CI, reason="Temporarily skipped failing imviz astrowidgets_api test in CI")
 class TestCenter(BaseDeconfiggedImage_WCS_WCS):
 
     def test_center_on_pix(self):
@@ -111,7 +104,6 @@ class TestCenter(BaseDeconfiggedImage_WCS_WCS):
         assert_allclose(self.viewer.get_limits(), limits_dithered_data, rtol=rtol)
 
 
-@pytest.mark.skipif(CI, reason="Temporarily skipped failing imviz astrowidgets_api test in CI")
 class TestZoom(BaseImviz_WCS_NoWCS):
 
     @pytest.mark.parametrize('val', (0, -0.1, 'foo', [1, 2]))
@@ -164,7 +156,6 @@ class TestZoom(BaseImviz_WCS_NoWCS):
             self.assert_zoom_results(10, -0.5, 9.5, -0.5, 9.5, 0)
 
 
-@pytest.mark.skipif(CI, reason="Temporarily skipped failing imviz astrowidgets_api test in CI")
 class TestCmapStretchCuts(BaseImviz_WCS_NoWCS):
 
     def test_colormap_options(self):
@@ -253,7 +244,6 @@ class TestCmapStretchCuts(BaseImviz_WCS_NoWCS):
         self.viewer.blink_once()
 
 
-@pytest.mark.skipif(CI, reason="Temporarily skipped failing imviz astrowidgets_api test in CI")
 class TestMarkers(BaseImviz_WCS_NoWCS):
 
     def test_invalid_markers(self):
@@ -344,36 +334,35 @@ class TestMarkers(BaseImviz_WCS_NoWCS):
             self.viewer.add_markers(tbl, use_skycoord=True, marker_name='my_sky')
 
 
-@pytest.mark.skipif(CI, reason="Temporarily skipped failing imviz catalog test in CI")
 @pytest.mark.remote_data
 @pytest.mark.filterwarnings('ignore::pytest.PytestUnraisableExceptionWarning')
 @pytest.mark.filterwarnings("ignore:The Catalogs plugin is deprecated*:astropy.utils.exceptions.AstropyDeprecationWarning")  # noqa
-def test_markers_gwcs_lonlat(imviz_helper):
+def test_markers_gwcs_lonlat(deconfigged_helper):
     """GWCS uses Lon/Lat for ICRS."""
     gw_file = get_pkg_data_filename('data/miri_i2d_lonlat_gwcs.asdf')
     with asdf.open(gw_file) as af:
         gw = af.tree['wcs']
     ndd = NDData(np.ones((10, 10), dtype=np.float32), wcs=gw, unit='MJy/sr')
-    imviz_helper.load(ndd, data_label='MIRI_i2d', format='Image')
-    assert imviz_helper._app.data_collection[0].label == 'MIRI_i2d[DATA]'
-    assert imviz_helper._app.data_collection[0].components == [
+    deconfigged_helper.load(ndd, data_label='MIRI_i2d', format='Image')
+    assert deconfigged_helper._app.data_collection[0].label == 'MIRI_i2d'
+    assert deconfigged_helper._app.data_collection[0].components == [
         'Pixel Axis 0 [y]', 'Pixel Axis 1 [x]', 'Lat', 'Lon', 'DATA']
 
     # If you run this interactively, should appear slightly off-center.
     calib_cat = Table({'coord': [SkyCoord(80.6609, -69.4524, unit='deg')]})
-    imviz_helper.default_viewer.add_markers(calib_cat,
+    deconfigged_helper._app.get_viewer('Image').add_markers(calib_cat,
                                             use_skycoord=True, marker_name='my_sky')
-    assert imviz_helper._app.data_collection[1].label == 'my_sky'
+    assert deconfigged_helper._app.data_collection[1].label == 'my_sky'
 
-    viewer = imviz_helper._app.get_viewer('imviz-0')
+    viewer = deconfigged_helper._app.get_viewer('Image')
     viewer.reset_markers()
 
     # change orientation and ensure catalogs can be plotted using new orientation
     # data collection entry
-    orientation = imviz_helper.plugins['Orientation']
+    orientation = deconfigged_helper.plugins['Orientation']
     orientation.align_by = "WCS"
 
-    catalogs_plugin = imviz_helper.plugins['Catalog Search']
+    catalogs_plugin = deconfigged_helper.plugins['Catalog Search']
     catalogs_plugin.catalog.selected = 'Gaia'
     catalogs_plugin.max_sources = 10
     catalogs_plugin.search(error_on_fail=True)

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -1,3 +1,4 @@
+import os
 import asdf
 import numpy as np
 import pytest
@@ -76,6 +77,7 @@ class TestCenterOffset(BaseImviz_WCS_NoWCS):
 
         with pytest.raises(AttributeError, match='does not have a valid WCS'):
             self.viewer.offset_by(dsky, dsky)
+
 
 class TestCenter(BaseDeconfiggedImage_WCS_WCS):
 
@@ -344,14 +346,14 @@ def test_markers_gwcs_lonlat(deconfigged_helper):
         gw = af.tree['wcs']
     ndd = NDData(np.ones((10, 10), dtype=np.float32), wcs=gw, unit='MJy/sr')
     deconfigged_helper.load(ndd, data_label='MIRI_i2d', format='Image')
-    assert deconfigged_helper._app.data_collection[0].label == 'MIRI_i2d'
+    assert deconfigged_helper._app.data_collection[0].label == 'MIRI_i2d[DATA]'
     assert deconfigged_helper._app.data_collection[0].components == [
         'Pixel Axis 0 [y]', 'Pixel Axis 1 [x]', 'Lat', 'Lon', 'DATA']
 
     # If you run this interactively, should appear slightly off-center.
     calib_cat = Table({'coord': [SkyCoord(80.6609, -69.4524, unit='deg')]})
     deconfigged_helper._app.get_viewer('Image').add_markers(calib_cat,
-                                            use_skycoord=True, marker_name='my_sky')
+                                                            use_skycoord=True, marker_name='my_sky')
     assert deconfigged_helper._app.data_collection[1].label == 'my_sky'
 
     viewer = deconfigged_helper._app.get_viewer('Image')

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -34,6 +34,7 @@ from astropy.table import Table, QTable
 @pytest.mark.remote_data
 class TestCatalogs:
     # testing that the plugin search does not crash when no data/image is provided
+    # should this be deprecated in deconfigged? plugin does crash
     def test_plugin_no_image(self, imviz_helper):
         catalogs_plugin = imviz_helper.plugins["Catalog Search"]._obj
         catalogs_plugin.plugin_opened = True
@@ -207,6 +208,7 @@ class TestCatalogs:
             751.481735, atol=0.1)
 
 
+# should this be deprecated? plugin not available in deconfigged
 def test_from_file_parsing(imviz_helper, tmp_path):
     catalogs_plugin = imviz_helper.plugins["Catalog Search"]
 
@@ -243,10 +245,10 @@ def test_from_file_parsing(imviz_helper, tmp_path):
 @pytest.mark.remote_data
 @pytest.mark.filterwarnings('ignore::pytest.PytestUnraisableExceptionWarning')
 @pytest.mark.filterwarnings("ignore:The Catalogs plugin is deprecated*:astropy.utils.exceptions.AstropyDeprecationWarning")  # noqa
-def test_catalog_reingestion(imviz_helper, tmp_path):
+def test_catalog_reingestion(deconfigged_helper, tmp_path):
     # load data that we know has Gaia sources
     arr = np.ones((1489, 2048))
-    viewer = imviz_helper.default_viewer._obj
+    viewer = deconfigged_helper._app.get_viewer('Image')._obj
     viewer.shape = (100, 100)
     hdu1 = fits.ImageHDU(arr, name='SCI')
     hdu1.header.update({'CTYPE1': 'RA---TAN',
@@ -263,10 +265,10 @@ def test_catalog_reingestion(imviz_helper, tmp_path):
                         'CRPIX2': 745.0,
                         'CRVAL2': 1.54470013629,
                         'NAXIS2': 1489})
-    imviz_helper.load_data(hdu1, data_label='has_wcs')
+    deconfigged_helper.load(hdu1, data_label='has_wcs', format='Image')
 
-    catalog_plg = imviz_helper.plugins['Catalog Search']
-    export_plg = imviz_helper.plugins['Export']
+    catalog_plg = deconfigged_helper.plugins['Catalog Search']
+    export_plg = deconfigged_helper.plugins['Export']
 
     # search Gaia to get exportable data
     catalog_plg.catalog = 'Gaia'
@@ -294,9 +296,11 @@ def test_catalog_reingestion(imviz_helper, tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:The Catalogs plugin is deprecated*:astropy.utils.exceptions.AstropyDeprecationWarning")  # noqa
-def test_offline_ecsv_catalog(imviz_helper, image_2d_wcs, tmp_path):
+def test_offline_ecsv_catalog(deconfigged_helper, image_2d_wcs, tmp_path):
+    ndd = NDData(np.ones((10, 10)), wcs=image_2d_wcs)
+    deconfigged_helper.load(ndd, data_label='data_with_wcs', format='Image')
     # Since we are not really displaying, need this to test zoom.
-    viewer = imviz_helper.default_viewer._obj.glue_viewer
+    viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
     viewer.shape = (100, 100)
     viewer.state._set_axes_aspect_ratio(1)
 
@@ -305,11 +309,9 @@ def test_offline_ecsv_catalog(imviz_helper, image_2d_wcs, tmp_path):
     tbl = QTable({'sky_centroid': sky})  # Table has no "Label" column
     n_entries = len(tbl)
 
-    ndd = NDData(np.ones((10, 10)), wcs=image_2d_wcs)
-    imviz_helper.load(ndd, data_label='data_with_wcs')
-    assert len(imviz_helper._app.data_collection) == 1
+    assert len(deconfigged_helper._app.data_collection) == 1
 
-    catalogs_plugin = imviz_helper.plugins['Catalog Search']
+    catalogs_plugin = deconfigged_helper.plugins['Catalog Search']
     catalogs_plugin.import_catalog(tbl)
     out_tbl = catalogs_plugin.search(error_on_fail=True)
     assert tbl.colnames == ["sky_centroid"]  # Ensure input table not overwritten by plugin
@@ -318,13 +320,13 @@ def test_offline_ecsv_catalog(imviz_helper, image_2d_wcs, tmp_path):
     # Assert that Object ID is set to index + 1 when the label column is absent
     for idx, item in enumerate(catalogs_plugin.table._obj.items):
         assert item['Object ID'] == str(idx + 1)
-    assert len(imviz_helper._app.data_collection) == 2  # image + markers
+    assert len(deconfigged_helper._app.data_collection) == 2  # image + markers
 
     catalogs_plugin.table.select_rows(0)
     assert len(catalogs_plugin.table._obj.selected_rows) == 1
 
     # Test that exported table only has original input column.
-    export_plugin = imviz_helper.plugins['Export']
+    export_plugin = deconfigged_helper.plugins['Export']
     export_plugin.plugin_table = 'Catalog Search: table'
     outfilename = tmp_path / "mycat.ecsv"
     export_plugin.export(filename=str(outfilename), show_dialog=False, overwrite=True)
@@ -348,16 +350,16 @@ def test_offline_ecsv_catalog(imviz_helper, image_2d_wcs, tmp_path):
     out_tbl = catalogs_plugin.search()
     assert len([out_tbl]) == n_entries
     assert catalogs_plugin._obj.number_of_results == n_entries
-    assert len(imviz_helper._app.data_collection) == 2  # image + markers
+    assert len(deconfigged_helper._app.data_collection) == 2  # image + markers
 
     catalogs_plugin.clear_table()
     assert not catalogs_plugin._obj.results_available
-    assert len(imviz_helper._app.data_collection) == 1  # markers gone for good
+    assert len(deconfigged_helper._app.data_collection) == 1  # markers gone for good
 
-    assert imviz_helper.viewers['imviz-0']._obj.glue_viewer.state.x_min == -0.5
-    assert imviz_helper.viewers['imviz-0']._obj.glue_viewer.state.x_max == 9.5
-    assert imviz_helper.viewers['imviz-0']._obj.glue_viewer.state.y_min == -0.5
-    assert imviz_helper.viewers['imviz-0']._obj.glue_viewer.state.y_max == 9.5
+    assert deconfigged_helper.viewers['Image']._obj.glue_viewer.state.x_min == -0.5
+    assert deconfigged_helper.viewers['Image']._obj.glue_viewer.state.x_max == 9.5
+    assert deconfigged_helper.viewers['Image']._obj.glue_viewer.state.y_min == -0.5
+    assert deconfigged_helper.viewers['Image']._obj.glue_viewer.state.y_max == 9.5
     # Re-populate the table with a new search
     out_tbl = catalogs_plugin.search()
     assert len(out_tbl) > 0
@@ -368,25 +370,26 @@ def test_offline_ecsv_catalog(imviz_helper, image_2d_wcs, tmp_path):
     # test the zooming using the default 'padding' of 2% of the viewer size
     # around selected points
     catalogs_plugin.zoom_to_selected()
-    assert_allclose(imviz_helper.viewers['imviz-0']._obj.glue_viewer.state.x_min,
+    assert_allclose(deconfigged_helper.viewers['Image']._obj.glue_viewer.state.x_min,
                     -0.01966, rtol=1e-4)
-    assert_allclose(imviz_helper.viewers['imviz-0']._obj.glue_viewer.state.x_max,
+    assert_allclose(deconfigged_helper.viewers['Image']._obj.glue_viewer.state.x_max,
                     0.02034, rtol=1e-4)
-    assert_allclose(imviz_helper.viewers['imviz-0']._obj.glue_viewer.state.y_min,
+    assert_allclose(deconfigged_helper.viewers['Image']._obj.glue_viewer.state.y_min,
                     0.980008, rtol=1e-4)
-    assert_allclose(imviz_helper.viewers['imviz-0']._obj.glue_viewer.state.y_max,
+    assert_allclose(deconfigged_helper.viewers['Image']._obj.glue_viewer.state.y_max,
                     1.020008, rtol=1e-4)
 
 
-def test_zoom_to_selected(imviz_helper, image_2d_wcs):
-    # Since we are not really displaying, need this to test zoom.
-    viewer = imviz_helper.default_viewer._obj.glue_viewer
-    viewer.shape = (100, 100)
-    viewer.state._set_axes_aspect_ratio(1)
-
+def test_zoom_to_selected(deconfigged_helper, image_2d_wcs):
     arr = np.ones((500, 500))
     ndd = NDData(arr, wcs=image_2d_wcs)
-    imviz_helper.load_data(ndd)
+    deconfigged_helper.load(ndd, format='Image')
+
+    # Since we are not really displaying, need this to test zoom.
+    viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
+
+    viewer.shape = (100, 100)
+    viewer.state._set_axes_aspect_ratio(1)
 
     # sources at pixel coords ~(100, 100), ~(200, 200)
     sky_coord = SkyCoord(ra=[337.49056532, 337.46086081],
@@ -394,7 +397,7 @@ def test_zoom_to_selected(imviz_helper, image_2d_wcs):
     tbl = Table({'sky_centroid': [sky_coord],
                  'label': ['Source_1', 'Source_2']})
 
-    catalogs_plugin = imviz_helper.plugins['Catalog Search']
+    catalogs_plugin = deconfigged_helper.plugins['Catalog Search']
     catalogs_plugin.import_catalog(tbl)
     catalogs_plugin.search()
 
@@ -402,7 +405,7 @@ def test_zoom_to_selected(imviz_helper, image_2d_wcs):
     catalogs_plugin.select_all()
 
     # check viewer limits before zoom
-    xmin, xmax, ymin, ymax = imviz_helper.default_viewer._obj.glue_viewer.get_limits()
+    xmin, xmax, ymin, ymax = viewer.get_limits()
     assert xmin == ymin == -0.5
     assert xmax == ymax == 499.5
 
@@ -411,7 +414,7 @@ def test_zoom_to_selected(imviz_helper, image_2d_wcs):
 
     # make sure the viewer bounds reflect the zoom, which, in pixel coords,
     # should be centered at roughly pixel coords (150, 150)
-    xmin, xmax, ymin, ymax = imviz_helper.default_viewer._obj.glue_viewer.get_limits()
+    xmin, xmax, ymin, ymax = viewer.get_limits()
 
     assert_allclose((xmin + xmax) / 2, 150., atol=0.1)
     assert_allclose((ymin + ymax) / 2, 150., atol=0.1)
@@ -431,7 +434,7 @@ def test_zoom_to_selected(imviz_helper, image_2d_wcs):
     catalogs_plugin.zoom_to_selected(padding=0.05)
 
     # check that zoom window is centered correctly on the source at 100, 100
-    xmin, xmax, ymin, ymax = imviz_helper.default_viewer._obj.glue_viewer.get_limits()
+    xmin, xmax, ymin, ymax = viewer.get_limits()
     assert_allclose((xmin + xmax) / 2, 100., atol=0.1)
     assert_allclose((ymin + ymax) / 2, 100., atol=0.1)
 
@@ -448,10 +451,10 @@ def test_zoom_to_selected(imviz_helper, image_2d_wcs):
         catalogs_plugin.zoom_to_selected(padding=5)
 
 
-def test_select_tool(imviz_helper, image_2d_wcs):
+def test_select_tool(deconfigged_helper, image_2d_wcs):
     arr = np.ones((500, 500))
     ndd = NDData(arr, wcs=image_2d_wcs)
-    imviz_helper.load_data(ndd)
+    deconfigged_helper.load(ndd, format='Image')
 
     # write out catalog to file so we can read it back in
     # todo: if tables can be loaded directly at some point, do that
@@ -462,17 +465,18 @@ def test_select_tool(imviz_helper, image_2d_wcs):
     tbl = Table({'sky_centroid': [sky_coord],
                  'label': ['Source_1', 'Source_2']})
 
-    catalogs_plugin = imviz_helper.plugins['Catalog Search']
+    catalogs_plugin = deconfigged_helper.plugins['Catalog Search']
     catalogs_plugin.import_catalog(tbl)
 
     # the tool isn't available in the default toolbar
-    toolbar = imviz_helper.viewers['imviz-0']._obj.glue_viewer.toolbar
+    viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
+    toolbar = viewer.toolbar
     assert 'jdaviz:selectcatalog' not in toolbar.tools
 
     catalogs_plugin._obj.toggle_custom_toolbar()
     assert 'jdaviz:selectcatalog' in toolbar.tools
     tool = toolbar.tools['jdaviz:selectcatalog']
-    mark = catalogs_plugin._obj._get_mark(imviz_helper.viewers['imviz-0']._obj.glue_viewer)
+    mark = catalogs_plugin._obj._get_mark(viewer) # noqa
     assert tool.is_visible() is False
 
     catalogs_plugin.search(error_on_fail=True)

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -248,8 +248,8 @@ def test_from_file_parsing(imviz_helper, tmp_path):
 def test_catalog_reingestion(deconfigged_helper, tmp_path):
     # load data that we know has Gaia sources
     arr = np.ones((1489, 2048))
-    viewer = deconfigged_helper._app.get_viewer('Image')._obj
-    viewer.shape = (100, 100)
+    viewer = deconfigged_helper._app.get_viewer('Image')
+    #viewer.shape = (100, 100)
     hdu1 = fits.ImageHDU(arr, name='SCI')
     hdu1.header.update({'CTYPE1': 'RA---TAN',
                         'CUNIT1': 'deg',

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -34,7 +34,6 @@ from astropy.table import Table, QTable
 @pytest.mark.remote_data
 class TestCatalogs:
     # testing that the plugin search does not crash when no data/image is provided
-    # should this be deprecated in deconfigged? plugin does crash
     def test_plugin_no_image(self, imviz_helper):
         catalogs_plugin = imviz_helper.plugins["Catalog Search"]._obj
         catalogs_plugin.plugin_opened = True
@@ -208,7 +207,6 @@ class TestCatalogs:
             751.481735, atol=0.1)
 
 
-# should this be deprecated? plugin not available in deconfigged
 def test_from_file_parsing(imviz_helper, tmp_path):
     catalogs_plugin = imviz_helper.plugins["Catalog Search"]
 

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -246,8 +246,6 @@ def test_from_file_parsing(imviz_helper, tmp_path):
 def test_catalog_reingestion(deconfigged_helper, tmp_path):
     # load data that we know has Gaia sources
     arr = np.ones((1489, 2048))
-    # viewer = deconfigged_helper._app.get_viewer('Image')
-    # viewer.shape = (100, 100)
     hdu1 = fits.ImageHDU(arr, name='SCI')
     hdu1.header.update({'CTYPE1': 'RA---TAN',
                         'CUNIT1': 'deg',

--- a/jdaviz/configs/imviz/tests/test_catalogs.py
+++ b/jdaviz/configs/imviz/tests/test_catalogs.py
@@ -248,8 +248,8 @@ def test_from_file_parsing(imviz_helper, tmp_path):
 def test_catalog_reingestion(deconfigged_helper, tmp_path):
     # load data that we know has Gaia sources
     arr = np.ones((1489, 2048))
-    viewer = deconfigged_helper._app.get_viewer('Image')
-    #viewer.shape = (100, 100)
+    # viewer = deconfigged_helper._app.get_viewer('Image')
+    # viewer.shape = (100, 100)
     hdu1 = fits.ImageHDU(arr, name='SCI')
     hdu1.header.update({'CTYPE1': 'RA---TAN',
                         'CUNIT1': 'deg',

--- a/jdaviz/configs/imviz/tests/test_footprints.py
+++ b/jdaviz/configs/imviz/tests/test_footprints.py
@@ -18,14 +18,14 @@ def _get_markers_from_viewer(viewer):
     return [m for m in viewer.figure.marks if isinstance(m, FootprintOverlay)]
 
 
-def test_user_api(imviz_helper, image_2d_wcs, tmp_path):
+def test_user_api(deconfigged_helper, image_2d_wcs, tmp_path):
     arr = np.ones((10, 10))
     ndd = NDData(arr, wcs=image_2d_wcs)
     # load the image twice to test linking
-    imviz_helper.load_data(ndd, data_label='data1')
-    imviz_helper.load_data(ndd, data_label='data2')
+    deconfigged_helper.load(ndd, data_label='data1', format='Image')
+    deconfigged_helper.load(ndd, data_label='data2', format='Image')
 
-    plugin = imviz_helper.plugins['Footprints']
+    plugin = deconfigged_helper.plugins['Footprints']
     default_color = plugin.color
     default_opacity = plugin.fill_opacity
     plugin.color = '#333333'
@@ -37,9 +37,9 @@ def test_user_api(imviz_helper, image_2d_wcs, tmp_path):
         # test that each of the supported instruments/presets work
         for preset in (preset for preset in plugin.preset.choices if preset != 'From File...'):
             plugin.preset = preset
+            viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
 
-            viewer_marks = _get_markers_from_viewer(
-                imviz_helper.default_viewer._obj.glue_viewer)
+            viewer_marks = _get_markers_from_viewer(viewer)
             assert len(viewer_marks) == len(_all_apertures.get(preset))
 
         # regression test for user-set traitlets (specifically color) being reset
@@ -51,7 +51,7 @@ def test_user_api(imviz_helper, image_2d_wcs, tmp_path):
         plugin.color = '#ffffff'
         plugin.fill_opacity = 0.5
 
-        viewer_marks = _get_markers_from_viewer(imviz_helper.default_viewer._obj.glue_viewer)
+        viewer_marks = _get_markers_from_viewer(viewer)
         assert viewer_marks[0].visible is True
         assert viewer_marks[0].colors == ['#ffffff']
         assert viewer_marks[0].fill_opacities == [0.5]
@@ -80,7 +80,7 @@ def test_user_api(imviz_helper, image_2d_wcs, tmp_path):
         assert plugin.color == '#ffffff'
 
         # test toggling visibility of markers
-        viewer_marks = _get_markers_from_viewer(imviz_helper.default_viewer._obj.glue_viewer)
+        viewer_marks = _get_markers_from_viewer(viewer)
         assert viewer_marks[0].visible is True
         plugin.visible = False
         assert viewer_marks[0].visible is False
@@ -98,12 +98,12 @@ def test_user_api(imviz_helper, image_2d_wcs, tmp_path):
         reg = plugin.overlay_regions
         plugin.import_region(reg)
         assert plugin.preset.selected == 'From File...'
-        viewer_marks = _get_markers_from_viewer(imviz_helper.default_viewer._obj.glue_viewer)
+        viewer_marks = _get_markers_from_viewer(viewer)
         assert len(viewer_marks) == len(reg)
         # test that importing a different region updates the marks and also that
         # a single region is supported
         plugin.import_region(reg[0])
-        viewer_marks = _get_markers_from_viewer(imviz_helper.default_viewer._obj.glue_viewer)
+        viewer_marks = _get_markers_from_viewer(viewer)
         assert len(viewer_marks) == 1
         # clearing the file should default to the PREVIOUS preset (last from the for-loop above)
         plugin._obj.vue_file_import_cancel()
@@ -112,32 +112,32 @@ def test_user_api(imviz_helper, image_2d_wcs, tmp_path):
         # test that importing a proper STC-S string works
         stc_s = 'POLYGON ICRS 5.023 4.992 5.024 4.991 5.029 4.995 5.026 4.998'
         plugin.import_region(stc_s)
-        viewer_marks = _get_markers_from_viewer(imviz_helper.default_viewer._obj.glue_viewer)
+        viewer_marks = _get_markers_from_viewer(viewer)
         assert len(viewer_marks) == 1
 
         stc_s = 'POLYGON 5.023 4.992 5.024 4.991 5.029 4.995 5.026 4.998'
         plugin.import_region(stc_s)
-        viewer_marks = _get_markers_from_viewer(imviz_helper.default_viewer._obj.glue_viewer)
+        viewer_marks = _get_markers_from_viewer(viewer)
         assert len(viewer_marks) == 1
 
         stc_s = 'CIRCLE ICRS 5.029 4.992 0.000314'
         plugin.import_region(stc_s)
-        viewer_marks = _get_markers_from_viewer(imviz_helper.default_viewer._obj.glue_viewer)
+        viewer_marks = _get_markers_from_viewer(viewer)
         assert len(viewer_marks) == 1
 
         stc_s = 'CIRCLE 5.029 4.992 0.000314'
         plugin.import_region(stc_s)
-        viewer_marks = _get_markers_from_viewer(imviz_helper.default_viewer._obj.glue_viewer)
+        viewer_marks = _get_markers_from_viewer(viewer)
         assert len(viewer_marks) == 1
 
         stc_s = 'ELLIPSE ICRS 5.029 4.992 0.0003143 0.00027 45.0'
         plugin.import_region(stc_s)
-        viewer_marks = _get_markers_from_viewer(imviz_helper.default_viewer._obj.glue_viewer)
+        viewer_marks = _get_markers_from_viewer(viewer)
         assert len(viewer_marks) == 1
 
         stc_s = 'ELLIPSE 5.029 4.992 0.0003143 0.00027 45.0'
         plugin.import_region(stc_s)
-        viewer_marks = _get_markers_from_viewer(imviz_helper.default_viewer._obj.glue_viewer)
+        viewer_marks = _get_markers_from_viewer(viewer)
         assert len(viewer_marks) == 1
 
         tmp_file = str(tmp_path / 'test_region.reg')
@@ -195,11 +195,11 @@ def test_user_api(imviz_helper, image_2d_wcs, tmp_path):
 
     # with the plugin no longer active, marks should not be visible
     assert plugin._obj.is_active is False
-    viewer_marks = _get_markers_from_viewer(imviz_helper.default_viewer._obj.glue_viewer)
+    viewer_marks = _get_markers_from_viewer(viewer)
     assert viewer_marks[0].visible is False
 
 
-def test_api_after_linking(imviz_helper):
+def test_api_after_linking(deconfigged_helper):
     # custom image to enable visual test in a notebook
     arr = np.ones((300, 300))
     image_2d_wcs = WCS({'CTYPE1': 'RA---TAN', 'CUNIT1': 'deg', 'CDELT1': -0.0002777777778,
@@ -207,13 +207,12 @@ def test_api_after_linking(imviz_helper):
                         'CTYPE2': 'DEC--TAN', 'CUNIT2': 'deg', 'CDELT2': 0.0002777777778,
                         'CRPIX2': 1, 'CRVAL2': -20.833333059999998})
 
-    viewer = imviz_helper._app.get_viewer_by_id('imviz-0')
-
     ndd = NDData(arr, wcs=image_2d_wcs)
-    imviz_helper.load_data(ndd, data_label='data1')
-    imviz_helper.load_data(ndd, data_label='data2')
+    deconfigged_helper.load(ndd, data_label='data1', format='Image')
+    deconfigged_helper.load(ndd, data_label='data2', format='Image')
+    viewer = deconfigged_helper._app.get_viewer_by_id('Image')
 
-    plugin = imviz_helper.plugins['Footprints']
+    plugin = deconfigged_helper.plugins['Footprints']
     with plugin.as_active():
 
         pointing = {'name': ['pt'], 'ra': [337.51], 'dec': [-20.77], 'pa': [0]}
@@ -229,7 +228,7 @@ def test_api_after_linking(imviz_helper):
         assert no_marks_displayed is True
 
         # link by wcs and retest
-        imviz_helper.link_data(align_by='wcs')
+        deconfigged_helper.plugins['Orientation'].align_by = 'WCS'
 
         viewer_marks = _get_markers_from_viewer(viewer)
         # distinguish default from custom overlay with color
@@ -240,7 +239,7 @@ def test_api_after_linking(imviz_helper):
         assert marks_displayed is True
 
 
-def test_footprint_updates_on_rotation(imviz_helper):
+def test_footprint_updates_on_rotation(deconfigged_helper):
     image_2d_wcs = WCS({'CTYPE1': 'RA---TAN', 'CUNIT1': 'deg',
                         'CRPIX1': 1, 'CRVAL1': 337.5202808,
                         'CTYPE2': 'DEC--TAN', 'CUNIT2': 'deg',
@@ -251,10 +250,10 @@ def test_footprint_updates_on_rotation(imviz_helper):
     arr = np.random.normal(size=(10, 10))
     ndd = NDData(arr, wcs=image_2d_wcs)
 
-    imviz_helper.load_data(ndd)
-    imviz_helper.link_data(align_by='wcs')
+    deconfigged_helper.load(ndd, format='Image')
+    deconfigged_helper.plugins['Orientation'].align_by = 'WCS'
 
-    footprints = imviz_helper.plugins['Footprints']
+    footprints = deconfigged_helper.plugins['Footprints']
     footprints.keep_active = True
 
     # this is near the pixel origin:
@@ -288,34 +287,37 @@ def test_footprint_updates_on_rotation(imviz_helper):
     assert not miri_region.contains(rectangle_center, image_2d_wcs)
     assert miri_region.contains(opposite_corner, image_2d_wcs)
 
-    marks = _get_markers_from_viewer(imviz_helper.default_viewer._obj.glue_viewer)
+    viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
+    marks = _get_markers_from_viewer(viewer)
 
     # check that the rectangle region appears near the bottom of the viewer:
     assert np.concatenate([marks[0].y, marks[1].y]).min() < -3
 
     # now rotate to north-up east-left:
-    orientation = imviz_helper.plugins['Orientation']
+    orientation = deconfigged_helper.plugins['Orientation']
     orientation.set_north_up_east_left()
 
     # If all footprint orientations have been updated, the lowest
     # mark should still be centered low. If the footprint
     # orientations aren't updated, both footprints will be
     # at the top of the viewer, and this test will fail.
-    marks = _get_markers_from_viewer(imviz_helper.default_viewer._obj.glue_viewer)
+    marks = _get_markers_from_viewer(viewer)
     assert np.concatenate([marks[0].y, marks[1].y]).min() < -3
 
 
-def test_footprint_select(imviz_helper):
+def test_footprint_select(deconfigged_helper):
     wcs = WCS({'CTYPE1': 'RA---TAN', 'CUNIT1': 'deg', 'CDELT1': -0.0002777777778,
                'CRPIX1': 1, 'CRVAL1': 9.423508457380343,
                'CTYPE2': 'DEC--TAN', 'CUNIT2': 'deg', 'CDELT2': 0.0002777777778,
                'CRPIX2': 1, 'CRVAL2': -33.71313112382379})
     arr = np.arange(40000).reshape(200, 200)
     ndd = NDData(arr, wcs=wcs)
-    imviz_helper.load_data(ndd)
-    fp = imviz_helper.plugins["Footprints"]
+    deconfigged_helper.load(ndd, format='Image')
+    fp = deconfigged_helper.plugins["Footprints"]
     fp._obj.toggle_custom_toolbar()
-    toolbar = imviz_helper.viewers['imviz-0']._obj.glue_viewer.toolbar
+    viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
+
+    toolbar = viewer.toolbar
     tool = toolbar.tools['jdaviz:selectfootprint']
     assert tool.is_visible() is False
 

--- a/jdaviz/configs/imviz/tests/test_line_profile_xy.py
+++ b/jdaviz/configs/imviz/tests/test_line_profile_xy.py
@@ -145,12 +145,12 @@ class TestLineProfileXYWCSLinked(BaseDeconfiggedImage_WCS_WCS):
         # assert lp_plugin.selected_y == 9
 
 
-def test_line_profile_with_nan(imviz_helper):
+def test_line_profile_with_nan(deconfigged_helper):
     arr = np.ones((10, 10))
     arr[5, 5] = np.nan
-    imviz_helper.load_data(arr)
+    deconfigged_helper.load(arr, format='Image')
 
-    lp_plugin = imviz_helper.plugins['Image Profiles (XY)']._obj
+    lp_plugin = deconfigged_helper.plugins['Image Profiles (XY)']._obj
     lp_plugin.plugin_opened = True
     lp_plugin.selected_x = 5
     lp_plugin.selected_y = 5

--- a/jdaviz/configs/imviz/tests/test_regions.py
+++ b/jdaviz/configs/imviz/tests/test_regions.py
@@ -208,13 +208,13 @@ class TestLoadRegionsFromFile(BaseRegionHandler):
         self.arr = np.ones((1024, 1024))
         self.raw_regions = Regions.read(self.region_file, format='ds9')
 
-    def test_ds9_load_all(self, imviz_helper):
+    def test_ds9_load_all(self, deconfigged_helper):
         with pytest.raises(ValueError, match="Cannot load regions without data"):
-            imviz_helper.load_data(self.region_file)
+            deconfigged_helper.load(self.region_file)
 
-        self.viewer = imviz_helper.default_viewer._obj.glue_viewer
-        imviz_helper.load(self.arr, data_label='my_image', format='Image')
-        bad_regions = imviz_helper.plugins['Subset Tools'].import_region(
+        deconfigged_helper.load(self.arr, data_label='my_image', format='Image')
+        self.viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
+        bad_regions = deconfigged_helper.plugins['Subset Tools'].import_region(
             self.region_file, return_bad_regions=True)
         assert len(bad_regions) == 1
 
@@ -222,40 +222,44 @@ class TestLoadRegionsFromFile(BaseRegionHandler):
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore',
                                     message='Regions skipped: MaskedSubset 1')
-            subsets = imviz_helper.plugins['Subset Tools'].get_regions()
+            subsets = deconfigged_helper.plugins['Subset Tools'].get_regions()
         assert list(subsets.keys()) == ['Subset 1', 'Subset 2', 'Subset 3',
                                         'Subset 4', 'Subset 5', 'Subset 6', 'Subset 7'], subsets
 
         # The other 1 is MaskedSubset
         self.verify_region_loaded('MaskedSubset 1', count=1)
 
-    def test_ds9_load_two_good(self, imviz_helper):
-        self.viewer = imviz_helper.default_viewer._obj.glue_viewer
-        imviz_helper.load(self.arr, data_label='my_image')
-        bad_regions = imviz_helper.plugins['Subset Tools'].import_region(
+    def test_ds9_load_two_good(self, deconfigged_helper):
+        deconfigged_helper.load(self.arr, data_label='my_image', format='Image')
+        self.viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
+        bad_regions = deconfigged_helper.plugins['Subset Tools'].import_region(
             self.region_file, max_num_regions=2, return_bad_regions=True)
         assert len(bad_regions) == 0
-        subsets = imviz_helper.plugins['Subset Tools'].get_regions()
+        subsets = deconfigged_helper.plugins['Subset Tools'].get_regions()
         assert list(subsets.keys()) == ['Subset 1', 'Subset 2'], subsets
         self.verify_region_loaded('MaskedSubset 1', count=0)
 
-    def test_ds9_load_one_bad(self, imviz_helper):
-        self.viewer = imviz_helper.default_viewer._obj.glue_viewer
-        imviz_helper.load(self.arr, data_label='my_image')
-        bad_regions = imviz_helper.plugins['Subset Tools'].import_region(
+    def test_ds9_load_one_bad(self, deconfigged_helper):
+        deconfigged_helper.load(self.arr, data_label='my_image', format='Image')
+
+        self.viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
+
+        bad_regions = deconfigged_helper.plugins['Subset Tools'].import_region(
             self.raw_regions[6], return_bad_regions=True)
         assert len(bad_regions) == 1
-        assert imviz_helper.plugins['Subset Tools'].get_regions() == {}
+        assert deconfigged_helper.plugins['Subset Tools'].get_regions() == {}
         self.verify_region_loaded('MaskedSubset 1', count=0)
 
-    def test_ds9_load_one_good_one_bad(self, imviz_helper):
-        self.viewer = imviz_helper.default_viewer._obj.glue_viewer
-        imviz_helper.load(self.arr, data_label='my_image')
-        bad_regions = imviz_helper.plugins['Subset Tools'].import_region(
+    def test_ds9_load_one_good_one_bad(self, deconfigged_helper):
+        deconfigged_helper.load(self.arr, data_label='my_image', format='Image')
+
+        self.viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
+
+        bad_regions = deconfigged_helper.plugins['Subset Tools'].import_region(
             [self.raw_regions[3], self.raw_regions[6]], return_bad_regions=True)
         assert len(bad_regions) == 1
 
-        subsets = imviz_helper.plugins['Subset Tools'].get_regions()
+        subsets = deconfigged_helper.plugins['Subset Tools'].get_regions()
         assert list(subsets.keys()) == ['Subset 1'], subsets
         self.verify_region_loaded('MaskedSubset 1', count=0)
 

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -23,6 +23,7 @@ from jdaviz.configs.imviz.tests.utils import BaseDeconfiggedImage_WCS_WCS, BaseI
 from jdaviz.core.custom_units_and_equivs import PIX2
 from jdaviz.core.unit_conversion_utils import flux_conversion_general
 
+
 photutils.future_column_names = True
 if minversion(photutils, '2.3.1.dev'):
     SEMIMAJOR_AXIS = 'semimajor_axis'
@@ -284,30 +285,32 @@ class TestSimpleAperPhot_NoWCS(BaseImviz_WCS_NoWCS):
 
 class TestAdvancedAperPhot:
     @pytest.fixture(autouse=True)
-    def setup_class(self, imviz_helper):
+    def setup_class(self, deconfigged_helper):
         # Reference image
         fn_1 = get_pkg_data_filename('data/gauss100_fits_wcs.fits')
-        imviz_helper.load_data(fn_1)
+        deconfigged_helper.load(fn_1, format='Image')
         # Different pixel scale
-        imviz_helper.load_data(get_pkg_data_filename('data/gauss100_fits_wcs_block_reduced.fits'))
+        deconfigged_helper.load(get_pkg_data_filename('data/gauss100_fits_wcs_block_reduced.fits'),
+                                format='Image')
         # Different pixel scale + rotated
-        imviz_helper.load_data(get_pkg_data_filename('data/gauss100_fits_wcs_block_reduced_rotated.fits'))  # noqa: E501
+        deconfigged_helper.load(get_pkg_data_filename('data/gauss100_fits_wcs_block_reduced_rotated.fits'), # noqa: E501
+                                format='Image')
 
         # Link them by WCS
-        imviz_helper.link_data(align_by='wcs')
-        w = imviz_helper._app.data_collection[0].coords
+        deconfigged_helper.plugins['Orientation'].align_by = 'WCS'
+        w = deconfigged_helper._app.data_collection[0].coords
 
         # Regions to be used for aperture photometry
-        imviz_helper.plugins['Subset Tools'].import_region([
+        deconfigged_helper.plugins['Subset Tools'].import_region([
             CirclePixelRegion(center=PixCoord(x=145.1, y=168.3), radius=5).to_sky(w),
             CirclePixelRegion(center=PixCoord(x=48.3, y=200.3), radius=5).to_sky(w),
             EllipsePixelRegion(center=PixCoord(x=84.7, y=224.1), width=23, height=9, angle=2.356 * u.rad).to_sky(w),  # noqa: E501
             RectanglePixelRegion(center=PixCoord(x=229, y=152), width=17, height=7).to_sky(w)],
             combination_mode='new')
 
-        self.imviz = imviz_helper
-        self.viewer = imviz_helper.default_viewer._obj
-        self.phot_plugin = imviz_helper.plugins["Aperture Photometry"]
+        self.imviz = deconfigged_helper
+        self.viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
+        self.phot_plugin = deconfigged_helper.plugins["Aperture Photometry"]
 
     @pytest.mark.parametrize(('data_label', 'local_bkg'), [
         ('gauss100_fits_wcs[PRIMARY,1]', 5.0),

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -293,7 +293,7 @@ class TestAdvancedAperPhot:
         deconfigged_helper.load(get_pkg_data_filename('data/gauss100_fits_wcs_block_reduced.fits'),
                                 format='Image')
         # Different pixel scale + rotated
-        deconfigged_helper.load(get_pkg_data_filename('data/gauss100_fits_wcs_block_reduced_rotated.fits'), # noqa: E501
+        deconfigged_helper.load(get_pkg_data_filename('data/gauss100_fits_wcs_block_reduced_rotated.fits'),  # noqa: E501
                                 format='Image')
 
         # Link them by WCS

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -164,7 +164,7 @@ def test_catalog_in_image_viewer(deconfigged_helper, image_2d_wcs,
 
     # Load the source catalog into the data collection, and into the image viewer
     deconfigged_helper.load(sky_coord_only_source_catalog, format='Catalog',
-                      data_label='my_catalog')
+                            data_label='my_catalog')
 
     iv = deconfigged_helper.viewers['Image']
     dm = iv.data_menu

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -18,6 +18,7 @@ from jdaviz.conftest import _image_hdu_wcs
 from numpy.testing import assert_allclose
 
 
+# should this be deprecated since deconfigged doesn't spawn viewers without data?
 @pytest.mark.parametrize(
     ('desired_name', 'actual_name'),
     [(None, 'imviz-1'),
@@ -46,36 +47,39 @@ def test_create_destroy_viewer(imviz_helper, desired_name, actual_name):
     assert po.viewer.labels == ['imviz-0']
 
 
-def test_create_viewer_align_by_wcs(imviz_helper, image_2d_wcs):
+def test_create_viewer_align_by_wcs(deconfigged_helper, image_2d_wcs):
     data = NDData(np.ones((128, 128)) * u.nJy, wcs=image_2d_wcs)
-    imviz_helper.load_data(data, data_label='my_data')
+    deconfigged_helper.load(data, data_label='my_data', format='Image')
 
-    imviz_helper.create_image_viewer(viewer_name='new-viewer')
-    dm = imviz_helper.viewers['new-viewer'].data_menu
+    new_viewer = deconfigged_helper.new_viewers['Image']
+    new_viewer()
+    dm = deconfigged_helper.viewers['Image (1)'].data_menu
     dm.add_data('my_data[DATA]')
 
     assert not dm._obj.orientation_align_by_wcs
 
-    imviz_helper.plugins['Orientation'].align_by = 'WCS'
+    deconfigged_helper.plugins['Orientation'].align_by = 'WCS'
 
     assert dm._obj.orientation_align_by_wcs
     assert dm.orientation.selected == 'Default orientation'
 
 
-def test_align_by_wcs_create_viewer(imviz_helper, image_2d_wcs):
+def test_align_by_wcs_create_viewer(deconfigged_helper, image_2d_wcs):
     data = NDData(np.ones((128, 128)) * u.nJy, wcs=image_2d_wcs)
-    imviz_helper.load_data(data, data_label='my_data')
+    deconfigged_helper.load(data, data_label='my_data', format='Image')
 
-    imviz_helper.plugins['Orientation'].align_by = 'WCS'
+    deconfigged_helper.plugins['Orientation'].align_by = 'WCS'
 
-    imviz_helper.create_image_viewer(viewer_name='new-viewer')
-    dm = imviz_helper.viewers['new-viewer'].data_menu
+    new_viewer = deconfigged_helper.new_viewers['Image']
+    new_viewer()
+    dm = deconfigged_helper.viewers['Image (1)'].data_menu
     dm.add_data('my_data[DATA]')
 
     assert dm._obj.orientation_align_by_wcs
     assert dm.orientation.selected == 'Default orientation'
 
 
+# should this be deprecated since deconfigged_helper doesn't spawn viewers automatically?
 def test_get_viewer_created(imviz_helper):
     # This viewer has no reference but has ID.
     viewer1 = imviz_helper.create_image_viewer()
@@ -83,6 +87,7 @@ def test_get_viewer_created(imviz_helper):
     assert viewer1 is viewer2
 
 
+# should this be deprecated since deconfigged_helper doesn't spawn viewers automatically?
 def test_destroy_viewer_invalid(imviz_helper):
     assert imviz_helper._app.get_viewer_ids() == ['imviz-0']
 
@@ -94,26 +99,27 @@ def test_destroy_viewer_invalid(imviz_helper):
     assert imviz_helper._app.get_viewer_ids() == ['imviz-0']
 
 
-def test_destroy_viewer_with_subset(imviz_helper):
+def test_destroy_viewer_with_subset(deconfigged_helper):
     """Regression test for https://github.com/spacetelescope/jdaviz/issues/1614"""
     arr = np.ones((10, 10))
-    imviz_helper.load_data(arr, data_label='my_array')
+    deconfigged_helper.load(arr, data_label='my_array', format='Image')
 
     # Create a second viewer.
-    imviz_helper.create_image_viewer(viewer_name='second')
+    new_viewer = deconfigged_helper.new_viewers['Image']
+    new_viewer()
 
     # Add existing data to second viewer.
-    imviz_helper._app.add_data_to_viewer('second', 'my_array')
+    deconfigged_helper._app.add_data_to_viewer('Image (1)', 'my_array')
 
     # Create a Subset.
     reg = CirclePixelRegion(center=PixCoord(x=4, y=4), radius=2)
-    imviz_helper.plugins['Subset Tools'].import_region(reg)
+    deconfigged_helper.plugins['Subset Tools'].import_region(reg)
 
     # Remove the second viewer.
-    imviz_helper.destroy_viewer('second')
+    deconfigged_helper._app.vue_destroy_viewer_item('Image (1)')
 
     # Delete the Subset: Should have no traceback.
-    imviz_helper._app.delete_subsets('Subset 1')
+    deconfigged_helper._app.delete_subsets('Subset 1')
 
 
 def test_mastviz_config():
@@ -137,37 +143,39 @@ def test_mastviz_config():
     assert im._app.data_collection[0].shape == (2, 2)
 
 
-def test_zoom_center_radius_init(imviz_helper):
+def test_zoom_center_radius_init(deconfigged_helper):
     """Regression test for https://github.com/spacetelescope/jdaviz/issues/3217"""
     arr = np.ones((10, 10))
-    imviz_helper.load_data(arr, data_label='my_array')
-    assert imviz_helper.default_viewer._obj.glue_viewer.state.zoom_center_x > 0
-    assert imviz_helper.default_viewer._obj.glue_viewer.state.zoom_center_y > 0
-    assert imviz_helper.default_viewer._obj.glue_viewer.state.zoom_radius > 0
+    deconfigged_helper.load(arr, data_label='my_array', format='Image')
+    viewer = deconfigged_helper.viewers['Image']
+
+    assert viewer._obj.glue_viewer.state.zoom_center_x > 0
+    assert viewer._obj.glue_viewer.state.zoom_center_y > 0
+    assert viewer._obj.glue_viewer.state.zoom_radius > 0
 
 
-def test_catalog_in_image_viewer(imviz_helper, image_2d_wcs,
+def test_catalog_in_image_viewer(deconfigged_helper, image_2d_wcs,
                                  sky_coord_only_source_catalog):
     data = NDData(np.ones((128, 128)) * u.nJy, wcs=image_2d_wcs)
-    imviz_helper.load_data(data, data_label='my_data')
+    deconfigged_helper.load(data, data_label='my_data', format='Image')
 
     # change alignment to WCS to enable catalog visibility
-    imviz_helper.plugins['Orientation'].align_by = 'WCS'
+    deconfigged_helper.plugins['Orientation'].align_by = 'WCS'
 
     # Load the source catalog into the data collection, and into the image viewer
-    imviz_helper.load(sky_coord_only_source_catalog, format='Catalog',
+    deconfigged_helper.load(sky_coord_only_source_catalog, format='Catalog',
                       data_label='my_catalog')
 
-    iv = imviz_helper.viewers['imviz-0']
+    iv = deconfigged_helper.viewers['Image']
     dm = iv.data_menu
-    po = imviz_helper.plugins['Plot Options']
+    po = deconfigged_helper.plugins['Plot Options']
 
     # both image and catalog should be in the data menu, able to be
     # loaded/removed from the image viewer
     assert dm.data_labels_visible == ['my_catalog', 'my_data[DATA]']
 
-    assert imviz_helper._app.data_collection[2].label == 'my_catalog'
-    assert imviz_helper._app.data_collection[2].meta.get('_importer') == 'CatalogImporter'
+    assert deconfigged_helper._app.data_collection[2].label == 'my_catalog'
+    assert deconfigged_helper._app.data_collection[2].meta.get('_importer') == 'CatalogImporter'
 
     # since catalog is already loaded, it should not be in the "available"
     # choices, but should be in the visible list
@@ -178,7 +186,7 @@ def test_catalog_in_image_viewer(imviz_helper, image_2d_wcs,
     assert 'my_catalog' in po.layer.choices
 
     # test that mouseover appears
-    mo = imviz_helper._coords_info
+    mo = deconfigged_helper._coords_info
     assert mo.dataset.selected == 'auto'
     assert 'my_catalog' in mo.dataset.choices
 
@@ -197,24 +205,24 @@ def test_catalog_in_image_viewer(imviz_helper, image_2d_wcs,
 
     # changing to pixel linking should set the layer to hidden
     # and remove from the plot options layer tabs
-    imviz_helper.plugins['Orientation'].align_by = 'Pixels'
+    deconfigged_helper.plugins['Orientation'].align_by = 'Pixels'
     assert 'my_catalog' not in dm.data_labels_visible
     assert 'my_catalog' not in po.layer.choices
 
     # test loading/removing another image dataset, which involves linking
-    imviz_helper.load_data(data, data_label='my_data_2')
+    deconfigged_helper.load(data, data_label='my_data_2', format='Image')
     dm.layer.selected = ['my_data_2[DATA]']
     dm.remove_from_app()
 
     # test sucessfully removing the catalog
     dm.layer.selected = ['my_catalog']
     dm.remove_from_app()
-    assert 'my_catalog' not in imviz_helper._app.data_collection.labels
+    assert 'my_catalog' not in deconfigged_helper._app.data_collection.labels
 
 
-def test_get_viewport_sky_region_wcs(imviz_helper, image_hdu_wcs):
-    imviz_helper.load(image_hdu_wcs)
-    viewer = imviz_helper.viewers['imviz-0']
+def test_get_viewport_sky_region_wcs(deconfigged_helper, image_hdu_wcs):
+    deconfigged_helper.load(image_hdu_wcs, data_label='image_hdu_wcs', format='Image')
+    viewer = deconfigged_helper.viewers['Image']
     region = viewer.get_viewport_region()
 
     expected_vertices = SkyCoord(
@@ -229,13 +237,13 @@ def test_get_viewport_sky_region_wcs(imviz_helper, image_hdu_wcs):
     )
 
 
-def test_get_viewport_sky_region_gwcs(imviz_helper):
+def test_get_viewport_sky_region_gwcs(deconfigged_helper):
     shape = (10, 10)
     data = np.ones(shape)
     ndd = NDData(data=data, wcs=create_example_gwcs(shape))
 
-    imviz_helper.load_data(ndd)
-    viewer = imviz_helper.viewers['imviz-0']
+    deconfigged_helper.load(ndd, data_label='ndd', format='Image')
+    viewer = deconfigged_helper.viewers['Image']
     region = viewer.get_viewport_region()
 
     expected_vertices = SkyCoord(
@@ -250,27 +258,27 @@ def test_get_viewport_sky_region_gwcs(imviz_helper):
     )
 
 
-def test_get_viewport_sky_no_wcs(imviz_helper):
+def test_get_viewport_sky_no_wcs(deconfigged_helper):
     shape = (10, 10)
     data = np.ones(shape)
     ndd = NDData(data=data)
 
-    imviz_helper.load_data(ndd)
-    viewer = imviz_helper.viewers['imviz-0']
+    deconfigged_helper.load(ndd, data_label='ndd', format='Image')
+    viewer = deconfigged_helper.viewers['Image']
 
     with pytest.warns(UserWarning, match="does not have valid WCS"):
         viewer.get_viewport_region()
 
 
-def test_get_viewport_pixel_region(imviz_helper):
+def test_get_viewport_pixel_region(deconfigged_helper):
     shape = (10, 10)
     data = np.ones(shape)
     ndd = NDData(data=data, wcs=create_example_gwcs(shape))
 
-    imviz_helper.load_data(ndd)
-    viewer = imviz_helper.viewers['imviz-0']
+    deconfigged_helper.load(ndd, data_label='ndd', format='Image')
+    viewer = deconfigged_helper.viewers['Image']
 
-    data_label = imviz_helper._app.data_collection[0].label
+    data_label = deconfigged_helper._app.data_collection[0].label
     region = viewer.get_viewport_region('pixel', data_label)
     assert_allclose(
         region.vertices.x, [-0.5, -0.5, 9.5, 9.5]
@@ -280,26 +288,26 @@ def test_get_viewport_pixel_region(imviz_helper):
     )
 
 
-def test_get_viewport_pixel_region_bad_label(imviz_helper):
+def test_get_viewport_pixel_region_bad_label(deconfigged_helper):
     shape = (10, 10)
     data = np.ones(shape)
     ndd = NDData(data=data)
-    imviz_helper.load_data(ndd, data_label='label 1')
+    deconfigged_helper.load(ndd, data_label='label 1', format='Image')
 
     with pytest.raises(ValueError, match="No data found with label xyz"):
-        viewer = imviz_helper.viewers['imviz-0']
+        viewer = deconfigged_helper.viewers['Image']
         viewer.get_viewport_region('pixel', 'xyz')
 
 
-def test_get_viewport_pixel_region_no_label(imviz_helper):
+def test_get_viewport_pixel_region_no_label(deconfigged_helper):
     shape = (10, 10)
     data = np.ones(shape)
     ndd = NDData(data=data)
-    imviz_helper.load_data(ndd, data_label='label 1')
+    deconfigged_helper.load(ndd, data_label='label 1', format='Image')
 
     with pytest.raises(ValueError,
                        match="`get_viewport_region` requires a data label"):
-        viewer = imviz_helper.viewers['imviz-0']
+        viewer = deconfigged_helper.viewers['Image']
         viewer.get_viewport_region('pixel')
 
 
@@ -319,14 +327,14 @@ class TestDeleteData(BaseImviz_WCS_NoWCS):
 
 class TestRegionOverlay:
     @pytest.fixture(autouse=True)
-    def setup_class(self, imviz_helper):
+    def setup_class(self, deconfigged_helper):
         np.random.seed(42)
         # Data with WCS
         hdu_wcs = _image_hdu_wcs(arr=np.arange(100).reshape((10, 10)))
-        imviz_helper.load_data(hdu_wcs)
+        deconfigged_helper.load(hdu_wcs, data_label='ndd', format='Image')
 
-        self.imviz = imviz_helper
-        self.viewer = imviz_helper.default_viewer._obj.glue_viewer
+        self.imviz = deconfigged_helper
+        self.viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
 
         # Since we are not really displaying, need this to test zoom.
         self.viewer.shape = (100, 100)

--- a/jdaviz/configs/imviz/tests/test_viewers.py
+++ b/jdaviz/configs/imviz/tests/test_viewers.py
@@ -18,7 +18,6 @@ from jdaviz.conftest import _image_hdu_wcs
 from numpy.testing import assert_allclose
 
 
-# should this be deprecated since deconfigged doesn't spawn viewers without data?
 @pytest.mark.parametrize(
     ('desired_name', 'actual_name'),
     [(None, 'imviz-1'),
@@ -79,7 +78,6 @@ def test_align_by_wcs_create_viewer(deconfigged_helper, image_2d_wcs):
     assert dm.orientation.selected == 'Default orientation'
 
 
-# should this be deprecated since deconfigged_helper doesn't spawn viewers automatically?
 def test_get_viewer_created(imviz_helper):
     # This viewer has no reference but has ID.
     viewer1 = imviz_helper.create_image_viewer()
@@ -87,7 +85,6 @@ def test_get_viewer_created(imviz_helper):
     assert viewer1 is viewer2
 
 
-# should this be deprecated since deconfigged_helper doesn't spawn viewers automatically?
 def test_destroy_viewer_invalid(imviz_helper):
     assert imviz_helper._app.get_viewer_ids() == ['imviz-0']
 

--- a/jdaviz/configs/rampviz/tests/test_helper.py
+++ b/jdaviz/configs/rampviz/tests/test_helper.py
@@ -11,7 +11,7 @@ def test_load_data_roman(deconfigged_helper, roman_level_1_ramp):
     assert len(deconfigged_helper._app.data_collection) == 3
 
     # each viewer should have one loaded data entry:
-    for refname in '3D Ramp, 3D Ramp Diff, Ramp Integration'.split(', '):
+    for refname in ['3D Ramp', '3D Ramp Diff', 'Ramp Integration']:
         viewer = deconfigged_helper._app.get_viewer(refname)
         assert len(viewer.state.layers) == 1
 
@@ -27,7 +27,7 @@ def test_load_data_jwst(deconfigged_helper, jwst_level_1b_ramp):
     assert len(deconfigged_helper._app.data_collection) == 3
 
     # each viewer should have one loaded data entry:
-    for refname in '3D Ramp, 3D Ramp Diff, Ramp Integration'.split(', '):
+    for refname in ['3D Ramp', '3D Ramp Diff', 'Ramp Integration']:
         viewer = deconfigged_helper._app.get_viewer(refname)
         assert len(viewer.state.layers) == 1
 

--- a/jdaviz/configs/rampviz/tests/test_helper.py
+++ b/jdaviz/configs/rampviz/tests/test_helper.py
@@ -3,32 +3,32 @@ from jdaviz.configs.imviz.plugins.parsers import HAS_ROMAN_DATAMODELS
 
 
 @pytest.mark.skipif(not HAS_ROMAN_DATAMODELS, reason="roman_datamodels is not installed")
-def test_load_data_roman(rampviz_helper, roman_level_1_ramp):
-    rampviz_helper.load_data(roman_level_1_ramp)
+def test_load_data_roman(deconfigged_helper, roman_level_1_ramp):
+    deconfigged_helper.load(roman_level_1_ramp)
 
     # on ramp cube load (1), the parser loads a diff cube (2) and
     # the ramp extraction plugin produces a default extraction (3):
-    assert len(rampviz_helper._app.data_collection) == 3
+    assert len(deconfigged_helper._app.data_collection) == 3
 
     # each viewer should have one loaded data entry:
-    for refname in 'group-viewer, diff-viewer, integration-viewer'.split(', '):
-        viewer = rampviz_helper._app.get_viewer(refname)
+    for refname in '3D Ramp, 3D Ramp Diff, Ramp Integration'.split(', '):
+        viewer = deconfigged_helper._app.get_viewer(refname)
         assert len(viewer.state.layers) == 1
 
     assert viewer.axis_x.label == 'Group'
     assert viewer.axis_y.label == 'DN'
 
 
-def test_load_data_jwst(rampviz_helper, jwst_level_1b_ramp):
-    rampviz_helper.load_data(jwst_level_1b_ramp)
+def test_load_data_jwst(deconfigged_helper, jwst_level_1b_ramp):
+    deconfigged_helper.load(jwst_level_1b_ramp)
 
     # on ramp cube load (1), the parser loads a diff cube (2) and
     # the ramp extraction plugin produces a default extraction (3):
-    assert len(rampviz_helper._app.data_collection) == 3
+    assert len(deconfigged_helper._app.data_collection) == 3
 
     # each viewer should have one loaded data entry:
-    for refname in 'group-viewer, diff-viewer, integration-viewer'.split(', '):
-        viewer = rampviz_helper._app.get_viewer(refname)
+    for refname in '3D Ramp, 3D Ramp Diff, Ramp Integration'.split(', '):
+        viewer = deconfigged_helper._app.get_viewer(refname)
         assert len(viewer.state.layers) == 1
 
     assert viewer.axis_x.label == 'Group'

--- a/jdaviz/configs/rampviz/tests/test_parser.py
+++ b/jdaviz/configs/rampviz/tests/test_parser.py
@@ -30,8 +30,9 @@ def test_load_level_1_and_2(
     # confirm that a "level-2" viewer is created, and that
     # the rate image is loaded into it
     assert len(deconfigged_helper.viewers) == 4
-    # this is not a default name in deconfigged - remove?
-    # assert 'level-2' in deconfigged_helper.viewers
+    print("the following viewers were loaded:")
+    print(deconfigged_helper.viewers)
+    assert 'Image' in deconfigged_helper.viewers
 
     layers = deconfigged_helper._app.get_viewer('3D Ramp').layers
     assert len(layers) == 1

--- a/jdaviz/configs/rampviz/tests/test_parser.py
+++ b/jdaviz/configs/rampviz/tests/test_parser.py
@@ -2,37 +2,38 @@ import pytest
 from jdaviz.utils import cached_uri
 
 
-def test_load_rectangular_ramp(rampviz_helper, jwst_level_1b_rectangular_ramp):
-    rampviz_helper.load_data(jwst_level_1b_rectangular_ramp)
+def test_load_rectangular_ramp(deconfigged_helper, jwst_level_1b_rectangular_ramp):
+    deconfigged_helper.load(jwst_level_1b_rectangular_ramp)
 
     # drop the integration axis
     original_cube_shape = jwst_level_1b_rectangular_ramp.shape[1:]
 
     # on ramp cube load (1), the parser loads a diff cube (2) and
     # the ramp extraction plugin produces a default extraction (3):
-    assert len(rampviz_helper._app.data_collection) == 3
+    assert len(deconfigged_helper._app.data_collection) == 3
 
-    parsed_cube_shape = rampviz_helper._app.data_collection[0].shape
+    parsed_cube_shape = deconfigged_helper._app.data_collection[0].shape
     assert parsed_cube_shape == (
         original_cube_shape[1], original_cube_shape[2], original_cube_shape[0]
     )
 
 
 def test_load_level_1_and_2(
-        rampviz_helper,
+        deconfigged_helper,
         jwst_level_1b_rectangular_ramp,
         jwst_level_2c_rate_image
 ):
     # load level 1 ramp and level 2 rate image
-    rampviz_helper.load_data(jwst_level_1b_rectangular_ramp)
-    rampviz_helper.load_data(jwst_level_2c_rate_image)
+    deconfigged_helper.load(jwst_level_1b_rectangular_ramp)
+    deconfigged_helper.load(jwst_level_2c_rate_image, format='Image')
 
     # confirm that a "level-2" viewer is created, and that
     # the rate image is loaded into it
-    assert len(rampviz_helper.viewers) == 4
-    assert 'level-2' in rampviz_helper.viewers
+    assert len(deconfigged_helper.viewers) == 4
+    # this is not a default name in deconfigged - remove?
+    # assert 'level-2' in deconfigged_helper.viewers
 
-    layers = rampviz_helper._app.get_viewer('level-2').layers
+    layers = deconfigged_helper._app.get_viewer('3D Ramp').layers
     assert len(layers) == 1
 
 

--- a/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/tests/test_line_analysis.py
@@ -274,26 +274,26 @@ def test_coerce_unit():
     assert not hasattr(q_coerced, 'uncertainty')
 
 
-def test_continuum_surrounding_spectral_subset(specviz_helper, spectrum1d):
+def test_continuum_surrounding_spectral_subset(deconfigged_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_data(spectrum1d, data_label=label)
+    deconfigged_helper.load(spectrum1d, data_label=label, format='1D Spectrum')
 
-    plugin = specviz_helper._app.get_tray_item_from_name('specviz-line-analysis')
+    plugin = deconfigged_helper._app.get_tray_item_from_name('Line Analysis')
     plugin.keep_active = True
 
     # continuum should be created, plotted, and visible
-    sv = specviz_helper._app.get_viewer('spectrum-viewer')
+    sv = deconfigged_helper._app.get_viewer('1D Spectrum')
     continuum_marks = [m for m in sv.figure.marks if isinstance(m, LineAnalysisContinuum)]
     assert len(continuum_marks) == 3
     assert np.all([cm.visible for cm in continuum_marks])
 
     # add a region and rerun stats for that region
-    unit = u.Unit(specviz_helper.plugins['Unit Conversion'].spectral_unit.selected)
-    specviz_helper.plugins['Subset Tools'].import_region(SpectralRegion(
+    unit = u.Unit(deconfigged_helper.plugins['Unit Conversion'].spectral_unit.selected)
+    deconfigged_helper.plugins['Subset Tools'].import_region(SpectralRegion(
         6500 * unit, 7400 * unit))
-    specviz_helper._app.state.drawer_content = 'plugins'
+    deconfigged_helper._app.state.drawer_content = 'plugins'
 
-    plugin = specviz_helper._app.get_tray_item_from_name('specviz-line-analysis')
+    plugin = deconfigged_helper._app.get_tray_item_from_name('Line Analysis')
     assert 'Subset 1' in plugin.spectral_subset.labels
     plugin.continuum_subset_selected = 'Surrounding'
     plugin.spectral_subset_selected = 'Subset 1'
@@ -324,7 +324,7 @@ def test_continuum_spectral_same_value(specviz_helper, spectrum1d):
 
     plugin = specviz_helper._app.get_tray_item_from_name('specviz-line-analysis')
     assert 'Subset 1' in plugin.spectral_subset.labels
-    plugin.continuum_subset_selected = 'Subset 1'
+    plugin.continuum.selected = 'Subset 1'
     plugin.spectral_subset_selected = 'Subset 1'
     plugin.width = 3
 
@@ -332,26 +332,26 @@ def test_continuum_spectral_same_value(specviz_helper, spectrum1d):
     assert plugin.get_results()[0]['result'] == ''
 
 
-def test_continuum_surrounding_invalid_width(specviz_helper, spectrum1d):
+def test_continuum_surrounding_invalid_width(deconfigged_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_data(spectrum1d, data_label=label)
+    deconfigged_helper.load(spectrum1d, data_label=label, format='1D Spectrum')
 
-    plugin = specviz_helper._app.get_tray_item_from_name('specviz-line-analysis')
+    plugin = deconfigged_helper._app.get_tray_item_from_name('Line Analysis')
     plugin.keep_active = True
 
     # continuum should be created, plotted, and visible
-    sv = specviz_helper._app.get_viewer('spectrum-viewer')
+    sv = deconfigged_helper._app.get_viewer('1D Spectrum')
     continuum_marks = [m for m in sv.figure.marks if isinstance(m, LineAnalysisContinuum)]
     assert len(continuum_marks) == 3
     assert np.all([cm.visible for cm in continuum_marks])
 
     # add a region and rerun stats for that region
-    unit = u.Unit(specviz_helper.plugins['Unit Conversion'].spectral_unit.selected)
-    specviz_helper.plugins['Subset Tools'].import_region(SpectralRegion(
+    unit = u.Unit(deconfigged_helper.plugins['Unit Conversion'].spectral_unit.selected)
+    deconfigged_helper.plugins['Subset Tools'].import_region(SpectralRegion(
         6500 * unit, 7400 * unit))
-    specviz_helper._app.state.drawer_content = 'plugins'
+    deconfigged_helper._app.state.drawer_content = 'plugins'
 
-    plugin = specviz_helper._app.get_tray_item_from_name('specviz-line-analysis')
+    plugin = deconfigged_helper._app.get_tray_item_from_name('Line Analysis')
     assert 'Subset 1' in plugin.spectral_subset.labels
     plugin.continuum_subset_selected = 'Surrounding'
     plugin.spectral_subset_selected = 'Subset 1'
@@ -380,7 +380,7 @@ def test_continuum_subset_spectral_entire(specviz_helper, spectrum1d):
 
     plugin = specviz_helper._app.get_tray_item_from_name('specviz-line-analysis')
     assert 'Subset 1' in plugin.spectral_subset.labels
-    plugin.continuum_subset_selected = 'Subset 1'
+    plugin.continuum.selected = 'Subset 1'
     plugin.spectral_subset_selected = 'Entire Spectrum'
     plugin.width = 3
 
@@ -416,33 +416,33 @@ def test_continuum_subset_spectral_subset2(specviz_helper, spectrum1d):
     assert plugin.spectral_subset.labels == ['Entire Spectrum', 'Subset 1', 'Subset 2']
 
     plugin.spectral_subset_selected = 'Subset 2'
-    plugin.continuum_subset_selected = 'Subset 1'
+    plugin.continuum.selected = 'Subset 1'
     plugin.width = 3
 
     # Values have not yet been validated
     np.testing.assert_allclose(float(plugin.get_results()[0]['result']), 1.482418e-14, atol=1e-16)
 
 
-def test_continuum_surrounding_no_right(specviz_helper, spectrum1d):
+def test_continuum_surrounding_no_right(deconfigged_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_data(spectrum1d, data_label=label)
+    deconfigged_helper.load(spectrum1d, data_label=label, format='1D Spectrum')
 
-    plugin = specviz_helper._app.get_tray_item_from_name('specviz-line-analysis')
+    plugin = deconfigged_helper._app.get_tray_item_from_name('Line Analysis')
     plugin.keep_active = True
 
     # continuum should be created, plotted, and visible
-    sv = specviz_helper._app.get_viewer('spectrum-viewer')
+    sv = deconfigged_helper._app.get_viewer('1D Spectrum')
     continuum_marks = [m for m in sv.figure.marks if isinstance(m, LineAnalysisContinuum)]
     assert len(continuum_marks) == 3
     assert np.all([cm.visible for cm in continuum_marks])
 
     # add a region and rerun stats for that region
-    unit = u.Unit(specviz_helper.plugins['Unit Conversion'].spectral_unit.selected)
-    specviz_helper.plugins['Subset Tools'].import_region(SpectralRegion(
+    unit = u.Unit(deconfigged_helper.plugins['Unit Conversion'].spectral_unit.selected)
+    deconfigged_helper.plugins['Subset Tools'].import_region(SpectralRegion(
         6500 * unit, 8000 * unit))
-    specviz_helper._app.state.drawer_content = 'plugins'
+    deconfigged_helper._app.state.drawer_content = 'plugins'
 
-    plugin = specviz_helper._app.get_tray_item_from_name('specviz-line-analysis')
+    plugin = deconfigged_helper._app.get_tray_item_from_name('Line Analysis')
     assert 'Subset 1' in plugin.spectral_subset.labels
 
     plugin.spectral_subset_selected = 'Subset 1'
@@ -453,26 +453,26 @@ def test_continuum_surrounding_no_right(specviz_helper, spectrum1d):
     np.testing.assert_allclose(float(plugin.get_results()[0]['result']), 4.204513e-14, atol=1e-16)
 
 
-def test_continuum_surrounding_no_left(specviz_helper, spectrum1d):
+def test_continuum_surrounding_no_left(deconfigged_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_data(spectrum1d, data_label=label)
+    deconfigged_helper.load(spectrum1d, data_label=label, format='1D Spectrum')
 
-    plugin = specviz_helper._app.get_tray_item_from_name('specviz-line-analysis')
+    plugin = deconfigged_helper._app.get_tray_item_from_name('Line Analysis')
     plugin.keep_active = True
 
     # continuum should be created, plotted, and visible
-    sv = specviz_helper._app.get_viewer('spectrum-viewer')
+    sv = deconfigged_helper._app.get_viewer('1D Spectrum')
     continuum_marks = [m for m in sv.figure.marks if isinstance(m, LineAnalysisContinuum)]
     assert len(continuum_marks) == 3
     assert np.all([cm.visible for cm in continuum_marks])
 
     # add a region and rerun stats for that region
-    unit = u.Unit(specviz_helper.plugins['Unit Conversion'].spectral_unit.selected)
-    specviz_helper.plugins['Subset Tools'].import_region(SpectralRegion(
+    unit = u.Unit(deconfigged_helper.plugins['Unit Conversion'].spectral_unit.selected)
+    deconfigged_helper.plugins['Subset Tools'].import_region(SpectralRegion(
         6000 * unit, 7500 * unit))
-    specviz_helper._app.state.drawer_content = 'plugins'
+    deconfigged_helper._app.state.drawer_content = 'plugins'
 
-    plugin = specviz_helper._app.get_tray_item_from_name('specviz-line-analysis')
+    plugin = deconfigged_helper._app.get_tray_item_from_name('Line Analysis')
     assert 'Subset 1' in plugin.spectral_subset.labels
 
     plugin.spectral_subset_selected = 'Subset 1'
@@ -483,36 +483,36 @@ def test_continuum_surrounding_no_left(specviz_helper, spectrum1d):
     np.testing.assert_allclose(float(plugin.get_results()[0]['result']), 7.570859e-14, atol=1e-16)
 
 
-def test_subset_changed(specviz_helper, spectrum1d):
+def test_subset_changed(deconfigged_helper, spectrum1d):
     label = "Test 1D Spectrum"
-    specviz_helper.load_data(spectrum1d, data_label=label)
+    deconfigged_helper.load(spectrum1d, data_label=label, format='1D Spectrum')
 
-    plugin = specviz_helper._app.get_tray_item_from_name('specviz-line-analysis')
+    plugin = deconfigged_helper._app.get_tray_item_from_name('Line Analysis')
     plugin.keep_active = True
 
     # continuum should be created, plotted, and visible
-    sv = specviz_helper._app.get_viewer('spectrum-viewer')
+    sv = deconfigged_helper._app.get_viewer('1D Spectrum')
     continuum_marks = [m for m in sv.figure.marks if isinstance(m, LineAnalysisContinuum)]
     assert len(continuum_marks) == 3
     assert np.all([cm.visible for cm in continuum_marks])
 
     # add a region and rerun stats for that region
-    unit = u.Unit(specviz_helper.plugins['Unit Conversion'].spectral_unit.selected)
-    specviz_helper.plugins['Subset Tools'].import_region(SpectralRegion(
+    unit = u.Unit(deconfigged_helper.plugins['Unit Conversion'].spectral_unit.selected)
+    deconfigged_helper.plugins['Subset Tools'].import_region(SpectralRegion(
         6000 * unit, 7500 * unit))
-    specviz_helper._app.state.drawer_content = 'plugins'
+    deconfigged_helper._app.state.drawer_content = 'plugins'
 
-    plugin = specviz_helper._app.get_tray_item_from_name('specviz-line-analysis')
+    plugin = deconfigged_helper._app.get_tray_item_from_name('Line Analysis')
     assert 'Subset 1' in plugin.spectral_subset.labels
 
     plugin.spectral_subset_selected = 'Subset 1'
     plugin.continuum_subset_selected = 'Surrounding'
     plugin.width = 3
 
-    specviz_helper.plugins['Subset Tools'].import_region(SpectralRegion(
+    deconfigged_helper.plugins['Subset Tools'].import_region(SpectralRegion(
         6500 * unit, 7500 * unit),
                                                          edit_subset='Subset 1')
-    specviz_helper._app.state.drawer_content = 'plugins'
+    deconfigged_helper._app.state.drawer_content = 'plugins'
 
     # Values have not yet been validated
     np.testing.assert_allclose(float(plugin.get_results()[0]['result']), 2.153181e-13, atol=1e-15)

--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -13,11 +13,11 @@ from jdaviz.core.custom_units_and_equivs import SPEC_PHOTON_FLUX_DENSITY_UNITS
     [("fail", "erg / (s cm2 Angstrom)", "Angstrom", "erg / (s cm2 Angstrom)"),
      ("None", "fail", "Angstrom", "Jy"),
      ("micron", "fail", "micron", "Jy")])
-def test_value_error_exception(specviz_helper, spectrum1d, new_spectral_axis, new_flux,
+def test_value_error_exception(deconfigged_helper, spectrum1d, new_spectral_axis, new_flux,
                                expected_spectral_axis, expected_flux):
-    specviz_helper.load_data(spectrum1d, data_label="Test 1D Spectrum")
-    viewer = specviz_helper._app.get_viewer('spectrum-viewer')
-    plg = specviz_helper.plugins["Unit Conversion"]
+    deconfigged_helper.load(spectrum1d, data_label="Test 1D Spectrum", format='1D Spectrum')
+    viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
+    plg = deconfigged_helper.plugins["Unit Conversion"]
 
     try:
         plg.spectral_unit = new_spectral_axis
@@ -30,7 +30,7 @@ def test_value_error_exception(specviz_helper, spectrum1d, new_spectral_axis, ne
         if "reverting selection to" not in repr(e):
             raise
 
-    assert len(specviz_helper._app.data_collection) == 1
+    assert len(deconfigged_helper._app.data_collection) == 1
     assert u.Unit(viewer.state.x_display_unit) == u.Unit(expected_spectral_axis)
     assert u.Unit(viewer.state.y_display_unit) == u.Unit(expected_flux)
 
@@ -45,55 +45,57 @@ def test_initialize_specviz_sb(deconfigged_helper, spectrum1d):
 
 
 @pytest.mark.parametrize('uncert', (False, True))
-def test_conv_wave_only(specviz_helper, spectrum1d, uncert):
+def test_conv_wave_only(deconfigged_helper, spectrum1d, uncert):
     if uncert is False:
         spectrum1d.uncertainty = None
-    specviz_helper.load_data(spectrum1d, data_label="Test 1D Spectrum")
+    deconfigged_helper.load(spectrum1d, data_label="Test 1D Spectrum", format='1D Spectrum')
 
-    viewer = specviz_helper._app.get_viewer('spectrum-viewer')
-    plg = specviz_helper.plugins["Unit Conversion"]
+    viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
+    plg = deconfigged_helper.plugins["Unit Conversion"]
     new_spectral_axis = "micron"
     plg.spectral_unit = new_spectral_axis
 
-    assert len(specviz_helper._app.data_collection) == 1
+    assert len(deconfigged_helper._app.data_collection) == 1
     assert u.Unit(viewer.state.x_display_unit) == u.Unit(new_spectral_axis)
     assert u.Unit(viewer.state.y_display_unit) == u.Unit('Jy')
 
 
 @pytest.mark.parametrize('uncert', (False, True))
-def test_conv_flux_only(specviz_helper, spectrum1d, uncert):
+def test_conv_flux_only(deconfigged_helper, spectrum1d, uncert):
     if uncert is False:
         spectrum1d.uncertainty = None
-    specviz_helper.load_data(spectrum1d, data_label="Test 1D Spectrum")
+    deconfigged_helper.load(spectrum1d, data_label="Test 1D Spectrum", format='1D Spectrum')
 
-    viewer = specviz_helper._app.get_viewer('spectrum-viewer')
-    plg = specviz_helper.plugins["Unit Conversion"]
+    viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
+    plg = deconfigged_helper.plugins["Unit Conversion"]
     new_flux = "erg / (s cm2 Angstrom)"
     plg._obj.flux_unit_selected = new_flux
 
-    assert len(specviz_helper._app.data_collection) == 1
+    assert len(deconfigged_helper._app.data_collection) == 1
     assert u.Unit(viewer.state.x_display_unit) == u.Unit('Angstrom')
     assert u.Unit(viewer.state.y_display_unit) == u.Unit(new_flux)
 
 
 @pytest.mark.parametrize('uncert', (False, True))
-def test_conv_wave_flux(specviz_helper, spectrum1d, uncert):
+def test_conv_wave_flux(deconfigged_helper, spectrum1d, uncert):
     if uncert is False:
         spectrum1d.uncertainty = None
-    specviz_helper.load_data(spectrum1d, data_label="Test 1D Spectrum")
+    deconfigged_helper.load(spectrum1d, data_label="Test 1D Spectrum", format='1D Spectrum')
 
-    viewer = specviz_helper._app.get_viewer('spectrum-viewer')
-    plg = specviz_helper.plugins["Unit Conversion"]
+    viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
+    plg = deconfigged_helper.plugins["Unit Conversion"]
     new_spectral_axis = "micron"
     new_flux = "erg / (s cm2 Angstrom)"
     plg.spectral_unit = new_spectral_axis
     plg._obj.flux_unit_selected = new_flux
 
-    assert len(specviz_helper._app.data_collection) == 1
+    assert len(deconfigged_helper._app.data_collection) == 1
     assert u.Unit(viewer.state.x_display_unit) == u.Unit(new_spectral_axis)
     assert u.Unit(viewer.state.y_display_unit) == u.Unit(new_flux)
 
 
+# should this be deprecated since plugin is not available
+# before loading data in deconfigged?
 def test_conv_no_data(specviz_helper, spectrum1d):
     """plugin unit selections won't have valid choices yet, preventing
     attempting to set display units."""
@@ -104,7 +106,7 @@ def test_conv_no_data(specviz_helper, spectrum1d):
         plg.spectral_unit = "micron"
     assert len(specviz_helper._app.data_collection) == 0
 
-    specviz_helper.load(spectrum1d, data_label="Test 1D Spectrum", format='1D Spectrum')
+    specviz_helper.load(spectrum1d, data_label="Test 1D Spectrum")
 
     # make sure we don't expose translations in Specviz
     assert hasattr(plg, 'flux_unit')
@@ -112,7 +114,7 @@ def test_conv_no_data(specviz_helper, spectrum1d):
     assert not hasattr(plg, 'spectral_y_type')
 
 
-def test_non_stddev_uncertainty(specviz_helper):
+def test_non_stddev_uncertainty(deconfigged_helper):
     flux = np.ones(10) * u.Jy
     stddev = 0.1
     var = stddev ** 2
@@ -124,13 +126,13 @@ def test_non_stddev_uncertainty(specviz_helper):
         spectral_axis=wavelength
     )
 
-    specviz_helper.load_data(spec)
+    deconfigged_helper.load(spec, data_label="Test 1D Spectrum", format='1D Spectrum')
 
-    po = specviz_helper.plugins['Plot Options']
+    po = deconfigged_helper.plugins['Plot Options']
     po.uncertainty_visible = True
 
     # check that the stddev uncertainties are drawn:
-    viewer = specviz_helper._app.get_viewer('spectrum-viewer')
+    viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
     np.testing.assert_allclose(
         np.abs(viewer.figure.marks[-1].y - viewer.figure.marks[-1].y.mean(0)),
         stddev

--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -94,8 +94,6 @@ def test_conv_wave_flux(deconfigged_helper, spectrum1d, uncert):
     assert u.Unit(viewer.state.y_display_unit) == u.Unit(new_flux)
 
 
-# should this be deprecated since plugin is not available
-# before loading data in deconfigged?
 def test_conv_no_data(specviz_helper, spectrum1d):
     """plugin unit selections won't have valid choices yet, preventing
     attempting to set display units."""

--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -104,7 +104,7 @@ def test_conv_no_data(specviz_helper, spectrum1d):
         plg.spectral_unit = "micron"
     assert len(specviz_helper._app.data_collection) == 0
 
-    specviz_helper.load(spectrum1d, data_label="Test 1D Spectrum")
+    specviz_helper.load(spectrum1d, data_label="Test 1D Spectrum", format='1D Spectrum')
 
     # make sure we don't expose translations in Specviz
     assert hasattr(plg, 'flux_unit')

--- a/jdaviz/configs/specviz/tests/test_helper.py
+++ b/jdaviz/configs/specviz/tests/test_helper.py
@@ -65,9 +65,7 @@ class TestSpecvizHelper:
 
     @pytest.mark.parametrize(
         'kwargs',
-        ({'data_label': [f"List test {i}" for i in (1, 2, 3)]},
-         {'sources': [f"1D Spectrum at index: {i}" for i in (0, 1, 2)]},
-         {'sources': '*'}))
+        ({'data_label': [f"List test {i}" for i in (1, 2, 3)]}))
     @pytest.mark.skipif(CI, reason="Temporarily skipped failing specviz test in CI")
     def test_load_spectrum_list_with_kwargs(self, kwargs):
         # When loading via the ``data_label`` argument, the length of the

--- a/jdaviz/configs/specviz/tests/test_tools.py
+++ b/jdaviz/configs/specviz/tests/test_tools.py
@@ -2,12 +2,12 @@ from numpy.testing import assert_allclose
 import pytest
 
 
-def test_homezoom_matchx(specviz_helper, spectrum1d):
+def test_homezoom_matchx(deconfigged_helper, spectrum1d):
     """
     Test HomeZoomMatchX tool activates and resets zoom in viewer.
     """
-    specviz_helper.load_data(spectrum1d, data_label='test')
-    viewer = specviz_helper._app.get_viewer('spectrum-viewer')
+    deconfigged_helper.load(spectrum1d, data_label='test', format='1D Spectrum')
+    viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
 
     # Change the zoom
     viewer.state.x_min = 6500
@@ -22,12 +22,12 @@ def test_homezoom_matchx(specviz_helper, spectrum1d):
     assert viewer.state.x_max > 7000
 
 
-def test_boxzoom_matchx(specviz_helper, spectrum1d):
+def test_boxzoom_matchx(deconfigged_helper, spectrum1d):
     """
     Test BoxZoomMatchX tool with zoom interaction.
     """
-    specviz_helper.load_data(spectrum1d, data_label='test')
-    viewer = specviz_helper._app.get_viewer('spectrum-viewer')
+    deconfigged_helper.load(spectrum1d, data_label='test', format='1D Spectrum')
+    viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
 
     # Activate box zoom tool
     tool = viewer.toolbar.tools['jdaviz:boxzoom_matchx']
@@ -41,12 +41,12 @@ def test_boxzoom_matchx(specviz_helper, spectrum1d):
     assert tool.match_axes == ('x',)
 
 
-def test_xrangezoom_matchx(specviz_helper, spectrum1d):
+def test_xrangezoom_matchx(deconfigged_helper, spectrum1d):
     """
     Test XRangeZoomMatchX tool with horizontal zoom interaction.
     """
-    specviz_helper.load_data(spectrum1d, data_label='test')
-    viewer = specviz_helper._app.get_viewer('spectrum-viewer')
+    deconfigged_helper.load(spectrum1d, data_label='test', format='1D Spectrum')
+    viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
 
     # Activate x-range zoom tool
     tool = viewer.toolbar.tools['jdaviz:xrangezoom_matchx']
@@ -62,12 +62,12 @@ def test_xrangezoom_matchx(specviz_helper, spectrum1d):
     assert_allclose(viewer.state.x_max, 7000, rtol=1e-5)
 
 
-def test_panzoom_matchx(specviz_helper, spectrum1d):
+def test_panzoom_matchx(deconfigged_helper, spectrum1d):
     """
     Test PanZoomMatchX tool activation and deactivation.
     """
-    specviz_helper.load_data(spectrum1d, data_label='test')
-    viewer = specviz_helper._app.get_viewer('spectrum-viewer')
+    deconfigged_helper.load(spectrum1d, data_label='test', format='1D Spectrum')
+    viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
 
     # Activate pan zoom tool
     tool = viewer.toolbar.tools['jdaviz:panzoom_matchx']
@@ -81,12 +81,12 @@ def test_panzoom_matchx(specviz_helper, spectrum1d):
     tool.deactivate()
 
 
-def test_panzoomx_matchx(specviz_helper, spectrum1d):
+def test_panzoomx_matchx(deconfigged_helper, spectrum1d):
     """
     Test PanZoomXMatchX tool for horizontal-only panning.
     """
-    specviz_helper.load_data(spectrum1d, data_label='test')
-    viewer = specviz_helper._app.get_viewer('spectrum-viewer')
+    deconfigged_helper.load(spectrum1d, data_label='test', format='1D Spectrum')
+    viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
 
     # Activate pan zoom x tool
     tool = viewer.toolbar.tools['jdaviz:panzoomx_matchx']
@@ -100,12 +100,12 @@ def test_panzoomx_matchx(specviz_helper, spectrum1d):
     tool.deactivate()
 
 
-def test_matched_zoom_between_viewers(specviz_helper, spectrum1d):
+def test_matched_zoom_between_viewers(deconfigged_helper, spectrum1d):
     """
     Test that matched zoom tools synchronize x-limits between viewers.
     """
-    specviz_helper.load_data(spectrum1d, data_label='test')
-    viewer = specviz_helper._app.get_viewer('spectrum-viewer')
+    deconfigged_helper.load(spectrum1d, data_label='test', format='1D Spectrum')
+    viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
 
     # Activate matched box zoom
     tool = viewer.toolbar.tools['jdaviz:boxzoom_matchx']
@@ -215,12 +215,12 @@ class TestMapLimits:
         tool.deactivate()
 
 
-def test_is_matched_viewer(specviz_helper, spectrum1d):
+def test_is_matched_viewer(deconfigged_helper, spectrum1d):
     """
     Test the _is_matched_viewer method identifies correct viewer types.
     """
-    specviz_helper.load_data(spectrum1d, data_label='test')
-    viewer = specviz_helper._app.get_viewer('spectrum-viewer')
+    deconfigged_helper.load(spectrum1d, data_label='test', format='1D Spectrum')
+    viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
 
     tool = viewer.toolbar.tools['jdaviz:homezoom_matchx']
 
@@ -232,12 +232,12 @@ def test_is_matched_viewer(specviz_helper, spectrum1d):
     assert tool._is_matched_viewer(viewer)
 
 
-def test_matched_zoom_disable_in_other_viewer(specviz_helper, spectrum1d):
+def test_matched_zoom_disable_in_other_viewer(deconfigged_helper, spectrum1d):
     """
     Test that activating matched zoom disables it in other viewers.
     """
-    specviz_helper.load_data(spectrum1d, data_label='test')
-    viewer = specviz_helper._app.get_viewer('spectrum-viewer')
+    deconfigged_helper.load(spectrum1d, data_label='test', format='1D Spectrum')
+    viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
 
     tool = viewer.toolbar.tools['jdaviz:boxzoom_matchx']
 
@@ -254,12 +254,12 @@ def test_matched_zoom_disable_in_other_viewer(specviz_helper, spectrum1d):
     tool.deactivate()
 
 
-def test_match_axes_property(specviz_helper, spectrum1d):
+def test_match_axes_property(deconfigged_helper, spectrum1d):
     """
     Test that matched zoom tools have correct match_axes property.
     """
-    specviz_helper.load_data(spectrum1d, data_label='test')
-    viewer = specviz_helper._app.get_viewer('spectrum-viewer')
+    deconfigged_helper.load(spectrum1d, data_label='test', format='1D Spectrum')
+    viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
 
     tool = viewer.toolbar.tools['jdaviz:homezoom_matchx']
 
@@ -269,12 +269,12 @@ def test_match_axes_property(specviz_helper, spectrum1d):
     assert 'x_max' in tool.match_keys
 
 
-def test_tool_icons_exist(specviz_helper, spectrum1d):
+def test_tool_icons_exist(deconfigged_helper, spectrum1d):
     """
     Test that all matched zoom tools have valid icon paths.
     """
-    specviz_helper.load_data(spectrum1d, data_label='test')
-    viewer = specviz_helper._app.get_viewer('spectrum-viewer')
+    deconfigged_helper.load(spectrum1d, data_label='test', format='1D Spectrum')
+    viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
 
     tool_ids = [
         'jdaviz:homezoom_matchx',

--- a/jdaviz/configs/specviz/tests/test_viewers.py
+++ b/jdaviz/configs/specviz/tests/test_viewers.py
@@ -13,7 +13,7 @@ from specutils import Spectrum
      (u.dimensionless_unscaled, 'Counts'),
      (u.erg / (u.s * u.cm ** 2), 'Flux'),
      (u.erg / u.s, 'Luminosity')])
-def test_spectrum_viewer_axis_labels(specviz_helper, input_unit, y_axis_label):
+def test_spectrum_viewer_axis_labels(deconfigged_helper, input_unit, y_axis_label):
 
     flux = np.arange(1, 10) * input_unit
     spectral_axis = np.arange(1, 10) * u.um
@@ -22,34 +22,34 @@ def test_spectrum_viewer_axis_labels(specviz_helper, input_unit, y_axis_label):
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=".*contains multiple slashes, which is discouraged by the FITS standard.*")  # noqa
-        specviz_helper.load_data(spec, data_label='test')
+        deconfigged_helper.load(spec, data_label='test', format='1D Spectrum')
 
-    label = specviz_helper._spectrum_viewer.figure.axes[1].label
+    label = deconfigged_helper.viewers['1D Spectrum']._obj.glue_viewer.figure.axes[1].label
 
     assert (y_axis_label in label)
 
 
-def test_spectrum_viewer_keep_unit_when_removed(specviz_helper, spectrum1d):
-    specviz_helper.load_data(spectrum1d, data_label="Test")
-    uc = specviz_helper.plugins["Unit Conversion"]
+def test_spectrum_viewer_keep_unit_when_removed(deconfigged_helper, spectrum1d):
+    deconfigged_helper.load(spectrum1d, data_label="Test", format='1D Spectrum')
+    uc = deconfigged_helper.plugins["Unit Conversion"]
     assert uc.flux_unit == "Jy"
     uc.flux_unit = "MJy"
-    specviz_helper._app.remove_data_from_viewer('spectrum-viewer', "Test")
-    specviz_helper._app.add_data_to_viewer('spectrum-viewer', "Test")
+    deconfigged_helper._app.remove_data_from_viewer('1D Spectrum', "Test")
+    deconfigged_helper._app.add_data_to_viewer('1D Spectrum', "Test")
     # Actual values not in display unit but should not affect display unit.
-    spec = specviz_helper.get_spectra(data_label="Test", apply_slider_redshift=False)
+    spec = deconfigged_helper.get_data(data_label="Test", apply_slider_redshift=False)
     assert spec.flux.unit == u.Jy
     assert uc.flux_unit.selected == "MJy"
-    assert specviz_helper._app._get_display_unit('spectral_y') == "MJy"
+    assert deconfigged_helper._app._get_display_unit('spectral_y') == "MJy"
 
 
-def test_limits_on_unit_change(specviz_helper, spectrum1d):
+def test_limits_on_unit_change(deconfigged_helper, spectrum1d):
     """
     Test that the x-limits are reset when changing units
     """
-    specviz_helper.load_data(spectrum1d, data_label="Test")
-    uc = specviz_helper.plugins["Unit Conversion"]
-    sv = specviz_helper.viewers['spectrum-viewer']
+    deconfigged_helper.load(spectrum1d, data_label="Test", format='1D Spectrum')
+    uc = deconfigged_helper.plugins["Unit Conversion"]
+    sv = deconfigged_helper.viewers['1D Spectrum']
 
     assert uc.spectral_unit == "Angstrom"
     assert np.allclose(sv._obj.glue_viewer.get_limits(),
@@ -70,10 +70,10 @@ def test_limits_on_unit_change(specviz_helper, spectrum1d):
 class TestResetLimitsTwoTests:
     """See https://github.com/spacetelescope/lcviz/pull/93"""
 
-    def test_reset_limits_01(self, specviz_helper, spectrum1d):
+    def test_reset_limits_01(self, deconfigged_helper, spectrum1d):
         """This should run first."""
-        specviz_helper.load_data(spectrum1d, data_label="Test")
-        sv = specviz_helper._app.get_viewer('spectrum-viewer')
+        deconfigged_helper.load(spectrum1d, data_label="Test", format='1D Spectrum')
+        sv = deconfigged_helper._app.get_viewer('1D Spectrum')
 
         orig_xlims = (sv.state.x_min, sv.state.x_max)
         orig_ylims = (sv.state.y_min, sv.state.y_max)
@@ -90,10 +90,10 @@ class TestResetLimitsTwoTests:
         sv.state._reset_y_limits()
         assert sv.state.y_min == orig_ylims[0]
 
-    def test_reset_limits_02(self, specviz_helper, spectrum1d_nm):
+    def test_reset_limits_02(self, deconfigged_helper, spectrum1d_nm):
         """This should run second and see if first polutes it."""
-        specviz_helper.load_data(spectrum1d_nm, data_label="Test")
-        sv = specviz_helper._app.get_viewer('spectrum-viewer')
+        deconfigged_helper.load(spectrum1d_nm, data_label="Test", format='1D Spectrum')
+        sv = deconfigged_helper._app.get_viewer('1D Spectrum')
 
         orig_xlims = (sv.state.x_min, sv.state.x_max)
         orig_ylims = (sv.state.y_min, sv.state.y_max)

--- a/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/specviz2d/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -181,12 +181,12 @@ def test_plugin(specviz2d_helper):
 
 @pytest.mark.remote_data
 @pytest.mark.filterwarnings('ignore')
-def test_user_api(specviz2d_helper):
+def test_user_api(deconfigged_helper):
     fn = download_file('https://stsci.box.com/shared/static/exnkul627fcuhy5akf2gswytud5tazmw.fits', cache=True)  # noqa
 
-    specviz2d_helper.load_data(spectrum_2d=fn)
+    deconfigged_helper.load(fn, format='2D Spectrum')
 
-    pext = specviz2d_helper.plugins['2D Spectral Extraction']
+    pext = deconfigged_helper.plugins['Spectral Extraction']
     pext.keep_active = True
 
     # test that setting a string to an AddResults object redirects to the label
@@ -206,10 +206,10 @@ def test_user_api(specviz2d_helper):
 @pytest.mark.remote_data
 @pytest.mark.skipif(GWCS_LT_0_18_1, reason='Needs GWCS 0.18.1 or later')
 @pytest.mark.filterwarnings("ignore::astropy.wcs.wcs.FITSFixedWarning")
-def test_background_extraction_and_display(specviz2d_helper):
+def test_background_extraction_and_display(deconfigged_helper):
     uri = 'mast:jwst/product/jw01538-o161_t002-s000000001_nirspec_f290lp-g395h-s1600a1_s2d.fits'
-    specviz2d_helper.load_data(spectrum_2d=cached_uri(uri), cache=True)
-    pext = specviz2d_helper._app.get_tray_item_from_name('spectral-extraction-2d')
+    deconfigged_helper.load(cached_uri(uri), format='2D Spectrum')
+    pext = deconfigged_helper._app.get_tray_item_from_name('2D Spectral Extraction')
 
     # check that the background extraction method and parameters are as expected
     assert pext.bg_type_selected == 'TwoSided'
@@ -218,10 +218,10 @@ def test_background_extraction_and_display(specviz2d_helper):
     # test extracting background and background subtracted images and adding
     # them to the viewer
     pext.export_bg_sub(add_data=True)
-    assert specviz2d_helper._app.data_collection[2].label == 'background-subtracted'
+    assert deconfigged_helper._app.data_collection[2].label == 'background-subtracted'
 
     pext.export_bg_img(add_data=True)
-    assert specviz2d_helper._app.data_collection[3].label == 'background'
+    assert deconfigged_helper._app.data_collection[3].label == 'background'
 
 
 @pytest.mark.filterwarnings('ignore')

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -58,17 +58,17 @@ def test_2d_parser_ext_hdulist(deconfigged_helper):
 
 
 @pytest.mark.remote_data
-def test_hlsp_goods_s2d(specviz2d_helper):
+def test_hlsp_goods_s2d(deconfigged_helper):
     uri='mast:HLSP/jades/dr3/goods-n/spectra/clear-prism/goods-n-mediumhst/hlsp_jades_jwst_nirspec_goods-n-mediumhst-00000804_clear-prism_v1.0_s2d.fits'  # noqa
-    specviz2d_helper.load(cached_uri(uri))
+    deconfigged_helper.load(cached_uri(uri), format='2D Spectrum')
 
     # ensure uncalibrated 2d spectrum extraction works
-    assert len(specviz2d_helper._app.data_collection) == 2
+    assert len(deconfigged_helper._app.data_collection) == 2
 
     # links: (glue.core.link_helpers.LinkSameWithUnits, glue.core.link_helpers.LinkSameWithUnits)
-    assert len(specviz2d_helper._app.data_collection.external_links) == 2
+    assert len(deconfigged_helper._app.data_collection.external_links) == 2
 
-    dc_0 = specviz2d_helper._app.data_collection[0]
+    dc_0 = deconfigged_helper._app.data_collection[0]
     assert dc_0.get_component('flux').shape == (27, 674)
 
 
@@ -232,30 +232,34 @@ def test_1d_parser(specviz2d_helper, spectrum1d):
     assert dc_0.meta['uncertainty_type'] == 'std'
 
 
-def test_2d_1d_parser(specviz2d_helper, mos_spectrum2d, spectrum1d):
-    specviz2d_helper.load_data(spectrum_2d=mos_spectrum2d, spectrum_1d=spectrum1d)
-    assert specviz2d_helper._app.data_collection.labels == ['Spectrum 2D', 'Spectrum 1D']
+# should this be deprecated since deconfigged loads 1d and 2d separately?
+def test_2d_1d_parser(deconfigged_helper, mos_spectrum2d, spectrum1d):
+    deconfigged_helper.load(mos_spectrum2d, format='2D Spectrum')
+    deconfigged_helper.load(spectrum1d, format='1D Spectrum')
+    assert deconfigged_helper._app.data_collection.labels == ['2D Spectrum', '2D Spectrum (auto-ext)', '1D Spectrum']
 
-    spec2d_viewer = specviz2d_helper._app.get_viewer('spectrum-2d-viewer')
+    spec2d_viewer = deconfigged_helper._app.get_viewer('2D Spectrum')
     assert spec2d_viewer.figure.axes[0].label == "x: pixels"  # -0.5, 14.5
     spec2d_viewer.apply_roi(XRangeROI(10, 12))
 
     spec2d_viewer.session.edit_subset_mode._mode = NewMode
 
-    spec1d_viewer = specviz2d_helper._app.get_viewer('spectrum-viewer')
-    assert spec1d_viewer.figure.axes[0].label == "Wavelength [Angstrom]"  # 6000, 8000
+    spec1d_viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
+    # is this a bug in deconfigged - defaults to meters instead of AA?
+    assert spec1d_viewer.figure.axes[0].label == "Wavelength [m]"  # 6000, 8000
     spec1d_viewer.apply_roi(XRangeROI(7000, 7100))
 
     # Subset 1 should follow Spectrum 2D viewer unit.
     # Subset 2 should follow Spectrum 1D viewer unit.
-    subsets = specviz2d_helper._app.get_subsets()
+    subsets = deconfigged_helper._app.get_subsets()
     assert len(subsets) == 2
     s1 = subsets["Subset 1"]
     s2 = subsets["Subset 2"]
     assert s1.lower.unit == s1.upper.unit == u.pix
-    assert s2.lower.unit == s2.upper.unit == u.AA
+    # may be a bug for deconfigged
+    assert s2.lower.unit == s2.upper.unit == u.m
 
 
-def test_parser_no_data(specviz2d_helper):
-    with pytest.raises(ValueError, match='Must provide spectrum_2d or spectrum_1d'):
-        specviz2d_helper.load_data()
+def test_parser_no_data(deconfigged_helper):
+    with pytest.raises(ValueError, match='Input must not be None'):
+        deconfigged_helper.load()

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -233,32 +233,28 @@ def test_1d_parser(specviz2d_helper, spectrum1d):
 
 
 # should this be deprecated since deconfigged loads 1d and 2d separately?
-def test_2d_1d_parser(deconfigged_helper, mos_spectrum2d, spectrum1d):
-    deconfigged_helper.load(mos_spectrum2d, format='2D Spectrum')
-    deconfigged_helper.load(spectrum1d, format='1D Spectrum')
-    assert (deconfigged_helper._app.data_collection.labels ==
-            ['2D Spectrum', '2D Spectrum (auto-ext)', '1D Spectrum'])
+def test_2d_1d_parser(specviz2d_helper, mos_spectrum2d, spectrum1d):
+    specviz2d_helper.load_data(spectrum_2d=mos_spectrum2d, spectrum_1d=spectrum1d)
+    assert specviz2d_helper._app.data_collection.labels == ['Spectrum 2D', 'Spectrum 1D']
 
-    spec2d_viewer = deconfigged_helper._app.get_viewer('2D Spectrum')
+    spec2d_viewer = specviz2d_helper._app.get_viewer('spectrum-2d-viewer')
     assert spec2d_viewer.figure.axes[0].label == "x: pixels"  # -0.5, 14.5
     spec2d_viewer.apply_roi(XRangeROI(10, 12))
 
     spec2d_viewer.session.edit_subset_mode._mode = NewMode
 
-    spec1d_viewer = deconfigged_helper._app.get_viewer('1D Spectrum')
-    # is this a bug in deconfigged - defaults to meters instead of AA?
-    assert spec1d_viewer.figure.axes[0].label == "Wavelength [m]"  # 6000, 8000
+    spec1d_viewer = specviz2d_helper._app.get_viewer('spectrum-viewer')
+    assert spec1d_viewer.figure.axes[0].label == "Wavelength [Angstrom]"  # 6000, 8000
     spec1d_viewer.apply_roi(XRangeROI(7000, 7100))
 
     # Subset 1 should follow Spectrum 2D viewer unit.
     # Subset 2 should follow Spectrum 1D viewer unit.
-    subsets = deconfigged_helper._app.get_subsets()
+    subsets = specviz2d_helper._app.get_subsets()
     assert len(subsets) == 2
     s1 = subsets["Subset 1"]
     s2 = subsets["Subset 2"]
     assert s1.lower.unit == s1.upper.unit == u.pix
-    # may be a bug for deconfigged
-    assert s2.lower.unit == s2.upper.unit == u.m
+    assert s2.lower.unit == s2.upper.unit == u.AA
 
 
 def test_parser_no_data(deconfigged_helper):

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -232,7 +232,6 @@ def test_1d_parser(specviz2d_helper, spectrum1d):
     assert dc_0.meta['uncertainty_type'] == 'std'
 
 
-# should this be deprecated since deconfigged loads 1d and 2d separately?
 def test_2d_1d_parser(specviz2d_helper, mos_spectrum2d, spectrum1d):
     specviz2d_helper.load_data(spectrum_2d=mos_spectrum2d, spectrum_1d=spectrum1d)
     assert specviz2d_helper._app.data_collection.labels == ['Spectrum 2D', 'Spectrum 1D']

--- a/jdaviz/configs/specviz2d/tests/test_parsers.py
+++ b/jdaviz/configs/specviz2d/tests/test_parsers.py
@@ -236,7 +236,8 @@ def test_1d_parser(specviz2d_helper, spectrum1d):
 def test_2d_1d_parser(deconfigged_helper, mos_spectrum2d, spectrum1d):
     deconfigged_helper.load(mos_spectrum2d, format='2D Spectrum')
     deconfigged_helper.load(spectrum1d, format='1D Spectrum')
-    assert deconfigged_helper._app.data_collection.labels == ['2D Spectrum', '2D Spectrum (auto-ext)', '1D Spectrum']
+    assert (deconfigged_helper._app.data_collection.labels ==
+            ['2D Spectrum', '2D Spectrum (auto-ext)', '1D Spectrum'])
 
     spec2d_viewer = deconfigged_helper._app.get_viewer('2D Spectrum')
     assert spec2d_viewer.figure.axes[0].label == "x: pixels"  # -0.5, 14.5


### PR DESCRIPTION
This PR is a continuation of PR 4262 which aims to swap deconfigged_helper in config tests (imviz, cubeviz, etc). This ticket addresses tests that were previously failing because deconfigged_helper does not have default viewer names (e.g. imviz-0) or a default_viewer attribute. Tests requiring a spawned viewer have been swapped to ```deconfigged_helper.get_viewer('Image')```, ```deconfigged_helper.get_viewer('1D Spectrum')``` and so on. 

I've also left a few inline comments for tests that might need to be deprecated since the deconfigged app works differently, particularly in trying to add data to the data collection without spawning a viewer.

Fixes #JDAT-6239

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
