### PR TITLE
change hyperlink icon to text in URL loader

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,8 +95,10 @@ New Features
 
 - Fix table selection color in dark mode, rename "Remove from app" to "Delete from app", and allow line profile to use upper or lower case "L". [#4348]
 
-- Updated documentation for the application and caching, updated the jdaviz logo, 
+- Updated documentation for the application and caching, updated the jdaviz logo,
   and improved the .dmg installation process [#4337]
+
+- Improve UI appearance for URL loader. [#4354]
 
 Mosviz
 ^^^^^^

--- a/jdaviz/core/loaders/resolvers/url/url.vue
+++ b/jdaviz/core/loaders/resolvers/url/url.vue
@@ -1,5 +1,3 @@
-<script setup>
-</script>
 <template>
   <j-loader
     :title="title"

--- a/jdaviz/core/loaders/resolvers/url/url.vue
+++ b/jdaviz/core/loaders/resolvers/url/url.vue
@@ -1,3 +1,5 @@
+<script setup>
+</script>
 <template>
   <j-loader
     :title="title"
@@ -30,13 +32,13 @@
       <j-flex-row style="margin-bottom: 24px">
         <v-text-field
           v-model='url'
-          prepend-icon='mdi-link-box'
           style="padding: 0px 8px"
           :label="api_hints_enabled ? 'ldr.url =' : ''"
           :class="api_hints_enabled ? 'api-hint' : null"
           :error-messages="parsed_input_not_resolvable_message ? [parsed_input_not_resolvable_message] : []"
           :hint="download_path_msg"
           persistent-hint
+        <template #prepend>  <span style="padding-right: 3px">URL:</span></template>
         ></v-text-field>
       </j-flex-row>
 

--- a/jdaviz/core/loaders/resolvers/url/url.vue
+++ b/jdaviz/core/loaders/resolvers/url/url.vue
@@ -33,11 +33,11 @@
           style="padding: 0px 8px"
           :label="api_hints_enabled ? 'ldr.url =' : ''"
           :class="api_hints_enabled ? 'api-hint' : null"
-          :error-messages="parsed_input_not_resolvable_message ? [parsed_input_not_resolvable_message] : []"
-          :hint="download_path_msg"
-          persistent-hint
+          :error-messages="url && parsed_input_not_resolvable_message ? [parsed_input_not_resolvable_message] : []"
+          :hint="url ? download_path_msg : 'Input a link to a file.'"
+          persistent-hint>
         <template #prepend>  <span style="padding-right: 3px">URL:</span></template>
-        ></v-text-field>
+        </v-text-field>
       </j-flex-row>
 
       <j-flex-row v-if="url_not_whitelisted">


### PR DESCRIPTION
This PR addresses the Roman Research Nexus feedback that it was difficult to read the URL text on the UI when loading data via URL. The requests were to 1) make the text bar scrollable, 2) show the full filename beneath the URL field, and 3) change the hyperlink icon to text saying "URL:". The first two were already taken care of in jdaviz>5.0 (RRN was running on 4.5.3) so I just changed the hyperlink icon to text.

Fixes #JDAT-6213

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
