### PR TITLE
Test correction for comparison with zero

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -1,3 +1,4 @@
+from packaging.version import parse
 import pytest
 import warnings
 
@@ -19,7 +20,7 @@ from jdaviz.core.custom_units_and_equivs import PIX2
 from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
                                                flux_conversion_general)
 from jdaviz.utils import cached_uri
-
+from photutils import __version__ as photutils_version
 
 calspec_url = "https://archive.stsci.edu/hlsps/reference-atlases/cdbs/current_calspec/"
 
@@ -291,8 +292,17 @@ def test_rectangle_aperture_with_exact(deconfigged_helper, spectrum1d_cube_large
 
     # The extracted spectrum has "steps" (aliased) but perhaps that is due to
     # how photutils is extracting a boxy aperture. There is still a slope.
-    expected_flux_step = [9.378906, 10.5625, 11.816406, 13.140625, 14.535156,
-                          16, 17.535156, 19.691406, 21.972656, 24.378906]
+    if parse(photutils_version) > parse('3.0.0'):
+        # after 3.0.0, "exact" rectangular extraction is truly exact,
+        expected_flux_step = [
+            9.519410133361816, 10.564827919006348, 11.725051879882812,
+            13.012691497802734, 14.441734313964844, 16, 17.535156,
+            19.691406, 21.972656, 24.378906
+        ]
+    else:
+        # up to 3.0.0, "exact" was  approximate
+        expected_flux_step = [9.378906, 10.5625, 11.816406, 13.140625, 14.535156,
+                              16, 17.535156, 19.691406, 21.972656, 24.378906]
     assert_allclose(collapsed_spec.flux.value[::301], expected_flux_step)
 
     extract_plg.wavelength_dependent = False

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -419,7 +419,7 @@ def test_composite_region_with_imviz(imviz_helper, image_2d_wcs):
     assert_quantity_allclose(reg[-1]['region'].center.y, ellipse1.center.y)
     assert_quantity_allclose(reg[-1]['region'].width, ellipse1.width)
     assert_quantity_allclose(reg[-1]['region'].height, ellipse1.height)
-    assert_quantity_allclose(reg[-1]['region'].angle, ellipse1.angle)
+    assert_quantity_allclose(reg[-1]['region'].angle, ellipse1.angle, atol=1e-7 * u.deg)
 
     expected_sky = ellipse1.to_sky(image_2d_wcs)
     assert_quantity_allclose(reg[-1]['sky_region'].center.ra, expected_sky.center.ra)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description

While testing https://github.com/spacetelescope/jdaviz/pull/4002, I noticed that the failing devdeps test could be fixed by doing an absolute comparison rather than relative. Trying that out in this PR.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
