### PR TITLE
Fix escaping overlay window when overwriting a file in export plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,8 @@ New Features
   
 - Keep visibility consistent between blink and plot options. [#4316]
 
+- Change appearance of the overwrite warning overlay shown in the export plugin. [#4338]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -128,6 +128,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                                       'filename_auto',
                                       'filename_invalid_msg')
 
+        self.filename_trunc = self._filename_trunc(self.filename.value)
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Export data/plots and other outputs to a file.'
@@ -226,12 +227,11 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                                       'plugin_plot_items'],
                 irrelevant_msg_callback=self.relevant_if_any_truthy)
 
-    def _file_trunc(self):
-        filename = self.filename.value
+    def _filename_trunc(self, filename):
         if len(filename) >= 20:
-            self.filename_trunc = str(filename[0:10]) + '...' + str(filename[-10:])
+            return filename[:10] + '...' + filename[-10:]
         else:
-            self.filename_trunc = filename
+            return filename
 
     def _is_valid_item(self, item):
         return self._is_not_stcs(item) or self._is_stcs_region_supported(item)
@@ -371,9 +371,8 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
     @observe('filename_value')
     def _is_filename_changed(self, event):
-        filename = self.filename_value
-
-        self.file_name_trunc = self._file_trunc(filename)
+        filename = self.filename.value
+        self.filename_trunc = self._filename_trunc(filename)
 
         # Update the UI Filepath if relative or absolute paths are provided
         # by user via self.filename_value

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -127,11 +127,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                                       'filename_default',
                                       'filename_auto',
                                       'filename_invalid_msg')
-        filename = self.filename.value
-        if len(filename) >= 20:
-            self.filename_trunc = str(filename[0:10]) + '...' + str(filename[-10:])
-        else:
-            self.filename_trunc = filename
+
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Export data/plots and other outputs to a file.'
@@ -229,6 +225,13 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                                       'plugin_table_items',
                                       'plugin_plot_items'],
                 irrelevant_msg_callback=self.relevant_if_any_truthy)
+
+    def _file_trunc(self):
+        filename = self.filename.value
+        if len(filename) >= 20:
+            self.filename_trunc = str(filename[0:10]) + '...' + str(filename[-10:])
+        else:
+            self.filename_trunc = filename
 
     def _is_valid_item(self, item):
         return self._is_not_stcs(item) or self._is_stcs_region_supported(item)
@@ -370,10 +373,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     def _is_filename_changed(self, event):
         filename = self.filename_value
 
-        if len(filename) >= 20:
-            self.filename_trunc = filename[:10] + '...' + filename[-10:]
-        else:
-            self.filename_trunc = filename
+        self.file_name_trunc = self._file_trunc(filename)
 
         # Update the UI Filepath if relative or absolute paths are provided
         # by user via self.filename_value

--- a/jdaviz/configs/default/plugins/export/export.py
+++ b/jdaviz/configs/default/plugins/export/export.py
@@ -91,6 +91,7 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
     plugin_plot_format_selected = Unicode().tag(sync=True)
 
     filename_value = Unicode().tag(sync=True)
+    filename_trunc = Unicode().tag(sync=True)
     filename_default = Unicode().tag(sync=True)
     filename_auto = Bool(True).tag(sync=True)
     filename_invalid_msg = Unicode('').tag(sync=True)
@@ -126,6 +127,11 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
                                       'filename_default',
                                       'filename_auto',
                                       'filename_invalid_msg')
+        filename = self.filename.value
+        if len(filename) >= 20:
+            self.filename_trunc = str(filename[0:10]) + '...' + str(filename[-10:])
+        else:
+            self.filename_trunc = filename
 
         # description displayed under plugin title in tray
         self._plugin_description = 'Export data/plots and other outputs to a file.'
