### PR TITLE
Load markers plugin table to app when image has no flux units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -119,6 +119,8 @@ Bug Fixes
 
 - Fix issue where snackbar is attached to the notebook rather than to the app. [#4313]
 
+- Allow markers plugin table to handle images with no flux units specified in the header. [#4320]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -560,7 +560,6 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
 
             except ValueError as err:  # pragma: no cover
                 raise ValueError(f'failed to add {row_info} to table: {repr(err)}')
-
             x, y = row_info['axes_x'], row_info['axes_y']
             self._get_mark(viewer).append_xy(getattr(x, 'value', x), getattr(y, 'value', y))
 

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -549,11 +549,18 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
                                    k.startswith('pixel_') else v
                                    for k, v in row_info.items()
                                    if k in self.table.headers_avail}
+
+                # explicitly set value:unit to None (not '') if flux has no units
+                # (this happens for Roman asdf image files)
+                if not row_item_to_add.get('value:unit'):
+                    row_item_to_add['value:unit'] = None
+
                 self.table.add_item(row_item_to_add)
                 self.hub.broadcast(MarkersPluginUpdate(table_length=len(self.table), sender=self))
 
             except ValueError as err:  # pragma: no cover
                 raise ValueError(f'failed to add {row_info} to table: {repr(err)}')
+
             x, y = row_info['axes_x'], row_info['axes_y']
             self._get_mark(viewer).append_xy(getattr(x, 'value', x), getattr(y, 'value', y))
 


### PR DESCRIPTION
This PR addresses an issue specific to Roman asdf image files which don't have a 'BUNIT' or similar header keyword indicating flux units. When you clicked on 'load table into app'  after creating markers in the markers plugin, you would get a traceback that the QTable has no unit attribute, and your marker table couldn't be added to the data collection or to the Image viewer. This explicitly creates a QTable column with `value:unit=None` for situations where `value:unit` isn't available in `self.table.headers_avail` so that the markers table can be added to the data collection as well as to the current or a new viewer.

Fixes #JDAT-6170

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
