### PR TITLE
Manual backport of #4264: Standalone build and workflow fixes

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -45,7 +45,7 @@ jobs:
       uses: pyvista/setup-headless-display-action@v4
 
     - name: Install jdaviz
-      run: pip install .[test,qt]
+      run: pip install -U ".[test,qt]"
 
     - name: Install pyinstaller
       # see https://github.com/erocarrera/pefile/issues/420 for performance issues on
@@ -60,8 +60,12 @@ jobs:
       run: (cd standalone; pyinstaller ./jdaviz.spec)
 
     - name: Run jdaviz cmd in background
-      run: ./standalone/dist/jdaviz/jdaviz-cli imviz --port 8765 &
-
+      env:
+        ASTROPY_ALLOW_INTERNET: "False"
+      run: |
+        # Start the app in the background so it immediately returns
+        ./standalone/dist/jdaviz/jdaviz-cli --port 8765 &
+        
     - name: Install playwright
       run: (pip install playwright; playwright install chromium)
 
@@ -72,6 +76,7 @@ jobs:
       uses: ifaxity/wait-on-action@a7d13170ec542bdca4ef8ac4b15e9c6aa00a6866  # v1.2.1
       with:
         resource: tcp:8765
+        delay: 20000
         timeout: 60000
 
     - name: Test standalone
@@ -117,7 +122,7 @@ jobs:
         python-version: "3.12"
 
     - name: Install jdaviz
-      run: pip install .[test,qt]
+      run: pip install U ".[test,qt]"
 
     - name: Install pyinstaller
       run: pip install "pyinstaller"
@@ -166,7 +171,9 @@ jobs:
 
     - name: Run jdaviz cmd in background
       if: ${{ matrix.os == 'macos-14' }}
