### PR TITLE
working URL loader for mast, https, s3 files in standalone app

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,12 @@ New Features
 
 - Table viewer UI to add/rename/remove columns. [#4282]
 
+- Fix issue where URLs could not be loaded into the standalone application. File location is now shown to the user [#4315]
+
+- Add caching mechanism for files downloaded from mast to standalone application.  Empty folders in cache are autodeleted when application closes, and files are deleted if they are more than 4 weeks old. [#4315]
+
+- Add menubar to standalone application. This includes Window (resizing/zooming application), Help (Documentation, Help desk), and Cache (manually empty jdaviz cache directory). [#4315]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/core/loaders/resolvers/url/url.py
+++ b/jdaviz/core/loaders/resolvers/url/url.py
@@ -28,9 +28,16 @@ class URLResolver(BaseResolver):
     local_path = Unicode("").tag(sync=True)
     timeout = FloatHandleEmpty(10).tag(sync=True)
     fsspec_filesystem = None
+    download_path_msg = Unicode("").tag(sync=True)
 
     def __init__(self, *args, **kwargs):
-        self.local_path = os.curdir
+
+        # set local path to the jdaviz_cache_dir for the standalone application
+        if 'JDAVIZ_CACHE_DIR' in os.environ:
+            self.local_path = os.environ['JDAVIZ_CACHE_DIR']
+        else:
+            self.local_path = os.curdir
+
         super().__init__(*args, **kwargs)
 
         self.fsspec_filesystem = kwargs.get('fsspec_filesystem', None)
@@ -126,14 +133,31 @@ class URLResolver(BaseResolver):
         url_file_extension = Path(self.url.strip()).suffix.lower()  # like '.fits'
         if self.url_scheme == 's3':
 
+            # do not show file path for s3 data since it does not download
+            if os.environ.get("JDAVIZ_START_DIR", ""):
+                self.download_path_msg = ''
+
             if url_file_extension in ['.fits', '.fit']:
                 return get_cloud_fits(self.url.strip(), fsspec_filesystem=self.fsspec_filesystem)
 
             elif url_file_extension == '.asdf':
                 return get_cloud_asdf(self.url.strip(), fsspec_filesystem=self.fsspec_filesystem)
 
-        return download_uri_to_path(self.url.strip(), cache=self.cache,
+        target_url = download_uri_to_path(self.url.strip(), cache=self.cache,
                                     local_path=self.local_path, timeout=self.timeout)
+
+        # only show file path when in standalone or browser and is downloaded from mast
+        if os.environ.get("JDAVIZ_START_DIR", ""):  
+
+            if self.url_scheme.lower() == 'mast':
+                self.download_path_msg = f"File at: {os.path.abspath(target_url)}"
+
+            else:
+                # since download_path_msg goes to a persistent hint in .vue file, 
+                # create empty message for non mast files
+                self.download_path_msg = ''
+
+        return target_url
 
     def parse_input(self):
         return self._uri_output_file

--- a/jdaviz/core/loaders/resolvers/url/url.py
+++ b/jdaviz/core/loaders/resolvers/url/url.py
@@ -3,6 +3,7 @@ from urllib.parse import urlparse
 import os
 from functools import cached_property
 from pathlib import Path
+import astropy
 
 from jdaviz.core.custom_traitlets import FloatHandleEmpty
 from jdaviz.core.registries import loader_resolver_registry
@@ -133,9 +134,7 @@ class URLResolver(BaseResolver):
         url_file_extension = Path(self.url.strip()).suffix.lower()  # like '.fits'
         if self.url_scheme == 's3':
 
-            # do not show file path for s3 data since it does not download
-            if os.environ.get("JDAVIZ_START_DIR", ""):
-                self.download_path_msg = ''
+            self.download_path_msg = 'Data is streaming from s3'
 
             if url_file_extension in ['.fits', '.fit']:
                 return get_cloud_fits(self.url.strip(), fsspec_filesystem=self.fsspec_filesystem)
@@ -146,17 +145,21 @@ class URLResolver(BaseResolver):
         target_url = download_uri_to_path(self.url.strip(), cache=self.cache,
                                     local_path=self.local_path, timeout=self.timeout)
 
-        # only show file path when in standalone or browser and is downloaded from mast
-        if os.environ.get("JDAVIZ_START_DIR", ""):  
+        # Set download persistent hint message
+        if self.url_scheme.lower() == 'mast':
+            self.download_path_msg = f"File stored at: {os.path.abspath(target_url)}"
 
-            if self.url_scheme.lower() == 'mast':
-                self.download_path_msg = f"File at: {os.path.abspath(target_url)}"
+        elif self.url_scheme.lower() in ('http', 'https', 'ftp'):
+            self.download_path_msg = f'File stored in astropy download cache at: {astropy.config.get_cache_dir()}'
 
-            else:
-                # since download_path_msg goes to a persistent hint in .vue file, 
-                # create empty message for non mast files
-                self.download_path_msg = ''
+        elif self.url_scheme.lower() == 's3':
+            self.download_path_msg = f'File stored in s3 download cache at: ({self.local_path}/s3_downloads)'
 
+        else:
+            # since download_path_msg goes to a persistent hint in .vue file, 
+            # create empty message for anything else
+            self.download_path_msg = ''
+        
         return target_url
 
     def parse_input(self):

--- a/jdaviz/core/loaders/resolvers/url/url.py
+++ b/jdaviz/core/loaders/resolvers/url/url.py
@@ -143,23 +143,25 @@ class URLResolver(BaseResolver):
                 return get_cloud_asdf(self.url.strip(), fsspec_filesystem=self.fsspec_filesystem)
 
         target_url = download_uri_to_path(self.url.strip(), cache=self.cache,
-                                    local_path=self.local_path, timeout=self.timeout)
+                                          local_path=self.local_path, timeout=self.timeout)
 
         # Set download persistent hint message
         if self.url_scheme.lower() == 'mast':
             self.download_path_msg = f"File stored at: {os.path.abspath(target_url)}"
 
         elif self.url_scheme.lower() in ('http', 'https', 'ftp'):
-            self.download_path_msg = f'File stored in astropy download cache at: {astropy.config.get_cache_dir()}'
+            self.download_path_msg = ('File stored in astropy download cache '
+                                      f'at: {astropy.config.get_cache_dir()}')
 
         elif self.url_scheme.lower() == 's3':
-            self.download_path_msg = f'File stored in s3 download cache at: ({self.local_path}/s3_downloads)'
+            self.download_path_msg = ('File stored in s3 download cache '
+                                      f'at: ({self.local_path}/s3_downloads)')
 
         else:
-            # since download_path_msg goes to a persistent hint in .vue file, 
+            # since download_path_msg goes to a persistent hint in .vue file,
             # create empty message for anything else
             self.download_path_msg = ''
-        
+
         return target_url
 
     def parse_input(self):

--- a/jdaviz/core/loaders/resolvers/url/url.vue
+++ b/jdaviz/core/loaders/resolvers/url/url.vue
@@ -35,6 +35,8 @@
           :label="api_hints_enabled ? 'ldr.url =' : ''"
           :class="api_hints_enabled ? 'api-hint' : null"
           :error-messages="parsed_input_not_resolvable_message ? [parsed_input_not_resolvable_message] : []"
+          :hint="download_path_msg"
+          persistent-hint
         ></v-text-field>
       </j-flex-row>
 

--- a/jdaviz/qt.py
+++ b/jdaviz/qt.py
@@ -109,21 +109,21 @@ def clear_cache(clear_all=False):
                 shutil.rmtree(cache_dir)
                 os.makedirs(cache_dir, exist_ok=True)
                 print("Cache cleared successfully.")
-
             else:
-                # remove all files that are > 4 weeks ago
-                for file in Path(cache_dir).rglob("*"):
-                    if file.is_file():
-                        file_modified_time = os.path.getmtime(file)
+                # go through all files and folders (inc. subfolders).
+                # files will be deleted first then folder checked to see if it is empty. 
+                for fil in list(Path(cache_dir).rglob("*"))[::-1]:
+                    # delete files > 4 weeks AND hidden files
+                    if fil.is_file():
+                        file_modified_time = os.path.getmtime(fil)
                         if file_modified_time < cutoff_time:
-                            os.remove(file)
-                print('Files in cache cleared sucessfully')
-
-                # remove all empty folders
-                for item in Path(cache_dir).iterdir():
-                    if item.is_dir() and not any(item.iterdir()):
-                        shutil.rmtree(item)
-                print("Folders in cache cleared successfully.")
+                            os.remove(fil)
+                        elif str(fil.name).startswith('.'):
+                            os.remove(fil)
+                    # delete empty folders (inc. subfolders)
+                    elif fil.is_dir() and not any(fil.iterdir()):
+                        shutil.rmtree(fil)
+                print("Files/folders cleared successfully.")
 
         except Exception as e:
             print(f"Failed to delete cache folders: {e}")
@@ -161,7 +161,7 @@ def run_qt(url, app_name="Jdaviz"):
             f"<h3>{app_name}</h3>"
             f"<p>Version: {version('jdaviz')}</p>"
             "<hr>"
-            "<p><small>© JDADF Developers</small></p>")
+            "<p><small>© 2026 JDADF Developers</small></p>")
         # Spawns a modal, native popup window
         QMessageBox.about(
             window_container,       
@@ -325,3 +325,4 @@ def run_qt(url, app_name="Jdaviz"):
     # without this, ctrl-c does not work in the terminal
     signal.signal(signal.SIGINT, signal.SIG_DFL)
     app.exec_()
+    

--- a/jdaviz/qt.py
+++ b/jdaviz/qt.py
@@ -3,11 +3,10 @@ import sys
 from typing import List
 import webbrowser
 try:
-    from qtpy.QtWidgets import QStyle, QApplication, QMainWindow,QMessageBox, QAction, QMenuBar,QVBoxLayout, QWidget, QTextEdit, QDialog
+    from qtpy.QtWidgets import QApplication, QMessageBox, QAction, QMenuBar, QVBoxLayout, QWidget
     from qtpy.QtWebEngineWidgets import QWebEngineView
     from qtpy.QtWebChannel import QWebChannel
     from qtpy import QtCore, QtGui
-    from qtpy.QtGui import QIcon
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError("""Qt browser requires Qt dependencies, run:
 $ pip install jdaviz[qt]
@@ -97,21 +96,22 @@ class QWebEngineViewWithPopup(QWebEngineView):
         QWebEngineViewWithPopup.windows.append(webview)
         return webview
 
+
 def clear_cache(clear_all=False):
-    cache_dir = os.environ['JDAVIZ_CACHE_DIR'] 
+    cache_dir = os.environ['JDAVIZ_CACHE_DIR']
     # Clear after 4 weeks
     seconds_in_two_weeks = 28 * 24 * 60 * 60
     cutoff_time = time.time() - seconds_in_two_weeks
     if os.path.exists(cache_dir):
         try:
             # clear all if button clicked
-            if clear_all: 
+            if clear_all:
                 shutil.rmtree(cache_dir)
                 os.makedirs(cache_dir, exist_ok=True)
                 print("Cache cleared successfully.")
             else:
                 # go through all files and folders (inc. subfolders).
-                # files will be deleted first then folder checked to see if it is empty. 
+                # files will be deleted first then folder checked to see if it is empty.
                 for fil in list(Path(cache_dir).rglob("*"))[::-1]:
                     # delete files > 4 weeks AND hidden files
                     if fil.is_file():
@@ -138,7 +138,7 @@ def run_qt(url, app_name="Jdaviz"):
     layout = QVBoxLayout(window_container)
     layout.setContentsMargins(0, 0, 0, 0)
     layout.setSpacing(0)
-    
+
     ############
     # Menu
     ############
@@ -156,6 +156,7 @@ def run_qt(url, app_name="Jdaviz"):
     about_action = QAction(f"&About {app_name}", window_container)
     about_action.setMenuRole(QAction.MenuRole.AboutRole)
     file_menu.addAction(about_action)
+
     def show_about_dialog():
         about_text = (
             f"<h3>{app_name}</h3>"
@@ -164,15 +165,14 @@ def run_qt(url, app_name="Jdaviz"):
             "<p><small>© 2026 JDADF Developers</small></p>")
         # Spawns a modal, native popup window
         QMessageBox.about(
-            window_container,       
-            f"About {app_name}",    
+            window_container,
+            f"About {app_name}",
             about_text)
     # Connect the button click to our popup trigger function
     about_action.triggered.connect(show_about_dialog)
-    
-    # Window menu dropdowns 
+
+    # Window menu dropdowns
     # ----------
-    style = window_container.style()
 
     # Minimize
     minimize_action = QAction("Minimize", window_container)
@@ -182,6 +182,7 @@ def run_qt(url, app_name="Jdaviz"):
 
     # Toggle zoom
     zoom_action = QAction("Zoom", window_container)
+
     def toggle_zoom():
         if window_container.isMaximized():
             window_container.showNormal()
@@ -193,6 +194,7 @@ def run_qt(url, app_name="Jdaviz"):
     # Fill Screen
     fill_action = QAction("Fill", window_container)
     fill_action.setShortcut("Ctrl+Meta+F")
+
     def fill_screen():
         # Grabs monitor dimensions excluding the global top menu bar and system dock
         screen_geometry = QApplication.primaryScreen().availableGeometry()
@@ -203,6 +205,7 @@ def run_qt(url, app_name="Jdaviz"):
     # Center Window
     center_action = QAction("Center", window_container)
     center_action.setShortcut("Ctrl+Meta+C")
+
     def center_window():
         screen_geometry = QApplication.primaryScreen().availableGeometry()
         window_geometry = window_container.frameGeometry()
@@ -216,6 +219,7 @@ def run_qt(url, app_name="Jdaviz"):
     # Full Screen
     fullscreen_action = QAction("Enter Full Screen", window_container)
     fullscreen_action.setShortcut("Ctrl+F")
+
     def toggle_fullscreen():
         if window_container.isFullScreen():
             window_container.showNormal()
@@ -227,31 +231,34 @@ def run_qt(url, app_name="Jdaviz"):
     window_menu.addSeparator()
 
     # Zoom in/out
-    current_zoom = [1.0] 
+    current_zoom = [1.0]
 
     # Zoom In Control
     zoom_in_action = QAction("Zoom In", window_container)
-    zoom_in_action.setShortcut("Ctrl++") # Maps to Cmd++ on macOS
+    zoom_in_action.setShortcut("Ctrl++")  # Maps to Cmd++ on macOS
+
     def zoom_in():
-        if current_zoom[0] < 3.0: # Enforce safe ceiling multiplier limit
+        if current_zoom[0] < 3.0:  # Enforce safe ceiling multiplier limit
             current_zoom[0] += 0.1
-            web.setZoomFactor(current_zoom[0])   
+            web.setZoomFactor(current_zoom[0])
     zoom_in_action.triggered.connect(zoom_in)
     window_menu.addAction(zoom_in_action)
 
     # Zoom Out Control
     zoom_out_action = QAction("Zoom Out", window_container)
-    zoom_out_action.setShortcut("Ctrl+-") # Maps to Cmd+- on macOS
+    zoom_out_action.setShortcut("Ctrl+-")  # Maps to Cmd+- on macOS
+
     def zoom_out():
-        if current_zoom[0] > 0.5: # Enforce safe basement floor multiplier limit
+        if current_zoom[0] > 0.5:  # Enforce safe basement floor multiplier limit
             current_zoom[0] -= 0.1
-            web.setZoomFactor(current_zoom[0])  
+            web.setZoomFactor(current_zoom[0])
     zoom_out_action.triggered.connect(zoom_out)
     window_menu.addAction(zoom_out_action)
 
     # Reset Zoom Target
     zoom_reset_action = QAction("Reset Zoom", window_container)
     zoom_reset_action.setShortcut("Ctrl+0")
+
     def zoom_reset():
         current_zoom[0] = 1.0
         web.setZoomFactor(1.0)
@@ -260,18 +267,22 @@ def run_qt(url, app_name="Jdaviz"):
 
     # Help Menu
     # ----------
-    
-    # ReadTheDocs 
+
+    # ReadTheDocs
     rtd_action = QAction("Jdaviz Documentation", window_container)
     rtd_action.triggered.connect(
-        lambda: QtGui.QDesktopServices.openUrl(QtCore.QUrl("https://jdaviz.readthedocs.io/en/latest/index.html"))
+        lambda: QtGui.QDesktopServices.openUrl(
+            QtCore.QUrl("https://jdaviz.readthedocs.io/en/latest/index.html")
+        )
     )
     help_menu.addAction(rtd_action)
 
     # Zenodo
     zenodo_action = QAction("Jdaviz Zenodo", window_container)
     zenodo_action.triggered.connect(
-        lambda: QtGui.QDesktopServices.openUrl(QtCore.QUrl("https://doi.org/10.5281/zenodo.5513927"))
+        lambda: QtGui.QDesktopServices.openUrl(
+            QtCore.QUrl("https://doi.org/10.5281/zenodo.5513927")
+        )
     )
     help_menu.addAction(zenodo_action)
 
@@ -286,16 +297,16 @@ def run_qt(url, app_name="Jdaviz"):
     # ----------
     clear_action = cache_menu.addAction("Empty Jdaviz Cache")
     clear_action.triggered.connect(lambda: clear_cache(True))
-    
+
     ############
     ############
 
     layout.addWidget(menu_bar)
     layout.addWidget(web)
-    
+
     window_container.resize(1024, 1024)
     window_container.show()
-    
+
     app.setApplicationDisplayName(app_name)
     app.setApplicationName(app_name)
     window_container.setWindowTitle(app_name)
@@ -318,7 +329,7 @@ def run_qt(url, app_name="Jdaviz"):
         # on macs, the .icns set in jdaviz.spec handles the window icon, while
         # qt.setWindowIcon handles it in windows/linux
         app.setWindowIcon(QtGui.QIcon(str(HERE / "data/icons/jdaviz_logo.png")))
-    
+
     # empty folders in cache on close
     app.aboutToQuit.connect(clear_cache)
 

--- a/jdaviz/qt.py
+++ b/jdaviz/qt.py
@@ -325,4 +325,3 @@ def run_qt(url, app_name="Jdaviz"):
     # without this, ctrl-c does not work in the terminal
     signal.signal(signal.SIGINT, signal.SIG_DFL)
     app.exec_()
-    

--- a/jdaviz/qt.py
+++ b/jdaviz/qt.py
@@ -3,17 +3,21 @@ import sys
 from typing import List
 import webbrowser
 try:
-    from qtpy.QtWidgets import QApplication
+    from qtpy.QtWidgets import QStyle, QApplication, QMainWindow,QMessageBox, QAction, QMenuBar,QVBoxLayout, QWidget, QTextEdit, QDialog
     from qtpy.QtWebEngineWidgets import QWebEngineView
     from qtpy.QtWebChannel import QWebChannel
     from qtpy import QtCore, QtGui
+    from qtpy.QtGui import QIcon
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError("""Qt browser requires Qt dependencies, run:
 $ pip install jdaviz[qt]
 to install.""") from e
 import signal
 from pathlib import Path
-
+from importlib.metadata import version
+import os
+import shutil
+import time
 HERE = Path(__file__).parent
 
 
@@ -93,17 +97,204 @@ class QWebEngineViewWithPopup(QWebEngineView):
         QWebEngineViewWithPopup.windows.append(webview)
         return webview
 
+def clear_cache(clear_all=False):
+    cache_dir = os.environ['JDAVIZ_CACHE_DIR'] 
+    # Clear after 4 weeks
+    seconds_in_two_weeks = 28 * 24 * 60 * 60
+    cutoff_time = time.time() - seconds_in_two_weeks
+    if os.path.exists(cache_dir):
+        try:
+            # clear all if button clicked
+            if clear_all: 
+                shutil.rmtree(cache_dir)
+                os.makedirs(cache_dir, exist_ok=True)
+                print("Cache cleared successfully.")
+            else:
+                for item in Path(cache_dir).iterdir():
+                    # clear folders
+                    if item.is_dir():
+                        shutil.rmtree(item)
+                        print("Folders in cache cleared successfully.")
+                    # clear files if modified time > 4 weeks old
+                    else:
+                        file_modified_time = os.path.getmtime(item)
+                        if file_modified_time < cutoff_time:
+                            os.remove(item)
+                            print('Files in cache cleared sucessfully')
+        except Exception as e:
+            print(f"Failed to delete cache folders: {e}")
+
 
 def run_qt(url, app_name="Jdaviz"):
     app = QApplication([])
+    window_container = QWidget()
     web = QWebEngineViewWithPopup()
     web.setUrl(QtCore.QUrl(url))
-    web.resize(1024, 1024)
-    web.show()
 
+    layout = QVBoxLayout(window_container)
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.setSpacing(0)
+    
+    ############
+    # Menu
+    ############
+
+    menu_bar = QMenuBar(window_container)
+
+    # Create Menu Bar menus
+    file_menu = menu_bar.addMenu("&File")
+    cache_menu = menu_bar.addMenu("&Cache")
+    window_menu = menu_bar.addMenu("&Window")
+    help_menu = menu_bar.addMenu("&Help")
+
+    # About menu
+    # ----------
+    about_action = QAction(f"&About {app_name}", window_container)
+    about_action.setMenuRole(QAction.MenuRole.AboutRole)
+    file_menu.addAction(about_action)
+    def show_about_dialog():
+        about_text = (
+            f"<h3>{app_name}</h3>"
+            f"<p>Version: {version('jdaviz')}</p>"
+            "<hr>"
+            "<p><small>© 2026 JDADF Developers</small></p>")
+        # Spawns a modal, native popup window
+        QMessageBox.about(
+            window_container,       
+            f"About {app_name}",    
+            about_text)
+    # Connect the button click to our popup trigger function
+    about_action.triggered.connect(show_about_dialog)
+    
+    # Window menu dropdowns 
+    # ----------
+    style = window_container.style()
+
+    # Minimize
+    minimize_action = QAction("Minimize", window_container)
+    minimize_action.setShortcut("Ctrl+M")
+    minimize_action.triggered.connect(window_container.showMinimized)
+    window_menu.addAction(minimize_action)
+
+    # Toggle zoom
+    zoom_action = QAction("Zoom", window_container)
+    def toggle_zoom():
+        if window_container.isMaximized():
+            window_container.showNormal()
+        else:
+            window_container.showMaximized()
+    zoom_action.triggered.connect(toggle_zoom)
+    window_menu.addAction(zoom_action)
+
+    # Fill Screen
+    fill_action = QAction("Fill", window_container)
+    fill_action.setShortcut("Ctrl+Meta+F")
+    def fill_screen():
+        # Grabs monitor dimensions excluding the global top menu bar and system dock
+        screen_geometry = QApplication.primaryScreen().availableGeometry()
+        window_container.setGeometry(screen_geometry)
+    fill_action.triggered.connect(fill_screen)
+    window_menu.addAction(fill_action)
+
+    # Center Window
+    center_action = QAction("Center", window_container)
+    center_action.setShortcut("Ctrl+Meta+C")
+    def center_window():
+        screen_geometry = QApplication.primaryScreen().availableGeometry()
+        window_geometry = window_container.frameGeometry()
+        # Find center coordinates matching the target frame size
+        center_point = screen_geometry.center()
+        window_geometry.moveCenter(center_point)
+        window_container.move(window_geometry.topLeft())
+    center_action.triggered.connect(center_window)
+    window_menu.addAction(center_action)
+
+    # Full Screen
+    fullscreen_action = QAction("Enter Full Screen", window_container)
+    fullscreen_action.setShortcut("Ctrl+F")
+    def toggle_fullscreen():
+        if window_container.isFullScreen():
+            window_container.showNormal()
+        else:
+            window_container.showFullScreen()
+    fullscreen_action.triggered.connect(toggle_fullscreen)
+    window_menu.addAction(fullscreen_action)
+
+    window_menu.addSeparator()
+
+    # Zoom in/out
+    current_zoom = [1.0] 
+
+    # Zoom In Control
+    zoom_in_action = QAction("Zoom In", window_container)
+    zoom_in_action.setShortcut("Ctrl++") # Maps to Cmd++ on macOS
+    def zoom_in():
+        if current_zoom[0] < 3.0: # Enforce safe ceiling multiplier limit
+            current_zoom[0] += 0.1
+            web.setZoomFactor(current_zoom[0])   
+    zoom_in_action.triggered.connect(zoom_in)
+    window_menu.addAction(zoom_in_action)
+
+    # Zoom Out Control
+    zoom_out_action = QAction("Zoom Out", window_container)
+    zoom_out_action.setShortcut("Ctrl+-") # Maps to Cmd+- on macOS
+    def zoom_out():
+        if current_zoom[0] > 0.5: # Enforce safe basement floor multiplier limit
+            current_zoom[0] -= 0.1
+            web.setZoomFactor(current_zoom[0])  
+    zoom_out_action.triggered.connect(zoom_out)
+    window_menu.addAction(zoom_out_action)
+
+    # Reset Zoom Target
+    zoom_reset_action = QAction("Reset Zoom", window_container)
+    zoom_reset_action.setShortcut("Ctrl+0")
+    def zoom_reset():
+        current_zoom[0] = 1.0
+        web.setZoomFactor(1.0)
+    zoom_reset_action.triggered.connect(zoom_reset)
+    window_menu.addAction(zoom_reset_action)
+
+    # Help Menu
+    # ----------
+    
+    # ReadTheDocs 
+    rtd_action = QAction("Jdaviz Documentation", window_container)
+    rtd_action.triggered.connect(
+        lambda: QtGui.QDesktopServices.openUrl(QtCore.QUrl("https://jdaviz.readthedocs.io/en/latest/index.html"))
+    )
+    help_menu.addAction(rtd_action)
+
+    # Zenodo
+    zenodo_action = QAction("Jdaviz Zenodo", window_container)
+    zenodo_action.triggered.connect(
+        lambda: QtGui.QDesktopServices.openUrl(QtCore.QUrl("https://doi.org/10.5281/zenodo.5513927"))
+    )
+    help_menu.addAction(zenodo_action)
+
+    # JWST Help Desk
+    jwst_action = QAction("JWST Help Desk", window_container)
+    jwst_action.triggered.connect(
+        lambda: QtGui.QDesktopServices.openUrl(QtCore.QUrl("https://stsci.service-now.com/jwst"))
+    )
+    help_menu.addAction(jwst_action)
+
+    # Cache Menu
+    # ----------
+    clear_action = cache_menu.addAction("Empty Jdaviz Cache")
+    clear_action.triggered.connect(lambda: clear_cache(True))
+    
+    ############
+    ############
+
+    layout.addWidget(menu_bar)
+    layout.addWidget(web)
+    
+    window_container.resize(1024, 1024)
+    window_container.show()
+    
     app.setApplicationDisplayName(app_name)
     app.setApplicationName(app_name)
-    web.setWindowTitle(app_name)
+    window_container.setWindowTitle(app_name)
     if sys.platform.startswith("darwin"):
         # Set app name, if PyObjC is installed
         # Python 2 has PyObjC preinstalled
@@ -123,6 +314,9 @@ def run_qt(url, app_name="Jdaviz"):
         # on macs, the .icns set in jdaviz.spec handles the window icon, while
         # qt.setWindowIcon handles it in windows/linux
         app.setWindowIcon(QtGui.QIcon(str(HERE / "data/icons/jdaviz_logo.png")))
+    
+    # empty folders in cache on close
+    app.aboutToQuit.connect(clear_cache)
 
     # without this, ctrl-c does not work in the terminal
     signal.signal(signal.SIGINT, signal.SIG_DFL)

--- a/jdaviz/qt.py
+++ b/jdaviz/qt.py
@@ -109,18 +109,22 @@ def clear_cache(clear_all=False):
                 shutil.rmtree(cache_dir)
                 os.makedirs(cache_dir, exist_ok=True)
                 print("Cache cleared successfully.")
+
             else:
-                for item in Path(cache_dir).iterdir():
-                    # clear folders
-                    if item.is_dir():
-                        shutil.rmtree(item)
-                        print("Folders in cache cleared successfully.")
-                    # clear files if modified time > 4 weeks old
-                    else:
-                        file_modified_time = os.path.getmtime(item)
+                # remove all files that are > 4 weeks ago
+                for file in Path(cache_dir).rglob("*"):
+                    if file.is_file():
+                        file_modified_time = os.path.getmtime(file)
                         if file_modified_time < cutoff_time:
-                            os.remove(item)
-                            print('Files in cache cleared sucessfully')
+                            os.remove(file)
+                print('Files in cache cleared sucessfully')
+
+                # remove all empty folders
+                for item in Path(cache_dir).iterdir():
+                    if item.is_dir() and not any(item.iterdir()):
+                        shutil.rmtree(item)
+                print("Folders in cache cleared successfully.")
+
         except Exception as e:
             print(f"Failed to delete cache folders: {e}")
 
@@ -157,7 +161,7 @@ def run_qt(url, app_name="Jdaviz"):
             f"<h3>{app_name}</h3>"
             f"<p>Version: {version('jdaviz')}</p>"
             "<hr>"
-            "<p><small>© 2026 JDADF Developers</small></p>")
+            "<p><small>© JDADF Developers</small></p>")
         # Spawns a modal, native popup window
         QMessageBox.about(
             window_container,       

--- a/standalone/hooks/hook-fsspec.py
+++ b/standalone/hooks/hook-fsspec.py
@@ -1,0 +1,6 @@
+from PyInstaller.utils.hooks import collect_submodules, collect_data_files, collect_all, copy_metadata
+
+hiddenimports = collect_submodules('s3fs') + collect_submodules('fsspec')
+# for CITATION.rst
+datas = collect_data_files('s3fs')
+datas += copy_metadata('s3fs')

--- a/standalone/jdaviz-cli-entrypoint.py
+++ b/standalone/jdaviz-cli-entrypoint.py
@@ -26,19 +26,17 @@ if __name__ == "__main__":
 
         # Define a safe user-writable path (e.g., user's home folder)
         user_home = Path.home() 
-        user_downloads = user_home / "Downloads"
 
-        # if the Downloads directory is found, set the JDAVIZ_CACHE_DIR to put mast downloaded data in Downloads
-        if user_downloads.is_dir():
-            os.environ['JDAVIZ_CACHE_DIR'] = str(user_downloads)
+        # create jdaviz_cache directory to save downloaded files
+        jdaviz_cache = user_home / ".cache" / "jdaviz"
+        jdaviz_cache.mkdir(exist_ok=True)
+        os.environ['JDAVIZ_CACHE_DIR'] = str(jdaviz_cache)
 
-        # if Downloads is not easily discoverable, create a directory in the home directory to save the data. 
-        else:
-            writable_cache_dir = user_home / "jdaviz_downloads"
-            writable_cache_dir.mkdir(exist_ok=True)
-            os.environ['JDAVIZ_CACHE_DIR'] = str(writable_cache_dir)
-
-        os.environ['ASTROPY_CACHE_DIR'] = str(user_home / ".cache" / "astropy")
+        # create astropy_cache directory to save downloaded files 
+        # (backup in case it had been deleted or astropy not installed)
+        astropy_cache = user_home / ".cache" / "astropy"
+        astropy_cache.mkdir(exist_ok=True)
+        os.environ['ASTROPY_CACHE_DIR'] = str(astropy_cache)
 
         # Change Python's working directory to a writable directory
         # This prevents Jdaviz from defaulting download_uri_to_path to the read-only _MEIPASS path

--- a/standalone/jdaviz-cli-entrypoint.py
+++ b/standalone/jdaviz-cli-entrypoint.py
@@ -15,11 +15,34 @@ matplotlib.use("module://matplotlib_inline.backend_inline")
 # it seems that matplotlib_inline.backend_inline is an alias for inline
 # so we make sure to communicate that to PyInstaller
 matplotlib.use("inline")
-
+from pathlib import Path
+import os
 import jdaviz.cli
 
 
 if __name__ == "__main__":
+
+    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+
+        # Define a safe user-writable path (e.g., user's home folder)
+        user_home = Path.home() 
+        user_downloads = user_home / "Downloads"
+
+        # if the Downloads directory is found, set the JDAVIZ_CACHE_DIR to put mast downloaded data in Downloads
+        if user_downloads.is_dir():
+            os.environ['JDAVIZ_CACHE_DIR'] = str(user_downloads)
+
+        # if Downloads is not easily discoverable, create a directory in the home directory to save the data. 
+        else:
+            writable_cache_dir = user_home / "jdaviz_downloads"
+            writable_cache_dir.mkdir(exist_ok=True)
+            os.environ['JDAVIZ_CACHE_DIR'] = str(writable_cache_dir)
+
+        # Change Python's working directory to a writable directory
+        # This prevents Jdaviz from defaulting download_uri_to_path to the read-only _MEIPASS path
+        os.chdir(user_home)
+
+
     # should change this to _main, but now it doesn't need arguments
     args = sys.argv.copy()
     # change the browser to qt if not specified

--- a/standalone/jdaviz-cli-entrypoint.py
+++ b/standalone/jdaviz-cli-entrypoint.py
@@ -38,6 +38,8 @@ if __name__ == "__main__":
             writable_cache_dir.mkdir(exist_ok=True)
             os.environ['JDAVIZ_CACHE_DIR'] = str(writable_cache_dir)
 
+        os.environ['ASTROPY_CACHE_DIR'] = str(user_home / ".cache" / "astropy")
+
         # Change Python's working directory to a writable directory
         # This prevents Jdaviz from defaulting download_uri_to_path to the read-only _MEIPASS path
         os.chdir(user_home)

--- a/standalone/jdaviz.spec
+++ b/standalone/jdaviz.spec
@@ -76,7 +76,7 @@ coll = COLLECT(
 app = BUNDLE(
     exe,
     coll,
-    name="jdaviz.app",
+    name="Jdaviz.app",
     icon=icon_file if sys.platform.startswith('darwin') else None,
     entitlements_file="entitlements.plist",
     bundle_identifier="edu.stsci.jdaviz",


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address the URL loader not working in the standalone application. This fix allows URLs to download and sets the users file directory to $HOME in the standalone application.

Additionally, it downloads MAST files to the $HOME/Downloads folder (or $HOME/jdaviz_downloads if the user does not have a $HOME/Downloads folder), and states the file path under the URL in the UI (file path for mast, Astropy cache for https, and informs the user it is streaming for s3 files)

It sets a astropy_cache_dir in case the user does not have astropy installed. 

Finally, it add the fsspec+s3fs hook in order to successfully download s3 files.  

tested with:
- mast:jwst/product/jw01538-o161_t002-s000000001_nirspec_f290lp-g395h-s1600a1_s2d.fits
- s3://stpubdata/jwst/public/jw01783/jw01783004007/jw01783004007_02101_00004_nrcalong_rate.fits
- https://cdsarc.cds.unistra.fr/ftp/J/A+A/562/A127/sp/2M0141_SINFONIspeclib_JHK.fits
- https://cdsarc.cds.unistra.fr/ftp/J/ApJ/874/53/table2.dat
- https://www.astropy.org/astropy-data/tutorials/FITS-images/HorseHead.fits

<img width="303" height="175" alt="Screenshot 2026-07-30 at 12 28 41 PM" src="https://github.com/user-attachments/assets/3f054424-0549-4b18-88c8-6a00bafd65cf" />
<img width="308" height="188" alt="Screenshot 2026-07-30 at 12 28 51 PM" src="https://github.com/user-attachments/assets/c650037a-8fbb-45a9-b1dc-eafd07de11f1" />
<img width="302" height="202" alt="Screenshot 2026-07-30 at 12 29 01 PM" src="https://github.com/user-attachments/assets/65e7f485-7ead-4009-95b1-a6a7911f05b0" />


To create the standalone application locally,
1. Jdaviz with QT must be installed locally on your machine (in whatever conda environment you want to create the application in. If you want to use your local git repo version of jdaviz, you cannot use the -e extension when pip installing.  Something in it fails when it uses the aliasing to get the package. Instead, you must install it with pip install .
2. Pyinstaller must be installed: pip install pyinstaller
3. Go into the jdaviz/standalone folder in your local copy in a terminal in the same conda environment you pip installed jdaviz and type: pyinstaller --clean jdaviz.spec
4. When it finishes, you will have 2 new folders in the jdaviz/standalone folder: build and dist 
5. Go into the dist folder and double click on the jdaviz.app to open it! 

if it fails, open the jdaviz-cli executable in the dist folder to determine what failed. 


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->



### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
