### PR TITLE
fixes for flux conversion to support mixed unit viewers in deconfigged

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,9 @@ New Features
   
 - Keep visibility consistent between blink and plot options. [#4316]
 
+- Improvements to flux / surface brightness unit conversion logic to support
+  workflows and avoid errors in mixed unit viewers in deconfigged. [#4336]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -58,9 +58,9 @@ from jdaviz.utils import (SnackbarQueue, alpha_index, alpha_index_to_int, data_h
                           _wcs_only_label, CONFIGS_WITH_LOADERS,
                           _get_celestial_wcs)
 from jdaviz.core.custom_units_and_equivs import SPEC_PHOTON_FLUX_DENSITY_UNITS, enable_spaxel_unit
-from jdaviz.core.unit_conversion_utils import (check_if_unit_is_per_solid_angle,
+from jdaviz.core.unit_conversion_utils import (is_unit_per_solid_angle,
                                                combine_flux_and_angle_units,
-                                               flux_conversion_general,
+                                               flux_unit_conversion,
                                                spectral_unit_conversion,
                                                supported_sq_angle_units,
                                                viewer_flux_conversion_equivalencies)
@@ -133,9 +133,9 @@ class UnitConverterWithSpectral:
                 spec = Spectrum(flux=data.data * u.Unit(original_units))
             # equivalencies for flux/surface brightness conversions
             viewer_equivs = viewer_flux_conversion_equivalencies(values, spec)
-            return flux_conversion_general(values, original_units,
-                                           target_units, viewer_equivs,
-                                           with_unit=False)
+            return flux_unit_conversion(
+                values, original_units, target_units, viewer_equivs,
+                with_unit=False)
         else:  # spectral axis
             return spectral_unit_conversion(values, original_units, target_units)
 
@@ -1657,7 +1657,7 @@ class PrivateApplication(VuetifyTemplate, HubListener):
                 # first check the spectrum viewer y axis for any solid angle unit (i think that it
                 # will ALWAYS be in flux, but just to be sure). If no solid angle unit is found,
                 # check the flux viewer for surface brightness units
-                sv_y_angle_unit = check_if_unit_is_per_solid_angle(sv_y_unit, return_unit=True)
+                sv_y_angle_unit = is_unit_per_solid_angle(sv_y_unit, return_unit=True)
 
                 # check flux viewer if none in spectral viewer
                 fv_angle_unit = None
@@ -1666,8 +1666,8 @@ class PrivateApplication(VuetifyTemplate, HubListener):
                         vname = self._jdaviz_helper._default_flux_viewer_reference_name
                         fv = self.get_viewer(vname)
                         fv_unit = fv.data()[0].get_object().flux.unit
-                        fv_angle_unit = check_if_unit_is_per_solid_angle(fv_unit,
-                                                                         return_unit=True)
+                        fv_angle_unit = is_unit_per_solid_angle(
+                            fv_unit, return_unit=True)
                     else:
                         # mosviz, not sure what to do here but can't access flux
                         # viewer the same way. once we force the UC plugin to

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -5,7 +5,7 @@ from astropy import units as u
 from specutils import Spectrum
 
 from jdaviz.core.custom_units_and_equivs import PIX2, _eqv_flux_to_sb_pixel
-from jdaviz.core.unit_conversion_utils import check_if_unit_is_per_solid_angle
+from jdaviz.core.unit_conversion_utils import is_unit_per_solid_angle
 
 __all__ = []
 
@@ -38,9 +38,9 @@ def _return_spectrum_with_correct_units(flux, wcs, metadata, data_type=None,
     # convert flux and uncertainty to per-pix2 if input is not a surface brightness
     target_flux_unit = None
     if (apply_pix2 and (data_type != "mask") and
-            (not check_if_unit_is_per_solid_angle(flux.unit))):
+            (not is_unit_per_solid_angle(flux.unit))):
         target_flux_unit = flux.unit / PIX2
-    elif check_if_unit_is_per_solid_angle(flux.unit, return_unit=True) == "spaxel":
+    elif is_unit_per_solid_angle(flux.unit, return_unit=True) == "spaxel":
         # We need to convert spaxel to pixel squared, since spaxel isn't fully supported by astropy
         # This is horribly ugly but just multiplying by u.Unit("spaxel") doesn't work
         target_flux_unit = flux.unit * u.Unit('spaxel') / PIX2

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/spectral_extraction.py
@@ -24,8 +24,8 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         with_spinner, with_temp_disable)
 from jdaviz.core.user_api import PluginUserApi
 from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
-                                               flux_conversion_general,
-                                               check_if_unit_is_per_solid_angle)
+                                               flux_unit_conversion,
+                                               is_unit_per_solid_angle)
 from jdaviz.configs.cubeviz.plugins.parsers import _return_spectrum_with_correct_units
 from jdaviz.configs.cubeviz.plugins.viewers import WithSliceIndicator
 
@@ -610,8 +610,8 @@ class SpectralExtraction3D(PluginTemplateMixin, ApertureSubsetSelectMixin,
             )  # returns an NDDataArray
 
             # Remove per solid angle denominator to turn sb into flux
-            sq_angle_unit = check_if_unit_is_per_solid_angle(collapsed_nddata.unit,
-                                                             return_unit=True)
+            sq_angle_unit = is_unit_per_solid_angle(
+                collapsed_nddata.unit, return_unit=True)
             if sq_angle_unit is not None:
                 # convert aperture area in steradians to the selected square angle unit
                 # NOTE: just forcing these units for now!! this is in steradians and
@@ -698,8 +698,9 @@ class SpectralExtraction3D(PluginTemplateMixin, ApertureSubsetSelectMixin,
             eqv = all_flux_unit_conversion_equivs(self.dataset.selected_obj.meta.get('PIXAR_SR', 1.0),  # noqa
                                                   self.dataset.selected_obj.spectral_axis)
 
-            return flux_conversion_general(extracted.flux.value, extracted.flux.unit,
-                                           self.spectrum_y_units, eqv)
+            return flux_unit_conversion(
+                extracted.flux.value, extracted.flux.unit,
+                self.spectrum_y_units, eqv)
 
         return extracted.flux
 

--- a/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
+++ b/jdaviz/configs/cubeviz/plugins/spectral_extraction/tests/test_spectral_extraction.py
@@ -18,7 +18,7 @@ from specutils.manipulation import FluxConservingResampler
 
 from jdaviz.core.custom_units_and_equivs import PIX2
 from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
-                                               flux_conversion_general)
+                                               flux_unit_conversion)
 from jdaviz.utils import cached_uri
 from photutils import __version__ as photutils_version
 
