### PR TITLE
allow importers to define multiple targets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,8 +81,10 @@ New Features
 
 - Child data now follows its parent into the same viewer(s). Viewer selection for child data
   is therefore hidden in the UI when parenting is set. [#4326]
-  
+
 - Keep visibility consistent between blink and plot options. [#4316]
+
+- Importers can now support multiple targets when filtering format options based on target. [#4345]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -159,7 +159,7 @@ class BaseImporter(PluginTemplateMixin, ValidatorMixin):
 
     @property
     def targets(self):
-        raise NotImplementedError("Importer subclass must implement target")  # pragma: nocover
+        raise NotImplementedError("Importer subclass must implement targets")  # pragma: nocover
 
     def __call__(self):
         # override by subclass - should act on self.output and load into jdaviz

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -158,7 +158,7 @@ class BaseImporter(PluginTemplateMixin, ValidatorMixin):
             # self.data_label_invalid_msg = msg
 
     @property
-    def target(self):
+    def targets(self):
         raise NotImplementedError("Importer subclass must implement target")  # pragma: nocover
 
     def __call__(self):
@@ -265,13 +265,11 @@ class BaseImporterToDataCollection(BaseImporter):
         return self._resolver.default_label
 
     @property
-    def target(self):
-        if len(self.viewer.create_new.choices) > 0:
-            return {'type': 'viewer',
-                    'icon': 'mdi-window-maximize',
-                    'label': self.viewer.create_new.choices[0]}
-        else:
-            return {}
+    def targets(self):
+        return [{'type': 'viewer',
+                 'icon': 'mdi-window-maximize',
+                 'label': choice}
+                for choice in self.viewer.create_new.choices]
 
     @observe('data_label_value', 'data_label_is_prefix', 'data_label_suffices')
     def _on_label_changed(self, msg={}):
@@ -513,10 +511,10 @@ class BaseImporterToPlugin(BaseImporter):
         raise NotImplementedError("Importer subclass must implement default_plugin")  # noqa pragma: nocover
 
     @property
-    def target(self):
-        return {'type': 'plugin',
-                'icon': 'mdi-toy-brick-outline',
-                'label': self.default_plugin}
+    def targets(self):
+        return [{'type': 'plugin',
+                 'icon': 'mdi-toy-brick-outline',
+                 'label': self.default_plugin}]
 
     @property
     def has_default_plugin(self):

--- a/jdaviz/core/loaders/importers/test_importer.py
+++ b/jdaviz/core/loaders/importers/test_importer.py
@@ -21,8 +21,8 @@ class TestBaseImporter(BaseImporter):
     # These are required to be implemented by the BaseImporter class
     # but are currently not tested here
     @property
-    def target(self):
-        return None
+    def targets(self):
+        return []
 
     def __call__(self, *args, **kwargs):
         return None

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -141,7 +141,8 @@ class FormatSelect(SelectPluginComponent):
                     if self.debug:
                         self._dbg_importers[label] = this_importer
                     if (self.plugin._restrict_to_target is not None and
-                            this_importer.target.get('label') != self.plugin._restrict_to_target):
+                            not any(target.get('label') == self.plugin._restrict_to_target
+                                    for target in this_importer.targets)):
                         # skip importers that do not match the target
                         self._invalid_importers[label] = 'Not matching target'
                         continue
@@ -150,7 +151,7 @@ class FormatSelect(SelectPluginComponent):
                             item = {'label': importer_name,
                                     'parser': parser_name,
                                     'importer': importer_name,
-                                    'target': this_importer.target}
+                                    'targets': this_importer.targets}
                             parser_pref = this_importer.parser_preference
                             if importer_name not in self._importers:
                                 all_formats.append(item)
@@ -239,9 +240,9 @@ class TargetSelect(SelectPluginComponent):
         # and use that list when compiling list of valid targets
         all_targets = []
         for importer in self.plugin.format._importers.values():
-            target = importer.target
-            if target not in all_targets:
-                all_targets.append(target)
+            for target in importer.targets:
+                if target not in all_targets:
+                    all_targets.append(target)
 
         self.items = [{'label': 'Any'}] + [item for item in all_targets if self._is_valid_item(item)]  # noqa
         self._apply_default_selection()
@@ -1024,7 +1025,7 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
     def _on_target_selected_changed(self, change={}):
         def matches_target_factory(target):
             def matches_target(importer):
-                return importer.target.get('label', '') == target
+                return any(item.get('label', '') == target for item in importer.targets)
             return matches_target
 
         if self._restrict_to_target is not None:

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -61,6 +61,17 @@ def test_resolver_matching(specviz_helper):
     assert len(specviz_helper._app.data_collection) == 1
 
 
+def test_catalog_format_available_for_table_target(deconfigged_helper):
+    table = Table({'ra': [1.0, 2.0], 'dec': [3.0, 4.0]})
+    ldr = deconfigged_helper.loaders['object']
+
+    ldr.object = table
+    assert 'Catalog' in ldr.format.choices
+
+    ldr.target = 'Table'
+    assert 'Catalog' in ldr.format.choices
+
+
 def test_dbg_access(deconfigged_helper):
     test_data = np.array([1, 2, 3])
     deconfigged_helper.loaders['object'].object = test_data


### PR DESCRIPTION
This PR allows importers to define multiple targets, which then fixes the case where format='Catalog' was hidden in a loader when setting `ldr.target = 'Table'`.  Previously, the target was set as the _first_ available viewer type.

Since `ldr.importer.target` was never exposed public API, this isn't considered a breaking change and so we could backport if necessary (although we should check to make sure that it is needed)