### PR TITLE
fixes catalog loader logic for coord frame and equinox

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,6 +98,9 @@ New Features
 - Updated documentation for the application and caching, updated the jdaviz logo, 
   and improved the .dmg installation process [#4337]
 
+- Coordinate frame and equinox are responsive to changes in ra / dec in catalog
+  loader. [#4347]
+
 Mosviz
 ^^^^^^
 
@@ -147,7 +150,7 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
-- fix case where file drop loader would not show importer options. [#4303]
+- Fix case where file drop loader would not show importer options. [#4303]
 
 - Fix image importer support for Roman L3 mosaic files. [#4309]
 
@@ -155,10 +158,13 @@ Bug Fixes
 
 - Allow markers plugin table to handle images with no flux units specified in the header. [#4320]
 
+<<<<<<< HEAD
 - Fix issue where removing an image from an Image viewer while a catalog (scatter) was present
   caused an index error from glue. [#4333]
 
 - Avoid triggering a 2D spectrum-related warning for NIRISS images. [#4342]
+=======
+>>>>>>> 7216a94e9 (change log)
 
 Mosviz
 ^^^^^^

--- a/jdaviz/core/loaders/importers/catalog/catalog.py
+++ b/jdaviz/core/loaders/importers/catalog/catalog.py
@@ -125,17 +125,28 @@ class CatalogImporter(BaseImporterToDataCollection):
         self.coord_frame = SelectPluginComponent(self,
                                                  items='coord_frame_items',
                                                  selected='coord_frame_selected',
-                                                 manual_options=['icrs', 'fk5',
+                                                 manual_options=['----', 'icrs', 'fk5',
                                                                  'fk4', 'galactic',
                                                                  'ecliptic'])
+
+        # only default to icrs if ra and dec were auto-detected
+        ra_detected = self.col_ra_selected not in ('---', '', None)
+        dec_detected = self.col_dec_selected not in ('---', '', None)
+        if ra_detected and dec_detected:
+            self.coord_frame_selected = 'icrs'
 
         self.coord_equinox = SelectPluginComponent(self,
                                                    items='coord_equinox_items',
                                                    selected='coord_equinox_selected',
-                                                   manual_options=['J2000.0',
+                                                   manual_options=['----',
+                                                                   'J2000.0',
                                                                    'J1950.0',
                                                                    'B1950.0',
                                                                    'B1900.0'])
+
+        # only default to J2000.0 if ra and dec were auto-detected
+        if ra_detected and dec_detected:
+            self.coord_equinox_selected = 'J2000.0'
 
         # dropdown for source ID column
         self.col_id = SelectPluginComponent(self,
@@ -391,6 +402,8 @@ class CatalogImporter(BaseImporterToDataCollection):
                 # disable import if RA is selected but Dec is not (or vice versa)
                 if (ra in ['---', ''] or ra is None) != (dec in ['---', ''] or dec is None):
                     import_disabled = True
+                self.coord_frame_selected = '----'
+                self.coord_equinox_selected = '----'
                 return
 
             has_units = False
@@ -420,6 +433,16 @@ class CatalogImporter(BaseImporterToDataCollection):
             # disable import if RA is selected but Dec is not (or vice versa)
             if (ra in ['---', ''] or ra is None) != (dec in ['---', ''] or dec is None):
                 import_disabled = True
+
+            # sync coord_frame and coord_equinox with ra/dec selection state
+            ra_is_invalid = ra in ('---', '', None)
+            dec_is_invalid = dec in ('---', '', None)
+            if ra_is_invalid or dec_is_invalid:
+                self.coord_frame_selected = '----'
+                self.coord_equinox_selected = '----'
+            elif self.coord_frame_selected == '----':
+                self.coord_frame_selected = 'icrs'
+                self.coord_equinox_selected = 'J2000.0'
 
         elif msg['name'] in ('col_x_selected', 'col_y_selected'):
             # disable import if RA is selected but Dec is not (or vice versa)

--- a/jdaviz/core/loaders/importers/catalog/catalog.vue
+++ b/jdaviz/core/loaders/importers/catalog/catalog.vue
@@ -70,7 +70,7 @@
         :api_hints_enabled="api_hints_enabled"
       ></plugin-select>
 
-      <plugin-select v-if="coord_frame_selected !== 'icrs' && coord_frame_selected !== 'galactic'"
+      <plugin-select v-if="coord_frame_selected !== 'icrs' && coord_frame_selected !== 'galactic' && coord_frame_selected !== '----'"
         :items="coord_equinox_items.map(i => i.label)"
         v-model:selected="coord_equinox_selected"
         label="Equinox"

--- a/jdaviz/core/loaders/importers/catalog/test_catalog.py
+++ b/jdaviz/core/loaders/importers/catalog/test_catalog.py
@@ -237,3 +237,45 @@ def test_catalog_loader_coord_frame(deconfigged_helper, frame_selected, equinox_
         sc_icrs = sc_input.transform_to(ICRS())
         assert_allclose(ra_loaded, sc_icrs.ra.deg)
         assert_allclose(dec_loaded, sc_icrs.dec.deg)
+
+
+def test_coord_frame_default_and_reset(deconfigged_helper):
+    """coord_frame and coord_equinox should default to icrs/J2000.0 when ra/dec are detected,
+    '----' otherwise, and reset to '----' when ra or dec is unselected."""
+
+    # table with detectable ra/dec columns: coord_frame/equinox should start as icrs/J2000.0
+    tab = QTable({'ra': [10.0] * u.deg, 'dec': [-5.0] * u.deg})
+    ldr = deconfigged_helper.loaders['object']
+    ldr.object = tab
+    ldr.format = 'Catalog'
+    importer = ldr.importer
+
+    # defaults, ra and dec cols autodetected so coord frame and equinox should
+    # also be set to their defaults
+    assert importer.col_ra.selected == 'ra'
+    assert importer.col_dec.selected == 'dec'
+    assert importer.coord_frame.selected == 'icrs'
+    assert importer.coord_equinox.selected == 'J2000.0'
+
+    # unselecting only ra resets both to '----'
+    importer.col_ra.selected = '---'
+    assert importer.coord_frame.selected == '----'
+    assert importer.coord_equinox.selected == '----'
+
+    # re-selecting ra when dec is already selected restores both defaults
+    importer.col_ra.selected = 'ra'
+    assert importer.coord_frame.selected == 'icrs'
+    assert importer.coord_equinox.selected == 'J2000.0'
+
+    # unselecting dec also resets both
+    importer.col_dec.selected = '---'
+    assert importer.coord_frame.selected == '----'
+    assert importer.coord_equinox.selected == '----'
+
+    # table with no detectable ra/dec columns: both should start as '----'
+    tab2 = QTable({'flux': [1.0], 'name': ['src']})
+    ldr.object = tab2
+    ldr.format = 'Catalog'
+    importer2 = ldr.importer
+    assert importer2.coord_frame.selected == '----'
+    assert importer2.coord_equinox.selected == '----'


### PR DESCRIPTION
These changes are demonstrated in the added test - coordinate frame and equinox now respond appropriately to changes in ra/dec selection.