### PR TITLE
Backport of 4193: Stop using SkyCoord.from_name() on RA and Dec coordinates (#4193)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 Bug Fixes
 ---------
 
+- Stop using SkyCoord.from_name() to try to resolve sources in the astroquery loader
+  that are already RA and Dec coordinates. [#4193]
+
 - fix case where file drop loader would not show importer options. [#4303]
 
 - fix URL loader not showing in UI. [#4361]
@@ -79,16 +82,10 @@ Bug Fixes
 - Fix aperture photometry plugin remaining visible in tray after all
   image viewers are removed. [#4189]
 
-- Stop using SkyCoord.from_name() to try to resolve sources in the astroquery loader
-  that are already RA and Dec coordinates. [#4193]
-
 - Catch more IOPub messages to help avoid/fix "IOPub message rate exceeded" jupyter warning when
   loading many datasets in a loop. [#4223]
 
 - Fix interference between slice tools of different types (ie ramp vs spectral slices). [#4225]
-
-Mosviz
-^^^^^^
 
 5.0.1 (2026-05-01)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,11 +79,16 @@ Bug Fixes
 - Fix aperture photometry plugin remaining visible in tray after all
   image viewers are removed. [#4189]
 
+- Stop using SkyCoord.from_name() to try to resolve sources in the astroquery loader
+  that are already RA and Dec coordinates. [#4193]
+
 - Catch more IOPub messages to help avoid/fix "IOPub message rate exceeded" jupyter warning when
   loading many datasets in a loop. [#4223]
 
 - Fix interference between slice tools of different types (ie ramp vs spectral slices). [#4225]
 
+Mosviz
+^^^^^^
 
 5.0.1 (2026-05-01)
 ==================

--- a/jdaviz/core/loaders/resolvers/astroquery/astroquery.py
+++ b/jdaviz/core/loaders/resolvers/astroquery/astroquery.py
@@ -78,19 +78,32 @@ class AstroqueryResolver(BaseConeSearchResolver):
             ],
         )
 
-    @with_spinner(spinner_traitlet="results_loading")
-    def query_archive(self):
-        output = None
-        skycoord_center = None
+    def _source_to_skycoord(self):
+        # Check to see if source is "[RA] [Dec]" (in degrees)
+        split_source = self.source.split(' ')
+        if len(split_source) == 2:
+            try:
+                return SkyCoord(self.source, unit=u.deg, frame=self.coordframe.selected)
+            except ValueError:
+                pass
 
+        # Otherwise try to resolve coordinates from the source name
         try:
-            skycoord_center = SkyCoord.from_name(self.source, frame=self.coordframe.selected)
+            return SkyCoord.from_name(self.source, frame=self.coordframe.selected)
         except NameResolveError as e:
             # Sesame name resolution can fail when the service is unreachable (SSL timeout,
             # redirect error, etc.). Surface the failure as a snackbar rather than propagating
             # the exception to the caller. Keep processing below so we clear stale results.
             errmsg = f"Unable to resolve source coordinates: {self.source}"
             self.hub.broadcast(SnackbarMessage(errmsg, color='error', sender=self, traceback=e))
+            return None
+
+    @with_spinner(spinner_traitlet="results_loading")
+    def query_archive(self):
+        output = None
+
+        skycoord_center = self._source_to_skycoord()
+
         radius = self.radius * u.Unit(self.radius_unit.selected)
 
         # Only query the selected archive when name resolution succeeded.

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -436,6 +436,15 @@ def test_resolver_table_as_query_astroquery(deconfigged_helper, tmp_path):
     assert len(ldr._obj.output) > 0
 
 
+@pytest.mark.remote_data
+def test_failed_astroquery(deconfigged_helper):
+    ldr = deconfigged_helper.loaders['astroquery']
+    ldr.source = "Bad Object"
+    ldr.query_archive()
+    snackbar_msg = "Unable to resolve source coordinates: Bad Object"
+    assert deconfigged_helper.plugins['Logger'].history[-1]['text'] == snackbar_msg
+
+
 def test_invoke_from_plugin(specviz_helper, spectrum1d, tmp_path):
     s = SpectralRegion(5*u.um, 6*u.um)
     local_path = str(tmp_path / 'spectral_region.ecsv')


### PR DESCRIPTION
Manual backport.