### PR TITLE
re run change log CI check when milestone is changed

### DIFF
--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -2,7 +2,7 @@ name: Check PR change log
 
 on:
   pull_request:
-    types: [opened, synchronize, labeled, unlabeled]
+    types: [opened, synchronize, labeled, unlabeled, milestoned, demilestoned]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
It was annoying me to have to manually re-run the change log CI check when a milestone was added, so this adds a line to re-run the check