### PR TITLE
minor alignment tweaks

### DIFF
--- a/jdaviz/components/toolbar_nested.vue
+++ b/jdaviz/components/toolbar_nested.vue
@@ -180,7 +180,7 @@
           'jdaviz:viewer_popout',
         ];
 
-        let style = 'min-width: 40px !important; width: 40px !important; height: 40px !important; padding: 0px !important;';
+        let style = 'min-width: 42px !important; width: 42px !important; height: 42px !important; padding: 0px !important;';
         if (viewerActionTools.includes(id)) {
           // top app-toolbar dark blue
           style += ' background-color: rgba(0, 59, 77, 1);';
@@ -240,7 +240,9 @@
 .toolbar-icon-img {
   width: 20px;
   height: 20px;
-  display: block;
+  display: inline-block;
+  object-fit: contain;
+  vertical-align: middle;
 }
 .suboptions-carrot:hover {
   scale: 1.75;

--- a/jdaviz/main_styles.vue
+++ b/jdaviz/main_styles.vue
@@ -83,6 +83,10 @@ div.output_wrapper {
   /*border-top: 1px solid #cccccc;*/
 }
 
+.jdaviz-viewer-figure-container .lm-Widget.bqplot.figure.jupyter-widgets.classic {
+  margin: 0 !important;
+}
+
 .lm_splitter {
   background: #e2e4e8;
   opacity: 1;

--- a/jdaviz/viewer_window.vue
+++ b/jdaviz/viewer_window.vue
@@ -36,8 +36,8 @@
         </v-toolbar-items>
         <j-play-pause-widget v-if="reference == 'table-viewer'" @event="$emit('call-viewer-method', {'id': id, 'method': 'next_row'})"></j-play-pause-widget>
         <j-tooltip v-if="focus_mode && coords_info_widget" tipid='coords-info-cycle'>
-          <v-btn variant="text" color="white" rounded="0" icon @click="cycle_coords_dataset()" style="height: 100%; width: 42px;">
-            <j-layer-viewer-icon :icon="coords_info_has_data ? coords_info_icon : coords_info_dataset_icon" color="white" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
+          <v-btn variant="text" color="white" rounded="0" icon @click="cycle_coords_dataset()" style="height: 42px; width: 42px; min-width: 42px; padding: 0; display: flex; align-items: center; justify-content: center;">
+            <j-layer-viewer-icon :icon="coords_info_has_data ? coords_info_icon : coords_info_dataset_icon" color="white" :icon_size="20" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
           </v-btn>
         </j-tooltip>
         <v-spacer></v-spacer>
@@ -45,7 +45,7 @@
       </j-flex-row>
     </div>
 
-    <v-card tile flat style="width: 100%; height: calc(100% - 42px); overflow: hidden;"
+    <v-card class="jdaviz-viewer-figure-container" tile flat style="width: 100%; height: calc(100% - 42px); overflow: hidden;"
       @mousemove="onFigureMouseMove"
       @mouseleave="onFigureMouseLeave"
     >


### PR DESCRIPTION
This PR improves a few alignment issues pointed out by @Jenneh related to the viewer focus mode: 

* the vertical size/alignment of the "magic wand" icon in the left of the toolbar
* the vertical alignment of the dark shading under the window controls on the right of the toolbar
* removes the white border (margin) around the viewer area (and between the toolbar and the viewer)