### PR TITLE
Backport PR #4304 on branch v5.0.x (Bugfix for AIDA for images without WCS)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Bug Fixes
 
 - fix URL loader not showing in UI. [#4361]
 
+- fix astro-image-display API for images without WCS. [#4304]
+
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/default/aida.py
+++ b/jdaviz/configs/default/aida.py
@@ -43,7 +43,9 @@ class AID:
         if center is None:
             return
 
-        imviz_aligned_by_wcs = self._app._align_by == 'wcs'
+        orientation = self._app._jdaviz_helper.plugins.get('Orientation', None)
+        imviz_aligned_by_wcs = orientation and orientation.align_by == 'WCS'
+
         if isinstance(center, SkyCoord):
             if imviz_aligned_by_wcs:
                 center = center.ra.degree, center.dec.degree
@@ -91,7 +93,7 @@ class AID:
 
         orientation = self._app._jdaviz_helper.plugins.get('Orientation', None)
 
-        if orientation.align_by != 'WCS':
+        if not orientation or orientation.align_by != 'WCS':
             raise ValueError("The viewer must be aligned by WCS to use `set_rotation`.")
 
         if isinstance(rotation, (u.Quantity, Angle)):
@@ -164,8 +166,9 @@ class AID:
             state.y_max - state.y_min
         )
 
-        if sky_or_pixel == 'pixel':
+        if sky_or_pixel == 'pixel' or (sky_or_pixel is None and wcs is None):
             return pixel_fov
+
         if not any(c.strip() for c in wcs.wcs.ctype):
             raise ValueError("The image must have valid WCS to return `fov` in `sky`.")
 
@@ -198,16 +201,17 @@ class AID:
         center_x = self.viewer.state.zoom_center_x
         center_y = self.viewer.state.zoom_center_y
 
-        if self._app._align_by == 'wcs':
+        orientation = self._app._jdaviz_helper.plugins.get('Orientation', None)
+
+        if orientation and orientation.align_by == 'WCS':
             reference_data = self.viewer.state.reference_data
         else:
             reference_data, image_label = self._get_image_glue_data(image_label)
 
         reference_wcs = reference_data.coords
-
-        # # if the image data have WCS, get the center sky coordinate:
-        if sky_or_pixel in ('sky', None):
-            if self._app._align_by == 'wcs':
+        if reference_wcs and sky_or_pixel == 'sky':
+            # # if the image data have WCS, get the center sky coordinate:
+            if orientation.align_by == 'WCS':
                 center = self.viewer._get_center_skycoord()
             else:
                 center = reference_wcs.pixel_to_world(center_x, center_y)
@@ -218,6 +222,10 @@ class AID:
 
     def _get_current_rotation(self):
         reference_data = self.viewer.state.reference_data
+
+        if not reference_data.coords:
+            return None
+
         degn = get_compass_info(
             reference_data.coords, reference_data.shape
         )[-3]

--- a/jdaviz/configs/default/tests/test_aida.py
+++ b/jdaviz/configs/default/tests/test_aida.py
@@ -151,3 +151,32 @@ def test_get_fov_no_wcs(imviz_helper, image_hdu_nowcs):
 
     with pytest.raises(ValueError, match=re.escape("The image must have valid WCS to return `fov` in `sky`.")):  # noqa
         viewer.aid.get_viewport()
+
+
+def test_get_viewport_no_wcs(deconfigged_helper):
+    image_no_wcs = np.random.normal(size=(50, 50))
+    deconfigged_helper.load(image_no_wcs, loader='object', format='Image')
+
+    viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
+    viewport = viewer.aid.get_viewport()
+
+    assert viewport['center'] == (24.5, 24.5)
+    assert viewport['fov'] == 50.0
+    assert viewport['rotation'] is None
+    assert viewport['projection'] is None
+    assert viewport['image_label'] == 'Image'
+
+
+def test_set_viewport_no_wcs(deconfigged_helper):
+    image_no_wcs = np.random.normal(size=(50, 50))
+    deconfigged_helper.load(image_no_wcs, loader='object', format='Image')
+
+    viewer = deconfigged_helper.viewers['Image']._obj.glue_viewer
+    viewer.aid.set_viewport(center=(0, 0), fov=10)
+    viewport = viewer.aid.get_viewport()
+
+    assert viewport['center'] == (0, 0)
+    assert viewport['fov'] == 10
+    assert viewport['rotation'] is None
+    assert viewport['projection'] is None
+    assert viewport['image_label'] == 'Image'


### PR DESCRIPTION
Manual backport of #4304.

(cherry picked from commit 3fe33614feb83170887a201d618257717ab3751a)

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
