### PR TITLE
Fix error during data menu renaming

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -123,6 +123,8 @@ Bug Fixes
 
 - Fix color picker not showing correctly. [#4332]
 
+- Fix error when typing while renaming data or subset. [#4359]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/components/j_rename_text.vue
+++ b/jdaviz/components/j_rename_text.vue
@@ -109,6 +109,10 @@ export default {
       default: true
     }
   },
+  // Declare emitted events so Vue 3 does not also fall them through to the root
+  // element as native DOM listeners (the bubbling native `input` event would
+  // otherwise deliver an InputEvent instead of the edited string).
+  emits: ['input', 'cancel', 'rename'],
   data() {
     return {
       hovering: false,

--- a/jdaviz/components/j_rename_text.vue
+++ b/jdaviz/components/j_rename_text.vue
@@ -17,7 +17,7 @@
           :style="hovering ? 'cursor: pointer; text-decoration: underline;' : 'cursor: pointer;'"
           style="min-width: 0; overflow-wrap: break-word;"
         >
-          {{ value }}
+          {{ pendingValue !== null ? pendingValue : value }}
         </span>
 
         <!-- Pencil icon - visible on hover in display mode, fixed to the right -->
@@ -118,11 +118,15 @@ export default {
       hovering: false,
       isEditing: this.autoEdit,
       editValue: this.value,
+      // Optimistic name shown after accepting, until the backend updates `value`.
+      pendingValue: null,
       suppressPropagation: false
     };
   },
   watch: {
     value(newVal) {
+      // Backend confirmed the label; drop any optimistic pending name.
+      this.pendingValue = null;
       if (!this.isEditing) {
         this.editValue = newVal;
       }
@@ -137,6 +141,7 @@ export default {
   methods: {
     startEditing() {
       this.isEditing = true;
+      this.pendingValue = null;
       this.editValue = this.value;
       // Suppress propagation when entering edit mode to prevent selection change
       this.suppressPropagation = true;
@@ -169,7 +174,9 @@ export default {
       if (trimmedValue && trimmedValue !== this.value) {
         // Emit with old_label and new_label keys for data_menu.vue handler
         this.$emit('rename', trimmedValue);
-        // Keep the new value in editValue so it displays while waiting for backend update
+        // Show the new name immediately (avoids a flash of the old name) until
+        // the backend rename updates the `value` prop.
+        this.pendingValue = trimmedValue;
         this.editValue = trimmedValue;
       } else {
         // No change was made, treat as cancel

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -774,7 +774,9 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
         new_label = info.get('new_label')
         is_subset = info.get('is_subset', False)
 
-        if old_label == new_label or new_label is None:
+        # new_label can arrive as a non-string (None or dict) from
+        # frontend events; in that case there is nothing to validate.
+        if not isinstance(new_label, str) or old_label == new_label:
             self._reset_rename_error_messages(old_label)
             return
 

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -774,9 +774,13 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
         new_label = info.get('new_label')
         is_subset = info.get('is_subset', False)
 
-        # new_label can arrive as a non-string (None or dict) from
-        # frontend events; in that case there is nothing to validate.
-        if not isinstance(new_label, str) or old_label == new_label:
+        # A spurious frontend event can deliver new_label as None or an empty
+        # dict (a serialized InputEvent); those carry no name to validate.  Any
+        # other non-string (e.g. a non-empty dict) is unexpected and is left to
+        # raise downstream so the regression can be tracked down.
+        if (old_label == new_label
+                or new_label is None
+                or (isinstance(new_label, dict) and not new_label)):
             self._reset_rename_error_messages(old_label)
             return
 

--- a/jdaviz/configs/default/plugins/data_menu/tests/test_data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/tests/test_data_menu.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from astropy.nddata import NDData
 import astropy.units as u
 from regions import CirclePixelRegion, PixCoord
@@ -76,8 +77,10 @@ def test_rename_data_and_subsets(deconfigged_helper, image_hdu_wcs):
 
 def test_check_rename_non_string_new_label(deconfigged_helper, image_hdu_wcs):
     """
-    A frontend event can deliver a non-string ``new_label`` (e.g. a
-    dict); ``vue_check_rename`` should handle it instead of raising.
+    A frontend event can deliver a benign non-string ``new_label`` (None or an
+    empty dict from a serialized InputEvent); ``vue_check_rename`` should treat
+    those as "nothing to validate" instead of raising.  Any other unexpected
+    shape (e.g. a non-empty dict) is deliberately left to surface.
     """
     deconfigged_helper.load(image_hdu_wcs, format='Image', data_label='original_data')
 
@@ -88,6 +91,11 @@ def test_check_rename_non_string_new_label(deconfigged_helper, image_hdu_wcs):
     dm.vue_check_rename({'old_label': 'original_data', 'new_label': None, 'is_subset': False})
 
     assert dm.rename_error_messages == {}
+
+    # An unexpected (non-empty) dict is not swallowed so the regression surfaces.
+    with pytest.raises(AttributeError):
+        dm.vue_check_rename({'old_label': 'original_data',
+                             'new_label': {'value': 'x'}, 'is_subset': False})
 
 
 def test_only_compatible_subsets_in_menu(deconfigged_helper, image_hdu_wcs, spectrum1d):

--- a/jdaviz/configs/default/plugins/data_menu/tests/test_data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/tests/test_data_menu.py
@@ -74,6 +74,22 @@ def test_rename_data_and_subsets(deconfigged_helper, image_hdu_wcs):
     assert 'Subset 1' not in [x['label'] for x in dm.layer_items]
 
 
+def test_check_rename_non_string_new_label(deconfigged_helper, image_hdu_wcs):
+    """
+    A frontend event can deliver a non-string ``new_label`` (e.g. a
+    dict); ``vue_check_rename`` should handle it instead of raising.
+    """
+    deconfigged_helper.load(image_hdu_wcs, format='Image', data_label='original_data')
+
+    dm = deconfigged_helper.viewers['Image'].data_menu._obj
+
+    # Should not raise (previously crashed in check_rename_availability via .strip())
+    dm.vue_check_rename({'old_label': 'original_data', 'new_label': {}, 'is_subset': False})
+    dm.vue_check_rename({'old_label': 'original_data', 'new_label': None, 'is_subset': False})
+
+    assert dm.rename_error_messages == {}
+
+
 def test_only_compatible_subsets_in_menu(deconfigged_helper, image_hdu_wcs, spectrum1d):
     deconfigged_helper.load(image_hdu_wcs, format='Image', data_label='image_data')
     deconfigged_helper.load(spectrum1d, format='1D Spectrum', data_label='spectrum')


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request fixes an error during data menu renaming by preventing non-strings.

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.
