### PR TITLE
Unify astroquery and VO backend and reporting behavior

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -105,8 +105,8 @@ New Features
 
 - Adds search to extension menu in loaders when there are more than 3 extensions available. [#4372]
 
-- Unify astroquery and VO reporting behavior. Both now show snackbars and banners in the UI
-  for the results of queries. [#4369]
+- Unify astroquery and VO reporting behavior. Both now show banners in the UI for the
+  results of queries. This information can also be found in the logger. [#4369]
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -105,6 +105,9 @@ New Features
 
 - Adds search to extension menu in loaders when there are more than 3 extensions available. [#4372]
 
+- Unify astroquery and VO reporting behavior. Both now show snackbars and banners in the UI
+  for the results of queries. [#4369]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -175,6 +175,7 @@ custom_components = {'j-tooltip': 'components/tooltip.vue',
                      'j-child-layer-icon': 'components/child_layer_icon.vue',
                      'j-about-menu': 'components/about_menu.vue',
                      'j-custom-toolbar-toggle': 'components/custom_toolbar_toggle.vue',
+                     'j-cone-search-messages': 'components/cone_search_messages.vue',
                      'loader-import-button': 'components/loader_import_button.vue',
                      'plugin-previews-temp-disabled': 'components/plugin_previews_temp_disabled.vue',  # noqa
                      'plugin-table': 'components/plugin_table.vue',

--- a/jdaviz/components/cone_search_messages.vue
+++ b/jdaviz/components/cone_search_messages.vue
@@ -1,0 +1,21 @@
+<template>
+  <div v-if="items.length > 0" style="margin-top: 12px">
+    <j-flex-row v-for="(item, index) in items" :key="index">
+      <v-alert :type="item.color" dense>
+        {{ item.text }}
+      </v-alert>
+    </j-flex-row>
+  </div>
+</template>
+
+<script>
+
+export default {
+  props: {
+    items: {
+      type: Array,
+      default: () => [],
+    },
+  },
+};
+</script>

--- a/jdaviz/core/loaders/resolvers/astroquery/astroquery.py
+++ b/jdaviz/core/loaders/resolvers/astroquery/astroquery.py
@@ -1,15 +1,11 @@
-from astropy.coordinates import SkyCoord
-from astropy.coordinates.name_resolve import NameResolveError
 from astropy import units as u
 
 
 from traitlets import Unicode, List
 
-from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import loader_resolver_registry
 from jdaviz.core.template_mixin import (
     SelectPluginComponent,
-    with_spinner,
 )
 from jdaviz.core.loaders.resolvers import BaseConeSearchResolver
 from jdaviz.core.user_api import LoaderUserApi
@@ -82,27 +78,9 @@ class AstroqueryResolver(BaseConeSearchResolver):
             ],
         )
 
-    def _source_to_skycoord(self):
-        # Strip parentheses from source if present
-        stripped_source = self.source.strip('()')
-        # Check to see if source is "[RA] [Dec]" (in degrees)
-        split_source = stripped_source.split(' ')
-        if len(split_source) == 2:
-            try:
-                return SkyCoord(stripped_source, unit=u.deg, frame=self.coordframe.selected)
-            except ValueError:
-                pass
-
-        # Otherwise try to resolve coordinates from the source name
-        try:
-            return SkyCoord.from_name(stripped_source, frame=self.coordframe.selected)
-        except NameResolveError as e:
-            # Sesame name resolution can fail when the service is unreachable (SSL timeout,
-            # redirect error, etc.). Surface the failure as a snackbar rather than propagating
-            # the exception to the caller. Keep processing below so we clear stale results.
-            errmsg = f"Unable to resolve source coordinates: {self.source}"
-            self.hub.broadcast(SnackbarMessage(errmsg, color='error', sender=self, traceback=e))
-            return None
+    @property
+    def _query_archive_label(self):
+        return self.telescope.selected
 
     def _query_single_coord(self, skycoord_center):
         """
@@ -123,64 +101,25 @@ class AstroqueryResolver(BaseConeSearchResolver):
 
             r_max = 3 * u.arcmin
             if radius > r_max:  # SDSS now has radius max limit
-                self.hub.broadcast(SnackbarMessage(
+                self._query_message(
                     f"Radius for {self.telescope.selected} has max radius of {r_max}\' but got "
                     f"{radius.to(u.arcmin)}, using {r_max}.",
-                    color='warning', sender=self))
+                    color='warning', raise_msg=True)
                 radius = r_max
 
             # queries the region (based on the provided center point and radius)
             # finds all the sources in that region
-            try:
-                output = SDSS.query_region(skycoord_center, radius=radius,
-                                           data_release=17)
-            except Exception as e:  # nosec
-                errmsg = (f"Failed to query {self.telescope.selected} with c={skycoord_center} and "
-                          f"r={radius}: {repr(e)}")
-                self.hub.broadcast(SnackbarMessage(errmsg, color='error',
-                                                   sender=self,
-                                                   traceback=e))
-                output = None  # will force returned_max_results = False, returned_no_results = True
+            output = SDSS.query_region(skycoord_center, radius=radius,
+                                       data_release=17)
+
         elif self.telescope.selected == 'Gaia':
             from astroquery.gaia import Gaia
 
             Gaia.ROW_LIMIT = self.max_results
             output = Gaia.query_object(skycoord_center, radius=radius)
         else:
+            # this can only occur in the API and therefore doesn't need to go through
+            # _query_message
             raise NotImplementedError(f"Querying for {self.telescope.selected} is not supported.")
 
         return output
-
-    @with_spinner(spinner_traitlet="results_loading")
-    def query_archive(self):
-        # Catalog mode: loop over all (selected) catalog rows and stack results.
-        if self.search_input_selected == 'Catalog':
-            self._query_catalog(self._query_single_coord)
-            return
-
-        # Source / Viewer mode: single coordinate.
-        output = None
-        skycoord_center = self._source_to_skycoord()
-
-        # Only query the selected archive when name resolution succeeded.
-        if skycoord_center is not None:
-            output = self._query_single_coord(skycoord_center)
-
-        if output is not None and len(output) > self.max_results:
-            output = output[:self.max_results]
-            self.returned_max_results = True
-        else:
-            self.returned_max_results = False
-        if output is None or len(output) == 0:
-            self.returned_no_results = True
-        else:
-            self.returned_no_results = False
-        self._output = output
-
-        self._resolver_input_updated()
-
-    def vue_query_archive(self, _=None):
-        self.query_archive()
-
-    def parse_input(self):
-        return self._output

--- a/jdaviz/core/loaders/resolvers/astroquery/astroquery.vue
+++ b/jdaviz/core/loaders/resolvers/astroquery/astroquery.vue
@@ -252,17 +252,7 @@
       </plugin-action-button>
     </j-flex-row>
 
-    <j-flex-row v-if="returned_no_results">
-      <v-alert type="warning">
-        The search returned no results. Please modify your query parameters and try again.
-      </v-alert>
-    </j-flex-row>
-
-    <j-flex-row v-if="returned_max_results">
-      <v-alert type="warning">
-        The number of results returned has reached the maximum limit set ({{ max_results }}). Consider increasing the maximum results to ensure all data is retrieved.
-      </v-alert>
-    </j-flex-row>
+    <j-cone-search-messages :items="query_message_items"></j-cone-search-messages>
   </j-loader>
 </template>
 

--- a/jdaviz/core/loaders/resolvers/astroquery/test_astroquery_load_catalog.py
+++ b/jdaviz/core/loaders/resolvers/astroquery/test_astroquery_load_catalog.py
@@ -7,8 +7,6 @@ from astropy.table import Table
 
 from glue.core.subset import RangeSubsetState
 
-from jdaviz.core.events import SnackbarMessage
-
 
 class TestCatalogConeSearch:
     @pytest.fixture(autouse=True)
@@ -38,12 +36,6 @@ class TestCatalogConeSearch:
         if name_col is not None:
             self.ldr.catalog_name_col.selected = name_col
         return label
-
-    def _capture_snackbars(self):
-        """Collect ``SnackbarMessage`` broadcasts on the loader's hub."""
-        msgs = []
-        self.ldr.hub.subscribe(self.ldr, SnackbarMessage, handler=lambda m: msgs.append(m))
-        return msgs
 
     @staticmethod
     def _fake_query(n_per_source=2):
@@ -194,12 +186,11 @@ class TestCatalogConeSearch:
 
     @pytest.mark.parametrize("fail_all", [False, True])
     def test_query_catalog_reports_unresolved(self, fail_all):
-        # Unresolved names are skipped, recorded in
-        # _source_name_query_failures, and summarized in a snackbar.
+        # Unresolved names are skipped, recorded in _source_name_query_failures,
+        # and summarized in a logger message.
         fail = self.source_names if fail_all else self.source_names[3:]
         self._enter_catalog_mode(col_other=['source_id'],
                                  col_type='source_name', name_col='source_id')
-        snackbars = self._capture_snackbars()
         fake = self._fake_query(n_per_source=1)
         self.ldr._query_single_coord = fake
 
@@ -220,22 +211,22 @@ class TestCatalogConeSearch:
             assert len(self.ldr._output) == n_ok
             assert self.ldr.returned_no_results is False
 
-        # check snackbar
-        assert any(f"Could not resolve {n_fail}/{n_total} source names" in m.text
-                   and "'source_id' column" in m.text and m.color == 'warning'
-                   for m in snackbars)
+        # check logger history
+        assert any(f"Could not resolve {n_fail}/{n_total} source names" in m['text']
+                   and "'source_id' column" in m['text'] and m['color'] == 'warning'
+                   for m in self.helper.plugins['Logger'].history)
 
         # the individual failures can be inspected
         failed_names = [name for f in self.ldr._source_name_query_failures for name in f]
         assert set(failed_names) == set(fail)
 
     @pytest.mark.parametrize("distinct,expect_hint", [(False, True), (True, False)])
-    def test_resolve_source_names_single_reason_snackbar(self, distinct, expect_hint):
+    def test_resolve_source_names_single_reason(self, distinct, expect_hint):
         # A single shared error across all failures emits a "single reason" hint
         # (a sign the resolver service may be down). Distinct errors do not.
         self._enter_catalog_mode(col_other=['source_id'],
                                  col_type='source_name', name_col='source_id')
-        snackbars = self._capture_snackbars()
+
         side_effect = self._fail_from_name(self.source_names, distinct=distinct)
         with patch.object(SkyCoord, 'from_name', side_effect=side_effect):
             coords = self.ldr._get_catalog_skycoords()
@@ -243,4 +234,4 @@ class TestCatalogConeSearch:
         # every row failed and is kept with its error string
         assert all(sc is None and err for sc, _, err in coords)
         hint = 'Single reason failure occurred during name resolution'
-        assert any(hint in m.text for m in snackbars) is expect_hint
+        assert any(hint in m['text'] for m in self.helper.plugins['Logger'].history) is expect_hint

--- a/jdaviz/core/loaders/resolvers/astroquery/test_astroquery_load_catalog.py
+++ b/jdaviz/core/loaders/resolvers/astroquery/test_astroquery_load_catalog.py
@@ -125,6 +125,19 @@ class TestCatalogConeSearch:
         assert self.ldr._output is None
         assert self.ldr.returned_no_results is True
 
+        # Reaching (without exceeding) max_results still queries every source and
+        # is reported as having hit the cap, since the archive may have had more.
+        n = len(self.sky_catalog)
+        self.ldr.max_results = n
+        fake = self._fake_query(n_per_source=1)
+        self.ldr._query_single_coord = fake
+
+        self.ldr.query_archive()
+
+        assert len(fake.calls) == n
+        assert len(self.ldr._output) == n
+        assert self.ldr.returned_max_results is True
+
     def test_query_catalog_with_subset(self):
         label = self._enter_catalog_mode()
         data = self.helper._app.data_collection[label]

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -731,8 +731,7 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
                 # (e.g. a table with Dataset + s_region but no URL-like column)
                 self.observation_table._clear_table()
                 self.file_table._clear_table()
-                for row in observation_table:
-                    self.observation_table.add_item(row)
+                self.observation_table.set_all_items_from_table(observation_table)
                 self.observation_table.headers_visible = [h for h in self.observation_table.headers_visible  # noqa
                                                           if h not in ['s_region']]
 

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -1221,7 +1221,7 @@ class BaseConeSearchResolver(BaseResolver):
         banner in the loader UI.
         """
         self.query_message_items = (self.query_message_items +
-                                    [{'text': text, 'color': color, 'traceback': traceback}])
+                                    [{'text': text, 'color': color, 'traceback': str(traceback)}])
         # broadcast with short(er) timeout since the message is also shown as a banner
         # broadcasting adds the message to the log otherwise we might consider
         # avoiding it

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -12,6 +12,7 @@ from astropy.coordinates import SkyCoord
 from astropy.coordinates.builtin_frames import __all__ as all_astropy_frames
 from astropy.coordinates.name_resolve import NameResolveError
 from astropy.table import Table as astropyTable
+from astropy import units as u
 from astroquery.mast import MastMissions
 
 from jdaviz.core.custom_traitlets import FloatHandleEmpty, IntHandleEmpty
@@ -1123,9 +1124,13 @@ class BaseConeSearchResolver(BaseResolver):
     returned_no_results = Bool(False).tag(sync=True)
     returned_max_results = Bool(False).tag(sync=True)
 
+    # Unified reporting for all cone-search resolvers. See ``_query_message``.
+    query_message_items = List([]).tag(sync=True)
     results_loading = Bool(False).tag(sync=True)
 
     _catalog_source_index_colname = 'source_index'
+    # label of the source currently being queried, used in query failure messages
+    _current_query_source_label = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1206,6 +1211,150 @@ class BaseConeSearchResolver(BaseResolver):
         self.hub.subscribe(self, AddDataMessage, handler=self.vue_center_on_data)
         self.hub.subscribe(self, RemoveDataMessage, handler=self.vue_center_on_data)
         self.hub.subscribe(self, LinkUpdatedMessage, handler=self._on_link_type_updated)
+
+    def _clear_query_messages(self):
+        self.query_message_items = []
+
+    def _query_message(self, text, color='error', traceback=None,
+                       raise_msg=False):
+        """
+        Report ``text`` to the user through both a snackbar and a persistent
+        banner in the loader UI.
+        """
+        self.query_message_items = (self.query_message_items +
+                                    [{'text': text, 'color': color, 'traceback': traceback}])
+        # broadcast with short(er) timeout since the message is also shown as a banner
+        # broadcasting adds the message to the log otherwise we might consider
+        # avoiding it
+        self.hub.broadcast(
+            SnackbarMessage(text, color=color, sender=self, traceback=traceback, timeout=3000)
+        )
+
+        if raise_msg and color == 'warning':
+            warnings.warn(text)
+
+        elif raise_msg and color == 'error' and traceback is not None:
+            raise traceback
+
+    @property
+    def _query_archive_label(self):
+        # override by subclass to identify the queried archive/resource
+        return ''
+
+    def _query_single_coord(self, skycoord_center):
+        # override by subclass. This should return an astropy table (or None) of
+        # the results from querying the archive/resource at the given coordinate
+        raise NotImplementedError("Cone search resolver subclass must implement _query_single_coord")  # noqa pragma: nocover
+
+    def _query_single_coord_reporting(self, skycoord_center):
+        """
+        Call ``_query_single_coord``, converting any failure into an error message
+        and a ``None`` result.
+
+        Failures are reported rather than raised so that a single unreachable
+        service or malformed response doesn't abort a multi-source (Catalog
+        mode) query.
+        """
+        try:
+            return self._query_single_coord(skycoord_center)
+        except NotImplementedError:
+            # not a query failure, but an unsupported configuration
+            raise
+        except Exception as e:  # nosec
+            archive = f'{self._query_archive_label}' if self._query_archive_label else ''
+            source_label = self._current_query_source_label or self.source
+            self._query_message(f"Failed to query {archive.strip()} for source: {source_label}.",
+                                color='error', traceback=e)
+            return None
+
+    def _source_to_skycoord(self, add_query_message=True):
+        """
+        Resolve ``source`` into a ``SkyCoord``. The input is first parsed as a
+        coordinate pair in degrees and, failing that, as a source name via
+        ``SkyCoord.from_name``.
+
+        Returns ``None`` (reporting the failure via `_query_message`) when the
+        source cannot be resolved, e.g. because the name is unknown or because
+        the Sesame name resolution service is unreachable.
+        """
+        # Strip parentheses from source if present
+        stripped_source = self.source.strip('()')
+        try:
+            return SkyCoord(stripped_source, unit=u.deg, frame=self.coordframe_selected)
+        except Exception:  # nosec
+            pass
+
+        try:
+            return SkyCoord.from_name(stripped_source, frame=self.coordframe_selected)
+        except Exception as e:  # nosec
+            if add_query_message:
+                self._query_message(f"Unable to resolve source name: {self.source}",
+                                    color='error', traceback=e)
+            return None
+
+    def _finalize_query_output(self, output, hit_cap=False):
+        """
+        Apply the ``max_results`` cap to ``output``, update the result-state
+        traitlets, report the outcome of the query, and notify the loader that
+        the resolver input has changed.
+        """
+        if output is not None and len(output) >= self.max_results:
+            output = output[:self.max_results]
+            hit_cap = True
+
+        n_results = 0 if output is None else len(output)
+        self.returned_no_results = n_results == 0
+        self.returned_max_results = hit_cap and (n_results > 0)
+        self._output = output if n_results else None
+        failures = [msg for msg in self.query_message_items if msg['color'] == 'error']
+
+        if self.returned_no_results and not failures:
+            self._query_message("The search returned no results. Please modify your "
+                                "query parameters and try again.",
+                                color='error')
+        elif self.returned_max_results:
+            self._query_message("The number of results returned has reached the maximum "
+                                f"limit set ({self.max_results}).",
+                                color='success')
+        else:
+            # There can be a scenario where the query returns failures for every result
+            # but the query itself was successful. In that case, we don't want to show the
+            # "0 results found" message.
+            if not self.returned_no_results:
+                self._query_message(f"{n_results} results found.", color='success')
+
+        self._resolver_input_updated()
+
+    @with_spinner(spinner_traitlet="results_loading")
+    def query_archive(self):
+        """
+        Query the selected archive/resource for the selected source(s).
+
+        In "Source"/"Viewer" input mode, a single cone search is run on the
+        resolved coordinates.  In "Catalog" input mode, the archive is queried
+        once per (selected) catalog row and the results are stacked
+        (see ``_query_catalog``).
+        """
+        self._clear_query_messages()
+
+        # Catalog mode: loop over all (selected) catalog rows and stack results.
+        if self.search_input_selected == 'Catalog':
+            self._query_catalog()
+            return
+
+        # Source / Viewer mode: single coordinate. Only query when name
+        # resolution succeeded so that stale results are still cleared.
+        skycoord_center = self._source_to_skycoord()
+        output = (self._query_single_coord_reporting(skycoord_center)
+                  if skycoord_center is not None else None)
+
+        self._finalize_query_output(output)
+
+    def vue_query_archive(self, _=None):
+        self.query_archive()
+
+    def parse_input(self):
+        return self._output
 
     @observe('catalog_selected')
     def _on_catalog_selected(self, msg=None):
@@ -1389,9 +1538,9 @@ class BaseConeSearchResolver(BaseResolver):
         # Specify this (mostly) to check for general network issues
         err_strings = [e for (_, _, e) in coords if e]
         if len(set(err_strings)) == 1:
-            self.hub.broadcast(SnackbarMessage(
+            self._query_message(
                 f"Single reason failure occurred during name resolution: {err_strings[0]}",
-                color='warning', sender=self))
+                color='warning')
 
         return coords
 
@@ -1433,11 +1582,13 @@ class BaseConeSearchResolver(BaseResolver):
             coords.append((sc, f"{ra_data[i]:.12f} {dec_data[i]:.12f}", None))
         return coords
 
-    def _query_catalog(self, single_coord_query_fn):
+    def _query_catalog(self, single_coord_query_fn=None):
         """
         Loop over the rows of the selected catalog, calling
         ``single_coord_query_fn(skycoord)`` for each, and vertically stack the
-        returned tables into ``self._output``.
+        returned tables into ``self._output``. Defaults to
+        ``_query_single_coord_reporting`` so that a failure on one source doesn't
+        abort the remaining queries.
 
         A ``source_index`` column is added to identify which queried source each
         returned row corresponds to. The loop stops early once ``max_results``
@@ -1446,6 +1597,9 @@ class BaseConeSearchResolver(BaseResolver):
         the final table.
         """
         from astropy.table import vstack
+
+        if single_coord_query_fn is None:
+            single_coord_query_fn = self._query_single_coord_reporting
 
         coords = self._get_catalog_skycoords()
         n = len(coords)
@@ -1460,6 +1614,7 @@ class BaseConeSearchResolver(BaseResolver):
                     continue
 
                 self.query_progress = f"Querying source {i + 1} of {n}"
+                self._current_query_source_label = label
                 result = single_coord_query_fn(sc)
                 if result is not None and len(result) > 0:
                     result = result.copy()
@@ -1473,32 +1628,20 @@ class BaseConeSearchResolver(BaseResolver):
 
         finally:
             self.query_progress = ""
+            self._current_query_source_label = None
 
-        if results:
-            output = vstack(results, metadata_conflicts='silent')
-            if len(output) > self.max_results:
-                output = output[:self.max_results]
-                hit_cap = True
-
-            self.returned_max_results = hit_cap
-            self.returned_no_results = False
-            self._output = output
-
-        else:
-            self.returned_max_results = False
-            self.returned_no_results = True
-            self._output = None
-
-        self._resolver_input_updated()
+        output = vstack(results, metadata_conflicts='silent') if results else None
 
         if self._source_name_query_failures:
             # Full per-name errors remain in ``self._source_name_query_failures``
             # for a developer to inspect if needed.
-            self.hub.broadcast(SnackbarMessage(
+            self._query_message(
                 f"Could not resolve {len(self._source_name_query_failures)}/{len(coords)} "
                 f"source names from the '{self.catalog_name_col_selected}' column. "
                 f"Check the source names in your catalog.",
-                color='warning', sender=self))
+                color='warning')
+
+        self._finalize_query_output(output, hit_cap=hit_cap)
 
     def _check_is_valid(self):
         """

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -703,8 +703,7 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
                 # search-results CSV with obs_id + dataURL + s_region). Fall through to
                 # the observation_table branch so footprint display works correctly.
                 if observation_table is None or 's_region' not in parsed_input_table.colnames:
-                    for row in file_table:
-                        self.file_table.add_item(row)
+                    self.file_table.set_all_items_from_table(file_table)
 
                     # Technically input isn't complete yet but if we don't set this now
                     # the UI will appear bugged with the 'input is empty' message for astroquery
@@ -715,8 +714,7 @@ class BaseResolver(PluginTemplateMixin, CustomToolbarToggleMixin, FootprintDispl
                     self.parsed_input_not_resolvable_message = ''
                     return
 
-                for row in observation_table:
-                    self.observation_table.add_item(row)
+                self.observation_table.set_all_items_from_table(observation_table)
                 self.observation_table.headers_visible = [h for h in self.observation_table.headers_visible  # noqa
                                                           if h not in ['s_region']]
 

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -1222,10 +1222,12 @@ class BaseConeSearchResolver(BaseResolver):
                                     [{'text': text, 'color': color, 'traceback': str(traceback)}])
 
         # add message to logger with/without broadcasting
-        snackbar_msg = SnackbarMessage(text, color=color, sender=self, traceback=traceback)
+        text_w_traceback = text + (f'Traceback: {traceback}' if traceback is not None else '')
+        snackbar_msg_w_traceback = SnackbarMessage(text_w_traceback,
+                                                   color=color, sender=self, traceback=traceback)
         self._app.state.snackbar_queue.put(self._app.state,
                                            self._app._jdaviz_helper.plugins['Logger'],
-                                           snackbar_msg,
+                                           snackbar_msg_w_traceback,
                                            history=True,
                                            popup=popup)
 

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -1213,19 +1213,22 @@ class BaseConeSearchResolver(BaseResolver):
     def _clear_query_messages(self):
         self.query_message_items = []
 
-    def _query_message(self, text, color='error', traceback=None, raise_msg=False):
+    def _query_message(self, text, color='error', popup=False, traceback=None, raise_msg=False):
         """
-        Report ``text`` to the user through both a snackbar and a persistent
-        banner in the loader UI.
+        Report ``text`` to the user through both a persistent banner in the loader UI.
+        The messages are still passed to the logger so they can be accessed after the
+        fact.
         """
         self.query_message_items = (self.query_message_items +
                                     [{'text': text, 'color': color, 'traceback': str(traceback)}])
-        # broadcast with short(er) timeout since the message is also shown as a banner
-        # broadcasting adds the message to the log otherwise we might consider
-        # avoiding it
-        self.hub.broadcast(
-            SnackbarMessage(text, color=color, sender=self, traceback=traceback, timeout=3000)
-        )
+
+        # add message to logger with/without broadcasting
+        snackbar_msg = SnackbarMessage(text, color=color, sender=self, traceback=traceback)
+        self._app.state.snackbar_queue.put(self._app.state,
+                                           self._app._jdaviz_helper.plugins['Logger'],
+                                           snackbar_msg,
+                                           history=True,
+                                           popup=popup)
 
         if raise_msg and color == 'warning':
             warnings.warn(text)

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -1309,8 +1309,10 @@ class BaseConeSearchResolver(BaseResolver):
         failures = [msg for msg in self.query_message_items if msg['color'] == 'error']
 
         if self.returned_no_results and not failures:
-            self._query_message("The search returned no results. Please modify your "
-                                "query parameters and try again.",
+            archive = self._query_archive_label.strip()
+            from_archive = f" from {archive}" if archive else ""
+            self._query_message(f"The search returned no results{from_archive}. Please modify "
+                                "your query parameters and try again.",
                                 color='error')
         elif self.returned_max_results:
             self._query_message("The number of results returned has reached the maximum "

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -1238,7 +1238,7 @@ class BaseConeSearchResolver(BaseResolver):
     @property
     def _query_archive_label(self):
         # override by subclass to identify the queried archive/resource
-        return ''
+        return 'no archive/resource selected (subclass must override _query_archive_label)'  # noqa pragma: nocover
 
     def _query_single_coord(self, skycoord_center):
         # override by subclass. This should return an astropy table (or None) of

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -1222,7 +1222,7 @@ class BaseConeSearchResolver(BaseResolver):
                                     [{'text': text, 'color': color, 'traceback': str(traceback)}])
 
         # add message to logger with/without broadcasting
-        text_w_traceback = text + (f'Traceback: {traceback}' if traceback is not None else '')
+        text_w_traceback = text + (f'; Traceback: {traceback}' if traceback is not None else '')
         snackbar_msg_w_traceback = SnackbarMessage(text_w_traceback,
                                                    color=color, sender=self, traceback=traceback)
         self._app.state.snackbar_queue.put(self._app.state,

--- a/jdaviz/core/loaders/resolvers/resolver.py
+++ b/jdaviz/core/loaders/resolvers/resolver.py
@@ -1215,8 +1215,7 @@ class BaseConeSearchResolver(BaseResolver):
     def _clear_query_messages(self):
         self.query_message_items = []
 
-    def _query_message(self, text, color='error', traceback=None,
-                       raise_msg=False):
+    def _query_message(self, text, color='error', traceback=None, raise_msg=False):
         """
         Report ``text`` to the user through both a snackbar and a persistent
         banner in the loader UI.
@@ -1257,13 +1256,10 @@ class BaseConeSearchResolver(BaseResolver):
         """
         try:
             return self._query_single_coord(skycoord_center)
-        except NotImplementedError:
-            # not a query failure, but an unsupported configuration
-            raise
         except Exception as e:  # nosec
-            archive = f'{self._query_archive_label}' if self._query_archive_label else ''
             source_label = self._current_query_source_label or self.source
-            self._query_message(f"Failed to query {archive.strip()} for source: {source_label}.",
+            self._query_message(f"Failed to query {self._query_archive_label.strip()} "
+                                f"for source: {source_label}.",
                                 color='error', traceback=e)
             return None
 
@@ -1306,13 +1302,11 @@ class BaseConeSearchResolver(BaseResolver):
         self.returned_no_results = n_results == 0
         self.returned_max_results = hit_cap and (n_results > 0)
         self._output = output if n_results else None
-        failures = [msg for msg in self.query_message_items if msg['color'] == 'error']
+        _failures = [msg for msg in self.query_message_items if msg['color'] == 'error']
 
-        if self.returned_no_results and not failures:
-            archive = self._query_archive_label.strip()
-            from_archive = f" from {archive}" if archive else ""
-            self._query_message(f"The search returned no results{from_archive}. Please modify "
-                                "your query parameters and try again.",
+        if self.returned_no_results and not len(_failures):
+            self._query_message(f"The search returned no results from {self._query_archive_label}. "
+                                f"Please modify your query parameters and try again.",
                                 color='error')
         elif self.returned_max_results:
             self._query_message("The number of results returned has reached the maximum "
@@ -1333,7 +1327,7 @@ class BaseConeSearchResolver(BaseResolver):
         Query the selected archive/resource for the selected source(s).
 
         In "Source"/"Viewer" input mode, a single cone search is run on the
-        resolved coordinates.  In "Catalog" input mode, the archive is queried
+        resolved coordinates. In "Catalog" input mode, the archive is queried
         once per (selected) catalog row and the results are stacked
         (see ``_query_catalog``).
         """

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/tests/test_vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/tests/test_vo.py
@@ -519,7 +519,6 @@ class TestVOImvizRemote:
         assert expected_error_msg in imviz_helper.plugins['Logger'].history[-1]["text"]
 
     @pytest.mark.filterwarnings("ignore:Some non-standard WCS keywords were excluded")
-    @pytest.mark.filterwarnings("ignore:column .* has a unit but is kept as")
     def test_HSTM51_data_url(self, imviz_helper):
         vo_ldr = self._init_vo_ldr_M51(imviz_helper)
 

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/tests/test_vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/tests/test_vo.py
@@ -285,6 +285,7 @@ class TestVOQueryPaths:
 
     @pytest.mark.parametrize("err_msg, n_calls, expected_error", [
         ("Wrong FORMAT=image/fits,image/fits", 2, None),
+        ("Service accepts only FORMAT = image/fits, ALL, or METADATA", 2, None),
         ("Unsupported service protocol", 1, "Failed to query FAKE for source"),
     ])
     def test_dal_query_error_retried_for_duplicate_format(self, deconfigged_helper, err_msg,

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/tests/test_vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/tests/test_vo.py
@@ -66,6 +66,15 @@ class TestVODeconfiggedImageLocal(BaseDeconfiggedImage_WCS_WCS):
         vo_ldr.viewer.selected = "Image (1)"
         assert vo_ldr.source == ""
 
+        # Coverage filtering requires a source, and the error message points at the
+        # empty viewer (rather than the source field) while in Viewer input mode
+        vo_ldr.resource_filter_coverage = True
+        with pytest.raises(ValueError, match="Load data into viewer"):
+            vo_ldr.waveband.selected = "optical"
+        # clear the waveband first so that neither reset re-triggers a registry query
+        vo_ldr.waveband.selected = ""
+        vo_ldr.resource_filter_coverage = False
+
         # Now load second data into second viewer and verify coordinates
         self.helper._app.add_data_to_viewer("Image (1)", "has_wcs_2")
         ra_str, dec_str = vo_ldr.source.split()
@@ -286,20 +295,19 @@ class TestVOImvizRemote:
 
         # If waveband selected and coverage filtering, can't query registry
         # if we don't have a source
-        expected_error_traceback = "Unable to resolve source coordinates:"
+        expected_error_msg = "Source is required for registry querying"
         vo_ldr.resource_filter_coverage = True
         vo_ldr.source = ""
         with pytest.raises(
-            Exception,
-            match=expected_error_traceback,
+            ValueError,
+            match=expected_error_msg,
         ):
             # Setting the waveband from nothing to something will trigger the query
             vo_ldr.waveband.selected = "optical"
-        # Also verify we get a snackbar message for it
-        assert any(
-            expected_error_traceback in d["text"]
-            for d in imviz_helper.plugins['Logger'].history
-        )
+        # Also verify we get a snackbar message for it, including how to resolve it
+        last_msg = imviz_helper.plugins['Logger'].history[-1]["text"]
+        assert expected_error_msg in last_msg
+        assert "Please enter your coordinates above" in last_msg
 
         # If waveband selected, but NOT filtering by coverage, then allow registry query
         vo_ldr.resource_filter_coverage = False
@@ -350,17 +358,15 @@ class TestVOImvizRemote:
         vo_ldr.radius = 1
         vo_ldr.radius_unit.selected = "deg"
 
-        # If we have coverage filtering on, we should get an error
+        # If we have coverage filtering on, we should get an error.
+        # The source-resolution failure is reported as itself, rather than being
+        # re-wrapped as a generic registry error.
         vo_ldr.resource_filter_coverage = True
-        # This is what shows in the snackbar/banner
-        expected_error_msg = "An error occurred querying the VO Registry"
-        # This is the actual traceback. In this case it also shows in the
-        # snackbar/banner, but in other cases it may not.
-        expected_error_traceback = "Unable to resolve source coordinates:"
-        with pytest.raises(LookupError, match=expected_error_traceback):
+        expected_error_msg = f"Unable to resolve source coordinates: {vo_ldr.source}"
+        with pytest.raises(LookupError, match=expected_error_msg):
             vo_ldr.waveband.selected = "optical"
         assert expected_error_msg in imviz_helper.plugins['Logger'].history[-1]["text"]
-        assert expected_error_traceback in imviz_helper.plugins['Logger'].history[-1]["text"]
+        assert "querying the VO Registry" not in imviz_helper.plugins['Logger'].history[-1]["text"]
         assert len(vo_ldr.resource.choices) == 0
 
         # By clearing coverage filtering, we should now be able to query the registry

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/tests/test_vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/tests/test_vo.py
@@ -8,22 +8,58 @@ from astropy.coordinates import SkyCoord
 from astropy.table import QTable, Table
 import astropy.units as u
 
+from pyvo.dal.exceptions import DALFormatError, DALQueryError
 from pyvo.io.vosi.endpoint import parse_capabilities
+from pyvo.utils.vocabularies import VocabularyError
 from pyvo.utils.xml.exceptions import UnknownElementWarning
+from requests.exceptions import ConnectionError as RequestConnectionError
 
 import jdaviz as jd
 from jdaviz.configs.imviz.tests.utils import BaseDeconfiggedImage_WCS_WCS
 
 
-class fake_siaresult:
-    """A mock class that simulates a SIAResult"""
+class _FakeVOResults(list):
+    """A mock class that simulates the results of a VO service search."""
 
-    def __init__(self, attrs):
-        for attr, value in attrs.items():
-            self.__setattr__(attr, value)
+    def to_table(self):
+        return Table({'access_url': list(self)})
 
-    def getdataurl(self):
-        return "Fake URL"
+
+class _FakeVOService:
+    """
+    A mock class that simulates the chain of pyvo objects the VO loader
+    interacts with: the registry results (``getcolumn`` and ``[short_name]``),
+    the resource that returns a service (``get_service``), and the service
+    itself (``search``).
+
+    ``search`` raises ``error`` (when given) on the first call only, so that
+    retry behavior can be exercised.
+    """
+
+    baseurl = "http://example.com/sia"
+
+    def __init__(self, short_names=('FAKE',), error=None):
+        self.short_names = list(short_names)
+        self.error = error
+        self.calls = []
+
+    # registry results
+    def getcolumn(self, name):
+        return self.short_names
+
+    def __getitem__(self, short_name):
+        return self
+
+    # resource
+    def get_service(self, service_type=None):
+        return self
+
+    # service
+    def search(self, coord, **kwargs):
+        self.calls.append(kwargs)
+        if self.error is not None and len(self.calls) == 1:
+            raise self.error
+        return _FakeVOResults(['a'])
 
 
 # TODO: Update all _obj calls to formal API calls once Plugin API is available
@@ -179,6 +215,97 @@ def test_vo_catalog_query_routes_to_query_catalog(deconfigged_helper):
     assert len(vo_ldr._output) == 6
     assert vo_ldr._catalog_source_index_colname in vo_ldr._output.colnames
     assert sorted(set(vo_ldr._output[vo_ldr._catalog_source_index_colname])) == [0, 1, 2]
+
+
+class TestVOQueryPaths:
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, deconfigged_helper):
+        self.vo_ldr = deconfigged_helper.loaders["virtual observatory"]._obj
+        self.source = "337.5 -20.8"
+        self.fake_name = 'FAKE'
+
+    @pytest.mark.parametrize("error, expected_msg", [
+        (DALFormatError(cause=RequestConnectionError("no route to host"),
+                        url="http://example.com/registry"), "Can't connect to VO registry"),
+        (VocabularyError("HTTP Error 403: Forbidden"), "Can't connect to VO registry"),
+        (ValueError("kaboom"), "An error occurred querying the VO Registry"),
+    ])
+    def test_registry_query_failures_reported(self, deconfigged_helper, error, expected_msg):
+        """Registry failures are both raised and reported to the user."""
+        vo_ldr = self.vo_ldr
+
+        def _raise(*constraints):
+            raise error
+
+        vo_ldr._registry_search = _raise
+
+        with pytest.raises(type(error)):
+            # setting the waveband triggers the registry query
+            vo_ldr.waveband.selected = "optical"
+
+        assert vo_ldr.resource.choices == []
+        errors = [d['text'] for d in vo_ldr.query_message_items if d['color'] == 'error']
+        assert len(errors) == 1 and expected_msg in errors[0]
+
+    def test_empty_registry_results_reported(self, deconfigged_helper):
+        """Check that empty registry results are reported to the user,
+        and that the message is cleared once results are available again."""
+        vo_ldr = self.vo_ldr
+        results = _FakeVOService([self.fake_name])
+        vo_ldr._registry_search = lambda *constraints: results
+
+        vo_ldr.waveband.selected = "optical"
+        assert vo_ldr.resource.choices == [self.fake_name]
+        assert vo_ldr.query_message_items == []
+
+        results.short_names = []
+        vo_ldr.waveband.selected = "radio"
+        assert vo_ldr.resource.choices == []
+        assert [(d['text'], d['color']) for d in vo_ldr.query_message_items] == [
+            (f"No {vo_ldr.waveband.selected} image resources found in the VO registry. "
+             f"Try a different waveband or product type.", 'warning')]
+
+        # with coverage filtering the registry query is source-constrained, so the
+        # source is identified and clearing the filter is offered as a way out
+        vo_ldr.source = self.source
+        vo_ldr.resource_filter_coverage = True
+        assert vo_ldr.resource.choices == []
+        assert [(d['text'], d['color']) for d in vo_ldr.query_message_items] == [
+            (f"No {vo_ldr.waveband.selected} image resources found in the VO registry for source: "
+             f"{vo_ldr.source}. Try a different waveband or product type, or "
+             f"disable coverage filtering.", 'warning')]
+        vo_ldr.resource_filter_coverage = False
+
+        # the message is cleared once the registry returns resources again
+        results.short_names = [self.fake_name]
+        vo_ldr.waveband.selected = "optical"
+        assert vo_ldr.resource.choices == [self.fake_name]
+        assert vo_ldr.query_message_items == []
+
+    @pytest.mark.parametrize("err_msg, n_calls, expected_error", [
+        ("Wrong FORMAT=image/fits,image/fits", 2, None),
+        ("Unsupported service protocol", 1, "Failed to query FAKE for source"),
+    ])
+    def test_dal_query_error_retried_for_duplicate_format(self, deconfigged_helper, err_msg,
+                                                          n_calls, expected_error):
+        vo_ldr = self.vo_ldr
+        vo_ldr.source = self.source
+        service = _FakeVOService([self.fake_name], error=DALQueryError(err_msg))
+        vo_ldr._full_registry_results = service
+        vo_ldr.resource.choices = [self.fake_name]
+        vo_ldr.resource_selected = self.fake_name
+
+        vo_ldr.query_archive()
+
+        assert len(service.calls) == n_calls
+        errors = [d['text'] for d in vo_ldr.query_message_items if d['color'] == 'error']
+        if expected_error is None:
+            assert errors == []
+            assert len(vo_ldr._output) == 1
+        else:
+            assert len(errors) == 1 and expected_error in errors[0]
+            assert vo_ldr._output is None
 
 
 class TestVOXMLInjectionWarning:

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/tests/test_vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/tests/test_vo.py
@@ -519,6 +519,7 @@ class TestVOImvizRemote:
         assert expected_error_msg in imviz_helper.plugins['Logger'].history[-1]["text"]
 
     @pytest.mark.filterwarnings("ignore:Some non-standard WCS keywords were excluded")
+    @pytest.mark.filterwarnings("ignore:column .* has a unit but is kept as")
     def test_HSTM51_data_url(self, imviz_helper):
         vo_ldr = self._init_vo_ldr_M51(imviz_helper)
 

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/tests/test_vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/tests/test_vo.py
@@ -284,20 +284,22 @@ class TestVOImvizRemote:
         vo_ldr.waveband.selected = ""
         assert len(vo_ldr.resource.choices) == 0
 
-        # If waveband selected and coverage filtering, can't query registry if don't have a source
+        # If waveband selected and coverage filtering, can't query registry
+        # if we don't have a source
+        expected_error_traceback = "Unable to resolve source coordinates:"
         vo_ldr.resource_filter_coverage = True
         vo_ldr.source = ""
         with pytest.raises(
-            ValueError,
-            match="Source is required for registry querying when coverage filtering is enabled.",
+            Exception,
+            match=expected_error_traceback,
         ):
             # Setting the waveband from nothing to something will trigger the query
             vo_ldr.waveband.selected = "optical"
-            # Also verify we get a snackbar message for it
-            assert any(
-                "Source is required" in d["text"]
-                for d in imviz_helper.plugins['Logger'].history
-            )
+        # Also verify we get a snackbar message for it
+        assert any(
+            expected_error_traceback in d["text"]
+            for d in imviz_helper.plugins['Logger'].history
+        )
 
         # If waveband selected, but NOT filtering by coverage, then allow registry query
         vo_ldr.resource_filter_coverage = False
@@ -350,14 +352,16 @@ class TestVOImvizRemote:
 
         # If we have coverage filtering on, we should get an error
         vo_ldr.resource_filter_coverage = True
-        expected_error_msg = "Unable to resolve source coordinates"
-        with pytest.raises(LookupError, match=expected_error_msg):
+        # This is what shows in the snackbar/banner
+        expected_error_msg = "An error occurred querying the VO Registry"
+        # This is the actual traceback. In this case it also shows in the
+        # snackbar/banner, but in other cases it may not.
+        expected_error_traceback = "Unable to resolve source coordinates:"
+        with pytest.raises(LookupError, match=expected_error_traceback):
             vo_ldr.waveband.selected = "optical"
-            assert any(
-                expected_error_msg in d["text"]
-                for d in imviz_helper.plugins['Logger'].history
-            )
-            assert len(vo_ldr.resource.choices) == 0
+        assert expected_error_msg in imviz_helper.plugins['Logger'].history[-1]["text"]
+        assert expected_error_traceback in imviz_helper.plugins['Logger'].history[-1]["text"]
+        assert len(vo_ldr.resource.choices) == 0
 
         # By clearing coverage filtering, we should now be able to query the registry
         # and return the full list of available resources:
@@ -369,11 +373,10 @@ class TestVOImvizRemote:
         # Clear existing messages
         imviz_helper.plugins['Logger'].clear_history()
         vo_ldr.resource.selected = "HST.M51"
+        # Snackbar banner only, no tracebacks.
+        expected_error_msg = f"Unable to resolve source name: {vo_ldr.source}"
         vo_ldr.query_archive()
-        assert any(
-            expected_error_msg in d["text"]
-            for d in imviz_helper.plugins['Logger'].history
-        )
+        assert expected_error_msg in imviz_helper.plugins['Logger'].history[-1]["text"]
 
     @pytest.mark.filterwarnings("ignore:Some non-standard WCS keywords were excluded")
     def test_HSTM51_data_url(self, imviz_helper):

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/tests/test_vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/tests/test_vo.py
@@ -283,16 +283,18 @@ class TestVOQueryPaths:
         assert vo_ldr.resource.choices == [self.fake_name]
         assert vo_ldr.query_message_items == []
 
-    @pytest.mark.parametrize("err_msg, n_calls, expected_error", [
-        ("Wrong FORMAT=image/fits,image/fits", 2, None),
-        ("Service accepts only FORMAT = image/fits, ALL, or METADATA", 2, None),
-        ("Unsupported service protocol", 1, "Failed to query FAKE for source"),
+    @pytest.mark.parametrize("error, n_calls, expected_error", [
+        (DALQueryError("Service accepts only FORMAT = image/fits, ALL, or METADATA"), 2, None),
+        # a service that doesn't accept the format argument at all
+        (TypeError("search() got an unexpected keyword argument 'format'"), 2, None),
+        (DALQueryError("Unsupported service protocol"), 1, "Failed to query FAKE for source"),
+        (RuntimeError("service is down"), 1, "Failed to query FAKE for source"),
     ])
-    def test_dal_query_error_retried_for_duplicate_format(self, deconfigged_helper, err_msg,
-                                                          n_calls, expected_error):
+    def test_query_error_retried_for_format_failures(self, deconfigged_helper, error,
+                                                     n_calls, expected_error):
         vo_ldr = self.vo_ldr
         vo_ldr.source = self.source
-        service = _FakeVOService([self.fake_name], error=DALQueryError(err_msg))
+        service = _FakeVOService([self.fake_name], error=error)
         vo_ldr._full_registry_results = service
         vo_ldr.resource.choices = [self.fake_name]
         vo_ldr.resource_selected = self.fake_name
@@ -300,6 +302,10 @@ class TestVOQueryPaths:
         vo_ldr.query_archive()
 
         assert len(service.calls) == n_calls
+        # the retry drops the format argument but preserves the cone-search size
+        if n_calls == 2:
+            assert 'format' not in service.calls[-1]
+            assert service.calls[-1]['size'] == service.calls[0]['size']
         errors = [d['text'] for d in vo_ldr.query_message_items if d['color'] == 'error']
         if expected_error is None:
             assert errors == []

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
@@ -117,7 +117,8 @@ class VOResolver(BaseConeSearchResolver):
             self._query_message(error_msg, color="error",
                                 traceback=ValueError(error_msg), raise_msg=True)
 
-        # Clear existing resources list
+        # Clear existing resources list and any messages
+        self._clear_query_messages()
         self.resource.choices = []
         self.resource_selected = ""
 
@@ -148,6 +149,14 @@ class VOResolver(BaseConeSearchResolver):
             self.resource.choices = list(
                 self._full_registry_results.getcolumn("short_name")
             )
+            if not self.resource.choices:
+                # otherwise the (empty) dropdown is the only indication of the outcome
+                self._query_message(
+                    f"No {self.waveband_selected} {self.producttype_selected.lower()} "
+                    f"resources found in the VO registry for {self.source}. "
+                    f"Try a different waveband or product type" +
+                    (", or disable coverage filtering." if self.resource_filter_coverage else "."),
+                    color='warning')
         except (DALFormatError, VocabularyError) as e:
             # HTTP Error 403 is being issued as a string as part of the
             # VocabularyError when the registry is having issues.

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
@@ -214,10 +214,11 @@ class VOResolver(BaseConeSearchResolver):
                 },
                 format=("" if self.producttype_selected == "Catalog" else "fits"),
             )
-        except DALQueryError as e:
-            # We've run into issues where the service assumes a FORMAT and injects it for us.
-            # If the "image/fits" is duplicated, remove our requested format and rely on theirs
-            if "Wrong FORMAT=image/fits,image/fits" not in str(e):
+        except (DALQueryError, TypeError, ValueError) as e:
+            # We've run into issues where the service assumes a FORMAT and injects it for us,
+            # or advertises a set of accepted FORMAT values that excludes ours. In either
+            # case, drop our requested format and rely on the service default.
+            if "format" not in str(e).lower():
                 # any other query failure is reported by _query_single_coord_reporting
                 raise
             vo_results = vo_service.search(

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
@@ -82,12 +82,6 @@ class VOResolver(BaseConeSearchResolver):
     def _query_archive_label(self):
         return self.resource_selected
 
-    # def _query_message(self, *args, **kwargs):
-    #     # override the base class to always raise a warning/error when a query fails
-    #     # since there's no built-in warning mechanism like astroquery
-    #     kwargs['raise_msg'] = True
-    #     super()._query_message(*args, **kwargs)
-
     @observe("producttype_selected", "waveband_selected",
              "source", "coordframe_selected",
              "radius", "radius_unit_selected",

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
@@ -114,28 +114,29 @@ class VOResolver(BaseConeSearchResolver):
                 )
                 + "or disable coverage filtering."
             )
-            self._query_message(error_msg, color="error", raise_msg=True)
+            self._query_message(error_msg, color="error",
+                                traceback=ValueError(error_msg), raise_msg=True)
 
         # Clear existing resources list
         self.resource.choices = []
         self.resource_selected = ""
+
+        # Resolve the coordinate used for coverage filtering before querying the
+        # registry.
+        coord = None
+        if self.resource_filter_coverage:
+            coord = self._source_to_skycoord(add_query_message=False)
+            if coord is None:
+                error_msg = f"Unable to resolve source coordinates: {self.source}"
+                self._query_message(error_msg, color="error",
+                                    traceback=LookupError(error_msg), raise_msg=True)
 
         try:
             registry_args = [
                 registry.Servicetype(VO_PROTOCOL[self.producttype_selected]['protocol']),
                 registry.Waveband(self.waveband_selected),
             ]
-            # If coverage filtering is enabled, lookup current
-            # source coordinate and add a Spatial search constraint
             if self.resource_filter_coverage:
-                coord = self._source_to_skycoord(add_query_message=False)
-                if coord is None:
-                    # snackbar failure already reported by _source_to_skycoord
-                    traceback = LookupError(
-                        f"Unable to resolve source coordinates: {self.source}"
-                    )
-                    self._query_message(repr(traceback), color="error",
-                                        traceback=traceback, raise_msg=True)
                 # noinspection bad-argument-type
                 registry_args.append(
                     registry.Spatial(
@@ -150,7 +151,9 @@ class VOResolver(BaseConeSearchResolver):
         except (DALFormatError, VocabularyError) as e:
             # HTTP Error 403 is being issued as a string as part of the
             # VocabularyError when the registry is having issues.
-            if type(e.cause) is RequestConnectionError or 'HTTP Error 403' in str(e):
+            # NOTE: VocabularyError does not carry a ``cause``.
+            cause = getattr(e, 'cause', None)
+            if type(cause) is RequestConnectionError or 'HTTP Error 403' in str(e):
                 self._query_message(
                     f"Can't connect to VO registry. Check your internet connection: {e}",
                     color="error", traceback=e, raise_msg=True
@@ -188,8 +191,8 @@ class VOResolver(BaseConeSearchResolver):
             # We've run into issues where the service assumes a FORMAT and injects it for us.
             # If the "image/fits" is duplicated, remove our requested format and rely on theirs
             if "Wrong FORMAT=image/fits,image/fits" not in str(e):
-                self._query_message(f"An error occurred querying the VO Registry: {e}",
-                                    color="error", traceback=e)
+                # any other query failure is reported by _query_single_coord_reporting
+                raise
             vo_results = vo_service.search(
                 skycoord_center,
                 **{

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
@@ -1,4 +1,3 @@
-from astropy.coordinates import SkyCoord
 from astropy import units as u
 
 from pyvo import registry
@@ -7,7 +6,6 @@ from pyvo.utils.vocabularies import VocabularyError
 from requests.exceptions import ConnectionError as RequestConnectionError
 from traitlets import Bool, Any, List, Unicode, observe
 
-from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import loader_resolver_registry
 from jdaviz.core.template_mixin import (
     SelectPluginComponent,
@@ -75,9 +73,20 @@ class VOResolver(BaseConeSearchResolver):
                 "catalog", "catalog_subset", "catalog_col_type", "catalog_name_col",
                 "query_progress",
                 "resource_filter_coverage", "waveband", "resource",
+                "max_results",
                 "query_archive"
             ],
         )
+
+    @property
+    def _query_archive_label(self):
+        return self.resource_selected
+
+    # def _query_message(self, *args, **kwargs):
+    #     # override the base class to always raise a warning/error when a query fails
+    #     # since there's no built-in warning mechanism like astroquery
+    #     kwargs['raise_msg'] = True
+    #     super()._query_message(*args, **kwargs)
 
     @observe("producttype_selected", "waveband_selected",
              "source", "coordframe_selected",
@@ -111,8 +120,7 @@ class VOResolver(BaseConeSearchResolver):
                 )
                 + "or disable coverage filtering."
             )
-            self.hub.broadcast(SnackbarMessage(error_msg, sender=self, color="error"))
-            raise ValueError(error_msg)
+            self._query_message(error_msg, color="error", raise_msg=True)
 
         # Clear existing resources list
         self.resource.choices = []
@@ -126,29 +134,15 @@ class VOResolver(BaseConeSearchResolver):
             # If coverage filtering is enabled, lookup current
             # source coordinate and add a Spatial search constraint
             if self.resource_filter_coverage:
-                try:
-                    # First parse user-provided source as direct coordinates
-                    coord = SkyCoord(
-                        self.source, unit=u.deg, frame=self.coordframe_selected
+                coord = self._source_to_skycoord(add_query_message=False)
+                if coord is None:
+                    # snackbar failure already reported by _source_to_skycoord
+                    traceback = LookupError(
+                        f"Unable to resolve source coordinates: {self.source}"
                     )
-                except Exception:
-                    try:
-                        # If that didn't work, try parsing it as an object name
-                        coord = SkyCoord.from_name(
-                            self.source, frame=self.coordframe_selected
-                        )
-                    except Exception as e:
-                        self.hub.broadcast(
-                            SnackbarMessage(
-                                f"Unable to resolve source coordinates: {self.source}",
-                                sender=self,
-                                color="error",
-                                traceback=e
-                            )
-                        )
-                        raise LookupError(
-                            f"Unable to resolve source coordinates: {self.source}"
-                        )
+                    self._query_message(repr(traceback), color="error",
+                                        traceback=traceback, raise_msg=True)
+                # noinspection bad-argument-type
                 registry_args.append(
                     registry.Spatial(
                         (coord, (self.radius * u.Unit(self.radius_unit.selected))),
@@ -163,151 +157,56 @@ class VOResolver(BaseConeSearchResolver):
             # HTTP Error 403 is being issued as a string as part of the
             # VocabularyError when the registry is having issues.
             if type(e.cause) is RequestConnectionError or 'HTTP Error 403' in str(e):
-                self.hub.broadcast(
-                    SnackbarMessage(
-                        f"Can't connect to VO registry. Check your internet connection: {e}",
-                        sender=self,
-                        color="error",
-                        traceback=e
-                    )
+                self._query_message(
+                    f"Can't connect to VO registry. Check your internet connection: {e}",
+                    color="error", traceback=e, raise_msg=True
                 )
             else:
-                raise e
+                self._query_message(f"An error occurred querying the VO Registry: {e}",
+                                    color="error", traceback=e, raise_msg=True)
         except Exception as e:
-            self.hub.broadcast(
-                SnackbarMessage(
-                    f"An error occured querying the VO Registry: {e}",
-                    sender=self,
-                    color="error",
-                    traceback=e
-                )
-            )
-            raise
+            self._query_message(f"An error occurred querying the VO Registry: {e}",
+                                color="error", traceback=e, raise_msg=True)
 
-    def _source_to_skycoord(self):
-        """
-        Resolve ``self.source`` into a ``SkyCoord``. First attempts to parse as
-        direct coordinates, then falls back to name resolution.
-        Returns None (and broadcasts a snackbar) if resolution fails.
-        """
-        # Strip parentheses from source if present
-        stripped_source = self.source.strip('()')
-        try:
-            return SkyCoord(stripped_source, unit=u.deg, frame=self.coordframe_selected)
-        except Exception:
-            try:
-                return SkyCoord.from_name(stripped_source, frame=self.coordframe_selected)
-            except Exception as e:
-                self.hub.broadcast(
-                    SnackbarMessage(
-                        f"Unable to resolve source coordinates: {self.source}",
-                        sender=self,
-                        color="error",
-                        traceback=e
-                    )
-                )
-                return None
-
-    def _query_single_coord(self, coord):
+    def _query_single_coord(self, skycoord_center):
         """
         Query the selected VO resource for a single ``SkyCoord`` center.
 
-        Returns an astropy Table (or None on failure / no results).
+        Returns an astropy Table (or None if the resource returned no results).
         """
+        vo_service = self._full_registry_results[
+            self.resource_selected
+        ].get_service(service_type=VO_PROTOCOL[self.producttype_selected]['protocol'])
+        # search service using these coords.
         try:
-            vo_service = self._full_registry_results[
-                self.resource_selected
-            ].get_service(service_type=VO_PROTOCOL[self.producttype_selected]['protocol'])
-            # search service using these coords.
-            try:
-                vo_results = vo_service.search(
-                    coord,
-                    **{
-                        VO_PROTOCOL[self.producttype_selected]['size_arg']: (
-                            (self.radius * u.Unit(self.radius_unit.selected))
-                            if self.radius > 0.0
-                            else None
-                        )
-                    },
-                    format=("" if self.producttype_selected == "Catalog" else "fits"),
-                )
-            except DALQueryError as e:
-                # We've run into issues where the service assumes a FORMAT and injects it for us.
-                # If the "image/fits" is duplicated, remove our requested format and rely on theirs
-                if "Wrong FORMAT=image/fits,image/fits" in str(e):
-                    vo_results = vo_service.search(
-                        coord,
-                        **{
-                            "diameter" if self.producttype_selected == "Spectrum" else "size": (
-                                (self.radius * u.Unit(self.radius_unit.selected))
-                                if self.radius > 0.0
-                                else None
-                            )
-                        },
+            vo_results = vo_service.search(
+                skycoord_center,
+                **{
+                    VO_PROTOCOL[self.producttype_selected]['size_arg']: (
+                        (self.radius * u.Unit(self.radius_unit.selected))
+                        if self.radius > 0.0
+                        else None
                     )
-                else:
-                    self.hub.broadcast(
-                        SnackbarMessage(
-                            f"Query failed: {e}",
-                            sender=self,
-                            traceback=e,
-                            color="error",
-                        )
-                    )
-                    return None
-            if len(vo_results) == 0:
-                self.hub.broadcast(
-                    SnackbarMessage(
-                        f"No observations returned at coords {coord} from VO resource: "
-                        f"{vo_service.baseurl}",
-                        sender=self,
-                        color="error",
-                    )
-                )
-                return None
-            return vo_results.to_table()
-        except Exception as e:
-            self.hub.broadcast(
-                SnackbarMessage(
-                    f"Unable to locate files for source {self.source}: {e}",
-                    sender=self,
-                    color="error",
-                    traceback=e
-                )
+                },
+                format=("" if self.producttype_selected == "Catalog" else "fits"),
             )
+        except DALQueryError as e:
+            # We've run into issues where the service assumes a FORMAT and injects it for us.
+            # If the "image/fits" is duplicated, remove our requested format and rely on theirs
+            if "Wrong FORMAT=image/fits,image/fits" not in str(e):
+                self._query_message(f"An error occurred querying the VO Registry: {e}",
+                                    color="error", traceback=e)
+            vo_results = vo_service.search(
+                skycoord_center,
+                **{
+                    "diameter" if self.producttype_selected == "Spectrum" else "size": (
+                        (self.radius * u.Unit(self.radius_unit.selected))
+                        if self.radius > 0.0
+                        else None
+                    )
+                },
+            )
+
+        if len(vo_results) == 0:
             return None
-
-    @with_spinner(spinner_traitlet="results_loading")
-    def query_archive(self):
-        """
-        Once a specific VO resource is selected, query it with the user-specified source target.
-        User input for source is first attempted to be parsed as a SkyCoord coordinate. If not,
-        then attempts to parse as a target name.
-
-        In "Catalog" input mode, the selected resource is queried once per catalog
-        row and the results are stacked (see ``_query_catalog``).
-        """
-        # Catalog mode: loop over all (selected) catalog rows and stack results.
-        if self.search_input_selected == 'Catalog':
-            self._query_catalog(self._query_single_coord)
-            return
-
-        # Source / Viewer mode: single coordinate.
-        coord = self._source_to_skycoord()
-        self._output = self._query_single_coord(coord) if coord is not None else []
-
-        if self._output is not None and len(self._output) > 0:
-            self.hub.broadcast(
-                SnackbarMessage(
-                    f"{len(self._output)} {self.producttype_selected} results found!",
-                    sender=self,
-                    color="success",
-                )
-            )
-        self._resolver_input_updated()
-
-    def vue_query_archive(self, _=None):
-        self.query_archive()
-
-    def parse_input(self):
-        return self._output
+        return vo_results.to_table()

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
@@ -82,6 +82,16 @@ class VOResolver(BaseConeSearchResolver):
     def _query_archive_label(self):
         return self.resource_selected
 
+    @staticmethod
+    def _registry_search(*constraints):
+        """
+        Search the VO registry for resources matching ``constraints``.
+
+        Split out from `query_registry_resources` to mirror `_query_single_coord`.
+        Doing so also allows for easier testing.
+        """
+        return registry.search(*constraints)
+
     @observe("producttype_selected", "waveband_selected",
              "source", "coordframe_selected",
              "radius", "radius_unit_selected",
@@ -145,18 +155,23 @@ class VOResolver(BaseConeSearchResolver):
                         intersect="overlaps",
                     )
                 )
-            self._full_registry_results = registry.search(*registry_args)
+            self._full_registry_results = self._registry_search(*registry_args)
             self.resource.choices = list(
                 self._full_registry_results.getcolumn("short_name")
             )
             if not self.resource.choices:
                 # otherwise the (empty) dropdown is the only indication of the outcome
-                self._query_message(
-                    f"No {self.waveband_selected} {self.producttype_selected.lower()} "
-                    f"resources found in the VO registry for {self.source}. "
-                    f"Try a different waveband or product type" +
-                    (", or disable coverage filtering." if self.resource_filter_coverage else "."),
-                    color='warning')
+                msg = f"No {self.waveband_selected} {self.producttype_selected.lower()} "\
+                      "resources found in the VO registry"
+                if self.resource_filter_coverage:
+                    msg += (f" for source: {self.source}. "
+                            f"Try a different waveband or product type, "
+                            f"or disable coverage filtering.")
+                else:
+                    msg += ". Try a different waveband or product type."
+
+                self._query_message(msg, color='warning')
+
         except (DALFormatError, VocabularyError) as e:
             # HTTP Error 403 is being issued as a string as part of the
             # VocabularyError when the registry is having issues.

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
@@ -1,7 +1,7 @@
 from astropy import units as u
 
 from pyvo import registry
-from pyvo.dal.exceptions import DALFormatError, DALQueryError
+from pyvo.dal.exceptions import DALFormatError
 from pyvo.utils.vocabularies import VocabularyError
 from requests.exceptions import ConnectionError as RequestConnectionError
 from traitlets import Bool, Any, List, Unicode, observe
@@ -201,36 +201,27 @@ class VOResolver(BaseConeSearchResolver):
         vo_service = self._full_registry_results[
             self.resource_selected
         ].get_service(service_type=VO_PROTOCOL[self.producttype_selected]['protocol'])
+        search_kwargs = {
+            VO_PROTOCOL[self.producttype_selected]['size_arg']: (
+                (self.radius * u.Unit(self.radius_unit.selected))
+                if self.radius > 0.0
+                else None
+            )
+        }
         # search service using these coords.
         try:
             vo_results = vo_service.search(
                 skycoord_center,
-                **{
-                    VO_PROTOCOL[self.producttype_selected]['size_arg']: (
-                        (self.radius * u.Unit(self.radius_unit.selected))
-                        if self.radius > 0.0
-                        else None
-                    )
-                },
+                **search_kwargs,
                 format=("" if self.producttype_selected == "Catalog" else "fits"),
             )
-        except (DALQueryError, TypeError, ValueError) as e:
-            # We've run into issues where the service assumes a FORMAT and injects it for us,
-            # or advertises a set of accepted FORMAT values that excludes ours. In either
-            # case, drop our requested format and rely on the service default.
+        except Exception as e:  # nosec
+            # Services are inconsistent in how they handle FORMAT. Whenever the failure looks
+            # FORMAT related, retry once relying on the service default instead.
+            # Any other query failure is reported by _query_single_coord_reporting.
             if "format" not in str(e).lower():
-                # any other query failure is reported by _query_single_coord_reporting
                 raise
-            vo_results = vo_service.search(
-                skycoord_center,
-                **{
-                    "diameter" if self.producttype_selected == "Spectrum" else "size": (
-                        (self.radius * u.Unit(self.radius_unit.selected))
-                        if self.radius > 0.0
-                        else None
-                    )
-                },
-            )
+            vo_results = vo_service.search(skycoord_center, **search_kwargs)
 
         if len(vo_results) == 0:
             return None

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.py
@@ -161,6 +161,9 @@ class VOResolver(BaseConeSearchResolver):
             )
             if not self.resource.choices:
                 # otherwise the (empty) dropdown is the only indication of the outcome
+                # TODO: no choices should also trigger the invalid 'This field is required'
+                #  message beneath the dropdown but it doesn't happen until you try to make
+                #  a selection on nothing.
                 msg = f"No {self.waveband_selected} {self.producttype_selected.lower()} "\
                       "resources found in the VO registry"
                 if self.resource_filter_coverage:

--- a/jdaviz/core/loaders/resolvers/virtual_observatory/vo.vue
+++ b/jdaviz/core/loaders/resolvers/virtual_observatory/vo.vue
@@ -248,6 +248,18 @@
         :api_hints_enabled="api_hints_enabled"
         hint="Select a resource to query"
       ></plugin-select>
+
+      <j-flex-row justify="space-between" style="margin-top: 12px">
+        <v-text-field
+          v-model.number='max_results'
+          type="number"
+          style="padding: 0px"
+          :label="api_hints_enabled ? 'ldr.max_results =' : 'Max Results'"
+          :class="api_hints_enabled ? 'api-hint' : null"
+          persistent-hint
+          hint="Maximum number of results to return from the query."
+        ></v-text-field>
+      </j-flex-row>
     </v-form>
 
     <j-flex-row class="row-no-outside-padding" justify="end">
@@ -267,6 +279,8 @@
           }}
       </plugin-action-button>
     </j-flex-row>
+
+    <j-cone-search-messages :items="query_message_items"></j-cone-search-messages>
   </j-loader>
 </template>
 

--- a/jdaviz/core/loaders/tests/test_cone_search_messages.py
+++ b/jdaviz/core/loaders/tests/test_cone_search_messages.py
@@ -95,21 +95,6 @@ class TestConeSearchMessages:
         assert self._query_msg_texts('error') == []
         assert len(self._query_msg_texts('success')) == 1
 
-    def test_unsupported_query_is_raised(self):
-        """
-        Unsupported configurations (e.g. an archive without a query implementation)
-        are raised rather than reported as a query failure.
-        """
-        ldr = self.ldr
-
-        def _unsupported(_):
-            raise NotImplementedError('Querying for Foo is not supported.')
-
-        ldr._query_single_coord = _unsupported
-
-        with pytest.raises(NotImplementedError, match='not supported'):
-            ldr.query_archive()
-
     def test_query_message_raise_behavior(self):
         """``raise_msg`` warns for warnings and raises errors that carry a traceback."""
         ldr = self.ldr

--- a/jdaviz/core/loaders/tests/test_cone_search_messages.py
+++ b/jdaviz/core/loaders/tests/test_cone_search_messages.py
@@ -2,8 +2,6 @@ import pytest
 from astropy.table import Table
 from astropy.utils.data import conf as data_conf
 
-from jdaviz.core.events import SnackbarMessage
-
 
 CONE_SEARCH_RESOLVERS = ['astroquery', 'virtual observatory']
 

--- a/jdaviz/core/loaders/tests/test_cone_search_messages.py
+++ b/jdaviz/core/loaders/tests/test_cone_search_messages.py
@@ -1,0 +1,170 @@
+import pytest
+from astropy.table import Table
+from astropy.utils.data import conf as data_conf
+
+from jdaviz.core.events import SnackbarMessage
+
+
+CONE_SEARCH_RESOLVERS = ['astroquery', 'virtual observatory']
+
+
+class TestConeSearchMessages:
+    """
+    Each cone-search resolver is set up with a resolvable source so that
+    ``query_archive`` only depends on the (patched) ``_query_single_coord``,
+    and both resolvers are expected to report results identically.
+    """
+
+    @pytest.fixture(autouse=True, params=CONE_SEARCH_RESOLVERS)
+    def setup_method(self, request, deconfigged_helper):
+        self.helper = deconfigged_helper
+        self.ldr = deconfigged_helper.loaders[request.param]._obj
+        self.ldr.source = '337.5 -20.8'
+        self.calls = []
+
+    def _query_msg_texts(self, color=None):
+        return [item['text'] for item in self.ldr.query_message_items
+                if color is None or item['color'] == color]
+
+    def _query_msg_tracebacks(self, color=None):
+        return [repr(item['traceback']) for item in self.ldr.query_message_items
+                if color is None or item['color'] == color]
+
+    def _fail_first(self, coord):
+        self.calls.append(coord)
+        if len(self.calls) == 1:
+            raise RuntimeError('service is down')
+        return Table({'flux': [1]})
+
+    @pytest.mark.parametrize('max_results, n_output, expected_msg, hit_cap',
+                             [(None, 3, '3 results found.', False),
+                              (2, 2, 'maximum limit set (2).', True)])
+    def test_success_reported(self, max_results, n_output, expected_msg, hit_cap):
+        """
+        A successful query is reported as a success banner which is also broadcast
+        as a snackbar and recorded in the logger history.
+        """
+        ldr = self.ldr
+        if max_results is not None:
+            ldr.max_results = max_results
+        ldr._query_single_coord = lambda coord: Table({'flux': [1, 2, 3]})
+
+        ldr.query_archive()
+
+        assert ldr.returned_no_results is False
+        assert ldr.returned_max_results is hit_cap
+        assert len(ldr._output) == n_output
+        success_msgs = self._query_msg_texts('success')
+        assert len(success_msgs) == 1
+        assert success_msgs[0].endswith(expected_msg)
+
+        # every banner message is also broadcast as a snackbar/recorded in the logger
+        assert [m['text'] for m in self.helper.plugins['Logger'].history] == self._query_msg_texts()
+        assert [m['color'] for m in self.helper.plugins['Logger'].history] == [
+            d['color'] for d in ldr.query_message_items]
+
+    def test_no_results_reported(self):
+        ldr = self.ldr
+        ldr._query_single_coord = lambda coord: None
+
+        ldr.query_archive()
+
+        assert ldr.returned_no_results is True
+        assert ldr._output is None
+        assert any(text.startswith('The search returned no results')
+                   for text in self._query_msg_texts('error'))
+        # the queried archive/resource (when known) is identified in the message
+        archive = ldr._query_archive_label.strip()
+        if archive:
+            assert any(f'no results from {archive}' in text
+                       for text in self._query_msg_texts('error'))
+
+    def test_query_failure_reported(self):
+        """A failing query is reported rather than raised, in both resolvers."""
+        ldr = self.ldr
+
+        ldr._query_single_coord = self._fail_first
+
+        ldr.query_archive()
+
+        assert ldr.returned_no_results is True
+        assert len(self._query_msg_texts('error')) == len(self._query_msg_tracebacks('error')) == 1
+        assert 'service is down' in self._query_msg_tracebacks('error')[0]
+
+        # a subsequent query clears the failure banner and is this time successful
+        ldr._query_single_coord = lambda coord: Table({'flux': [1]})
+        ldr.query_archive()
+        assert self._query_msg_texts('error') == []
+        assert len(self._query_msg_texts('success')) == 1
+
+    def test_unsupported_query_is_raised(self):
+        """
+        Unsupported configurations (e.g. an archive without a query implementation)
+        are raised rather than reported as a query failure.
+        """
+        ldr = self.ldr
+
+        def _unsupported(_):
+            raise NotImplementedError('Querying for Foo is not supported.')
+
+        ldr._query_single_coord = _unsupported
+
+        with pytest.raises(NotImplementedError, match='not supported'):
+            ldr.query_archive()
+
+    def test_query_message_raise_behavior(self):
+        """``raise_msg`` warns for warnings and raises errors that carry a traceback."""
+        ldr = self.ldr
+
+        with pytest.warns(UserWarning, match='heads up'):
+            ldr._query_message('heads up', color='warning', raise_msg=True)
+
+        with pytest.raises(ValueError, match='fatal'):
+            ldr._query_message('fatal', color='error',
+                               traceback=ValueError('fatal'), raise_msg=True)
+
+        # an error without a traceback can only be reported, never raised
+        ldr._query_message('reported only', color='error', raise_msg=True)
+        assert 'reported only' in self._query_msg_texts('error')
+
+    def test_unresolvable_source_reported(self):
+        """Name resolution failures are reported rather than raised, in both resolvers."""
+        ldr = self.ldr
+        ldr.source = 'ThisIsAFakeTarget'
+
+        calls = []
+        ldr._query_single_coord = lambda coord: calls.append(coord)
+
+        # disabling astropy's internet access makes Sesame name resolution fail immediately
+        with data_conf.set_temp('allow_internet', False):
+            ldr.query_archive()
+
+        assert ldr.returned_no_results is True
+        assert calls == []
+        # Check both message text and traceback for the error
+        assert any(f'Unable to resolve source name: {ldr.source}' in text
+                   for text in self._query_msg_texts('error'))
+        assert any('All Sesame queries failed' in tb for tb in self._query_msg_tracebacks('error'))
+
+    def test_catalog_mode_failure_identifies_source(self, sky_coord_only_source_catalog):
+        """A failure on one catalog row is reported per-source and does not abort the loop."""
+        ldr = self.ldr
+        self.helper.load(sky_coord_only_source_catalog, format='Catalog')
+        label = [d.label for d in self.helper._app.data_collection
+                 if d.meta.get('_importer') == 'CatalogImporter'][-1]
+        ldr.search_input.selected = 'Catalog'
+        ldr.catalog.selected = label
+
+        ldr._query_single_coord = self._fail_first
+
+        ldr.query_archive()
+
+        # all rows are still queried and the surviving results are kept
+        assert len(self.calls) == len(sky_coord_only_source_catalog)
+        assert len(ldr._output) == len(sky_coord_only_source_catalog) - 1
+        errors = self._query_msg_texts('error')
+        tracebacks = self._query_msg_tracebacks('error')
+        assert len(errors) == len(tracebacks) == 1
+        # the failing source is identified by its catalog row label, not by ldr.source
+        assert f"{float(sky_coord_only_source_catalog['ra'][0]):.6f}" in errors[0]
+        assert 'service is down' in tracebacks[0]

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -632,7 +632,9 @@ def test_failed_astroquery(deconfigged_helper):
     ldr = deconfigged_helper.loaders['astroquery']
     ldr.source = "Bad Object"
     ldr.query_archive()
-    snackbar_msg = "Unable to resolve source name: Bad Object"
+    snackbar_msg = ("Unable to resolve source name: Bad Object; "
+                    "Traceback: Unable to find coordinates for name 'Bad Object' "
+                    "using https://cds.unistra.fr/cgi-bin/nph-sesame/SNV?Bad%20Object")
     assert snackbar_msg in [d['text'] for d in deconfigged_helper.plugins['Logger'].history]
 
 

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -632,8 +632,8 @@ def test_failed_astroquery(deconfigged_helper):
     ldr = deconfigged_helper.loaders['astroquery']
     ldr.source = "Bad Object"
     ldr.query_archive()
-    snackbar_msg = "Unable to resolve source coordinates: Bad Object"
-    assert deconfigged_helper.plugins['Logger'].history[-1]['text'] == snackbar_msg
+    snackbar_msg = "Unable to resolve source as name: Bad Object"
+    assert snackbar_msg in [d['text'] for d in deconfigged_helper.plugins['Logger'].history]
 
 
 def test_invoke_from_plugin(specviz_helper, spectrum1d, tmp_path):

--- a/jdaviz/core/loaders/tests/test_loaders.py
+++ b/jdaviz/core/loaders/tests/test_loaders.py
@@ -632,7 +632,7 @@ def test_failed_astroquery(deconfigged_helper):
     ldr = deconfigged_helper.loaders['astroquery']
     ldr.source = "Bad Object"
     ldr.query_archive()
-    snackbar_msg = "Unable to resolve source as name: Bad Object"
+    snackbar_msg = "Unable to resolve source name: Bad Object"
     assert snackbar_msg in [d['text'] for d in deconfigged_helper.plugins['Logger'].history]
 
 

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -7,6 +7,8 @@ import time
 import warnings
 from contextlib import contextmanager
 from functools import cached_property, wraps
+
+from astropy.utils.exceptions import AstropyUserWarning
 from traitlets import link
 
 import astropy.units as u
@@ -6329,7 +6331,11 @@ class Table(PluginSubcomponent):
             self._clear_table()
             return
         # Cache the QTable
-        self._qtable = QTable(table)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",
+                                    message="ignore:column .* has a unit but is kept as",
+                                    category=AstropyUserWarning)
+            self._qtable = QTable(table)
         # Update headers
         all_headers = list(table.colnames)
         missing_headers = [h for h in all_headers if h not in self.headers_avail]

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -6333,7 +6333,7 @@ class Table(PluginSubcomponent):
         # Cache the QTable
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore",
-                                    message="ignore:column .* has a unit but is kept as",
+                                    message="column .* has a unit but is kept as",
                                     category=AstropyUserWarning)
             self._qtable = QTable(table)
         # Update headers


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address disparities between error reporting in VO and Astroquery. Neither were consistent in reporting issues as snackbars or as a banner beneath the loader in the front end or otherwise raising the error in console. This PR unifies the reporting by merging the functionality of the two where possible to create a more generic `ConeSearchResolver` pipeline that consistently handles warnings/errors etc. It also posts all warnings/errors/successes to both snackbars and banners in the loader UI via shared UI component. Where possible/reasonable, reporting was kept the same. Issues that raised snackbars in addition to errors/warnings continue to do so. I've updated the tests to correspond with these changes---the behavior should be the same, the old tests have only had their error/exception text modified; new tests cover everything else about the new `query_message` system. 

I also fixed several VO bugs along the way:
* prevented VO from aborting a catalog search for a single bad source
* `max_results` was technically available to VO but not implemented in the front end
* generalized VO retry logic for bad formatting
* fixed some VO error reporting logic
* fixed a VO issue where some services provided data that couldn't be broadcast to the size needed by the query table