### PR TITLE
allow viewer.create_new to accept different viewer types and add test…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,8 @@ New Features
 
 - Add ability to view data in multiple viewers with row click in table viewer. [#4279]
 
+- Allow markers plugin table to create other viewer types besides Scatter (i.e. Table or Histogram). [#4331]
+
 - Add ability to specify coordinate frame and equinox in catalog loader. [#4207]
 
 - Table viewer UI to add/rename/remove columns. [#4282]
@@ -81,7 +83,7 @@ New Features
 
 - Child data now follows its parent into the same viewer(s). Viewer selection for child data
   is therefore hidden in the UI when parenting is set. [#4326]
-  
+
 - Keep visibility consistent between blink and plot options. [#4316]
 
 Mosviz

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -227,6 +227,8 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
     def _create_viewer_callbacks(self, viewer):
         if not self.is_active:
             return
+        if not hasattr(viewer, 'add_event_callback'):
+            return
         callback = self._viewer_callback(viewer, self._on_viewer_key_event)
         viewer.add_event_callback(callback, events=['keydown'])
 
@@ -234,6 +236,8 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
         self._create_viewer_callbacks(self._app.get_viewer_by_id(msg.viewer_id))
 
     def _recompute_mark_positions(self, viewer):
+        if not hasattr(viewer, 'figure'):
+            return
         if self.table is None or self.table._qtable is None:
             return
         if 'world_ra' not in self.table.headers_avail:
@@ -475,6 +479,9 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
         return snapped_coords
 
     def _get_mark(self, viewer):
+        if not hasattr(viewer, 'figure'):
+            # this will be the case for a Table viewer with no marks
+            return None
         matches = [mark for mark in viewer.figure.marks if isinstance(mark, MarkersMark)]
         if len(matches):
             return matches[0]

--- a/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
+++ b/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
@@ -805,5 +805,5 @@ def test_markers_mouseover_and_load_into_new_viewer(deconfigged_helper, image_hd
     # verify that the new viewer has the expected data from the markers table
     new_viewer = deconfigged_helper.viewers[viewer_type]
     assert new_viewer is not None
-    assert len(new_viewer._obj.glue_viewer.data_labels_visible) == 1
-    assert new_viewer._obj.glue_viewer.data_labels_visible[0] == 'Catalog'
+    assert len(new_viewer.data_menu.data_labels_visible) == 1
+    assert new_viewer.data_menu.data_labels_visible[0] == 'Catalog'

--- a/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
+++ b/jdaviz/configs/default/plugins/markers/tests/test_markers_plugin.py
@@ -748,3 +748,62 @@ def test_markers_load_table_into_data_collection(deconfigged_helper, spectrum1d)
     assert loaded_table['spectral_axis'][0] == 4623
     assert loaded_table['spectral_axis'][1] == 5000
     assert loaded_table['spectral_axis'][2] == 6000
+
+
+@pytest.mark.parametrize('viewer_type', ['Scatter', 'Table', 'Histogram'])
+def test_markers_mouseover_and_load_into_new_viewer(deconfigged_helper, image_hdu_wcs, viewer_type):
+    """
+    Test creating markers in the UI, loading table into app, then
+    create new viewers from the plugin table: scatter, table, histogram
+    """
+    # Load initial data into deconfigged helper
+    deconfigged_helper.load(image_hdu_wcs, format='Image')
+
+    # Create a 1D viewer
+    viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
+
+    # Get the markers plugin
+    mp = deconfigged_helper.plugins['Markers']
+    mp.keep_active = True
+
+    # Get coords_info tool for mouseover events
+    label_mouseover = deconfigged_helper._coords_info
+
+    # Add first marker via mouseover + key event (mimics UI 'm' press)
+    label_mouseover._viewer_mouse_event(viewer,
+                                        {'event': 'mousemove',
+                                         'domain': {'x': 4623, 'y': 50}})
+    mp._obj._on_viewer_key_event(viewer, {'event': 'keydown', 'key': 'm'})
+
+    # Add second marker
+    label_mouseover._viewer_mouse_event(viewer,
+                                        {'event': 'mousemove',
+                                         'domain': {'x': 5000, 'y': 60}})
+    mp._obj._on_viewer_key_event(viewer, {'event': 'keydown', 'key': 'm'})
+
+    # Add third marker
+    label_mouseover._viewer_mouse_event(viewer,
+                                        {'event': 'mousemove',
+                                         'domain': {'x': 6000, 'y': 70}})
+    mp._obj._on_viewer_key_event(viewer, {'event': 'keydown', 'key': 'm'})
+
+    # export table to markers plugin
+    qtbl = mp.export_table()
+    assert qtbl is not None
+    assert len(qtbl) == 3
+    mp._obj.table.loader_panel_ind = 0
+
+    # verify new viewers can be generated with marker table
+    ldr = mp._obj.table.loaders['object']
+    assert ldr.object is not None
+    ldr.format.selected = 'Catalog'
+    assert viewer_type in ldr.importer.viewer.create_new.choices
+    ldr.importer.viewer.create_new = viewer_type
+    ldr.importer.viewer = viewer_type
+    ldr.load()
+
+    # verify that the new viewer has the expected data from the markers table
+    new_viewer = deconfigged_helper.viewers[viewer_type]
+    assert new_viewer is not None
+    assert len(new_viewer._obj.glue_viewer.data_labels_visible) == 1
+    assert new_viewer._obj.glue_viewer.data_labels_visible[0] == 'Catalog'

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -224,8 +224,16 @@ class UserApiWrapper:
                 exp_obj.selected = value
                 return
             elif len(exp_obj.create_new.choices) > 0:
-                exp_obj.create_new.selected = exp_obj.create_new.choices[0]
-                exp_obj.new_label.value = value
+                if value in exp_obj.create_new.choices:
+                    # value matches a viewer type label (e.g. 'Table', 'Scatter') -
+                    # select that type and the label will also default to that type
+                    exp_obj.create_new.selected = value
+                else:
+                    # if value is not a valid viewer type,
+                    # assume value is intended as a new viewer label -
+                    # default to the first available viewer type
+                    exp_obj.create_new.selected = exp_obj.create_new.choices[0]
+                    exp_obj.new_label.value = value
                 return
 
         if isinstance(exp_obj, SelectPluginComponent):

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -228,9 +228,17 @@ class UserApiWrapper:
                     # value matches a viewer type label (e.g. 'Table', 'Scatter') -
                     # select that type and the label will also default to that type
                     exp_obj.create_new.selected = value
+                elif (isinstance(value, str)
+                      and ':' in value
+                      and value.split(':')[0] in exp_obj.create_new.choices):
+                    # value is of the form "viewer_type:label" - select that type and set the label
+                    viewer_type, label = value.split(':', 1)
+                    exp_obj.create_new.selected = viewer_type
+                    exp_obj.new_label.value = label
                 else:
-                    raise ValueError(f"{value} is not a valid viewer type."
-                                     f"  Valid labels are: {exp_obj.create_new.choices}")
+                    # assume value is meant to be a label and default to first available choice
+                    exp_obj.create_new.selected = exp_obj.create_new.choices[0]
+                    exp_obj.new_label.value = value
                 return
 
         if isinstance(exp_obj, SelectPluginComponent):

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -229,11 +229,8 @@ class UserApiWrapper:
                     # select that type and the label will also default to that type
                     exp_obj.create_new.selected = value
                 else:
-                    # if value is not a valid viewer type,
-                    # assume value is intended as a new viewer label -
-                    # default to the first available viewer type
-                    exp_obj.create_new.selected = exp_obj.create_new.choices[0]
-                    exp_obj.new_label.value = value
+                    raise ValueError(f"{value} is not a valid viewer type."
+                                     f"  Valid labels are: {exp_obj.create_new.choices}")
                 return
 
         if isinstance(exp_obj, SelectPluginComponent):

--- a/jdaviz/tests/test_user_api.py
+++ b/jdaviz/tests/test_user_api.py
@@ -148,6 +148,38 @@ def test_wildcard_match_extension(imviz_helper, multi_extension_image_hdu_wcs):
     assert selection_obj.multiselect is True
 
 
+def test_viewer_create_new_type_selection(deconfigged_helper, sky_coord_only_source_catalog):
+    """
+    Setting ldr.importer.viewer = type_label (where type_label is one of the create_new
+    choices, e.g. 'Table', 'Scatter') should select that viewer type,
+    not treat the string as a new viewer label that then defaults to a scatter viewer.
+    """
+    
+    ldr = deconfigged_helper.loaders['object']
+    ldr.object = sky_coord_only_source_catalog
+    ldr.format = 'Catalog'
+
+    importer_viewer = ldr.importer._obj.viewer
+
+    assert 'Scatter' in importer_viewer.create_new.choices
+    assert 'Table' in importer_viewer.create_new.choices
+
+    # setting via the user-api wrapper to 'Table' should select the Table type,
+    # not label a scatter viewer labeled 'Table'
+    ldr.importer.viewer = 'Table'
+    assert importer_viewer.create_new.selected == 'Table'
+
+    # setting to 'Scatter' should switch the type back
+    ldr.importer.viewer = 'Scatter'
+    assert importer_viewer.create_new.selected == 'Scatter'
+
+    # setting to a string that is NOT a type label should be treated as a new viewer label
+    # and should default the type to the first available choice ('Scatter')
+    ldr.importer.viewer = 'my-custom-viewer'
+    assert importer_viewer.create_new.selected == importer_viewer.create_new.choices[0]
+    assert importer_viewer.new_label.value == 'my-custom-viewer'
+
+
 def test_viewer_create_new(deconfigged_helper, spectrum1d):
     assert len(deconfigged_helper.new_viewers.keys()) == 0
     # passing [] should not load into a new viewer nor should it create a new viewer

--- a/jdaviz/tests/test_user_api.py
+++ b/jdaviz/tests/test_user_api.py
@@ -154,7 +154,7 @@ def test_viewer_create_new_type_selection(deconfigged_helper, sky_coord_only_sou
     choices, e.g. 'Table', 'Scatter') should select that viewer type,
     not treat the string as a new viewer label that then defaults to a scatter viewer.
     """
-    
+
     ldr = deconfigged_helper.loaders['object']
     ldr.object = sky_coord_only_source_catalog
     ldr.format = 'Catalog'

--- a/jdaviz/tests/test_user_api.py
+++ b/jdaviz/tests/test_user_api.py
@@ -173,9 +173,16 @@ def test_viewer_create_new_type_selection(deconfigged_helper, sky_coord_only_sou
     ldr.importer.viewer = 'Scatter'
     assert importer_viewer.create_new.selected == 'Scatter'
 
-    # setting to a string that is NOT a type label should raise an error
-    with pytest.raises(ValueError):
-        ldr.importer.viewer = 'my-custom-viewer'
+    # setting to a string that is NOT a type label should default to
+    # the first type in the create_new.choices list (which is 'Scatter' in this case)
+    ldr.importer.viewer = 'my-custom-viewer'
+    assert importer_viewer.create_new.selected == importer_viewer.create_new.choices[0]
+    assert importer_viewer.new_label == 'my-custom-viewer'
+
+    # setting to a string of the format Type:label should select the type and set the label
+    ldr.importer.viewer = 'Table:my-custom-table'
+    assert importer_viewer.create_new.selected == 'Table'
+    assert importer_viewer.new_label == 'my-custom-table'
 
 
 def test_viewer_create_new(deconfigged_helper, spectrum1d):
@@ -198,14 +205,8 @@ def test_viewer_create_new(deconfigged_helper, spectrum1d):
     assert len(deconfigged_helper.viewers) == 1
     assert len(deconfigged_helper.viewers['1D Spectrum'].data_menu.layer.choices) == 2
 
-    # passing a string of a viewer that does not exist in create_new.choices should raise an error
-    with pytest.raises(ValueError):
-        deconfigged_helper.load(spectrum1d, format='1D Spectrum',
-                                viewer='user-defined-viewer', data_label='data4')
-    # instead have to spawn a new viewer first, then load into it
-    nv = deconfigged_helper.new_viewers['1D Spectrum']
-    nv.viewer_label = 'user-defined-viewer'
-    nv()
+    # passing a string of a viewer that does not exist in create_new.choices
+    # should default to the first viewer type in create_new.choices
     deconfigged_helper.load(spectrum1d, format='1D Spectrum',
                             viewer='user-defined-viewer', data_label='data4')
     assert len(deconfigged_helper._app.data_collection) == 4

--- a/jdaviz/tests/test_user_api.py
+++ b/jdaviz/tests/test_user_api.py
@@ -173,12 +173,9 @@ def test_viewer_create_new_type_selection(deconfigged_helper, sky_coord_only_sou
     ldr.importer.viewer = 'Scatter'
     assert importer_viewer.create_new.selected == 'Scatter'
 
-    # setting to a string that is NOT a type label should be treated as a new viewer label
-    # and should default the type to the first available choice ('Scatter')
-    ldr.importer.viewer = 'my-custom-viewer'
-    assert importer_viewer.create_new.selected == importer_viewer.create_new.choices[0]
-    assert importer_viewer.new_label.value == 'my-custom-viewer'
-
+    # setting to a string that is NOT a type label should raise an error
+    with pytest.raises(ValueError):
+        ldr.importer.viewer = 'my-custom-viewer'
 
 def test_viewer_create_new(deconfigged_helper, spectrum1d):
     assert len(deconfigged_helper.new_viewers.keys()) == 0
@@ -200,8 +197,16 @@ def test_viewer_create_new(deconfigged_helper, spectrum1d):
     assert len(deconfigged_helper.viewers) == 1
     assert len(deconfigged_helper.viewers['1D Spectrum'].data_menu.layer.choices) == 2
 
-    # passing a string of a viewer that does not exist should create a viewer with that label
-    deconfigged_helper.load(spectrum1d, format='1D Spectrum', viewer='user-defined-viewer', data_label='data4')  # noqa
+    # passing a string of a viewer that does not exist in create_new.choices should raise an error
+    with pytest.raises(ValueError):
+        deconfigged_helper.load(spectrum1d, format='1D Spectrum',
+                                viewer='user-defined-viewer', data_label='data4')
+    # instead have to spawn a new viewer first, then load into it
+    nv = deconfigged_helper.new_viewers['1D Spectrum']
+    nv.viewer_label = 'user-defined-viewer'
+    nv()
+    deconfigged_helper.load(spectrum1d, format='1D Spectrum',
+                            viewer='user-defined-viewer', data_label='data4')
     assert len(deconfigged_helper._app.data_collection) == 4
     assert len(deconfigged_helper.viewers) == 2
     assert len(deconfigged_helper.viewers['1D Spectrum'].data_menu.layer.choices) == 2

--- a/jdaviz/tests/test_user_api.py
+++ b/jdaviz/tests/test_user_api.py
@@ -177,6 +177,7 @@ def test_viewer_create_new_type_selection(deconfigged_helper, sky_coord_only_sou
     with pytest.raises(ValueError):
         ldr.importer.viewer = 'my-custom-viewer'
 
+
 def test_viewer_create_new(deconfigged_helper, spectrum1d):
     assert len(deconfigged_helper.new_viewers.keys()) == 0
     # passing [] should not load into a new viewer nor should it create a new viewer

--- a/jdaviz/tests/test_user_api.py
+++ b/jdaviz/tests/test_user_api.py
@@ -174,7 +174,7 @@ def test_viewer_create_new_type_selection(deconfigged_helper, sky_coord_only_sou
     assert importer_viewer.create_new.selected == 'Scatter'
 
     # setting to a string that is NOT a type label should default to
-    # the first type in the create_new.choices list (which is 'Scatter' in this case)
+    # the first type in the create_new.choices list
     ldr.importer.viewer = 'my-custom-viewer'
     assert importer_viewer.create_new.selected == importer_viewer.create_new.choices[0]
     assert importer_viewer.new_label == 'my-custom-viewer'


### PR DESCRIPTION
This PR addresses an issue where creating a new viewer for a table loaded into the markers plugin always produced a scatter plot, e.g.:

`plg = jd.plugins['Markers']`
`ldr = plg.table.loaders['object']`
`ldr.format = 'Catalog'`
`ldr.importer.viewer.create_new = 'Table'`
`ldr.importer.viewer = 'Table'`
`ldr.load()`

would still produce a scatter plot even though we set `create_new` to Table. This was because `create_new` in the user API always defaults to the first available viewer type, which is usually a scatter viewer. I changed this so that `create_new` will first check if it was passed a viewer type (e.g. Table, Scatter, Histogram), and if it's some random other string, assume the user meant it as a viewer label and default to scatter. Also added a test for this.

**EDIT**: I also added a new argument type which is Type:label, e.g. 'Table:mytable' would produce a Table viewer labelled mytable. This makes it so that spawning a new viewer via jd.load with a custom label won't break the above fix.

Fixes #JDAT-6321

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
