### PR TITLE
fix backport from 4250/4263

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Bug Fixes
 
 - fix case where file drop loader would not show importer options. [#4303]
 
+- fix URL loader not showing in UI. [#4361]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/components/loader.vue
+++ b/jdaviz/components/loader.vue
@@ -128,13 +128,13 @@
             <v-alert type="warning" style="margin-right: -12px; width: 100%">
                 Input cannot be resolved: {{ parsed_input_not_resolvable_message }}
             </v-alert>
-          </j-flex-row>
-          <j-flex-row v-if="parsed_input_not_resolvable_message">
+          </v-row>
+          <v-row v-if="parsed_input_is_empty">
             <v-alert type="warning" style="margin-right: -12px; width: 100%">
-                Input cannot be resolved: {{ parsed_input_not_resolvable_message }}
+                Input is empty.
             </v-alert>
-          </j-flex-row>
-          <j-flex-row v-else-if="!parsed_input_is_query && format_items.length == 0 && valid_import_formats">
+          </v-row>
+          <v-row v-else-if="!parsed_input_is_query && format_items.length == 0 && valid_import_formats">
               <v-alert type="warning" style="margin-right: -12px; width: 100%">
                   No compatible importer found. Supported input types include: {{ valid_import_formats }}.
               </v-alert>

--- a/jdaviz/core/loaders/resolvers/url/url.vue
+++ b/jdaviz/core/loaders/resolvers/url/url.vue
@@ -3,7 +3,6 @@
     :title="title"
     :popout_button="popout_button"
     :spinner="spinner"
-    :spinner_success_message="spinner_success_message"
     :parsed_input_not_resolvable_message="parsed_input_not_resolvable_message"
     :parsed_input_is_query="parsed_input_is_query"
     :treat_table_as_query.sync="treat_table_as_query"


### PR DESCRIPTION
This PR fixes a failed backport from #4250/#4263 which introduced lines compatible with 5.1.x but not 5.0.x and effectively resulted in the URL loader not rendering due to syntax errors.

This is currently targeting the 5.0.x branch directly since the changes should intentionally not show in main (but maybe the changelog entry should be forward-ported?).