### PR TITLE
add missing changelog for 4303

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,8 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- fix case where file drop loader would not show importer options. [#4303]
+
 Mosviz
 ^^^^^^
 


### PR DESCRIPTION
accidentally merged #4303 without a changelog entry.  Backport for changelog entry is already included in #4306 so marking this as milestone 5.1 and no changelog required.