### PR TITLE
Fix how list items display in UX

### DIFF
--- a/jdaviz/main_styles.vue
+++ b/jdaviz/main_styles.vue
@@ -362,4 +362,21 @@ span.api-hint-header {
   color: #C6F0FD !important;
 }
 
+.v-list-item-content {
+  display: inline !important;
+  flex: none !important;
+  white-space: nowrap !important;
+}
+
+/* Restore the Vuetify 2-like flex alignment so that icons and text stay vertically centered. */
+.v-list-item__content {
+  display: flex !important;
+  align-items: center !important;
+}
+
+/* Adjust the separation between 'Select/Clear All' icons and text. */
+.v-list-item-action {
+  margin-right: 8px;
+}
+
 </style>


### PR DESCRIPTION
* Text is now inline again
* Icons and text are properly vertically aligned
* Separation has been added between select/clear all icon and text

Before --

<img width="309" height="290" alt="Screenshot 2026-08-06 at 10 45 44 AM" src="https://github.com/user-attachments/assets/b3ce5a47-63aa-4f54-aa60-a200504fdaab" />

After --

<img width="309" height="267" alt="Screenshot 2026-08-06 at 10 45 09 AM" src="https://github.com/user-attachments/assets/4d99fd9b-17b8-4ecc-919d-b032af281f8a" />
