### PR TITLE
fix: file drop empty importer after FITS upload

### DIFF
--- a/jdaviz/core/loaders/resolvers/file_drop/file_drop.py
+++ b/jdaviz/core/loaders/resolvers/file_drop/file_drop.py
@@ -137,7 +137,6 @@ class FileDropResolver(BaseResolver):
         self.nfiles = len(file_infos)
         self._file_info = file_infos[0]
         self._resolver_input_updated()
-        self._update_format_items()
         self.progress = 100
 
     @property

--- a/jdaviz/core/loaders/resolvers/file_drop/test_file_drop.py
+++ b/jdaviz/core/loaders/resolvers/file_drop/test_file_drop.py
@@ -116,15 +116,13 @@ class TestFileDropResolverFileHandling:
         # Mock the internal methods to track calls but avoid any unintended
         # side effects that we don't need to check here.
         with patch.object(file_drop_resolver, '_resolver_input_updated') as mock_input_updated:
-            with patch.object(file_drop_resolver, '_update_format_items') as mock_update_format:
-                file_drop_resolver._on_file_updated(file_info)
+            file_drop_resolver._on_file_updated(file_info)
 
-                assert file_drop_resolver.nfiles == len(file_info)
-                assert file_drop_resolver._file_info == file_info[0] if len(file_info) > 1 else file_info  # noqa
-                assert file_drop_resolver.progress == 100
+            assert file_drop_resolver.nfiles == len(file_info)
+            assert file_drop_resolver._file_info == file_info[0] if len(file_info) > 1 else file_info  # noqa
+            assert file_drop_resolver.progress == 100
 
-                mock_input_updated.assert_called_once()
-                mock_update_format.assert_called_once()
+            mock_input_updated.assert_called_once()
 
     def test_on_file_updated_empty_list(self, file_drop_resolver):
         """


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address emty importer after uploading fits file with drag and  drop.

Avoid refreshing format items twice when processing a dropped file.
_resolver_input_updated() already performs the appropriate refresh, and
the second pass invalidates the in-memory FITS parser state, leaving no
available importer.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
