### PR TITLE
Restore extension search in loaders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -103,6 +103,8 @@ New Features
 
 - Improve UI appearance for URL loader. [#4354]
 
+- Adds search to extension menu in loaders when there are more than 3 extensions available. [#4372]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/components/plugin_select.vue
+++ b/jdaviz/components/plugin_select.vue
@@ -32,6 +32,7 @@
             hide-details
             autofocus
             style="margin: 8px;"
+            @keydown.space.stop
           />
           <v-divider class="mt-2"></v-divider>
         </div>

--- a/jdaviz/core/loaders/importers/catalog/catalog.vue
+++ b/jdaviz/core/loaders/importers/catalog/catalog.vue
@@ -7,6 +7,7 @@
       v-model:selected="extension_selected"
       :show_if_single_entry="true"
       :multiselect="extension_multiselect"
+      :search="extension_items.length > 3"
       label="Extension"
       api_hint="ldr.importer.extension ="
       :api_hints_enabled="api_hints_enabled"

--- a/jdaviz/core/loaders/importers/image/image.vue
+++ b/jdaviz/core/loaders/importers/image/image.vue
@@ -6,6 +6,7 @@
       v-model:selected="extension_selected"
       :show_if_single_entry="true"
       :multiselect="extension_multiselect"
+      :search="extension_items.length > 3"
       label="Extension"
       api_hint="ldr.extension ="
       :api_hints_enabled="api_hints_enabled"

--- a/jdaviz/core/loaders/importers/spectrum1d/spectrum1d.vue
+++ b/jdaviz/core/loaders/importers/spectrum1d/spectrum1d.vue
@@ -8,6 +8,7 @@
       :exists_in_dc="existing_data_in_dc"
       label="Extension"
       api_hint="ldr.importer.extension ="
+      :search="extension_items.length > 3"
       :api_hints_enabled="api_hints_enabled"
       hint="Extension to use for the data."
     ></plugin-select>

--- a/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.vue
+++ b/jdaviz/core/loaders/importers/spectrum2d/spectrum2d.vue
@@ -6,6 +6,7 @@
       :show_if_single_entry="true"
       :multiselect="multiselect"
       :exists_in_dc="existing_data_in_dc"
+      :search="extension_items.length > 3"
       label="Extension"
       api_hint="ldr.importer.extension ="
       :api_hints_enabled="api_hints_enabled"

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.vue
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.vue
@@ -8,6 +8,7 @@
       :multiselect="multiselect"
       :nonmultiselect_allow_clear="true"
       :exists_in_dc="existing_data_in_dc"
+      :search="extension_items.length > 3"
       label="Extension"
       api_hint="ldr.importer.extension ="
       :api_hints_enabled="api_hints_enabled"


### PR DESCRIPTION
Allows users to search the extensions list when there are more than 3 options. I picked 3 arbitrarily as an amount that seemed like it wouldn't need scrolling, if anyone thinks that number should be different I can update.