@@ -362,6 +368,13 @@ class Export(PluginTemplateMixin, ViewerSelectMixin, SubsetSelectMixin,
 
     @observe('filename_value')
     def _is_filename_changed(self, event):
+        filename = self.filename_value
+
+        if len(filename) >= 20:
+            self.filename_trunc = filename[:10] + '...' + filename[-10:]
+        else:
+            self.filename_trunc = filename
+
         # Update the UI Filepath if relative or absolute paths are provided
         # by user via self.filename_value
         expanded_path = os.path.expanduser(self.filename_value)

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -334,15 +334,15 @@
     </div>
 
       <v-overlay
-        absolute
-        opacity=0.5
+        absolute contained
+        opacity=0.25
         :model-value="overwrite_warn"
         :zIndex=3
         style="grid-area: 1/1;
                margin-left: -24px;
                margin-right: -24px">
 
-      <v-card color="transparent" elevation=0 >
+      <v-card color="primary" elevation=4 >
         <v-card-text width="100%">
           <div class="white--text">
             A file with this name is already on disk. Overwrite?
@@ -351,8 +351,8 @@
 
         <v-card-actions>
           <j-flex-row justify="end">
-            <v-btn rounded="0" small color="primary" class="mr-2" @click="overwrite_warn=false">Cancel</v-btn>
-            <v-btn rounded="0" small color="accent" class="mr-4" @click="overwrite_from_ui">Overwrite</v-btn>
+            <v-btn rounded="0" small color="primary" variant="flat" class="mr-2" @click="overwrite_warn=false">Cancel</v-btn>
+            <v-btn rounded="0" small color="accent" variant="flat" class="mr-4" @click="overwrite_from_ui">Overwrite</v-btn>
           </j-flex-row>
         </v-card-actions>
       </v-card>

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -335,26 +335,29 @@
 
       <v-overlay
         absolute contained
-        opacity=0.25
+        opacity=0.5
         :model-value="overwrite_warn"
         :zIndex=3
         style="grid-area: 1/1;
                margin-left: -24px;
                margin-right: -24px">
 
-      <v-card color="primary" elevation=4 >
-        <v-card-text width="100%">
+      <v-card color="primary" elevation=4 class="overwrite-card">
+        <v-card-text width="100%" class="overwrite-card-text">
           <div class="white--text">
-            A file with this name is already on disk. Overwrite?
+            A file named "{{ filename_value.length > 20 ? '...' : '' }}{{ filename_value.slice(-20) }}"
+            is already on disk. Overwrite?
           </div>
         </v-card-text>
 
-        <v-card-actions>
+        <v-card-actions class="overwrite-card-actions">
           <j-flex-row justify="end">
-            <v-btn rounded="0" small color="primary" variant="flat" class="mr-2" @click="overwrite_warn=false">Cancel</v-btn>
-            <v-btn rounded="0" small color="accent" variant="flat" class="mr-4" @click="overwrite_from_ui">Overwrite</v-btn>
+            <v-btn rounded="2" small color="secondary" variant="flat" class="mr-2" @click="overwrite_warn=false">Cancel</v-btn>
+            <v-btn rounded="2" small color="accent" variant="flat" class="mr-4" @click="overwrite_from_ui">Overwrite</v-btn>
           </j-flex-row>
         </v-card-actions>
+
+
       </v-card>
 
       </v-overlay>
@@ -382,6 +385,17 @@
     margin-left: 32px;
     width: 100%;
     padding-right: 24px;
+  }
+
+  .overwrite-card-text {
+    padding-top: 8px !important;
+    padding-bottom: 4px !important;
+  }
+
+  .overwrite-card-actions {
+  min-height: 40px !important;
+  padding-top: 4px !important;
+  padding-bottom: 8px !important;
   }
 
 </style>

--- a/jdaviz/configs/default/plugins/export/export.vue
+++ b/jdaviz/configs/default/plugins/export/export.vue
@@ -293,6 +293,7 @@
     <plugin-auto-label
       v-model:value="filename_value"
       :default="filename_default"
+      v-model:trunc="filename_trunc"
       v-model:auto="filename_auto"
       :invalid_msg="filename_invalid_msg"
       label="Filename"
@@ -345,8 +346,7 @@
       <v-card color="primary" elevation=4 class="overwrite-card">
         <v-card-text width="100%" class="overwrite-card-text">
           <div class="white--text">
-            A file named "{{ filename_value.length > 20 ? '...' : '' }}{{ filename_value.slice(-20) }}"
-            is already on disk. Overwrite?
+            A file named "{{ filename_trunc }}" is already on disk. Overwrite?
           </div>
         </v-card-text>
 


### PR DESCRIPTION
This PR addresses an issue where the overlay window that pops up when you try to overwrite a file in the export plugin was escaping the app window and showing in the corner of the Jupyter browser window. This was because in vue3, `v-overlay absolute` spans the whole window, so the overlay should instead be set to `absolute contained`. 

This fixes the span of the window, but the overlay is still too transparent to be legible. Before vue3, the "cancel" and "overwrite" buttons were in white text over blue and orange buttons, but now it is blue and orange text on a semi-transparent background. I explicitly made them `v-btn` buttons and made the whole overlay window opaque blue so you can read the text. Since the window covers up the filename field, I changed the message from "A file with this name is already on disk" to "A file named blah...blah.png already exists on disk." (truncated for long file names).

New result:

<img width="325" height="594" alt="Screenshot 2026-08-14 at 11 39 08 AM" src="https://github.com/user-attachments/assets/cab070af-2c99-4b59-a902-44d665790bc8" />

c.f. old way before vue3:

<img width="383" height="696" alt="Screenshot 2026-08-12 at 3 12 48 PM" src="https://github.com/user-attachments/assets/a136eba6-d688-4393-9d7f-4a211ebcdfeb" />

Fixes #JDAT-6274

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