@@ -722,10 +722,9 @@ def test_spectral_extraction_flux_unit_conversions(cubeviz_helper,
 
             # make sure extraction preview was translated to new display units
             new_sum_y_values = se._obj.marks['extract'].y
-            new_converted_to_old_unit = flux_conversion_general(new_sum_y_values,
-                                                                u.Unit(new_flux_unit),
-                                                                u.Unit(flux_unit),
-                                                                equivs, with_unit=False)
+            new_converted_to_old_unit = flux_unit_conversion(
+                new_sum_y_values, u.Unit(new_flux_unit),
+                u.Unit(flux_unit), equivs, with_unit=False)
             np.testing.assert_allclose(original_sum_y_values, new_converted_to_old_unit)
 
             # collapsed result will still have the native data flux unit

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_aperphot.py
@@ -10,8 +10,8 @@ from numpy.testing import assert_allclose
 from regions import RectanglePixelRegion, PixCoord
 
 from jdaviz.core.custom_units_and_equivs import PIX2
-from jdaviz.core.unit_conversion_utils import (flux_conversion_general,
-                                               handle_squared_flux_unit_conversions)
+from jdaviz.core.unit_conversion_utils import (flux_unit_conversion,
+                                               squared_flux_unit_conversions)
 
 # subset of possible units to test various conversions, testing all is time intensive
 FLUX_UNITS = ['Jy', 'erg / (Hz s cm2)', 'W / (Hz m2)', 'ph / (Angstrom s cm2)']
@@ -276,15 +276,11 @@ def _compare_table_units(orig_tab, new_tab, orig_flux_unit=None,
             orig = float(row['result']) * orig_unit
 
             if 'var' in row['function']:  # variance is in units of flux/sb squared
-                orig_converted = handle_squared_flux_unit_conversions(orig.value,
-                                                                      orig_unit,
-                                                                      new_unit,
-                                                                      equivalencies)
+                orig_converted = squared_flux_unit_conversions(
+                    orig.value, orig_unit, new_unit, equivalencies)
             else:
-                orig_converted = flux_conversion_general(orig.value,
-                                                         orig_unit,
-                                                         new_unit,
-                                                         equivalencies)
+                orig_converted = flux_unit_conversion(
+                    orig.value, orig_unit, new_unit, equivalencies)
 
             # low rtol for match, phot table is rounded
             assert_quantity_allclose(orig_converted, new, rtol=1e-03)

--- a/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
+++ b/jdaviz/configs/cubeviz/plugins/tests/test_cubeviz_unit_conversion.py
@@ -123,7 +123,8 @@ def test_basic_unit_conversions(cubeviz_helper, angle_unit):
         assert_allclose(ap_plg.background_value, bg_ans, rtol=1e-4)
 
 
-@pytest.mark.parametrize("flux_unit, expected_choices", [(u.count, ['ct']),
+@pytest.mark.parametrize("flux_unit, expected_choices", [(u.count, []),
+                                                         (u.count / PIX2, []),
                                                          (u.Jy, SPEC_PHOTON_FLUX_DENSITY_UNITS),
                                                          (u.nJy, SPEC_PHOTON_FLUX_DENSITY_UNITS + ['nJy'])])  # noqa
 def test_flux_unit_choices(deconfigged_helper, flux_unit, expected_choices):
@@ -141,9 +142,15 @@ def test_flux_unit_choices(deconfigged_helper, flux_unit, expected_choices):
 
     uc_plg = deconfigged_helper.plugins['Unit Conversion']
 
-    assert uc_plg.angle_unit.selected == 'pix2'  # will always be pix2
+    assert uc_plg.angle_unit.selected == 'pix2'
 
-    assert uc_plg.flux_unit.selected == flux_unit.to_string()
+    # loading data with non-physical flux units (counts) should not set the
+    # global display unit or populate any choices for flux unit conversion
+    if u.Unit(flux_unit) in (u.ct, u.ct / PIX2):
+        assert uc_plg.flux_unit.selected == ''
+    else:
+        assert uc_plg.flux_unit.selected == flux_unit.to_string()
+
     assert uc_plg.flux_unit.choices == expected_choices
 
 
@@ -314,22 +321,25 @@ def test_contour_unit_conversion(deconfigged_helper, spectrum1d_cube_fluxunit_jy
 
 
 @pytest.mark.parametrize("angle_unit", [u.sr, PIX2])
-def test_cubeviz_flux_sb_translation_counts(cubeviz_helper, angle_unit):
+def test_cubeviz_flux_sb_translation_counts(cubeviz_helper, angle_unit, flux_unit=u.ct):
 
     """
-    When a cube is loaded in counts, 'count' should be the only
-    available option for flux unit. The y axis can be translated
-    between flux and sb. Test a flux cube which will be converted
-    to ct/pix2, and a sb cube ct/sr.
+    When a cube is loaded in counts, there should be no options available for unit
+    conversion but the y axis can be translated between flux and sb. Test toggling
+    between flux and surface brightness for a cube in units of counts (for solid
+    angle units of both PIX2 and sr), including that the mouseover info is updated correctly.
+
+    TODO: this test needs to be moved to deconfigged once toggling is fixed
     """
 
     angle_str = angle_unit.to_string()
+    flux_unit_str = flux_unit.to_string()
 
     # custom cube to have Surface Brightness units
     w, wcs_dict = cubeviz_wcs_dict()
     flux = np.zeros((30, 20, 3001), dtype=np.float32)
     flux[5:15, 1:11, :] = 1
-    cube = Spectrum(flux=flux * (u.ct / angle_unit), wcs=w, meta=wcs_dict)
+    cube = Spectrum(flux=flux * (flux_unit / angle_unit), wcs=w, meta=wcs_dict)
     cubeviz_helper.load(cube, data_label="test")
 
     uc_plg = cubeviz_helper.plugins['Unit Conversion']
@@ -337,9 +347,8 @@ def test_cubeviz_flux_sb_translation_counts(cubeviz_helper, angle_unit):
 
     # ensure that per solid angle cube defaults to Flux spectrum
     assert uc_plg.spectral_y_type == 'Flux'
-    # flux choices is populated with only one choice, counts
-    assert len(uc_plg.flux_unit.choices) == 1
-    assert 'ct' in uc_plg.flux_unit.choices
+    # flux choices is populated with no additional choices since the cube is in counts
+    assert len(uc_plg.flux_unit.choices) == 0
     # and angle choices should be the only the input angle
     assert len(uc_plg.angle_unit.choices) == 1
     assert angle_str in uc_plg.angle_unit.choices
@@ -352,7 +361,7 @@ def test_cubeviz_flux_sb_translation_counts(cubeviz_helper, angle_unit):
     uc_plg.spectral_y_type.selected = 'Surface Brightness'
 
     y_display_unit = u.Unit(viewer_1d.state.y_display_unit)
-    assert y_display_unit == u.ct / angle_unit
+    assert y_display_unit == flux_unit / angle_unit
 
     # and test mouseover info
     label_mouseover = cubeviz_helper._coords_info
@@ -363,7 +372,7 @@ def test_cubeviz_flux_sb_translation_counts(cubeviz_helper, angle_unit):
         flux_viewer, {"event": "mousemove", "domain": {"x": 10, "y": 8}}
     )
     assert label_mouseover.as_text() == (
-            f"Pixel x=00010.0 y=00008.0 Value +1.00000e+00 ct / {angle_str}",
+            f"Pixel x=00010.0 y=00008.0 Value +1.00000e+00 {flux_unit_str} / {angle_str}",
             "World 13h39m59.7037s +27d00m03.2400s (ICRS)",
             "204.9987654313 27.0008999946 (deg)")
 

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -30,10 +30,36 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
 from jdaviz.core.custom_traitlets import IntHandleEmpty
 from jdaviz.core.user_api import PluginUserApi
 from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
-                                               flux_conversion_general)
+                                               flux_unit_conversion,
+                                               is_physical_spectral_unit)
 from jdaviz.core.custom_units_and_equivs import PIX2
 
 __all__ = ['ModelFitting']
+
+
+def _flux_conversion_strip_spectral(values, original_unit, target_unit,
+                                    equivalencies=None, with_unit=True):
+    """Strip common spectral-axis denominator from both units, convert, then re-apply."""
+    orig = u.Unit(original_unit)
+    targ = u.Unit(target_unit)
+    spectral_denom = None
+    for base, power in zip(orig.bases, orig.powers):
+        if power < 0 and is_physical_spectral_unit(base):
+            spectral_denom = base ** (-power)
+            break
+    # only strip if the target also has a spectral unit in its denominator
+    if spectral_denom is not None and not any(
+            power < 0 and is_physical_spectral_unit(base)
+            for base, power in zip(targ.bases, targ.powers)):
+        spectral_denom = None
+    if spectral_denom is None:
+        return flux_unit_conversion(values, orig, targ, equivalencies, with_unit=with_unit)
+    result = flux_unit_conversion(
+        values, orig * spectral_denom, targ * spectral_denom,
+        equivalencies, with_unit=with_unit)
+    if with_unit:
+        return result / spectral_denom
+    return result
 
 
 class _EmptyParam:
@@ -697,9 +723,8 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
                     cube_wave = viewer.slice_value * u.Unit(self._app._get_display_unit('spectral'))
                     equivs = all_flux_unit_conversion_equivs(pixar_sr, cube_wave)
 
-                    initial_val = flux_conversion_general([default_param.value],
-                                                          default_param.unit,
-                                                          default_units, equivs)
+                    initial_val = _flux_conversion_strip_spectral(
+                        [default_param.value], default_param.unit, default_units, equivs)
                 else:
                     initial_val = default_param
 
@@ -751,10 +776,8 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
             pixar_sr = masked_spectrum.meta.get('_pixel_scale_factor', 1.0)
             equivs = all_flux_unit_conversion_equivs(pixar_sr, init_x.mean())
 
-            init_y = flux_conversion_general(init_y.value,
-                                             init_y.unit,
-                                             self._units['y'],
-                                             equivs)
+            init_y = _flux_conversion_strip_spectral(
+                init_y.value, init_y.unit, self._units['y'], equivs)
 
         # We need this for models where we average over the spatial axes to initialize
         spectral_axis_index = masked_spectrum.spectral_axis_index
@@ -867,10 +890,10 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
 
                     # Try to convert the current value to the new unit
                     try:
-                        new_quant = flux_conversion_general(current_quant.value,
-                                                            current_quant.unit,
-                                                            new_param_unit,
-                                                            equivalencies=equivalencies)
+                        new_quant = _flux_conversion_strip_spectral(current_quant.value,
+                                                                    current_quant.unit,
+                                                                    new_param_unit,
+                                                                    equivalencies=equivalencies)
                         param['value'] = new_quant.value
                         param['unit'] = str(new_quant.unit)
 
@@ -878,10 +901,10 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
                         if ('std' in param and param['std'] is not None
                                 and not np.isnan(param['std'])):
                             current_std_quant = param['std'] * u.Unit(old_param_unit)
-                            new_std = flux_conversion_general(current_std_quant.value,
-                                                              current_std_quant.unit,
-                                                              new_param_unit,
-                                                              equivalencies=equivalencies)
+                            new_std = _flux_conversion_strip_spectral(current_std_quant.value,
+                                                                      current_std_quant.unit,
+                                                                      new_param_unit,
+                                                                      equivalencies=equivalencies)
                             param['std'] = new_std.value
                     except Exception:
                         # If conversion fails, mark as incompatible
@@ -1674,7 +1697,7 @@ class ModelFitting(PluginTemplateMixin, DatasetSelectMixin,
         spatial_axes.remove(spec.spectral_axis_index)
 
         sb_unit = self._app._get_display_unit('sb')
-        if spec.flux.unit != sb_unit:
+        if sb_unit and spec.flux.unit != sb_unit:
             # ensure specutils has access to jdaviz custom unit equivalencies
             pixar_sr = spec.meta.get('_pixel_scale_factor', None)
             equivalencies = all_flux_unit_conversion_equivs(pixar_sr=pixar_sr,

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -54,8 +54,8 @@ from jdaviz.core.registries import viewer_registry
 from jdaviz.core.template_mixin import WithCache, TemplateMixin, show_widget
 from jdaviz.core.tools import _get_skycoords_from_table, _get_pixel_coords_from_table
 from jdaviz.core.user_api import ViewerUserApi
-from jdaviz.core.unit_conversion_utils import (check_if_unit_is_per_solid_angle,
-                                               flux_conversion_general,
+from jdaviz.core.unit_conversion_utils import (is_unit_per_solid_angle,
+                                               flux_unit_conversion,
                                                all_flux_unit_conversion_equivs)
 from jdaviz.utils import (ColorCycler, get_subset_type, _wcs_only_label,
                           layer_is_image_data, layer_is_not_dq, layer_is_3d)
@@ -1200,10 +1200,11 @@ class JdavizProfileView(JdavizViewerMixin, BqplotProfileView):
                     cube_wave = data.get_component('spectral')
 
                     eqv = all_flux_unit_conversion_equivs(pixar_sr=psc, cube_wave=cube_wave)
-                    flux_conversion_general([1, 1],
-                                            data.get_component('flux').data.units,
-                                            self.state.y_display_unit,
-                                            equivalencies=eqv)
+                    flux_unit_conversion(
+                        [1, 1],
+                        data.get_component('flux').data.units,
+                        self.state.y_display_unit,
+                        equivalencies=eqv)
             except Exception as e:
                 # Raising exception here introduces a dirty state that messes up next load_data
                 # but not raising exception also causes weird behavior unless we remove the data
@@ -1417,7 +1418,7 @@ class JdavizProfileView(JdavizViewerMixin, BqplotProfileView):
         # get square angle from 'sb' display unit
         sb_unit = self.jdaviz_app._get_display_unit(axis='sb')
         if sb_unit is not None:
-            solid_angle_unit = check_if_unit_is_per_solid_angle(sb_unit, return_unit=True)
+            solid_angle_unit = is_unit_per_solid_angle(sb_unit, return_unit=True)
         else:
             solid_angle_unit = None
 

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -27,9 +27,9 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin, DatasetMultiSelectM
                                         SubsetSelect, ApertureSubsetSelectMixin,
                                         TableMixin, PlotMixin, MultiselectMixin, with_spinner)
 from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
-                                               check_if_unit_is_per_solid_angle,
-                                               flux_conversion_general,
-                                               handle_squared_flux_unit_conversions)
+                                               is_unit_per_solid_angle,
+                                               flux_unit_conversion,
+                                               squared_flux_unit_conversions)
 from jdaviz.core.user_api import PluginUserApi
 from jdaviz.utils import PRIHDR_KEY, _get_celestial_wcs
 
@@ -185,7 +185,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
             comp = data.get_component(data.main_components[0])
             img_unit = u.Unit(comp.units) if comp.units else u.dimensionless_unscaled
-            solid_angle_unit = check_if_unit_is_per_solid_angle(img_unit, return_unit=True)
+            solid_angle_unit = is_unit_per_solid_angle(img_unit, return_unit=True)
             if solid_angle_unit is None:  # this is encountered sometimes ??
                 return
 
@@ -365,11 +365,9 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
                     equivs = all_flux_unit_conversion_equivs(pixar_sr,
                                                              self._cube_wave) + u.spectral()
 
-                    self.background_value = flux_conversion_general(self.background_value,
-                                                                    prev_unit,
-                                                                    new_unit,
-                                                                    equivs,
-                                                                    with_unit=False)
+                    self.background_value = flux_unit_conversion(
+                        self.background_value, prev_unit, new_unit,
+                        equivs, with_unit=False)
 
             # convert flux scaling to new unit
             if self.flux_scaling is not None:
@@ -377,11 +375,9 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
                 new_unit = u.Unit(self.flux_scaling_display_unit)
                 if prev_unit != new_unit:
                     equivs = u.spectral_density(self._cube_wave)
-                    self.flux_scaling = flux_conversion_general(self.flux_scaling,
-                                                                prev_unit,
-                                                                new_unit,
-                                                                equivs,
-                                                                with_unit=False)
+                    self.flux_scaling = flux_unit_conversion(
+                        self.flux_scaling, prev_unit, new_unit,
+                        equivs, with_unit=False)
 
     def _set_display_unit_of_selected_dataset(self):
         """
@@ -398,7 +394,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
         # this check needs to be here because 'get_display_unit' will sometimes
         # return non surface brightness units or even None when the app is starting
         # up. this can be removed once that is fixed (see PR #3144)
-        if disp_unit is None or not check_if_unit_is_per_solid_angle(disp_unit):
+        if disp_unit is None or not is_unit_per_solid_angle(disp_unit):
             self.display_unit = ''
             self.flux_scaling_display_unit = ''
             return
@@ -407,7 +403,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
         # get angle component of surface brightness
         # note: could add 'axis=angle' when cleaning this code up to avoid repeating this
-        display_solid_angle_unit = check_if_unit_is_per_solid_angle(disp_unit, return_unit=True)
+        display_solid_angle_unit = is_unit_per_solid_angle(disp_unit, return_unit=True)
         if display_solid_angle_unit is not None:
             self.display_solid_angle_unit = display_solid_angle_unit.to_string()
         else:
@@ -447,11 +443,9 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             # if display unit is different, translate
             if self._has_display_unit_support:
                 disp_unit = u.Unit(self.display_unit)
-                mjy2abmag = flux_conversion_general(mjy2abmag,
-                                                    u.MJy / u.sr,
-                                                    disp_unit,
-                                                    u.spectral_density(self._cube_wave),
-                                                    with_unit=False)
+                mjy2abmag = flux_unit_conversion(
+                    mjy2abmag, u.MJy / u.sr, disp_unit,
+                    u.spectral_density(self._cube_wave), with_unit=False)
 
             if 'photometry' in meta and 'pixelarea_arcsecsq' in meta['photometry']:
                 defaults['pixel_area'] = meta['photometry']['pixelarea_arcsecsq']
@@ -624,11 +618,9 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
         # convert background median to display unit, if necessary (cubes only)
         if self._has_display_unit_support and comp.units:
-            bg_md = flux_conversion_general(bg_md,
-                                            u.Unit(comp.units),
-                                            u.Unit(self.display_unit),
-                                            u.spectral_density(self._cube_wave),
-                                            with_unit=False)
+            bg_md = flux_unit_conversion(
+                bg_md, u.Unit(comp.units), u.Unit(self.display_unit),
+                u.spectral_density(self._cube_wave), with_unit=False)
 
         return bg_md
 
@@ -764,11 +756,9 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             # cube loaders: background_value set in plugin is in display units
             # convert temporarily to image units for calculations
             if self._has_display_unit_support and img_unit is not None:
-                background_value = flux_conversion_general(background_value,
-                                                           display_unit,
-                                                           img_unit,
-                                                           u.spectral_density(self._cube_wave),
-                                                           with_unit=False)
+                background_value = flux_unit_conversion(
+                    background_value, display_unit, img_unit,
+                    u.spectral_density(self._cube_wave), with_unit=False)
         elif background is None and dataset is None:
 
             # use the previously-computed value in the plugin
@@ -777,11 +767,9 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             # cubes: background_value set in plugin is in display units
             # convert temporarily to image units for calculations
             if self._has_display_unit_support and img_unit is not None:
-                background_value = flux_conversion_general(background_value,
-                                                           display_unit,
-                                                           img_unit,
-                                                           u.spectral_density(self._cube_wave),
-                                                           with_unit=False)
+                background_value = flux_unit_conversion(
+                    background_value, display_unit, img_unit,
+                    u.spectral_density(self._cube_wave), with_unit=False)
         else:
             bg_reg = self.aperture._get_spatial_region(subset=background if background is not None else self.background.selected,  # noqa
                                                        dataset=dataset if dataset is not None else self.dataset.selected)  # noqa
@@ -790,11 +778,9 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             # cubes: computed background median will be in display units,
             # convert temporarily back to image units for calculations
             if self._has_display_unit_support and img_unit is not None:
-                background_value = flux_conversion_general(background_value,
-                                                           display_unit,
-                                                           img_unit,
-                                                           u.spectral_density(self._cube_wave),
-                                                           with_unit=False)
+                background_value = flux_unit_conversion(
+                    background_value, display_unit, img_unit,
+                    u.spectral_density(self._cube_wave), with_unit=False)
         try:
             bg = float(background_value)
         except ValueError:  # Clearer error message
@@ -844,7 +830,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             comp_data = comp_data << img_unit
             bg = bg * img_unit
 
-            if check_if_unit_is_per_solid_angle(img_unit):  # if units are surface brightness
+            if is_unit_per_solid_angle(img_unit):  # if units are surface brightness
                 try:
                     pixarea = float(pixel_area if pixel_area is not None else self.pixel_area)
                 except ValueError:  # Clearer error message
@@ -871,7 +857,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
                     (self.flux_scaling is not None)):
 
                 # convert flux_scaling from flux display unit to native flux unit
-                flux_scaling = flux_conversion_general(
+                flux_scaling = flux_unit_conversion(
                     self.flux_scaling,
                     u.Unit(self.flux_scaling_display_unit),
                     img_unit * u.Unit(self.display_solid_angle_unit),
@@ -906,8 +892,8 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             if self._has_display_unit_support:
                 display_solid_angle_unit = u.Unit(self.display_solid_angle_unit)
             else:
-                if comp.units and check_if_unit_is_per_solid_angle(u.Unit(comp.units)):
-                    display_solid_angle_unit = check_if_unit_is_per_solid_angle(u.Unit(comp.units), return_unit=True)  # noqa: E501
+                if comp.units and is_unit_per_solid_angle(u.Unit(comp.units)):
+                    display_solid_angle_unit = is_unit_per_solid_angle(u.Unit(comp.units), return_unit=True)  # noqa: E501
                 else:
                     # this scenario should not be encountered since 'include_pixarea_fac'
                     # is True only if data or display unit is surface brightness, but just
@@ -928,7 +914,7 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
             else:
                 pixarea = pixarea * (u.arcsec * u.arcsec / PIX2)
                 # NOTE: Sum already has npix value encoded, so we simply apply the npix unit here.
-                # don't need to go though flux_conversion_general since these units
+                # don't need to go though flux_unit_conversion since these units
                 # arent per-pixel and won't need a workaround.
                 pixarea_fac = PIX2 * pixarea.to(display_solid_angle_unit / PIX2)
 
@@ -980,43 +966,44 @@ class SimpleAperturePhotometry(PluginTemplateMixin, ApertureSubsetSelectMixin,
 
                 if display_unit != '':
                     if phot_table['background'].unit != display_unit:
-                        bg_conv = flux_conversion_general(phot_table['background'].value,
-                                                          phot_table['background'].unit,
-                                                          display_unit,
-                                                          equivs)
+                        bg_conv = flux_unit_conversion(
+                            phot_table['background'].value,
+                            phot_table['background'].unit,
+                            display_unit,
+                            equivs)
                         phot_table['background'] = bg_conv
 
                     phot_sum = phot_table['sum']
                     if include_pixarea_fac:
                         if phot_sum.unit != (display_unit * pixarea_fac).unit:
-                            phot_table['sum'] = flux_conversion_general(phot_sum.value,
-                                                                        phot_sum.unit,
-                                                                        (display_unit * pixarea_fac).unit,  # noqa: E501
-                                                                        equivs)
+                            phot_table['sum'] = flux_unit_conversion(
+                                phot_sum.value,
+                                phot_sum.unit,
+                                (display_unit * pixarea_fac).unit,  # noqa: E501
+                                equivs)
 
                     elif phot_sum.unit != display_unit:
-                        phot_table['sum'] = flux_conversion_general(phot_sum.value,
-                                                                    phot_sum.unit,
-                                                                    display_unit,
-                                                                    equivs)
+                        phot_table['sum'] = flux_unit_conversion(
+                            phot_sum.value, phot_sum.unit,
+                            display_unit, equivs)
 
                     for key in ['min', 'max', 'mean', 'median', 'mode', 'std',
                                 'mad_std', 'biweight_location']:
                         if phot_table[key].unit != display_unit:
-                            phot_table[key] = flux_conversion_general(phot_table[key].value,
-                                                                      phot_table[key].unit,
-                                                                      display_unit,
-                                                                      equivs)
+                            phot_table[key] = flux_unit_conversion(
+                                phot_table[key].value, phot_table[key].unit,
+                                display_unit, equivs)
 
                     for key in ['var', 'biweight_midvariance']:
                         # these values will be in units of flux or surface brightness
                         # squared, so unit conversion is another special case if additional
                         # equivalencies are required
                         if phot_table[key].unit != display_unit**2:
-                            conv = handle_squared_flux_unit_conversions(phot_table[key].value,
-                                                                        phot_table[key].unit,
-                                                                        display_unit**2,
-                                                                        equivs)
+                            conv = squared_flux_unit_conversions(
+                                phot_table[key].value,
+                                phot_table[key].unit,
+                                display_unit**2,
+                                equivs)
                             phot_table[key] = conv
 
         if add_to_table:
@@ -1424,11 +1411,9 @@ def _radial_profile(data, reg_bb, centroid, raw=False,
 
         # convert array from native data unit to display unit, if they differ
         if image_unit != display_unit:
-            y_arr = flux_conversion_general(y_arr,
-                                            u.Unit(image_unit),
-                                            u.Unit(display_unit),
-                                            equivalencies=equivalencies,
-                                            with_unit=False)
+            y_arr = flux_unit_conversion(
+                y_arr, u.Unit(image_unit), u.Unit(display_unit),
+                equivalencies=equivalencies, with_unit=False)
 
     return x_arr, y_arr
 
@@ -1530,7 +1515,7 @@ def _curve_of_growth(data, centroid, aperture, wcs=None, background=0, n_datapoi
 
         # multiply data unit by its solid angle to convert sum in sb to sum in flux
         if pixarea_fac is not None:
-            sa = check_if_unit_is_per_solid_angle(sum_unit, return_unit=True)
+            sa = is_unit_per_solid_angle(sum_unit, return_unit=True)
             sum_unit *= sa
             sum_arr = sum_arr * pixarea_fac.value
             if do_flux_conv:
@@ -1538,11 +1523,9 @@ def _curve_of_growth(data, centroid, aperture, wcs=None, background=0, n_datapoi
 
         # convert array from native data unit to display unit, if they differ
         if do_flux_conv:
-            sum_arr = flux_conversion_general(sum_arr,
-                                              sum_unit,
-                                              disp_unit,
-                                              equivalencies=equivalencies,
-                                              with_unit=False)
+            sum_arr = flux_unit_conversion(
+                sum_arr, sum_unit, disp_unit,
+                equivalencies=equivalencies, with_unit=False)
             y_label = disp_unit.to_string()
         else:
             y_label = sum_unit.to_string()

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -13,16 +13,17 @@ from jdaviz.configs.mosviz.plugins.viewers import (MosvizImageView,
                                                    MosvizProfile2DView)
 from jdaviz.configs.rampviz.plugins.viewers import RampvizImageView, RampvizProfileView
 from jdaviz.configs.specviz.plugins.viewers import Spectrum1DViewer, Spectrum2DViewer
-from jdaviz.core.custom_units_and_equivs import PIX2
 from jdaviz.core.events import ViewerAddedMessage, ViewerRenamedMessage, GlobalDisplayUnitChanged
 from jdaviz.core.helpers import data_has_valid_wcs
 from jdaviz.core.marks import PluginScatter, PluginLine
 from jdaviz.core.registries import tool_registry
 from jdaviz.core.template_mixin import TemplateMixin, DatasetSelectMixin
 from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
-                                               check_if_unit_is_per_solid_angle,
-                                               flux_conversion_general,
-                                               spectral_unit_conversion)
+                                               is_unit_per_solid_angle,
+                                               flux_unit_conversion,
+                                               spectral_unit_conversion,
+                                               is_physical_flux_unit,
+                                               unit_is_from_moment_map)
 
 __all__ = ['CoordsInfo']
 
@@ -651,12 +652,13 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                     # no layers loaded, so no display unit set
                     disp_unit = None
                 if (isinstance(viewer, (ImvizImageView, Spectrum2DViewer))
-                        and unit != '' and disp_unit is not None
+                        and unit != '' and disp_unit
+                        and is_physical_flux_unit(unit)
                         and u.Unit(self._app._get_display_unit(attribute)).physical_type
                         not in ['frequency', 'wavelength', 'length']
                         and unit != self._app._get_display_unit(attribute)):
                     to_unit = self._app._get_display_unit(attribute)
-                    if (check_if_unit_is_per_solid_angle(unit) and attribute == 'flux'):
+                    if (is_unit_per_solid_angle(unit) and attribute == 'flux'):
                         to_unit = self._app._get_display_unit('sb')
 
                     try:
@@ -664,10 +666,8 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                     except UnboundLocalError:
                         # wave is not defined (image viewer without spectral axis)
                         equivalencies = None
-                    value = flux_conversion_general(value, unit,
-                                                    to_unit,
-                                                    equivalencies,
-                                                    with_unit=False)
+                    value = flux_unit_conversion(
+                        value, unit, to_unit, equivalencies, with_unit=False)
                     unit = to_unit
 
             elif isinstance(viewer, (CubevizImageView, RampvizImageView)):
@@ -677,25 +677,8 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                     image, arr, x, y, viewer
                 )
 
-                # We don't want to convert for things like moment maps, so check
-                # physical type If unit is flux per pix2, the type will be
-                # 'unknown' rather than surface brightness, so multiply out pix2
-                # and check if the numerator is a spectral/photon flux density
-                if check_if_unit_is_per_solid_angle(unit, return_unit=True) == PIX2:
-                    physical_type = (unit * PIX2).physical_type
-                else:
-                    physical_type = unit.physical_type
-
-                valid_physical_types = ["spectral flux density",
-                                        "surface brightness",
-                                        "surface brightness wav",
-                                        "photon surface brightness wav",
-                                        "photon surface brightness",
-                                        "power density/spectral flux density wav",
-                                        "photon flux density wav",
-                                        "photon flux density"]
-
-                if str(physical_type) in valid_physical_types and self.image_unit is not None:
+                # Avoid converting for moment maps / non-physical flux units
+                if self.image_unit is not None and (is_physical_flux_unit(unit) and not unit_is_from_moment_map(unit)):  # noqa
 
                     # Create list of potentially needed equivalencies for flux/sb unit conversions
                     pixar_sr = self._app.data_collection[0].meta.get('PIXAR_SR', 1)
@@ -708,8 +691,9 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                     equivalencies = all_flux_unit_conversion_equivs(pixar_sr,
                                                                     cube_wave)
 
-                    value = flux_conversion_general(value, unit, u.Unit(self.image_unit),
-                                                    equivalencies, with_unit=False)
+                    value = flux_unit_conversion(
+                        value, unit, u.Unit(self.image_unit),
+                        equivalencies, with_unit=False)
                     unit = self.image_unit
 
                 if associated_dq_layers is not None:
@@ -831,10 +815,10 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                                                                 sp.spectral_axis)
 
                 if sp.flux.unit is not None and viewer.state.y_display_unit is not None:
-                    disp_flux = flux_conversion_general(sp.flux.value,
-                                                        sp.flux.unit,
-                                                        viewer.state.y_display_unit,
-                                                        equivalencies, with_unit=False)  # noqa: E501
+                    disp_flux = flux_unit_conversion(
+                        sp.flux.value, sp.flux.unit,
+                        viewer.state.y_display_unit,
+                        equivalencies, with_unit=False)  # noqa: E501
                 else:
                     disp_flux = sp.flux
 

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -21,7 +21,7 @@ from jdaviz.configs.imviz.plugins.aper_phot_simple.aper_phot_simple import (
     _curve_of_growth, _radial_profile)
 from jdaviz.configs.imviz.tests.utils import BaseDeconfiggedImage_WCS_WCS, BaseImviz_WCS_NoWCS
 from jdaviz.core.custom_units_and_equivs import PIX2
-from jdaviz.core.unit_conversion_utils import flux_conversion_general
+from jdaviz.core.unit_conversion_utils import flux_unit_conversion
 
 
 photutils.future_column_names = True
@@ -663,10 +663,8 @@ def _compare_image_table_units(orig_tab, new_tab, orig_unit, new_unit):
             orig_val = float(row['result']) * orig_u
 
             # Convert original value to new unit
-            orig_converted = flux_conversion_general(orig_val.value,
-                                                     orig_u,
-                                                     new_u,
-                                                     equivalencies=[])
+            orig_converted = flux_unit_conversion(
+                orig_val.value, orig_u, new_u, equivalencies=[])
 
             # Low rtol for match since phot table is rounded
             assert_quantity_allclose(orig_converted, new_val, rtol=1e-03)

--- a/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
+++ b/jdaviz/configs/specviz/plugins/line_analysis/line_analysis.py
@@ -29,7 +29,7 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         with_spinner)
 from jdaviz.core.user_api import PluginUserApi
 from jdaviz.core.tools import ICON_DIR
-from jdaviz.core.unit_conversion_utils import (check_if_unit_is_per_solid_angle,
+from jdaviz.core.unit_conversion_utils import (is_unit_per_solid_angle,
                                                coerce_unit)
 
 
@@ -383,8 +383,8 @@ class LineAnalysis(PluginTemplateMixin, DatasetSelectMixin, TableMixin,
                 else:
                     add_flux = False
 
-                solid_angle_in_flux_unit = check_if_unit_is_per_solid_angle(flux_unit,
-                                                                            return_unit=True)
+                solid_angle_in_flux_unit = is_unit_per_solid_angle(
+                    flux_unit, return_unit=True)
                 if solid_angle_in_flux_unit is None:
                     # use dimensionless_unscaled as a placeholder unit.
                     # is_equivalent() checks won't pass anyway if theres no

--- a/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/tests/test_unit_conversion.py
@@ -2,8 +2,10 @@ import numpy as np
 import pytest
 from astropy import units as u
 from astropy.nddata import InverseVariance
+from astropy.wcs import WCS
 from specutils import Spectrum
 
+from jdaviz.configs.imviz.tests.utils import _image_nddata_wcs
 from jdaviz.core.custom_units_and_equivs import SPEC_PHOTON_FLUX_DENSITY_UNITS
 
 
@@ -137,7 +139,7 @@ def test_non_stddev_uncertainty(deconfigged_helper):
     )
 
 
-@pytest.mark.parametrize("flux_unit, expected_choices", [(u.count, ['ct']),
+@pytest.mark.parametrize("flux_unit, expected_choices", [(u.count, []),
                                                          (u.Jy, SPEC_PHOTON_FLUX_DENSITY_UNITS),
                                                          (u.nJy, SPEC_PHOTON_FLUX_DENSITY_UNITS + ['nJy'])])  # noqa
 def test_flux_unit_choices(deconfigged_helper, flux_unit, expected_choices):
@@ -152,7 +154,10 @@ def test_flux_unit_choices(deconfigged_helper, flux_unit, expected_choices):
 
     uc_plg = deconfigged_helper.plugins['Unit Conversion']
 
-    assert uc_plg.flux_unit.selected == flux_unit.to_string()
+    if u.Unit(flux_unit) == u.ct:
+        assert uc_plg.flux_unit.selected == ''
+    else:
+        assert uc_plg.flux_unit.selected == flux_unit.to_string()
     assert uc_plg.flux_unit.choices == expected_choices
 
 
@@ -313,6 +318,82 @@ def test_image_deconfigged(deconfigged_helper, image_nddata_wcs):
                                          '337.5199835909 -20.8330552820 (deg)')
 
 
+def test_image_viewer_mouseover_unit(deconfigged_helper):
+    """
+    Test that the image viewer mouseover shows the correct flux unit for both
+    physical (Jy) and non-physical (counts) data loaded in separate viewers.
+    """
+    ct_img = _image_nddata_wcs(unit=u.ct)
+    jy_img = _image_nddata_wcs(unit=u.Jy)
+
+    # Load counts image into the default Image viewer
+    deconfigged_helper.load(ct_img, format='Image', data_label='ct_image')
+
+    # Create a second Image viewer and load Jy image into it
+    vc = deconfigged_helper.new_viewers['Image']
+    vc()
+    deconfigged_helper.load(jy_img, format='Image', data_label='jy_image',
+                            viewer='Image (1)')
+
+    ct_viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
+    jy_viewer = deconfigged_helper.viewers['Image (1)']._obj.glue_viewer
+    label_mouseover = deconfigged_helper._app.session.application._tools['g-coords-info']
+
+    label_mouseover._viewer_mouse_event(ct_viewer,
+                                        {'event': 'mousemove',
+                                         'domain': {'x': 1, 'y': 1}})
+    assert '+1.00000e+00 ct' in label_mouseover.as_text()[0]
+
+    label_mouseover._viewer_mouse_event(jy_viewer,
+                                        {'event': 'mousemove',
+                                         'domain': {'x': 1, 'y': 1}})
+    assert '+1.00000e+00 Jy' in label_mouseover.as_text()[0]
+
+
+def test_mixed_physical_nonphysical_flux_unit_load(deconfigged_helper):
+    """
+    Test that loading a non-physical (counts) cube does not set the global
+    flux display unit, but loading a physical (Jy) image afterwards does.
+    """
+    wcs_dict = {"CTYPE1": "WAVE-LOG", "CTYPE2": "DEC--TAN", "CTYPE3": "RA---TAN",
+                "CRVAL1": 4.622e-7, "CRVAL2": 27, "CRVAL3": 205,
+                "CDELT1": 8e-11, "CDELT2": 0.0001, "CDELT3": -0.0001,
+                "CRPIX1": 0, "CRPIX2": 0, "CRPIX3": 0, "PIXAR_SR": 8e-11}
+    w = WCS(wcs_dict)
+    flux = np.ones((5, 5, 5), dtype=np.float32)
+    cube = Spectrum(flux=flux * (u.ct / u.sr), wcs=w, meta=wcs_dict)
+
+    deconfigged_helper.load(cube, format='3D Spectrum', data_label='ct_cube')
+
+    uc_plg = deconfigged_helper.plugins['Unit Conversion']
+
+    # non-physical flux should not populate the global flux display unit
+    assert uc_plg.flux_unit.selected == ''
+    assert uc_plg.flux_unit.choices == []
+
+    # loading a physical image should set the global flux display unit
+    jy_img = _image_nddata_wcs(unit=u.Jy / u.sr)
+    deconfigged_helper.load(jy_img, format='Image', data_label='jy_image')
+
+    assert uc_plg.flux_unit.selected == 'Jy'
+    assert uc_plg.flux_unit.choices == SPEC_PHOTON_FLUX_DENSITY_UNITS
+
+    # cube viewer should show native ct / sr despite the global display unit being Jy
+    cube_viewer = deconfigged_helper.viewers['3D Spectrum']._obj.glue_viewer
+    image_viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
+    label_mouseover = deconfigged_helper._app.session.application._tools['g-coords-info']
+
+    label_mouseover._viewer_mouse_event(cube_viewer,
+                                        {'event': 'mousemove',
+                                         'domain': {'x': 2, 'y': 2}})
+    assert '+1.00000e+00 ct / sr' in label_mouseover.as_text()[0]
+
+    label_mouseover._viewer_mouse_event(image_viewer,
+                                        {'event': 'mousemove',
+                                         'domain': {'x': 1, 'y': 1}})
+    assert '+1.00000e+00 Jy / sr' in label_mouseover.as_text()[0]
+
+
 def test_data_unload_reload(specviz2d_helper):
     """
     Test that when data is loaded (which sets ths initial unit selection
@@ -456,7 +537,55 @@ def test_mixed_1d_2d_spectral_unit_load_order(deconfigged_helper, pix_spec, dim_
     assert u.Unit(plg.spectral_unit.selected) == u.Unit('Hz')
 
 
-def test_plugin_enabled_disabled(deconfigged_helper, sky_coord_only_source_catalog, spectrum1d):
+@pytest.mark.parametrize('ct_spec', ['1d', '2d'])
+@pytest.mark.parametrize('dim_1d_first', [True, False])
+def test_mixed_1d_2d_flux_unit_load_order(deconfigged_helper, ct_spec, dim_1d_first):
+    """
+    Test loading a 1D and a 2D spectrum in either order, with counts flux on
+    either the 1D or 2D spectrum. Flux unit choices should be populated from
+    the physical-unit spectrum regardless of load order, and flux unit
+    conversion should work without errors.
+    """
+    spec_1d_flux = u.ct if ct_spec == '1d' else u.Jy
+    spec_2d_flux = u.ct if ct_spec == '2d' else u.Jy
+
+    spec_1d = Spectrum(flux=[1, 2, 3] * spec_1d_flux,
+                       spectral_axis=[1, 2, 3] * u.nm)
+    spec_2d = Spectrum(flux=np.ones((3, 3)) * spec_2d_flux,
+                       spectral_axis=[1, 2, 3] * u.nm,
+                       spectral_axis_index=-1)
+
+    # whether the first-loaded spectrum has non-physical (counts) flux
+    first_is_ct = (dim_1d_first and ct_spec == '1d') or (not dim_1d_first and ct_spec == '2d')
+
+    if dim_1d_first:
+        deconfigged_helper.load(spec_1d, data_label='spec_1d', format='1D Spectrum')
+        plg = deconfigged_helper.plugins["Unit Conversion"]
+        if first_is_ct:
+            assert plg.flux_unit.selected == ''
+        else:
+            assert u.Unit(plg.flux_unit.selected) == u.Jy
+        deconfigged_helper.load(spec_2d, data_label='spec_2d', format='2D Spectrum')
+    else:
+        deconfigged_helper.load(spec_2d, data_label='spec_2d', format='2D Spectrum')
+        plg = deconfigged_helper.plugins["Unit Conversion"]
+        if first_is_ct:
+            assert plg.flux_unit.selected == ''
+        else:
+            assert u.Unit(plg.flux_unit.selected) == u.Jy
+        deconfigged_helper.load(spec_1d, data_label='spec_1d', format='1D Spectrum')
+
+    # after both are loaded, choices should be populated from the Jy spectrum
+    assert len(plg.flux_unit.choices) > 0
+    assert u.Unit(plg.flux_unit.selected) == u.Jy
+
+    # converting to MJy should not raise errors
+    plg.flux_unit = 'MJy'
+    assert u.Unit(plg.flux_unit.selected) == u.MJy
+
+
+def test_plugin_enabled_disabled(deconfigged_helper, sky_coord_only_source_catalog,
+                                 image_nddata_wcs, spectrum1d):
     """
     Test that the Unit Conversion plugin is enabled when data is loaded in a
     relevant viewer, disabled when all data is removed, and re-enabled when
@@ -466,6 +595,8 @@ def test_plugin_enabled_disabled(deconfigged_helper, sky_coord_only_source_catal
 
     plg = deconfigged_helper.plugins["Unit Conversion"]
 
+    msg = 'Unit Conversion unavailable without data loaded in a viewer'
+
     # plugin should be enabled when data is loaded
     assert plg._obj.disabled_msg == ''
 
@@ -473,15 +604,47 @@ def test_plugin_enabled_disabled(deconfigged_helper, sky_coord_only_source_catal
     dm = deconfigged_helper.viewers['1D Spectrum'].data_menu
     dm.layer.selected = ['test']
     dm.remove_from_viewer()
-    assert plg._obj.disabled_msg == 'Unit Conversion unavailable without data loaded in a viewer'
+    assert plg._obj.disabled_msg == msg
 
     # load a catalog, which will be added to a new scatter viewer by default.
     # the unit conversion plugin should still be disabled since the check for
     # relevancy is for data in spectrum/image/cube viewers
     deconfigged_helper.load(sky_coord_only_source_catalog, format='Catalog')
     assert 'Scatter' in deconfigged_helper.viewers
-    assert plg._obj.disabled_msg == 'Unit Conversion unavailable without data loaded in a viewer'
+    assert plg._obj.disabled_msg == msg
 
-    # add the data back to the spectrum viewer, plugin should be reenabled
-    dm.add_data('test')
+    # loading an image should re-enable the plugin
+    deconfigged_helper.load(image_nddata_wcs, format='Image',
+                            data_label='test_image')
     assert plg._obj.disabled_msg == ''
+
+
+def test_unit_reset_on_all_data_removed(deconfigged_helper, spectrum1d):
+    """
+    Test that unit selections are reset when all data is removed from the app.
+    """
+    deconfigged_helper.load(spectrum1d, data_label='spec', format='1D Spectrum')
+
+    plg = deconfigged_helper.plugins["Unit Conversion"]._obj
+    # make sure the initial unit selections match the loaded data
+    assert plg.spectral_unit_selected == 'Angstrom'
+    assert plg.flux_unit_selected == 'Jy'
+
+    # remove the data from the app
+    app = deconfigged_helper._app
+    deconfigged_helper._app.data_collection.remove(app.data_collection['spec'])
+
+    assert len(app.data_collection) == 0
+
+    # all unit selections should be cleared
+    assert plg.spectral_unit_selected == ''
+    assert plg.flux_unit_selected == ''
+    assert plg.angle_unit_selected == ''
+    assert plg.sb_unit_selected == ''
+    assert plg.spectral_unit.choices == []
+    assert plg.flux_unit.choices == []
+
+    # check that loading new data after all data was removed resets the units
+    deconfigged_helper.load(spectrum1d, data_label='spec2', format='1D Spectrum')
+    assert plg.spectral_unit_selected == 'Angstrom'
+    assert plg.flux_unit_selected == 'Jy'

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -2,11 +2,12 @@ from contextlib import nullcontext
 
 from astropy import units as u
 from glue.core import Data as glue_core_data
+from glue.core.message import DataCollectionDeleteMessage
 from glue.core.subset_group import GroupedSubset
 from glue_jupyter.bqplot.image import BqplotImageView
-from specutils import Spectrum
-from traitlets import List, Unicode, observe, Bool
 from specreduce import tracing
+from specutils import Spectrum
+from traitlets import Bool, List, Unicode, observe
 
 from jdaviz.configs.default.plugins.viewers import JdavizProfileView
 from jdaviz.configs.specviz.plugins.viewers import Spectrum1DViewer
@@ -17,32 +18,16 @@ from jdaviz.core.events import (GlobalDisplayUnitChanged, AddDataMessage,
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin, UnitSelectPluginComponent,
                                         SelectPluginComponent, PluginUserApi)
-from jdaviz.core.unit_conversion_utils import (create_equivalent_spectral_axis_units_list,
+from jdaviz.core.unit_conversion_utils import (create_equivalent_angle_units_list,
                                                create_equivalent_flux_units_list,
-                                               check_if_unit_is_per_solid_angle,
-                                               create_equivalent_angle_units_list,
+                                               create_equivalent_spectral_axis_units_list,
                                                flux_to_sb_unit,
-                                               is_physical_spectral_unit)
+                                               is_physical_flux_unit,
+                                               is_physical_spectral_unit,
+                                               is_unit_per_solid_angle,
+                                               valid_glue_display_unit)
 
 __all__ = ['UnitConversion']
-
-
-def _valid_glue_display_unit(unit_str, viewer, axis='x'):
-    # need to make sure the unit string is formatted according to the list of valid choices
-    # that glue will accept (may not be the same as the defaults of the installed version of
-    # astropy)
-    if not unit_str or not viewer:
-        return unit_str
-    unit_u = u.Unit(unit_str)
-    if not hasattr(viewer.state.__class__, f'{axis}_display_unit'):
-        return unit_str
-    choices_str = getattr(viewer.state.__class__, f'{axis}_display_unit').get_choices(viewer.state)  # noqa
-    choices_str = [choice for choice in choices_str if choice is not None]
-    choices_u = [u.Unit(choice) for choice in choices_str]
-    if unit_u not in choices_u:
-        raise ValueError(f"{unit_str} could not find match in valid {axis} display units {choices_str}")  # noqa
-    ind = choices_u.index(unit_u)
-    return choices_str[ind]
 
 
 @tray_registry('g-unit-conversion', label="Unit Conversion",
@@ -124,6 +109,8 @@ class UnitConversion(PluginTemplateMixin):
                                    handler=self._on_add_data_to_viewer)
         self.session.hub.subscribe(self, RemoveDataMessage,
                                    handler=self._on_remove_data_from_viewer)
+        self.session.hub.subscribe(self, DataCollectionDeleteMessage,
+                                   handler=self._on_data_collection_delete)
         self.session.hub.subscribe(self, ViewerRemovedMessage,
                                    handler=self._on_viewer_removed)
         self.session.hub.subscribe(self, SliceValueUpdatedMessage,
@@ -240,9 +227,26 @@ class UnitConversion(PluginTemplateMixin):
             # if layers do remain in the viewer, re-validate and re-apply the
             # current spectral x unit to the viewer state and refresh plot axes.
             elif viewer.reference == 'spectrum-viewer' and len(viewer.layers):
-                xunit = _valid_glue_display_unit(self.spectral_unit.selected, viewer, 'x')
+                xunit = valid_glue_display_unit(self.spectral_unit.selected, viewer, 'x')
                 viewer.state.x_display_unit = xunit
                 viewer.set_plot_axes()
+
+    def _on_data_collection_delete(self, msg):
+        if len(self._app.data_collection) == 0:
+            self._reset_unit_selections()
+
+    def _reset_unit_selections(self):
+        """Clear all unit selections when no data remains in the app."""
+        self.spectral_unit.choices = []
+        self.flux_unit.choices = []
+        self.angle_unit.choices = []
+        self.time_unit.choices = []
+        self.spectral_unit_selected = ''
+        self.flux_unit_selected = ''
+        self.angle_unit_selected = ''
+        self.sb_unit_selected = ''
+        self.time_unit_selected = ''
+        self.spectral_y_type_selected = ''
 
     def _on_viewer_removed(self, msg):
 
@@ -293,7 +297,7 @@ class UnitConversion(PluginTemplateMixin):
                 display_unit = u.Unit(self.spectral_unit_selected)
                 unit_types = [str(x) for x in [orig_unit.physical_type, display_unit.physical_type]]
                 if unit_types.count('unknown') + unit_types.count('dimensionless') != 1:
-                    xunit = _valid_glue_display_unit(self.spectral_unit.selected, viewer, 'x')
+                    xunit = valid_glue_display_unit(self.spectral_unit.selected, viewer, 'x')
                     viewer.state.x_display_unit = xunit
                     viewer.set_plot_axes()
 
@@ -323,15 +327,16 @@ class UnitConversion(PluginTemplateMixin):
                     except ValueError:
                         self.spectral_unit.selected = ''
 
-                angle_unit = check_if_unit_is_per_solid_angle(data_obj.flux.unit, return_unit=True)
+                angle_unit = is_unit_per_solid_angle(data_obj.flux.unit, return_unit=True)
                 flux_unit = data_obj.flux.unit if angle_unit is None else data_obj.flux.unit * angle_unit  # noqa
 
                 if not self.flux_unit_selected:
-                    self.flux_unit.choices = create_equivalent_flux_units_list(flux_unit)
-                    try:
-                        self.flux_unit.selected = str(flux_unit)
-                    except ValueError:
-                        self.flux_unit.selected = ''
+                    if is_physical_flux_unit(flux_unit):
+                        self.flux_unit.choices = create_equivalent_flux_units_list(flux_unit)
+                        try:
+                            self.flux_unit.selected = str(flux_unit)
+                        except ValueError:
+                            self.flux_unit.selected = ''
 
                 if not self.angle_unit_selected:
                     self.angle_unit.choices = create_equivalent_angle_units_list(angle_unit)
@@ -359,6 +364,13 @@ class UnitConversion(PluginTemplateMixin):
                         self.spectral_y_type_selected = 'Flux'
                     else:
                         self.spectral_y_type_selected = 'Surface Brightness'
+
+                # for non-physical flux (counts/DN), set sb_unit_selected directly
+                # from the native flux and angle units so the Flux<->SB toggle works
+                if (not self.flux_unit_selected and not self.sb_unit_selected
+                        and self.angle_unit_selected):
+                    self.sb_unit_selected = flux_to_sb_unit(
+                        str(flux_unit), self.angle_unit_selected)
 
                 # setting default values will trigger the observes to set the units
                 # in _on_unit_selected, so return here to avoid setting twice
@@ -404,20 +416,23 @@ class UnitConversion(PluginTemplateMixin):
                 if not self.flux_unit_selected:
                     flux_unit = data_obj.flux.unit if hasattr(data_obj, 'flux') else data_obj.unit
                     # get flux/sb unit from data object, and solid angle to turn sb into flux
-                    angle_unit = check_if_unit_is_per_solid_angle(flux_unit,
-                                                                  return_unit=True)
+                    angle_unit = is_unit_per_solid_angle(flux_unit, return_unit=True)
                     flux_unit = flux_unit if angle_unit is None else flux_unit * angle_unit  # noqa
 
-                    self.flux_unit.choices = create_equivalent_flux_units_list(flux_unit)
-                    try:
-                        self.flux_unit.selected = str(flux_unit)
-                    except ValueError:
-                        self.flux_unit.selected = ''
+                    if is_physical_flux_unit(flux_unit):
+                        self.flux_unit.choices = create_equivalent_flux_units_list(flux_unit)
+                        try:
+                            self.flux_unit.selected = str(flux_unit)
+                        except ValueError:
+                            self.flux_unit.selected = ''
 
                 if not self.angle_unit_selected:
-                    flux_unit = data_obj.flux.unit if hasattr(data_obj, 'flux') else data_obj.unit
-                    angle_unit = check_if_unit_is_per_solid_angle(flux_unit,
-                                                                  return_unit=True)
+                    # reuse values computed above if available, otherwise derive them now
+                    if not self.flux_unit_selected:
+                        pass  # flux_unit and angle_unit already set above
+                    else:
+                        _raw = data_obj.flux.unit if hasattr(data_obj, 'flux') else data_obj.unit
+                        angle_unit = is_unit_per_solid_angle(_raw, return_unit=True)
                     self.angle_unit.choices = create_equivalent_angle_units_list(angle_unit)
                     try:
                         if angle_unit is None:
@@ -447,8 +462,9 @@ class UnitConversion(PluginTemplateMixin):
              'time_unit_selected')
     def _on_unit_selected(self, msg):
         """
-        When any user selection is made, update the relevant viewer(s) with the new unit,
-        and then emit a GlobalDisplayUnitChanged message to notify other plugins of the change.
+        When any user selection is made, update the relevant viewer(s) with the
+        new unit, and then emit a GlobalDisplayUnitChanged message to notify
+        other plugins of the change.
         """
         if not len(msg.get('new', '')):
             # empty string, nothing to set yet
@@ -461,7 +477,7 @@ class UnitConversion(PluginTemplateMixin):
                 if not (is_physical_spectral_unit(self.spectral_unit.selected)
                         and is_physical_spectral_unit(sv.state.x_display_unit)):
                     continue
-                xunit = _valid_glue_display_unit(self.spectral_unit.selected, sv, 'x')
+                xunit = valid_glue_display_unit(self.spectral_unit.selected, sv, 'x')
                 sv.state.x_display_unit = xunit
                 sv.set_plot_axes()
             for s2dv in self.spectrum_2d_viewers:
@@ -470,7 +486,9 @@ class UnitConversion(PluginTemplateMixin):
                 if not (is_physical_spectral_unit(self.spectral_unit.selected)
                         and is_physical_spectral_unit(s2dv.state.x_display_unit)):
                     continue
-                xunit = _valid_glue_display_unit(self.spectral_unit.selected, s2dv, 'x')
+                xunit = valid_glue_display_unit(self.spectral_unit.selected, s2dv, 'x')
+                s2dv.state.x_display_unit = xunit
+                s2dv.set_plot_axes()
 
         elif axis == 'flux':
             # handle spectral y-unit first since that is a more apparent change to the user
@@ -478,6 +496,9 @@ class UnitConversion(PluginTemplateMixin):
             if self.spectral_y_type_selected == 'Flux':
                 self._handle_spectral_y_unit()
             for sv in self.spectrum_1d_viewers:
+                if not (is_physical_flux_unit(self.flux_unit.selected)
+                        and is_physical_flux_unit(sv.state.y_display_unit)):
+                    continue
                 sv.set_plot_axes()
 
             if len(self.angle_unit_selected):
@@ -500,11 +521,14 @@ class UnitConversion(PluginTemplateMixin):
         elif axis == 'sb':
             # handle spectral y-unit first since that is a more apparent change to the user
             # and feels laggy if it is done later
-            if self.spectral_y_type and self.spectral_y_type_selected == 'Surface Brightness':
+            if self.spectral_y_type_selected == 'Surface Brightness':
                 self._handle_spectral_y_unit()
 
             self._handle_attribute_display_unit(self.sb_unit_selected)
             for sv in self.spectrum_1d_viewers:
+                if not (is_physical_flux_unit(self.sb_unit_selected)
+                        and is_physical_flux_unit(sv.state.y_display_unit)):
+                    continue
                 sv.set_plot_axes()
 
         # custom axes downstream can override _on_unit_selected if anything needs to be
@@ -523,14 +547,21 @@ class UnitConversion(PluginTemplateMixin):
         GlobalDisplayUnitChanged message to notify
         """
         if self.spectral_y_type_selected:
-            yunit = _valid_glue_display_unit(self.spectral_y_unit, self.spectrum_viewer, 'y')
+            yunit = valid_glue_display_unit(self.spectral_y_unit, self.spectrum_viewer, 'y')
         elif self.sb_unit_selected:
-            yunit = _valid_glue_display_unit(self.sb_unit_selected, self.spectrum_viewer, 'y')
+            yunit = valid_glue_display_unit(self.sb_unit_selected, self.spectrum_viewer, 'y')
         else:
-            yunit = _valid_glue_display_unit(self.flux_unit_selected, self.spectrum_viewer, 'y')
+            yunit = valid_glue_display_unit(self.flux_unit_selected, self.spectrum_viewer, 'y')
+
+        if not yunit:
+            return
 
         spectral_y_change = False
         for sv in self.spectrum_1d_viewers:
+            sv_yunit = sv.state.y_display_unit
+            # skip only if switching between incompatible types (physical <-> non-physical)
+            if sv_yunit and is_physical_flux_unit(yunit) != is_physical_flux_unit(sv_yunit):
+                continue
 
             if self.spectral_unit.selected != yunit:
                 spectral_y_change = True
@@ -586,5 +617,5 @@ class UnitConversion(PluginTemplateMixin):
             else:
                 ctx = nullcontext()
             with ctx:
-                layer.state.attribute_display_unit = _valid_glue_display_unit(
+                layer.state.attribute_display_unit = valid_glue_display_unit(
                     attr_unit, layer, 'attribute')

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -20,7 +20,7 @@ from jdaviz.core.registries import viewer_registry
 from jdaviz.core.marks import SpectralLine
 from jdaviz.core.linelists import load_preset_linelist, get_available_linelists
 from jdaviz.core.unit_conversion_utils import (spectral_unit_conversion,
-                                               flux_conversion_general,
+                                               flux_unit_conversion,
                                                all_flux_unit_conversion_equivs)
 from jdaviz.utils import SPECTRAL_AXIS_COMP_LABELS
 from jdaviz.core.freezable_state import FreezableProfileViewerState
@@ -80,7 +80,7 @@ class Spectrum1DViewer(JdavizProfileView, WithSliceIndicator):
                 return False
             equivs = all_flux_unit_conversion_equivs(cube_wave=[1]*u.Unit(viewer_xunit))
             try:
-                flux_conversion_general([1], data_yunit, viewer_yunit, equivalencies=equivs)
+                flux_unit_conversion([1], data_yunit, viewer_yunit, equivalencies=equivs)
             except u.UnitConversionError:
                 return False
 

--- a/jdaviz/configs/specviz2d/plugins/cross_dispersion_profile/cross_dispersion_profile.py
+++ b/jdaviz/configs/specviz2d/plugins/cross_dispersion_profile/cross_dispersion_profile.py
@@ -15,7 +15,7 @@ from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (DatasetSelect, PluginTemplateMixin,
                                         PlotMixin)
 from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
-                                               flux_conversion_general)
+                                               flux_unit_conversion)
 from jdaviz.core.user_api import PluginUserApi
 
 __all__ = ['CrossDispersionProfile']
@@ -355,8 +355,8 @@ class CrossDispersionProfile(PluginTemplateMixin, PlotMixin):
                 wav = None
             eqv = all_flux_unit_conversion_equivs(data.meta.get('PIXAR_SR', 1.0),
                                                   wav)
-            profile = flux_conversion_general(profile.value, profile.unit,
-                                              self.flux_display_unit, eqv)
+            profile = flux_unit_conversion(
+                profile.value, profile.unit, self.flux_display_unit, eqv)
 
         self._profile = profile
 

--- a/jdaviz/core/freezable_state.py
+++ b/jdaviz/core/freezable_state.py
@@ -9,7 +9,7 @@ from glue.viewers.matplotlib.state import DeferredDrawCallbackProperty as DDCPro
 
 from jdaviz.utils import get_reference_image_data
 from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
-                                               flux_conversion_general,
+                                               flux_unit_conversion,
                                                spectral_unit_conversion)
 
 __all__ = ['FreezableState', 'FreezableProfileViewerState', 'FreezableBqplotImageViewerState']
@@ -104,7 +104,7 @@ class FreezableProfileViewerState(ProfileViewerState, FreezableState):
                 eqv = all_flux_unit_conversion_equivs(cube_wave=spectral_axis)
                 spectral_axis = None
 
-            y_corners_new = flux_conversion_general(y_corners, old_unit, new_unit, eqv, with_unit=False)  # noqa
+            y_corners_new = flux_unit_conversion(y_corners, old_unit, new_unit, eqv, with_unit=False)  # noqa
 
             with delay_callback(self, 'y_min', 'y_max'):
                 self.y_min = np.nanmin(y_corners_new)

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -34,8 +34,8 @@ from jdaviz.core.user_api import (DataApi, SpectralDataApi, SpatialDataApi,
 from jdaviz.utils import (JDAVIZ_CONFIGS, data_has_valid_wcs, CONFIGS_WITH_LOADERS,
                           suppress_widget_comms)
 from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
-                                               check_if_unit_is_per_solid_angle,
-                                               flux_conversion_general,
+                                               is_unit_per_solid_angle,
+                                               flux_unit_conversion,
                                                spectral_unit_conversion)
 
 
@@ -677,8 +677,8 @@ class ConfigHelper(HubListener):
                 # starting the app? ideally this should raise an error, and this
                 # should allow pix2/spaxel but it doesn't - keeping this
                 # condition as-is until further investigation
-                orig_sa = check_if_unit_is_per_solid_angle(u.Unit(data.flux.unit))
-                targ_sa = check_if_unit_is_per_solid_angle(u.Unit(y_unit))
+                orig_sa = is_unit_per_solid_angle(u.Unit(data.flux.unit))
+                targ_sa = is_unit_per_solid_angle(u.Unit(y_unit))
                 skip_flux_conv = ('_pixel_scale_factor' not in data.meta) & (orig_sa != targ_sa)
 
                 # equivalencies for flux/sb unit conversions
@@ -701,29 +701,31 @@ class ConfigHelper(HubListener):
                         new_uncert = uncertainty
 
                     # convert uncertainty units to display units
-                    if skip_flux_conv:
+                    if skip_flux_conv or not y_unit:
                         new_uncert = StdDevUncertainty(new_uncert, unit=data.flux.unit)
                     else:
-                        new_uncert_conv = flux_conversion_general(new_uncert.quantity.value,
-                                                                  new_uncert.unit,
-                                                                  y_unit,
-                                                                  eqv,
-                                                                  with_unit=False)
+                        new_uncert_conv = flux_unit_conversion(
+                            new_uncert.quantity.value,
+                            new_uncert.unit,
+                            y_unit,
+                            eqv,
+                            with_unit=False)
                         new_uncert = StdDevUncertainty(new_uncert_conv,
                                                        unit=y_unit)
                 else:
                     new_uncert = None
 
                 # convert flux/sb units to display units
-                if skip_flux_conv:
+                if skip_flux_conv or not y_unit:
                     new_y = data.flux.value * u.Unit(data.flux.unit)
                 else:
                     # multiply by unit rather than using with_unit because of
                     # edge case for dimensionless we want here
-                    new_y = flux_conversion_general(data.flux.value,
-                                                    data.flux.unit,
-                                                    y_unit,
-                                                    eqv, with_unit=False) * u.Unit(y_unit)
+                    new_y = flux_unit_conversion(
+                        data.flux.value,
+                        data.flux.unit,
+                        y_unit,
+                        eqv, with_unit=False) * u.Unit(y_unit)
 
                 # convert spectral axis to display units
                 if spectral_unit != '' and data.spectral_axis.unit != spectral_unit:

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
@@ -15,7 +15,7 @@ from jdaviz.core.loaders.importers.image.image import _spatial_assign_component_
 from jdaviz.core.template_mixin import (AutoTextField,
                                         SelectPluginComponent,
                                         ViewerSelectCreateNew)
-from jdaviz.core.unit_conversion_utils import (check_if_unit_is_per_solid_angle,
+from jdaviz.core.unit_conversion_utils import (is_unit_per_solid_angle,
                                                _eqv_flux_to_sb_pixel)
 from jdaviz.core.user_api import ImporterUserApi
 
@@ -453,9 +453,9 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
         sp = self.spectrum
 
         # convert flux and uncertainty to per-pix2 if input is not a surface brightness
-        if not check_if_unit_is_per_solid_angle(sp.flux.unit):
+        if not is_unit_per_solid_angle(sp.flux.unit):
             target_flux_unit = sp.flux.unit / PIX2
-        elif check_if_unit_is_per_solid_angle(sp.flux.unit, return_unit=True) == "spaxel":
+        elif is_unit_per_solid_angle(sp.flux.unit, return_unit=True) == "spaxel":
             # We need to convert spaxel to pix2, since spaxel isn't fully supported by astropy
             # This is horribly ugly but just multiplying by u.Unit("spaxel") doesn't work
             target_flux_unit = sp.flux.unit * u.Unit('spaxel') / PIX2

--- a/jdaviz/core/loaders/importers/spectrum_common.py
+++ b/jdaviz/core/loaders/importers/spectrum_common.py
@@ -16,7 +16,7 @@ from traitlets import Any, Bool, List, Unicode, observe
 
 from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.template_mixin import SelectFileExtensionComponent
-from jdaviz.core.unit_conversion_utils import check_if_unit_is_per_solid_angle
+from jdaviz.core.unit_conversion_utils import is_unit_per_solid_angle
 from jdaviz.core.custom_units_and_equivs import PIX2, _eqv_flux_to_sb_pixel
 from jdaviz.utils import (standardize_metadata,
                           create_data_hash,
@@ -680,9 +680,9 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
         apply_pix2 = 'FLUX' in self.extension.selected or 'ERR' in self.extension.selected
         flux = sc.flux
         if (apply_pix2 and
-                (not check_if_unit_is_per_solid_angle(flux.unit))):
+                (not is_unit_per_solid_angle(flux.unit))):
             target_flux_unit = flux.unit / PIX2
-        elif check_if_unit_is_per_solid_angle(flux.unit, return_unit=True) == "spaxel":
+        elif is_unit_per_solid_angle(flux.unit, return_unit=True) == "spaxel":
             # We need to convert spaxel to pixel squared, since spaxel isn't fully supported
             # by astropy
             # This is horribly ugly but just multiplying by u.Unit("spaxel") doesn't work

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -12,8 +12,8 @@ from jdaviz.core.events import (SliceToolStateMessage, LineIdentifyMessage,
                                 SpectralMarksChangedMessage,
                                 RedshiftMessage)
 from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
-                                               check_if_unit_is_per_solid_angle,
-                                               flux_conversion_general,
+                                               is_unit_per_solid_angle,
+                                               flux_unit_conversion,
                                                spectral_unit_conversion)
 
 
@@ -218,7 +218,7 @@ class PluginMark:
 
         # spectrum y-values in viewer have already been converted, don't convert again
         # if a spectral_y_type is changed, just update the unit
-        if self.yunit is not None and check_if_unit_is_per_solid_angle(self.yunit) != check_if_unit_is_per_solid_angle(unit):  # noqa
+        if self.yunit is not None and is_unit_per_solid_angle(self.yunit) != is_unit_per_solid_angle(unit):  # noqa
             self.yunit = unit
             return
 
@@ -237,8 +237,8 @@ class PluginMark:
                 else:
                     wave = self.x * self.xunit
                 equivs = all_flux_unit_conversion_equivs(pixar_sr, wave)
-                y = flux_conversion_general(self.y, self.yunit, unit,
-                                            equivs, with_unit=False)
+                y = flux_unit_conversion(
+                    self.y, self.yunit, unit, equivs, with_unit=False)
 
             self.y = y
 

--- a/jdaviz/core/tests/test_unit_conversion_utils.py
+++ b/jdaviz/core/tests/test_unit_conversion_utils.py
@@ -8,10 +8,10 @@ from jdaviz.core.custom_units_and_equivs import (PIX2,
                                                  SPEC_PHOTON_FLUX_DENSITY_UNITS,
                                                  _eqv_pixar_sr)
 from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
-                                               check_if_unit_is_per_solid_angle,
+                                               is_unit_per_solid_angle,
                                                combine_flux_and_angle_units,
-                                               flux_conversion_general,
-                                               handle_squared_flux_unit_conversions,
+                                               flux_unit_conversion,
+                                               squared_flux_unit_conversions,
                                                viewer_flux_conversion_equivalencies)
 
 
@@ -19,26 +19,26 @@ from jdaviz.core.unit_conversion_utils import (all_flux_unit_conversion_equivs,
     ('erg / sr', True), ('erg / (deg * deg)', True), ('erg / (deg * arcsec)', True),
     ('erg / (deg**2)', True), ('erg deg**-2', True), ('erg sr^-1', True),
     ('erg / degree', False), ('erg sr^-2', False)])
