### PR TITLE
Add new Spectral Lines plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -109,6 +109,10 @@ New Features
 
 - Generate a Gaussian curve from Line Analysis plugin results and optionally add to the 1D Spectrum viewer. [#4374]
 
+- Initial addition of the Spectral Lines plugin, which provides tools for managing
+  and analyzing spectral line data, grouping these lines by components for easier
+  management and analysis. This plugin will eventually replace the Line Lists plugin. [#4375]
+
 Mosviz
 ^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -109,9 +109,6 @@ New Features
 
 - Generate a Gaussian curve from Line Analysis plugin results and optionally add to the 1D Spectrum viewer. [#4374]
 
-- Initial addition of the Spectral Lines plugin, which provides tools for managing
-  and analyzing spectral line data, grouping these lines by components for easier
-  management and analysis. This plugin will eventually replace the Line Lists plugin. [#4375]
 
 Mosviz
 ^^^^^^

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -13,6 +13,7 @@ Jdaviz provides a wide range of data analysis plugins for different types of ast
    model_fitting
    line_analysis
    line_lists
+   spectral_lines
    gaussian_smooth
    collapse
    moment_maps
@@ -41,6 +42,7 @@ Plugins provide specialized analysis capabilities tailored to different data typ
   - Model Fitting
   - Line Analysis
   - Line Lists
+  - Spectral Lines
   - Gaussian Smooth
 
 **Cube Analysis (3D)**

--- a/docs/plugins/spectral_lines.rst
+++ b/docs/plugins/spectral_lines.rst
@@ -1,0 +1,52 @@
+.. _plugins-spectral_lines:
+.. rst-class:: section-icon-mdi-tune-variant
+
+**************
+Spectral Lines
+**************
+.. plugin-availability::
+
+Plot spectral lines from a loaded line list, grouped into components.
+
+Description
+===========
+
+The Spectral Lines plugin loads a spectral line list and organizes lines into
+one or more named "components". Each component tracks its own redshift, which is
+applied to the lines to compute their observed wavelengths independently of other
+components. These changes are reflected in the displayed observed wavelengths
+for each line in both the plugin and in the associated data table.
+
+.. warning::
+
+   The Spectral Lines plugin is still under active development. The API is
+   not yet fully exposed, line plotting functionality has not been implemented
+   yet, and there are planned changes to the interface for loading lines.
+   It is currently only available when developer mode for the plugin is
+   enabled (``app.state.dev_spectral_lines_plugin = True``).
+
+**Key Features:**
+
+* Load a spectral line list via the Spectral Line Database loader
+* Create, rename, and remove components
+* Set an independent redshift per component
+* View each line's name, rest wavelength, and observed wavelength
+
+UI Access
+=========
+
+Click the :guilabel:`Spectral Lines` icon in the plugin toolbar to:
+
+1. Select or create a component
+2. Load spectral lines into the component
+3. Set the redshift for the selected component
+4. View and toggle the lines belonging to the component
+
+API Access
+==========
+
+The public API for this plugin is in development.
+
+.. plugin-api-refs::
+   :module: jdaviz.configs.default.plugins.spectral_lines.spectral_lines
+   :class: SpectralLines

--- a/docs/reference/api_plugins.rst
+++ b/docs/reference/api_plugins.rst
@@ -36,6 +36,9 @@ Plugins API
 .. automodapi:: jdaviz.configs.default.plugins.plot_options.plot_options
    :no-inheritance-diagram:
 
+.. automodapi:: jdaviz.configs.default.plugins.spectral_lines.spectral_lines
+   :no-inheritance-diagram:
+
 .. automodapi:: jdaviz.configs.default.plugins.subset_tools.subset_tools
    :no-inheritance-diagram:
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -363,6 +363,11 @@ class ApplicationState(State):
 
     dev_loaders = CallbackProperty(
         False, docstring='Whether to enable developer mode for new loaders infrastructure')
+
+    # PRs to add to changelog when removing dev_mos_loader dev-flag: 4375
+    dev_spectral_lines_plugin = CallbackProperty(
+        False, docstring='Whether to enable developer mode for the Spectral Lines plugin')
+
     loader_items = ListCallbackProperty(
         docstring="List of loaders available to the application.")
     loader_selected = CallbackProperty(

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -366,7 +366,7 @@ class ApplicationState(State):
 
     # PRs to add to changelog when removing dev_mos_loader dev-flag: 4375
     dev_spectral_lines_plugin = CallbackProperty(
-        True, docstring='Whether to enable developer mode for the Spectral Lines plugin')
+        False, docstring='Whether to enable developer mode for the Spectral Lines plugin')
 
     loader_items = ListCallbackProperty(
         docstring="List of loaders available to the application.")

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -366,7 +366,7 @@ class ApplicationState(State):
 
     # PRs to add to changelog when removing dev_mos_loader dev-flag: 4375
     dev_spectral_lines_plugin = CallbackProperty(
-        False, docstring='Whether to enable developer mode for the Spectral Lines plugin')
+        True, docstring='Whether to enable developer mode for the Spectral Lines plugin')
 
     loader_items = ListCallbackProperty(
         docstring="List of loaders available to the application.")

--- a/jdaviz/configs/default/plugins/__init__.py
+++ b/jdaviz/configs/default/plugins/__init__.py
@@ -7,6 +7,7 @@ from .subset_widget.subset_widget import * # noqa
 from .model_fitting.model_fitting import *  # noqa
 from .collapse.collapse import *  # noqa
 from .line_lists.line_lists import *  # noqa
+from .spectral_lines.spectral_lines import *  # noqa
 from .metadata_viewer.metadata_viewer import *  # noqa
 from .export.export import *  # noqa
 from .plot_options.plot_options import *  # noqa

--- a/jdaviz/configs/default/plugins/spectral_lines/__init__.py
+++ b/jdaviz/configs/default/plugins/spectral_lines/__init__.py
@@ -1,0 +1,1 @@
+from .spectral_lines import *  # noqa

--- a/jdaviz/configs/default/plugins/spectral_lines/spectral_lines.py
+++ b/jdaviz/configs/default/plugins/spectral_lines/spectral_lines.py
@@ -1,0 +1,366 @@
+from glue.core.message import DataCollectionAddMessage, DataCollectionDeleteMessage
+from traitlets import List, Unicode, observe
+
+from jdaviz.core.custom_traitlets import FloatHandleEmpty
+from jdaviz.core.events import AddDataMessage, RemoveDataMessage, DataRenamedMessage
+from jdaviz.core.registries import tray_registry
+from jdaviz.core.template_mixin import (PluginTemplateMixin, ViewerSelectMixin, LoadersMixin,
+                                        EditableSelectPluginComponent)
+from jdaviz.core.user_api import PluginUserApi
+
+__all__ = ['SpectralLines']
+
+
+@tray_registry('g-spectral-lines', label="Spectral Lines", category="data:analysis")
+class SpectralLines(PluginTemplateMixin, ViewerSelectMixin, LoadersMixin):
+    template_file = __file__, "spectral_lines.vue"
+
+    component_mode = Unicode().tag(sync=True)
+    component_edit_value = Unicode().tag(sync=True)
+    component_items = List().tag(sync=True)
+    component_selected = Unicode().tag(sync=True)
+
+    # redshift for all lines in the currently selected component. kept in sync
+    # with the corresponding entry in self._components
+    component_redshift = FloatHandleEmpty(0).tag(sync=True)
+
+    # read-only: per-line info (name, rest, obs, show) for the currently
+    # selected component, for display in the UI
+    component_lines = List().tag(sync=True)
+
+    # read-only: label of the data-collection table holding the spectral lines.
+    # each component corresponds to a 'observed wavelength:<component>' column in
+    # this table.
+    line_table = Unicode().tag(sync=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # maps component label to other info that is set per component (e.g redshift,
+        # eventually plotting options). this is kept in sync with the component
+        # select widget and is responsive to deleting or renaming components
+        self._components = {}
+
+        self._syncing_component_info = False
+
+        self.viewer.add_filter('is_spectrum_viewer')
+
+        self.component = EditableSelectPluginComponent(
+            self,
+            name='component',
+            mode='component_mode',
+            edit_value='component_edit_value',
+            items='component_items',
+            selected='component_selected',
+            manual_options=['default'],
+            on_add=self._on_component_add,
+            on_rename=self._on_component_rename,
+            on_remove=self._on_component_remove,
+        )
+
+        self.hub.subscribe(self, AddDataMessage,
+                           handler=self._on_viewer_data_changed)
+
+        self.hub.subscribe(self, RemoveDataMessage,
+                           handler=self._on_viewer_data_changed)
+
+        # keep track of the spectral lines table in the data collection: pick up
+        # a newly loaded line table, follow it if renamed, and drop the association
+        # if it gets deleted.
+        self.hub.subscribe(self, DataCollectionAddMessage,
+                           handler=self._on_data_collection_add)
+
+        self.hub.subscribe(self, DataCollectionDeleteMessage,
+                           handler=self._on_data_collection_delete)
+
+        self.hub.subscribe(self, DataRenamedMessage,
+                           handler=self._on_data_renamed)
+
+        self.observe_traitlets_for_relevancy(
+            traitlets_to_observe=['viewer_items'],
+            irrelevant_msg_callback=self._irrelevant_msg_callback
+        )
+
+        self._plugin_description = 'Plot spectral lines.'
+        self.docs_link = f'https://jdaviz.readthedocs.io/en/{self.vdocs}/plugins/spectral_lines.html'  # noqa
+
+    def _irrelevant_msg_callback(self, *args):
+        if not hasattr(self, 'viewer'):
+            return None
+
+        if not getattr(self._app.state, 'dev_spectral_lines_plugin', False):
+            return 'Spectral Lines unavailable (requires dev_spectral_lines_plugin to be enabled)'
+
+        has_spectrum_data = (len(self.viewer_items) > 0
+                             and self.viewer.selected_obj is not None
+                             and len(self.viewer.selected_obj.state.layers) > 0)
+
+        if has_spectrum_data or self._table_viewer_has_line_table():
+            return ''
+
+        return ('Spectral Lines unavailable without either data loaded in a spectrum '
+                'viewer or a line list loaded in a table viewer')
+
+    def _table_viewer_has_line_table(self):
+        """Whether any table viewer is currently displaying data loaded via the
+        Spectral Line Database loader."""
+        from jdaviz.configs.default.plugins.viewers import JdavizTableViewer
+        for viewer in self._app._viewer_store.values():
+            if not isinstance(viewer, JdavizTableViewer):
+                continue
+            for layer in viewer.state.layers:
+                if getattr(layer.layer, 'meta', {}).get('_importer') == 'SpectralLinesImporter':
+                    return True
+        return False
+
+    def _default_component_info(self):
+        """Default entry stored per-component in ``self._components``."""
+        # 'show' maps line-table row index to visibility (defaults to True)
+        return {'redshift': 0.0, 'show': {}}
+
+    @staticmethod
+    def _component_col_name(lbl):
+        """Name of the line-table column corresponding to a component."""
+        return f'observed wavelength:{lbl}'
+
+    def _get_line_table_data(self):
+        """The glue Data object for the spectral lines table, or None."""
+        if self.line_table and self.line_table in self._app.data_collection.labels:
+            return self._app.data_collection[self.line_table]
+        return None
+
+    def _get_data_component_id(self, data, col_name):
+        """ComponentID in ``data`` with label ``col_name``, or None."""
+        for cid in data.components:
+            if cid.label == col_name:
+                return cid
+        return None
+
+    def _add_component_column(self, lbl, data=None):
+        """
+        Add or update the 'observed wavelength:<lbl>' column in the line table,
+        applying the component's redshift to the table's original spectral
+        location column (recomputed from the original values each time to
+        avoid building up precision errors).
+        """
+        if data is None:
+            data = self._get_line_table_data()
+        if data is None:
+            return
+
+        source_col = data.meta.get('_jdaviz_loader_spectral_loc_col')
+        source_cid = (self._get_data_component_id(data, source_col)
+                      if source_col is not None else None)
+        if source_cid is None:
+            return
+
+        redshift = self._components.get(lbl, self._default_component_info())['redshift']
+        self._app._jdaviz_helper._set_data_component(
+            data, self._component_col_name(lbl), data[source_cid] * (1 + redshift)
+        )
+
+    def _get_line_names(self, data):
+        """Values of a line-name-like column in ``data``, or None."""
+        for cid in data.components:
+            if cid.label.lower() in ('linename', 'line_name', 'name', 'line', 'id', 'label'):
+                comp = data.get_component(cid)
+                # categorical (string) components store original values in .labels
+                return comp.labels if hasattr(comp, 'labels') else data[cid]
+        return None
+
+    def _update_component_lines(self):
+        """
+        Rebuild ``component_lines`` (name, rest, observed wavelength, and
+        visibility of each line) for the currently selected component.
+        """
+        data = self._get_line_table_data()
+        source_col = (data.meta.get('_jdaviz_loader_spectral_loc_col')
+                      if data is not None else None)
+        source_cid = (self._get_data_component_id(data, source_col)
+                      if source_col is not None else None)
+        if source_cid is None:
+            self.component_lines = []
+            return
+
+        if self.component_selected:
+            info = self._components.setdefault(self.component_selected,
+                                               self._default_component_info())
+        else:
+            info = self._default_component_info()
+
+        rest_values = data[source_cid]
+        unit = data.get_component(source_cid).units or ''
+        names = self._get_line_names(data)
+
+        self.component_lines = [
+            {'linename': str(names[i]) if names is not None else f'Line {i + 1}',
+             'rest': float(rest),
+             'obs': float(rest) * (1 + info['redshift']),
+             'unit': unit,
+             'show': bool(info['show'].get(i, True))}
+            for i, rest in enumerate(rest_values)
+        ]
+
+    def vue_toggle_line_visibility(self, line_ind):
+        if not self.component_selected:
+            return
+        info = self._components.setdefault(self.component_selected,
+                                           self._default_component_info())
+        info['show'][line_ind] = not info['show'].get(line_ind, True)
+        self._update_component_lines()
+
+    def _remove_component_column(self, lbl):
+        data = self._get_line_table_data()
+        if data is None:
+            return
+        cid = self._get_data_component_id(data, self._component_col_name(lbl))
+        if cid is not None:
+            data.remove_component(cid)
+
+    def _on_component_add(self, lbl):
+        self._components.setdefault(lbl, self._default_component_info())
+        self._add_component_column(lbl)
+
+    def _on_component_rename(self, old_lbl, new_lbl):
+        info = self._components.pop(old_lbl, self._default_component_info())
+        self._components[new_lbl] = info
+
+        # move the old column to the new name in the line table
+        data = self._get_line_table_data()
+        if data is None:
+            return
+        old_cid = self._get_data_component_id(data, self._component_col_name(old_lbl))
+        if old_cid is None:
+            return
+        self._app._jdaviz_helper._set_data_component(
+            data, self._component_col_name(new_lbl), data[old_cid]
+        )
+        data.remove_component(old_cid)
+
+    def _on_component_remove(self, lbl):
+        self._components.pop(lbl, None)
+        self._remove_component_column(lbl)
+
+    @observe('component_selected')
+    def _on_component_selected_changed(self, change=None):
+        # load the redshift for the newly-selected component into the traitlet,
+        # creating a default entry the first time this component is seen
+        if self.component_selected:
+            info = self._components.setdefault(self.component_selected,
+                                               self._default_component_info())
+        else:
+            # no component selected (encountered when removing the final component)
+            info = self._default_component_info()
+
+        self._syncing_component_info = True
+        try:
+            self.component_redshift = info['redshift']
+        finally:
+            self._syncing_component_info = False
+
+        self._update_component_lines()
+
+    @observe('component_redshift')
+    def _on_component_redshift_changed(self, change):
+        if self._syncing_component_info or not self.component_selected:
+            # either this is us loading a value above (not a user edit), or there is
+            # currently no selected component to store the value against
+            return
+        if self.component_redshift == '':
+            return
+        if self.component_redshift < 0:
+            # redshift cannot be negative
+            self._syncing_component_info = True
+            try:
+                self.component_redshift = 0
+            finally:
+                self._syncing_component_info = False
+        self._components.setdefault(self.component_selected, self._default_component_info())
+        self._components[self.component_selected]['redshift'] = self.component_redshift
+        # recompute this component's column from the original values
+        self._add_component_column(self.component_selected)
+        self._update_component_lines()
+
+    @property
+    def user_api(self):
+        return PluginUserApi(self, expose=('component', 'redshift'))
+
+    def _on_viewer_data_changed(self, msg=None):
+        self._set_relevant()
+        if self.disabled_msg or self.irrelevant_msg:
+            return
+
+    def _on_data_collection_add(self, msg):
+        # only interested in line-list tables
+        data = msg.data
+        if data.meta.get('_importer') != 'SpectralLinesImporter':
+            return
+
+        self.line_table = data.label
+
+        # add a rest-wavelength column for every existing component
+        for lbl in self.component.choices:
+            self._components.setdefault(lbl, self._default_component_info())
+            self._add_component_column(lbl, data=data)
+
+        self._update_component_lines()
+
+    def _on_data_collection_delete(self, msg):
+        if msg.data.label == self.line_table:
+            self.line_table = ''
+            self._update_component_lines()
+
+    def _on_data_renamed(self, msg):
+        if msg.old_label == self.line_table:
+            self.line_table = msg.new_label
+
+    def _update_loader_items(self):
+        # override to skip restrict_to_target: the Spectral Line Database loader
+        # (and any other source loading spectral lines) uses BaseImporterToDataCollection
+        # rather than BaseImporterToPlugin, so importers would never match this plugin's
+        # target if restricted. Instead, just default the source to the Spectral Line
+        # Database loader.
+
+        def open_accordion():
+            self.open_in_tray()
+            self.loader_panel_ind = 0
+
+        def close_accordion():
+            self.loader_panel_ind = None
+
+        def set_active_loader(resolver):
+            self.loader_selected = resolver
+
+        import jdaviz.core.loaders  # noqa
+        from jdaviz.core.registries import loader_resolver_registry
+
+        disabled_loaders = self._app.state.settings.get('disabled_loaders')
+        if disabled_loaders is None:
+            # Default: disable loaders based on server_is_remote setting
+            if self._app.state.settings.get('server_is_remote', False):
+                disabled_loaders = ['file', 'file drop', 'url', 'object',
+                                    'astroquery', 'virtual observatory']
+            else:
+                disabled_loaders = []
+
+        loader_items = []
+        for name, Resolver in loader_resolver_registry.members.items():
+            if name in disabled_loaders:
+                continue
+            loader = Resolver(app=self._app,
+                              open_callback=open_accordion,
+                              close_callback=close_accordion,
+                              set_active_loader_callback=set_active_loader)
+            loader_items.append({
+                'name': name,
+                'label': name,
+                'requires_api_support': loader.requires_api_support,
+                'widget': 'IPY_MODEL_' + loader.model_id
+            })
+        self.loader_items = loader_items
+
+        default_name = 'spectral line database'
+        if any(item['name'] == default_name for item in loader_items):
+            self.loader_selected = default_name
+        elif len(loader_items):
+            self.loader_selected = loader_items[0]['name']

--- a/jdaviz/configs/default/plugins/spectral_lines/spectral_lines.vue
+++ b/jdaviz/configs/default/plugins/spectral_lines/spectral_lines.vue
@@ -1,0 +1,100 @@
+<template>
+  <j-tray-plugin
+    :description="docs_description || 'Plot spectral lines.'"
+    :link="docs_link"
+    :irrelevant_msg="irrelevant_msg"
+    :disabled_msg="disabled_msg"
+
+  >
+
+    <j-plugin-section-header>Add Spectral Lines</j-plugin-section-header>
+
+    <plugin-loaders-panel
+      v-if="!server_is_remote"
+      v-model:loader_panel_ind="loader_panel_ind"
+      :loader_items="loader_items"
+      v-model:loader_selected="loader_selected"
+      :api_hints_enabled="api_hints_enabled"
+      :api_hints_obj="api_hints_obj"
+      style="margin-bottom: 12px"
+    ></plugin-loaders-panel>
+
+    <j-plugin-section-header>Select Component to Modify</j-plugin-section-header>
+    <plugin-editable-select
+      v-model:mode="component_mode"
+      v-model:edit_value="component_edit_value"
+      :items="component_items"
+      v-model:selected="component_selected"
+      label="Component"
+      api_hint="plg.component ="
+      api_hint_add="plg.component.add_choice"
+      api_hint_rename="plg.component.rename_choice"
+      api_hint_remove="plg.component.remove_choice"
+      :api_hints_enabled="api_hints_enabled"
+      hint="Current selected kinematic component. Select or create new to modify."
+    ></plugin-editable-select>
+
+    <j-plugin-section-header>Set Component Redshift</j-plugin-section-header>
+
+    <v-row>
+      <v-text-field
+        v-model.number="component_redshift"
+        type="number"
+        step="0.0001"
+        min="0"
+        label="Redshift"
+        hint="Redshift for all lines in the currently selected component."
+        persistent-hint
+      ></v-text-field>
+    </v-row>
+
+    <div v-if="component_lines.length">
+      <j-plugin-section-header>Lines in Component</j-plugin-section-header>
+
+      <div v-for="(line, line_ind) in component_lines" :key="line_ind" style="width: 100%">
+        <v-row class="row-no-vertical-padding-margin vuetify2" style="margin: 0px">
+          <v-col cols=9 style="padding: 0">
+            <span class='text--primary' style="overflow-wrap: anywhere; font-size: 16pt; padding-top: 3px;">
+              <b>{{ line.linename }}</b>
+            </span>
+          </v-col>
+          <v-col cols=3 align="right" style="padding: 0">
+            <v-btn
+              :color="line.show ? 'accent' : 'inherit'"
+              icon
+              variant="text"
+              density="compact"
+              @click="toggle_line_visibility(line_ind)">
+              <v-icon>{{ line.show ? "mdi-eye" : "mdi-eye-off" }}</v-icon>
+            </v-btn>
+          </v-col>
+        </v-row>
+        <v-row class="row-min-bottom-padding vuetify2">
+          <v-col cols=6 style="padding-bottom: 3px; padding-top: 0px">
+            <v-subheader class="pl-0 slider-label" style="height: 16px"><b>Rest</b></v-subheader>
+            <v-text-field
+              :model-value="line.rest"
+              class="mt-0 pt-0"
+              density="compact"
+              :hint="line.unit"
+              persistent-hint
+              disabled
+            ></v-text-field>
+          </v-col>
+          <v-col cols=6 style="padding-top: 0px">
+            <v-subheader class="pl-0 slider-label" style="height: 16px"><b>Observed</b></v-subheader>
+            <v-text-field
+              :model-value="line.obs"
+              class="mt-0 pt-0"
+              density="compact"
+              :hint="line.unit"
+              persistent-hint
+              disabled
+            ></v-text-field>
+          </v-col>
+        </v-row>
+      </div>
+    </div>
+
+  </j-tray-plugin>
+</template>

--- a/jdaviz/configs/default/plugins/spectral_lines/tests/test_spectral_lines.py
+++ b/jdaviz/configs/default/plugins/spectral_lines/tests/test_spectral_lines.py
@@ -1,0 +1,153 @@
+import astropy.units as u
+import numpy as np
+from astropy.table import QTable
+from numpy.testing import assert_allclose
+
+
+def test_spectral_lines_relevancy(deconfigged_helper, spectrum1d, image_nddata_wcs):
+
+    deconfigged_helper._app.state.dev_spectral_lines_plugin = True
+
+    # 'plugins' dict only exposes relevant plugins, so fetch from tray directly
+    plugin = deconfigged_helper._app.get_tray_item_from_name('g-spectral-lines')
+
+    # no spectrum viewer yet, plugin should be irrelevant and not in the API
+    assert plugin.irrelevant_msg != ''
+    assert 'Spectral Lines' not in deconfigged_helper.plugins
+
+    # load a spectrum (creates the 1D Spectrum viewer), plugin should be relevant
+    deconfigged_helper.load(spectrum1d, format='1D Spectrum', data_label='my_spec')
+    assert plugin.irrelevant_msg == ''
+    assert 'Spectral Lines' in deconfigged_helper.plugins
+
+    # remove the spectrum, plugin should be irrelevant again
+    deconfigged_helper._app.data_item_remove('my_spec')
+    assert plugin.irrelevant_msg != ''
+    assert 'Spectral Lines' not in deconfigged_helper.plugins
+
+    # loading a non-spectrum (image) should not make the plugin relevant
+    deconfigged_helper.load(image_nddata_wcs, format='Image', data_label='my_image')
+    assert plugin.irrelevant_msg != ''
+    assert 'Spectral Lines' not in deconfigged_helper.plugins
+
+
+def test_spectral_lines_relevancy_table_viewer(deconfigged_helper):
+
+    deconfigged_helper._app.state.dev_spectral_lines_plugin = True
+
+    plugin = deconfigged_helper._app.get_tray_item_from_name('g-spectral-lines')
+
+    # no viewers at all yet, plugin should be irrelevant
+    assert plugin.irrelevant_msg != ''
+
+    # load a line list into a table viewer (no spectrum viewer involved)
+    ldr = deconfigged_helper.loaders['object']
+    ldr.object = QTable({'wavelength': [6562.8, 7000.0] * u.AA, 'name': ['Ha', 'line2']})
+    ldr.format = 'Spectral Lines'
+    importer = ldr.importer
+    importer.viewer.create_new = 'Table'
+    importer()
+
+    # a table viewer showing spectral-line data should make the plugin relevant
+    # even without a spectrum viewer
+    assert plugin.irrelevant_msg == ''
+
+    # removing the table viewer's data should make it irrelevant again
+    deconfigged_helper._app.data_item_remove(deconfigged_helper._app.data_collection[0].label)
+    assert plugin.irrelevant_msg != ''
+
+
+def test_spectral_lines_components(deconfigged_helper, spectrum1d):
+
+    deconfigged_helper._app.state.dev_spectral_lines_plugin = True
+
+    # load a spectrum1d that spans 6000-8000 angstrom
+    deconfigged_helper.load(spectrum1d, format='1D Spectrum', data_label='my_spec')
+
+    # 'plugins' dict only exposes relevant plugins, so fetch from tray directly
+    plugin = deconfigged_helper._app.get_tray_item_from_name('g-spectral-lines')
+
+    # import a line list with lines in range of the loaded spectrum
+    rest_wav = np.array([6562.8, 7000.0])
+    ldr = deconfigged_helper.loaders['object']
+    ldr.object = QTable({'wavelength': rest_wav * u.AA, 'name': ['Ha', 'line2']})
+    ldr.format = 'Spectral Lines'
+    importer = ldr.importer
+    importer.col_other = ['name']
+    importer()
+
+    # plugin picked up the table and added a column for the default component
+    assert plugin.line_table != ''
+    line_data = deconfigged_helper._app.data_collection[plugin.line_table]
+
+    def col(component_lbl):
+        cid = plugin._get_data_component_id(line_data,
+                                            f'observed wavelength:{component_lbl}')
+        assert cid is not None
+        return line_data[cid]
+
+    def component_lines_field(field):
+        return [line[field] for line in plugin.component_lines]
+
+    assert plugin.component_selected == 'default'
+    assert_allclose(col('default'), rest_wav)
+
+    # component_lines reflects the names/rest/observed wavelengths of the
+    # currently selected component, all initially visible
+    assert component_lines_field('linename') == ['Ha', 'line2']
+    assert_allclose(component_lines_field('rest'), rest_wav)
+    assert_allclose(component_lines_field('obs'), rest_wav)
+    assert component_lines_field('show') == [True, True]
+
+    # a new component gets its own column, initially unshifted (z=0)
+    plugin.component.add_choice('second')
+    assert plugin.component_selected == 'second'
+    assert plugin.component_redshift == 0
+    assert_allclose(col('second'), rest_wav)
+    assert_allclose(component_lines_field('obs'), rest_wav)
+
+    # adjusting the redshift updates only the selected component's column
+    # and its entries in component_lines
+    plugin.component_redshift = 0.1
+    assert_allclose(col('second'), rest_wav * 1.1)
+    assert_allclose(col('default'), rest_wav)
+    assert_allclose(component_lines_field('obs'), rest_wav * 1.1)
+    assert_allclose(component_lines_field('rest'), rest_wav)
+
+    # toggling visibility only affects the current component's display state
+    plugin.vue_toggle_line_visibility(0)
+    assert component_lines_field('show') == [False, True]
+
+    # switching to another component keeps its own (unaffected) visibility...
+    plugin.component_selected = 'default'
+    assert component_lines_field('show') == [True, True]
+    assert_allclose(component_lines_field('obs'), rest_wav)
+
+    # ...and switching back restores the toggled state and redshifted values
+    plugin.component_selected = 'second'
+    assert component_lines_field('show') == [False, True]
+    assert_allclose(component_lines_field('obs'), rest_wav * 1.1)
+
+    # renaming moves the shifted column to the new name and keeps the redshift
+    plugin.component.rename_choice('second', 'renamed')
+    assert plugin._get_data_component_id(line_data, 'observed wavelength:second') is None
+    assert_allclose(col('renamed'), rest_wav * 1.1)
+    assert plugin.component_selected == 'renamed'
+    assert plugin.component_redshift == 0.1
+
+    # component_lines follows the rename, keeping the shifted values and
+    # per-line visibility state
+    assert component_lines_field('linename') == ['Ha', 'line2']
+    assert_allclose(component_lines_field('obs'), rest_wav * 1.1)
+    assert component_lines_field('show') == [False, True]
+
+    # removing a component removes its column, leaving others untouched
+    plugin.component.remove_choice('renamed')
+    assert plugin._get_data_component_id(line_data, 'observed wavelength:renamed') is None
+    assert plugin.component_selected == 'default'
+    assert plugin.component_redshift == 0
+    assert_allclose(col('default'), rest_wav)
+
+    # component_lines reflects the fallback to 'default', unshifted and visible
+    assert_allclose(component_lines_field('obs'), rest_wav)
+    assert component_lines_field('show') == [True, True]

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.py
@@ -99,6 +99,7 @@ class SubsetTools(PluginTemplateMixin, LoadersMixin):
     * :meth:`rename_subset`
     * :meth:`update_subset`
     * :meth:`simplify_subset`
+    * :meth:`delete_subset`
     """
     template_file = __file__, "subset_tools.vue"
     select = List([]).tag(sync=True)

--- a/jdaviz/configs/default/plugins/subset_tools/subset_tools.vue
+++ b/jdaviz/configs/default/plugins/subset_tools/subset_tools.vue
@@ -14,6 +14,7 @@
       :loader_items="loader_items"
       v-model:loader_selected="loader_selected"
       :api_hints_enabled="api_hints_enabled"
+      :api_hints_obj="api_hints_obj"
       style="margin-bottom: 12px"
     ></plugin-loaders-panel>
 


### PR DESCRIPTION
This PR adds a Spectral Lines plugin with basic functionality to load lines, group them by component, and apply redshift changes per-component. There will be follow up efforts to flesh this out (plotting lines, unit conversion support, defining individual custom lines that, UI improvements, etc) but this PR adds the basic functionality for the plugin that will eventually replace the Line Lists plugin.


I wanted to point out that we need to add line name info to the table loaded in from the spectral lines, so until that is done the lines are displayed in the plugin with a generic name.
<img width="325" height="340" alt="Screenshot 2026-09-02 at 10 16 55 AM" src="https://github.com/user-attachments/assets/6febbdda-59ce-423b-838a-9f93e75c5969" />
