### PR TITLE
Fix snackbar positioning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -107,6 +107,8 @@ Bug Fixes
 
 - Fix image importer support for Roman L3 mosaic files. [#4309]
 
+- Fix issue where snackbar is attached to the notebook rather than to the app. [#4313]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app
     id="web-app"
-    :style="checkNotebookContext() ? 'display: inline; --jdaviz-notebook-max-height: ' + state_settings.context.notebook.max_height : 'display: flex'"
+    :style="(checkNotebookContext() ? 'display: inline; --jdaviz-notebook-max-height: ' + state_settings.context.notebook.max_height : 'display: flex') + '; position: relative'"
     :class="'jdaviz ' + config + (checkNotebookContext() ? ' jdaviz-notebook-context' : '')"
     ref="mainapp"
   >
@@ -449,6 +449,7 @@
       location="top right"
       transition="slide-x-transition"
       absolute
+      attach
       style="margin-right: 95px; margin-top: -2px"
     >
       {{ state_snackbar.text }}


### PR DESCRIPTION
This pull request fixes an issue introduced by vue3 where the snackbar is attached to the notebook rather than to the app

before --

<img width="1572" height="968" alt="Screenshot 2026-07-29 at 10 58 51 AM" src="https://github.com/user-attachments/assets/704ab2dc-e576-4d0e-b98f-1619e3040cf1" />

after --

<img width="1572" height="968" alt="Screenshot 2026-07-29 at 10 59 26 AM" src="https://github.com/user-attachments/assets/c63f9255-7ab6-4fdf-9cff-01141817f8cf" />