-def test_check_if_unit_is_per_solid_angle(unit, is_solid_angle):
+def test_is_unit_per_solid_angle(unit, is_solid_angle):
     # test function that tests if a unit string or u.Unit is per solid angle
-    assert check_if_unit_is_per_solid_angle(unit) == is_solid_angle
+    assert is_unit_per_solid_angle(unit) == is_solid_angle
 
     # turn string into u.Unit, and make sure it also passes
-    assert check_if_unit_is_per_solid_angle(u.Unit(unit)) == is_solid_angle
+    assert is_unit_per_solid_angle(u.Unit(unit)) == is_solid_angle
 
 
 def test_general_flux_conversion():
     """
-    This test function tests that the `flux_conversion_general` function is able
+    This test function tests that the `flux_unit_conversion` function is able
     to convert between all available flux units in the unit conversion plugin
     for data in spectral/photon flux density (e.g Jy, erg/s/cm2/A) or surface
-    brightness. `flux_conversion_general` handles special cases where flux and
+    brightness. `flux_unit_conversion` handles special cases where flux and
     surface brightness can't be converted directly, so it is used
     in place of astropy.units.to() across the application to handle flux/sb unit
     conversions. This test ensures that all advertised conversions are supported
     and correct.
 
-    Also tests the `handle_squared_flux_unit_conversions` function, which is used
+    Also tests the `squared_flux_unit_conversions` function, which is used
     to convert units for the aperture photometry table.
     """
 
