### PR TITLE
simplify asdf_in_fits test

### DIFF
--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -13,7 +13,7 @@ from gwcs import WCS as GWCS
 from numpy.testing import assert_allclose, assert_array_equal
 from regions import CirclePixelRegion, EllipsePixelRegion, PixCoord, RectanglePixelRegion
 from skimage.io import imsave
-from stdatamodels import asdf_in_fits
+from stdatamodels.jwst.datamodels import Level1bModel
 import photutils
 
 from jdaviz.configs.imviz.helper import split_filename_with_fits_ext
@@ -254,12 +254,10 @@ class TestParseImage:
             imviz_helper.load_data(flist, data_label='foo', show_in_viewer=False, format='Image')
 
     def test_parse_asdf_in_fits_4d(self, deconfigged_helper, tmp_path):
-        hdulist = fits.HDUList([
-            fits.PrimaryHDU(),
-            fits.ImageHDU(np.zeros((1, 2, 5, 5)), name='SCI')])
-        tree = {'data': {'data': hdulist['SCI'].data}}
         filename = str(tmp_path / 'myasdf.fits')
-        asdf_in_fits.write(filename, tree, hdulist=hdulist, overwrite=True)
+        model = Level1bModel()
+        model.data = np.zeros((1, 2, 5, 5))
+        model.save(filename)
 
         with pytest.raises(ValueError, match='Imviz cannot load this HDU'):
             parse_data(deconfigged_helper._app, filename)


### PR DESCRIPTION
### Description

Simplify a test that uses stdatamodels.asdf_in_fits to generate a pseudo-jwst test file to instead use the corresponding stdatamodels.jwst.datamodels API. This produces a file that is closer to files produced by the pipeline (which uses the datamodels API). Level1bModel was selected since the original issue https://github.com/spacetelescope/jdaviz/issues/1058 mentions an "uncal" (Level 1B) file.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
