### PR TITLE
fix support for Roman L3 sky cells

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -105,6 +105,8 @@ Bug Fixes
 
 - fix case where file drop loader would not show importer options. [#4303]
 
+- Fix image importer support for Roman L3 mosaic files. [#4309]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -297,8 +297,9 @@ def test_rectangle_aperture_with_exact(deconfigged_helper, spectrum1d_cube_large
         # after 3.0.0, "exact" rectangular extraction is truly exact,
         expected_flux_step = [
             9.519410133361816, 10.564827919006348, 11.725051879882812,
-            13.012691497802734, 14.441734313964844, 16, 17.535156,
-            19.691406, 21.972656, 24.378906
+            13.012691497802734, 14.441734313964844, 16.027719497680664,
+            17.787872314453125, 19.7413272857666, 21.909305572509766,
+            24.31537437438965
         ]
     else:
         # up to 3.0.0, "exact" was  approximate

--- a/jdaviz/conftest.py
+++ b/jdaviz/conftest.py
@@ -173,6 +173,18 @@ def roman_level_1_ramp():
     return data_model
 
 
+@pytest.fixture
+def roman_level_3_mosaic():
+    from roman_datamodels.datamodels import MosaicModel
+
+    rng = np.random.default_rng(seed=42)
+
+    shape = (5000, 5000)
+    data_model = MosaicModel.create_fake_data(shape=shape)
+    data_model.data = rng.uniform(size=shape)
+    return data_model
+
+
 def _make_jwst_ramp(shape=(1, 10, 25, 25)):
     from stdatamodels.jwst.datamodels import Level1bModel
 

--- a/jdaviz/core/loaders/importers/image/image.py
+++ b/jdaviz/core/loaders/importers/image/image.py
@@ -115,7 +115,7 @@ class ImageImporter(BaseImporterToDataCollection):
             input = fits.HDUList([input])
 
         input_is_roman_imagemodel = (
-            HAS_ROMAN_DATAMODELS and isinstance(input, rdd.ImageModel)
+            HAS_ROMAN_DATAMODELS and isinstance(input, (rdd.ImageModel, rdd.MosaicModel))
         )
         input_is_roman_asdf = isinstance(input, asdf.AsdfFile) and 'roman' in input
 

--- a/jdaviz/core/loaders/importers/image/test_image.py
+++ b/jdaviz/core/loaders/importers/image/test_image.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 import astropy.units as u
 from astropy.nddata import NDData, StdDevUncertainty
@@ -5,6 +6,7 @@ from astropy.io import fits
 from specutils import Spectrum
 
 from jdaviz.core.loaders.importers.image.image import ImageImporter
+from jdaviz.configs.imviz.plugins.parsers import HAS_ROMAN_DATAMODELS
 
 
 def test_image_importer_is_valid(deconfigged_helper):
@@ -51,3 +53,17 @@ def test_image_importer_is_valid(deconfigged_helper):
                     wcs=s.wcs)
     importer = _create_importer(input_data=nddata)
     assert importer._check_is_valid() == 'Input has spectral WCS coordinates.'
+
+
+@pytest.mark.skipif(not HAS_ROMAN_DATAMODELS, reason="roman_datamodels is not installed")
+def test_roman_level_3(deconfigged_helper, roman_level_3_mosaic):
+    resolver = deconfigged_helper.loaders['object']._obj
+
+    def _create_importer(input_data=None):
+        return ImageImporter(app=deconfigged_helper._app,
+                             resolver=resolver, parser=None,
+                             input=input_data)
+
+    # check that the importer works on Roman L3s
+    importer = _create_importer(input_data=roman_level_3_mosaic)
+    assert importer._check_is_valid() == ''


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description


Recent Roman builds have made L3 sky cell files available for testing. They can't be loaded into jdaviz yet because the `ImageImporter` checks for `roman_datamodels.datamodels.ImageModel`s specifically, but L3s are `MosaicModel`s. I didn't anticipate that the class would be different when I wrote the ASDF parser years ago, so I'm considering this a bugfix.

This PR lets `MosaicModel`s through the parser as well.

You can test this with the [L3 ASDF file for download here](https://stsci.box.com/shared/static/bq6hct434h3m6isekxeinuphs8tbngbt.asdf) and 
```python
import jdaviz as jd
import roman_datamodels.datamodels as rdd

path = 'r00164_p_v01002001001001_082m68x25y34_f158_coadd.asdf'
l3 = rdd.open(path)

jd.load(l3, loader='object', format='Image')
jd.show()
```

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