@@ -51,8 +51,8 @@ def test_general_flux_conversion():
     all_convertable_units_sr = SPEC_PHOTON_FLUX_DENSITY_UNITS + sr_sbs
     for combo in combinations(all_convertable_units_sr, 2):
         original_unit, target_unit = (u.Unit(x) for x in combo)
-        converted = flux_conversion_general([1, 2, 3], original_unit,
-                                            target_unit, equivalencies)
+        converted = flux_unit_conversion(
+            [1, 2, 3], original_unit, target_unit, equivalencies)
         assert len(converted) == 3
 
     # next test all conversions between flux and surface brightness units (per
@@ -62,15 +62,15 @@ def test_general_flux_conversion():
     all_convertable_units_pix = set(all_convertable_units_pix) - set(all_convertable_units_sr)
     for combo in combinations(all_convertable_units_pix, 2):
         original_unit, target_unit = (u.Unit(x) for x in combo)
-        converted = flux_conversion_general([1, 2, 3], original_unit,
-                                            target_unit, equivalencies)
+        converted = flux_unit_conversion(
+            [1, 2, 3], original_unit, target_unit, equivalencies)
         assert len(converted) == 3
 
     # test that a unit combination passed in without the correct equivalency
     # raises the correct error
     msg = 'Could not convert Jy / pix2 to Jy / sr with provided equivalencies.'
     with pytest.raises(u.UnitConversionError, match=msg):
