### PR TITLE
Adjust threshold for data menu to show more layers button

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -160,6 +160,8 @@ Bug Fixes
 
 - Avoid triggering a 2D spectrum-related warning for NIRISS images. [#4342]
 
+- Adjust data menu behavior to allow for showing more icons when the viewer is short. [#4352]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -458,9 +458,9 @@
         if (!container) return;
         const viewerHeight = container.getBoundingClientRect().height;
         const itemHeight = 30;
-        // Cap legend at 80% of viewer height or 400px, whichever is smaller.
+        // Guarantee itemHeight of space beneath legend.
         // Reserve 2 slots: 1 for the viewer icon header, 1 for the "more" indicator.
-        const usableHeight = Math.min(viewerHeight * 0.80, 400);
+        const usableHeight = viewerHeight - itemHeight;
         this.max_legend_items = Math.max(1, Math.floor(usableHeight / itemHeight) - 2);
       },
       isSafari() {

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -458,9 +458,10 @@
         if (!container) return;
         const viewerHeight = container.getBoundingClientRect().height;
         const itemHeight = 30;
-        // Cap legend at 55% of viewer height so it doesn't dominate the view.
+        // Cap legend at 80% of viewer height or 400px, whichever is smaller,
+        // so it doesn't dominate the view.
         // Reserve 2 slots: 1 for the viewer icon header, 1 for the "more" indicator.
-        const usableHeight = viewerHeight * 0.55;
+        const usableHeight = Math.min(viewerHeight * 0.80, 400);
         this.max_legend_items = Math.max(1, Math.floor(usableHeight / itemHeight) - 2);
       },
       isSafari() {

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.vue
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.vue
@@ -458,8 +458,7 @@
         if (!container) return;
         const viewerHeight = container.getBoundingClientRect().height;
         const itemHeight = 30;
-        // Cap legend at 80% of viewer height or 400px, whichever is smaller,
-        // so it doesn't dominate the view.
+        // Cap legend at 80% of viewer height or 400px, whichever is smaller.
         // Reserve 2 slots: 1 for the viewer icon header, 1 for the "more" indicator.
         const usableHeight = Math.min(viewerHeight * 0.80, 400);
         this.max_legend_items = Math.max(1, Math.floor(usableHeight / itemHeight) - 2);

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -1070,8 +1070,6 @@ class TestParenting:
         assert self._loaded() == ['Image[SCI,1]', 'Image[ERR,1]']
         assert self._loaded('Image (1)') == []
 
-    # TODO: Remove skip once this behavior is fixed
-    @pytest.mark.skip
     def test_load_unload_parenting_behavior(self):
         ldr = self.ldr
         dcf_helper = self.dcf_helper


### PR DESCRIPTION
Per feedback from user testing. See #4137 for the original implementation.

I also removed a skip from a test that should now pass. This was originally part of another effort but the issue has since been resolved.