### PR TITLE
Fix wrap issue in data menu

### DIFF
--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -617,15 +617,6 @@
   .layer-select > .v-list-item__content > .v-list-item-action:first-child {
     margin-right: 6px !important;
   }
-  /* Global .v-list-item-content styling (see main_styles.vue) prevents data menu
-   row labels from shrinking/wrapping and instead pushes the copy/visibility
-   icons out of the menu. We overwrite that styling here. */
-  .layer-select > .v-list-item__content > .v-list-item-content {
-    display: block !important;
-    flex: 1 1 auto !important;
-    min-width: 0 !important;
-    white-space: normal !important;
-  }
   .layer-select {
     /* spacing between entries so selections are more apparent */
     margin-top: 1px !important;

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -617,6 +617,15 @@
   .layer-select > .v-list-item__content > .v-list-item-action:first-child {
     margin-right: 6px !important;
   }
+  /* Global .v-list-item-content styling (see main_styles.vue) prevents data menu
+   row labels from shrinking/wrapping and instead pushes the copy/visibility
+   icons out of the menu. We overwrite that styling here. */
+  .layer-select > .v-list-item__content > .v-list-item-content {
+    display: block !important;
+    flex: 1 1 auto !important;
+    min-width: 0 !important;
+    white-space: normal !important;
+  }
   .layer-select {
     /* spacing between entries so selections are more apparent */
     margin-top: 1px !important;

--- a/jdaviz/main_styles.vue
+++ b/jdaviz/main_styles.vue
@@ -363,9 +363,10 @@ span.api-hint-header {
 }
 
 .v-list-item-content {
-  display: inline !important;
-  flex: none !important;
-  white-space: nowrap !important;
+  display: block !important;
+  flex: 1 1 auto !important;
+  min-width: 0 !important;
+  white-space: normal !important;
 }
 
 /* Restore the Vuetify 2-like flex alignment so that icons and text stay vertically centered. */


### PR DESCRIPTION
Fix an issue (see screenshot) where data menu labels don't wrap. This issue was introduced by the changes in #4328 and has been fixed by explicitly overwriting that behavior for data menus. 

<img width="491" height="330" alt="Screenshot 2026-08-17 at 6 23 24 PM" src="https://github.com/user-attachments/assets/d1989670-cc3e-48f8-ae81-9a96dfc72f15" />

The changes should only be on lines 620-628... I'm not sure why all the whitespace has changed. I tried editing this through github UI by copying and pasting the original file from main and then only adding the lines I changed but the diff is still the same. 