-        converted = flux_conversion_general([1, 2, 3], u.Jy / PIX2, u.Jy / u.sr)
+        converted = flux_unit_conversion([1, 2, 3], u.Jy / PIX2, u.Jy / u.sr)
 
     # and finally, numerically verify a subset of possible unit conversion combos
     # a case of each 'type' of conversion is covered here
@@ -90,13 +90,13 @@ def test_general_flux_conversion():
 
     equivalencies = all_flux_unit_conversion_equivs(pixar_sr=4, cube_wave=1*u.nm)
     for orig, targ, truth in units_and_expected:
-        converted_value = flux_conversion_general([1], orig, targ, equivalencies)
+        converted_value = flux_unit_conversion([1], orig, targ, equivalencies)
         assert_allclose(converted_value[0].value, truth)
         assert converted_value.unit == targ
 
         # as a bonus, also test the function that converts squared flux units
         # (relevant in aperture photometry)
-        sq = handle_squared_flux_unit_conversions(1, orig**2, targ**2, equivalencies)
+        sq = squared_flux_unit_conversions(1, orig**2, targ**2, equivalencies)
         assert_allclose(sq.value, truth**2, rtol=1e-06)
         assert sq.unit == targ ** 2
 
@@ -149,58 +149,61 @@ def test_general_flux_conversion_continuted():
                    ]
 
     for orig, targ, expected in test_combos:
