### PR TITLE
sync toggle buttons in table data-assoc columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,7 +65,7 @@ New Features
 
 - Add consolidated emission line list and ability to query database in API. [#4314]
 
-- Table viewer "active row" selection to control data visible in other viewers. [#4279, #4322]
+- Table viewer "active row" selection to control data visible in other viewers. [#4279, #4322, #4350]
 
 - Add ability to specify coordinate frame and equinox in catalog loader. [#4207]
 
@@ -81,7 +81,7 @@ New Features
 
 - Child data now follows its parent into the same viewer(s). Viewer selection for child data
   is therefore hidden in the UI when parenting is set. [#4326]
-  
+
 - Keep visibility consistent between blink and plot options. [#4316]
 
 - Improvements to flux / surface brightness unit conversion logic to support

--- a/jdaviz/components/table_viewer.py
+++ b/jdaviz/components/table_viewer.py
@@ -9,7 +9,7 @@ TO REVERT once upstream glue-jupyter is updated:
   3. Update the glue-jupyter version pin.
 """
 
-from echo import ListCallbackProperty
+from echo import DictCallbackProperty, ListCallbackProperty
 from glue_jupyter.table.viewer import TableGlue, TableState, TableViewer
 
 
@@ -23,6 +23,9 @@ if not hasattr(TableState, 'renameable_components'):
         docstring='Attributes whose column header can be renamed')
     TableState.removable_components = ListCallbackProperty(
         docstring='Attributes whose column can be removed from the table')
+    # absent key means synced; only de-synced columns are stored as False
+    TableState.column_sync_state = DictCallbackProperty(
+        docstring='Per column-label sync enable state; absent == True (synced)')
 
     def _is_renameable(self, component_id):
         """Check if a component's header can be renamed (identity comparison)."""
@@ -38,8 +41,12 @@ if not hasattr(TableState, 'renameable_components'):
                 return True
         return False
 
+    def _is_synced(self, column_label):
+        return self.column_sync_state.get(str(column_label), True)
+
     TableState.is_renameable = _is_renameable
     TableState.is_removable = _is_removable
+    TableState.is_synced = _is_synced
 
 
 # ---------------------------------------------------------------------------
@@ -53,6 +60,7 @@ if not hasattr(TableViewer, '_shim_patched'):
         _orig_viewer_init(self, session, state=state)
         self.state.add_callback('renameable_components', self._update_renameable)
         self.state.add_callback('removable_components', self._update_removable)
+        self.state.add_callback('column_sync_state', self._update_sync_state)
 
     def _update_renameable(self, *args):
         self.widget_table._update_columns()
@@ -60,9 +68,13 @@ if not hasattr(TableViewer, '_shim_patched'):
     def _update_removable(self, *args):
         self.widget_table._update_columns()
 
+    def _update_sync_state(self, *args):
+        self.widget_table._update_columns()
+
     TableViewer.__init__ = _patched_viewer_init
     TableViewer._update_renameable = _update_renameable
     TableViewer._update_removable = _update_removable
+    TableViewer._update_sync_state = _update_sync_state
     TableViewer._shim_patched = True
 
 
@@ -79,6 +91,7 @@ class JdavizTableGlue(TableGlue):
         if self.data is None:
             return []
         components = self.get_visible_components()
+        assoc_columns = set(self.data.meta.get('_viewer_data_columns') or {})
         return [
             {
                 'text': str(k),
@@ -89,6 +102,8 @@ class JdavizTableGlue(TableGlue):
                 'editable': self.state is not None and self.state.is_editable(k),
                 'renameable': self.state is not None and self.state.is_renameable(k),
                 'removable': self.state is not None and self.state.is_removable(k),
+                'toggleable_sync': str(k) in assoc_columns,
+                'synced': self.state is None or self.state.is_synced(str(k)),
             }
             for k in components
         ]
@@ -137,6 +152,14 @@ class JdavizTableGlue(TableGlue):
             self._update()
         for fn in getattr(self, '_column_removed_callbacks', []):
             fn(label)
+
+    def vue_toggle_column_sync(self, data):
+        """Toggle the row-link sync state for a data-association column."""
+        label = data.get('column', '')
+        if not label or self.state is None:
+            return
+        current = self.state.column_sync_state.get(label, True)
+        self.state.column_sync_state = {**self.state.column_sync_state, label: not current}
 
 
 __all__ = ['JdavizTableGlue']

--- a/jdaviz/components/table_viewer.vue
+++ b/jdaviz/components/table_viewer.vue
@@ -74,12 +74,17 @@
                 style="cursor: pointer; user-select: none; padding: 0 8px; white-space: nowrap; position: relative;"
                 :style="editingHeader === header.value ? {minWidth: '240px'} : {}"
             >
-              {{ header.text }}
-              <v-icon v-if="options.sortBy && options.sortBy[0] === header.value">
-                {{ options.sortDesc && options.sortDesc[0] ? 'arrow_drop_down' : 'arrow_drop_up' }}
-              </v-icon>
-              <v-icon size="x-small" v-if="hoverHeader === header.value && editingHeader !== header.value && header.renameable" @click.stop="enterHeaderRename(header.value)" style="cursor:pointer;margin-left:2px" title="Rename column">mdi-pencil</v-icon>
-              <v-icon size="x-small" v-if="hoverHeader === header.value && editingHeader !== header.value && header.removable" @click.stop="enterHeaderRemove(header.value)" style="cursor:pointer" title="Delete column">mdi-delete</v-icon>
+              <div style="display:flex;flex-direction:column;align-items:center;gap:0;">
+                <v-icon size="x-small" v-if="header.toggleable_sync" @click.stop="toggle_column_sync({column: header.value})" style="cursor:pointer;" :title="header.synced ? 'Synced (click to disable row-link sync)' : 'Not synced (click to enable row-link sync)'">{{ header.synced ? 'mdi-link' : 'mdi-link-off' }}</v-icon>
+                <div>
+                  {{ header.text }}
+                  <v-icon v-if="options.sortBy && options.sortBy[0] === header.value">
+                    {{ options.sortDesc && options.sortDesc[0] ? 'arrow_drop_down' : 'arrow_drop_up' }}
+                  </v-icon>
+                  <v-icon size="x-small" v-if="hoverHeader === header.value && editingHeader !== header.value && header.renameable" @click.stop="enterHeaderRename(header.value)" style="cursor:pointer;margin-left:2px" title="Rename column">mdi-pencil</v-icon>
+                  <v-icon size="x-small" v-if="hoverHeader === header.value && editingHeader !== header.value && header.removable" @click.stop="enterHeaderRemove(header.value)" style="cursor:pointer" title="Delete column">mdi-delete</v-icon>
+                </div>
+              </div>
 
               <!-- Rename mode: fills the th (min-width ensures it fits) -->
               <span v-if="editingHeader === header.value && headerMode === 'rename'" @click.stop style="position:absolute;top:0;left:0;right:0;bottom:0;display:inline-flex;align-items:center;gap:4px;background:white;padding:0 4px;z-index:1;"><input :data-header="header.value" v-model="headerEditValue" @keyup.enter.stop="acceptHeader(header.value)" @keyup.escape.stop="cancelHeader()" @click.stop class="glue-header-edit-input"/><v-icon size="x-small" @click.stop="cancelHeader()" style="cursor:pointer" title="Cancel (Esc)">mdi-close</v-icon><v-icon size="x-small" @click.stop="acceptHeader(header.value)" style="cursor:pointer" title="Accept (Enter)">mdi-check</v-icon></span>

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -1799,7 +1799,6 @@ class JdavizTableViewer(JdavizViewerMixin, TableViewer):
         synced : bool
             ``True`` to sync (default); ``False`` to disable.
         """
-        column_name = str(column_name)
         self.state.column_sync_state = {**self.state.column_sync_state,
                                         column_name: bool(synced)}
 
@@ -1816,7 +1815,7 @@ class JdavizTableViewer(JdavizViewerMixin, TableViewer):
         bool
             ``True`` if synced (default when not explicitly set).
         """
-        return self.state.is_synced(str(column_name))
+        return self.state.is_synced(column_name)
 
     def _on_checked_changed(self, change):
         """Update highlight marks in image viewers when checked rows change."""

--- a/jdaviz/configs/default/plugins/viewers.py
+++ b/jdaviz/configs/default/plugins/viewers.py
@@ -426,7 +426,7 @@ class JdavizViewerMixin(WithCache):
             if isinstance(self, AIDAMixin):
                 expose += ['set_viewport', 'get_viewport']
         elif isinstance(self, TableViewer):
-            expose += []
+            expose += ['set_column_sync']
         else:
             expose += ['set_limits', 'reset_limits', 'set_tick_format']
         return ViewerUserApi(self, expose=expose)
@@ -1788,6 +1788,35 @@ class JdavizTableViewer(JdavizViewerMixin, TableViewer):
             raise ValueError(f"Column '{column_name}' does not exist in the table. Use add_column to add it first.")  # noqa: E501
 
         self._add_or_update_column(column_name, data)
+
+    def set_column_sync(self, column_name, synced):
+        """Enable or disable row-link syncing for a data-association column.
+
+        Parameters
+        ----------
+        column_name : str
+            Name of the ``Data: <viewer>`` column to toggle.
+        synced : bool
+            ``True`` to sync (default); ``False`` to disable.
+        """
+        column_name = str(column_name)
+        self.state.column_sync_state = {**self.state.column_sync_state,
+                                        column_name: bool(synced)}
+
+    def get_column_sync(self, column_name):
+        """Return the current sync state for a data-association column.
+
+        Parameters
+        ----------
+        column_name : str
+            Name of the column to query.
+
+        Returns
+        -------
+        bool
+            ``True`` if synced (default when not explicitly set).
+        """
+        return self.state.is_synced(str(column_name))
 
     def _on_checked_changed(self, change):
         """Update highlight marks in image viewers when checked rows change."""

--- a/jdaviz/core/loaders/importers/catalog/row_link.py
+++ b/jdaviz/core/loaders/importers/catalog/row_link.py
@@ -212,6 +212,8 @@ class CatalogRowLinkManager(HubListener):
         # dataset that no longer exists
         available_labels = self.app.data_collection.labels
         for column_name, viewer_ref in column_to_viewer.items():
+            if not self._is_column_synced_in_viewer(viewer, column_name):
+                continue
             target_viewer = self.app.get_viewer(viewer_ref)
             if target_viewer is None:
                 continue
@@ -306,6 +308,8 @@ class CatalogRowLinkManager(HubListener):
             active_rows = tv.widget_table.checked
             if not active_rows:
                 continue
+            if not self._is_column_synced_in_viewer(tv, column_name):
+                continue
             active_row = active_rows[0]
             visible_labels = self._get_visible_data_labels(viewer)
             try:
@@ -314,6 +318,14 @@ class CatalogRowLinkManager(HubListener):
                 self._set_object_column(catalog, column_name, values)
             except Exception:  # nosec
                 pass
+
+    @staticmethod
+    def _is_column_synced_in_viewer(table_viewer, column_name):
+        """False only when the viewer explicitly marks this column as de-synced."""
+        state = getattr(table_viewer, 'state', None)
+        if state is None or not hasattr(state, 'is_synced'):
+            return True
+        return state.is_synced(column_name)
 
     def _get_visible_data_labels(self, viewer):
         """Return the labels of all visible non-subset data layers in ``viewer``."""


### PR DESCRIPTION
This PR adds buttons at the top of each data-association column that allows you to toggle whether that column is synced (2 way) to the active row.  Currently when syncing an unsynced column, nothing immediately happens (the column doesn't adopt the current state and the viewer doesn't adopt the values in the column), but rather updates will occur on the next change to the viewer or to the active row.

This also relies on our current override of the vue for the table viewer - if we want to adopt upstream vue if/when https://github.com/glue-viz/glue-jupyter/pull/552 is merged, then we may also want to request or implement the ability to inject/override the column headers instead of having to override the entire table vue.