### PR TITLE
Fix remove image when catalog present from Image viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -139,6 +139,9 @@ Bug Fixes
 
 - Allow markers plugin table to handle images with no flux units specified in the header. [#4320]
 
+- Fix issue where removing an image from an Image viewer while a catalog (scatter) was present
+  caused an index error from glue. [#4333]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -806,11 +806,6 @@ class PrivateApplication(VuetifyTemplate, HubListener):
 
         new_refdata = self.data_collection[new_refdata_label]
 
-        if new_refdata.ndim < 2:
-            # an image viewer requires reference data with at least two pixel components
-            raise ValueError(f"'{new_refdata_label}' has {new_refdata.ndim} dimension(s) and "
-                             "cannot be used as reference data in an image viewer.")
-
         # make sure new refdata can be selected:
         refdata_choices = [choice.label for choice in viewer.state.ref_data_helper.choices]
         if new_refdata_label not in refdata_choices:
@@ -3054,6 +3049,21 @@ class PrivateApplication(VuetifyTemplate, HubListener):
                 if viewer.state.reference_data.label == data_label:
                     self._change_reference_data(base_wcs_layer_label, viewer_id)
             self.remove_data_from_viewer(viewer_id, data_label)
+
+            if len(viewer.layers) != 0 and getattr(viewer.state, 'reference_data', '') is None:
+                data_to_remove = [other_data.label for other_data in self.data_collection
+                                  if other_data.label in viewer.data_menu.data_labels_loaded and
+                                  other_data.label != data_label]
+
+                _ = [self.remove_data_from_viewer(viewer_id, data_label)
+                     for data_label in data_to_remove]
+
+                snackbar_message = SnackbarMessage(
+                    f"Reference data for viewer '{viewer_id}' was removed from the app. "
+                    f"The viewer no longer supports the following data: "
+                    f"{', '.join(data_to_remove)}.",
+                    sender=self, color="warning")
+                self.hub.broadcast(snackbar_message)
 
         data_to_remove = self.data_collection[data_label]
         if self.config in CONFIGS_WITH_LOADERS:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -806,6 +806,11 @@ class PrivateApplication(VuetifyTemplate, HubListener):
 
         new_refdata = self.data_collection[new_refdata_label]
 
+        if new_refdata.ndim < 2:
+            # an image viewer requires reference data with at least two pixel components
+            raise ValueError(f"'{new_refdata_label}' has {new_refdata.ndim} dimension(s) and "
+                             "cannot be used as reference data in an image viewer.")
+
         # make sure new refdata can be selected:
         refdata_choices = [choice.label for choice in viewer.state.ref_data_helper.choices]
         if new_refdata_label not in refdata_choices:

--- a/jdaviz/configs/imviz/tests/test_delete_data.py
+++ b/jdaviz/configs/imviz/tests/test_delete_data.py
@@ -1,9 +1,7 @@
 import numpy as np
 import pytest
-from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.nddata import NDData
-from astropy.table import QTable
 from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_allclose
 from regions import PixCoord, CirclePixelRegion, RectanglePixelRegion, EllipsePixelRegion

--- a/jdaviz/configs/imviz/tests/test_delete_data.py
+++ b/jdaviz/configs/imviz/tests/test_delete_data.py
@@ -1,6 +1,9 @@
 import numpy as np
+import pytest
+from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.nddata import NDData
+from astropy.table import QTable
 from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_allclose
 from regions import PixCoord, CirclePixelRegion, RectanglePixelRegion, EllipsePixelRegion
@@ -109,3 +112,45 @@ class TestDeleteWCSLayerWithSubset(BaseImviz_WCS_GWCS):
         assert_quantity_allclose(reg.height, out_reg_d.height, rtol=1e-5)
         assert_quantity_allclose(reg.width, out_reg_d.width, rtol=1e-5)
         assert_quantity_allclose(reg.angle, out_reg_d.angle, rtol=1e-5)
+
+
+@pytest.mark.parametrize(
+    ('align_by', 'reference_data_label'),
+    [
+        ('Pixels', 'image_hdu_wcs (1)'),
+        ('WCS', 'Default orientation')
+    ])
+def test_delete_image_with_catalog(deconfigged_helper, align_by, reference_data_label,
+                                   image_hdu_wcs, wcs_linked_mixed_coord_catalog):
+    deconfigged_helper.load(image_hdu_wcs, format='Image', data_label='image_hdu_wcs')
+    # start with two images to check glue reference data assignment
+    deconfigged_helper.load(image_hdu_wcs, format='Image', data_label='image_hdu_wcs (1)')
+    deconfigged_helper.plugins['Orientation'].align_by = align_by
+    glue_viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
+
+    deconfigged_helper.load(wcs_linked_mixed_coord_catalog, format='Catalog', data_label='catalog')
+
+    # remove one, the second image should be used
+    # as reference data instead of the catalog
+    deconfigged_helper._app.data_item_remove('image_hdu_wcs')
+    assert glue_viewer.state.reference_data.label == reference_data_label
+
+    # test that changing the reference data to catalog raises an error
+    with pytest.raises(ValueError, match='cannot be used as reference data'):
+        deconfigged_helper._app._change_reference_data('catalog')
+
+    # remove the second image
+    deconfigged_helper._app.data_item_remove('image_hdu_wcs (1)')
+
+    if align_by == 'Pixels':
+        # no reference data is available since the catalog cannot be used as such
+        assert glue_viewer.state.reference_data is None
+        assert deconfigged_helper._app.data_collection.labels == ['catalog']
+        assert [lyr.layer.label for lyr in glue_viewer.state.layers] == ['catalog']
+    else:  # WCS
+        # the WCS-only orientation layer remains as valid reference data,
+        # so the catalog layer can still be displayed
+        assert glue_viewer.state.reference_data.label == reference_data_label
+        assert 'catalog' in deconfigged_helper._app.data_collection.labels
+        cat_layer = [lyr for lyr in glue_viewer.layers if lyr.layer.label == 'catalog'][0]
+        assert cat_layer.enabled

--- a/jdaviz/configs/imviz/tests/test_delete_data.py
+++ b/jdaviz/configs/imviz/tests/test_delete_data.py
@@ -124,27 +124,33 @@ def test_delete_image_with_catalog(deconfigged_helper, align_by, reference_data_
     # start with two images to check glue reference data assignment
     deconfigged_helper.load(image_hdu_wcs, format='Image', data_label='image_hdu_wcs (1)')
     deconfigged_helper.plugins['Orientation'].align_by = align_by
-    glue_viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
+    image_viewer = deconfigged_helper.viewers['Image']
+    data_menu = image_viewer.data_menu
+    glue_viewer = image_viewer._obj.glue_viewer
 
     deconfigged_helper.load(wcs_linked_mixed_coord_catalog, format='Catalog', data_label='catalog')
 
     # remove one, the second image should be used
     # as reference data instead of the catalog
-    deconfigged_helper._app.data_item_remove('image_hdu_wcs')
+    data_menu.layer = 'image_hdu_wcs'
+    data_menu.remove_from_app()
     assert glue_viewer.state.reference_data.label == reference_data_label
 
-    # test that changing the reference data to catalog raises an error
-    with pytest.raises(ValueError, match='cannot be used as reference data'):
-        deconfigged_helper._app._change_reference_data('catalog')
-
     # remove the second image
-    deconfigged_helper._app.data_item_remove('image_hdu_wcs (1)')
+    data_menu.layer = 'image_hdu_wcs (1)'
+    data_menu.remove_from_app()
 
     if align_by == 'Pixels':
         # no reference data is available since the catalog cannot be used as such
         assert glue_viewer.state.reference_data is None
         assert deconfigged_helper._app.data_collection.labels == ['catalog']
-        assert [lyr.layer.label for lyr in glue_viewer.state.layers] == ['catalog']
+        assert [lyr.layer.label for lyr in glue_viewer.state.layers] == []
+
+        # TODO: the catalog *should not* be able to be loaded back into the viewer
+        #  since there's no reference data and it won't show up.
+        #  This will be fixed in a follow-up effort.
+        # with pytest.raises(Exception):
+        #     data_menu.add_data('catalog')
     else:  # WCS
         # the WCS-only orientation layer remains as valid reference data,
         # so the catalog layer can still be displayed

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -393,6 +393,11 @@ class UnitConversion(PluginTemplateMixin):
             # NOTE: this assumes that all image data is coerced to surface brightness units
             layers = [lyr for lyr in msg.viewer.layers if lyr.layer.data.label == msg.data.label]
 
+            if not (hasattr(data_obj, 'flux') or hasattr(data_obj, 'unit')):
+                # e.g. a catalog/table loaded into an image viewer, which carries no
+                # flux or surface brightness units to sync with the plugin
+                return
+
             if not isinstance(data_obj, tracing.Trace):
 
                 if not len(self.spectral_unit_selected) and hasattr(data_obj, 'spectral_axis'):

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -3,6 +3,7 @@ from echo import delay_callback, CallbackProperty
 import numpy as np
 
 from astropy import units as u
+from glue.core import BaseData
 from glue.viewers.profile.state import ProfileViewerState
 from glue_jupyter.bqplot.image.state import BqplotImageViewerState
 from glue.viewers.matplotlib.state import DeferredDrawCallbackProperty as DDCProperty
@@ -131,6 +132,24 @@ class FreezableBqplotImageViewerState(BqplotImageViewerState, FreezableState):
     def _set_viewer(self, viewer):
         self._viewer = viewer
         self._set_axes_lim()
+
+    def _update_combo_ref_data(self):
+        # exclude any data that cannot act as reference data for an image
+        # viewer (e.g. 1D catalogs/tables). Without this, removing the last image from a
+        # viewer that still contains a catalog would result in the catalog being selected
+        # as reference data, which then raises an IndexError in glue since the reference
+        # data is expected to have at least two pixel components.
+        self.ref_data_helper.set_multiple_data([data for data in self.layers_data
+                                                if data.ndim > 1])
+
+    def _set_reference_data(self):
+        # skip any data that cannot act as reference data for an image viewer.
+        # If no valid reference data is available, reference_data is left as None.
+        if self.reference_data is None:
+            for layer in self.layers:
+                if isinstance(layer.layer, BaseData) and layer.layer.ndim > 1:
+                    self.reference_data = layer.layer
+                    return
 
     @contextmanager
     def during_zoom_sync(self):


### PR DESCRIPTION
When both an image and a catalog are loaded into an Image viewer and these are aligned by pixel, glue uses the image as the 2D reference layer. This causes an issue when the image gets removed because glue then assigns the 1D catalog to be the reference layer which it then attempts to access as a 2D data object. When aligned by WCS, the reference layer is the WCS layer so the error doesn't get raised.

This PR addresses the issue by preventing glue from assigning any 1D data as the reference layer. In practice, it sets `reference_data = None` and removes the catalog from the viewer. Future work should prevent the catalog from being able to be loaded into a pixel aligned image viewer. As it currently stands, the catalog can be reloaded into the existing viewer which then shows as blank.