### PR TITLE
Fix visible columns in the plot options plugin

### DIFF
--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -303,6 +303,8 @@
         attach
         :menu-props="{ location: 'bottom start' }"
         :items="table_columns_visible_sync.choices"
+        item-title="text"
+        item-value="value"
         v-model="table_columns_visible_value"
         :label="api_hints_enabled ? 'plg.table_columns_visible =' : 'Visible Columns'"
         :class="api_hints_enabled ? 'api-hint' : null"


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes visible columns in the plot options plugin. It used to show `[object Object]` in the plugin with a table viewer loaded and now shows the correct column names.

Example code for testing:

```
from astropy import units as u
from astropy.table import Table
import jdaviz as jd

jd.show()

catalog = Table()
catalog['ra'] = [337.50293, 337.52763, 337.52844, 337.47438, 337.47432] * u.deg
catalog['dec'] = [-20.81483, -20.80438, -20.82707, -20.82683, -20.80342] * u.deg
catalog['magnitude'] = [12.5, 14.2, 13.8, 15.1, 16.3] * u.mag
catalog['source_id'] = ['src_001', 'src_002', 'src_003', 'src_004', 'src_005']


ldr = jd.loaders['object']
ldr.object = catalog
ldr.format = 'Catalog'
ldr.importer.viewer.create_new = 'Table'
ldr.load()
```


### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.