-      run: ./standalone/dist/jdaviz.app/Contents/MacOS/jdaviz-cli imviz --port=8765 &
+      env:
+        ASTROPY_ALLOW_INTERNET: "False"
+      run: ./standalone/dist/jdaviz.app/Contents/MacOS/jdaviz-cli --port=8765 &
 
     - name: Install playwright
       run: (pip install playwright; playwright install chromium)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Bug Fixes
 
 - Fix horizontal spacing of the app-level toolbar for small displays. [#4245]
 
+- Updates to standalone app hooks, spec, and workflow due to updates in astropy8.0 [#4264]
+
 - Safely handle case where meta.wcs may be None. [#4272]
 
 5.0.2 (2026-06-12)
@@ -42,7 +44,7 @@ Bug Fixes
 
 - Fix bug related to loading catalogs where units are determined from coordinate string. [#4199]
 
-- Fix aperture photometry plugin remaining visible in tray after all 
+- Fix aperture photometry plugin remaining visible in tray after all
   image viewers are removed. [#4189]
 
 - Catch more IOPub messages to help avoid/fix "IOPub message rate exceeded" jupyter warning when

--- a/standalone/hooks/hook-glue.py
+++ b/standalone/hooks/hook-glue.py
@@ -1,4 +1,8 @@
-from PyInstaller.utils.hooks import collect_data_files, copy_metadata
+from PyInstaller.utils.hooks import collect_data_files, copy_metadata, collect_all
 
-datas = collect_data_files('glue')
+
+datas, binaries, hiddenimports = collect_all('glue')
+
+# datas = collect_data_files('glue')
 datas += copy_metadata('glue-core')
+# hiddenimports += [

--- a/standalone/hooks/hook-ipyvuetify.py
+++ b/standalone/hooks/hook-ipyvuetify.py
@@ -1,5 +1,10 @@
-from PyInstaller.utils.hooks import collect_data_files, copy_metadata, collect_submodules
+from PyInstaller.utils.hooks import collect_all, collect_data_files, copy_metadata, collect_submodules
 
 hiddenimports = collect_submodules("ipyvuetify")
 datas = collect_data_files('ipyvuetify')
 datas += copy_metadata('ipyvuetify')
+
+vue_datas, binaries, vue_hidden = collect_all('ipyvue')
+
+datas += vue_datas
+hiddenimports += vue_hidden

--- a/standalone/hooks/hook-ipywidgets.py
+++ b/standalone/hooks/hook-ipywidgets.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_all
+
+datas, binaries, hiddenimports = collect_all('ipywidgets')

--- a/standalone/hooks/hook-photutils.py
+++ b/standalone/hooks/hook-photutils.py
@@ -1,5 +1,6 @@
-from PyInstaller.utils.hooks import collect_submodules, collect_data_files
+from PyInstaller.utils.hooks import collect_submodules, collect_data_files, copy_metadata
 
 hiddenimports = collect_submodules("photutils")
 # for CITATION.rst
 datas = collect_data_files('photutils')
+datas += copy_metadata('photutils')

--- a/standalone/hooks/hook-pythreejs.py
+++ b/standalone/hooks/hook-pythreejs.py
@@ -1,0 +1,10 @@
+"""PyInstaller hook for pythreejs.
+
+pythreejs requires JSON data files at runtime for shader definitions.
+This hook ensures those files are bundled with the application.
+"""
+
+from PyInstaller.utils.hooks import collect_data_files
+
+# Collect all JSON files from pythreejs package
+datas = collect_data_files('pythreejs', includes=['**/*.json'])

--- a/standalone/hooks/hook-pyvo.py
+++ b/standalone/hooks/hook-pyvo.py
@@ -1,0 +1,4 @@
+from PyInstaller.utils.hooks import collect_data_files
+
+# Collect all JSON files from pythreejs package
+datas = collect_data_files('pyvo', includes=['**/*.png', '**/*.xml'])

--- a/standalone/hooks/hook-scipy.py
+++ b/standalone/hooks/hook-scipy.py
@@ -1,5 +1,10 @@
-from PyInstaller.utils.hooks import collect_data_files, copy_metadata, collect_submodules
+from PyInstaller.utils.hooks import check_requirement, collect_data_files, copy_metadata, collect_submodules
 
 hiddenimports = collect_submodules("scipy")
 datas = collect_data_files('scipy')
 datas += copy_metadata('scipy')
+
+if check_requirement("scipy >= 1.14.0") and check_requirement("scipy < 1.18.0"): 
+    hiddenimports += ['scipy._lib.array_api_compat.numpy.fft'] 
+elif check_requirement("scipy >= 1.18.0"): 
+    hiddenimports += ['scipy._external.array_api_compat.numpy.fft'] 

--- a/standalone/hooks/hook-solara.py
+++ b/standalone/hooks/hook-solara.py
@@ -1,5 +1,8 @@
-from PyInstaller.utils.hooks import collect_data_files, copy_metadata, collect_submodules
+from PyInstaller.utils.hooks import collect_data_files, copy_metadata, collect_submodules, collect_all
 
-hiddenimports = collect_submodules("solara")
-datas = collect_data_files('solara')
+# hiddenimports = collect_submodules("solara")
+
+datas, binaries, hiddenimports = collect_all('solara')
+
+# datas = collect_data_files('solara')
 datas += collect_data_files('solara-ui')

--- a/standalone/jdaviz.spec
+++ b/standalone/jdaviz.spec
@@ -6,6 +6,7 @@ import os
 from PyInstaller.building.build_main import Analysis
 from PyInstaller.building.api import COLLECT, EXE, PYZ
 from PyInstaller.building.osx import BUNDLE
+from PyInstaller.utils.hooks import copy_metadata
 
 import jdaviz
 from jdaviz.configs import Specviz, Specviz2d, Cubeviz, Mosviz, Imviz
@@ -15,8 +16,8 @@ codesign_identity = os.environ.get("DEVELOPER_ID_APPLICATION")
 # for all the widgets
 datas = [
     (Path(sys.prefix) / "share" / "jupyter", "./share/jupyter"),
-    (Path(sys.prefix) / "etc" / "jupyter", "./etc/jupyter"),
-]
+    (Path(sys.prefix) / "etc" / "jupyter", "./etc/jupyter")] + \
+    copy_metadata('echo') 
 
 block_cipher = None
 
@@ -26,7 +27,7 @@ a = Analysis(
     pathex=[],
     binaries=[],
     datas=datas,
-    hiddenimports=["rich.logging"],
+    hiddenimports=["rich.logging", 'glue.plugins.coordinate_helpers', 'glue.plugins.coordinate_helpers.link_helpers'],
     hookspath=["hooks"],
     hooksconfig={},
     runtime_hooks=[],
@@ -41,6 +42,7 @@ pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 exe = EXE(
     pyz,
     a.scripts,
+    [],
     [],
     exclude_binaries=True,
     # executable name: dist/jdaviz/jdaviz-cli


### PR DESCRIPTION
This was missed and is needed for the 5.0.3 release.