### PR TITLE
Add new viewer to bottom, preserve layout of other viewers

### DIFF
--- a/jdaviz/temp_components/golden-layout.vue
+++ b/jdaviz/temp_components/golden-layout.vue
@@ -570,21 +570,38 @@ function reconcileStateItem(item, templateMaps) {
   return cloned
 }
 
-function findFirstStack(item) {
+function stripLayoutSizes(item) {
   if (!item || typeof item !== 'object') {
-    return null
+    return
   }
-  if (item.type === 'stack') {
-    return item
-  }
+  // Force GoldenLayout to redistribute space evenly, exactly like the fresh template
+  delete item.size
+  delete item.minSize
+  delete item.width
+  delete item.height
   const content = Array.isArray(item.content) ? item.content : []
   for (const child of content) {
-    const nested = findFirstStack(child)
-    if (nested) {
-      return nested
-    }
+    stripLayoutSizes(child)
   }
-  return null
+}
+
+function appendBottomStacks(root, newStacks) {
+  // Add the new stacks as full-width rows at the bottom of the vertical column,
+  // keeping a row-rooted layout that mirrors the slot template (which renders
+  // reliably); a column root or leftover runtime sizes can blank the viewer area.
+  const appendIntoColumn = (node) => {
+    if (node && node.type === 'column' && Array.isArray(node.content)) {
+      node.content.push(...newStacks)
+      return node
+    }
+    return { type: 'column', content: [node, ...newStacks] }
+  }
+
+  if (root && root.type === 'row' && Array.isArray(root.content) && root.content.length === 1) {
+    root.content[0] = appendIntoColumn(root.content[0])
+    return root
+  }
+  return { type: 'row', content: [appendIntoColumn(root)] }
 }
 
 function collectExistingComponentKeys(root) {
@@ -651,16 +668,6 @@ function sameSet(left, right) {
   return true
 }
 
-function countLayoutStacks(item) {
-  if (!item || typeof item !== 'object') {
-    return 0
-  }
-
-  const content = Array.isArray(item.content) ? item.content : []
-  const nestedCount = content.reduce((total, child) => total + countLayoutStacks(child), 0)
-  return (item.type === 'stack' ? 1 : 0) + nestedCount
-}
-
 function reconcileLayoutState(baseState, templateLayout) {
   if (!templateLayout || !templateLayout.root) {
     return baseState
@@ -684,35 +691,14 @@ function reconcileLayoutState(baseState, templateLayout) {
   })
 
   if (missingComponents.length) {
-    if (countLayoutStacks(templateLayout.root) > countLayoutStacks(reconciledRoot)) {
-      return cloneValue(templateLayout)
-    }
-
-    let targetStack = findFirstStack(reconciledRoot)
-
-    if (!targetStack) {
-      targetStack = {
-        type: 'stack',
-        isClosable: false,
-        content: [],
-      }
-      if (Array.isArray(reconciledRoot.content)) {
-        reconciledRoot.content.push(targetStack)
-      } else {
-        reconciledRoot = {
-          type: 'row',
-          isClosable: false,
-          content: [reconciledRoot, targetStack],
-        }
-      }
-    }
-
-    if (!Array.isArray(targetStack.content)) {
-      targetStack.content = []
-    }
-    for (const component of missingComponents) {
-      targetStack.content.push(cloneValue(component))
-    }
+    // Preserve the existing (possibly user-rearranged) layout and add each new
+    // viewer as a full-width row below the existing block rather than resetting.
+    const newStacks = missingComponents.map((component) => ({
+      type: 'stack',
+      content: [cloneValue(component)],
+    }))
+    reconciledRoot = appendBottomStacks(reconciledRoot, newStacks)
+    stripLayoutSizes(reconciledRoot)
   }
 
   return {


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request makes it so new viewers are added to the bottom as a new row while preserving the viewer layout above that row.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.
