### PR TITLE
Allow data to be removed from viewer when Orientation is set to wcs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,6 +112,8 @@ New Features
 - Unify astroquery and VO reporting behavior. Both now show banners in the UI for the
   results of queries. This information can also be found in the logger. [#4369]
 
+- Fix issue where catalog datasets could not be deleted from scatter viewers when aligned by WCS. [#4389]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -3054,8 +3054,9 @@ class PrivateApplication(VuetifyTemplate, HubListener):
         # Make sure the data isn't loaded in any viewers and isn't the selected orientation
         for viewer_id, viewer in list(self._viewer_store.items()):
             if orientation_plugin is not None and self._align_by == 'wcs':
-                if viewer.state.reference_data.label == data_label:
-                    self._change_reference_data(base_wcs_layer_label, viewer_id)
+                if hasattr(viewer.state, 'reference_data') and viewer.state.reference_data is not None: # noqa
+                    if viewer.state.reference_data.label == data_label:
+                        self._change_reference_data(base_wcs_layer_label, viewer_id)
             self.remove_data_from_viewer(viewer_id, data_label)
 
             if len(viewer.layers) != 0 and getattr(viewer.state, 'reference_data', '') is None:

--- a/jdaviz/tests/test_app.py
+++ b/jdaviz/tests/test_app.py
@@ -598,3 +598,31 @@ def test_add_custom_loader_open_in_tray(deconfigged_helper, tmp_path):
 
     # The loader should be returned and the name should match
     assert repr(loader) == '<test API>'
+
+
+def test_delete_catalog_with_wcs_from_viewer(deconfigged_helper, sky_coord_only_source_catalog):
+    # load an image
+    image_data = np.ones((10, 10))
+    deconfigged_helper.load(image_data, format='Image', data_label='image')
+
+    # load the catalog
+    deconfigged_helper.load(sky_coord_only_source_catalog,
+                            format='Catalog',
+                            data_label='my_catalog')
+
+    # create a scatter viewer
+    create_scatter_viewer = deconfigged_helper.new_viewers['Scatter']
+    create_scatter_viewer.dataset = 'my_catalog'
+    create_scatter_viewer()
+
+    # verify the catalog is loaded in the viewer
+    dm = deconfigged_helper.viewers['Scatter'].data_menu
+    assert 'my_catalog' in dm.layer.choices
+
+    # now remove the catalog from the app
+    dm.layer = 'my_catalog'
+    dm.remove_from_app()
+
+    # verify the catalog was removed
+    assert 'my_catalog' not in deconfigged_helper._app.data_collection.labels
+    assert 'my_catalog' not in dm.layer.choices


### PR DESCRIPTION
This PR addresses a bug where you couldn't delete a catalog dataset from a Scatter viewer *specifically* if the orientation was set to `align_by=WCS`. The traceback stated that the ScatterViewerState from glue has no `reference_data` attribute; then since `app.py` required changing the reference data to a WCS-aligned dataset before moving to the `remove_data_from_viewer` step, you'd get an attribute error.  `App.py` now checks for the reference data attribute, but if it doesn't exist, it just deletes the existing dataset. Also added a test for this.

To test, you can use @bmorris3 's example notebook: https://gist.github.com/bmorris3/c2503e165e545b47efe172558b31b5d6 and try deleting 'Catalog' from the data menu after the scatter viewer is created. 


Fixes #JDAT-6364

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] If new remote data is added that uses MAST, is the URI added to the `cache-download.yml` workflow?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone. Bugfix milestone also needs an accompanying backport label.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
