### PR TITLE
skip display on jd.show within notebook ci

### DIFF
--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1,5 +1,6 @@
 import inspect
 import os
+import logging
 import re
 import threading
 import time
@@ -124,6 +125,19 @@ def show_widget(widget, loc, title, height=None):  # pragma: no cover
     from IPython import get_ipython
     from IPython.display import display
     import ipywidgets as widgets
+
+    # Displaying jdaviz in a sidecar can leave the frontend {'execution_state': 'busy'},
+    # which causes timeout failures in notebook ci with `spacetelescope/notebook-ci-actions`, since
+    # `nbval` listens for {'execution_state': 'idle'} before advancing to the next cell.
+    # Here we check for a CI environment variable - if true, we skip calls to `display`.
+    # This no-op is not specific to loc='sidecar' so that tests aren't broken when calling
+    # `jd.show()` within a sidecar context in the notebook.
+    if os.getenv('CI') == 'true':
+        logging.debug(
+            'environment variable "CI = true" was found, jdaviz will '
+            'skip all show/display commands.'
+        )
+        return
 
     # Check if the user is running Jdaviz in the correct environments.
     # If not, provide a friendly msg to guide them!

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -132,9 +132,9 @@ def show_widget(widget, loc, title, height=None):  # pragma: no cover
     # Here we check for a CI environment variable - if true, we skip calls to `display`.
     # This no-op is not specific to loc='sidecar' so that tests aren't broken when calling
     # `jd.show()` within a sidecar context in the notebook.
-    if os.getenv('CI') == 'true':
+    if os.getenv('JDAVIZ_SKIP_DISPLAY') == 'true':
         logging.debug(
-            'environment variable "CI = true" was found, jdaviz will '
+            'environment variable "JDAVIZ_SKIP_DISPLAY = true" was found, jdaviz will '
             'skip all show/display commands.'
         )
         return


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description

Displaying jdaviz in a sidecar can leave the frontend `{'execution_state': 'busy'}`, which causes timeout failures in notebook ci with [spacetelescope/notebook-ci-actions](https://github.com/spacetelescope/notebook-ci-actions/), since [nbval](https://github.com/computationalmodelling/nbval) listens for the jupyter kernel `{'execution_state': 'idle'}` before executing the next cell. Since that message isn't sent, cells calling `jd.show` within a sidecar will timeout. Here we check for a `JDAVIZ_SKIP_DISPLAY` environment variable, which we can set in github Actions. If the environment variable exists and is true, we skip calls to `display`, which unblocks Cobalt notebook contributions to `mast_notebooks` with jdaviz, specifically https://github.com/spacetelescope/mast_notebooks/pull/163. The environment variable is added to `mast_notebooks` CI jobs in https://github.com/spacetelescope/mast_notebooks/pull/177.


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
