### PR TITLE
add line list importer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,8 @@ New Features
 - Add ability to query VO and Astroquery from catalog/using viewer coordinates as the source. The former source selection
   choice 'Manual' is also now 'Source'. [#4275]
 
+- Add importer for line lists. [#4305]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/default/tests/test_data_menu.py
+++ b/jdaviz/configs/default/tests/test_data_menu.py
@@ -423,7 +423,8 @@ def test_catalog_excluded_from_layer_reordering(imviz_helper, image_2d_wcs,
     imviz_helper.plugins['Orientation'].align_by = 'WCS'
 
     # load catalog
-    imviz_helper.load(sky_coord_only_source_catalog, data_label='catalog')
+    imviz_helper.load(sky_coord_only_source_catalog, data_label='catalog',
+                      format='Catalog')
 
     # load catalog. with the presence of a 'Default Orientation' layer that is
     # NOT listed in the data menu, loading a catalog will cause the layer

--- a/jdaviz/core/loaders/importers/__init__.py
+++ b/jdaviz/core/loaders/importers/__init__.py
@@ -11,4 +11,5 @@ from .trace import *  # noqa
 from .catalog import *  # noqa
 from .footprint import *  # noqa
 from .line_list import *  # noqa
+from .spectral_lines import *  # noqa
 from .footprint import *  # noqa

--- a/jdaviz/core/loaders/importers/spectral_lines/__init__.py
+++ b/jdaviz/core/loaders/importers/spectral_lines/__init__.py
@@ -1,0 +1,1 @@
+from .spectral_lines import *  # noqa

--- a/jdaviz/core/loaders/importers/spectral_lines/spectral_lines.py
+++ b/jdaviz/core/loaders/importers/spectral_lines/spectral_lines.py
@@ -1,0 +1,265 @@
+from astropy.table import Table, QTable
+import astropy.units as u
+import re
+from traitlets import Bool, List, Unicode, observe
+
+from jdaviz.core.loaders.importers import BaseImporterToDataCollection
+from jdaviz.core.template_mixin import SelectPluginComponent
+from jdaviz.core.registries import loader_importer_registry
+from jdaviz.core.user_api import ImporterUserApi
+
+__all__ = ['SpectralLinesImporter']
+
+# Physical types that represent valid spectral axes
+_SPECTRAL_PHYSICAL_TYPES = ('length', 'frequency', 'energy', 'wavenumber')
+
+# Regex patterns for guessing spectral location columns by name
+_SPECTRAL_LOC_PATTERNS = [
+    re.compile(r'^wavelength$|wavelength|^wave$|^wav$|^wl$|^lambda$|^lam$'
+               r'|^restwave$|^rest_wave$', re.IGNORECASE),
+    re.compile(r'^frequency$|frequency|^freq$|^nu$'
+               r'|^restfreq$|^rest_freq$', re.IGNORECASE),
+    re.compile(r'^wavenumber$|wavenumber|^wave_number$', re.IGNORECASE),
+    re.compile(r'^energy$', re.IGNORECASE),
+]
+
+
+@loader_importer_registry("Spectral Lines")
+class SpectralLinesImporter(BaseImporterToDataCollection):
+    """
+    Importer for spectral line list tables.
+
+    Accepts an astropy ``Table`` or ``QTable``, and lets the user designate a
+    spectral location column along with its unit and the wavelength medium
+    (vacuum or air).
+    """
+
+    template_file = __file__, "./spectral_lines.vue"
+
+    # --- spectral location column ---
+    spectral_loc_items = List().tag(sync=True)
+    spectral_loc_selected = Unicode().tag(sync=True)
+    # True when the selected column already carries valid spectral units,
+    # so the unit dropdown can be hidden.
+    spectral_loc_has_unit = Bool(False).tag(sync=True)
+
+    # --- spectral unit (shown when spectral_loc_has_unit is False) ---
+    spectral_loc_unit_items = List().tag(sync=True)
+    spectral_loc_unit_selected = Unicode().tag(sync=True)
+
+    # --- medium ---
+    medium_items = List().tag(sync=True)
+    medium_selected = Unicode().tag(sync=True)
+
+    # --- additional columns (optional, multiselect) ---
+    col_other_items = List().tag(sync=True)
+    col_other_selected = List().tag(sync=True)
+    col_other_multiselect = Bool(True).tag(sync=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not self.is_valid:
+            return
+
+        input_table = self.input
+
+        self.spectral_loc = SelectPluginComponent(
+            self,
+            items='spectral_loc_items',
+            selected='spectral_loc_selected',
+            manual_options=self._guess_spectral_loc_col(),
+            filters=[self._filter_numeric_col],
+            apply_filters_to_manual_options=True,
+        )
+
+        self.spectral_loc_unit = SelectPluginComponent(
+            self,
+            items='spectral_loc_unit_items',
+            selected='spectral_loc_unit_selected',
+            manual_options=self._valid_spectral_units(),
+        )
+
+        self.medium = SelectPluginComponent(
+            self,
+            items='medium_items',
+            selected='medium_selected',
+            manual_options=['Vacuum', 'Air'],
+        )
+
+        self.col_other = SelectPluginComponent(
+            self,
+            items='col_other_items',
+            selected='col_other_selected',
+            manual_options=input_table.colnames,
+            multiselect='col_other_multiselect',
+        )
+
+    def _check_is_valid(self):
+        if not getattr(self._app.state, 'dev_loaders', False):
+            return ('Spectral Lines importer is under active development '
+                    '(requires dev_loaders to be enabled).')
+
+        if not isinstance(self.input, (Table, QTable)):
+            return 'Input must be an astropy Table or QTable.'
+
+        if len(self.input) == 0:
+            return 'Input table is empty.'
+
+        return ''
+
+    def _guess_spectral_loc_col(self):
+        """
+        Guess the spectral location column from common naming conventions.
+
+        First checks whether any column already carries a recognised spectral
+        unit (length, frequency, energy, or wavenumber).  If none, falls back
+        to pattern-matching against common column names.
+
+        Returns a list of column names ordered so the best guess is first,
+        followed by ``'---'`` (no selection) and then the remaining columns.
+        If no match is found, ``'---'`` is the first item.
+        """
+        input_table = self.input
+        colnames = input_table.colnames
+
+        # column already has a recognised spectral unit
+        for i, col in enumerate(colnames):
+            col_data = input_table[col]
+            if hasattr(col_data, 'unit') and col_data.unit is not None:
+                physical_type = str(u.Unit(col_data.unit).physical_type)
+                if physical_type in _SPECTRAL_PHYSICAL_TYPES:
+                    return_cols = colnames if i == 0 else (colnames[i:] + colnames[:i])
+                    return [return_cols[0]] + ['---'] + list(return_cols[1:])
+
+        # if no unit match was found, pattern-match column names
+        for pattern in _SPECTRAL_LOC_PATTERNS:
+            for i, col in enumerate(colnames):
+                tokens = re.split(r'[\s_\-\.]+', col.lower().strip())
+                if any(pattern.search(t) for t in tokens):
+                    return_cols = colnames if i == 0 else (colnames[i:] + colnames[:i])
+                    return [return_cols[0]] + ['---'] + list(return_cols[1:])
+
+        return ['---'] + list(colnames)
+
+    def _filter_numeric_col(self, item):
+        """
+        Filter for ``spectral_loc``: keep only the ``'---'`` sentinel and
+        columns whose values can be cast to float.
+        """
+        label = item.get('label') if isinstance(item, dict) else item
+        if label == '---':
+            return True
+        input_table = self.input
+        if not isinstance(input_table, (Table, QTable)):
+            return True
+        if label not in input_table.colnames:
+            return True
+        try:
+            input_table[label].astype(float)
+            return True
+        except (AttributeError, ValueError):
+            return False
+
+    @staticmethod
+    def _valid_spectral_units():
+        """Return valid spectral unit choices."""
+        return [
+            'Angstrom', 'nm', 'um', 'mm', 'm',
+            'Hz', 'kHz', 'MHz', 'GHz', 'THz',
+            'eV', 'keV',
+            '1/cm',
+        ]
+
+    @observe('spectral_loc_selected')
+    def _on_spectral_loc_selected(self, msg):
+        """
+        React to a change in the selected spectral location column. Determines
+        whether the column already has valid spectral units and sets
+        ``spectral_loc_has_unit`` accordingly (controlling the unit dropdown
+        visibility), and sets ``import_disabled_msg`` when no valid column is
+        selected.
+        """
+        col = self.spectral_loc_selected
+
+        if col in ('---', '', None):
+            # No column selected – hide unit dropdown and block import
+            self.spectral_loc_has_unit = True
+            self.import_disabled_msg = (
+                'Cannot import spectral lines without a Spectral Location column. '
+                'Select a column under Definitions.'
+            )
+            return
+
+        input_table = self.input
+        if not isinstance(input_table, (Table, QTable)):
+            return
+
+        has_units = False
+        if col in input_table.colnames:
+            col_data = input_table[col]
+            if hasattr(col_data, 'unit') and col_data.unit is not None:
+                physical_type = str(u.Unit(col_data.unit).physical_type)
+                has_units = physical_type in _SPECTRAL_PHYSICAL_TYPES
+
+        self.spectral_loc_has_unit = has_units
+        self.import_disabled_msg = ''
+
+    @property
+    def user_api(self):
+        expose = ['spectral_loc', 'spectral_loc_unit', 'medium', 'col_other']
+        return ImporterUserApi(self, expose=expose)
+
+    @staticmethod
+    def _get_supported_viewers():
+        return [
+            {'label': 'Scatter', 'reference': 'scatter-viewer'},
+            {'label': 'Table', 'reference': 'table-viewer'},
+            {'label': 'Histogram', 'reference': 'histogram-viewer'},
+        ]
+
+    @property
+    def output_cols(self):
+        """Ordered list of column names that will appear in ``output``."""
+        input_table = self.input
+        if not isinstance(input_table, (Table, QTable)):
+            return []
+
+        cols = []
+        if self.spectral_loc_selected not in ('---', '', None):
+            cols.append(self.spectral_loc_selected)
+        for col in self.col_other_selected:
+            if col not in cols:
+                cols.append(col)
+        return [col for col in cols if col in input_table.colnames]
+
+    @property
+    def output(self):
+        """
+        Build the output ``QTable`` to add to the data collection.
+        """
+        input_table = self.input
+        if not isinstance(input_table, (Table, QTable)):
+            return None
+
+        output_table = QTable()
+        output_table.meta['_jdaviz_loader_medium'] = self.medium_selected
+
+        # Spectral location column
+        if self.spectral_loc_selected not in ('---', '', None):
+            col_name = self.spectral_loc_selected
+            col_data = input_table[col_name]
+
+            if not self.spectral_loc_has_unit:
+                # Column has no (or non-spectral) units – apply the chosen unit
+                col_data = col_data.astype(float) * u.Unit(self.spectral_loc_unit_selected)
+
+            output_table[col_name] = col_data
+            output_table.meta['_jdaviz_loader_spectral_loc_col'] = col_name
+
+        # Additional columns
+        for col in self.col_other_selected:
+            if col not in output_table.colnames and col in input_table.colnames:
+                output_table[col] = input_table[col]
+
+        return output_table

--- a/jdaviz/core/loaders/importers/spectral_lines/spectral_lines.vue
+++ b/jdaviz/core/loaders/importers/spectral_lines/spectral_lines.vue
@@ -1,0 +1,83 @@
+<template>
+  <v-container>
+
+    <j-plugin-section-header>Definitions</j-plugin-section-header>
+
+    <plugin-select
+      :items="spectral_loc_items.map(i => i.label)"
+      v-model:selected="spectral_loc_selected"
+      label="Spectral Location"
+      hint="Column containing the spectral positions (e.g. wavelength, frequency, energy)."
+      api_hint="ldr.importer.spectral_loc ="
+      :api_hints_enabled="api_hints_enabled"
+    ></plugin-select>
+
+    <plugin-select v-if="!spectral_loc_has_unit"
+      :items="spectral_loc_unit_items.map(i => i.label)"
+      v-model:selected="spectral_loc_unit_selected"
+      label="Spectral Unit"
+      hint="Unit for the spectral location column."
+      api_hint="ldr.importer.spectral_loc_unit ="
+      :api_hints_enabled="api_hints_enabled"
+    ></plugin-select>
+
+    <plugin-select
+      :items="medium_items.map(i => i.label)"
+      v-model:selected="medium_selected"
+      label="Medium"
+      hint="Medium in which the spectral line positions are defined."
+      api_hint="ldr.importer.medium ="
+      :api_hints_enabled="api_hints_enabled"
+    ></plugin-select>
+
+    <j-plugin-section-header>Select Additional Columns</j-plugin-section-header>
+    <plugin-select
+      :items="col_other_items.map(i => i.label)"
+      v-model:selected="col_other_selected"
+      :multiselect="col_other_multiselect"
+      label="Other Columns"
+      hint="Select additional columns to include in the loaded table."
+      api_hint="ldr.importer.col_other ="
+      :api_hints_enabled="api_hints_enabled"
+    />
+
+    <plugin-auto-label
+      v-model:value="data_label_value"
+      :default="data_label_default"
+      v-model:auto="data_label_auto"
+      :invalid_msg="data_label_invalid_msg"
+      label="Line list label"
+      api_hint="ldr.importer.label ="
+      :api_hints_enabled="api_hints_enabled"
+      hint="Label to assign to the line list in the data collection."
+    ></plugin-auto-label>
+
+    <plugin-viewer-create-new
+      :items="viewer_items"
+      v-model:selected="viewer_selected"
+      :create_new_items="viewer_create_new_items"
+      v-model:create_new_selected="viewer_create_new_selected"
+      v-model:new_label_value="viewer_label_value"
+      :new_label_default="viewer_label_default"
+      v-model:new_label_auto="viewer_label_auto"
+      :new_label_invalid_msg="viewer_label_invalid_msg"
+      :multiselect="viewer_multiselect"
+      :show_multiselect_toggle="false"
+      label="Viewer"
+      api_hint='ldr.importer.viewer = '
+      :api_hints_enabled="api_hints_enabled"
+      :show_if_single_entry="true"
+      hint="Select the viewer to display the line list in."
+    ></plugin-viewer-create-new>
+
+    <loader-import-button
+      :spinner="import_spinner"
+      :disabled_msg="import_disabled_msg"
+      :api_hints_enabled="api_hints_enabled"
+      api_hint="ldr.load()"
+      :data_label_overwrite="data_label_overwrite"
+      @click="import_clicked">
+    </loader-import-button>
+
+  </v-container>
+</template>

--- a/jdaviz/core/loaders/importers/spectral_lines/test_spectral_lines.py
+++ b/jdaviz/core/loaders/importers/spectral_lines/test_spectral_lines.py
@@ -1,0 +1,178 @@
+import astropy.units as u
+from astropy.table import QTable, Table
+import pytest
+
+from jdaviz.core.loaders.importers.spectral_lines.spectral_lines import SpectralLinesImporter
+
+
+def test_spectral_lines_importer_is_valid(deconfigged_helper):
+    """Test _check_is_valid for SpectralLinesImporter: success and failure cases."""
+    app = deconfigged_helper._app
+
+    valid_table = QTable({'wavelength': [6562.8, 4861.3] * u.AA,
+                          'name': ['Ha', 'Hb']})
+
+    importer = SpectralLinesImporter(app=app, resolver=None, parser=None,
+                                     input=valid_table)
+    assert importer.is_valid
+    assert importer._check_is_valid() == ''
+
+    # non table input (a string) should not be valid
+    importer._input = 'not_a_table'
+    assert importer._check_is_valid() == 'Input must be an astropy Table or QTable.'
+
+    # an empty table should not be valid
+    importer._input = QTable({'wavelength': [] * u.AA})
+    assert importer._check_is_valid() == 'Input table is empty.'
+
+    # a regular astropy Table (not QTable) should be accepted
+    importer._input = Table({'wavelength': [6562.8], 'name': ['Ha']})
+    assert importer._check_is_valid() == ''
+
+
+@pytest.mark.parametrize('col_name', [
+    'wavelength', 'Wavelength', 'WAVELENGTH',
+    'wave', 'Wav', 'wl', 'lambda', 'lam',
+    'restwave', 'rest_wave', 'frequency', 'FREQ', 'nu', 'rest-freq', 'rest freq'
+])
+def test_wavelength_column_detection(deconfigged_helper, col_name):
+    """
+    Wavelength and frequency-like column names should be automatically detected for
+    'spectral_loc'. Added some variation in capitalization / spacing to ensure
+    flexibility.
+    """
+    ldr = deconfigged_helper.loaders['object']
+    ldr.object = QTable({col_name: [6562.8, 4861.3], 'flux': [1.0, 0.5]})
+    ldr.format = 'Spectral Lines'
+    importer = ldr.importer
+    assert importer.spectral_loc == col_name
+
+    # load into a Table viewer and verify the data appears there
+    importer.viewer.create_new = 'Table'
+    importer()
+
+    tv = deconfigged_helper.viewers['Table']
+    assert len(tv._obj.glue_viewer.layers) == 1
+
+
+def test_spectral_unit_column_detection(deconfigged_helper):
+    """
+    Columns from a Q table that already have spectral units should be detected,
+    even if the column name doesn't indicate that it is a frequency or
+    wavelength column.
+    """
+    ldr = deconfigged_helper.loaders['object']
+    ldr.object = QTable({'pos': [6562.8, 4861.3] * u.AA, 'name': ['Ha', 'Hb']})
+    ldr.format = 'Spectral Lines'
+    importer = ldr.importer
+    assert importer.spectral_loc == 'pos'
+
+
+def test_spectral_loc_excludes_non_numeric_columns(deconfigged_helper):
+    """
+    Non-numeric columns should be filtered out of spectral_loc choices,
+    otherwise an error is raised when they are cast to a float.
+    """
+    ldr = deconfigged_helper.loaders['object']
+    ldr.object = QTable({'wavelength': [6562.8, 4861.3],
+                         'name': ['Ha', 'Hb'],       # string – not numeric
+                         'flag': [True, False]})      # bool – not float-castable via astype
+    ldr.format = 'Spectral Lines'
+    importer = ldr.importer
+
+    choices = importer.spectral_loc.choices
+    assert 'wavelength' in choices
+    assert '---' in choices
+    assert 'name' not in choices
+
+
+def test_no_spectral_column_detected(deconfigged_helper):
+    """When no spectral column is found, selection should default to '---'."""
+    ldr = deconfigged_helper.loaders['object']
+    ldr.object = QTable({'flux': [1.0, 0.5], 'name': ['Ha', 'Hb']})
+    ldr.format = 'Spectral Lines'
+    importer = ldr.importer
+    assert importer.spectral_loc == '---'
+
+
+def test_spectral_loc_has_unit_true(deconfigged_helper):
+    """spectral_loc_has_unit should be True when column has recognised spectral units."""
+    app = deconfigged_helper._app
+    table = QTable({'wavelength': [6562.8, 4861.3] * u.AA})
+    importer = SpectralLinesImporter(app=app, resolver=None, parser=None, input=table)
+
+    importer.spectral_loc_selected = 'wavelength'
+    assert importer.spectral_loc_has_unit is True
+
+
+def test_spectral_loc_has_unit_false(deconfigged_helper):
+    """spectral_loc_has_unit should be False when column has no units."""
+    app = deconfigged_helper._app
+    table = QTable({'wavelength': [6562.8, 4861.3]})  # no units
+    importer = SpectralLinesImporter(app=app, resolver=None, parser=None, input=table)
+
+    importer.spectral_loc_selected = 'wavelength'
+    assert importer.spectral_loc_has_unit is False
+
+
+def test_spectral_loc_no_selection_disables_import(deconfigged_helper):
+    """Selecting '---' should set import_disabled_msg."""
+    app = deconfigged_helper._app
+    table = QTable({'wavelength': [6562.8] * u.AA})
+    importer = SpectralLinesImporter(app=app, resolver=None, parser=None, input=table)
+
+    importer.spectral_loc_selected = '---'
+    assert importer.import_disabled_msg != ''
+
+
+def test_output_with_units_already_present(deconfigged_helper):
+    """When the spectral column has units, they should pass through unchanged."""
+    app = deconfigged_helper._app
+    table = QTable({'wavelength': [6562.8, 4861.3] * u.AA, 'name': ['Ha', 'Hb']})
+    importer = SpectralLinesImporter(app=app, resolver=None, parser=None, input=table)
+    importer.spectral_loc_selected = 'wavelength'
+    importer.medium_selected = 'Vacuum'
+
+    out = importer.output
+    assert isinstance(out, QTable)
+    assert 'wavelength' in out.colnames
+    assert out['wavelength'].unit == u.AA
+    assert out.meta['_jdaviz_loader_spectral_loc_col'] == 'wavelength'
+    assert out.meta['_jdaviz_loader_medium'] == 'Vacuum'
+
+
+def test_output_unit_applied_when_missing(deconfigged_helper):
+    """When the spectral column has no units, the chosen unit should be applied."""
+    app = deconfigged_helper._app
+    table = QTable({'wavelength': [6562.8, 4861.3]})
+    importer = SpectralLinesImporter(app=app, resolver=None, parser=None, input=table)
+    importer.spectral_loc_selected = 'wavelength'
+    importer.spectral_loc_unit_selected = 'nm'
+    importer.medium_selected = 'Air'
+
+    out = importer.output
+    assert out['wavelength'].unit == u.nm
+    assert out.meta['_jdaviz_loader_medium'] == 'Air'
+
+
+def test_output_additional_columns(deconfigged_helper):
+    """Selected additional columns should appear in the output."""
+    app = deconfigged_helper._app
+    table = QTable({'wavelength': [6562.8] * u.AA, 'flux': [1.0], 'name': ['Ha']})
+    importer = SpectralLinesImporter(app=app, resolver=None, parser=None, input=table)
+    importer.spectral_loc_selected = 'wavelength'
+    importer.col_other_selected = ['flux', 'name']
+
+    out = importer.output
+    assert 'flux' in out.colnames
+    assert 'name' in out.colnames
+
+
+def test_supported_viewers():
+    """_get_supported_viewers should include Scatter, Table and Histogram viewers."""
+    viewers = SpectralLinesImporter._get_supported_viewers()
+    assert len(viewers) == 3
+    references = [v['reference'] for v in viewers]
+    assert 'scatter-viewer' in references
+    assert 'table-viewer' in references
+    assert 'histogram-viewer' in references

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -182,10 +182,13 @@ class FormatSelect(SelectPluginComponent):
                     else:
                         self._invalid_importers[label] = this_importer.is_valid.message
 
-        # Sort to move Catalog to the end of the list
+        # Sort generic table importers to the end of the list so more specific
+        # formats are selected by default.  Order: other > Catalog > Spectral Lines.
+        spectral_lines_formats = [f for f in all_formats if f['label'] == 'Spectral Lines']
         catalog_formats = [f for f in all_formats if f['label'] == 'Catalog']
-        other_formats = [f for f in all_formats if f['label'] != 'Catalog']
-        self.items = other_formats + catalog_formats
+        other_formats = [f for f in all_formats
+                         if f['label'] not in ('Catalog', 'Spectral Lines')]
+        self.items = other_formats + catalog_formats + spectral_lines_formats
         self._apply_default_selection()
 
 

--- a/jdaviz/core/loaders/tests/test_load_catalogs.py
+++ b/jdaviz/core/loaders/tests/test_load_catalogs.py
@@ -88,7 +88,8 @@ def test_load_catalog_no_source_positions(imviz_helper, image_2d_wcs):
     imviz_helper.load(data)
 
     # load catalog, all columns
-    imviz_helper.load(catalog_obj, col_other=['col1', 'col2', 'col3'])
+    imviz_helper.load(catalog_obj, col_other=['col1', 'col2', 'col3'],
+                      format='Catalog')
 
     # check for the table in the data collection
     dc = imviz_helper._app.data_collection
@@ -113,7 +114,7 @@ def test_load_catalog_with_string_coord_cols(imviz_helper):
     catalog_obj = _make_catalog_string_coord_columns()
 
     # load catalog
-    imviz_helper.load(catalog_obj)
+    imviz_helper.load(catalog_obj, format='Catalog')
 
     dc = imviz_helper._app.data_collection
     assert len(dc) == 1
@@ -157,7 +158,7 @@ def test_load_catalog_xy_and_radec(imviz_helper, tmp_path, from_file, with_units
         catalog = catalog_obj
 
     # load catalog
-    imviz_helper.load(catalog)
+    imviz_helper.load(catalog, format='Catalog')
 
     dc = imviz_helper._app.data_collection
     assert len(dc) == 1
@@ -248,7 +249,7 @@ def test_load_catalog(imviz_helper, image_2d_wcs, tmp_path, from_file, with_unit
     imviz_helper.plugins['Orientation'].align_by = 'WCS'
 
     # load catalog
-    imviz_helper.load(catalog)
+    imviz_helper.load(catalog, format='Catalog')
 
     # ensure that it is in the data collection with the correct label "Catalog"
     dc = imviz_helper._app.data_collection
@@ -287,19 +288,19 @@ def test_load_catalog(imviz_helper, image_2d_wcs, tmp_path, from_file, with_unit
     assert ldr.importer._obj.col_ra_has_unit == with_units
 
     # load it again, make sure label incremented by 1
-    imviz_helper.load(catalog)
+    imviz_helper.load(catalog, format='Catalog')
     assert len(dc) == 4  # image, orientation layer, and 2 catalogs
     assert 'Catalog (1)' in imviz_helper._app.data_collection.labels
 
     # load with custom label and check label
-    imviz_helper.load(catalog, data_label='my_catalog')
+    imviz_helper.load(catalog, data_label='my_catalog', format='Catalog')
     assert len(dc) == 5  # image, orientation layer, and 3 catalogs
     assert 'my_catalog' in imviz_helper._app.data_collection.labels
 
     # test other loader API options. switch RA and Dec col just to test
     # non-default column selection
     imviz_helper.load(catalog, data_label='with_flux', col_other='flux',
-                      col_ra='Dec', col_dec='RA')
+                      col_ra='Dec', col_dec='RA', format='Catalog')
     assert len(dc) == 6  # image, orientation layer, and 4 catalogs
     assert 'flux' in dc['with_flux'].get_object(QTable).colnames
     qtab = imviz_helper._app.data_collection[-1].get_object(QTable)
@@ -328,7 +329,7 @@ def test_load_catalog_skycoord(imviz_helper, tmp_path, from_file):
         catalog = catalog_obj
 
     # load catalog
-    imviz_helper.load(catalog)
+    imviz_helper.load(catalog, format='Catalog')
 
     dc = imviz_helper._app.data_collection
     assert len(dc) == 1
@@ -365,9 +366,10 @@ def test_astroquery_load_catalog_source(deconfigged_helper):
         raise
     except requests.exceptions.RequestException as exc:
         pytest.skip(f"Transient remote archive failure: {exc}")
-    assert 'Catalog' in ldr.format.choices
-    ldr.format = 'Catalog'
 
+    assert 'Catalog' in ldr.format.choices
+
+    ldr.format = 'Catalog'
     ldr.importer.col_ra = 'ra'
     ldr.importer.col_dec = 'dec'
     ldr.importer.col_id = 'source_id'
@@ -632,7 +634,7 @@ def test_catalog_visibility(imviz_helper, image_2d_wcs):
     table_x_y_only = orig_catalog['X', 'Y', 'Obj_ID']
 
     imviz_helper.load(table_ra_dec_only,
-                      data_label='catalog0')
+                      data_label='catalog0', format='Catalog')
 
     # since we're pixel linked and catalog has only world coordinates,
     # visibility should be off by default
@@ -646,7 +648,7 @@ def test_catalog_visibility(imviz_helper, image_2d_wcs):
 
     # but if we load the catalog with X, Y, it should be visible
     imviz_helper.load(table_x_y_only,
-                      data_label='catalog1')
+                      data_label='catalog1', format='Catalog')
     assert dm.data_labels_visible == ['catalog1', 'Image[DATA]']
 
     assert po.layer.choices == ['Image[DATA]', 'catalog1']  # catalog layer is now an option
@@ -657,7 +659,7 @@ def test_catalog_visibility(imviz_helper, image_2d_wcs):
     # load catalog with RA, Dec only again. Its default visibility should
     # now be on since we're WCS linked
     imviz_helper.load(table_ra_dec_only,
-                      data_label='catalog2')
+                      data_label='catalog2', format='Catalog')
 
     # the pixel-only 'catalog1' should now be hidden
     assert dm.data_labels_visible == ['catalog2', 'Image[DATA]']
@@ -665,7 +667,7 @@ def test_catalog_visibility(imviz_helper, image_2d_wcs):
     # loading a pixel-coordinate-only catalog should now be hidden by default
     # since were WCS linked
     imviz_helper.load(table_x_y_only,
-                      data_label='catalog3')
+                      data_label='catalog3', format='Catalog')
     assert 'catalog3' not in dm.data_labels_visible
 
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -4892,7 +4892,8 @@ class DatasetSelect(SelectPluginComponent):
             return len(data.shape) == 2
 
         def is_catalog(data):
-            return data.meta.get('_importer', '') == 'CatalogImporter'
+            return data.meta.get('_importer', '') in ['SpectralLinesImporter',
+                                                      'CatalogImporter']
 
         def is_catalog_or_image_not_spectrum(data):
             return is_catalog(data) or is_image_not_spectrum(data)


### PR DESCRIPTION
This PR adds an importer for line lists. Similar to the catalog importer, designated columns (spectral location and unit, medium) are assigned, and any other additional columns can be imported as well.