-        converted = flux_conversion_general(values, orig, targ, equivs)
+        converted = flux_unit_conversion(values, orig, targ, equivs)
         assert_allclose(converted, expected * targ, rtol=1e-05)
 
     # some other misc test cases from previous test
-    converted = flux_conversion_general(1., u.MJy / u.sr,
-                                        u.erg / (u.s * u.cm**2 * u.Hz * u.sr),
-                                        equivs)
+    converted = flux_unit_conversion(
+        1., u.MJy / u.sr,
+        u.erg / (u.s * u.cm**2 * u.Hz * u.sr),
+        equivs)
     assert_allclose(converted, 1.e-17 * u.erg / (u.s * u.cm**2 * u.Hz * u.sr))
 
     # another old test case
-    converted = flux_conversion_general(10., u.MJy / u.sr, u.Jy / u.sr)
+    converted = flux_unit_conversion(10., u.MJy / u.sr, u.Jy / u.sr)
     assert_allclose(converted, 10000000. * u.Jy / u.sr)
 
     # Quantity scalar pixel scale factor
     eqv = _eqv_pixar_sr(0.1 * (u.sr / u.pix))
-    assert_allclose(flux_conversion_general(values, u.Jy / u.sr, u.Jy, eqv),
+    assert_allclose(flux_unit_conversion(values, u.Jy / u.sr, u.Jy, eqv),
                     [1, 2, 3] * u.Jy)
-    assert_allclose(flux_conversion_general(values, u.Jy, u.Jy / u.sr, eqv),
+    assert_allclose(flux_unit_conversion(values, u.Jy, u.Jy / u.sr, eqv),
                     [100, 200, 300] * u.Jy / u.sr)
 
     # values == 2
-    assert_allclose(flux_conversion_general([10, 20], u.Jy / u.sr, u.Jy, eqv),
+    assert_allclose(flux_unit_conversion([10, 20], u.Jy / u.sr, u.Jy, eqv),
                     [1, 2] * u.Jy)
-    assert_allclose(flux_conversion_general([10, 20], u.Jy, u.Jy / u.sr, eqv),
+    assert_allclose(flux_unit_conversion([10, 20], u.Jy, u.Jy / u.sr, eqv),
                     [100, 200] * u.Jy / u.sr)
 
     # array scale factor, same length arrays
-    res = flux_conversion_general(values, u.Jy / u.sr, u.Jy,
-                                  _eqv_pixar_sr([0.1, 0.2, 0.3]))
+    res = flux_unit_conversion(
+        values, u.Jy / u.sr, u.Jy,
+        _eqv_pixar_sr([0.1, 0.2, 0.3]))
     assert_allclose(res, [1., 4., 9.] * u.Jy)
 
-    res = flux_conversion_general(values, u.Jy, u.Jy / u.sr,
-                                  _eqv_pixar_sr([0.1, 0.2, 0.3]))
+    res = flux_unit_conversion(
+        values, u.Jy, u.Jy / u.sr,
+        _eqv_pixar_sr([0.1, 0.2, 0.3]))
     assert_allclose(res, [100, 100, 100] * u.Jy / u.sr)
 
     # array + quantity scale factor, same length arrays
     eqv = _eqv_pixar_sr([0.1, 0.2, 0.3] * (u.sr / u.pix))
-    assert_allclose(flux_conversion_general(values, u.Jy / u.sr, u.Jy, eqv),
+    assert_allclose(flux_unit_conversion(values, u.Jy / u.sr, u.Jy, eqv),
                     [1., 4., 9.] * u.Jy)
-    assert_allclose(flux_conversion_general(values, u.Jy, u.Jy / u.sr, eqv),
+    assert_allclose(flux_unit_conversion(values, u.Jy, u.Jy / u.sr, eqv),
                     [100, 100, 100] * u.Jy / u.sr)
 
     # values != 2 but _pixel_scale_factor size mismatch
     with pytest.raises(ValueError, match="operands could not be broadcast together"):
         eqv = _eqv_pixar_sr([0.1, 0.2, 0.3, 0.4])
-        flux_conversion_general(values, u.Jy / u.sr, u.Jy, eqv)
+        flux_unit_conversion(values, u.Jy / u.sr, u.Jy, eqv)
 
     # Other kind of flux conversion unrelated to _pixel_scale_factor.
     # The answer was obtained from synphot unit conversion.
     targ = [2.99792458e-12, 1.49896229e-12, 9.99308193e-13]
     targ *= (u.erg / (u.AA * u.cm * u.cm * u.s))
-    assert_allclose(flux_conversion_general(values, u.Jy, targ.unit, equivs), targ)
+    assert_allclose(flux_unit_conversion(values, u.Jy, targ.unit, equivs), targ)
 
 
 def test_viewer_flux_conversion():
@@ -222,11 +225,13 @@ def test_viewer_flux_conversion():
 
     # test for when scale factor array len > 2 but there are 2 values to be
     # converted, the min/max should be used. min_max = [0.1, 0.3]
-    res = flux_conversion_general([10, 20], u.Jy / u.sr, u.Jy,
-                                  viewer_equivs)
+    res = flux_unit_conversion(
+        [10, 20], u.Jy / u.sr, u.Jy,
+        viewer_equivs)
     assert_allclose(res, [1, 6] * u.Jy)
-    res = flux_conversion_general([10, 20], u.Jy, u.Jy / u.sr,
-                                  viewer_equivs)
+    res = flux_unit_conversion(
+        [10, 20], u.Jy, u.Jy / u.sr,
+        viewer_equivs)
     assert_allclose(res, [100, 66.66666666666667] * u.Jy / u.sr)
 
     # test converting 2 values when spectral axis for u.spectral,
@@ -234,5 +239,5 @@ def test_viewer_flux_conversion():
     values = [10, 20]
     targ = [2.99792458e-12, 5.99584916e-12]
     targ *= (u.erg / (u.AA * u.cm * u.cm * u.s))  # FLAM
-    assert_allclose(flux_conversion_general(values, u.Jy, targ.unit, viewer_equivs),
+    assert_allclose(flux_unit_conversion(values, u.Jy, targ.unit, viewer_equivs),
                     targ)

--- a/jdaviz/core/unit_conversion_utils.py
+++ b/jdaviz/core/unit_conversion_utils.py
@@ -11,17 +11,36 @@ from jdaviz.core.custom_units_and_equivs import (PIX2,
                                                  _eqv_flux_to_sb_pixel,
                                                  _spectral_and_photon_flux_density_units)
 
-__all__ = ["all_flux_unit_conversion_equivs", "check_if_unit_is_per_solid_angle",
+__all__ = ["all_flux_unit_conversion_equivs", "is_unit_per_solid_angle",
            "coerce_unit", "combine_flux_and_angle_units",
            "convert_integrated_sb_unit",
            "create_equivalent_angle_units_list",
            "create_equivalent_flux_units_list",
            "create_equivalent_spectral_axis_units_list",
-           "flux_conversion_general", "handle_squared_flux_unit_conversions",
+           "flux_unit_conversion", "squared_flux_unit_conversions",
            "is_physical_flux_unit", "is_physical_spectral_unit",
            "supported_sq_angle_units", "spectral_unit_conversion",
            "units_to_strings", "flux_to_sb_unit", "to_flux_density_unit",
-           "spectrum_ensure_flux_density_unit", "viewer_flux_conversion_equivalencies"]
+           "spectrum_ensure_flux_density_unit", "viewer_flux_conversion_equivalencies",
+           "valid_glue_display_unit"]
+
+
+def valid_glue_display_unit(unit_str, viewer, axis='x'):
+    """Return the canonical glue-formatted string for ``unit_str`` by matching
+    it against the valid choices for the given viewer axis."""
+    if not unit_str or not viewer:
+        return unit_str
+    unit_u = u.Unit(unit_str)
+    if not hasattr(viewer.state.__class__, f'{axis}_display_unit'):
+        return unit_str
+    choices_str = getattr(viewer.state.__class__, f'{axis}_display_unit').get_choices(viewer.state)  # noqa
+    choices_str = [choice for choice in choices_str if choice is not None]
+    choices_u = [u.Unit(choice) for choice in choices_str]
+    if unit_u not in choices_u:
+        raise ValueError(
+            f"{unit_str} could not find match in valid {axis} display units {choices_str}")
+    ind = choices_u.index(unit_u)
+    return choices_str[ind]
 
 
 def all_flux_unit_conversion_equivs(pixar_sr=None, cube_wave=None):
@@ -114,7 +133,7 @@ def viewer_flux_conversion_equivalencies(values, spec):
     return equivs
 
 
-def check_if_unit_is_per_solid_angle(unit, return_unit=False):
+def is_unit_per_solid_angle(unit, return_unit=False):
     """
     Check if a given Unit or unit string (that can be converted to
     a Unit) represents some unit per solid angle. If 'return_unit'
@@ -141,11 +160,11 @@ def check_if_unit_is_per_solid_angle(unit, return_unit=False):
 
     Examples
     --------
-    >>> check_if_unit_is_per_solid_angle('erg / (s cm^2 sr)')
+    >>> is_unit_per_solid_angle('erg / (s cm^2 sr)')
     True
-    >>> check_if_unit_is_per_solid_angle('erg / s cm^2')
+    >>> is_unit_per_solid_angle('erg / s cm^2')
     False
-    >>> check_if_unit_is_per_solid_angle('Jy * sr^-1')
+    >>> is_unit_per_solid_angle('Jy * sr^-1')
     True
 
     """
@@ -268,6 +287,13 @@ def is_physical_flux_unit(flux_unit):
         unit = u.Unit(flux_unit)
     except Exception:
         return False
+
+    # strip solid angle from SB units (e.g MJy/sr -> MJy) so that only
+    # the flux numerator is checked against physical flux density units
+    angle_unit = is_unit_per_solid_angle(unit, return_unit=True)
+    if angle_unit is not None:
+        unit = unit * angle_unit
+
     equiv = u.spectral_density(1 * u.m)
     for phys_unit in SPEC_PHOTON_FLUX_DENSITY_UNITS:
         if unit.is_equivalent(phys_unit, equiv):
@@ -389,7 +415,7 @@ def create_equivalent_spectral_axis_units_list(spectral_axis_unit,
     return sorted(units_to_strings(additional_units)) + spectral_axis_unit_equivalencies_titles
 
 
-def _check_if_unit_is_from_moment_map(unit):
+def unit_is_from_moment_map(unit):
     """
     Check if a unit is likely from a moment map to avoid attempting unit
     conversion on this data. Check for moment 0 by multiplying by length/freq unit
@@ -438,8 +464,8 @@ def _check_if_unit_is_from_moment_map(unit):
         return False
 
 
-def flux_conversion_general(values, original_unit, target_unit,
-                            equivalencies=None, with_unit=True):
+def flux_unit_conversion(values, original_unit, target_unit,
+                         equivalencies=None, with_unit=True):
     """
     Converts ``values`` from ``original_unit`` to ``target_unit`` using the
     provided ``equivalencies`` while handling special cases where direct unit
@@ -495,15 +521,22 @@ def flux_conversion_general(values, original_unit, target_unit,
     target_unit = u.Unit(target_unit)
 
     # get solid angle component of input and target (e.g sr in Jy/sr) if present
-    solid_angle_in_orig = check_if_unit_is_per_solid_angle(original_unit,
-                                                           return_unit=True)
-    solid_angle_in_targ = check_if_unit_is_per_solid_angle(target_unit,
-                                                           return_unit=True)
+    solid_angle_in_orig = is_unit_per_solid_angle(
+        original_unit, return_unit=True)
+    solid_angle_in_targ = is_unit_per_solid_angle(
+        target_unit, return_unit=True)
 
     # if the units being converted are likely from a moment map, skip conversion
     # (which will fail anyway) without erroring and just return input (with or
     # without units attached, as requested)
-    if _check_if_unit_is_from_moment_map(original_unit):
+    if unit_is_from_moment_map(original_unit):
+        if with_unit:
+            return values * original_unit
+        return values
+
+    # do not attempt to convert if either unit is pixel / dimensionless,
+    # to support mixed-unit viewing. If the units are the same, just return values
+    if not np.all([is_physical_flux_unit(x) for x in (original_unit, target_unit)]):
         if with_unit:
             return values * original_unit
         return values
@@ -544,11 +577,11 @@ def flux_conversion_general(values, original_unit, target_unit,
         return converted_values
 
 
-def handle_squared_flux_unit_conversions(value, original_unit=None,
-                                         target_unit=None, equivalencies=None):
+def squared_flux_unit_conversions(value, original_unit=None,
+                                  target_unit=None, equivalencies=None):
     """
-    Handles conversions between squared flux or surface brightness units
-    that cannot be directly converted, even with the correct equivalencies.
+    This function handles conversions between squared flux or surface brightness
+    units that cannot be directly converted, even with the correct equivalencies.
 
     This function is specifically designed to address cases where squared
     units, such as (MJy/sr)**2 to (Jy/sr)**2, appear in contexts like
@@ -574,11 +607,9 @@ def handle_squared_flux_unit_conversions(value, original_unit=None,
     """
 
     # get scale factor between non-squared units
-    converted = flux_conversion_general(1.,
-                                        original_unit ** 0.5,
-                                        target_unit ** 0.5,
-                                        equivalencies,
-                                        with_unit=False)
+    converted = flux_unit_conversion(
+        1., original_unit ** 0.5, target_unit ** 0.5,
+        equivalencies, with_unit=False)
 
     # square conversion factor and re-apply squared unit
     converted = converted ** 2 * value * target_unit
@@ -615,7 +646,8 @@ def spectral_unit_conversion(values, original_units, target_units, with_unit=Fal
     orig = u.Unit(original_units)
     targ = u.Unit(target_units)
 
-    # do not convert values if one of the units is pixel/dimensionless and the other is not.
+    # do not attempt to convert if either unit is pixel / dimensionless,
+    # to support mixed-unit viewing. If the units are the same, just return values
     if not np.all([is_physical_spectral_unit(x) for x in (orig, targ)]) and orig != targ:
         if with_unit:
             return values * orig
@@ -689,7 +721,7 @@ def convert_integrated_sb_unit(u1, spectral_axis_unit, desired_freq_unit, desire
     uu = u1 / spectral_axis_unit
 
     # multiply solid angle unit out of surface brightness to compare just flux components
-    flux = uu * check_if_unit_is_per_solid_angle(uu.unit, return_unit=True)
+    flux = uu * is_unit_per_solid_angle(uu.unit, return_unit=True)
 
     # then check if flux unit is a per-frequency or per-wavelength flux unit
     wav_units = _spectral_and_photon_flux_density_units(wav_only=True, as_units=True)
@@ -714,7 +746,8 @@ def convert_integrated_sb_unit(u1, spectral_axis_unit, desired_freq_unit, desire
 
 
 def flux_to_sb_unit(flux_unit, angle_unit):
-    if angle_unit not in supported_sq_angle_units(as_strings=True):
+    # use unit-object comparison to avoid string format mismatches (e.g. 'pix^2' vs 'pix2')
+    if u.Unit(angle_unit) not in supported_sq_angle_units():
         sb_unit = flux_unit
     else:
         # str > unit > str to remove formatting inconsistencies with
@@ -746,7 +779,7 @@ def to_flux_density_unit(input_unit, pixar_sr=1.0):
     # If it's surface brightness, convert to flux density
     elif input_unit.physical_type == 'surface brightness':
         # Extract the angle/pixel unit from the surface brightness unit
-        angle_unit = check_if_unit_is_per_solid_angle(input_unit, return_unit=True)
+        angle_unit = is_unit_per_solid_angle(input_unit, return_unit=True)
 
         # Use pixar_sr for pixel-based units, otherwise use the extracted angle unit
         if angle_unit == PIX2:

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -12,7 +12,7 @@ from jdaviz.core.config import get_configuration
 from jdaviz.app import PrivateApplication
 from jdaviz.utils import alpha_index
 from jdaviz.configs.default.plugins.gaussian_smooth.gaussian_smooth import GaussianSmooth
-from jdaviz.core.unit_conversion_utils import (flux_conversion_general,
+from jdaviz.core.unit_conversion_utils import (flux_unit_conversion,
                                                viewer_flux_conversion_equivalencies)
 
 
@@ -351,9 +351,9 @@ def test_to_unit(cubeviz_helper):
 
     spec = data.get_object(cls=Spectrum)
     viewer_equivs = viewer_flux_conversion_equivalencies(values, spec)
-    value = flux_conversion_general(values, original_units,
-                                    target_units, viewer_equivs,
-                                    with_unit=False)
+    value = flux_unit_conversion(
+        values, original_units, target_units, viewer_equivs,
+        with_unit=False)
 
     # will be a uniform array since not wavelength dependent
     # so test first value in array
@@ -366,9 +366,9 @@ def test_to_unit(cubeviz_helper):
     target_units = u.erg / u.cm**2 / u.s / u.AA
 
     viewer_equivs = viewer_flux_conversion_equivalencies(values, spec)
-    new_values = flux_conversion_general(values, original_units,
-                                         target_units, viewer_equivs,
-                                         with_unit=False)
+    new_values = flux_unit_conversion(
+        values, original_units, target_units, viewer_equivs,
+        with_unit=False)
 
     assert np.allclose(new_values,
                        (values * original_units)
@@ -383,9 +383,9 @@ def test_to_unit(cubeviz_helper):
     target_units = u.erg / u.cm**2 / u.s / u.AA
 
     viewer_equivs = viewer_flux_conversion_equivalencies(values, spec)
-    new_values = flux_conversion_general(values, original_units,
-                                         target_units, viewer_equivs,
-                                         with_unit=False)
+    new_values = flux_unit_conversion(
+        values, original_units, target_units, viewer_equivs,
+        with_unit=False)
 
     # In this case we do a regular spectral density conversion, but using the
     # first value in the spectral axis for the equivalency


### PR DESCRIPTION
this PR introduces some additional logic and fixes for flux conversion to avoid converting dimensionless data to current display unit, enabling mixed unit type viewer workflows to proceed without error